### PR TITLE
MHV-47290 Card-Design-details-link

### DIFF
--- a/src/applications/mhv/medical-records/components/RecordList/AllergyListItem.jsx
+++ b/src/applications/mhv/medical-records/components/RecordList/AllergyListItem.jsx
@@ -13,7 +13,10 @@ const AllergyListItem = props => {
           className="record-list-item vads-u-padding--3 vads-u-border-color--gray-light vads-u-border--0 vads-u-background-color--gray-lightest card"
           data-testid="record-list-item"
         >
-          <h3 className="vads-u-font-size--h4 vads-u-margin--0 vads-u-line-height--4">
+          <h3
+            className="vads-u-font-size--h4 vads-u-margin--0 vads-u-line-height--4"
+            aria-label={`${record.name} with a date of ${record.date}`}
+          >
             {record.name}
           </h3>
 
@@ -55,12 +58,19 @@ const AllergyListItem = props => {
           <Link
             to={`/allergies/${record.id}`}
             className="vads-u-margin--0 no-print"
+            aria-describedby={`details-button-description-${record.id}`}
           >
             <strong>Details</strong>
             <i
               className="fas fa-angle-right details-link-icon"
               aria-hidden="true"
             />
+            <span
+              id={`details-button-description-${record.id}`}
+              className="sr-only"
+            >
+              '{record.name}' with a date of '{record.date}'
+            </span>
           </Link>
         </div>
       );

--- a/src/applications/mhv/medical-records/components/RecordList/CareSummariesAndNotesListItem.jsx
+++ b/src/applications/mhv/medical-records/components/RecordList/CareSummariesAndNotesListItem.jsx
@@ -19,9 +19,13 @@ const CareSummariesAndNotesListItem = props => {
       className="record-list-item vads-u-padding-y--2 vads-u-border-color--gray-light vads-u-border--0 vads-u-background-color--gray-lightest card"
       data-testid="record-list-item"
     >
-      <h3 className="vads-u-font-size--h4 vads-u-margin--0 vads-u-line-height--4">
+      <h3
+        className="vads-u-font-size--h4 vads-u-margin--0 vads-u-line-height--4"
+        aria-label={`${record.name} with a date of ${dateOrDates()}`}
+      >
         {record.name}
       </h3>
+
       <div className="fields">
         <div>{dateOrDates()}</div>
         {record.location !== EMPTY_FIELD && <div>{record.location}</div>}
@@ -35,12 +39,19 @@ const CareSummariesAndNotesListItem = props => {
       <Link
         to={`/care-summaries-and-notes/${record.id}`}
         className="vads-u-margin-y--0p5 no-print"
+        aria-describedby={`details-button-description-${record.id}`}
       >
         <strong>Details</strong>
         <i
           className="fas fa-angle-right details-link-icon"
           aria-hidden="true"
         />
+        <span
+          id={`details-button-description-${record.id}`}
+          className="sr-only"
+        >
+          '{record.name}' with a date of '{dateOrDates()}'
+        </span>
       </Link>
     </div>
   );

--- a/src/applications/mhv/medical-records/components/RecordList/ConditionListItem.jsx
+++ b/src/applications/mhv/medical-records/components/RecordList/ConditionListItem.jsx
@@ -14,19 +14,30 @@ const ConditionListItem = props => {
           className="record-list-item vads-u-padding--3 vads-u-border-color--gray-light vads-u-border--0 vads-u-background-color--gray-lightest card"
           data-testid="record-list-item"
         >
-          <h3 className="vads-u-font-size--h4 vads-u-margin--0 vads-u-line-height--4">
+          <h3
+            className="vads-u-font-size--h4 vads-u-margin--0 vads-u-line-height--4"
+            aria-label={`${record.name} with a date of ${formattedDate}`}
+          >
             {record.name}
           </h3>
+
           <p className="vads-u-margin--0">Date entered: {formattedDate}</p>
           <Link
             to={`/health-conditions/${record.id}`}
             className="vads-u-margin--0 no-print"
+            aria-describedby={`details-button-description-${record.id}`}
           >
             <strong>Details</strong>
             <i
               className="fas fa-angle-right details-link-icon"
               aria-hidden="true"
             />
+            <span
+              id={`details-button-description-${record.id}`}
+              className="sr-only"
+            >
+              '{record.name}' with a date of '{formattedDate}'
+            </span>
           </Link>
         </div>
       );

--- a/src/applications/mhv/medical-records/components/RecordList/LabsAndTestsListItem.jsx
+++ b/src/applications/mhv/medical-records/components/RecordList/LabsAndTestsListItem.jsx
@@ -24,9 +24,13 @@ const LabsAndTestsListItem = props => {
       className="record-list-item vads-u-padding--3 vads-u-border-color--gray-light vads-u-border--0 vads-u-background-color--gray-lightest card"
       data-testid="record-list-item"
     >
-      <h3 className="vads-u-font-size--h4 vads-u-margin--0 vads-u-line-height--4">
+      <h3
+        className="vads-u-font-size--h4 vads-u-margin--0 vads-u-line-height--4"
+        aria-label={`${record.name} with a date of ${formattedDate}`}
+      >
         {record.name}
       </h3>
+
       <div className="fields">
         <div>{formattedDate}</div>
         {record.type === labTypes.RADIOLOGY && (
@@ -42,12 +46,19 @@ const LabsAndTestsListItem = props => {
       <Link
         to={`/labs-and-tests/${record.id}`}
         className="vads-u-margin-y--0p5 no-print"
+        aria-describedby={`details-button-description-${record.id}`}
       >
         <strong>Details</strong>
         <i
           className="fas fa-angle-right details-link-icon"
           aria-hidden="true"
         />
+        <span
+          id={`details-button-description-${record.id}`}
+          className="sr-only"
+        >
+          '{record.name}' with a date of '{formattedDate}'
+        </span>
       </Link>
     </div>
   );

--- a/src/applications/mhv/medical-records/components/RecordList/VaccinesListItem.jsx
+++ b/src/applications/mhv/medical-records/components/RecordList/VaccinesListItem.jsx
@@ -13,9 +13,13 @@ const VaccinesListItem = props => {
       className="record-list-item vads-u-padding-y--2 vads-u-border-color--gray-light vads-u-border--0 vads-u-background-color--gray-lightest card"
       data-testid="record-list-item"
     >
-      <h3 className="vads-u-font-size--h4 vads-u-margin--0 vads-u-line-height--4">
+      <h3
+        className="vads-u-font-size--h4 vads-u-margin--0 vads-u-line-height--4"
+        aria-label={`${record.name} with a date of ${formattedDate}`}
+      >
         {record.name}
       </h3>
+
       <div className="fields">
         <div>
           <span className="field-label">Date received:</span> {formattedDate}
@@ -39,12 +43,19 @@ const VaccinesListItem = props => {
       <Link
         to={`/vaccines/${record.id}`}
         className="vads-u-margin-y--0p5 no-print"
+        aria-describedby={`details-button-description-${record.id}`}
       >
         <strong>Details</strong>
         <i
           className="fas fa-angle-right details-link-icon"
           aria-hidden="true"
         />
+        <span
+          id={`details-button-description-${record.id}`}
+          className="sr-only"
+        >
+          '{record.name}' with a date of '{formattedDate}'
+        </span>
       </Link>
     </div>
   );

--- a/src/applications/mhv/medical-records/tests/components/CareSummariesAndNotesListItem.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/CareSummariesAndNotesListItem.unit.spec.jsx
@@ -33,35 +33,28 @@ describe('CareSummariesAndNotesListItem', () => {
 
   it('renders without errors', () => {
     const screen = setup();
-    expect(
-      screen.getByText(
-        'Physician procedure note with a date of August 5, 2022',
-        { exact: true },
-      ),
-    ).to.exist;
+    expect(screen.getByText('Physician procedure note', { exact: true })).to
+      .exist;
   });
 
   it('should contain the name of the record', () => {
     const screen = setup();
-    const recordName = screen.getByText(
-      'Physician procedure note with a date of August 5, 2022',
-      {
-        exact: true,
-      },
-    );
+    const recordName = screen.getByText('Physician procedure note', {
+      exact: true,
+    });
     expect(recordName).to.exist;
   });
 
   it('should contain the date of the record', () => {
     const screen = setup();
-    const recordDate = screen.getByText('August', { exact: false });
-    expect(recordDate).to.exist;
+    const recordDate = screen.getAllByText('August', { exact: false });
+    expect(recordDate).to.eq(2);
   });
 
   it('should contain a link to view record details', () => {
     const screen = setup();
     const recordDetailsLink = screen.getByRole('link', {
-      name: 'Details',
+      name: /Details/,
     });
     expect(recordDetailsLink).to.exist;
   });

--- a/src/applications/mhv/medical-records/tests/components/CareSummariesAndNotesListItem.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/CareSummariesAndNotesListItem.unit.spec.jsx
@@ -48,7 +48,7 @@ describe('CareSummariesAndNotesListItem', () => {
   it('should contain the date of the record', () => {
     const screen = setup();
     const recordDate = screen.getAllByText('August', { exact: false });
-    expect(recordDate).to.eq(2);
+    expect(recordDate).to.exist;
   });
 
   it('should contain a link to view record details', () => {

--- a/src/applications/mhv/medical-records/tests/components/CareSummariesAndNotesListItem.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/CareSummariesAndNotesListItem.unit.spec.jsx
@@ -33,15 +33,22 @@ describe('CareSummariesAndNotesListItem', () => {
 
   it('renders without errors', () => {
     const screen = setup();
-    expect(screen.getByText('Physician procedure note', { exact: true })).to
-      .exist;
+    expect(
+      screen.getByText(
+        'Physician procedure note with a date of August 5, 2022',
+        { exact: true },
+      ),
+    ).to.exist;
   });
 
   it('should contain the name of the record', () => {
     const screen = setup();
-    const recordName = screen.getByText('Physician procedure note', {
-      exact: true,
-    });
+    const recordName = screen.getByText(
+      'Physician procedure note with a date of August 5, 2022',
+      {
+        exact: true,
+      },
+    );
     expect(recordName).to.exist;
   });
 

--- a/src/applications/mhv/medical-records/tests/components/LabsAndTestsListItem.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/LabsAndTestsListItem.unit.spec.jsx
@@ -35,7 +35,7 @@ describe('LabsAndTestsListItem component', () => {
     const screen = setup();
     expect(
       screen.getAllByText(
-        'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN: with a date of January 21, 2021',
+        'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN:',
         { exact: true },
       )[0],
     ).to.exist;
@@ -44,12 +44,12 @@ describe('LabsAndTestsListItem component', () => {
   it('should contain the name and date of the record', () => {
     const screen = setup();
     const recordName = screen.getAllByText(
-      'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN: with a date of January 21, 2021"',
+      'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN:',
       {
         exact: true,
       },
     )[0];
-    const recordDate = screen.getByText('January', { exact: false });
+    const recordDate = screen.getAllByText('January', { exact: false });
     expect(recordName).to.exist;
     expect(recordDate).to.exist;
   });
@@ -57,7 +57,7 @@ describe('LabsAndTestsListItem component', () => {
   it('should contain a link to view record details', () => {
     const screen = setup();
     const recordDetailsLink = screen.getByRole('link', {
-      name: 'Details',
+      name: /Details/,
     });
     expect(recordDetailsLink).to.exist;
   });

--- a/src/applications/mhv/medical-records/tests/components/LabsAndTestsListItem.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/LabsAndTestsListItem.unit.spec.jsx
@@ -35,7 +35,7 @@ describe('LabsAndTestsListItem component', () => {
     const screen = setup();
     expect(
       screen.getAllByText(
-        'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN:',
+        'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN: with a date of January 21, 2021',
         { exact: true },
       )[0],
     ).to.exist;
@@ -44,7 +44,7 @@ describe('LabsAndTestsListItem component', () => {
   it('should contain the name and date of the record', () => {
     const screen = setup();
     const recordName = screen.getAllByText(
-      'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN:',
+      'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN: with a date of January 21, 2021"',
       {
         exact: true,
       },

--- a/src/applications/mhv/medical-records/tests/components/VaccineListItem.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/VaccineListItem.unit.spec.jsx
@@ -33,34 +33,28 @@ describe('VaccineListItem', () => {
   it('renders without errors', () => {
     const screen = setup();
     expect(
-      screen.getByText(
-        'INFLUENZA, INJECTABLE, QUADRIVALENT with a date of August 5, 2022',
-        { exact: true },
-      ),
+      screen.getByText('INFLUENZA, INJECTABLE, QUADRIVALENT', { exact: true }),
     ).to.exist;
   });
 
   it('should contain the name of the record', () => {
     const screen = setup();
-    const recordName = screen.getByText(
-      'INFLUENZA, INJECTABLE, QUADRIVALENT with a date of August 5, 2022',
-      {
-        exact: true,
-      },
-    );
+    const recordName = screen.getByText('INFLUENZA, INJECTABLE, QUADRIVALENT', {
+      exact: true,
+    });
     expect(recordName).to.exist;
   });
 
   it('should contain the date of the record', () => {
     const screen = setup();
-    const recordDate = screen.getByText('August', { exact: false });
-    expect(recordDate).to.exist;
+    const recordDate = screen.getAllByText('August', { exact: false });
+    expect(recordDate.length).to.eq(2);
   });
 
   it('should contain a link to view record details', () => {
     const screen = setup();
     const recordDetailsLink = screen.getByRole('link', {
-      name: 'Details',
+      name: /Details/,
     });
     expect(recordDetailsLink).to.exist;
   });

--- a/src/applications/mhv/medical-records/tests/components/VaccineListItem.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/VaccineListItem.unit.spec.jsx
@@ -48,7 +48,7 @@ describe('VaccineListItem', () => {
   it('should contain the date of the record', () => {
     const screen = setup();
     const recordDate = screen.getAllByText('August', { exact: false });
-    expect(recordDate.length).to.eq(2);
+    expect(recordDate).to.exist;
   });
 
   it('should contain a link to view record details', () => {

--- a/src/applications/mhv/medical-records/tests/components/VaccineListItem.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/VaccineListItem.unit.spec.jsx
@@ -33,15 +33,21 @@ describe('VaccineListItem', () => {
   it('renders without errors', () => {
     const screen = setup();
     expect(
-      screen.getByText('INFLUENZA, INJECTABLE, QUADRIVALENT', { exact: true }),
+      screen.getByText(
+        'INFLUENZA, INJECTABLE, QUADRIVALENT with a date of August 5, 2022',
+        { exact: true },
+      ),
     ).to.exist;
   });
 
   it('should contain the name of the record', () => {
     const screen = setup();
-    const recordName = screen.getByText('INFLUENZA, INJECTABLE, QUADRIVALENT', {
-      exact: true,
-    });
+    const recordName = screen.getByText(
+      'INFLUENZA, INJECTABLE, QUADRIVALENT with a date of August 5, 2022',
+      {
+        exact: true,
+      },
+    );
     expect(recordName).to.exist;
   });
 


### PR DESCRIPTION
## Summary
Revised the card design to enhance accessibility for screen readers by adding `aria-describedby` attributes to detail links and `aria-label` attributes to H4 headers.

## Related issue(s)
[MHV-47290]( https://jira.devops.va.gov/secure/RapidBoard.jspa?rapidView=601&view=detail&selectedIssue=MHV-47290&quickFilter=1677)

User Story: As a Medical Records User, I want to understand the hierarchy of each page/card as a screen reader user

AC1 Update description for all MR details links
AC2 Use Aria-described for headers--header of the card and date of the card to be read by screen readers.
AC3
AC4
AC5

Links to UCD:
Sketch Link:
User Flow:
Mobile:
Desktop:
Other Design Notes:

## Testing done

1. Conducted manual testing to confirm that both the screen reader and the user interface accurately present the relevant information.
2. Ran yarn test:unit

## What areas of the site does it impact?

The provided code now includes `aria-label` and `aria-describedby` for the H3 headers/detail button, ensuring that screen readers can convey the information  within the card layout on the "/my-health/medical-records/" page.

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as 

### Authentication

- [x ] Did you login to a local build and verify all authenticated routes work as expected with a test user




