### PR TITLE
NOD | Fix NOD infinite loop

### DIFF
--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -46,6 +46,7 @@ export const FormApp = ({
           issuesNeedUpdating(
             contestableIssues?.issues,
             formData.contestedIssues,
+            { showPart3 },
           )
         ) {
           setFormData({
@@ -93,7 +94,6 @@ export const FormApp = ({
       showPart3,
     ],
   );
-
   const content = isLoading ? (
     <h1 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
       <va-loading-indicator set-focus message="Loading application..." />

--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -85,17 +85,16 @@ export const FormApp = ({
           { showPart3 },
         )
       ) {
-        const contestedIssues = getEligibleContestableIssues(
-          contestableIssues?.issues,
-          {
-            showPart3,
-          },
-        );
         setFormData({
           ...formData,
           // Filters and normalizes the issues. See function definition for more
           // details.
-          contestedIssues,
+          contestedIssues: getEligibleContestableIssues(
+            contestableIssues?.issues,
+            {
+              showPart3,
+            },
+          ),
         });
       }
     },

--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -17,11 +17,9 @@ import { getContestableIssues as getContestableIssuesAction } from '../actions';
 
 import { copyAreaOfDisagreementOptions } from '../../shared/utils/areaOfDisagreement';
 
-import {
-  getSelected,
-  getIssueNameAndDate,
-  issuesNeedUpdating,
-} from '../../shared/utils/issues';
+import { getSelected, getIssueNameAndDate } from '../../shared/utils/issues';
+
+import { issuesNeedUpdating } from '../utils/issues';
 
 export const FormApp = ({
   isLoading,
@@ -87,16 +85,17 @@ export const FormApp = ({
           { showPart3 },
         )
       ) {
+        const contestedIssues = getEligibleContestableIssues(
+          contestableIssues?.issues,
+          {
+            showPart3,
+          },
+        );
         setFormData({
           ...formData,
           // Filters and normalizes the issues. See function definition for more
           // details.
-          contestedIssues: getEligibleContestableIssues(
-            contestableIssues?.issues,
-            {
-              showPart3,
-            },
-          ),
+          contestedIssues,
         });
       }
     },

--- a/src/applications/appeals/10182/tests/containers/FormApp.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/containers/FormApp.unit.spec.jsx
@@ -167,7 +167,10 @@ describe('FormApp', () => {
     );
 
     await waitFor(() => {
-      const action = store.getActions()[0];
+      // Here, we are checking the second action, which is dispatched within the
+      // second `useEffect` in `FormApp`. This second `useEffect` is the one that
+      // manages contestable issues.
+      const action = store.getActions()[1];
       expect(action.type).to.eq(SET_DATA);
       expect(action.data.contestedIssues.length).to.eq(1);
     });

--- a/src/applications/appeals/10182/tests/utils/issues.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/issues.unit.spec.js
@@ -1,0 +1,148 @@
+import { expect } from 'chai';
+import moment from 'moment';
+import { SHOW_PART3 } from '../../constants';
+import { issuesNeedUpdating } from '../../utils/issues';
+
+describe('issuesNeedUpdating', () => {
+  const yesterday = moment().format('YYYY-MM-DD');
+  const longAgo = '2000-01-01';
+
+  const createEntry = (
+    ratingIssueSubjectText = '',
+    approxDecisionDate = longAgo,
+  ) => ({
+    attributes: {
+      ratingIssueSubjectText,
+      approxDecisionDate,
+    },
+  });
+
+  it('returns false if loadedIssues have a decision date older than a year and existingIssues is empty', () => {
+    let result;
+    result = issuesNeedUpdating([createEntry('Old Issue', longAgo)], []);
+    expect(result).to.be.false;
+
+    result = issuesNeedUpdating(
+      [createEntry('Old Issue', longAgo), createEntry('Old Issue', longAgo)],
+      [],
+    );
+    expect(result).to.be.false;
+  });
+
+  it('return false if loadedIssues have a decision date older than a year and existingIssues is identical to loadedIssues', () => {
+    let result;
+    result = issuesNeedUpdating(
+      [createEntry('Old Issue', longAgo)],
+      [createEntry('Old Issue', longAgo)],
+    );
+    expect(result).to.be.false;
+
+    result = issuesNeedUpdating(
+      [
+        createEntry('Old Issue 1', longAgo),
+        createEntry('Old Issue 2', longAgo),
+      ],
+      [
+        createEntry('Old Issue 1', longAgo),
+        createEntry('Old Issue 2', longAgo),
+      ],
+    );
+    expect(result).to.be.false;
+  });
+
+  it('returns true if loadedIssues has new issues that existingIssues does not yet have', () => {
+    let result;
+    result = issuesNeedUpdating(
+      [createEntry('Old Issue', longAgo), createEntry('New Issue', yesterday)],
+      [createEntry('Old Issue', longAgo)],
+    );
+    expect(result).to.be.true;
+
+    result = issuesNeedUpdating([createEntry('New Issue', yesterday)], []);
+    expect(result).to.be.true;
+
+    result = issuesNeedUpdating(
+      [
+        createEntry('New Issue 1', yesterday),
+        createEntry('New Issue 2', yesterday),
+      ],
+      [createEntry('New Issue 1', yesterday)],
+    );
+    expect(result).to.be.true;
+  });
+
+  describe('when showPart3 is true', () => {
+    it('returns true if loadedIssues have a decision date older than a year and existingIssues is empty', () => {
+      const options = { showPart3: SHOW_PART3 };
+      let result;
+      result = issuesNeedUpdating(
+        [createEntry('Old Issue', longAgo)],
+        [],
+        options,
+      );
+      expect(result).to.be.true;
+
+      result = issuesNeedUpdating(
+        [createEntry('Old Issue', longAgo), createEntry('Old Issue', longAgo)],
+        [],
+        options,
+      );
+      expect(result).to.be.true;
+    });
+
+    it('return false if loadedIssues have a decision date older than a year and existingIssues is identical to loadedIssues', () => {
+      const options = { showPart3: SHOW_PART3 };
+      let result;
+      result = issuesNeedUpdating(
+        [createEntry('Old Issue', longAgo)],
+        [createEntry('Old Issue', longAgo)],
+        options,
+      );
+      expect(result).to.be.false;
+
+      result = issuesNeedUpdating(
+        [
+          createEntry('Old Issue 1', longAgo),
+          createEntry('Old Issue 2', longAgo),
+        ],
+        [
+          createEntry('Old Issue 1', longAgo),
+          createEntry('Old Issue 2', longAgo),
+        ],
+        options,
+      );
+      expect(result).to.be.false;
+    });
+
+    it('returns true if loadedIssues has new issues that existingIssues does not yet have', () => {
+      const options = { showPart3: SHOW_PART3 };
+      let result;
+      result = issuesNeedUpdating(
+        [
+          createEntry('Old Issue', longAgo),
+          createEntry('New Issue', yesterday),
+        ],
+        [createEntry('Old Issue', longAgo)],
+        options,
+      );
+      expect(result).to.be.true;
+
+      result = issuesNeedUpdating(
+        [createEntry('New Issue', yesterday)],
+        [],
+        options,
+      );
+      expect(result).to.be.true;
+
+      result = issuesNeedUpdating(
+        [
+          createEntry('New Issue 1', yesterday),
+          createEntry('New Issue 2', yesterday),
+        ],
+        [createEntry('New Issue 1', yesterday)],
+        options,
+      );
+      expect(result).to.be.true;
+    });
+  });
+});

--- a/src/applications/appeals/10182/utils/issues.js
+++ b/src/applications/appeals/10182/utils/issues.js
@@ -1,8 +1,8 @@
 import { getEligibleContestableIssues } from './submit';
 
-// This function checks whether contestable issue data loaded from the API (`loaded`)
+// This function checks whether contestable issue data loaded from the API (`loadedIssues`)
 // is different from the contestable issue data already present in `formData`
-// (`formIssues`). We use it to determine whether we need to update `formData`.
+// (`existingIssues`). We use it to determine whether we need to update `formData`.
 // with contestable issue data from the API. This function is adapted from the
 // `issuesNeedUpdating` function defined in `src/applications/appeals/shared/utils/issues.js`.
 // The only difference (other than variable naming) is that we are calling

--- a/src/applications/appeals/10182/utils/issues.js
+++ b/src/applications/appeals/10182/utils/issues.js
@@ -1,0 +1,23 @@
+import { getEligibleContestableIssues } from './submit';
+
+export const issuesNeedUpdating = (
+  loaded = [],
+  formIssues = [],
+  options = {},
+) => {
+  const { showPart3 } = options;
+  const loadedIssues = getEligibleContestableIssues(loaded, { showPart3 });
+  const existingIssues = getEligibleContestableIssues(formIssues, {
+    showPart3,
+  });
+  return loadedIssues.length !== existingIssues.length
+    ? true
+    : !loadedIssues.every(({ attributes }, index) => {
+        const existing = existingIssues[index]?.attributes || {};
+        return (
+          attributes.ratingIssueSubjectText ===
+            existing.ratingIssueSubjectText &&
+          attributes.approxDecisionDate === existing.approxDecisionDate
+        );
+      });
+};

--- a/src/applications/appeals/10182/utils/issues.js
+++ b/src/applications/appeals/10182/utils/issues.js
@@ -5,25 +5,28 @@ import { getEligibleContestableIssues } from './submit';
 // (`formIssues`). We use it to determine whether we need to update `formData`.
 // with contestable issue data from the API. This function is adapted from the
 // `issuesNeedUpdating` function defined in `src/applications/appeals/shared/utils/issues.js`.
-// The only difference is that we are calling `getEligibleContestableIssues`
-// instead of `processContestableIssues`. This ensures that we are comparing
-// filtered data from the API with filtered data from `formData`.
+// The only difference (other than variable naming) is that we are calling
+// `getEligibleContestableIssues` instead of `processContestableIssues`.
+// This ensures that we are comparing filtered data from the API with filtered
+// data from `formData`.
 export const issuesNeedUpdating = (
-  loaded = [],
-  formIssues = [],
+  loadedIssues = [],
+  existingIssues = [],
   options = {},
 ) => {
   const { showPart3 } = options;
   // `getEligibleContestableIssues` filters out deferred issues, and issues
   // with a decision date older than a year.
-  const loadedIssues = getEligibleContestableIssues(loaded, { showPart3 });
-  const existingIssues = getEligibleContestableIssues(formIssues, {
+  const filteredLoadedIssues = getEligibleContestableIssues(loadedIssues, {
     showPart3,
   });
-  return loadedIssues.length !== existingIssues.length
+  const filteredExistingIssues = getEligibleContestableIssues(existingIssues, {
+    showPart3,
+  });
+  return filteredLoadedIssues.length !== filteredExistingIssues.length
     ? true
-    : !loadedIssues.every(({ attributes }, index) => {
-        const existing = existingIssues[index]?.attributes || {};
+    : !filteredLoadedIssues.every(({ attributes }, index) => {
+        const existing = filteredExistingIssues[index]?.attributes || {};
         return (
           attributes.ratingIssueSubjectText ===
             existing.ratingIssueSubjectText &&

--- a/src/applications/appeals/10182/utils/issues.js
+++ b/src/applications/appeals/10182/utils/issues.js
@@ -1,11 +1,21 @@
 import { getEligibleContestableIssues } from './submit';
 
+// This function checks whether contestable issue data loaded from the API (`loaded`)
+// is different from the contestable issue data already present in `formData`
+// (`formIssues`). We use it to determine whether we need to update `formData`.
+// with contestable issue data from the API. This function is adapted from the
+// `issuesNeedUpdating` function defined in `src/applications/appeals/shared/utils/issues.js`.
+// The only difference is that we are calling `getEligibleContestableIssues`
+// instead of `processContestableIssues`. This ensures that we are comparing
+// filtered data from the API with filtered data from `formData`.
 export const issuesNeedUpdating = (
   loaded = [],
   formIssues = [],
   options = {},
 ) => {
   const { showPart3 } = options;
+  // `getEligibleContestableIssues` filters out deferred issues, and issues
+  // with a decision date older than a year.
   const loadedIssues = getEligibleContestableIssues(loaded, { showPart3 });
   const existingIssues = getEligibleContestableIssues(formIssues, {
     showPart3,

--- a/src/applications/appeals/10182/utils/submit.js
+++ b/src/applications/appeals/10182/utils/submit.js
@@ -38,6 +38,8 @@ export const getEligibleContestableIssues = (issues, { showPart3 } = {}) => {
     }
     return showPart3 || date.add(1, 'years').isAfter(today);
   });
+  // This normalizes the contestable issues data. See function definition for
+  // more detail.
   return processContestableIssues(result);
 };
 

--- a/src/applications/appeals/shared/utils/issues.js
+++ b/src/applications/appeals/shared/utils/issues.js
@@ -1,5 +1,6 @@
 // import the toggleValues helper
 import { SELECTED, REGEXP } from '../constants';
+import { getEligibleContestableIssues } from '../../10182/utils/submit';
 
 import { replaceDescriptionContent } from './replace';
 import '../definitions';
@@ -120,9 +121,15 @@ export const processContestableIssues = contestableIssues => {
 export const calculateIndexOffset = (index, contestableIssuesLength) =>
   index - contestableIssuesLength;
 
-export const issuesNeedUpdating = (loaded = [], formIssues = []) => {
-  const loadedIssues = processContestableIssues(loaded);
-  const existingIssues = processContestableIssues(formIssues);
+export const issuesNeedUpdating = (
+  loaded = [],
+  formIssues = [],
+  { showPart3 = {} },
+) => {
+  const loadedIssues = getEligibleContestableIssues(loaded, { showPart3 });
+  const existingIssues = getEligibleContestableIssues(formIssues, {
+    showPart3,
+  });
   return loadedIssues.length !== existingIssues.length
     ? true
     : !loadedIssues.every(({ attributes }, index) => {

--- a/src/applications/appeals/shared/utils/issues.js
+++ b/src/applications/appeals/shared/utils/issues.js
@@ -1,6 +1,5 @@
 // import the toggleValues helper
 import { SELECTED, REGEXP } from '../constants';
-import { getEligibleContestableIssues } from '../../10182/utils/submit';
 
 import { replaceDescriptionContent } from './replace';
 import '../definitions';
@@ -121,15 +120,9 @@ export const processContestableIssues = contestableIssues => {
 export const calculateIndexOffset = (index, contestableIssuesLength) =>
   index - contestableIssuesLength;
 
-export const issuesNeedUpdating = (
-  loaded = [],
-  formIssues = [],
-  { showPart3 = {} },
-) => {
-  const loadedIssues = getEligibleContestableIssues(loaded, { showPart3 });
-  const existingIssues = getEligibleContestableIssues(formIssues, {
-    showPart3,
-  });
+export const issuesNeedUpdating = (loaded = [], formIssues = []) => {
+  const loadedIssues = processContestableIssues(loaded);
+  const existingIssues = processContestableIssues(formIssues);
   return loadedIssues.length !== existingIssues.length
     ? true
     : !loadedIssues.every(({ attributes }, index) => {


### PR DESCRIPTION
## Summary

Fixing NOD useEffect infinite loop issue.

We encountered an issue where `useEffect` would be called over and over because an `issuesNeedUpdating` check therein was guaranteed to return `true` if a Veteran had contestable issues with a decision date older than one year.

For context, this `issuesNeedUpdating` function was intended to check whether contestable issue data loaded from the API was different from contestable issue data that already existed in `formData`. If the data was different, we would run a series of data normalization and filtering functions that would, among other things, ensure that Veterans could not see contestable issues with a decision date older than a year. These checks are somewhat expensive, so we didn't want to run them unless we needed to. Which is why the `issuesNeedUpdating` check was there.

However, the `issuesNeedUpdating` function was comparing _unfiltered_ data from the API (i.e. all contested issues, regardless of decision date) with _filtered_ data from `formData` (only containing issues with a decision date within the past year). This meant that when a Veteran had issues with a decision date older than one year, `issuesNeedUpdating` was guaranteed to return `true`, no matter what, because the filtered data would necessarily be different from the unfiltered data. Which meant `useEffect` would update `formData` _ad infinitum_ and crash the page.

The fix, introduced here, is to compare _filtered_ data from the API with _filtered_ data from `formData`, in `issuesNeedUpdating`. This filtering is done by a pre-existing function `getEligibleContestableIssues`. Since NOD currently has its own NOD-specific `getEligibleContestableIssues` function (defined in `src/applications/appeals/10182/utils/submit.js`), for the time being, we are using an NOD-specific `issuesNeedUpdating` function (defined in `src/applications/appeals/10182/utils/issues.js`) instead of the shared one (defined in `src/applications/appeals/shared/utils/issues.js`). This will ensure that the changes we are making won't impact the other forms. That being said, after this bugfix, we will spend some time refactoring these functions across our forms. I will create a follow-up ticket for that work.

A final note: this PR introduces two performance improvements. First, we've split out all the code relating to contested issues into its own `useEffect`. This is because the code is a bit expensive, and not something we want to run every single time `formData` changes. Second, in `setFormData` we are setting `contestedIssues` to the result of `getEligibleContestableIssues` (the filtering function), which itself calls `processContestableIssues` (the data normalization function). Before, we were calling `processContesableIssues` on the result of `getEligibleContestableIssues`, which was redundant.

I work for the Decision Reviews Team on Benefits Team 1, which is responsible for the Notice of Disagreement form.

This bugfix is not hidden behind a feature toggle.

## Related issue(s)

Ticket forthcoming. For now, please reference the summary above, which contains all necessary context for this issue.

## Testing done

- Before, a Veteran with at least one contestable issue with a decision date older than a year would, upon visiting `/decision-reviews/board-appeal/request-board-appeal-form-10182`, get a frozen page.
- I have tested locally to verify this is no longer the case.  Additionally, all automated tests pass, including new regression tests I've introduced to cover the particular issue which caused this bug. 
- To test locally, I stubbed `V0::NoticeOfDisagreements::ContestableIssuesController#index` with the data in `spec/fixtures/notice_of_disagreements/NOD_contestable_issues_response_200.json`, which contains a contestable issue with a decision date older than one year. I then logged in locally as User 228, verified my identity, and visited `/decision-reviews/board-appeal/request-board-appeal-form-10182`, which rendered without issue.
- After merging and deploying this fix, we will immediately test that the fix worked as intended in production, using a VA account belonging to one of the Veterans on our team.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

The Notice of Disagreement form.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable) (**COMING UP NEXT**)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
