### PR TITLE
Change Your to Alternate signer in form 21-0972

### DIFF
--- a/src/applications/simple-forms/21-0972/config/form.js
+++ b/src/applications/simple-forms/21-0972/config/form.js
@@ -132,11 +132,11 @@ const formConfig = {
   defaultDefinitions: {},
   chapters: {
     preparerPersonalInformationChapter: {
-      title: 'Your personal information',
+      title: 'Alternate signer’s personal information',
       pages: {
         preparerPersonalInformation: {
           path: 'preparer-personal-information',
-          title: 'Your personal information',
+          title: 'Alternate signer’s personal information',
           // we want req'd fields prefilled for LOCAL testing/previewing
           // one single initialData prop here will suffice for entire form
           initialData:
@@ -149,33 +149,33 @@ const formConfig = {
       },
     },
     preparerAddressChapter: {
-      title: 'Your mailing address',
+      title: 'Alternate signer’s mailing address',
       pages: {
         preparerAddress: {
           path: 'preparer-address',
-          title: 'Your mailing address',
+          title: 'Alternate signer’s mailing address',
           uiSchema: preparerAddress.uiSchema,
           schema: preparerAddress.schema,
         },
       },
     },
     preparerContactInformationChapter: {
-      title: 'Your contact information',
+      title: 'Alternate signer’s contact information',
       pages: {
         preparerContactInformation: {
           path: 'preparer-contact-information',
-          title: 'Your contact information',
+          title: 'Alternate signer’s contact information',
           uiSchema: preparerContactInformation.uiSchema,
           schema: preparerContactInformation.schema,
         },
       },
     },
     claimantIdentificationChapter: {
-      title: 'Who you’ll be signing for',
+      title: 'Who the alternate signer will be signing for',
       pages: {
         claimantIdentification: {
           path: 'claimant-identification',
-          title: 'Who you’ll be signing for',
+          title: 'Who the alternate signer will be signing for',
           uiSchema: claimantIdentification.uiSchema,
           schema: claimantIdentification.schema,
         },


### PR DESCRIPTION
## Summary
This PR changes some verbiage, namely the use of "Your" is removed in favor of language like "Alternate signer", to be clearer. Please see [this PR](https://github.com/department-of-veterans-affairs/VA.gov-team-forms/pull/528/files) for the source of truth.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/527

## Testing done

Tested in browser.

## What areas of the site does it impact?

A few steps from form 21-0972
