### PR TITLE
MHV-47374 Add-From-Newest-To-Oldest-To-The-End-OF-The-Pagination-Bar

### DIFF
--- a/src/applications/mhv/medical-records/components/RecordList/RecordList.jsx
+++ b/src/applications/mhv/medical-records/components/RecordList/RecordList.jsx
@@ -66,9 +66,8 @@ const RecordList = props => {
           displayNums[1]
         } of ${totalEntries} records from newest to oldest`}
       >
-        Showing {displayNums[0]}
-        &#8211;
-        {displayNums[1]} of {totalEntries} records from newest to oldest
+        Showing {displayNums[0]} &#8211; {displayNums[1]} of {totalEntries}{' '}
+        records from newest to oldest
       </h2>
       <div className="no-print">
         {currentRecords?.length > 0 &&

--- a/src/applications/mhv/medical-records/tests/containers/Allergies.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/Allergies.unit.spec.jsx
@@ -42,7 +42,7 @@ describe('Allergies list container', () => {
   });
 
   it('displays a count of the records', () => {
-    expect(screen.getByText('Showing 1–5 of 5 records', { exact: false })).to
+    expect(screen.getByText('Showing 1 – 5 of 5 records', { exact: false })).to
       .exist;
   });
 

--- a/src/applications/mhv/medical-records/tests/containers/LabsAndTests.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/LabsAndTests.unit.spec.jsx
@@ -41,8 +41,8 @@ describe('LabsAndTests list container', () => {
   });
 
   it('displays a count of the records', () => {
-    expect(screen.getByText('Showing 1–10 of 13 records', { exact: false })).to
-      .exist;
+    expect(screen.getByText('Showing 1 – 10 of 13 records', { exact: false }))
+      .to.exist;
   });
 
   it('displays a list of records', async () => {


### PR DESCRIPTION
## Summary
Append "from newest to oldest" to the end of the pagination bar text across all domains in the list of pages. Please note that only a space between the dashes was required, as additional text was added in a separate ticket.

## Related issue(s)

[MHV-47374](https://jira.devops.va.gov/browse/MHV-47374) - Add "from newest to oldest" to the end of the pagination bar text in the list of pages for all domains

User Story: As a Medical Records User, I want to change my
Acceptance Criteria:
AC1
AC2 "From newest to oldest" has been added to the end of the pagination bar text
AC3
AC4
AC5

Links to UCD:
Sketch Link:
User Flow:
Mobile:
Desktop:
Other Design Notes:

Architectural Notes: Always check for the latest designs in Sketch!

## Testing done

Utilize a test user to perform a manual website test, ensuring visual confirmation of the space between the dashes on the pagination bar text of the Medical Records page.

Ran unit 

## What areas of the site does it impact?
The modification had an effect on the pagination text element within the Medical Records page. 

## Acceptance criteria

### Quality Assurance & Testing

- [ x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x ] Did you login to a local build and verify all authenticated routes work as expected with a test user
