### PR TITLE
fix credit card purpose

### DIFF
--- a/src/applications/financial-status-report/components/householdExpenses/CreditCardBill.jsx
+++ b/src/applications/financial-status-report/components/householdExpenses/CreditCardBill.jsx
@@ -84,8 +84,19 @@ const CreditCardBill = props => {
   const updateFormData = e => {
     setSubmitted(true);
     e.preventDefault();
+
+    // Create a copy of the current creditCardBills array
     const newCreditCardBillArray = [...creditCardBills];
-    newCreditCardBillArray[index] = creditCardBillRecord;
+    // If it's a new record, set the purpose to 'Credit card payment' explicitly
+    if (creditCardBills.length === index) {
+      newCreditCardBillArray.push({
+        ...defaultRecord[0], // You can include other default values as needed
+        ...creditCardBillRecord,
+      });
+    } else {
+      // Update an existing record
+      newCreditCardBillArray[index] = creditCardBillRecord;
+    }
 
     if (
       creditCardBillRecord.amountDueMonthly &&
@@ -99,7 +110,7 @@ const CreditCardBill = props => {
         }));
       }
 
-      // update form data
+      // Update form data
       setFormData({
         ...data,
         expenses: {


### PR DESCRIPTION

## Summary

- this PR resolves the missing purpose field from the generated pdf
---
### Tasks
- [x] Update credit card object so it includes a purpose or name label that is filled in on the PDF. 

### Acceptance Criteria
- [x] All installment contracts and credit card bills have a purpose or name field populated. 


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#64174

## Testing done

-  Submitted form to test changes, also generated PDF and verified changes are in place
- To replicate this bug, on stage submit a few credit card bills and notice when you genrate the PDF only one purpose field populates


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |   ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/00f0519c-0262-4cd2-ac05-d3e5c35b4248) | <img width="924" alt="Screenshot 2023-08-29 at 1 22 45 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/6dc4ced1-3071-42e7-8c2b-d3df6fc26bf4"> |


## What areas of the site does it impact?

Financial Status Report

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed


### Error Handling

- [x] Browser console contains no warnings or errors.



