### PR TITLE
Add more validation to shared address schema in 686c-674

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/address-schema.js
+++ b/src/applications/disability-benefits/686c-674/config/address-schema.js
@@ -246,15 +246,31 @@ export const addressUISchema = (
       addressLine2: {
         'ui:title': 'Street address line 2',
         'ui:autocomplete': 'address-line2',
+        'ui:errorMessages': {
+          pattern: 'Street address must be 35 characters or less',
+        },
         'ui:options': {
           hideEmptyValueInReview: true,
+          updateSchema: (formData, schema) => {
+            return Object.assign(schema, {
+              maxLength: 35,
+            });
+          },
         },
       },
       addressLine3: {
         'ui:title': 'Street address line 3',
         'ui:autocomplete': 'address-line3',
+        'ui:errorMessages': {
+          pattern: 'Street address must be 35 characters or less',
+        },
         'ui:options': {
           hideEmptyValueInReview: true,
+          updateSchema: (formData, schema) => {
+            return Object.assign(schema, {
+              maxLength: 35,
+            });
+          },
         },
       },
       city: {

--- a/src/applications/disability-benefits/686c-674/config/address-schema.js
+++ b/src/applications/disability-benefits/686c-674/config/address-schema.js
@@ -247,7 +247,7 @@ export const addressUISchema = (
         'ui:title': 'Street address line 2',
         'ui:autocomplete': 'address-line2',
         'ui:errorMessages': {
-          pattern: 'Street address lines 2 must be 35 characters or less',
+          pattern: 'Street address line 2 must be 35 characters or less',
         },
         'ui:options': {
           hideEmptyValueInReview: true,

--- a/src/applications/disability-benefits/686c-674/config/address-schema.js
+++ b/src/applications/disability-benefits/686c-674/config/address-schema.js
@@ -247,7 +247,7 @@ export const addressUISchema = (
         'ui:title': 'Street address line 2',
         'ui:autocomplete': 'address-line2',
         'ui:errorMessages': {
-          pattern: 'Street address must be 35 characters or less',
+          pattern: 'Street address lines 2 must be 35 characters or less',
         },
         'ui:options': {
           hideEmptyValueInReview: true,
@@ -262,7 +262,7 @@ export const addressUISchema = (
         'ui:title': 'Street address line 3',
         'ui:autocomplete': 'address-line3',
         'ui:errorMessages': {
-          pattern: 'Street address must be 35 characters or less',
+          pattern: 'Street address line 3 must be 35 characters or less',
         },
         'ui:options': {
           hideEmptyValueInReview: true,


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/64342

- address line 2
- address line 3

## Summary

- Adds validation to "address line 2" and "address line 3" fields in the shared address schema for 686c-674.
- This resolves a bug where the user could submit lines that were too long for the target database, causing an exception and a failed form submission (and subsequent null claim error).
- We're using the existing framework for length validation, no new ground trod here.
- This file and project are owned by my team.
- This is not behind flipper and can go out immediately.

## Related issue(s)

- [#64342](https://github.com/department-of-veterans-affairs/va.gov-team/issues/64342


## Testing done

- The old behavior would allow the user to enter more than 35 characters and also would not error with more than 35 characters entered.
- The new behavior limits the character count on the field and also adds validation in case the user gets around it (by editing the HTML, for instance).

## Screenshots

The second screenshot shows both the new maxlength behavior as well as the behavior if the user (in this case, me) manually removes the maxlength attribute on a field.

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![image](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/5a97d6bc-1409-42db-a065-2e46428edc76)|![field-length](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/8b86e3cb-901c-40cb-b123-d2527ecd5eb9)|

## What areas of the site does it impact?

- 686c-747 address fields.

## Acceptance criteria

- Users are no longer able to submit addresses that cannot be inserted into the database.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
