### PR TITLE
MHV-45002: Refill history UI updates

### DIFF
--- a/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
@@ -300,7 +300,7 @@ const PrescriptionDetails = () => {
                   <h3 className="vads-u-font-size--lg vads-u-font-family--sans">
                     {i + 1 === refillHistory.length
                       ? 'Original Fill'
-                      : `Refill #${i + 1}`}
+                      : `Refill #${refillHistory.length - i - 1}`}
                   </h3>
                   <h4 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin--0">
                     Filled by pharmacy on

--- a/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
@@ -298,14 +298,10 @@ const PrescriptionDetails = () => {
               refillHistory.map((entry, i) => (
                 <div key={entry.id}>
                   <h3 className="vads-u-font-size--lg vads-u-font-family--sans">
-                    {dateFormat(entry.dispensedDate, 'MMMM D, YYYY')}
+                    {i + 1 === refillHistory.length
+                      ? 'Original Fill'
+                      : `Refill #${i + 1}`}
                   </h3>
-                  <h4 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin--0">
-                    Refill requested on
-                  </h4>
-                  <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
-                    {dateFormat(entry.refillSubmitDate, 'MMMM D, YYYY')}
-                  </p>
                   <h4 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin--0">
                     Filled by pharmacy on
                   </h4>
@@ -326,7 +322,7 @@ const PrescriptionDetails = () => {
                   </h4>
                   <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
                     {/* TODO: Not yet available */}
-                    Not noted
+                    None noted
                   </p>
                   <div className="no-print">
                     <va-additional-info trigger="Review image">


### PR DESCRIPTION
## Summary

Minor Refill History UI updates:
* Removed 'Refill requested on' field
* Titles updated from using `dispensedDate ` to 'Original Fill" for the oldest refill and 'Refill N' to all consecutive ones

## Related issue(s)

[Jira ticket](https://jira.devops.va.gov/browse/MHV-45002)

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="383" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/a58473ea-630d-4d59-a37a-5ed3836e89fc"> |  <img width="377" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/3ce23254-91b3-4e07-bc7f-59b7a05e40e0"> |
| Desktop | <img width="1721" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/96346661-ce2c-4835-abfd-54b8ac8b59dc"> | <img width="1718" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/9e3fcc47-44b6-4f9c-890b-f460d9558e9f"> |

## What areas of the site does it impact?

my-health/Medications 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
