### PR TITLE
Update breadcrumb for VA appt request flow

### DIFF
--- a/src/applications/vaos/new-appointment/components/DateTimeRequestPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeRequestPage/index.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import moment from 'moment';
-
+import PropTypes from 'prop-types';
 import {
   onCalendarChange,
   routeToNextAppointmentPage,
@@ -19,6 +19,7 @@ import {
 import DateTimeRequestOptions from './DateTimeRequestOptions';
 import SelectedIndicator, { getSelectedLabel } from './SelectedIndicator';
 import { FETCH_STATUS, FLOW_TYPES } from '../../../utils/constants';
+import { selectFeatureBreadcrumbUrlUpdate } from '../../../redux/selectors';
 
 const pageKey = 'requestDateTime';
 const pageTitle = 'Choose an appointment day and time';
@@ -46,7 +47,11 @@ function goForward({ dispatch, data, history, setSubmitted }) {
   }
 }
 
-export default function DateTimeRequestPage() {
+export default function DateTimeRequestPage({ changeCrumb }) {
+  const featureBreadcrumbUrlUpdate = useSelector(state =>
+    selectFeatureBreadcrumbUrlUpdate(state),
+  );
+
   const { data, pageChangeInProgress } = useSelector(
     state => getFormPageInfo(state, pageKey),
     shallowEqual,
@@ -63,6 +68,9 @@ export default function DateTimeRequestPage() {
   useEffect(() => {
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
+    if (featureBreadcrumbUrlUpdate) {
+      changeCrumb(pageTitle);
+    }
   }, []);
 
   const { selectedDates } = data;
@@ -131,3 +139,7 @@ export default function DateTimeRequestPage() {
     </div>
   );
 }
+
+DateTimeRequestPage.propTypes = {
+  changeCrumb: PropTypes.func,
+};

--- a/src/applications/vaos/new-appointment/components/TypeOfVisitPage.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfVisitPage.jsx
@@ -1,11 +1,13 @@
 import React, { useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import FormButtons from '../../components/FormButtons';
 import { getFormPageInfo } from '../redux/selectors';
 import { TYPE_OF_VISIT } from '../../utils/constants';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
+import { selectFeatureBreadcrumbUrlUpdate } from '../../redux/selectors';
 import {
   openFormPage,
   routeToNextAppointmentPage,
@@ -36,7 +38,11 @@ const uiSchema = {
 const pageKey = 'visitType';
 const pageTitle = 'Choose a type of appointment';
 
-export default function TypeOfVisitPage() {
+export default function TypeOfVisitPage({ changeCrumb }) {
+  const featureBreadcrumbUrlUpdate = useSelector(state =>
+    selectFeatureBreadcrumbUrlUpdate(state),
+  );
+
   const { schema, data, pageChangeInProgress } = useSelector(
     state => getFormPageInfo(state, pageKey),
     shallowEqual,
@@ -47,6 +53,9 @@ export default function TypeOfVisitPage() {
     dispatch(openFormPage(pageKey, uiSchema, initialSchema));
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
+    if (featureBreadcrumbUrlUpdate) {
+      changeCrumb(pageTitle);
+    }
   }, []);
 
   return (
@@ -78,3 +87,7 @@ export default function TypeOfVisitPage() {
     </div>
   );
 }
+
+TypeOfVisitPage.propTypes = {
+  changeCrumb: PropTypes.func,
+};

--- a/src/applications/vaos/new-appointment/index.jsx
+++ b/src/applications/vaos/new-appointment/index.jsx
@@ -77,18 +77,15 @@ export function NewAppointment() {
           <Route path={`${match.url}/contact-info`}>
             <ContactInfoPage changeCrumb={newTitle => setCrumb(newTitle)} />
           </Route>
-
           <Route path={`${match.url}/choose-facility-type`}>
             <TypeOfFacilityPage changeCrumb={newTitle => setCrumb(newTitle)} />
           </Route>
-          <Route
-            path={`${match.url}/choose-visit-type`}
-            component={TypeOfVisitPage}
-          />
+          <Route path={`${match.url}/choose-visit-type`}>
+            <TypeOfVisitPage changeCrumb={newTitle => setCrumb(newTitle)} />
+          </Route>
           <Route path={`${match.url}/choose-sleep-care`}>
             <TypeOfSleepCarePage changeCrumb={newTitle => setCrumb(newTitle)} />
           </Route>
-
           <Route path={`${match.url}/choose-eye-care`}>
             <TypeOfEyeCarePage changeCrumb={newTitle => setCrumb(newTitle)} />
           </Route>
@@ -100,15 +97,12 @@ export function NewAppointment() {
           <Route path={`${match.url}/preferred-date`}>
             <PreferredDatePage changeCrumb={newTitle => setCrumb(newTitle)} />
           </Route>
-
-          <Route
-            path={`${match.url}/request-date`}
-            component={DateTimeRequestPage}
-          />
+          <Route path={`${match.url}/request-date`}>
+            <DateTimeRequestPage changeCrumb={newTitle => setCrumb(newTitle)} />
+          </Route>
           <Route path={`${match.url}/select-date`}>
             <DateTimeSelectPage changeCrumb={newTitle => setCrumb(newTitle)} />
           </Route>
-
           <Route path={`${match.url}/va-facility-2`}>
             <VAFacilityPageV2 changeCrumb={newTitle => setCrumb(newTitle)} />
           </Route>


### PR DESCRIPTION
## Summary
This PR updates the breadcrumb structure on the VA request workflow in the appointments application. Since the breadcrumb for direct schedule flow was completed in a previous tickets, [#61284](https://github.com/department-of-veterans-affairs/va.gov-team/issues/61284)  and a majority of these files as shared by the VA requests flow, only "Choose an appointment date and time page" page and "Choose a type of appointment" page needs updating.

## Acceptance Criteria
Background: the `va_online_scheduling_breadcrumb_url_update` toggle is on

Given the user is on `Upcoming VA appointments` landing page, 
And the user clicks on `Start Scheduling` button and lands on the,  


- [ ] Choose an appointment date and time page, then breadcrumb will be `VA.gov home > My HealtheVet > Appointments > [Page Header]`

- [ ] Choose a type of appointment, then breadcrumb will be `VA.gov home > My HealtheVet > Appointments > [Page Header]`




## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#61289


## Testing done

n/a

## Screenshots

![Screenshot 2023-09-05 at 12 42 41 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/ea290974-ced2-4308-a526-24e376021491)

___

![Screenshot 2023-09-05 at 12 43 02 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/63a158c8-ea4e-436d-a9c4-59986ec0bd42)


## What areas of the site does it impact?

VAOS breadcrumb

