### PR TITLE
MHV-47413 Aria Label/Tag Needs for 1 - 15 Newest to Oldest

### DIFF
--- a/src/applications/mhv/medical-records/components/RecordList/RecordList.jsx
+++ b/src/applications/mhv/medical-records/components/RecordList/RecordList.jsx
@@ -62,10 +62,12 @@ const RecordList = props => {
         className="pagination vads-u-line-height--4 vads-u-font-size--base vads-u-font-family--sans vads-u-margin-top--0 vads-u-font-weight--normal vads-u-padding-y--1 vads-u-margin-bottom--2 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-light no-print"
         hidden={hidePagination}
         id="showingRecords"
+        aria-label={`Showing ${displayNums[0]} to ${
+          displayNums[1]
+        } of ${totalEntries} records from newest to oldest`}
       >
-        Showing {displayNums[0]}
-        &#8211;
-        {displayNums[1]} of {totalEntries} records from newest to oldest
+        Showing {displayNums[0]} &#8211; {displayNums[1]} of {totalEntries}{' '}
+        records from newest to oldest
       </h2>
       <div className="no-print">
         {currentRecords?.length > 0 &&

--- a/src/applications/mhv/medical-records/components/RecordList/RecordList.jsx
+++ b/src/applications/mhv/medical-records/components/RecordList/RecordList.jsx
@@ -66,8 +66,9 @@ const RecordList = props => {
           displayNums[1]
         } of ${totalEntries} records from newest to oldest`}
       >
-        Showing {displayNums[0]} &#8211; {displayNums[1]} of {totalEntries}{' '}
-        records from newest to oldest
+        Showing {displayNums[0]}
+        &#8211;
+        {displayNums[1]} of {totalEntries} records from newest to oldest
       </h2>
       <div className="no-print">
         {currentRecords?.length > 0 &&


### PR DESCRIPTION
## Summary
Revised the card design to enhance accessibility for screen readers by adding aria-label attributes to H2 headers.

## Related issue(s)
[MHV-47413](https://jira.devops.va.gov/browse/MHV-47413)

User Story: As a Medical Records screen reader user, I want the understand the content, Showing 1 - 10 of 15 records from newest to oldest.

Acceptance Criteria:
AC1 Aria label added to "Showing 1 - 10 of 15 records from newest to oldest" in 
AC2
AC3
AC4
AC5

Links to UCD:
Sketch Link:
User Flow:
Mobile:
Desktop:
Other Design Notes:

## Testing done

1. Conducted manual testing to confirm that both the screen reader and the user interface accurately present the relevant information.
2. Ran yarn test:unit



## What areas of the site does it impact?

The provided code now includes `aria-label` attributes for the H2 headers, ensuring that screen readers can convey the information "Showing 1 - 10 of 15 records from newest to oldest" within the card layout on the "/my-health/medical-records/" page.

my-health/medical-records

## Acceptance criteria

- [ ]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [ ]  Documentation has been updated (link to documentation)
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ]  Feature/bug has a monitor built into Datadog or Grafana (if applicable)
- [ ]  If app impacted requires authentication, did you login to a local build and verify all authenticated routes work as 


### Authentication

- [ x] Did you login to a local build and verify all authenticated routes work as expected with a test user
