### PR TITLE
fix: clean up ga event to remove req bool

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationChannel.jsx
@@ -124,7 +124,7 @@ const NotificationChannel = props => {
                 event: 'int-checkbox-group-option-click',
                 'checkbox-group-optionLabel': `${label} - ${newValue}`,
                 'checkbox-group-label': itemName,
-                'checkbox-group-required': false,
+                'checkbox-group-required': '-',
               };
 
               recordEvent(eventPayload);


### PR DESCRIPTION
## Summary

- Removes the required boolean as it was muddying up the GA dashboards with multiple booleans and making it hard to read what the actual value was for the checkbox.

![Screenshot 2023-09-07 at 8 47 42 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/62dc1b8f-1a6e-45fa-81f6-5eeed30f579e)


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/63727

## Testing done

- Tested locally, but just a minor GA event payload change to reduce noise on dashboards

## Screenshots

NA

## What areas of the site does it impact?

PROFILE

## Acceptance criteria

- [x] Ga event updated
