### PR TITLE
MHV-49254 Added live Allergies data behind a feature flag

### DIFF
--- a/src/applications/mhv/medical-records/actions/allergies.js
+++ b/src/applications/mhv/medical-records/actions/allergies.js
@@ -3,18 +3,21 @@ import { getAllergies, getAllergy } from '../api/MrApi';
 import * as Constants from '../util/constants';
 import { addAlert } from './alerts';
 
-export const getAllergiesList = () => async dispatch => {
+export const getAllergiesList = useLiveData => async dispatch => {
   try {
-    const response = await getAllergies();
+    const response = await getAllergies(useLiveData);
     dispatch({ type: Actions.Allergies.GET_LIST, response });
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR));
   }
 };
 
-export const getAllergyDetails = conditionId => async dispatch => {
+export const getAllergyDetails = (
+  conditionId,
+  useLiveData,
+) => async dispatch => {
   try {
-    const response = await getAllergy(conditionId);
+    const response = await getAllergy(conditionId, useLiveData);
     dispatch({ type: Actions.Allergies.GET, response });
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR));

--- a/src/applications/mhv/medical-records/api/MrApi.js
+++ b/src/applications/mhv/medical-records/api/MrApi.js
@@ -110,7 +110,7 @@ export const getCondition = id => {
 };
 
 export const getAllergies = useLiveData => {
-  if (useLiveData && IS_TESTING) {
+  if (useLiveData) {
     return apiRequest(`${apiBasePath}/medical_records/allergies`, {
       headers,
     });
@@ -123,7 +123,7 @@ export const getAllergies = useLiveData => {
 };
 
 export const getAllergy = (id, useLiveData) => {
-  if (useLiveData && IS_TESTING) {
+  if (useLiveData) {
     return apiRequest(`${apiBasePath}/medical_records/allergies/${id}`, {
       headers,
     });

--- a/src/applications/mhv/medical-records/api/MrApi.js
+++ b/src/applications/mhv/medical-records/api/MrApi.js
@@ -109,8 +109,8 @@ export const getCondition = id => {
   });
 };
 
-export const getAllergies = () => {
-  if (environment.BUILDTYPE === 'localhost' && IS_TESTING) {
+export const getAllergies = useLiveData => {
+  if (useLiveData && IS_TESTING) {
     return apiRequest(`${apiBasePath}/medical_records/allergies`, {
       headers,
     });
@@ -122,8 +122,8 @@ export const getAllergies = () => {
   });
 };
 
-export const getAllergy = id => {
-  if (environment.BUILDTYPE === 'localhost' && IS_TESTING) {
+export const getAllergy = (id, useLiveData) => {
+  if (useLiveData && IS_TESTING) {
     return apiRequest(`${apiBasePath}/medical_records/allergies/${id}`, {
       headers,
     });

--- a/src/applications/mhv/medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv/medical-records/containers/Allergies.jsx
@@ -6,6 +6,7 @@ import { focusElement } from '@department-of-veterans-affairs/platform-utilities
 import RecordList from '../components/RecordList/RecordList';
 import { setBreadcrumbs } from '../actions/breadcrumbs';
 import {
+  mhvMedicalRecordsDisplayDomains,
   recordType,
   EMPTY_FIELD,
   ALERT_TYPE_ERROR,
@@ -22,7 +23,6 @@ import {
 } from '../util/helpers';
 import AccessTroubleAlertBox from '../components/shared/AccessTroubleAlertBox';
 import { updatePageTitle } from '../../shared/util/helpers';
-import { mhvMedicalRecordsDisplayDomains } from '../util/constants';
 
 const Allergies = () => {
   const dispatch = useDispatch();

--- a/src/applications/mhv/medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv/medical-records/containers/Allergies.jsx
@@ -22,19 +22,26 @@ import {
 } from '../util/helpers';
 import AccessTroubleAlertBox from '../components/shared/AccessTroubleAlertBox';
 import { updatePageTitle } from '../../shared/util/helpers';
+import { mhvMedicalRecordsDisplayDomains } from '../util/constants';
 
 const Allergies = () => {
   const dispatch = useDispatch();
   const allergies = useSelector(state => state.mr.allergies.allergiesList);
   const user = useSelector(state => state.user.profile);
+  const displayDomain = useSelector(state =>
+    mhvMedicalRecordsDisplayDomains(state),
+  );
   const name = nameFormat(user.userFullName);
   const dob = dateFormat(user.dob, 'LL');
   const alertList = useSelector(state => state.mr.alerts?.alertList);
   const [activeAlert, setActiveAlert] = useState();
 
-  useEffect(() => {
-    dispatch(getAllergiesList());
-  }, []);
+  useEffect(
+    () => {
+      dispatch(getAllergiesList(displayDomain));
+    },
+    [displayDomain],
+  );
 
   useEffect(
     () => {

--- a/src/applications/mhv/medical-records/containers/AllergyDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/AllergyDetails.jsx
@@ -11,13 +11,17 @@ import { setBreadcrumbs } from '../actions/breadcrumbs';
 import PrintHeader from '../components/shared/PrintHeader';
 import PrintDownload from '../components/shared/PrintDownload';
 import { processList, sendErrorToSentry } from '../util/helpers';
-import { ALERT_TYPE_ERROR, EMPTY_FIELD, pageTitles } from '../util/constants';
+import {
+  mhvMedicalRecordsDisplayDomains,
+  ALERT_TYPE_ERROR,
+  EMPTY_FIELD,
+  pageTitles,
+} from '../util/constants';
 import AccessTroubleAlertBox from '../components/shared/AccessTroubleAlertBox';
 import {
   generatePdfScaffold,
   updatePageTitle,
 } from '../../shared/util/helpers';
-import { mhvMedicalRecordsDisplayDomains } from '../util/constants';
 
 const AllergyDetails = () => {
   const allergy = useSelector(state => state.mr.allergies.allergyDetails);
@@ -34,7 +38,7 @@ const AllergyDetails = () => {
     () => {
       if (allergyId) dispatch(getAllergyDetails(allergyId, displayDomain));
     },
-    [allergyId, dispatch],
+    [allergyId, dispatch, displayDomain],
   );
 
   useEffect(

--- a/src/applications/mhv/medical-records/containers/AllergyDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/AllergyDetails.jsx
@@ -17,10 +17,14 @@ import {
   generatePdfScaffold,
   updatePageTitle,
 } from '../../shared/util/helpers';
+import { mhvMedicalRecordsDisplayDomains } from '../util/constants';
 
 const AllergyDetails = () => {
   const allergy = useSelector(state => state.mr.allergies.allergyDetails);
   const user = useSelector(state => state.user.profile);
+  const displayDomain = useSelector(state =>
+    mhvMedicalRecordsDisplayDomains(state),
+  );
   const { allergyId } = useParams();
   const dispatch = useDispatch();
   const alertList = useSelector(state => state.mr.alerts?.alertList);
@@ -28,7 +32,7 @@ const AllergyDetails = () => {
 
   useEffect(
     () => {
-      if (allergyId) dispatch(getAllergyDetails(allergyId));
+      if (allergyId) dispatch(getAllergyDetails(allergyId, displayDomain));
     },
     [allergyId, dispatch],
   );

--- a/src/applications/mhv/medical-records/util/constants.js
+++ b/src/applications/mhv/medical-records/util/constants.js
@@ -102,7 +102,7 @@ export const interpretationMap = {
 
 export const EMPTY_FIELD = 'None noted';
 
-export const IS_TESTING = true;
+export const IS_TESTING = false;
 
 export const vitalTypes = {
   BLOOD_PRESSURE: 'BLOOD_PRESSURE',

--- a/src/applications/mhv/medical-records/util/constants.js
+++ b/src/applications/mhv/medical-records/util/constants.js
@@ -1,3 +1,8 @@
+import { toggleValues } from '@department-of-veterans-affairs/platform-site-wide/selectors';
+
+export const mhvMedicalRecordsDisplayDomains = state =>
+  toggleValues(state).mhvMedicalRecordsDisplayDomains;
+
 export const recordType = {
   HEALTH_CONDITIONS: 'health conditions',
   LABS_AND_TESTS: 'lab and test results',
@@ -97,7 +102,7 @@ export const interpretationMap = {
 
 export const EMPTY_FIELD = 'None noted';
 
-export const IS_TESTING = false;
+export const IS_TESTING = true;
 
 export const vitalTypes = {
   BLOOD_PRESSURE: 'BLOOD_PRESSURE',

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -91,6 +91,7 @@ export default Object.freeze({
   manageDependents: 'dependents_management',
   medicalCopaysHtmlMedicalStatementsViewEnabled: 'medical_copays_html_medical_statements_view_enabled',
   mhvLandingPageEnabled: 'mhv_landing_page_enabled',
+  mhvMedicalRecordsDisplayDomains: 'mhv_medical_records_display_domains',
   mhvSecureMessagingToVaGovRelease: 'mhv_secure_messaging_to_va_gov_release',
   mhvToLogingovAccountTransition: 'mhv_to_logingov_account_transition',
   mhvToLogingovAccountTransitionModal: 'mhv_to_logingov_account_transition_modal',


### PR DESCRIPTION
## Summary

Reimplemented allergies API calls to get live data, but put it behind a feature flag to ensure it can be switched off if there are any errors. The toggle is really intended for staging, to ensure we don't interrupt staging audits while we implement our fix to use live data. Once everything is verified to work, it will be removed.

## Related issue(s)
This feature toggle was added in PR https://github.com/department-of-veterans-affairs/vets-api/pull/13765
### [MHV-49254](https://jira.devops.va.gov/browse/MHV-49254) - Find/create MR test users for staging (and dev if possible)###

> Currently we are still using mock data in the VA.gov staging and dev environments. We need to find users in VA.gov who are linked to MHV users that have valid test data. (Or add test data to those MHV accounts)

## Testing done

- Manual testing to ensure the feature toggle works. If everything is fine, the toggle will be eventually removed for this purpose.

## Screenshots


## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
