### PR TITLE
VACMS-14931 PACT Act initial questions setup

### DIFF
--- a/src/applications/pact-act/actions/index.js
+++ b/src/applications/pact-act/actions/index.js
@@ -1,8 +1,34 @@
-import { PAW_VIEWED_RESULTS_PAGE_1 } from '../constants';
+import {
+  PAW_UPDATE_BURN_PIT_2_1,
+  PAW_UPDATE_SERVICE_PERIOD,
+  PAW_VIEWED_INTRO_PAGE,
+  PAW_VIEWED_RESULTS_PAGE_1,
+} from '../constants';
+
+export const updateIntroPageViewed = value => {
+  return {
+    type: PAW_VIEWED_INTRO_PAGE,
+    payload: value,
+  };
+};
 
 export const updateResultsPage1Viewed = value => {
   return {
     type: PAW_VIEWED_RESULTS_PAGE_1,
+    payload: value,
+  };
+};
+
+export const updateServicePeriod = value => {
+  return {
+    type: PAW_UPDATE_SERVICE_PERIOD,
+    payload: value,
+  };
+};
+
+export const updateBurnPit21 = value => {
+  return {
+    type: PAW_UPDATE_BURN_PIT_2_1,
     payload: value,
   };
 };

--- a/src/applications/pact-act/constants/index.js
+++ b/src/applications/pact-act/constants/index.js
@@ -1,6 +1,14 @@
+export const PAW_UPDATE_BURN_PIT_2_1 = 'pact-act/PAW_UPDATE_BURN_PIT_2_1';
+export const PAW_UPDATE_SERVICE_PERIOD = 'pact-act/PAW_UPDATE_SERVICE_PERIOD';
+export const PAW_VIEWED_INTRO_PAGE = 'pact-act/PAW_VIEWED_INTRO_PAGE';
 export const PAW_VIEWED_RESULTS_PAGE_1 = 'pact-act/PAW_VIEWED_RESULTS_PAGE_1';
 
+// Except for HOME and results pages, left side must match
+// short name codes in utilities/question-data-map
 export const ROUTES = {
+  BURN_PIT_2_1: 'burn-pit-2-1',
+  HOME: 'introduction',
   RESULTS_SET_1_PAGE_1: 'results-1-1',
   RESULTS_SET_1_PAGE_2: 'results-1-2',
+  SERVICE_PERIOD: 'service-period-1',
 };

