### PR TITLE
Allow requests to /my-health/* to pass-through

### DIFF
--- a/src/applications/mhv/landing-page/routes.jsx
+++ b/src/applications/mhv/landing-page/routes.jsx
@@ -8,7 +8,7 @@ const routes = (
     <Route exact path="/about-medications" key="medicationLandingPage">
       <LandingPage />
     </Route>
-    <Route path="/" key="mhvLandingPage">
+    <Route exact path="/" key="mhvLandingPage">
       <App />
     </Route>
   </Switch>


### PR DESCRIPTION
Allow requests to `/my-health/*` to pass-through. Addresses problem raised about the staging environment and being unable to navigate to `/my-health/appointments`

Slack thread: https://dsva.slack.com/archives/C04DRS3L9NV/p1693422415575829

To verify:

- Sign in, visit `/my-health/appointments`, page is shown