### PR TITLE
VACMS-14931 PAW URL change

### DIFF
--- a/src/applications/pact-act/manifest.json
+++ b/src/applications/pact-act/manifest.json
@@ -2,5 +2,5 @@
   "appName": "PACT Act",
   "entryFile": "./pact-act-entry.jsx",
   "entryName": "pact-act",
-  "rootUrl": "/test/pact-act"
+  "rootUrl": "/pact-act-wizard-test"
 }


### PR DESCRIPTION
## Summary
Our previous URL for the PACT Act wizard (including `/test/`) was being rejected by the VA servers. We needed to update to a new URL.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14931