--- a/src/applications/pact-act/containers/HomePage.jsx
+++ b/src/applications/pact-act/containers/HomePage.jsx
@@ -1,0 +1,52 @@
+import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { ROUTES } from '../constants';
+import { updateIntroPageViewed } from '../actions';
+import { pageSetup } from '../utilities/page-setup';
+
+const HomePage = ({ router, setIntroPageViewed }) => {
+  const H1 = 'Page heading';
+
+  useEffect(() => {
+    pageSetup(H1);
+    setIntroPageViewed(true);
+  });
+
+  const startForm = event => {
+    event.preventDefault();
+    router.push(ROUTES.SERVICE_PERIOD);
+  };
+
+  return (
+    <>
+      <h1>{H1}</h1>
+      <p>Intro text here TBD</p>
+      {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+      <a
+        data-testid="paw-start-form"
+        href="#"
+        className="vads-u-display--block vads-u-margin-top--4 vads-c-action-link--green"
+        onClick={startForm}
+      >
+        Begin
+      </a>
+    </>
+  );
+};
+
+HomePage.propTypes = {
+  router: PropTypes.shape({
+    push: PropTypes.func,
+  }).isRequired,
+  setIntroPageViewed: PropTypes.func.isRequired,
+};
+
+const mapDispatchToProps = {
+  setIntroPageViewed: updateIntroPageViewed,
+};
+
+export default connect(
+  null,
+  mapDispatchToProps,
+)(HomePage);

--- a/src/applications/pact-act/containers/questions/ServicePeriod.jsx
+++ b/src/applications/pact-act/containers/questions/ServicePeriod.jsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import {
+  VaButtonPair,
+  VaRadio,
+  VaRadioOption,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { updateServicePeriod } from '../../actions';
+import { RESPONSES, SHORT_NAME_MAP } from '../../utilities/question-data-map';
+import { ROUTES } from '../../constants';
+import { navigateForward } from '../../utilities/display-logic';
+import { pageSetup } from '../../utilities/page-setup';
+
+const ServicePeriod = ({
+  formResponses,
+  router,
+  setServicePeriod,
+  viewedIntroPage,
+}) => {
+  const [formError, setFormError] = useState(false);
+  const H1 = 'Service Period 1';
+  const servicePeriod = formResponses[SHORT_NAME_MAP.SERVICE_PERIOD];
+
+  useEffect(() => {
+    pageSetup(H1);
+  });
+
+  useEffect(
+    () => {
+      if (!viewedIntroPage) {
+        router.push(ROUTES.HOME);
+      }
+    },
+    [router, viewedIntroPage],
+  );
+
+  const onContinueClick = () => {
+    if (!servicePeriod) {
+      setFormError(true);
+    } else {
+      setFormError(false);
+      navigateForward(SHORT_NAME_MAP.SERVICE_PERIOD, formResponses, router);
+    }
+  };
+
+  const onBackClick = () => {
+    router.push(ROUTES.HOME);
+  };
+
+  const onValueChange = event => {
+    const { value } = event?.detail;
+    setServicePeriod(value);
+
+    if (value) {
+      setFormError(false);
+    }
+  };
+
+  const onBlurInput = () => {
+    if (servicePeriod) {
+      setFormError(false);
+    }
+  };
+
+  return (
+    <>
+      <h1>{H1}</h1>
+      <VaRadio
+        data-testid="paw-servicePeriod"
+        onBlur={onBlurInput}
+        className="vads-u-margin-bottom--3"
+        error={(formError && 'TBD error message') || null}
+        hint=""
+        label={H1}
+        onVaValueChange={onValueChange}
+      >
+        <VaRadioOption
+          checked={servicePeriod === RESPONSES.NINETY_OR_LATER}
+          label={RESPONSES.NINETY_OR_LATER}
+          name={SHORT_NAME_MAP.SERVICE_PERIOD}
+          value={RESPONSES.NINETY_OR_LATER}
+        />
+        <VaRadioOption
+          checked={servicePeriod === RESPONSES.EIGHTYNINE_OR_EARLIER}
+          label={RESPONSES.EIGHTYNINE_OR_EARLIER}
+          name={SHORT_NAME_MAP.SERVICE_PERIOD}
+          value={RESPONSES.EIGHTYNINE_OR_EARLIER}
+        />
+        <VaRadioOption
+          checked={servicePeriod === RESPONSES.DURING_BOTH_PERIODS}
+          label={RESPONSES.DURING_BOTH_PERIODS}
+          name={SHORT_NAME_MAP.SERVICE_PERIOD}
+          value={RESPONSES.DURING_BOTH_PERIODS}
+        />
+      </VaRadio>
+      <VaButtonPair
+        data-testid="paw-buttonPair"
+        onPrimaryClick={onContinueClick}
+        onSecondaryClick={onBackClick}
+        continue
+      />
+    </>
+  );
+};
+
+const mapStateToProps = state => ({
+  formResponses: state?.pactAct?.form,
+  viewedIntroPage: state?.pactAct?.viewedIntroPage,
+});
+
+const mapDispatchToProps = {
+  setServicePeriod: updateServicePeriod,
+};
+
+ServicePeriod.propTypes = {
+  formResponses: PropTypes.object.isRequired,
+  setServicePeriod: PropTypes.func.isRequired,
+  viewedIntroPage: PropTypes.bool.isRequired,
+  router: PropTypes.shape({
+    push: PropTypes.func,
+  }),
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ServicePeriod);

--- a/src/applications/pact-act/containers/questions/burn-pit/BurnPit-2-1.jsx
+++ b/src/applications/pact-act/containers/questions/burn-pit/BurnPit-2-1.jsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import {
+  VaButtonPair,
+  VaRadio,
+  VaRadioOption,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { updateBurnPit21 } from '../../../actions';
+import {
+  RESPONSES,
+  SHORT_NAME_MAP,
+} from '../../../utilities/question-data-map';
+import { ROUTES } from '../../../constants';
+import {
+  areDisplayConditionsMet,
+  navigateForward,
+} from '../../../utilities/display-logic';
+import { pageSetup } from '../../../utilities/page-setup';
+
+const BurnPit21 = ({
+  formResponses,
+  router,
+  setBurnPit21,
+  viewedIntroPage,
+}) => {
+  const [formError, setFormError] = useState(false);
+  const H1 = 'Burn pit S2.1.0, did you serve in any of these locations?';
+  const burnPit21 = formResponses[SHORT_NAME_MAP.BURN_PIT_2_1];
+
+  useEffect(() => {
+    pageSetup(H1);
+  });
+
+  useEffect(
+    () => {
+      if (
+        !viewedIntroPage ||
+        !areDisplayConditionsMet(SHORT_NAME_MAP.BURN_PIT_2_1, formResponses)
+      ) {
+        router.push(ROUTES.HOME);
+      }
+    },
+    [formResponses, router, viewedIntroPage],
+  );
+
+  const onContinueClick = () => {
+    if (!burnPit21) {
+      setFormError(true);
+    } else {
+      setFormError(false);
+      navigateForward(SHORT_NAME_MAP.BURN_PIT_2_1, formResponses, router);
+    }
+  };
+
+  const onBackClick = () => {
+    router.push(ROUTES.SERVICE_PERIOD);
+  };
+
+  const onValueChange = event => {
+    const { value } = event?.detail;
+    setBurnPit21(value);
+
+    if (value) {
+      setFormError(false);
+    }
+  };
+
+  const onBlurInput = () => {
+    if (burnPit21) {
+      setFormError(false);
+    }
+  };
+
+  return (
+    <>
+      <h1>{H1}</h1>
+      <VaRadio
+        data-testid="paw-burnPit2_1"
+        onBlur={onBlurInput}
+        className="vads-u-margin-bottom--3"
+        error={(formError && 'TBD error message') || null}
+        hint=""
+        label={H1}
+        onVaValueChange={onValueChange}
+      >
+        <ul>
+          <li>Bahrain</li>
+          <li>Iraq</li>
+          <li>Kuwait</li>
+          <li>Oman</li>
+          <li>Qatar</li>
+          <li>Saudi Arabia</li>
+          <li>Somalia</li>
+          <li>The United Arab Emirates (UAE)</li>
+          <li>The airspace above any of these locations</li>
+        </ul>
+        <VaRadioOption
+          checked={burnPit21 === RESPONSES.YES}
+          label={RESPONSES.YES}
+          name={RESPONSES.YES}
+          value={RESPONSES.YES}
+        />
+        <VaRadioOption
+          checked={burnPit21 === RESPONSES.NO}
+          label={RESPONSES.NO}
+          name={RESPONSES.NO}
+          value={RESPONSES.NO}
+        />
+        <VaRadioOption
+          checked={burnPit21 === RESPONSES.NOT_SURE}
+          label={RESPONSES.NOT_SURE}
+          name={RESPONSES.NOT_SURE}
+          value={RESPONSES.NOT_SURE}
+        />
+      </VaRadio>
+      <VaButtonPair
+        data-testid="paw-buttonPair"
+        onPrimaryClick={onContinueClick}
+        onSecondaryClick={onBackClick}
+        continue
+      />
+    </>
+  );
+};
+
+const mapStateToProps = state => ({
+  formResponses: state?.pactAct?.form,
+  viewedIntroPage: state?.pactAct?.viewedIntroPage,
+});
+
+const mapDispatchToProps = {
+  setBurnPit21: updateBurnPit21,
+};
+
+BurnPit21.propTypes = {
+  formResponses: PropTypes.object.isRequired,
+  setBurnPit21: PropTypes.func.isRequired,
+  viewedIntroPage: PropTypes.bool.isRequired,
+  router: PropTypes.shape({
+    push: PropTypes.func,
+  }),
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(BurnPit21);

--- a/src/applications/pact-act/containers/results/1/Page1.jsx
+++ b/src/applications/pact-act/containers/results/1/Page1.jsx
@@ -1,31 +1,30 @@
+// TODO: uncomment all when user research is complete
 import React, { useEffect } from 'react';
-import { connect } from 'react-redux';
+// import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import PropTypes from 'prop-types';
 import { waitForRenderThenFocus } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { ROUTES } from '../../../constants';
-import { updateResultsPage1Viewed } from '../../../actions';
+// import { updateResultsPage1Viewed } from '../../../actions';
 import { customizeTitle } from '../../../utilities/customize-title';
 
-const ResultsSet1Page1 = ({
-  router,
-  updateResults1Viewed,
-  viewedResultsPage1,
-}) => {
+const ResultsSet1Page1 = () => {
   const H1 = 'You may be eligible for VA benefits';
 
-  useEffect(
-    () => {
-      document.title = customizeTitle(H1);
+  useEffect(() => {
+    document.title = customizeTitle(H1);
+  });
 
-      if (!viewedResultsPage1) {
-        router.push('/');
-      }
+  // useEffect(
+  // () => {
+  // if (!viewedResultsPage1) {
+  //   router.push('/');
+  // }
 
-      updateResults1Viewed(true);
-    },
-    [router, updateResults1Viewed, viewedResultsPage1],
-  );
+  // updateResults1Viewed(true);
+  // },
+  // [router, updateResults1Viewed, viewedResultsPage1],
+  // );
 
   useEffect(() => {
     window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
@@ -84,19 +83,20 @@ ResultsSet1Page1.propTypes = {
   router: PropTypes.shape({
     push: PropTypes.func,
   }).isRequired,
-  viewedResultsPage1: PropTypes.bool.isRequired,
-  updateResults1Viewed: PropTypes.bool,
+  // viewedResultsPage1: PropTypes.bool.isRequired,
+  // updateResults1Viewed: PropTypes.bool,
 };
 
-const mapStateToProps = state => ({
-  viewedResultsPage1: state?.pactAct?.viewedResultsPage1,
-});
+// const mapStateToProps = state => ({
+//   viewedResultsPage1: state?.pactAct?.viewedResultsPage1,
+// });
 
-const mapDispatchToProps = {
-  updateResults1Viewed: updateResultsPage1Viewed,
-};
+// const mapDispatchToProps = {
+//   updateResults1Viewed: updateResultsPage1Viewed,
+// };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ResultsSet1Page1);
+// export default connect(
+//   mapStateToProps,
+//   mapDispatchToProps,
+// )(ResultsSet1Page1);
+export default ResultsSet1Page1;

--- a/src/applications/pact-act/containers/results/1/Page2.jsx
+++ b/src/applications/pact-act/containers/results/1/Page2.jsx
@@ -1,12 +1,13 @@
+// TODO: uncomment all when user research is complete
 import React, { useEffect, useState } from 'react';
-import { connect } from 'react-redux';
+// import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { waitForRenderThenFocus } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { accordions } from '../../../constants/results-set-1-page-2-accordions';
 import { customizeTitle } from '../../../utilities/customize-title';
-import { ROUTES } from '../../../constants';
+// import { ROUTES } from '../../../constants';
 
-const ResultsSet1Page2 = ({ viewedResultsPage1, router }) => {
+const ResultsSet1Page2 = () => {
   const [hasScrolled, setHasScrolled] = useState(false);
   const H1 = 'Apply for VA benefits now';
 
@@ -14,14 +15,14 @@ const ResultsSet1Page2 = ({ viewedResultsPage1, router }) => {
     document.title = customizeTitle(H1);
   });
 
-  useEffect(
-    () => {
-      if (!viewedResultsPage1) {
-        router.push(ROUTES.RESULTS_SET_1_PAGE_1);
-      }
-    },
-    [viewedResultsPage1, router],
-  );
+  // useEffect(
+  //   () => {
+  //     if (!viewedResultsPage1) {
+  //       router.push(ROUTES.RESULTS_SET_1_PAGE_1);
+  //     }
+  //   },
+  //   [viewedResultsPage1, router],
+  // );
 
   useEffect(
     () => {
@@ -124,15 +125,16 @@ const ResultsSet1Page2 = ({ viewedResultsPage1, router }) => {
   );
 };
 
-const mapStateToProps = state => ({
-  viewedResultsPage1: state?.pactAct?.viewedResultsPage1,
-});
-
 ResultsSet1Page2.propTypes = {
   router: PropTypes.shape({
     push: PropTypes.func,
   }).isRequired,
-  viewedResultsPage1: PropTypes.bool.isRequired,
+  // viewedResultsPage1: PropTypes.bool.isRequired,
 };
 
-export default connect(mapStateToProps)(ResultsSet1Page2);
+// const mapStateToProps = state => ({
+//   viewedResultsPage1: state?.pactAct?.viewedResultsPage1,
+// });
+
+// export default connect(mapStateToProps)(ResultsSet1Page2);
+export default ResultsSet1Page2;

--- a/src/applications/pact-act/reducers/index.js
+++ b/src/applications/pact-act/reducers/index.js
@@ -1,18 +1,59 @@
-import { PAW_VIEWED_RESULTS_PAGE_1 } from '../constants';
+import {
+  PAW_UPDATE_BURN_PIT_2_1,
+  PAW_UPDATE_SERVICE_PERIOD,
+  PAW_VIEWED_INTRO_PAGE,
+  PAW_VIEWED_RESULTS_PAGE_1,
+} from '../constants';
+import { SHORT_NAME_MAP } from '../utilities/question-data-map';
+
+export const createFormStore = shortNameMap => {
+  const storeObject = {};
+
+  for (const question of Object.keys(shortNameMap)) {
+    storeObject[question] = null;
+  }
+
+  return storeObject;
+};
 
 const initialState = {
+  form: createFormStore(SHORT_NAME_MAP),
+  viewedIntroPage: false,
   viewedResultsPage1: false,
 };
 
 const pactAct = (state = initialState, action) => {
-  if (action.type === PAW_VIEWED_RESULTS_PAGE_1) {
-    return {
-      ...state,
-      viewedResultsPage1: action.payload,
-    };
+  switch (action.type) {
+    case PAW_UPDATE_BURN_PIT_2_1:
+      return {
+        ...state,
+        form: {
+          ...state.form,
+          BURN_PIT_2_1: action.payload,
+        },
+      };
+    case PAW_UPDATE_SERVICE_PERIOD:
+      return {
+        ...state,
+        form: {
+          // When the answer to Service Period is changed, wipe the rest of the form clean
+          ...createFormStore(SHORT_NAME_MAP),
+          SERVICE_PERIOD: action.payload,
+        },
+      };
+    case PAW_VIEWED_INTRO_PAGE:
+      return {
+        ...state,
+        viewedIntroPage: action.payload,
+      };
+    case PAW_VIEWED_RESULTS_PAGE_1:
+      return {
+        ...state,
+        viewedResultsPage1: action.payload,
+      };
+    default:
+      return state;
   }
-
-  return state;
 };
 
 export default {

--- a/src/applications/pact-act/routes.jsx
+++ b/src/applications/pact-act/routes.jsx
@@ -1,18 +1,24 @@
+import BurnPit21 from './containers/questions/burn-pit/BurnPit-2-1';
+import HomePage from './containers/HomePage';
 import PACTActApp from './components/PACTActApp';
 import Results1Page1 from './containers/results/1/Page1';
 import Results1Page2 from './containers/results/1/Page2';
+import ServicePeriod from './containers/questions/ServicePeriod';
 import { ROUTES } from './constants';
 
 const routes = {
   path: '/',
   component: PACTActApp,
   indexRoute: {
-    onEnter: (nextState, replace) => replace(`/${ROUTES.RESULTS_SET_1_PAGE_1}`),
+    onEnter: (nextState, replace) => replace(`/${ROUTES.HOME}`),
     component: Results1Page1,
   },
   childRoutes: [
+    { path: ROUTES.BURN_PIT_2_1, component: BurnPit21 },
+    { path: ROUTES.HOME, component: HomePage },
     { path: ROUTES.RESULTS_SET_1_PAGE_1, component: Results1Page1 },
     { path: ROUTES.RESULTS_SET_1_PAGE_2, component: Results1Page2 },
+    { path: ROUTES.SERVICE_PERIOD, component: ServicePeriod },
   ],
 };
 

--- a/src/applications/pact-act/tests/BurnPit-2-1.unit.spec.js
+++ b/src/applications/pact-act/tests/BurnPit-2-1.unit.spec.js
@@ -1,0 +1,129 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { RESPONSES } from '../utilities/question-data-map';
+import { ROUTES } from '../constants';
+
+import BurnPit21 from '../containers/questions/burn-pit/BurnPit-2-1';
+
+const mockStoreStandard = {
+  getState: () => ({
+    pactAct: {
+      form: {
+        BURN_PIT_2_1_0: null,
+        SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
+      },
+      viewedIntroPage: true,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const mockStoreNoIntroPage = {
+  getState: () => ({
+    pactAct: {
+      form: {
+        BURN_PIT_2_1_0: null,
+        SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
+      },
+      viewedIntroPage: false,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const mockStoreDCsNotMet = {
+  getState: () => ({
+    pactAct: {
+      form: {
+        BURN_PIT_2_1_0: null,
+        SERVICE_PERIOD: null,
+      },
+      viewedIntroPage: true,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const setBurnPitStub = sinon.stub();
+const pushStub = sinon.stub();
+
+const propsStandard = {
+  formResponses: {
+    BURN_PIT_2_1_0: null,
+    SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
+  },
+  setBurnPit21: setBurnPitStub,
+  router: {
+    push: pushStub,
+  },
+  viewedIntroPage: true,
+};
+
+const propsNoIntroPage = {
+  formResponses: {
+    BURN_PIT_2_1_0: null,
+    SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
+  },
+  setBurnPit21: setBurnPitStub,
+  router: {
+    push: pushStub,
+  },
+  viewedIntroPage: false,
+};
+
+const propsDCsNotMet = {
+  formResponses: {
+    BURN_PIT_2_1_0: null,
+    SERVICE_PERIOD: null,
+  },
+  setBurnPit21: setBurnPitStub,
+  router: {
+    push: pushStub,
+  },
+  viewedIntroPage: true,
+};
+
+describe('Burn Pit 2.1 Page', () => {
+  afterEach(() => {
+    setBurnPitStub.resetHistory();
+    pushStub.resetHistory();
+  });
+
+  it('should correctly load the burn pit page in the standard flow', () => {
+    const screen = render(
+      <Provider store={mockStoreStandard}>
+        <BurnPit21 {...propsStandard} />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId('paw-burnPit2_1')).to.exist;
+  });
+
+  describe('redirects', () => {
+    it('should redirect to home when the intro page has not been viewed', () => {
+      render(
+        <Provider store={mockStoreNoIntroPage}>
+          <BurnPit21 {...propsNoIntroPage} />
+        </Provider>,
+      );
+
+      expect(pushStub.withArgs(ROUTES.HOME).called).to.be.true;
+    });
+
+    it('should redirect to home when the display conditions are not met', () => {
+      render(
+        <Provider store={mockStoreDCsNotMet}>
+          <BurnPit21 {...propsDCsNotMet} />
+        </Provider>,
+      );
+
+      expect(pushStub.withArgs(ROUTES.HOME).called).to.be.true;
+    });
+  });
+});

--- a/src/applications/pact-act/tests/HomePage.unit.spec.js
+++ b/src/applications/pact-act/tests/HomePage.unit.spec.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+
+import HomePage from '../containers/HomePage';
+
+const mockStoreStandard = {
+  getState: () => {},
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const propsStandard = {
+  setIntroPageViewed: () => {},
+  router: {
+    push: () => {},
+  },
+};
+
+describe('Home Page', () => {
+  it('should correctly load the home page in the standard flow', () => {
+    const screen = render(
+      <Provider store={mockStoreStandard}>
+        <HomePage {...propsStandard} />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId('paw-start-form')).to.exist;
+  });
+});

--- a/src/applications/pact-act/tests/ServicePeriod.unit.spec.js
+++ b/src/applications/pact-act/tests/ServicePeriod.unit.spec.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { RESPONSES } from '../utilities/question-data-map';
+import { ROUTES } from '../constants';
+
+import ServicePeriod from '../containers/questions/ServicePeriod';
+
+const mockStoreStandard = {
+  getState: () => ({
+    pactAct: {
+      form: {
+        BURN_PIT_2_1_0: null,
+        SERVICE_PERIOD: null,
+      },
+      viewedIntroPage: true,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const mockStoreNoIntroPage = {
+  getState: () => ({
+    pactAct: {
+      form: {
+        BURN_PIT_2_1_0: null,
+        SERVICE_PERIOD: null,
+      },
+      viewedIntroPage: false,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const pushStub = sinon.stub();
+
+const propsStandard = {
+  formResponses: {
+    BURN_PIT_2_1_0: null,
+    SERVICE_PERIOD: null,
+  },
+  setServicePeriod: () => {},
+  router: {
+    push: pushStub,
+  },
+  viewedIntroPage: true,
+};
+
+const propsNoIntroPage = {
+  formResponses: {
+    BURN_PIT_2_1_0: null,
+    SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
+  },
+  setServicePeriod: () => {},
+  router: {
+    push: pushStub,
+  },
+  viewedIntroPage: false,
+};
+
+describe('Service Period Page', () => {
+  afterEach(() => {
+    pushStub.resetHistory();
+  });
+
+  it('should correctly load the service period page in the standard flow', () => {
+    const screen = render(
+      <Provider store={mockStoreStandard}>
+        <ServicePeriod {...propsStandard} />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId('paw-servicePeriod')).to.exist;
+  });
+
+  it('should redirect to home when the intro page has not been viewed', () => {
+    render(
+      <Provider store={mockStoreNoIntroPage}>
+        <ServicePeriod {...propsNoIntroPage} />
+      </Provider>,
+    );
+
+    expect(pushStub.withArgs(ROUTES.HOME).called).to.be.true;
+  });
+});

--- a/src/applications/pact-act/tests/cypress/README.md
+++ b/src/applications/pact-act/tests/cypress/README.md
@@ -1,0 +1,25 @@
+# Cypress Test Approach
+
+Reference: [Mural](https://app.mural.co/t/departmentofveteransaffairs9999/m/departmentofveteransaffairs9999/1692989444688/0044b9825c82d8d23920601f68c41a61d047d681?sender=ue51e6049230e03c1248b5078)
+
+We want to test all possible flows to ensure the display logic is functioning as expected, and the user can
+navigate forward and backward correctly in any situation. This includes navigation between questions, and
+to and from the introduction screen and results screens.
+
+## Service Period Folders
+
+There are 3 folders for SERVICE_PERIOD ("When did you serve in the U.S. military?") responses:
+- 1990 or later
+- 1989 or earlier
+- During both of these time periods
+
+These three folders correspond to the 3 response options for this question.
+
+Each of these responses takes a unique path through the application, with "During both of these time periods"
+being the most complex, and including the most questions.
+
+## Service Period Files (Yes, No, I'm not sure)
+
+Each of the files inside the 3 folders listed above have a "Yes," "No" and "I'm not sure" spec file. This means that every question that has
+radio options will be answered based on the file name (answered "Yes" in the `yes.cypress.spec.js` file, for instance). Checkboxes in these flows
+will have one response.

--- a/src/applications/pact-act/tests/cypress/helpers.js
+++ b/src/applications/pact-act/tests/cypress/helpers.js
@@ -1,0 +1,57 @@
+export const START_LINK = 'paw-start-form';
+
+export const SERVICE_PERIOD_INPUT = 'paw-servicePeriod';
+export const BURN_PIT_2_1_INPUT = 'paw-burnPit2_1';
+
+export const clickStart = () =>
+  cy
+    .findByTestId(START_LINK)
+    .should('be.visible')
+    .click();
+
+export const verifyUrl = link =>
+  cy.url().should('contain', `/pact-act-wizard-test/${link}`);
+
+export const verifyElement = selector =>
+  cy.findByTestId(selector).should('exist');
+
+export const selectRadio = (selector, index) =>
+  cy
+    .findByTestId(selector)
+    .should('exist')
+    .get('va-radio-option')
+    .eq(index)
+    .click();
+
+export const clickBack = () =>
+  cy
+    .findByTestId('paw-buttonPair')
+    .shadow()
+    .get('va-button')
+    .first()
+    .should('be.visible')
+    .click();
+
+export const clickContinue = () =>
+  cy
+    .findByTestId('paw-buttonPair')
+    .shadow()
+    .get('va-button')
+    .eq(1)
+    .should('be.visible')
+    .click();
+
+export const verifyFormErrorNotShown = selector =>
+  cy
+    .findByTestId(selector)
+    .shadow()
+    .get('span[role="alert"]')
+    .should('not.be.visible');
+
+export const checkFormAlertText = (selector, expectedValue) =>
+  cy
+    .findByTestId(selector)
+    .shadow()
+    .get('span[role="alert"]')
+    .should('be.visible')
+    .should('have.text', expectedValue);

--- a/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/im-not-sure.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/im-not-sure.cypress.spec.js
@@ -1,0 +1,35 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+
+// Note: anything requiring a VA button click is tested here as unit tests cannot
+// target the shadow DOM
+describe('PACT Act', () => {
+  describe(`1989 or earlier - "I'm not sure" and single checkbox responses throughout`, () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit('/pact-act-wizard-test');
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.selectRadio(h.SERVICE_PERIOD_INPUT, 1);
+      h.clickContinue();
+
+      // TODO: test navigation to Agent Orange question(s) when they exist
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.clickBack();
+
+      // Home
+      h.verifyElement(h.START_LINK);
+    });
+  });
+});

--- a/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/no.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/no.cypress.spec.js
@@ -1,0 +1,35 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+
+// Note: anything requiring a VA button click is tested here as unit tests cannot
+// target the shadow DOM
+describe('PACT Act', () => {
+  describe('1989 or earlier - "No" and single checkbox responses throughout', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit('/pact-act-wizard-test');
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.selectRadio(h.SERVICE_PERIOD_INPUT, 1);
+      h.clickContinue();
+
+      // TODO: test navigation to Agent Orange question(s) when they exist
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.clickBack();
+
+      // Home
+      h.verifyElement(h.START_LINK);
+    });
+  });
+});

--- a/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/yes.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/yes.cypress.spec.js
@@ -1,0 +1,35 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+
+// Note: anything requiring a VA button click is tested here as unit tests cannot
+// target the shadow DOM
+describe('PACT Act', () => {
+  describe('1989 or earlier - "Yes" and single checkbox responses throughout', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit('/pact-act-wizard-test');
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.selectRadio(h.SERVICE_PERIOD_INPUT, 1);
+      h.clickContinue();
+
+      // TODO: test navigation to Agent Orange question(s) when they exist
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.clickBack();
+
+      // Home
+      h.verifyElement(h.START_LINK);
+    });
+  });
+});

--- a/src/applications/pact-act/tests/cypress/service-period-1990-or-later/im-not-sure.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1990-or-later/im-not-sure.cypress.spec.js
@@ -1,0 +1,47 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+
+// Note: anything requiring a VA button click is tested here as unit tests cannot
+// target the shadow DOM
+describe('PACT Act', () => {
+  describe(`1990 or later - "I'm not sure" and single checkbox responses throughout`, () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit('/pact-act-wizard-test');
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.selectRadio(h.SERVICE_PERIOD_INPUT, 0);
+      h.clickContinue();
+
+      // BURN_PIT_2_1
+      h.verifyUrl(ROUTES.BURN_PIT_2_1);
+      h.verifyElement(h.BURN_PIT_2_1_INPUT);
+      h.selectRadio(h.BURN_PIT_2_1_INPUT, 2);
+      h.clickContinue();
+
+      // TODO: test navigation to Burn Pits 2.1.1 when that mapping logic exists
+      // BURN_PIT_2_11
+
+      // BURN_PIT_2_1
+      h.verifyUrl(ROUTES.BURN_PIT_2_1);
+      h.verifyElement(h.BURN_PIT_2_1_INPUT);
+      h.clickBack();
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.clickBack();
+
+      // Home
+      h.verifyElement(h.START_LINK);
+    });
+  });
+});

--- a/src/applications/pact-act/tests/cypress/service-period-1990-or-later/no.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1990-or-later/no.cypress.spec.js
@@ -1,0 +1,47 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+
+// Note: anything requiring a VA button click is tested here as unit tests cannot
+// target the shadow DOM
+describe('PACT Act', () => {
+  describe('1990 or later - "No" and single checkbox responses throughout', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit('/pact-act-wizard-test');
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.selectRadio(h.SERVICE_PERIOD_INPUT, 0);
+      h.clickContinue();
+
+      // BURN_PIT_2_1
+      h.verifyUrl(ROUTES.BURN_PIT_2_1);
+      h.verifyElement(h.BURN_PIT_2_1_INPUT);
+      h.selectRadio(h.BURN_PIT_2_1_INPUT, 1);
+      h.clickContinue();
+
+      // TODO: test navigation to Burn Pits 2.1.1 when that mapping logic exists
+      // BURN_PIT_2_11
+
+      // BURN_PIT_2_1
+      h.verifyUrl(ROUTES.BURN_PIT_2_1);
+      h.verifyElement(h.BURN_PIT_2_1_INPUT);
+      h.clickBack();
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.clickBack();
+
+      // Home
+      h.verifyElement(h.START_LINK);
+    });
+  });
+});

--- a/src/applications/pact-act/tests/cypress/service-period-1990-or-later/yes.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1990-or-later/yes.cypress.spec.js
@@ -1,0 +1,47 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+
+// Note: anything requiring a VA button click is tested here as unit tests cannot
+// target the shadow DOM
+describe('PACT Act', () => {
+  describe('1990 or later - "Yes" and single checkbox responses throughout', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit('/pact-act-wizard-test');
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.selectRadio(h.SERVICE_PERIOD_INPUT, 0);
+      h.clickContinue();
+
+      // BURN_PIT_2_1
+      h.verifyUrl(ROUTES.BURN_PIT_2_1);
+      h.verifyElement(h.BURN_PIT_2_1_INPUT);
+      h.selectRadio(h.BURN_PIT_2_1_INPUT, 0);
+      h.clickContinue();
+
+      // TODO: test navigation to Results screen 1 when that mapping logic exists
+      // Results screen 1
+
+      // BURN_PIT_2_1
+      h.verifyUrl(ROUTES.BURN_PIT_2_1);
+      h.verifyElement(h.BURN_PIT_2_1_INPUT);
+      h.clickBack();
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.clickBack();
+
+      // Home
+      h.verifyElement(h.START_LINK);
+    });
+  });
+});

--- a/src/applications/pact-act/tests/cypress/service-period-during-both/deep-linking.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/deep-linking.cypress.spec.js
@@ -1,0 +1,28 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+
+// Note: anything requiring a VA button click is tested here as unit tests cannot
+// target the shadow DOM
+describe('PACT Act', () => {
+  describe('During both of these time periods - deep linking', () => {
+    it('redirects to home when the service period page is loaded without the right criteria', () => {
+      cy.visit('/pact-act-wizard-test/service-period-1');
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+    });
+
+    it('redirects to home when the burn pit 2-1 page is loaded without the right criteria', () => {
+      cy.visit('/pact-act-wizard-test/burn-pit-2-1');
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+});

--- a/src/applications/pact-act/tests/cypress/service-period-during-both/form-validation.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/form-validation.cypress.spec.js
@@ -1,0 +1,47 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+
+// Note: anything requiring a VA button click is tested here as unit tests cannot
+// target the shadow DOM
+describe('PACT Act', () => {
+  describe('During both of these time periods - form validation', () => {
+    it('displays the correct error text when no answer is selected', () => {
+      cy.visit('/pact-act-wizard-test');
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // SERVICE_PERIOD -------------------------------
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      cy.injectAxeThenAxeCheck();
+      h.verifyFormErrorNotShown(h.SERVICE_PERIOD_INPUT);
+
+      h.clickContinue();
+      h.checkFormAlertText(h.SERVICE_PERIOD_INPUT, 'Error TBD error message');
+
+      h.selectRadio(h.SERVICE_PERIOD_INPUT, 2);
+      h.verifyFormErrorNotShown(h.SERVICE_PERIOD_INPUT);
+      h.clickContinue();
+
+      // BURN_PIT_2_1 --------------------------------
+      h.verifyUrl(ROUTES.BURN_PIT_2_1);
+      h.verifyElement(h.BURN_PIT_2_1_INPUT);
+      cy.injectAxeThenAxeCheck();
+      h.verifyFormErrorNotShown(h.BURN_PIT_2_1_INPUT);
+
+      h.clickContinue();
+      h.checkFormAlertText(h.BURN_PIT_2_1_INPUT, 'Error TBD error message');
+
+      h.selectRadio(h.BURN_PIT_2_1_INPUT, 0);
+      h.clickContinue();
+
+      // TODO: test navigation to Results screen 1 when that mapping logic exists
+      // Results screen 1
+    });
+  });
+});

--- a/src/applications/pact-act/tests/cypress/service-period-during-both/im-not-sure.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/im-not-sure.cypress.spec.js
@@ -1,0 +1,47 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+
+// Note: anything requiring a VA button click is tested here as unit tests cannot
+// target the shadow DOM
+describe('PACT Act', () => {
+  describe(`During both of these time periods - "I'm not sure" and single checkbox responses throughout`, () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit('/pact-act-wizard-test');
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.selectRadio(h.SERVICE_PERIOD_INPUT, 2);
+      h.clickContinue();
+
+      // BURN_PIT_2_1
+      h.verifyUrl(ROUTES.BURN_PIT_2_1);
+      h.verifyElement(h.BURN_PIT_2_1_INPUT);
+      h.selectRadio(h.BURN_PIT_2_1_INPUT, 2);
+      h.clickContinue();
+
+      // TODO: test navigation to Burn Pit 2.1.1 when that question exists
+      // BURN_PIT_2_11
+
+      // BURN_PIT_2_1
+      h.verifyUrl(ROUTES.BURN_PIT_2_1);
+      h.verifyElement(h.BURN_PIT_2_1_INPUT);
+      h.clickBack();
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.clickBack();
+
+      // Home
+      h.verifyElement(h.START_LINK);
+    });
+  });
+});

--- a/src/applications/pact-act/tests/cypress/service-period-during-both/no.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/no.cypress.spec.js
@@ -1,0 +1,47 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+
+// Note: anything requiring a VA button click is tested here as unit tests cannot
+// target the shadow DOM
+describe('PACT Act', () => {
+  describe('During both of these time periods - "No" and single checkbox responses throughout', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit('/pact-act-wizard-test');
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.selectRadio(h.SERVICE_PERIOD_INPUT, 2);
+      h.clickContinue();
+
+      // BURN_PIT_2_1
+      h.verifyUrl(ROUTES.BURN_PIT_2_1);
+      h.verifyElement(h.BURN_PIT_2_1_INPUT);
+      h.selectRadio(h.BURN_PIT_2_1_INPUT, 1);
+      h.clickContinue();
+
+      // TODO: test navigation to Burn Pit 2.1.1 when that question exists
+      // BURN_PIT_2_11
+
+      // BURN_PIT_2_1
+      h.verifyUrl(ROUTES.BURN_PIT_2_1);
+      h.verifyElement(h.BURN_PIT_2_1_INPUT);
+      h.clickBack();
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.clickBack();
+
+      // Home
+      h.verifyElement(h.START_LINK);
+    });
+  });
+});

--- a/src/applications/pact-act/tests/cypress/service-period-during-both/yes.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/yes.cypress.spec.js
@@ -1,0 +1,47 @@
+import * as h from '../helpers';
+import { ROUTES } from '../../../constants';
+
+// Note: anything requiring a VA button click is tested here as unit tests cannot
+// target the shadow DOM
+describe('PACT Act', () => {
+  describe('During both of these time periods - "Yes" and single checkbox responses throughout', () => {
+    it('navigates through the flow forward and backward successfully', () => {
+      cy.visit('/pact-act-wizard-test');
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+      h.clickStart();
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.selectRadio(h.SERVICE_PERIOD_INPUT, 2);
+      h.clickContinue();
+
+      // BURN_PIT_2_1
+      h.verifyUrl(ROUTES.BURN_PIT_2_1);
+      h.verifyElement(h.BURN_PIT_2_1_INPUT);
+      h.selectRadio(h.BURN_PIT_2_1_INPUT, 0);
+      h.clickContinue();
+
+      // TODO: test navigation to Results screen 1 when that mapping logic exists
+      // Results screen 1
+
+      // BURN_PIT_2_1
+      h.verifyUrl(ROUTES.BURN_PIT_2_1);
+      h.verifyElement(h.BURN_PIT_2_1_INPUT);
+      h.clickBack();
+
+      // SERVICE_PERIOD
+      h.verifyUrl(ROUTES.SERVICE_PERIOD);
+      h.verifyElement(h.SERVICE_PERIOD_INPUT);
+      h.clickBack();
+
+      // Home
+      h.verifyElement(h.START_LINK);
+    });
+  });
+});

--- a/src/applications/pact-act/tests/display-logic.unit.spec.js
+++ b/src/applications/pact-act/tests/display-logic.unit.spec.js
@@ -1,0 +1,79 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import {
+  areDisplayConditionsMet,
+  navigateForward,
+} from '../utilities/display-logic';
+import { ROUTES } from '../constants';
+import { RESPONSES, SHORT_NAME_MAP } from '../utilities/question-data-map';
+
+describe('utils: display logic', () => {
+  describe('areDisplayConditionsMet', () => {
+    describe('displaying SERVICE_PERIOD', () => {
+      it('SERVICE PERIOD: should return true when the display conditions are met', () => {
+        const formResponses = {
+          BURN_PIT_2_1: null,
+          SERVICE_PERIOD: null,
+        };
+
+        expect(
+          areDisplayConditionsMet('SERVICE_PERIOD', formResponses),
+        ).to.equal(true);
+      });
+    });
+
+    describe('displaying BURN_PIT_2_1', () => {
+      it('BURN_PIT_2_1: should return true when the display conditions are met', () => {
+        const formResponses = {
+          BURN_PIT_2_1: null,
+          SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
+        };
+
+        expect(areDisplayConditionsMet('BURN_PIT_2_1', formResponses)).to.equal(
+          true,
+        );
+      });
+
+      it('BURN_PIT_2_1: should return true when the display conditions are met', () => {
+        const formResponses = {
+          BURN_PIT_2_1: null,
+          SERVICE_PERIOD: RESPONSES.DURING_BOTH_PERIODS,
+        };
+
+        expect(areDisplayConditionsMet('BURN_PIT_2_1', formResponses)).to.equal(
+          true,
+        );
+      });
+
+      it('BURN_PIT_2_1: should return false when the display conditions are not met', () => {
+        const formResponses = {
+          BURN_PIT_2_1: null,
+          SERVICE_PERIOD: RESPONSES.EIGHTYNINE_OR_EARLIER,
+        };
+
+        expect(areDisplayConditionsMet('BURN_PIT_2_1', formResponses)).to.equal(
+          false,
+        );
+      });
+    });
+  });
+
+  describe('navigateForward', () => {
+    describe('routing to BURN_PIT_2_1', () => {
+      const formResponses = {
+        SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
+        BURN_PIT_2_1: null,
+      };
+
+      const router = {
+        push: sinon.spy(),
+      };
+
+      it('SERVICE_PERIOD: should correctly route to the next question', () => {
+        navigateForward(SHORT_NAME_MAP.SERVICE_PERIOD, formResponses, router);
+        expect(router.push.firstCall.calledWith(ROUTES.BURN_PIT_2_1)).to.be
+          .true;
+      });
+    });
+  });
+});

--- a/src/applications/pact-act/tests/reducers.unit.spec.js
+++ b/src/applications/pact-act/tests/reducers.unit.spec.js
@@ -1,0 +1,18 @@
+import { expect } from 'chai';
+import { createFormStore } from '../reducers';
+
+describe('reducer', () => {
+  describe('utilities: createFormStore', () => {
+    const SHORT_NAME_MAP = {
+      SERVICE_PERIOD: 'SERVICE_PERIOD',
+      BURN_PIT_2_1: 'BURN_PIT_2_1',
+    };
+
+    it('should correctly populate the store with all of the question short names', () => {
+      expect(createFormStore(SHORT_NAME_MAP)).to.deep.equal({
+        SERVICE_PERIOD: null,
+        BURN_PIT_2_1: null,
+      });
+    });
+  });
+});

--- a/src/applications/pact-act/utilities/display-conditions.js
+++ b/src/applications/pact-act/utilities/display-conditions.js
@@ -1,0 +1,21 @@
+import { RESPONSES } from './question-data-map';
+
+// Display conditions are:
+// --> SHORT_NAME for a question (A)
+// set equal to:
+// --> list of SHORT_NAMEs for other questions in the flow
+// that affect whether (A) should display
+//
+// This is used when navigating forward and backward in the flow
+//
+// Example:
+// QUESTION_3: {
+//   QUESTION_2: QUESTION_2 response(s) required to show QUESTION_3
+//   QUESTION_1: QUESTION_1 response(s) required to show QUESTION_3
+// }
+export const DISPLAY_CONDITIONS = {
+  SERVICE_PERIOD: {},
+  BURN_PIT_2_1: {
+    SERVICE_PERIOD: [RESPONSES.NINETY_OR_LATER, RESPONSES.DURING_BOTH_PERIODS],
+  },
+};

--- a/src/applications/pact-act/utilities/display-logic.js
+++ b/src/applications/pact-act/utilities/display-logic.js
@@ -1,0 +1,75 @@
+import { DISPLAY_CONDITIONS } from './display-conditions';
+import { ROUTES } from '../constants';
+
+// Create an array of all questions in the flow in order
+const ROADMAP = Object.keys(DISPLAY_CONDITIONS);
+
+// Get the position of a given question in the ROADMAP
+const ROADMAP_INDEX = SHORT_NAME => ROADMAP.indexOf(SHORT_NAME);
+
+// Get the SHORT_NAME of a given index in the ROADMAP
+const ROADMAP_SHORT_NAME = index => ROADMAP[index];
+
+// Evaluates whether a question should display
+// Used when navigating forward and backward
+export const areDisplayConditionsMet = (SHORT_NAME, formResponses) => {
+  const displayConditionsForShortName = DISPLAY_CONDITIONS[SHORT_NAME];
+  let displayConditionsAreMet = false;
+  const listOfOtherQuestionsToEvaluate = Object.keys(
+    displayConditionsForShortName,
+  );
+
+  // If display conditions are empty
+  if (!listOfOtherQuestionsToEvaluate.length) {
+    return true;
+  }
+
+  // If question has display conditions, loop through display conditions questions and
+  // compare the required responses with the responses in the form data
+  for (const questionShortName of listOfOtherQuestionsToEvaluate) {
+    const formResponse = formResponses[questionShortName];
+    const requiredResponses =
+      DISPLAY_CONDITIONS?.[SHORT_NAME]?.[questionShortName];
+
+    if (Array.isArray(formResponse)) {
+      // TODO when multi-checkboxes are added
+    } else if (!requiredResponses.includes(formResponse)) {
+      return false;
+    }
+
+    displayConditionsAreMet = true;
+  }
+
+  return displayConditionsAreMet;
+};
+
+// Responsible for determining next question in flow, or redirecting to a results screen
+// Requires SHORT_NAME for current question, form answers in Redux store, and router for pushing to new URLs
+export const navigateForward = (SHORT_NAME, formResponses, router) => {
+  const currentIndex = ROADMAP_INDEX(SHORT_NAME);
+  let nextIndex = null;
+
+  if (currentIndex !== ROADMAP.length - 1) {
+    nextIndex = currentIndex + 1;
+  } else {
+    // TODO go to a results page
+  }
+
+  while (nextIndex <= ROADMAP.length - 1) {
+    if (!areDisplayConditionsMet(ROADMAP[nextIndex], formResponses)) {
+      nextIndex += 1;
+    } else {
+      const shortName = ROADMAP_SHORT_NAME(nextIndex);
+      const nextRoute = ROUTES[shortName];
+
+      if (shortName && nextRoute) {
+        router.push(nextRoute);
+        return;
+      }
+
+      // eslint-disable-next-line no-console
+      console.error('Unable to determine next question to display');
+      return;
+    }
+  }
+};

--- a/src/applications/pact-act/utilities/page-setup.js
+++ b/src/applications/pact-act/utilities/page-setup.js
@@ -1,0 +1,8 @@
+import { waitForRenderThenFocus } from '@department-of-veterans-affairs/platform-utilities/ui';
+import { customizeTitle } from './customize-title';
+
+export const pageSetup = H1 => {
+  window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+  waitForRenderThenFocus('h1');
+  document.title = customizeTitle(H1);
+};

--- a/src/applications/pact-act/utilities/question-batches.js
+++ b/src/applications/pact-act/utilities/question-batches.js
@@ -1,0 +1,8 @@
+// These are the question categories in the PACT Act flow
+// https://app.mural.co/t/departmentofveteransaffairs9999/m/departmentofveteransaffairs9999/1692989444688/0044b9825c82d8d23920601f68c41a61d047d681?sender=ue51e6049230e03c1248b5078
+export const BATCHES = {
+  AGENT_ORANGE: 'Agent Orange',
+  BURN_PITS: 'Burn pits',
+  CAMP_LEJEUNE: 'Lejeune',
+  RADIATION: 'Radiation',
+};

--- a/src/applications/pact-act/utilities/question-component-map.js
+++ b/src/applications/pact-act/utilities/question-component-map.js
@@ -1,0 +1,7 @@
+import { BATCHES } from './question-batches';
+
+// This maps SNAKE_CASE name for a question to the batch (category) for results screen branching
+export const QUESTIONS = {
+  SERVICE_PERIOD: null,
+  BURN_PIT_2_1: BATCHES.BURN_PITS,
+};

--- a/src/applications/pact-act/utilities/question-data-map.js
+++ b/src/applications/pact-act/utilities/question-data-map.js
@@ -1,0 +1,21 @@
+// This file serves to be the source of truth for question text and response text
+// to make content edits simpler and keep responses DRY
+export const QUESTION_MAP = {
+  SERVICE_PERIOD: 'When did you serve in the U.S. military?',
+  BURN_PIT_2_1: 'Did you serve in any of these locations?',
+};
+
+// Left side must match routes in constants/index.js (ROUTES)
+export const SHORT_NAME_MAP = {
+  SERVICE_PERIOD: 'SERVICE_PERIOD',
+  BURN_PIT_2_1: 'BURN_PIT_2_1',
+};
+
+export const RESPONSES = {
+  DURING_BOTH_PERIODS: 'During both of these time periods',
+  EIGHTYNINE_OR_EARLIER: '1989 or earlier',
+  NINETY_OR_LATER: '1990 or later',
+  NO: 'No',
+  NOT_SURE: `I'm not sure`,
+  YES: 'Yes',
+};


### PR DESCRIPTION
## Summary
Add the Service Period question and first Burn Pit question to the PACT Act flow.

Highlights:
- Set up display logic (decision tree) and companion utilities for displaying questions
- Set up constants to define SHORT_NAMEs, question responses, question batch names for DRY code
- Set up comprehensive Cypress suite
- Set up unit tests

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14931

## Testing done
- Tons of Cypress and unit tests
- Manual testing through all Cypress and unit test scenarios

Notes:
- It is expected that trying to deep-link to `/service-period-1` or `/burn-pit-2-1` should redirect to `/introduction`
- Is it expected that some "Continue" buttons do nothing. If the path doesn't exist further, the button will do nothing
- Deep-linking to `/results-1-1` is possible because of Cindy's research study

## Screenshots

<img width="853" alt="Screenshot 2023-09-11 at 10 30 50 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/24286a41-7b89-4d8b-a17a-716cfe1db544">
<img width="851" alt="Screenshot 2023-09-11 at 10 30 55 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/8c9ea7da-eaae-4370-b4f1-8cd0743e68ce">
<img width="850" alt="Screenshot 2023-09-11 at 10 32 06 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/e1a2119c-4bf9-42a3-8403-87a555c1c702">

## Acceptance criteria
- [x] Add introduction page with text simply “intro text here TBD” and a "Begin" CTA link (green-arrow variety)
  - [x] url: /pact-act-wizard-test/introduction
- [x] Add service period question - lorem = service period S1
  - [x] radio button choices: 1990 or later; 1989 or earlier; During both of these time periods
  - [x] logic: ask everyone
  - [x] url: /test/pact-act/service-period-temp
- [x] Added burn pit question 2.1.0 - lorem = burn pit  S2.1.0, did you serve in any of these locations?
  - [x] Logic: only displays if user selected ≥1990 or Both re svc period
  - [x] radio button choices: Yes, No, Not sure
  - [x] url: /test/pact-act/burn-pit-2-1-0
- [x] Implemented Cypress tests and unit tests (for display conditions logic)

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.