### PR TITLE
Make a field no longer required in 21-0972

### DIFF
--- a/src/applications/simple-forms/21-0972/pages/veteranIdentificationInformation1.js
+++ b/src/applications/simple-forms/21-0972/pages/veteranIdentificationInformation1.js
@@ -15,9 +15,6 @@ export default {
           N: 'No, the Veteran has never filed a VA claim.',
         },
       },
-      'ui:errorMessages': {
-        required: 'Please select if the Veteran has ever filed a claim with VA',
-      },
     },
   },
   schema: {
@@ -25,6 +22,5 @@ export default {
     properties: {
       veteranHasFiledClaim: yesNoSchema,
     },
-    required: ['veteranHasFiledClaim'],
   },
 };

--- a/src/applications/simple-forms/21-0972/tests/e2e/fixtures/data/minimal-test.json
+++ b/src/applications/simple-forms/21-0972/tests/e2e/fixtures/data/minimal-test.json
@@ -19,6 +19,5 @@
     "last": "Veteran"
   },
   "veteranDateOfBirth": "1950-10-25",
-  "veteranHasFiledClaim": true,
   "veteranSsn": "999442222"
 }

--- a/src/applications/simple-forms/21-0972/tests/pages/veteranIdentificationInformation1.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0972/tests/pages/veteranIdentificationInformation1.unit.spec.jsx
@@ -20,7 +20,7 @@ testNumberOfWebComponentFields(
   pageTitle,
 );
 
-const expectedNumberOfErrors = 1;
+const expectedNumberOfErrors = 0;
 testNumberOfErrorsOnSubmitForWebComponents(
   formConfig,
   schema,


### PR DESCRIPTION
## Summary

Remove `required` validation from the `veteranHasFiledClaim` field on form 21-0972. This arose from the staging review.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/64661

## Testing done

Tested in the browser and updated the fixture.


## What areas of the site does it impact?
Form 21-0972

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).