### PR TITLE
MHV-45377: Added confirmation logic, disabled button on success, cleanup

### DIFF
--- a/src/applications/mhv/medications/actions/prescriptions.js
+++ b/src/applications/mhv/medications/actions/prescriptions.js
@@ -28,6 +28,7 @@ export const fillPrescription = prescriptionId => async dispatch => {
     return null;
   } catch (error) {
     const err = error.errors[0];
+    err.id = prescriptionId;
     dispatch({
       type: Actions.Prescriptions.FILL_ERROR,
       err,

--- a/src/applications/mhv/medications/components/shared/FillRefillButton.jsx
+++ b/src/applications/mhv/medications/components/shared/FillRefillButton.jsx
@@ -1,18 +1,19 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { fillPrescription } from '../../actions/prescriptions';
 
 const FillRefillButton = rx => {
   const dispatch = useDispatch();
-  const [isAlertVisible, setAlertVisible] = useState(false);
 
   const {
     cmopDivisionPhone,
     dispensedDate,
+    error,
     prescriptionId,
     refillRemaining,
     refillStatus,
+    success,
   } = rx;
 
   if (
@@ -25,9 +26,15 @@ const FillRefillButton = rx => {
   if (refillStatus === 'active' || refillStatus === 'activeParked') {
     return (
       <div className="no-print">
-        {/* TODO: Confirmation Message goes here */}
-        <div hidden={!isAlertVisible}>
-          <va-alert status="error" visible={isAlertVisible}>
+        {success && (
+          <va-alert status="success">
+            <p className="vads-u-margin-y--0">
+              The fill request has been submitted successfully
+            </p>
+          </va-alert>
+        )}
+        {error && (
+          <va-alert status="error">
             <p className="vads-u-margin-y--0">
               We didn’t get your refill request. Try again.
             </p>
@@ -46,11 +53,12 @@ const FillRefillButton = rx => {
               )}
             </p>
           </va-alert>
-        </div>
+        )}
         <button
           className="vads-u-width--responsive"
+          disabled={success}
           onClick={() => {
-            setAlertVisible(dispatch(fillPrescription(prescriptionId)));
+            dispatch(fillPrescription(prescriptionId));
           }}
         >
           {`Request ${dispensedDate ? 'a refill' : 'the first fill'}`}
@@ -66,9 +74,11 @@ FillRefillButton.propTypes = {
   rx: PropTypes.shape({
     cmopDivisionPhone: PropTypes.string,
     dispensedDate: PropTypes.string,
-    isRefillable: PropTypes.bool,
+    error: PropTypes.object,
     prescriptionId: PropTypes.number,
+    refillRemaining: PropTypes.number,
     refillStatus: PropTypes.string,
+    success: PropTypes.bool,
   }),
 };
 

--- a/src/applications/mhv/medications/reducers/prescriptions.js
+++ b/src/applications/mhv/medications/reducers/prescriptions.js
@@ -37,17 +37,32 @@ export const prescriptionsReducer = (state = initialState, action) => {
     case Actions.Prescriptions.FILL: {
       return {
         ...state,
+        prescriptionsList: state.prescriptionsList?.map(
+          rx =>
+            rx.prescriptionId === action.response.id
+              ? { ...rx, error: undefined, success: true }
+              : rx,
+        ),
+        prescriptionDetails: {
+          ...state.prescriptionDetails,
+          error: undefined,
+          success: true,
+        },
       };
     }
     case Actions.Prescriptions.FILL_ERROR: {
       return {
         ...state,
         prescriptionsList: state.prescriptionsList?.map(
-          rx => (rx.id === action.err.id ? { ...rx, error: action.err } : rx),
+          rx =>
+            rx.prescriptionId === action.err.id
+              ? { ...rx, error: action.err, success: undefined }
+              : rx,
         ),
         prescriptionDetails: {
           ...state.prescriptionDetails,
           error: action.err,
+          success: undefined,
         },
       };
     }


### PR DESCRIPTION
## Summary

* Added confirmation logic + alert
* Made Fill/Refill button disabled on success
* Minor existing logic cleanup

## Related issue(s)

[Jira ticket](https://jira.devops.va.gov/browse/MHV-45377)

## Screenshots

<img width="513" alt="Screenshot 2023-08-31 at 6 14 16 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/3bb1b5c8-ada2-4fde-b5e2-d39d408cd1c4">

<img width="509" alt="Screenshot 2023-08-31 at 6 13 39 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/d149b76c-efb6-49b9-992e-bcbde5fd4ebf">

## What areas of the site does it impact?

my-health/Medications 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
