### PR TITLE
Enables the rest of the wilkes-barre facilities to allow travel claims.

### DIFF
--- a/src/applications/check-in/utils/appConstants/index.js
+++ b/src/applications/check-in/utils/appConstants/index.js
@@ -242,6 +242,11 @@ const travelAllowList = {
   '693GA': {},
   '693GB': {},
   '693': {},
+  '693GC': {},
+  '693GG': {},
+  '693QA': {},
+  '693GF': {},
+  '693QB': {},
 };
 
 const isInAllowList = appointment => {


### PR DESCRIPTION
## Summary

Adds the remaining Wilkes-Barre facilities to the allow list for filing travel claims during e-check-in.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#64900

## Testing done

N/A - config change

## What areas of the site does it impact?

Travel claims during day-of check-in

## Acceptance criteria

- [ ] All Wilkes-Barre facilities are in the allow list for travel claims.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
