### PR TITLE
Supplemental Claim | Update e2e tests

### DIFF
--- a/src/applications/appeals/995/tests/995-supplemental-claim.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-supplemental-claim.cypress.spec.js
@@ -89,10 +89,18 @@ const testConfig = createTestConfig(
                 cy.get('.add-new-issue').click();
                 cy.url().should('include', `${BASE_URL}/add-issue?index=`);
                 cy.axeCheck();
-                cy.get('#issue-name')
-                  .shadow()
-                  .find('input')
-                  .type(additionalIssue.issue);
+                if (navigator.userAgent.includes('Chrome')) {
+                  cy.get('#issue-name')
+                    .shadow()
+                    .find('input')
+                    .focus()
+                    .realType(additionalIssue.issue);
+                } else {
+                  cy.get('#issue-name')
+                    .shadow()
+                    .find('input')
+                    .type(additionalIssue.issue);
+                }
                 cy.fillDate('decision-date', getRandomDate());
                 cy.get('#submit').click();
               }
@@ -140,6 +148,7 @@ const testConfig = createTestConfig(
                   cy.get('#add-location-name')
                     .shadow()
                     .find('input')
+                    .focus()
                     .realType(location.locationAndName);
                 } else {
                   cy.get('#add-location-name')

--- a/src/applications/appeals/995/tests/995-supplemental-claim.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-supplemental-claim.cypress.spec.js
@@ -116,7 +116,10 @@ const testConfig = createTestConfig(
         afterHook(() => {
           cy.get('@testData').then(({ form5103Acknowledged }) => {
             if (form5103Acknowledged) {
-              cy.get('va-checkbox').click();
+              cy.get('va-checkbox')
+                .shadow()
+                .find('input')
+                .click();
             }
             cy.findByText('Continue', { selector: 'button' }).click();
           });
@@ -134,7 +137,8 @@ const testConfig = createTestConfig(
                 cy.get('#add-location-name')
                   .shadow()
                   .find('input')
-                  .type(location.locationAndName);
+                  // increasing the timeout since this is a flaky action (#62239)
+                  .type(location.locationAndName, { timeout: 5000 }); // default = 4000
                 location?.issues.forEach(issue => {
                   cy.get(`va-checkbox[value="${issue}"]`)
                     .shadow()
@@ -177,7 +181,10 @@ const testConfig = createTestConfig(
         afterHook(() => {
           cy.get('@testData').then(data => {
             if (data.privacyAgreementAccepted) {
-              cy.get('va-checkbox').click();
+              cy.get('va-checkbox')
+                .shadow()
+                .find('input')
+                .click();
             }
             cy.findByText('Continue', { selector: 'button' }).click();
           });

--- a/src/applications/appeals/995/tests/995-supplemental-claim.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-supplemental-claim.cypress.spec.js
@@ -134,11 +134,19 @@ const testConfig = createTestConfig(
                 if (index > 0) {
                   cy.url().should('include', `index=${index}`);
                 }
-                cy.get('#add-location-name')
-                  .shadow()
-                  .find('input')
-                  // increasing the timeout since this is a flaky action (#62239)
-                  .type(location.locationAndName, { timeout: 5000 }); // default = 4000
+                if (navigator.userAgent.includes('Chrome')) {
+                  // using realType to hopefully fix the input fields appear to
+                  // be disabled in CI causing the stress test to fail
+                  cy.get('#add-location-name')
+                    .shadow()
+                    .find('input')
+                    .realType(location.locationAndName);
+                } else {
+                  cy.get('#add-location-name')
+                    .shadow()
+                    .find('input')
+                    .type(location.locationAndName);
+                }
                 location?.issues.forEach(issue => {
                   cy.get(`va-checkbox[value="${issue}"]`)
                     .shadow()

--- a/src/platform/testing/e2e/cypress/support/commands/formHelpers.js
+++ b/src/platform/testing/e2e/cypress/support/commands/formHelpers.js
@@ -91,13 +91,15 @@ const vaMemorableDate = (element, vaMemorableDateMonthSelect, date) => {
           .find('va-select.usa-form-group--month-select')
           .shadow()
           .find('select')
-          .select(date[1]);
+          .focus();
+        cy.select(date[1]);
       } else if (isChrome) {
         cy.wrap(el)
           .find(getSelectors('month'))
           .shadow()
           .find('input')
-          .realType(date[1]);
+          .focus();
+        cy.realType(date[1]);
       } else {
         cy.wrap(el)
           .find(getSelectors('month'))

--- a/src/platform/testing/e2e/cypress/support/commands/formHelpers.js
+++ b/src/platform/testing/e2e/cypress/support/commands/formHelpers.js
@@ -38,7 +38,8 @@ Cypress.Commands.add('selectRadio', (fieldName, value) => {
   }
 });
 /**
- * Works with Date widget. And va-date and va-memorable-date web components
+ * Works with Date widget. And va-date and va-memorable-date web components;
+ * expects dateString in YYYY-MM-DD format
  */
 Cypress.Commands.add('fillDate', (fieldName, dateString) => {
   // Split the date & remove leading zeros
@@ -48,6 +49,10 @@ Cypress.Commands.add('fillDate', (fieldName, dateString) => {
   cy.document().then(doc => {
     const vaMemorableDate = doc.querySelector(
       `va-memorable-date[name="${fieldName}"]`,
+    );
+    // USWDS v3 only
+    const vaMemorableDateMonthSelect = doc.querySelector(
+      `va-memorable-date[name="${fieldName}"][monthselect]`,
     );
     const vaDate = doc.querySelector(`va-date[name="${fieldName}"]`);
     const monthYearOnly = doc.querySelector(
@@ -78,21 +83,37 @@ Cypress.Commands.add('fillDate', (fieldName, dateString) => {
       cy.wrap(vaMemorableDate)
         .shadow()
         .then(el => {
+          if (vaMemorableDateMonthSelect) {
+            cy.wrap(el)
+              .find('va-select.usa-form-group--month-select')
+              .shadow()
+              .find('select')
+              .select(date[1]);
+          } else {
+            cy.wrap(el)
+              .find(
+                'va-text-input.input-month, va-text-input.usa-form-group--month-input',
+              )
+              .shadow()
+              .find('input')
+              .type(date[1]);
+          }
           cy.wrap(el)
-            .find('va-text-input.input-month')
+            .find(
+              'va-text-input.input-day, va-text-input.usa-form-group--day-input',
+            )
             .shadow()
             .find('input')
-            .type(date[1]);
+            // increasing the timeout since this is a flaky action (#62239)
+            .type(date[2], { timeout: 5000 }); // default = 4000
           cy.wrap(el)
-            .find('va-text-input.input-day')
+            .find(
+              'va-text-input.input-year, va-text-input.usa-form-group--year-input',
+            )
             .shadow()
             .find('input')
-            .type(date[2]);
-          cy.wrap(el)
-            .find('va-text-input.input-year')
-            .shadow()
-            .find('input')
-            .type(date[0]);
+            // increasing the timeout since this is a flaky action (#62239)
+            .type(date[0], { timeout: 5000 }); // default = 4000
         });
     } else {
       cy.get(`#${fieldName}Month`).select(date[1]);

--- a/src/platform/testing/e2e/cypress/support/commands/formHelpers.js
+++ b/src/platform/testing/e2e/cypress/support/commands/formHelpers.js
@@ -146,7 +146,7 @@ Cypress.Commands.add('fillDate', (fieldName, dateString) => {
         `va-date[name="${fieldName}"][monthyearonly]`,
       );
       vaDate(vaDateElement, !!monthYearOnly, date);
-    } else if (vaMemorableDate) {
+    } else if (vaMemorableDateElement) {
       // USWDS v3 only
       const vaMemorableDateMonthSelect = !!doc.querySelector(
         `va-memorable-date[name="${fieldName}"][monthselect]`,


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > - Fixed Supplemental Claim e2e tests to get Cypress to properly click on the checkbox with a description
  > - Updated `fillDate` Cypress command to work with `va-memorable-date` with `uswds` property set, and with `uswds` month select enabled
  > <br />
  > Note: The error we're encountering is <code>CypressError: 'cy.type()' failed because it targeted a disabled element.</code> which is a global issue. After discussing this with other engineers, a work-around was found where interaction of the element <code>cy.type()</code> would not work in Chrome, but using <code>cy.realType()</code> would work. Other browsers, like Firefox, may not support <code>cy.realType()</code>, so we'd have to detect the browser being used and switch which function is being used.
  > <br /><br />
  > The result is adding a check for chrome and use <code>cy.realType()</code>, otherwise use <code>cy.type()</code>. The related PR has been updated to follow this pattern.
- _(If bug, how to reproduce)_
  > Supplemental Claim e2e test are currently disabled as being flaky
- _(What is the solution, why is this the solution)_
  > Increase time out & properly target the checkbox
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#62239](https://github.com/department-of-veterans-affairs/va.gov-team/issues/62239)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Supplemental Claim e2e test was disabled due to delay in `va-memorable-date` rendering; the broken checkbox issue is secondary to this because the tests were being skipped for being flaky
- _Describe the steps required to verify your changes are working as expected_
  > Passing e2e tests in CI
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

- Supplemental Claims
- Any app using Cypress `fillDate` command to fill `va-memorable-date`

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
