### PR TITLE
Fix retirement field bug

### DIFF
--- a/src/applications/financial-status-report/utils/calculateIncome.js
+++ b/src/applications/financial-status-report/utils/calculateIncome.js
@@ -30,7 +30,12 @@ const defaultIncome = {
 
 // filters for deductions
 const taxFilters = ['State tax', 'Federal tax', 'Local tax'];
-const retirementFilters = ['401K', 'IRA', 'Pension'];
+const retirementFilters = [
+  'Retirement accounts (401k, IRAs, 403b, TSP)',
+  '401K',
+  'IRA',
+  'Pension',
+];
 const socialSecFilters = ['FICA (Social Security and Medicare)'];
 const allFilters = [...taxFilters, ...retirementFilters, ...socialSecFilters];
 
@@ -107,7 +112,6 @@ const calculateIncome = (
   const retirement = filterReduceByName(deductions, retirementFilters);
   const socialSec = filterReduceByName(deductions, socialSecFilters);
   const other = otherDeductionsAmt(deductions, allFilters);
-
   const totDeductions = taxes + retirement + socialSec + other;
   const otherIncome = addlInc + benefitsAmount + socSecAmt;
   const netIncome = grossSalary - totDeductions;


### PR DESCRIPTION

## Summary

This PR resolves a display issue where retirement was showing up as 0.00 but populating in Other as the value + deductions

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/0d086d95-15d1-45d1-9f6e-5b52fdb6fd59)


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#64170


## Testing done

- Tested with SW and EFSR off and was able to get the correct numbers
- Tested streamlined flow
- Tested EFSR maximal flow

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

![Screenshot 2023-09-06 at 1 58 42 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/ccbf61fe-c7e9-4bf9-8d50-80cb72bdd1f7)


## What areas of the site does it impact?

Financial Status Report

### Tasks
 Update transform so Retirement accounts values is populated correctly
 
### Acceptance Criteria

 Retirement field is populated correctly.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed


### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution


