### PR TITLE
Remove the session clear to test testIsolation in version 12

### DIFF
--- a/src/applications/check-in/day-of/tests/e2e/appointment-details-display/appointment-details.complete.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointment-details-display/appointment-details.complete.cypress.spec.js
@@ -11,6 +11,7 @@ import Confirmation from '../pages/Confirmation';
 import AppointmentDetails from '../../../../tests/e2e/pages/AppointmentDetails';
 
 // TODO: remove commment once this is not disallowed
+
 describe('Check In Experience', () => {
   describe('Appointment details day-of', () => {
     beforeEach(() => {

--- a/src/applications/check-in/day-of/tests/e2e/appointment-details-display/appointment-details.complete.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointment-details-display/appointment-details.complete.cypress.spec.js
@@ -10,6 +10,7 @@ import Appointments from '../pages/Appointments';
 import Confirmation from '../pages/Confirmation';
 import AppointmentDetails from '../../../../tests/e2e/pages/AppointmentDetails';
 
+// TODO: remove commment once this is not disallowed
 describe('Check In Experience', () => {
   describe('Appointment details day-of', () => {
     beforeEach(() => {

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/veterans.may.refresh.their.appointments.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/veterans.may.refresh.their.appointments.cypress.spec.js
@@ -10,6 +10,7 @@ import Appointments from '../pages/Appointments';
 import sharedData from '../../../../api/local-mock-api/mocks/v2/shared';
 
 // TODO: remove commment once this is not disallowed
+
 describe('Check In Experience -- ', () => {
   describe('Appointment display -- ', () => {
     beforeEach(() => {

--- a/src/applications/check-in/day-of/tests/e2e/appointments-display/veterans.may.refresh.their.appointments.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointments-display/veterans.may.refresh.their.appointments.cypress.spec.js
@@ -9,6 +9,7 @@ import Appointments from '../pages/Appointments';
 
 import sharedData from '../../../../api/local-mock-api/mocks/v2/shared';
 
+// TODO: remove commment once this is not disallowed
 describe('Check In Experience -- ', () => {
   describe('Appointment display -- ', () => {
     beforeEach(() => {

--- a/src/applications/check-in/pre-check-in/tests/e2e/app-reload/reload.page.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/app-reload/reload.page.cypress.spec.js
@@ -9,6 +9,7 @@ import Introduction from '../pages/Introduction';
 import Confirmation from '../pages/Confirmation';
 
 // TODO: remove commment once this is not disallowed
+
 describe('Pre-Check In Experience', () => {
   describe('reload pages', () => {
     beforeEach(() => {

--- a/src/applications/check-in/pre-check-in/tests/e2e/app-reload/reload.page.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/app-reload/reload.page.cypress.spec.js
@@ -8,6 +8,7 @@ import EmergencyContact from '../../../../tests/e2e/pages/EmergencyContact';
 import Introduction from '../pages/Introduction';
 import Confirmation from '../pages/Confirmation';
 
+// TODO: remove commment once this is not disallowed
 describe('Pre-Check In Experience', () => {
   describe('reload pages', () => {
     beforeEach(() => {

--- a/src/applications/check-in/pre-check-in/tests/e2e/demographics-display/information.display.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/demographics-display/information.display.cypress.spec.js
@@ -5,6 +5,7 @@ import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
 import Demographics from '../../../../tests/e2e/pages/Demographics';
 
+// TODO: remove commment once this is not disallowed
 describe('Pre-Check In Experience', () => {
   describe('Demographics Page', () => {
     beforeEach(() => {

--- a/src/applications/check-in/pre-check-in/tests/e2e/demographics-display/information.display.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/demographics-display/information.display.cypress.spec.js
@@ -6,6 +6,7 @@ import Introduction from '../pages/Introduction';
 import Demographics from '../../../../tests/e2e/pages/Demographics';
 
 // TODO: remove commment once this is not disallowed
+
 describe('Pre-Check In Experience', () => {
   describe('Demographics Page', () => {
     beforeEach(() => {

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/fields.are.required.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/fields.are.required.cypress.spec.js
@@ -4,6 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
 
+// TODO: remove commment once this is not disallowed
 describe('Pre-Check In Experience', () => {
   describe('Validation Page', () => {
     beforeEach(() => {

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/fields.are.required.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/fields.are.required.cypress.spec.js
@@ -5,6 +5,7 @@ import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
 
 // TODO: remove commment once this is not disallowed
+
 describe('Pre-Check In Experience', () => {
   describe('Validation Page', () => {
     beforeEach(() => {

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.cypress.spec.js
@@ -4,6 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
 
+// TODO: remove commment once this is not disallowed
 describe('Pre-Check In Experience', () => {
   describe('Validate Page', () => {
     beforeEach(() => {

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.cypress.spec.js
@@ -5,6 +5,7 @@ import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
 
 // TODO: remove commment once this is not disallowed
+
 describe('Pre-Check In Experience', () => {
   describe('Validate Page', () => {
     beforeEach(() => {

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.dob.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.dob.cypress.spec.js
@@ -5,54 +5,56 @@ import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
 
 // TODO: remove commment once this is not disallowed
-describe('Pre-Check In Experience', () => {
-  describe('Validate Page', () => {
-    beforeEach(() => {
-      const {
-        initializeFeatureToggle,
-        initializeSessionGet,
-        initializeSessionPost,
-        initializePreCheckInDataGet,
-        initializePreCheckInDataPost,
-      } = ApiInitializer;
+for (let i = 0; i < 20; i++) {
+  describe('Pre-Check In Experience', () => {
+    describe('Validate Page', () => {
+      beforeEach(() => {
+        const {
+          initializeFeatureToggle,
+          initializeSessionGet,
+          initializeSessionPost,
+          initializePreCheckInDataGet,
+          initializePreCheckInDataPost,
+        } = ApiInitializer;
 
-      initializeFeatureToggle.withCurrentFeatures();
-      initializeSessionGet.withSuccessfulNewSession();
-      initializePreCheckInDataGet.withSuccess();
+        initializeFeatureToggle.withCurrentFeatures();
+        initializeSessionGet.withSuccessfulNewSession();
+        initializePreCheckInDataGet.withSuccess();
 
-      initializeSessionPost.withValidation();
-      initializePreCheckInDataPost.withSuccess();
+        initializeSessionPost.withValidation();
+        initializePreCheckInDataPost.withSuccess();
 
-      cy.visitPreCheckInWithUUID();
-    });
-    afterEach(() => {
-      cy.window().then(window => {
-        window.sessionStorage.clear();
+        cy.visitPreCheckInWithUUID();
+      });
+      afterEach(() => {
+        cy.window().then(window => {
+          window.sessionStorage.clear();
+        });
+      });
+      it('validation failed with failed response from server', () => {
+        cy.injectAxeThenAxeCheck();
+        // First Attempt
+        ValidateVeteran.validateVeteranDobWithFailure();
+        ValidateVeteran.attemptToGoToNextPage();
+        ValidateVeteran.validateErrorAlert();
+
+        // Second Attempt
+        ValidateVeteran.validateVeteranDobWithFailure();
+        ValidateVeteran.attemptToGoToNextPage();
+        ValidateVeteran.validateErrorAlert();
+      });
+      it('fails validation once and then succeeds on the second attempt', () => {
+        cy.injectAxeThenAxeCheck();
+        // First Attempt
+        ValidateVeteran.validateVeteranDobWithFailure();
+        ValidateVeteran.attemptToGoToNextPage();
+        ValidateVeteran.validateErrorAlert();
+
+        // Second Attempt
+        ValidateVeteran.validateVeteran();
+        ValidateVeteran.attemptToGoToNextPage();
+        Introduction.validatePageLoaded();
       });
     });
-    it('validation failed with failed response from server', () => {
-      cy.injectAxeThenAxeCheck();
-      // First Attempt
-      ValidateVeteran.validateVeteranDobWithFailure();
-      ValidateVeteran.attemptToGoToNextPage();
-      ValidateVeteran.validateErrorAlert();
-
-      // Second Attempt
-      ValidateVeteran.validateVeteranDobWithFailure();
-      ValidateVeteran.attemptToGoToNextPage();
-      ValidateVeteran.validateErrorAlert();
-    });
-    it('fails validation once and then succeeds on the second attempt', () => {
-      cy.injectAxeThenAxeCheck();
-      // First Attempt
-      ValidateVeteran.validateVeteranDobWithFailure();
-      ValidateVeteran.attemptToGoToNextPage();
-      ValidateVeteran.validateErrorAlert();
-
-      // Second Attempt
-      ValidateVeteran.validateVeteran();
-      ValidateVeteran.attemptToGoToNextPage();
-      Introduction.validatePageLoaded();
-    });
   });
-});
+}

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.dob.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.dob.cypress.spec.js
@@ -4,6 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
 
+// TODO: remove commment once this is not disallowed
 describe('Pre-Check In Experience', () => {
   describe('Validate Page', () => {
     beforeEach(() => {

--- a/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.dob.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.dob.cypress.spec.js
@@ -5,56 +5,55 @@ import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
 
 // TODO: remove commment once this is not disallowed
-for (let i = 0; i < 20; i++) {
-  describe('Pre-Check In Experience', () => {
-    describe('Validate Page', () => {
-      beforeEach(() => {
-        const {
-          initializeFeatureToggle,
-          initializeSessionGet,
-          initializeSessionPost,
-          initializePreCheckInDataGet,
-          initializePreCheckInDataPost,
-        } = ApiInitializer;
 
-        initializeFeatureToggle.withCurrentFeatures();
-        initializeSessionGet.withSuccessfulNewSession();
-        initializePreCheckInDataGet.withSuccess();
+describe('Pre-Check In Experience', () => {
+  describe('Validate Page', () => {
+    beforeEach(() => {
+      const {
+        initializeFeatureToggle,
+        initializeSessionGet,
+        initializeSessionPost,
+        initializePreCheckInDataGet,
+        initializePreCheckInDataPost,
+      } = ApiInitializer;
 
-        initializeSessionPost.withValidation();
-        initializePreCheckInDataPost.withSuccess();
+      initializeFeatureToggle.withCurrentFeatures();
+      initializeSessionGet.withSuccessfulNewSession();
+      initializePreCheckInDataGet.withSuccess();
 
-        cy.visitPreCheckInWithUUID();
-      });
-      afterEach(() => {
-        cy.window().then(window => {
-          window.sessionStorage.clear();
-        });
-      });
-      it('validation failed with failed response from server', () => {
-        cy.injectAxeThenAxeCheck();
-        // First Attempt
-        ValidateVeteran.validateVeteranDobWithFailure();
-        ValidateVeteran.attemptToGoToNextPage();
-        ValidateVeteran.validateErrorAlert();
+      initializeSessionPost.withValidation();
+      initializePreCheckInDataPost.withSuccess();
 
-        // Second Attempt
-        ValidateVeteran.validateVeteranDobWithFailure();
-        ValidateVeteran.attemptToGoToNextPage();
-        ValidateVeteran.validateErrorAlert();
-      });
-      it('fails validation once and then succeeds on the second attempt', () => {
-        cy.injectAxeThenAxeCheck();
-        // First Attempt
-        ValidateVeteran.validateVeteranDobWithFailure();
-        ValidateVeteran.attemptToGoToNextPage();
-        ValidateVeteran.validateErrorAlert();
-
-        // Second Attempt
-        ValidateVeteran.validateVeteran();
-        ValidateVeteran.attemptToGoToNextPage();
-        Introduction.validatePageLoaded();
+      cy.visitPreCheckInWithUUID();
+    });
+    afterEach(() => {
+      cy.window().then(window => {
+        window.sessionStorage.clear();
       });
     });
+    it('validation failed with failed response from server', () => {
+      cy.injectAxeThenAxeCheck();
+      // First Attempt
+      ValidateVeteran.validateVeteranDobWithFailure();
+      ValidateVeteran.attemptToGoToNextPage();
+      ValidateVeteran.validateErrorAlert();
+
+      // Second Attempt
+      ValidateVeteran.validateVeteranDobWithFailure();
+      ValidateVeteran.attemptToGoToNextPage();
+      ValidateVeteran.validateErrorAlert();
+    });
+    it('fails validation once and then succeeds on the second attempt', () => {
+      cy.injectAxeThenAxeCheck();
+      // First Attempt
+      ValidateVeteran.validateVeteranDobWithFailure();
+      ValidateVeteran.attemptToGoToNextPage();
+      ValidateVeteran.validateErrorAlert();
+
+      // Second Attempt
+      ValidateVeteran.validateVeteran();
+      ValidateVeteran.attemptToGoToNextPage();
+      Introduction.validatePageLoaded();
+    });
   });
-}
+});

--- a/src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy-path.already.completed.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy-path.already.completed.cypress.spec.js
@@ -4,6 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Confirmation from '../pages/Confirmation';
 
+// TODO: remove commment once this is not disallowed
 describe('Pre-Check In Experience ', () => {
   beforeEach(() => {
     const {

--- a/src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy-path.already.completed.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy-path.already.completed.cypress.spec.js
@@ -17,11 +17,6 @@ describe('Pre-Check In Experience ', () => {
     initializeSessionPost.withSuccess();
     initializePreCheckInDataGet.withAlreadyCompleted();
   });
-  afterEach(() => {
-    cy.window().then(window => {
-      window.sessionStorage.clear();
-    });
-  });
   it('Pre-checkin skipped when already completed', () => {
     cy.visitPreCheckInWithUUID();
 

--- a/src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy-path.already.completed.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy-path.already.completed.cypress.spec.js
@@ -17,6 +17,11 @@ describe('Pre-Check In Experience ', () => {
     initializeSessionPost.withSuccess();
     initializePreCheckInDataGet.withAlreadyCompleted();
   });
+  afterEach(() => {
+    cy.window().then(window => {
+      window.sessionStorage.clear();
+    });
+  });
   it('Pre-checkin skipped when already completed', () => {
     cy.visitPreCheckInWithUUID();
 

--- a/src/applications/check-in/pre-check-in/tests/e2e/intro-display/accordion.toggle.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/intro-display/accordion.toggle.cypress.spec.js
@@ -3,7 +3,7 @@ import '../../../../tests/e2e/commands';
 import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
-
+// TODO: remove commment once this is not disallowed
 describe('Pre-Check In Experience', () => {
   describe('Introduction Page', () => {
     beforeEach(() => {

--- a/src/applications/check-in/pre-check-in/tests/e2e/intro-display/accordion.toggle.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/intro-display/accordion.toggle.cypress.spec.js
@@ -3,6 +3,7 @@ import '../../../../tests/e2e/commands';
 import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
+
 // TODO: remove commment once this is not disallowed
 describe('Pre-Check In Experience', () => {
   describe('Introduction Page', () => {

--- a/src/applications/check-in/pre-check-in/tests/e2e/loading-session/returning.session.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/loading-session/returning.session.cypress.spec.js
@@ -3,6 +3,7 @@ import '../../../../tests/e2e/commands';
 import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import Introduction from '../pages/Introduction';
 
+// TODO: remove commment once this is not disallowed
 describe('Pre-Check In Experience ', () => {
   beforeEach(() => {
     const {

--- a/src/applications/check-in/pre-check-in/tests/e2e/loading-session/returning.session.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/loading-session/returning.session.cypress.spec.js
@@ -4,6 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import Introduction from '../pages/Introduction';
 
 // TODO: remove commment once this is not disallowed
+
 describe('Pre-Check In Experience ', () => {
   beforeEach(() => {
     const {

--- a/src/applications/check-in/pre-check-in/tests/e2e/pages/Introduction.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/pages/Introduction.js
@@ -79,7 +79,7 @@ class Introduction {
       .shadow()
       .find('h2 button[aria-controls="content"]')
       .eq(accordionIndex)
-      .click();
+      .click({ waitForAnimations: true });
     if (open) {
       cy.get('[data-testid="intro-accordion-item"]')
         .shadow()

--- a/src/applications/check-in/pre-check-in/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
@@ -4,50 +4,48 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
 
-for (let i = 0; i < 20; i += 1) {
-  describe('Pre Check In Experience', () => {
-    describe('session', () => {
-      beforeEach(() => {
-        const {
-          initializeFeatureToggle,
-          initializeSessionGet,
-          initializeSessionPost,
-          initializePreCheckInDataGet,
-        } = ApiInitializer;
-        initializeFeatureToggle.withCurrentFeatures();
-        initializeSessionGet.withSuccessfulNewSession();
+describe('Pre Check In Experience', () => {
+  describe('session', () => {
+    beforeEach(() => {
+      const {
+        initializeFeatureToggle,
+        initializeSessionGet,
+        initializeSessionPost,
+        initializePreCheckInDataGet,
+      } = ApiInitializer;
+      initializeFeatureToggle.withCurrentFeatures();
+      initializeSessionGet.withSuccessfulNewSession();
 
-        initializeSessionPost.withSuccess();
-        initializePreCheckInDataGet.withSuccess();
+      initializeSessionPost.withSuccess();
+      initializePreCheckInDataGet.withSuccess();
+    });
+    afterEach(() => {
+      cy.window().then(window => {
+        window.sessionStorage.clear();
       });
-      afterEach(() => {
-        cy.window().then(window => {
-          window.sessionStorage.clear();
+    });
+    it('On page reload, the data should be pull from session storage and redirected to landing screen with data loaded', () => {
+      cy.visitPreCheckInWithUUID();
+      ValidateVeteran.validatePage.preCheckIn();
+      ValidateVeteran.validateVeteran();
+      ValidateVeteran.attemptToGoToNextPage();
+      Introduction.validatePageLoaded();
+
+      cy.window().then(window => {
+        const data = window.sessionStorage.getItem(
+          'health.care.pre.check.in.current.uuid',
+        );
+        const sample = JSON.stringify({
+          token: '46bebc0a-b99c-464f-a5c5-560bc9eae287',
         });
-      });
-      it('On page reload, the data should be pull from session storage and redirected to landing screen with data loaded', () => {
-        cy.visitPreCheckInWithUUID();
+        expect(data).to.equal(sample);
+        cy.reload();
+        // redirected back to landing page to reload the data
+        cy.url().should('include', 'id=46bebc0a-b99c-464f-a5c5-560bc9eae287');
+
         ValidateVeteran.validatePage.preCheckIn();
-        ValidateVeteran.validateVeteran();
-        ValidateVeteran.attemptToGoToNextPage();
-        Introduction.validatePageLoaded();
-
-        cy.window().then(window => {
-          const data = window.sessionStorage.getItem(
-            'health.care.pre.check.in.current.uuid',
-          );
-          const sample = JSON.stringify({
-            token: '46bebc0a-b99c-464f-a5c5-560bc9eae287',
-          });
-          expect(data).to.equal(sample);
-          cy.reload();
-          // redirected back to landing page to reload the data
-          cy.url().should('include', 'id=46bebc0a-b99c-464f-a5c5-560bc9eae287');
-
-          ValidateVeteran.validatePage.preCheckIn();
-          cy.injectAxeThenAxeCheck();
-        });
+        cy.injectAxeThenAxeCheck();
       });
     });
   });
-}
+});

--- a/src/applications/check-in/pre-check-in/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
@@ -4,48 +4,50 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
 
-describe('Pre Check In Experience', () => {
-  describe('session', () => {
-    beforeEach(() => {
-      const {
-        initializeFeatureToggle,
-        initializeSessionGet,
-        initializeSessionPost,
-        initializePreCheckInDataGet,
-      } = ApiInitializer;
-      initializeFeatureToggle.withCurrentFeatures();
-      initializeSessionGet.withSuccessfulNewSession();
+for (let i = 0; i < 20; i += 1) {
+  describe('Pre Check In Experience', () => {
+    describe('session', () => {
+      beforeEach(() => {
+        const {
+          initializeFeatureToggle,
+          initializeSessionGet,
+          initializeSessionPost,
+          initializePreCheckInDataGet,
+        } = ApiInitializer;
+        initializeFeatureToggle.withCurrentFeatures();
+        initializeSessionGet.withSuccessfulNewSession();
 
-      initializeSessionPost.withSuccess();
-      initializePreCheckInDataGet.withSuccess();
-    });
-    afterEach(() => {
-      cy.window().then(window => {
-        window.sessionStorage.clear();
+        initializeSessionPost.withSuccess();
+        initializePreCheckInDataGet.withSuccess();
       });
-    });
-    it('On page reload, the data should be pull from session storage and redirected to landing screen with data loaded', () => {
-      cy.visitPreCheckInWithUUID();
-      ValidateVeteran.validatePage.preCheckIn();
-      ValidateVeteran.validateVeteran();
-      ValidateVeteran.attemptToGoToNextPage();
-      Introduction.validatePageLoaded();
-
-      cy.window().then(window => {
-        const data = window.sessionStorage.getItem(
-          'health.care.pre.check.in.current.uuid',
-        );
-        const sample = JSON.stringify({
-          token: '46bebc0a-b99c-464f-a5c5-560bc9eae287',
+      afterEach(() => {
+        cy.window().then(window => {
+          window.sessionStorage.clear();
         });
-        expect(data).to.equal(sample);
-        cy.reload();
-        // redirected back to landing page to reload the data
-        cy.url().should('match', /id=46bebc0a-b99c-464f-a5c5-560bc9eae287/);
-
+      });
+      it('On page reload, the data should be pull from session storage and redirected to landing screen with data loaded', () => {
+        cy.visitPreCheckInWithUUID();
         ValidateVeteran.validatePage.preCheckIn();
-        cy.injectAxeThenAxeCheck();
+        ValidateVeteran.validateVeteran();
+        ValidateVeteran.attemptToGoToNextPage();
+        Introduction.validatePageLoaded();
+
+        cy.window().then(window => {
+          const data = window.sessionStorage.getItem(
+            'health.care.pre.check.in.current.uuid',
+          );
+          const sample = JSON.stringify({
+            token: '46bebc0a-b99c-464f-a5c5-560bc9eae287',
+          });
+          expect(data).to.equal(sample);
+          cy.reload();
+          // redirected back to landing page to reload the data
+          cy.url().should('include', 'id=46bebc0a-b99c-464f-a5c5-560bc9eae287');
+
+          ValidateVeteran.validatePage.preCheckIn();
+          cy.injectAxeThenAxeCheck();
+        });
       });
     });
   });
-});
+}

--- a/src/applications/check-in/pre-check-in/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
@@ -4,6 +4,7 @@ import ApiInitializer from '../../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../../tests/e2e/pages/ValidateVeteran';
 import Introduction from '../pages/Introduction';
 
+// TODO: remove commment once this is not disallowed
 describe('Pre Check In Experience', () => {
   describe('session', () => {
     beforeEach(() => {


### PR DESCRIPTION
## Summary

- Attempt to get disallowed tests removed from the list

### Disallowed tests
- src/applications/check-in/pre-check-in/tests/e2e/happy-path/happy-path.already.completed.cypress.spec.js
- src/applications/check-in/pre-check-in/tests/e2e/session/session.reloads.on.refresh.cypress.spec.js
- src/applications/check-in/pre-check-in/tests/e2e/intro-display/accordion.toggle.cypress.spec.js
- src/applications/check-in/day-of/tests/e2e/appointment-details-display/appointment-details.complete.cypress.spec.js
- src/applications/check-in/day-of/tests/e2e/appointments-display/veterans.may.refresh.their.appointments.cypress.spec.js
- src/applications/check-in/pre-check-in/tests/e2e/loading-session/returning.session.cypress.spec.js
- src/applications/check-in/pre-check-in/tests/e2e/app-reload/reload.page.error.cypress.spec.js
- src/applications/check-in/pre-check-in/tests/e2e/demographics-display/information.display.cypress.spec.js
- src/applications/check-in/pre-check-in/tests/e2e/extra-validation/fields.are.required.cypress.spec.js
- src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.cypress.spec.js
- src/applications/check-in/pre-check-in/tests/e2e/extra-validation/validation.failed.dob.cypress.spec.js

## Related issue(s)

- [department-of-veterans-affairs/va.gov-team#60976](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60976)


