### PR TITLE
Dbex/64446 toxic exposure intro

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -3,9 +3,9 @@ import { connect } from 'react-redux';
 import * as Sentry from '@sentry/browser';
 import PropTypes from 'prop-types';
 
-import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
-import { RequiredLoginView } from 'platform/user/authorization/components/RequiredLoginView';
-import backendServices from 'platform/user/profile/constants/backendServices';
+import RoutedSavableApp from '@department-of-veterans-affairs/platform-forms/RoutedSavableApp';
+import { RequiredLoginView } from '@department-of-veterans-affairs/platform-user/RequiredLoginView';
+import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
 import {
   WIZARD_STATUS_COMPLETE,
   WIZARD_STATUS_RESTARTING,
@@ -14,6 +14,7 @@ import { isLoggedIn } from 'platform/user/selectors';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
+import { setData } from 'platform/forms-system/src/js/actions';
 import formConfig from './config/form';
 import AddPerson from './containers/AddPerson';
 import ITFWrapper from './containers/ITFWrapper';
@@ -25,23 +26,25 @@ import {
 
 import { MVI_ADD_SUCCEEDED } from './actions';
 import {
-  WIZARD_STATUS,
-  SHOW_8940_4192,
-  PAGE_TITLE_SUFFIX,
   DOCUMENT_TITLE_SUFFIX,
+  PAGE_TITLE_SUFFIX,
+  SHOW_8940_4192,
+  SHOW_TOXIC_EXPOSURE,
+  WIZARD_STATUS,
 } from './constants';
 import {
-  show526Wizard,
   isBDD,
   getPageTitle,
+  getShowToxicExposure,
+  isExpired,
+  show526Wizard,
   showSubform8940And4192,
   wrapWithBreadcrumb,
-  isExpired,
 } from './utils';
 import {
-  getBranches,
-  fetchBranches,
   clearBranches,
+  fetchBranches,
+  getBranches,
 } from './utils/serviceBranches';
 
 export const serviceRequired = [
@@ -69,6 +72,7 @@ export const isIntroPage = ({ pathname = '' } = {}) =>
 
 export const Form526Entry = ({
   children,
+  formData,
   inProgressFormId,
   isBDDForm,
   location,
@@ -76,7 +80,9 @@ export const Form526Entry = ({
   mvi,
   router,
   savedForms,
+  setFormData,
   showSubforms,
+  showToxicExposurePages,
   showWizard,
   user,
 }) => {
@@ -124,8 +130,27 @@ export const Form526Entry = ({
         Sentry.setTag('account_uuid', profile.accountUuid);
         Sentry.setTag('in_progress_form_id', inProgressFormId);
       }
+
+      if (
+        showToxicExposurePages &&
+        typeof formData[SHOW_TOXIC_EXPOSURE] === 'undefined'
+      ) {
+        setFormData({
+          ...formData,
+          [SHOW_TOXIC_EXPOSURE]: showToxicExposurePages,
+        });
+      }
     },
-    [showSubforms, wizardStatus, inProgressFormId, profile, location],
+    [
+      formData,
+      inProgressFormId,
+      location,
+      profile,
+      setFormData,
+      showSubforms,
+      showToxicExposurePages,
+      wizardStatus,
+    ],
   );
 
   useEffect(
@@ -221,6 +246,7 @@ export const Form526Entry = ({
 Form526Entry.propTypes = {
   accountUuid: PropTypes.string,
   children: PropTypes.any,
+  formData: PropTypes.object,
   inProgressFormId: PropTypes.number,
   isBDDForm: PropTypes.bool,
   isStartingOver: PropTypes.bool,
@@ -235,7 +261,9 @@ Form526Entry.propTypes = {
     push: PropTypes.func,
   }),
   savedForms: PropTypes.array,
+  setFormData: PropTypes.func,
   showSubforms: PropTypes.bool,
+  showToxicExposurePages: PropTypes.bool,
   showWizard: PropTypes.bool,
   user: PropTypes.shape({
     profile: PropTypes.shape({}),
@@ -250,9 +278,18 @@ const mapStateToProps = state => ({
   loggedIn: isLoggedIn(state),
   mvi: state.mvi,
   savedForms: state?.user?.profile?.savedForms || [],
+  formData: state?.form?.data,
   showSubforms: showSubform8940And4192(state),
+  showToxicExposurePages: getShowToxicExposure(state),
   showWizard: show526Wizard(state),
   user: state.user,
 });
 
-export default connect(mapStateToProps)(Form526Entry);
+const mapDispatchToProps = {
+  setFormData: setData,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Form526Entry);

--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -15,6 +15,7 @@ import { isLoggedIn } from 'platform/user/selectors';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
 import { setData } from 'platform/forms-system/src/js/actions';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles/useFeatureToggle';
 import formConfig from './config/form';
 import AddPerson from './containers/AddPerson';
 import ITFWrapper from './containers/ITFWrapper';
@@ -35,7 +36,6 @@ import {
 import {
   isBDD,
   getPageTitle,
-  getShowToxicExposure,
   isExpired,
   show526Wizard,
   showSubform8940And4192,
@@ -82,12 +82,15 @@ export const Form526Entry = ({
   savedForms,
   setFormData,
   showSubforms,
-  showToxicExposurePages,
   showWizard,
   user,
 }) => {
   const { profile = {} } = user;
   const wizardStatus = sessionStorage.getItem(WIZARD_STATUS);
+  const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
+  const showToxicExposurePages = useToggleValue(
+    TOGGLE_NAMES.disability526ToxicExposure,
+  );
 
   const hasSavedForm = savedForms.some(
     form =>
@@ -148,7 +151,6 @@ export const Form526Entry = ({
       profile,
       setFormData,
       showSubforms,
-      showToxicExposurePages,
       wizardStatus,
     ],
   );
@@ -263,7 +265,6 @@ Form526Entry.propTypes = {
   savedForms: PropTypes.array,
   setFormData: PropTypes.func,
   showSubforms: PropTypes.bool,
-  showToxicExposurePages: PropTypes.bool,
   showWizard: PropTypes.bool,
   user: PropTypes.shape({
     profile: PropTypes.shape({}),
@@ -280,7 +281,6 @@ const mapStateToProps = state => ({
   savedForms: state?.user?.profile?.savedForms || [],
   formData: state?.form?.data,
   showSubforms: showSubform8940And4192(state),
-  showToxicExposurePages: getShowToxicExposure(state),
   showWizard: show526Wizard(state),
   user: state.user,
 });

--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -9,10 +9,10 @@ import backendServices from '@department-of-veterans-affairs/platform-user/profi
 import {
   WIZARD_STATUS_COMPLETE,
   WIZARD_STATUS_RESTARTING,
-} from 'platform/site-wide/wizard';
+} from '@department-of-veterans-affairs/platform-site-wide/wizard';
 import { isLoggedIn } from 'platform/user/selectors';
 
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import scrollToTop from '@department-of-veterans-affairs/platform-utilities/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
 import { setData } from 'platform/forms-system/src/js/actions';
 import { useFeatureToggle } from '~/platform/utilities/feature-toggles/useFeatureToggle';
@@ -151,6 +151,7 @@ export const Form526Entry = ({
       profile,
       setFormData,
       showSubforms,
+      showToxicExposurePages,
       wizardStatus,
     ],
   );

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -43,6 +43,7 @@ import {
   showPtsdCombat,
   showPtsdNonCombat,
   showSeparationLocation,
+  showToxicExposurePages,
 } from '../utils';
 
 import captureEvents from '../analytics-functions';
@@ -301,14 +302,16 @@ const formConfig = {
         toxicExposureIntro: {
           title: 'Toxic Exposure',
           path: 'toxic-exposure-intro',
-          /* depends: TODO add toggle */
+          depends: showToxicExposurePages,
           uiSchema: toxicExposureIntro.uiSchema,
           schema: toxicExposureIntro.schema,
         },
         toxicExposureConfirm: {
           title: 'Toxic Exposure Confirmation',
           path: 'toxic-exposure-confirm',
-          /* depends: TODO add toggle */
+          depends: formData =>
+            showToxicExposurePages &&
+            ['no', 'notSure'].includes(formData['view:toxicExposureStatus']),
           uiSchema: toxicExposureConfirm.uiSchema,
           schema: toxicExposureConfirm.schema,
         },

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -43,7 +43,6 @@ import {
   showPtsdCombat,
   showPtsdNonCombat,
   showSeparationLocation,
-  showToxicExposurePages,
 } from '../utils';
 
 import captureEvents from '../analytics-functions';
@@ -99,8 +98,6 @@ import {
   summaryOfDisabilities,
   summaryOfEvidence,
   terminallyIll,
-  toxicExposureConfirm,
-  toxicExposureIntro,
   trainingPay,
   trainingPayWaiver,
   uploadPersonalPtsdDocuments,
@@ -110,6 +107,7 @@ import {
   veteranInfo,
   workBehaviorChanges,
 } from '../pages';
+import { toxicExposurePages } from '../pages/toxicExposure/toxicExposurePages';
 
 import { ancillaryFormsWizardDescription } from '../content/ancillaryFormsWizardIntro';
 
@@ -121,8 +119,8 @@ import { createFormConfig781, createFormConfig781a } from './781';
 import createformConfig8940 from './8940';
 
 import {
-  PTSD_INCIDENT_ITERATION,
   NULL_CONDITION_STRING,
+  PTSD_INCIDENT_ITERATION,
   WIZARD_STATUS,
 } from '../constants';
 
@@ -299,22 +297,7 @@ const formConfig = {
     disabilities: {
       title: 'Disabilities', // this probably needs to change
       pages: {
-        toxicExposureIntro: {
-          title: 'Toxic Exposure',
-          path: 'toxic-exposure-intro',
-          depends: showToxicExposurePages,
-          uiSchema: toxicExposureIntro.uiSchema,
-          schema: toxicExposureIntro.schema,
-        },
-        toxicExposureConfirm: {
-          title: 'Toxic Exposure Confirmation',
-          path: 'toxic-exposure-confirm',
-          depends: formData =>
-            showToxicExposurePages &&
-            ['no', 'notSure'].includes(formData['view:toxicExposureStatus']),
-          uiSchema: toxicExposureConfirm.uiSchema,
-          schema: toxicExposureConfirm.schema,
-        },
+        ...toxicExposurePages,
         claimType: {
           title: 'Claim type',
           path: 'claim-type',

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -98,6 +98,8 @@ import {
   summaryOfDisabilities,
   summaryOfEvidence,
   terminallyIll,
+  toxicExposureConfirm,
+  toxicExposureIntro,
   trainingPay,
   trainingPayWaiver,
   uploadPersonalPtsdDocuments,
@@ -296,6 +298,20 @@ const formConfig = {
     disabilities: {
       title: 'Disabilities', // this probably needs to change
       pages: {
+        toxicExposureIntro: {
+          title: 'Toxic Exposure',
+          path: 'toxic-exposure-intro',
+          /* depends: TODO add toggle */
+          uiSchema: toxicExposureIntro.uiSchema,
+          schema: toxicExposureIntro.schema,
+        },
+        toxicExposureConfirm: {
+          title: 'Toxic Exposure Confirmation',
+          path: 'toxic-exposure-confirm',
+          /* depends: TODO add toggle */
+          uiSchema: toxicExposureConfirm.uiSchema,
+          schema: toxicExposureConfirm.schema,
+        },
         claimType: {
           title: 'Claim type',
           path: 'claim-type',

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -339,3 +339,6 @@ export const CHAR_LIMITS = [
 export const MAX_HOUSING_STRING_LENGTH = 500;
 
 export const OMB_CONTROL = '2900-0747';
+
+// used to save feature flag in form data for toxic exposure
+export const SHOW_TOXIC_EXPOSURE = 'view:showToxicExposure';

--- a/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export const confirmDescription = () => {
+  return (
+    <>
+      <p>
+        We want to make sure you get any disability benefits you may be eligible
+        for.
+      </p>
+      <p>
+        We automatically assume (or “presume”) that certain toxic exposures
+        during military service cause certain health conditions. We call these
+        “presumptive conditions.”
+      </p>
+      <p>
+        If you have a presumptive condition, you don’t need to prove that your
+        service caused the condition to get VA disability compensation. You only
+        need to meet the minimum service requirements for the presumption.
+      </p>
+      <p>
+        The recent PACT Act law has many added presumptive conditions and
+        locations for toxic exposures.
+      </p>
+    </>
+  );
+};

--- a/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
@@ -1,5 +1,11 @@
 import React from 'react';
 
+export const introQuestion =
+  'Are you filing a claim for a condition related to a toxic exposure?';
+
+export const confirmQuestion =
+  'Do you think your condition could be connected to a toxic exposure?';
+
 export const confirmDescription = () => {
   return (
     <>

--- a/src/applications/disability-benefits/all-claims/pages/index.js
+++ b/src/applications/disability-benefits/all-claims/pages/index.js
@@ -80,6 +80,8 @@ import * as summaryOfDisabilities from './summaryOfDisabilities';
 import * as summaryOfEvidence from './summaryOfEvidence';
 import * as supplementalBenefits from './supplementalBenefits';
 import * as terminallyIll from './terminallyIll';
+import * as toxicExposureIntro from './toxicExposure/toxicExposureIntro';
+import * as toxicExposureConfirm from './toxicExposure/toxicExposureConfirm';
 import * as trainingPay from './trainingPay';
 import * as trainingPayWaiver from './trainingPayWaiver';
 import * as unemployabilityAdditionalInformation from './unemployabilityAdditionalInformation';
@@ -181,6 +183,8 @@ export {
   summaryOfEvidence,
   supplementalBenefits,
   terminallyIll,
+  toxicExposureConfirm,
+  toxicExposureIntro,
   trainingPay,
   trainingPayWaiver,
   unemployabilityAdditionalInformation,

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposureConfirm.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposureConfirm.js
@@ -11,7 +11,7 @@ export const uiSchema = {
     </h3>
   ),
   'ui:description': confirmDescription,
-  'view:exposureStatus': {
+  'view:confirmExposureStatus': {
     'ui:title': confirmQuestion,
     'ui:widget': 'yesNo',
   },
@@ -19,9 +19,9 @@ export const uiSchema = {
 
 export const schema = {
   type: 'object',
-  required: ['view:exposureStatus'],
+  required: ['view:confirmExposureStatus'],
   properties: {
-    'view:exposureStatus': {
+    'view:confirmExposureStatus': {
       type: 'boolean',
     },
   },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposureConfirm.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposureConfirm.js
@@ -1,5 +1,8 @@
 import React from 'react';
-import { confirmDescription } from '../../content/toxicExposure';
+import {
+  confirmDescription,
+  confirmQuestion,
+} from '../../content/toxicExposure';
 
 export const uiSchema = {
   'ui:title': (
@@ -9,8 +12,7 @@ export const uiSchema = {
   ),
   'ui:description': confirmDescription,
   'view:exposureStatus': {
-    'ui:title':
-      'Do you think your condition could be connected to a toxic exposure?',
+    'ui:title': confirmQuestion,
     'ui:widget': 'yesNo',
   },
 };

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposureConfirm.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposureConfirm.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { confirmDescription } from '../../content/toxicExposure';
+
+export const uiSchema = {
+  'ui:title': (
+    <h3 className="vads-u-font-size--h4 vads-u-margin--0">
+      Toxic Exposure Confirmation
+    </h3>
+  ),
+  'ui:description': confirmDescription,
+  'view:exposureStatus': {
+    'ui:title':
+      'Do you think your condition could be connected to a toxic exposure?',
+    'ui:widget': 'yesNo',
+  },
+};
+
+export const schema = {
+  type: 'object',
+  required: ['view:exposureStatus'],
+  properties: {
+    'view:exposureStatus': {
+      type: 'boolean',
+    },
+  },
+};

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposureIntro.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposureIntro.js
@@ -1,12 +1,12 @@
 import React from 'react';
+import { introQuestion } from '../../content/toxicExposure';
 
 export const uiSchema = {
   'ui:title': (
     <h3 className="vads-u-font-size--h4 vads-u-margin--0">Toxic Exposure</h3>
   ),
   'view:toxicExposureStatus': {
-    'ui:title':
-      'Are you filing a claim for a condition related to a toxic exposure?',
+    'ui:title': introQuestion,
     'ui:description':
       'Toxic exposures include exposures to substances like Agent Orange, burn pits, radiation, asbestos, or contaminated water.',
     'ui:widget': 'radio',

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposureIntro.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposureIntro.js
@@ -5,7 +5,7 @@ export const uiSchema = {
   'ui:title': (
     <h3 className="vads-u-font-size--h4 vads-u-margin--0">Toxic Exposure</h3>
   ),
-  'view:toxicExposureStatus': {
+  'view:exposureStatus': {
     'ui:title': introQuestion,
     'ui:description':
       'Toxic exposures include exposures to substances like Agent Orange, burn pits, radiation, asbestos, or contaminated water.',
@@ -22,9 +22,9 @@ export const uiSchema = {
 
 export const schema = {
   type: 'object',
-  required: ['view:toxicExposureStatus'],
+  required: ['view:exposureStatus'],
   properties: {
-    'view:toxicExposureStatus': {
+    'view:exposureStatus': {
       type: 'string',
       enum: ['yes', 'no', 'notSure'],
     },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposureIntro.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposureIntro.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export const uiSchema = {
+  'ui:title': (
+    <h3 className="vads-u-font-size--h4 vads-u-margin--0">Toxic Exposure</h3>
+  ),
+  'view:toxicExposureStatus': {
+    'ui:title':
+      'Are you filing a claim for a condition related to a toxic exposure?',
+    'ui:description':
+      'Toxic exposures include exposures to substances like Agent Orange, burn pits, radiation, asbestos, or contaminated water.',
+    'ui:widget': 'radio',
+    'ui:options': {
+      labels: {
+        yes: 'Yes',
+        no: 'No',
+        notSure: 'I’m not sure',
+      },
+    },
+  },
+};
+
+export const schema = {
+  type: 'object',
+  required: ['view:toxicExposureStatus'],
+  properties: {
+    'view:toxicExposureStatus': {
+      type: 'string',
+      enum: ['yes', 'no', 'notSure'],
+    },
+  },
+};

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
@@ -1,0 +1,21 @@
+import { toxicExposureConfirm, toxicExposureIntro } from '..';
+import { showToxicExposurePages } from '../../utils/index';
+
+export const toxicExposurePages = {
+  toxicExposureIntro: {
+    title: 'Toxic Exposure',
+    path: 'toxic-exposure-intro',
+    depends: showToxicExposurePages,
+    uiSchema: toxicExposureIntro.uiSchema,
+    schema: toxicExposureIntro.schema,
+  },
+  toxicExposureConfirm: {
+    title: 'Toxic Exposure Confirmation',
+    path: 'toxic-exposure-confirm',
+    depends: formData =>
+      showToxicExposurePages &&
+      ['no', 'notSure'].includes(formData['view:toxicExposureStatus']),
+    uiSchema: toxicExposureConfirm.uiSchema,
+    schema: toxicExposureConfirm.schema,
+  },
+};

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
@@ -14,7 +14,7 @@ export const toxicExposurePages = {
     path: 'toxic-exposure-confirm',
     depends: formData =>
       showToxicExposurePages &&
-      ['no', 'notSure'].includes(formData['view:toxicExposureStatus']),
+      ['no', 'notSure'].includes(formData['view:exposureStatus']),
     uiSchema: toxicExposureConfirm.uiSchema,
     schema: toxicExposureConfirm.schema,
   },

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/minimal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/minimal-test.json
@@ -144,8 +144,6 @@
       "view:bankAccountNumber": "*********1234",
       "view:bankRoutingNumber": "*****2115",
       "view:bankName": "Comerica"
-    },
-    "view:exposureStatus": "no",
-    "view:confirmExposureStatus": "no"
+    }
   }
 }

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/minimal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/minimal-test.json
@@ -144,6 +144,8 @@
       "view:bankAccountNumber": "*********1234",
       "view:bankRoutingNumber": "*****2115",
       "view:bankName": "Comerica"
-    }
+    },
+    "view:exposureStatus": "no",
+    "view:confirmExposureStatus": "no"
   }
 }

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/toxicExposureConfirm.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/toxicExposureConfirm.unit.spec.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
+import userEvent from '@testing-library/user-event';
+import formConfig from '../../../config/form';
+import { confirmQuestion } from '../../../content/toxicExposure';
+
+describe('Toxic Exposure Confirm', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.disabilities.pages.toxicExposureConfirm;
+
+  it('should render confirm page', () => {
+    const screen = render(
+      <DefinitionTester schema={schema} uiSchema={uiSchema} />,
+    );
+
+    // verify both options are present
+    screen.getByRole('radio', { name: 'Yes' });
+    screen.getByRole('radio', { name: 'No' });
+
+    screen.getByText(confirmQuestion);
+  });
+
+  it('should display error when none of the options are selected', () => {
+    const screen = render(
+      <DefinitionTester schema={schema} uiSchema={uiSchema} />,
+    );
+
+    userEvent.click(screen.getByRole('button'));
+
+    screen.getByText('Please provide a response');
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/toxicExposureIntro.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/toxicExposureIntro.unit.spec.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
+import userEvent from '@testing-library/user-event';
+import formConfig from '../../../config/form';
+import { introQuestion } from '../../../content/toxicExposure';
+
+describe('Toxic Exposure Intro', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.disabilities.pages.toxicExposureIntro;
+
+  it('should render intro page', () => {
+    const screen = render(
+      <DefinitionTester schema={schema} uiSchema={uiSchema} />,
+    );
+
+    // verify all 3 options are present
+    screen.getByRole('radio', { name: 'Yes' });
+    screen.getByRole('radio', { name: 'No' });
+    screen.getByRole('radio', { name: 'I’m not sure' });
+
+    screen.getByText(introQuestion);
+  });
+
+  it('should display error when none of the options are selected', () => {
+    const screen = render(
+      <DefinitionTester schema={schema} uiSchema={uiSchema} />,
+    );
+
+    userEvent.click(screen.getByRole('button'));
+
+    screen.getByText('Please provide a response');
+  });
+});

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -669,6 +669,9 @@ export const show526Wizard = state => toggleValues(state).show526Wizard;
 export const showSubform8940And4192 = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.subform89404192];
 
+export const getShowToxicExposure = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.disability526ToxicExposure];
+
 export const show526MaxRating = state =>
   toggleValues(state).disability526MaximumRating;
 

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -27,6 +27,7 @@ import {
   START_TEXT,
   FORM_STATUS_BDD,
   CHAR_LIMITS,
+  SHOW_TOXIC_EXPOSURE,
 } from '../constants';
 import { getBranches } from './serviceBranches';
 
@@ -316,6 +317,8 @@ export const isDisabilityPtsd = disability => {
 
 export const hasRatedDisabilities = formData =>
   formData?.ratedDisabilities?.length > 0;
+
+export const showToxicExposurePages = formData => formData[SHOW_TOXIC_EXPOSURE];
 
 export const isClaimingNew = formData =>
   _.get(

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -53,6 +53,7 @@ export default Object.freeze({
   dependencyVerification: 'dependency_verification',
   dhpConnectedDevicesFitbit: 'dhp_connected_devices_fitbit',
   disability526MaximumRating: 'disability_526_maximum_rating',
+  disability526ToxicExposure: 'disability_526_toxic_exposure',
   dischargeWizardFeatures: 'discharge_wizard_features',
   enrollmentVerification: 'enrollment_verification',
   facilitiesPpmsSuppressAll: 'facilities_ppms_suppress_all',


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
Create the first two pages in the new Toxic Exposure flow ([mocks](https://www.sketch.com/s/c353146f-eceb-4626-9918-7603c693417f/p/BD4968C7-42BF-4104-B376-689E46E4292D/canvas)) 
- _(If bug, how to reproduce)_
n/a
- _(What is the solution, why is this the solution)_
Solution is to create the new pages since they don't currently exist on the digital form
- _(Which team do you work for, does your team own the maintenance of this component?)_
DBEx, yes
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
Date unknown, we are still in research synthesis phase of the project, but created this [placeholder ticket](https://app.zenhub.com/workspaces/disability-experience-63dbdb0a401c4400119d3a44/issues/gh/department-of-veterans-affairs/va.gov-team/65089) to clean up the toggle near the end of the project. Completed target will be 100% of 526 users.

## Related issue(s)
- related vets-api pr to create toggle: https://github.com/department-of-veterans-affairs/vets-api/pull/13766
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team/issues/64446
- _Link to previous change of the code/bug (if applicable)_
n/a
- _Link to epic if not included in ticket_
n/a

## Testing done

- _Describe what the old behavior was prior to the change_
Previously these pages did not exist on the digital form
- _Describe the steps required to verify your changes are working as expected_
1. Enable toggle `disability_526_toxic_exposure`
2. Start a new claim
3. At the beginning of the Disabilities chapter, new TE intro page should display
4. If user selects 'No' or 'Not Sure' on the intro page, then it will take them to the confirm page. If they select 'Yes', it will skip the confirm page.
5. In both cases, it should take you to the claim type page next
- _Describe the tests completed and the results_
Unit tests, manual tests and also looked into e2e tests. Although since we're still dealing with a moving target didn't seem appropriate to modify all the e2e tests yet, but was able to get it working locally.
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/95ae42b4-7508-40f6-8a18-d2b65783905e)

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/a7a74e3c-f031-4a9d-b704-dbf3ead30e6d)

## What areas of the site does it impact?
526EZ

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
