### PR TITLE
Fix typo on Health Care Application Confirmation page

### DIFF
--- a/src/applications/hca/containers/ConfirmationPage.jsx
+++ b/src/applications/hca/containers/ConfirmationPage.jsx
@@ -35,7 +35,7 @@ const ConfirmationPage = ({ form, profile, isLoggedIn }) => {
       <section>
         <h2>What to do if you have questions now</h2>
         <p>
-          If we haven’t contact you within a week after you submitted your
+          If we haven’t contacted you within a week after you submitted your
           application, please don’t apply again:
         </p>
         <ul>


### PR DESCRIPTION
## Description
This PR corrects a small typo on the confirmation page of the Health Care Application. The typo occurs in a section titled "What to do if you have questions now".

## Related issue(s)
department-of-veterans-affairs/va.gov-team#64937

## Acceptance criteria
- Information sentences flow correctly and are free of typos