### PR TITLE
Ndbex 63627 burial review page staging fixes (Second round)

### DIFF
--- a/src/applications/burials/components/NoFormPage.jsx
+++ b/src/applications/burials/components/NoFormPage.jsx
@@ -191,7 +191,7 @@ const generateData = (type, formData) => {
 };
 
 const ArrayComponent = ({ value }) => {
-  return value[0].size
+  return value[0]?.size
     ? value.map((name, index) => {
         return (
           <div
@@ -200,10 +200,10 @@ const ArrayComponent = ({ value }) => {
           >
             <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
               <u>
-                <strong>{name.name}</strong>
+                <strong>{name?.name ? name?.name : ''}</strong>
               </u>
             </p>
-            <p>{bytesToKB(name.size)}</p>
+            <p>{name?.size ? bytesToKB(name?.size) : ''}</p>
           </div>
         );
       })
@@ -212,19 +212,19 @@ const ArrayComponent = ({ value }) => {
           <div className="vads-u-background-color--gray-lightest vads-u-padding--1p5">
             <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
               <strong>First: </strong>
-              {name.first}
+              {name?.first ? name?.first : ''}
             </p>
             <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
               <strong>Middle: </strong>
-              {name.middle ? name.middle : 'None'}
+              {name?.middle ? name?.middle : 'None'}
             </p>
             <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
               <strong>Last: </strong>
-              {name.last}
+              {name?.last ? name?.last : ''}
             </p>
             <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
               <strong>Suffix: </strong>
-              {name.suffix ? name.suffix : 'None'}
+              {name?.suffix ? name?.suffix : 'None'}
             </p>
           </div>
         </div>

--- a/src/applications/burials/components/NoFormPage.jsx
+++ b/src/applications/burials/components/NoFormPage.jsx
@@ -71,7 +71,7 @@ const determineDeathCertificate = formData => {
   }
   return formData?.deathCertificate?.length > 0
     ? formData?.deathCertificate
-    : [];
+    : '';
 };
 
 const determineReceipts = formData => {
@@ -85,7 +85,7 @@ const determineReceipts = formData => {
   }
   return formData?.transportationReceipts?.length > 0
     ? formData?.transportationReceipts
-    : [];
+    : '';
 };
 
 const generateData = (type, formData) => {

--- a/src/applications/burials/components/NoFormPage.jsx
+++ b/src/applications/burials/components/NoFormPage.jsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { apiRequest } from 'platform/utilities/api';
 import { formatSSN } from 'platform/utilities/ui';
 import { isLoggedIn } from '@department-of-veterans-affairs/platform-user/selectors';
+import environment from 'platform/utilities/environment';
 
 const convertDateFormat = date => {
   return date.replace(/^(\d{4})-(\d{2})-(\d{2})$/, '$2/$3/$1');
@@ -61,6 +62,31 @@ const renderFields = [
     id: 'additional-information',
   },
 ];
+
+const determineDeathCertificate = formData => {
+  if (environment.isLocalhost()) {
+    return formData?.transportationReceipts?.length > 0
+      ? formData?.transportationReceipts?.slice(0, 1)
+      : '';
+  }
+  return formData?.deathCertificate?.length > 0
+    ? formData?.deathCertificate
+    : [];
+};
+
+const determineReceipts = formData => {
+  if (environment.isLocalhost()) {
+    return formData?.transportationReceipts?.length > 0
+      ? formData?.transportationReceipts?.slice(
+          1,
+          formData?.transportationReceipts?.length,
+        )
+      : '';
+  }
+  return formData?.transportationReceipts?.length > 0
+    ? formData?.transportationReceipts
+    : [];
+};
 
 const generateData = (type, formData) => {
   switch (type) {
@@ -172,17 +198,10 @@ const generateData = (type, formData) => {
             : '',
         },
         'Document upload': {
-          'Veterans death certificate':
-            formData?.transportationReceipts?.length > 0
-              ? formData?.transportationReceipts?.slice(0, 1)
-              : '',
-          'Documentation for transportation of the Veteran’s remains or other supporting evidence':
-            formData?.transportationReceipts?.length > 0
-              ? formData?.transportationReceipts?.slice(
-                  1,
-                  formData?.transportationReceipts?.length,
-                )
-              : '',
+          'Veterans death certificate': determineDeathCertificate(formData),
+          'Documentation for transportation of the Veteran’s remains or other supporting evidence': determineReceipts(
+            formData,
+          ),
         },
       };
     default:


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
- During staging reviews, we noticed that the document upload portion of the form captures uploaded data differently based on if which environment you're in. 
For example: All documents that are uploaded in the local environment are added to the `transportationReceipts` array, but when uploading in staging, the first file uploaded is placed in it's own array labeled `deathCertificate` and the other files uploaded are then added to `transportationReceipts`

- _(What is the solution, why is this the solution)_
- Adding an environment check and custom handlers that inject the needed data to the `ArrayComponent`

- _(Which team do you work for, does your team own the maintenance of this component?)_
- Non-disability Benefits Experience
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
- Flipper is set up inversely. This page shows only if feature flag `burial_form_enabled` is `Disabled`
## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
