### PR TITLE
Replacing Select React with react-binding version

### DIFF
--- a/.eslintrc.changed.js
+++ b/.eslintrc.changed.js
@@ -39,10 +39,6 @@ module.exports = {
         use: '<va-pagination>',
       },
       {
-        name: '@department-of-veterans-affairs/component-library/Select',
-        use: '<va-select>',
-      },
-      {
         name: '@department-of-veterans-affairs/component-library/FileInput',
         use: '<va-file-input>',
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,10 +92,6 @@ module.exports = {
         use: '<va-telephone>',
       },
       {
-        name: '@department-of-veterans-affairs/component-library/Select',
-        use: '<va-select>',
-      },
-      {
         name: '@department-of-veterans-affairs/component-library/FileInput',
         use: '<va-file-input>',
       },

--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 import {
   VaModal,
   VaPagination,
+  VaSelect,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { connect } from 'react-redux';
-import Select from '@department-of-veterans-affairs/component-library/Select';
 
 // Relative imports.
 import recordEvent from 'platform/monitoring/record-event';
@@ -238,15 +238,20 @@ export const SearchResults = ({
         </h2>
 
         {/* SORT WIDGET */}
-        <Select
-          additionalClass="find-forms-search--sort-select"
+        <VaSelect
           label="Sort By"
-          includeBlankOption={false}
           name="findFormsSortBySelect"
-          onValueChange={setSortByPropertyNameState(formMetaInfo)}
-          options={FAF_SORT_OPTIONS}
-          value={{ value: sortByPropertyName }}
-        />
+          onVaSelect={({ detail: value }) => {
+            setSortByPropertyNameState(formMetaInfo)(value);
+          }}
+          value={sortByPropertyName}
+        >
+          {FAF_SORT_OPTIONS.map(opt => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </VaSelect>
       </div>
 
       <ul className="vads-l-grid-container--full usa-unstyled-list vads-u-margin-top--2">

--- a/src/applications/find-forms/tests/e2e/find-forms-required.cypress.spec.js
+++ b/src/applications/find-forms/tests/e2e/find-forms-required.cypress.spec.js
@@ -19,7 +19,7 @@ const SELECTORS = {
   SEARCH_FORM: '[data-e2e-id="find-form-search-form"]',
   SEARCH_RESULT_TITLE: '[data-e2e-id="result-title"]',
   NEXT_PAGE: '.pagination-next > li > button',
-  SORT_SELECT_WIDGET: 'select.find-forms-search--sort-select',
+  SORT_SELECT_WIDGET: 'va-select[name="findFormsSortBySelect"]',
 };
 
 describe('functionality of Find Forms', () => {
@@ -94,11 +94,14 @@ describe('functionality of Find Forms', () => {
 
     // Ensure Sort Widget exists
     cy.get(`${SELECTORS.SORT_SELECT_WIDGET}`);
-    cy.get(`${SELECTORS.SORT_SELECT_WIDGET} option`).should(
-      'have.length',
-      FAF_SORT_OPTIONS.length,
-    );
-    cy.get(`${SELECTORS.SORT_SELECT_WIDGET} option:first`)
+    cy.get(`${SELECTORS.SORT_SELECT_WIDGET}`)
+      .shadow()
+      .get(`option`)
+      // Finds both the shadow DOM option and the React Fiber option, so have to multiply 'expected' by 2
+      .should('have.length', FAF_SORT_OPTIONS.length * 2);
+    cy.get(`${SELECTORS.SORT_SELECT_WIDGET}`)
+      .shadow()
+      .get(`option:first`)
       .should('be.selected')
       .should('contain', FAF_SORT_OPTIONS[0]);
   });


### PR DESCRIPTION
## Summary

- Replacing the last remaining instance of the component-library's React Select component with it's web component version via react-binding.
- I work for the design system team.

## Related issue(s)

- Closes #[1915](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1915)

## Testing done

- Tested locally against test data and the dev api using Brave browser.

## What areas of the site does it impact?

Affects the /find-forms app.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [X] The vets-website header does not contain any web-components
- [X] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [X] I reached out in the `#sitewide-public-websites` Slack channel for questions