### PR TITLE
Adding env check to update region in speech token calls

### DIFF
--- a/src/applications/virtual-agent/components/webchat/WebChat.jsx
+++ b/src/applications/virtual-agent/components/webchat/WebChat.jsx
@@ -121,6 +121,12 @@ const WebChat = ({ token, WebChatFramework, apiSession }) => {
   };
 
   async function createPonyFill(webchat) {
+    const region =
+      environment.BASE_URL ===
+      (environment.isDev() || environment.isLocalhost())
+        ? 'eastus'
+        : 'eastus2';
+
     async function callVirtualAgentVoiceTokenApi() {
       return apiRequest('/virtual_agent_speech_token', {
         method: 'POST',
@@ -129,7 +135,7 @@ const WebChat = ({ token, WebChatFramework, apiSession }) => {
     const speechToken = await callVirtualAgentVoiceTokenApi();
     return webchat.createCognitiveServicesSpeechServicesPonyfillFactory({
       credentials: {
-        region: 'eastus',
+        region,
         authorizationToken: speechToken.token,
       },
     });


### PR DESCRIPTION
## Summary

- Fixed bug is reproducible by attempting to access to Rx skilll on staging: the mic doesn't show, because the call to get the cognitive services speech functionality is failing. 
- Made the 'region' var in the speech token call conditional based on environment (dev, prod or staging).
- Chatbot/Virtual Agent