### PR TITLE
Use accordion v2 instead of v3 in 21-0972

### DIFF
--- a/src/applications/simple-forms/21-0972/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-0972/containers/ConfirmationPage.jsx
@@ -24,15 +24,8 @@ const childContent = (
       section-heading={{
         value: 'null',
       }}
-      uswds={{
-        value: 'true',
-      }}
     >
-      <va-accordion-item
-        header="Accrued benefits"
-        id="first"
-        uswds={{ value: 'true' }}
-      >
+      <va-accordion-item header="Accrued benefits" id="first">
         <ul>
           <li>
             Application for Accrued Amounts Due a Deceased Beneficiary (VA Form
@@ -44,7 +37,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item header="Appeals" id="second" uswds={{ value: 'true' }}>
+      <va-accordion-item header="Appeals" id="second">
         <ul>
           <li>
             Decision Review Request: Supplemental Claim (VA Form 20-0995)
@@ -70,11 +63,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item
-        header="Auto allowance"
-        id="third"
-        uswds={{ value: 'true' }}
-      >
+      <va-accordion-item header="Auto allowance" id="third">
         <ul>
           <li>
             Application for Automobile or Other Conveyance and Adaptive
@@ -89,7 +78,6 @@ const childContent = (
       <va-accordion-item
         header="Benefits for certain children with disabilities"
         id="fourth"
-        uswds={{ value: 'true' }}
       >
         <ul>
           <li>
@@ -102,11 +90,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item
-        header="Compensation"
-        id="fifth"
-        uswds={{ value: 'true' }}
-      >
+      <va-accordion-item header="Compensation" id="fifth">
         <ul>
           <li>
             Application for Disability Compensation and Related Compensation
@@ -118,11 +102,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item
-        header="Compensation or Pension"
-        id="sixth"
-        uswds={{ value: 'true' }}
-      >
+      <va-accordion-item header="Compensation or Pension" id="sixth">
         <ul>
           <li>
             Intent to File a Claim for Compensation and/or Pension, or Survivors
@@ -134,11 +114,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item
-        header="Dependents"
-        id="seventh"
-        uswds={{ value: 'true' }}
-      >
+      <va-accordion-item header="Dependents" id="seventh">
         <ul>
           <li>
             Application Request to Add and/or Remove Dependents (VA Form
@@ -150,11 +126,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item
-        header="Dependent parent(s)"
-        id="eighth"
-        uswds={{ value: 'true' }}
-      >
+      <va-accordion-item header="Dependent parent(s)" id="eighth">
         <ul>
           <li>
             Statement of Dependency of Parent(s) (VA Form 21P-509)
@@ -165,11 +137,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item
-        header="Individual unemployability"
-        id="ninth"
-        uswds={{ value: 'true' }}
-      >
+      <va-accordion-item header="Individual unemployability" id="ninth">
         <ul>
           <li>
             Veteran’s Application for Increased Compensation Based on
@@ -181,7 +149,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item header="Pension" id="tenth" uswds={{ value: 'true' }}>
+      <va-accordion-item header="Pension" id="tenth">
         <ul>
           <li>
             Application for Veterans Pension (VA Form 21P-527EZ)
@@ -243,11 +211,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item
-        header="Posttraumatic stress disorder"
-        id="twelfth"
-        uswds={{ value: 'true' }}
-      >
+      <va-accordion-item header="Posttraumatic stress disorder" id="twelfth">
         <ul>
           <li>
             Statement in Support of Claim for Service Connection for
@@ -277,7 +241,6 @@ const childContent = (
       <va-accordion-item
         header="School-age children (ages 18 to 23 and in school)"
         id="thirteenth"
-        uswds={{ value: 'true' }}
       >
         <ul>
           <li>
@@ -292,7 +255,6 @@ const childContent = (
       <va-accordion-item
         header="Specially adapted housing or special home adaptation"
         id="fourteenth"
-        uswds={{ value: 'true' }}
       >
         <ul>
           <li>
@@ -305,11 +267,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item
-        header="Survivor benefits"
-        id="fifteenth"
-        uswds={{ value: 'true' }}
-      >
+      <va-accordion-item header="Survivor benefits" id="fifteenth">
         <ul>
           <li>
             Application for DIC, Survivors Pension, and/or Accrued Benefit (VA


### PR DESCRIPTION
## Summary
This PR reverts our accordions from v3 to v2 per @jeana-adhoc 's advice. The reason we want to do this is that in the Confirmation page of form 21-0972 the v3 accordions will hijack the scroll behavior of the user, which is disorienting. Jeana has also filed [a bug](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2060) about the problem in the component.

## Related issue(s)

https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/64220

## Testing done
Tested in the browser and the scroll is gone.

## What areas of the site does it impact?

21-0972 Confimration page