### PR TITLE
Replace en-dash and em-dash with hyphen and proceed as before

### DIFF
--- a/src/applications/facility-locator/components/LocationHours.jsx
+++ b/src/applications/facility-locator/components/LocationHours.jsx
@@ -11,7 +11,6 @@ import { formatOperatingHours } from '../utils/helpers';
 const LocationHours = ({ location, showHoursSpecialInstructions }) => {
   // Derive the formatted hours info.
   const hoursInfo = get(location, 'attributes.hours');
-
   // Derive the time ranges for each day.
   const sunday = formatOperatingHours(get(hoursInfo, 'sunday'));
   const monday = formatOperatingHours(get(hoursInfo, 'monday'));

--- a/src/applications/facility-locator/utils/helpers.jsx
+++ b/src/applications/facility-locator/utils/helpers.jsx
@@ -164,8 +164,10 @@ export const validateIdString = (urlObj, urlPrefixString) => {
  */
 export const formatOperatingHours = operatingHours => {
   if (!operatingHours) return operatingHours;
-  // Remove all whitespace.
-  const sanitizedOperatingHours = operatingHours.replace(/ /g, '');
+  // Remove all whitespace and sanitize dashes.
+  const sanitizedOperatingHours = operatingHours
+    .replace(/ /g, '')
+    .replace(/[–—]/g, '-'); // Replace en and em dashes with hyphens.
 
   if (sanitizedOperatingHours.search(/AM-PM/i) === 0) {
     return operatingHours;


### PR DESCRIPTION
The operating hours sanitizing mechanism didn't handle em- and en- dashes. Replace all types of dashes with hyphen (as expected by processor).

## Summary

- updated helper to process out en- and em- dashes
- times entered such as `"7:30 a.m. – 4:00 p.m."` or `"7:30 a.m. — 4:00 p.m."` could not be processed. 
- Replace dashes with hyphens
- Sitewide Facilities 
- No flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14855

## Testing done

- Tested on: http://localhost:3002/find-locations/facility/vba_349ad (not correct prior)
- Tested on: http://localhost:3002/find-locations/facility/vba_349ac (correct prior)
- Checked multiple locations' opening and closing hours

## Screenshots

Problem screen (facility: vba_349ad)

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   <img width="1120" alt="Screenshot 2023-09-06 at 5 36 26 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/5606931/bb53a989-a5bd-4dd7-939c-d067e526bcf8">    |   <img width="1119" alt="Screenshot 2023-09-06 at 5 42 51 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/5606931/0c5973b0-160c-4892-8551-440bbfe7203a">    |
| Desktop |   <img width="1669" alt="Screenshot 2023-09-06 at 5 35 35 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/5606931/5d02258b-376a-41bf-846f-f85b11a9f347">     |   <img width="1115" alt="Screenshot 2023-09-06 at 5 43 08 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/5606931/a19a70cf-8065-4756-ae91-1e888043960c">    |

Non-problem screen (no change: vba_349ac)

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   <img width="1122" alt="Screenshot 2023-09-06 at 5 41 33 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/5606931/8b68eeda-aca6-4840-973e-99ea080f7766">    |    <img width="1116" alt="Screenshot 2023-09-06 at 5 42 22 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/5606931/c58abc85-c0fa-4454-bf9a-c13c5c2d7f1e">   |
| Desktop |    <img width="1102" alt="Screenshot 2023-09-06 at 5 41 46 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/5606931/d314a92d-8a5d-4e4c-83f4-1fb5b064a816">   |   <img width="1120" alt="Screenshot 2023-09-06 at 5 42 07 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/5606931/6483f82a-e1c1-444d-97fe-91abd6f26802">   |


## What areas of the site does it impact?

Hours of operation display

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable -- helpers are not tested).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (inline code documentation about dashes)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable - N/A)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user


## Requested Feedback (QA steps)

1. Go to: http://595eed4287c3067e2219a633918084eb.review.vetsgov-internal/find-locations/facility/vba_349ad
2. Check that hours are M-F 7:30 a.m. - 4:00 p.m.