### PR TITLE
Add form options for full width control

### DIFF
--- a/src/applications/appeals/testing/config/form.js
+++ b/src/applications/appeals/testing/config/form.js
@@ -61,7 +61,8 @@ const formConfig = {
   subTitle: 'VA Form 10182 (Notice of Disagreement)',
   formOptions: {
     noTitle: true,
-    noNav: true,
+    noTopNav: true,
+    noBottomNav: true,
     fullWidth: true,
   },
 

--- a/src/applications/appeals/testing/config/form.js
+++ b/src/applications/appeals/testing/config/form.js
@@ -59,6 +59,11 @@ const formConfig = {
   },
   title: 'Request a Board Appeal',
   subTitle: 'VA Form 10182 (Notice of Disagreement)',
+  formOptions: {
+    noTitle: true,
+    noNav: true,
+    fullWidth: true,
+  },
 
   defaultDefinitions: {},
   // when true, initial focus on page to H3s by default, and enable page

--- a/src/applications/appeals/testing/containers/App.jsx
+++ b/src/applications/appeals/testing/containers/App.jsx
@@ -7,18 +7,22 @@ import formConfig from '../config/form';
 export default function App(props) {
   const { location, children } = props;
 
-  const isIntroPage = true; // WIP! location.pathname === '/introduction';
+  const isIntroPage = location.pathname === '/introduction';
 
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
       {isIntroPage ? (
-        children
+        <div className="row">
+          <div className="usa-width-two-thirds medium-8 columns">
+            {children}
+          </div>
+        </div>
       ) : (
         <>
-          {/* <div className="vads-u-background-color--primary-alt-lightest">
+          <div className="vads-u-background-color--primary-alt-lightest vads-u-padding--4">
             {formConfig.title} (VA Form 10182)
           </div>
-          <div className="vads-u-background-color--primary-alt-lightest vads-u-display--flex">
+          {/* <div className="vads-u-background-color--primary-alt-lightest vads-u-display--flex">
             <div>
               <a href="#">Back</a>
               <span role="presentation">|</span>
@@ -27,7 +31,11 @@ export default function App(props) {
               <a href="#">Exit form</a>
             </div>
           </div> */}
-          {children}
+          <div className="row">
+            <div className="usa-width-two-thirds medium-8 columns">
+              {children}
+            </div>
+          </div>
         </>
       )}
     </RoutedSavableApp>

--- a/src/applications/appeals/testing/sass/appeals-testing.scss
+++ b/src/applications/appeals/testing/sass/appeals-testing.scss
@@ -5,3 +5,8 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "../../../../platform/forms/sass/m-form-confirmation";
+
+#main .progress-box {
+  margin: 0;
+  padding: 0;
+}

--- a/src/platform/forms-system/src/js/containers/FormApp.jsx
+++ b/src/platform/forms-system/src/js/containers/FormApp.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 
 import { isLoggedIn } from 'platform/user/selectors';
 
@@ -41,7 +42,8 @@ class FormApp extends React.Component {
       typeof formConfig.title === 'function'
         ? formConfig.title(this.props)
         : formConfig.title;
-    const { noTitle, noNav, fullWidth } = formConfig?.formOptions || {};
+    const { noTitle, noTopNav, fullWidth } = formConfig?.formOptions || {};
+    const notProd = !environment.isProduction();
 
     let formTitle;
     let formNav;
@@ -79,17 +81,16 @@ class FormApp extends React.Component {
         <Footer formConfig={formConfig} currentLocation={currentLocation} />
       );
     }
-    const wrapperClass = fullWidth
-      ? ''
-      : 'usa-width-two-thirds medium-8 columns';
+    const wrapperClass =
+      notProd && fullWidth ? '' : 'usa-width-two-thirds medium-8 columns';
 
     return (
       <div>
-        <div className={fullWidth ? '' : 'row'}>
+        <div className={notProd && fullWidth ? '' : 'row'}>
           <div className={wrapperClass}>
             <Element name="topScrollElement" />
-            {noTitle ? null : formTitle}
-            {noNav ? null : formNav}
+            {notProd && noTitle ? null : formTitle}
+            {notProd && noTopNav ? null : formNav}
             <Element name="topContentElement" />
             {renderedChildren}
           </div>

--- a/src/platform/forms-system/src/js/containers/FormApp.jsx
+++ b/src/platform/forms-system/src/js/containers/FormApp.jsx
@@ -41,6 +41,7 @@ class FormApp extends React.Component {
       typeof formConfig.title === 'function'
         ? formConfig.title(this.props)
         : formConfig.title;
+    const { noTitle, noNav, fullWidth } = formConfig?.formOptions || {};
 
     let formTitle;
     let formNav;
@@ -78,14 +79,17 @@ class FormApp extends React.Component {
         <Footer formConfig={formConfig} currentLocation={currentLocation} />
       );
     }
+    const wrapperClass = fullWidth
+      ? ''
+      : 'usa-width-two-thirds medium-8 columns';
 
     return (
       <div>
-        <div className="row">
-          <div className="usa-width-two-thirds medium-8 columns">
+        <div className={fullWidth ? '' : 'row'}>
+          <div className={wrapperClass}>
             <Element name="topScrollElement" />
-            {formTitle}
-            {formNav}
+            {noTitle ? null : formTitle}
+            {noNav ? null : formNav}
             <Element name="topContentElement" />
             {renderedChildren}
           </div>

--- a/src/platform/forms-system/src/js/containers/FormPage.jsx
+++ b/src/platform/forms-system/src/js/containers/FormPage.jsx
@@ -173,6 +173,8 @@ class FormPage extends React.Component {
 
     const showNavLinks =
       environment.isLocalhost() && route.formConfig?.dev?.showNavLinks;
+    const hideNavButtons =
+      !environment.isProduction() && route.formConfig?.formOptions?.noBottomNav;
 
     // Bypass the SchemaForm and render the custom component
     // NOTE: I don't think FormPage is rendered on the review page, so I believe
@@ -221,13 +223,19 @@ class FormPage extends React.Component {
           onChange={this.onChange}
           onSubmit={this.onSubmit}
         >
-          {contentBeforeButtons}
-          <FormNavButtons
-            goBack={!isFirstRoutePage && this.goBack}
-            goForward={callOnContinue}
-            submitToContinue
-          />
-          {contentAfterButtons}
+          {hideNavButtons ? (
+            <div />
+          ) : (
+            <>
+              {contentBeforeButtons}
+              <FormNavButtons
+                goBack={!isFirstRoutePage && this.goBack}
+                goForward={callOnContinue}
+                submitToContinue
+              />
+              {contentAfterButtons}
+            </>
+          )}
         </SchemaForm>
       </div>
     );
@@ -288,6 +296,9 @@ FormPage.propTypes = {
     formConfig: PropTypes.shape({
       dev: PropTypes.shape({
         showNavLinks: PropTypes.bool,
+      }),
+      formOptions: PropTypes.shape({
+        noBottomNav: PropTypes.bool,
       }),
     }),
     pageList: PropTypes.arrayOf(

--- a/src/platform/forms-system/test/js/containers/FormApp.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/containers/FormApp.unit.spec.jsx
@@ -88,4 +88,33 @@ describe('Schemaform <FormApp>', () => {
     tree.reRender({ formData, currentLocation, formConfig });
     expect(tree.everySubTree('FormTitle')[0].props.title).to.equal(titles[1]);
   });
+
+  it('should hide title, nav and layout classes when formOptions are set', () => {
+    const formConfig = {
+      formOptions: { noTitle: true, noTopNav: true, fullWidth: true },
+    };
+    const currentLocation = {
+      pathname: '/veteran-information/personal-information',
+      search: '',
+    };
+    const routes = [
+      {
+        pageList: [{ path: currentLocation.pathname }],
+      },
+    ];
+
+    const tree = SkinDeep.shallowRender(
+      <FormApp
+        formConfig={formConfig}
+        routes={routes}
+        currentLocation={currentLocation}
+      >
+        <div className="child" />
+      </FormApp>,
+    );
+    expect(tree.everySubTree('.child')).not.to.be.empty;
+    expect(tree.everySubTree('FormTitle')).to.be.empty;
+    expect(tree.everySubTree('.row')).to.be.empty;
+    expect(tree.everySubTree('.usa-width-two-thirds')).to.be.empty;
+  });
 });

--- a/src/platform/forms-system/test/js/containers/FormPage.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/containers/FormPage.unit.spec.jsx
@@ -91,6 +91,19 @@ describe('Schemaform <FormPage>', () => {
     expect(tree.everySubTree('SchemaForm')).not.to.be.empty;
     expect(tree.everySubTree('FormNavButtons')).not.to.be.empty;
   });
+
+  it('should hide nav buttons when formOptions set', () => {
+    const route = makeRoute({
+      formConfig: { formOptions: { noBottomNav: true } },
+    });
+    const tree = SkinDeep.shallowRender(
+      <FormPage form={makeForm()} route={route} location={location} />,
+    );
+
+    expect(tree.everySubTree('SchemaForm')).not.to.be.empty;
+    expect(tree.everySubTree('FormNavButtons')).to.be.empty;
+  });
+
   describe('should handle', () => {
     let tree;
     let setData;

--- a/src/platform/forms/tests/forms.unit.spec.js
+++ b/src/platform/forms/tests/forms.unit.spec.js
@@ -80,6 +80,7 @@ const formConfigKeys = [
   'reviewErrors',
   'useCustomScrollAndFocus',
   'v3SegmentedProgressBar',
+  'formOptions',
 ];
 
 const validProperty = (


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > We're building a prototype where the form will need to render a full screen width background. To accomplish this, this PR adds `formOptions` to the `formConfig`:
  > - `noTitle` - prevents rendering the the form title (`H1`)
  > - `noTopNav` - prevents rendering the Step header (`H2`) and progress bar
  > - `noBottomNav` - prevents rendering of the back and continue buttons under the form
  > - `fullWidth` - removes the class names that add margins & padding around the rendered children
  > We only plan for these to be temporary settings. Once the research we're conducting has been completed, we will remove these settings, and implement the necessary changes within the form system if the research is validated
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > `FormApp` renders the form title, progress bar & adds layout classes to limit the column width
  > `FormPage` renders the back & continue buttons
  > Since we're implementing a custom top bar, top navigation & bottom navigation we needed these options to not render these elements
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision review
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#64388](https://github.com/department-of-veterans-affairs/va.gov-team/issues/64388)

## Testing done

- _Describe what the old behavior was prior to the change_
  > See screenshots - impossible to render an element at full width
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         |  |
| ------- | ----- |
| Design | <img width="886" alt="design" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/7e1d1ade-9547-4622-bdb4-f87178ff54eb"> |
| Before (not full width) | <img width="1138" alt="Screenshot 2023-08-29 at 3 58 37 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/2db26f93-2d24-424f-85a7-ad148ef2dd21"> |
| After (full width light blue background) | <img width="1132" alt="Screenshot 2023-08-29 at 3 58 17 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/4b673603-5e96-49b8-9adb-be736d6845fb"> |

## What areas of the site does it impact?

[Appeals testing app](https://staging.va.gov/decision-reviews/appeals-testing/)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
