### PR TITLE
Check in/65049/remove tz offset

### DIFF
--- a/src/applications/check-in/hooks/tests/useTravelPayFlags/useTravelPayFlags.unit.spec.jsx
+++ b/src/applications/check-in/hooks/tests/useTravelPayFlags/useTravelPayFlags.unit.spec.jsx
@@ -144,7 +144,7 @@ describe('check-in', () => {
           </Provider>,
         );
         expect(component.getByTestId('travelPayData')).to.contain.text(
-          '2022-08-12T15:15:00',
+          '2022-08-12T15:15:00Z',
         );
       });
     });

--- a/src/applications/check-in/hooks/useTravelPayFlags.jsx
+++ b/src/applications/check-in/hooks/useTravelPayFlags.jsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { format, formatISO } from 'date-fns';
 import { makeSelectCurrentContext, makeSelectForm } from '../selectors';
 import { makeSelectFeatureToggles } from '../utils/selectors/feature-toggles';
+import { removeTimezoneOffset } from '../utils/formatters';
 
 const useTravelPayFlags = appointment => {
   const [travelPayClaimSent, setTravelPayClaimSent] = useState();
@@ -24,7 +25,7 @@ const useTravelPayFlags = appointment => {
   } = data;
 
   const startDate = isTravelLogicEnabled
-    ? formatISO(new Date(appointment.startTime))
+    ? removeTimezoneOffset(formatISO(new Date(appointment.startTime)))
     : format(new Date(appointment.startTime), 'yyyy-LL-dd');
 
   let travelPayData = {

--- a/src/applications/check-in/utils/formatters/formatters.test.unit.spec.js
+++ b/src/applications/check-in/utils/formatters/formatters.test.unit.spec.js
@@ -1,5 +1,10 @@
 import { expect } from 'chai';
-import { formatPhone, formatDemographicString, toCamelCase } from './index';
+import {
+  formatPhone,
+  formatDemographicString,
+  toCamelCase,
+  removeTimezoneOffset,
+} from './index';
 
 describe('check in', () => {
   describe('format helpers', () => {
@@ -37,6 +42,19 @@ describe('check in', () => {
         const str = 'Mailing Address';
         const transformedString = toCamelCase(str);
         expect(transformedString).to.equal('mailingAddress');
+      });
+    });
+    describe('removeTimezoneOffset', () => {
+      it('removes timezone offset', () => {
+        const str1 = removeTimezoneOffset('2023-09-06T16:51:29-07:00');
+        const str2 = removeTimezoneOffset('2023-09-06T16:51:29+07:00');
+        const str3 = removeTimezoneOffset('2023-09-06T16:51:29+0700');
+        const str4 = removeTimezoneOffset('2023-09-06T16:51:29Z');
+
+        expect(str1).to.equal('2023-09-06T16:51:29Z');
+        expect(str2).to.equal('2023-09-06T16:51:29Z');
+        expect(str3).to.equal('2023-09-06T16:51:29Z');
+        expect(str4).to.equal('2023-09-06T16:51:29Z');
       });
     });
   });

--- a/src/applications/check-in/utils/formatters/index.js
+++ b/src/applications/check-in/utils/formatters/index.js
@@ -41,4 +41,17 @@ const toCamelCase = str => {
     .join('');
 };
 
-export { formatPhone, formatDemographicString, toCamelCase };
+/**
+ * @param {string} str
+ */
+
+const removeTimezoneOffset = str => {
+  return str.replace(/(T.*)(Z|[+-](\d{2}:?\d{2}$)|([+-]\d{2}$))/, '$1Z');
+};
+
+export {
+  formatPhone,
+  formatDemographicString,
+  toCamelCase,
+  removeTimezoneOffset,
+};


### PR DESCRIPTION
## Summary

The travel claim API expects the date to not have a TZ offset. This PR adds a utility to remove it.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#25558

## Testing done

Adds unit test for utility.
Updates date string match in cy test.


## What areas of the site does it impact?

Day-of check-in travel claims

## Acceptance criteria

[ ] - date gets submitted with no TZ offset

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

