### PR TITLE
NOD prototype | Add `uswds` prop to file uploads

### DIFF
--- a/src/applications/appeals/testing/utils/additionalInfoUpload.js
+++ b/src/applications/appeals/testing/utils/additionalInfoUpload.js
@@ -44,6 +44,7 @@ export const additionalInfoUploadUI = {
     },
     classNames: '',
     attachmentName: false,
+    uswds: true,
   }),
   'ui:description': AdditionalInfoUploadDescription,
 };

--- a/src/applications/appeals/testing/utils/evidenceUpload.js
+++ b/src/applications/appeals/testing/utils/evidenceUpload.js
@@ -44,6 +44,7 @@ export const evidenceUploadUI = {
     },
     classNames: '',
     attachmentName: false,
+    uswds: true,
   }),
   'ui:description': EvidenceUploadDescription,
 };

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -104,6 +104,7 @@ const FileField = props => {
   const attachmentIdRequired = schema.additionalItems.required
     ? schema.additionalItems.required.includes('attachmentId')
     : false;
+  const uswds = uiOptions.uswds || null;
 
   const content = {
     upload: uiOptions.buttonText || 'Upload',
@@ -415,6 +416,7 @@ const FileField = props => {
         onPrimaryButtonClick={() => closeRemoveModal({ remove: true })}
         onSecondaryButtonClick={closeRemoveModal}
         visible={showRemoveModal}
+        uswds={uswds}
       >
         <p>
           {removeIndex !== null
@@ -512,6 +514,7 @@ const FileField = props => {
                       {file.name}
                     </strong>
                     <br />
+                    {/* no USWDS v3 "activity progress bar" */}
                     <va-progress-bar percent={progress} />
                     <va-button
                       secondary
@@ -521,6 +524,7 @@ const FileField = props => {
                       }}
                       label={content.cancelLabel(file.name)}
                       text={content.cancel}
+                      uswds={uswds}
                     />
                   </div>
                 )}
@@ -593,6 +597,7 @@ const FileField = props => {
                     index={index}
                     onSubmitPassword={onSubmitPassword}
                     passwordLabel={content.passwordLabel(file.name)}
+                    uswds={uswds}
                   />
                 )}
                 {!formContext.reviewMode &&
@@ -614,6 +619,7 @@ const FileField = props => {
                                 : content.newFile
                             }
                             text={retryButtonText}
+                            uswds={uswds}
                           />
                         )}
                       <va-button
@@ -624,6 +630,7 @@ const FileField = props => {
                         }}
                         label={content.deleteLabel(file.name)}
                         text={deleteButtonText}
+                        uswds={uswds}
                       />
                     </div>
                   )}
@@ -652,6 +659,7 @@ const FileField = props => {
                   onClick={() => fileInputRef?.current?.click()}
                   label={`${uploadText} ${titleString || ''}`}
                   text={uploadText}
+                  uswds={uswds}
                 />
               </label>
             )}

--- a/src/platform/forms-system/src/js/utilities/file/ShowPdfPassword.jsx
+++ b/src/platform/forms-system/src/js/utilities/file/ShowPdfPassword.jsx
@@ -10,6 +10,7 @@ const ShowPdfPassword = ({
   onSubmitPassword,
   passwordLabel = null,
   testVal = '', // for testing
+  uswds,
 }) => {
   const [value, setValue] = useState(testVal);
   const [dirty, setDirty] = useState(false);
@@ -47,6 +48,7 @@ const ShowPdfPassword = ({
         onInput={({ target }) => setValue(target.value || '')}
         onBlur={() => setDirty(true)}
         messageAriaDescribedby={passwordLabel}
+        uswds={uswds}
       />
       <va-button
         className="vads-u-width--auto"
@@ -61,6 +63,7 @@ const ShowPdfPassword = ({
           }
         }}
         label={passwordLabel}
+        uswds={uswds}
       />
     </div>
   );
@@ -71,6 +74,7 @@ ShowPdfPassword.propTypes = {
   index: PropTypes.number,
   passwordLabel: PropTypes.string,
   testVal: PropTypes.string,
+  uswds: PropTypes.bool,
   onSubmitPassword: PropTypes.func,
 };
 

--- a/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
@@ -100,6 +100,47 @@ describe('Schemaform <FileField>', () => {
       .exist;
   });
 
+  it('should render uswds components', () => {
+    const idSchema = {
+      $id: 'field',
+    };
+    const schema = {
+      additionalItems: {},
+      items: [
+        {
+          properties: {},
+        },
+      ],
+    };
+    const uiSchema = fileUploadUI('Files', { uswds: true });
+    const formData = [
+      {
+        confirmationCode: 'abcdef',
+        name: 'Test file name.pdf',
+      },
+    ];
+    const registry = {
+      fields: {
+        SchemaField: () => <div />,
+      },
+    };
+    const { container } = render(
+      <FileField
+        registry={registry}
+        schema={schema}
+        uiSchema={uiSchema}
+        idSchema={idSchema}
+        formData={formData}
+        formContext={formContext}
+        onChange={f => f}
+        requiredSchema={requiredSchema}
+      />,
+    );
+
+    expect($('.delete-upload[uswds]', container)).to.exist;
+    expect($('#upload-button[uswds]', container)).to.exist;
+  });
+
   it('should remove files with empty file object when initializing', async () => {
     const idSchema = {
       $id: 'field',

--- a/src/platform/forms-system/test/js/utilities/file.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/file.unit.spec.js
@@ -304,6 +304,15 @@ describe('ShowPdfPassword', () => {
 
     expect($('va-text-input', container)).to.exist;
     expect($('va-button', container)).to.exist;
+    expect($('va-text-input[uswds]', container)).to.not.exist;
+    expect($('va-button[uswds]', container)).to.not.exist;
+  });
+  it('should render uswds components', () => {
+    const props = getProps();
+    const { container } = render(<ShowPdfPassword {...props} uswds />);
+
+    expect($('va-text-input[uswds]', container)).to.exist;
+    expect($('va-button[uswds]', container)).to.exist;
   });
   it('should show validation error', () => {
     const props = getProps();


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Adding `uswds` property so USWDS v3 web components are rendered within our Notice of Disagreement prototype to be used for user testing
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > To maintain consistency within our testing app, added a `uswds` value to the `ui:options` so it can be passed along to the `FileField` and `ShowPdfPassword` components.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#64944](https://github.com/department-of-veterans-affairs/va.gov-team/issues/64944)

## Testing done

N/A - user testing a prototype

## Screenshots

N/A

## What areas of the site does it impact?

[NOD prototype app ](https://staging.va.gov/decision-reviews/appeals-testing)

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
