### PR TITLE
Update statement of truth to support functions for the body

### DIFF
--- a/src/platform/forms/components/review/PreSubmitSection.jsx
+++ b/src/platform/forms/components/review/PreSubmitSection.jsx
@@ -48,6 +48,20 @@ export function fullNameReducer(fullNameString) {
   return fullNameString?.replaceAll(' ', '').toLowerCase();
 }
 
+function statementOfTruthBodyElement(formData, statementOfTruthBody) {
+  switch (typeof statementOfTruthBody) {
+    case 'function':
+      if (typeof statementOfTruthBody(formData) === 'string') {
+        return <p>{statementOfTruthBody(formData)}</p>;
+      }
+      return statementOfTruthBody(formData);
+    case 'string':
+      return <p>{statementOfTruthBody}</p>;
+    default:
+      return statementOfTruthBody;
+  }
+}
+
 /*
 *  RenderPreSubmitSection - renders PreSubmitSection by default or presubmit.CustomComponent
 *  PreSubmitSection - ~Default component that renders if no CustomComponent is provided~ (this describes a decision in RenderPreSubmitSection- describe what PreSubmitSection is, remove this since it's not a prop, or add it as a prop with a default value)
@@ -124,11 +138,7 @@ export function PreSubmitSection(props) {
           </p>
           <article className="vads-u-background-color--gray-lightest vads-u-padding-bottom--3 vads-u-padding-x--3 vads-u-padding-top--1px vads-u-margin-bottom--3">
             <h3>{statementOfTruth.heading || 'Statement of truth'}</h3>
-            {typeof statementOfTruth.body === 'string' ? (
-              <p>{statementOfTruth.body}</p>
-            ) : (
-              statementOfTruth.body
-            )}
+            {statementOfTruthBodyElement(form?.data, statementOfTruth.body)}
             <p>
               I have read and accept the{' '}
               <a href="/privacy-policy/" target="_blank">


### PR DESCRIPTION
## Summary
This updates the statement of truth functionality on the review page to support functions for the body property. This mirrors the functionality already added for the full name path. This is done in order to support conditional logic.

As of now, no forms are taking advantage of this functionality, but future forms in our queue will require it.

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#529