### PR TITLE
Add accessibility changes to mock header form

### DIFF
--- a/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomFormApp.jsx
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomFormApp.jsx
@@ -4,10 +4,10 @@ import Scroll from 'react-scroll';
 
 import { isLoggedIn } from 'platform/user/selectors';
 
-import FormNav from 'platform/forms-system/src/js/components/FormNav';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import { isInProgress } from 'platform/forms-system/src/js/helpers';
 import { setGlobalScroll } from 'platform/forms-system/src/js/utilities/ui';
+import FormNav from './CustomFormNav';
 
 const { Element } = Scroll;
 

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomFormNav.jsx
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomFormNav.jsx
@@ -1,0 +1,211 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import uniq from 'lodash/uniq';
+
+import {
+  getChaptersLengthDisplay,
+  createFormPageList,
+  createPageList,
+  getActiveExpandedPages,
+  getCurrentChapterDisplay,
+} from 'platform/forms-system/src/js/helpers';
+
+import {
+  focusByOrder,
+  customScrollAndFocus,
+  defaultFocusSelector,
+} from 'platform/utilities/ui';
+
+import { REVIEW_APP_DEFAULT_MESSAGE } from 'platform/forms-system/src/js/constants';
+
+/**
+ * This is a duplicate of FormNav that adds "CHAPTER" above va-segmented-progress-bar
+ * and also an div with an id wrapping the CHAPTER + stepper
+ */
+
+export default function FormNav(props) {
+  const {
+    formConfig = {},
+    currentPath,
+    formData,
+    isLoggedIn,
+    inProgressFormId,
+  } = props;
+
+  const [index, setIndex] = useState(0);
+
+  // This is converting the config into a list of pages with chapter keys,
+  // finding the current page, then getting the chapter name using the key
+  const formPages = createFormPageList(formConfig);
+  const pageList = createPageList(formConfig, formPages);
+
+  const eligiblePageList = getActiveExpandedPages(pageList, formData);
+
+  const uniqueChapters = uniq(
+    eligiblePageList.map(p => p.chapterKey).filter(key => !!key),
+  );
+
+  let page = eligiblePageList.filter(p => p.path === currentPath)[0];
+  // If the page isn’t active, it won’t be in the eligiblePageList
+  // This is a fallback to still find the chapter name if you open the page directly
+  // (the chapter index will probably be wrong, but this isn’t a scenario that happens in normal use)
+  if (!page) {
+    page =
+      formPages.find(p => `${formConfig.urlPrefix}${p.path}` === currentPath) ||
+      {};
+  }
+
+  let current;
+  let chapterName;
+  let inProgressMessage = null;
+
+  if (page.chapterKey) {
+    const onReviewPage = page.chapterKey === 'review';
+    current = uniqueChapters.indexOf(page.chapterKey) + 1;
+
+    // The review page is always part of our forms, but isn’t listed in chapter list
+    chapterName = onReviewPage
+      ? formConfig?.customText?.reviewPageTitle || REVIEW_APP_DEFAULT_MESSAGE
+      : formConfig.chapters[page.chapterKey].title;
+    if (typeof chapterName === 'function' && !onReviewPage) {
+      // for FormNav, we only call chapter-config title-function if
+      // not on review-page.
+      chapterName = chapterName({ formData, formConfig, onReviewPage });
+    }
+  }
+
+  if (isLoggedIn) {
+    inProgressMessage = (
+      <span className="vads-u-display--block vads-u-font-family--sans vads-u-font-weight--normal vads-u-font-size--base">
+        We&rsquo;ll save your application on every change.{' '}
+        {inProgressFormId &&
+          `Your application ID number is ${inProgressFormId}.`}
+      </span>
+    );
+  }
+
+  const showHeader = Math.abs(current - index) === 1;
+  // Some chapters may have progress-bar & step-header hidden via hideFormNavProgress.
+  const hideFormNavProgress =
+    formConfig?.chapters[page.chapterKey]?.hideFormNavProgress;
+  // Ensure other chapters [that do show progress-bar & step-header] have
+  // the correct number & total [with progress-hidden chapters discounted].
+  // formConfig, current, & chapters.length should NOT be manipulated,
+  // as they are likely used elsewhere in functional logic.
+  const chaptersLengthDisplay = getChaptersLengthDisplay({
+    uniqueChapters,
+    formConfig,
+  });
+  // Returns NaN if the current chapter isn't found
+  const currentChapterDisplay = getCurrentChapterDisplay(formConfig, current);
+  const stepText = Number.isNaN(currentChapterDisplay)
+    ? ''
+    : `Step ${currentChapterDisplay} of ${chaptersLengthDisplay}: ${chapterName ||
+        ''}`;
+
+  // The goal with this is to quickly "remove" the header from the DOM, and
+  // immediately re-render the component with the header included.
+  // `current` changes when the form chapter changes, and when this happens
+  // we want to force react to remove the <h2> and re-render it. This should
+  // ensure that VoiceOver on iOS will pick up on the new <h2>
+  // https://github.com/department-of-veterans-affairs/va.gov-team/issues/12323
+  useEffect(
+    () => {
+      if (current > index + 1) {
+        setIndex(index + 1);
+      } else if (current === index) {
+        setIndex(index - 1);
+      }
+
+      return () => {
+        // Check main toggle to enable custom focus; the unmounting of the page
+        // before the review & submit page may cause the customScrollAndFocus
+        // function to be called inadvertently
+        if (
+          formConfig.useCustomScrollAndFocus &&
+          !(
+            page.chapterKey === 'review' ||
+            window.location.pathname.endsWith('review-and-submit')
+          )
+        ) {
+          customScrollAndFocus(page.scrollAndFocusTarget, index);
+        } else {
+          // h2 fallback for confirmation page
+          focusByOrder([defaultFocusSelector, 'h2']);
+        }
+      };
+    },
+    [
+      current,
+      formConfig.useCustomScrollAndFocus,
+      index,
+      page.chapterKey,
+      page.scrollAndFocusTarget,
+    ],
+  );
+
+  const v3SegmentedProgressBar = formConfig?.v3SegmentedProgressBar;
+  // show progress-bar and stepText only if hideFormNavProgress is falsy.
+  return (
+    <div>
+      {!hideFormNavProgress && (
+        <div id="alternate-header-stepper">
+          <div className="vads-u-color--primary vads-u-font-weight--bold">
+            CHAPTER
+          </div>
+          <va-segmented-progress-bar
+            total={chaptersLengthDisplay}
+            current={currentChapterDisplay}
+            uswds={v3SegmentedProgressBar}
+            heading-text={chapterName ?? ''} // functionality only available for v3
+            {...(v3SegmentedProgressBar ? { 'header-level': '2' } : {})}
+          />
+        </div>
+      )}
+      {!v3SegmentedProgressBar &&
+        !hideFormNavProgress && (
+          <div className="schemaform-chapter-progress">
+            <div className="nav-header nav-header-schemaform">
+              {showHeader ? (
+                <h2
+                  id="nav-form-header"
+                  data-testid="navFormHeader"
+                  className="vads-u-font-size--h4"
+                >
+                  {stepText}
+                  {inProgressMessage}
+                </h2>
+              ) : (
+                <div data-testid="navFormDiv" className="vads-u-font-size--h4">
+                  {stepText}
+                  {inProgressMessage}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+    </div>
+  );
+}
+
+FormNav.defaultProps = {
+  currentPath: '',
+  formData: {},
+  isLoggedIn: false,
+  inProgressFormId: null,
+};
+
+FormNav.propTypes = {
+  formConfig: PropTypes.shape({
+    chapters: PropTypes.shape({}),
+    customText: PropTypes.shape({
+      reviewPageTitle: PropTypes.string,
+    }),
+    urlPrefix: PropTypes.string,
+    useCustomScrollAndFocus: PropTypes.bool,
+  }).isRequired,
+  currentPath: PropTypes.string,
+  formData: PropTypes.shape({}),
+  inProgressFormId: PropTypes.number,
+  isLoggedIn: PropTypes.bool,
+};

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomHeader.jsx
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomHeader.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, withRouter } from 'react-router';
 import {
   createPageList,
@@ -11,7 +11,9 @@ import { getPreviousPagePath } from 'platform/forms-system/src/js/routing';
  * A light blue bar across the top of each page of the form.
  * Contains the form title with form id, a back link, and an exit form link.
  */
-const CustomHeader = ({ formData, formConfig, router, currentLocation }) => {
+const CustomHeader = ({ formData, formConfig, currentLocation }) => {
+  const [previousPage, setPreviousPage] = useState('/');
+
   const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
   const { additionalRoutes } = formConfig;
   let nonFormPages = [];
@@ -23,18 +25,21 @@ const CustomHeader = ({ formData, formConfig, router, currentLocation }) => {
   const isNonFormPage = nonFormPages.includes(lastPathComponent);
   const isReviewPage = trimmedPathname.endsWith('review-and-submit');
 
-  function goBack() {
-    const formPages = createFormPageList(formConfig);
-    const pageList = createPageList(formConfig, formPages);
+  useEffect(
+    () => {
+      const formPages = createFormPageList(formConfig);
+      const pageList = createPageList(formConfig, formPages);
 
-    const path = getPreviousPagePath(
-      pageList,
-      formData,
-      currentLocation.pathname,
-    );
+      const newPreviousPage =
+        isIntroductionPage || isNonFormPage
+          ? ''
+          : getPreviousPagePath(pageList, formData, currentLocation?.pathname);
 
-    router.push(path);
-  }
+      setPreviousPage(newPreviousPage);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [currentLocation],
+  );
 
   return !isIntroductionPage && !isNonFormPage && !isReviewPage ? (
     <div className="vads-u-background-color--primary-alt-lightest vads-u-padding-y--2 vads-u-margin-bottom--2">
@@ -54,12 +59,16 @@ const CustomHeader = ({ formData, formConfig, router, currentLocation }) => {
                 aria-hidden="true"
                 className="fas fa-arrow-left va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--0p5 vads-u-color--gray-medium"
               />
-              {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-              <Link onClick={goBack} className="vads-u-margin-right--4">
+              <Link
+                to={previousPage}
+                className="va-button-link vads-u-margin-right--4"
+              >
                 Back
               </Link>
             </span>
-            <Link to="/">Exit form</Link>
+            <Link to="/" className="va-button-link">
+              Exit form
+            </Link>
           </div>
         </div>
       </div>

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomHeader.jsx
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomHeader.jsx
@@ -66,9 +66,9 @@ const CustomHeader = ({ formData, formConfig, currentLocation }) => {
                 Back
               </Link>
             </span>
-            <Link to="/" className="va-button-link">
+            <a href={formConfig.rootUrl} className="va-button-link">
               Exit form
-            </Link>
+            </a>
           </div>
         </div>
       </div>

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/components/customTitlePattern.jsx
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/components/customTitlePattern.jsx
@@ -11,7 +11,10 @@ import React from 'react';
 export const titleH1UI = (title, description) => {
   return {
     'ui:title': (
-      <h1 className="vads-u-color--gray-dark vads-u-font-size--h3 medium-screen:vads-u-font-size--h1 vads-u-margin-y--neg2">
+      <h1
+        aria-describedby="alternate-header-stepper"
+        className="vads-u-color--gray-dark vads-u-font-size--h3 medium-screen:vads-u-font-size--h1 vads-u-margin-y--neg2"
+      >
         {title}
       </h1>
     ),

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/config/form.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/config/form.js
@@ -1,4 +1,5 @@
 import footerContent from 'platform/forms/components/FormFooter';
+import { focusElement, scrollTo } from 'platform/utilities/ui';
 import manifest from '../manifest.json';
 
 import IntroductionPage from '../containers/IntroductionPage';
@@ -19,6 +20,21 @@ import { CustomPage } from '../components/CustomPage';
  * Check 21-0845 for the actual form
  */
 
+const pageScrollAndFocus = () => {
+  return () => {
+    const header = document.querySelector('h1');
+    // reenable if using web component radio
+    // if (!header) {
+    //   header = document.querySelector('va-radio');
+    //   if (header?.shadowRoot) {
+    //     header = header.shadowRoot.querySelector('h1');
+    //   }
+    // }
+    focusElement(header);
+    scrollTo('topScrollElement');
+  };
+};
+
 /** @type {FormConfig} */
 const formConfig = {
   rootUrl: manifest.rootUrl,
@@ -31,6 +47,7 @@ const formConfig = {
   confirmation: ConfirmationPage,
   v3SegmentedProgressBar: true,
   CustomHeader,
+  useCustomScrollAndFocus: true,
   preSubmitInfo: {},
   formId: 'FORM_MOCK_ALT_HEADER',
   saveInProgress: {
@@ -66,6 +83,7 @@ const formConfig = {
           uiSchema: authorizerType.uiSchema,
           schema: authorizerType.schema,
           CustomPage,
+          scrollAndFocusTarget: pageScrollAndFocus(),
         },
       },
     },
@@ -78,6 +96,7 @@ const formConfig = {
           uiSchema: nameAndDate.uiSchema,
           schema: nameAndDate.schema,
           CustomPage,
+          scrollAndFocusTarget: pageScrollAndFocus(),
         },
         identificationInfoPage: {
           path: 'identification-information',
@@ -85,6 +104,7 @@ const formConfig = {
           uiSchema: identificationInformation.uiSchema,
           schema: identificationInformation.schema,
           CustomPage,
+          scrollAndFocusTarget: pageScrollAndFocus(),
         },
         mailingAddressPage: {
           path: 'mailing-address',
@@ -92,6 +112,7 @@ const formConfig = {
           uiSchema: address.uiSchema,
           schema: address.schema,
           CustomPage,
+          scrollAndFocusTarget: pageScrollAndFocus(),
         },
         phoneAndEmailPage: {
           path: 'phone-and-email',
@@ -99,6 +120,7 @@ const formConfig = {
           uiSchema: phoneAndEmail.uiSchema,
           schema: phoneAndEmail.schema,
           CustomPage,
+          scrollAndFocusTarget: pageScrollAndFocus(),
         },
       },
     },
@@ -112,6 +134,7 @@ const formConfig = {
           uiSchema: thirdPartyType.uiSchema,
           schema: thirdPartyType.schema,
           CustomPage,
+          scrollAndFocusTarget: pageScrollAndFocus(),
         },
         organizationInfoPage: {
           path: 'organization-information',
@@ -119,6 +142,7 @@ const formConfig = {
           uiSchema: organizationInfo.uiSchema,
           schema: organizationInfo.schema,
           CustomPage,
+          scrollAndFocusTarget: pageScrollAndFocus(),
         },
       },
     },

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/containers/IntroductionPage.jsx
@@ -72,7 +72,7 @@ class IntroductionPage extends React.Component {
           <Link
             onClick={this.handleClick}
             to={this.getStartPage}
-            className="schemaform-start-button"
+            className="vads-c-action-link--green schemaform-start-button"
           >
             Start your application without signing in
           </Link>

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/pages/authorizerType.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/pages/authorizerType.js
@@ -1,20 +1,38 @@
-import {
-  radioUI,
-  radioSchema,
-} from 'platform/forms-system/src/js/web-component-patterns';
+import React from 'react';
+import { radioSchema } from 'platform/forms-system/src/js/web-component-patterns';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    authorizerType: radioUI({
-      title: "Who's submitting this authorization?",
-      labels: {
-        veteran: "I'm a Veteran submitting on my own behalf",
-        nonVeteran:
-          "I'm a non-Veteran beneficiary or claimant submitting on behalf of a Veteran",
+    authorizerType: {
+      'ui:title': (
+        <h1
+          aria-describedby="alternate-header-stepper"
+          className="vads-u-color--gray-dark vads-u-font-size--h3 medium-screen:vads-u-font-size--h1"
+        >
+          Who's submitting this authorization?
+        </h1>
+      ),
+      'ui:widget': 'radio',
+      'ui:options': {
+        labels: {
+          veteran: "I'm a Veteran submitting on my own behalf",
+          nonVeteran:
+            "I'm a non-Veteran beneficiary or claimant submitting on behalf of a Veteran",
+        },
       },
-      labelHeaderLevel: '1',
-    }),
+    },
+    // web component implementation
+    // disabled until radio issues are resolved
+    // authorizerType: radioUI({
+    //   title: "Who's submitting this authorization?",
+    //   labels: {
+    //     veteran: "I'm a Veteran submitting on my own behalf",
+    //     nonVeteran:
+    //       "I'm a non-Veteran beneficiary or claimant submitting on behalf of a Veteran",
+    //   },
+    //   labelHeaderLevel: '1',
+    // }),
   },
   schema: {
     type: 'object',

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/pages/nameAndDate.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/pages/nameAndDate.js
@@ -1,5 +1,6 @@
-import definitions from 'vets-json-schema/dist/definitions.json';
 import {
+  dateOfBirthUI,
+  dateOfBirthSchema,
   fullNameNoSuffixUI,
   fullNameNoSuffixSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
@@ -10,10 +11,7 @@ export default {
   uiSchema: {
     'view:title': titleH1UI('Your name and date of birth'),
     veteranFullName: fullNameNoSuffixUI(),
-    veteranDateOfBirth: {
-      'ui:title': 'Date of birth',
-      'ui:widget': 'date',
-    },
+    veteranDateOfBirth: dateOfBirthUI(),
   },
   schema: {
     type: 'object',
@@ -21,7 +19,7 @@ export default {
     properties: {
       'view:title': titleH1Schema,
       veteranFullName: fullNameNoSuffixSchema,
-      veteranDateOfBirth: definitions.date,
+      veteranDateOfBirth: dateOfBirthSchema,
     },
   },
 };

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/pages/thirdPartyType.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/pages/thirdPartyType.js
@@ -1,22 +1,40 @@
-import {
-  radioUI,
-  radioSchema,
-} from 'platform/forms-system/src/js/web-component-patterns/radioPattern';
+import React from 'react';
+import { radioSchema } from 'platform/forms-system/src/js/web-component-patterns/radioPattern';
 
 import { THIRD_PARTY_TYPES } from '../definitions/constants';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    thirdPartyType: radioUI({
-      title:
-        'Do you authorize us to release your information to a specific person or to an organization?',
-      labels: {
-        [THIRD_PARTY_TYPES.PERSON]: 'A specific person',
-        [THIRD_PARTY_TYPES.ORGANIZATION]: 'An organization',
+    thirdPartyType: {
+      'ui:title': (
+        <h1
+          aria-describedby="alternate-header-stepper"
+          className="vads-u-color--gray-dark vads-u-font-size--h3 medium-screen:vads-u-font-size--h1"
+        >
+          Do you authorize us to release your information to a specific person
+          or to an organization?
+        </h1>
+      ),
+      'ui:widget': 'radio',
+      'ui:options': {
+        labels: {
+          [THIRD_PARTY_TYPES.PERSON]: 'A specific person',
+          [THIRD_PARTY_TYPES.ORGANIZATION]: 'An organization',
+        },
       },
-      labelHeaderLevel: '1',
-    }),
+    },
+    // web component implementation
+    // disabled until radio issues are resolved
+    // radioUI({
+    //   title:
+    //     'Do you authorize us to release your information to a specific person or to an organization?',
+    //   labels: {
+    //     [THIRD_PARTY_TYPES.PERSON]: 'A specific person',
+    //     [THIRD_PARTY_TYPES.ORGANIZATION]: 'An organization',
+    //   },
+    //   labelHeaderLevel: '1',
+    // }),
   },
   schema: {
     type: 'object',

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/sass/mock-alternate-header-0845.scss
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/sass/mock-alternate-header-0845.scss
@@ -5,3 +5,7 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "../../../../platform/forms/sass/m-form-confirmation";
+
+.rjsf legend > h1 {
+    display: inline;
+}

--- a/src/platform/forms-system/src/js/web-component-fields/commonFieldMapping.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/commonFieldMapping.jsx
@@ -3,7 +3,9 @@ export default function commonFieldMapping(props) {
   const { label, required, error, uiOptions, childrenProps } = props;
 
   return {
-    class: uiOptions?.classNames || '',
+    class: `rjsf-web-component-field${
+      uiOptions?.classNames ? ` ${uiOptions.classNames}` : ''
+    }`,
     enableAnalytics: uiOptions?.enableAnalytics,
     error,
     hint: uiOptions?.hint,


### PR DESCRIPTION
## Summary

- Add fixes for accessibility review feedback for alternate header prototype
- Use widget radio instead of wed component radio for now because of several issues
  - Needing custom CSS and a custom aria-describedby on the h1 in the title of the radio
  - The width of the header of the radio being too small
  - Accessibility focus issues inside of the radio
- Add chapter text above the stepper, And change date component to web component
- Add custom scrolling to focus the h1

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#509

## Testing done

- Browser and mobile view testing

## Screenshots

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/74170256-078e-41af-9a83-70ede690ba13)


## What areas of the site does it impact?

Just the mock prototype form for the alternate header

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
