### PR TITLE
VACMS-11789 Fallback to birds-eye radius if driving-distance excludes all Vet centers, remove nearby section if none

### DIFF
--- a/src/applications/static-pages/facilities/vet-center/NearByVetCenters.jsx
+++ b/src/applications/static-pages/facilities/vet-center/NearByVetCenters.jsx
@@ -190,24 +190,34 @@ const NearByVetCenters = props => {
   const normalizeFetchedVetCenters = vcs => {
     return vcs
       .map(vc => normalizeFetchedVetCenterProperties(vc))
-      .filter(center => center.distance < NEARBY_VET_CENTER_RADIUS_MILES)
-      .sort((a, b) => (a.distance < b.distance ? 1 : -1));
+      .sort((a, b) => a.distance - b.distance);
   };
 
-  const renderNearbyVetCenterContainer = sortedVetCenters => (
-    <div>
-      <h2
-        className="vads-u-font-size--xl vads-u-margin-top--3 medium-screen:vads-u-margin-top--5 vads-u-margin-bottom--2p5
+  const renderNearbyVetCenterContainer = sortedVetCenters => {
+    // Filter here so we can choose to use the sorted list if there are no Vet centers within the birds-eye radius
+    const filteredByDistance = sortedVetCenters.filter(
+      vc => vc.distance < NEARBY_VET_CENTER_RADIUS_MILES,
+    );
+
+    // Distance is calculated using the driving distance not birds-eye distance so all results may be outside the radius
+    const useSorted = filteredByDistance.length === 0;
+
+    return (
+      <div>
+        <h2
+          className="vads-u-font-size--xl vads-u-margin-top--3 medium-screen:vads-u-margin-top--5 vads-u-margin-bottom--2p5
                   medium-screen:vads-u-margin-bottom--3"
-        id="other-near-locations"
-      >
-        Other nearby Vet Centers
-      </h2>
-      {sortedVetCenters.map(vc =>
-        renderVetCenter(vc, props.mainVetCenterPhone),
-      )}
-    </div>
-  );
+          id="other-near-locations"
+        >
+          Other nearby Vet Centers
+        </h2>
+
+        {(useSorted ? sortedVetCenters : filteredByDistance).map(vc => {
+          return renderVetCenter(vc, props.mainVetCenterPhone);
+        })}
+      </div>
+    );
+  };
 
   const filteredVetCenters = fetchedVetCenters.filter(
     vc =>
@@ -215,9 +225,11 @@ const NearByVetCenters = props => {
       !(props.satteliteVetCenters || []).includes(vc.id),
   );
   if (filteredVetCenters.length > 0) {
-    return renderNearbyVetCenterContainer(
-      normalizeFetchedVetCenters(filteredVetCenters),
+    // only render the section if there are some facilities within the birds-eye radius
+    const normalizedFetchedVetCenters = normalizeFetchedVetCenters(
+      filteredVetCenters,
     );
+    return renderNearbyVetCenterContainer(normalizedFetchedVetCenters);
   }
   return null;
 };


### PR DESCRIPTION
## Summary

- Creates fallback if exclusion of driving distances removes all nearby Vet centers
- Go to any Vet center e.g., `/grand-rapids-vet-center/locations/`
- Locator search with a radius of 120 miles retrieves multiple facilities, without this workaround no Vet center facilities are retrieved and a header without a section data is displayed.
- Facilities
- No flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11789

## Testing done

- Prior to change: No Vet centers display in Nearby Vet centers section (heading still displays) https://va.gov/grand-rapids-vet-center/locations/
- Go to page on review instance: http://01c0624fa06f1f7adf65d186e115fb2b.review.vetsgov-internal/grand-rapids-vet-center/locations/
- Tested at above location and at: `/antelope-valley-vet-center/locations/`
- Checked each distance of nearest facility manually with the Google driving directions link

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  <img width="408" alt="Screenshot 2023-08-31 at 5 06 47 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/5606931/6c639c64-966b-432f-b82f-c9e605b7b68e">    |   <img width="409" alt="Screenshot 2023-08-31 at 5 05 05 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/5606931/e0a2cbdd-c373-48a9-bc5c-15be618afeec">   |
| Desktop |    <img width="1671" alt="Screenshot 2023-08-31 at 5 03 52 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/5606931/c48c62b1-0062-404b-aa8f-28c0227d5c84">    |  <img width="1669" alt="Screenshot 2023-08-31 at 5 05 19 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/5606931/f49a5a94-e87b-4742-ac54-ebce55a3bc18">     |

Unaffected locations list (sort order was changed to most proximal location first as described in original issue)

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |    <img width="1709" alt="Screenshot 2023-09-01 at 5 05 18 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/5606931/709d366c-e032-40fd-b8f9-3c94ba46bca3">    |    <img width="1728" alt="Screenshot 2023-09-01 at 5 06 29 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/5606931/dc19b5bd-4fed-4c7c-88af-60a286455072">   |



## What areas of the site does it impact?

Code only reaches the NearbyVetCenters component and does not change anything outside that boundary.

## Acceptance criteria

See comment: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11789#issuecomment-1701935293

- [x] Vet Center "Other nearby Vet Centers" displays up to 5 Vet Centers or Vet Center Outstations within 120 miles as default
- [x] Vet Center "Other nearby Vet Centers" displays up to 5 Vet Centers or Vet Center Outstations within 120 miles birds-eye-view as fallback
- [x] If no locations are within 120 miles birds-eye-view, remove the header "Other nearby Vet Centers"


### Quality Assurance & Testing

- [x] No unit tests due to dynamic content
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated -- in-code documentation added
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable - N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (No auth routes affected)

## Requested Feedback

- [ ] Test any Vet Center /locations page (or use those mentioned above)
- [ ] Verify that either nearby facilities are listed or that there is no header for the "Other nearby Vet Centers" 