### PR TITLE
21-0845 - Remove Intro page H1 top-margin

### DIFF
--- a/src/applications/simple-forms/21-0845/sass/0845-auth-disclose.scss
+++ b/src/applications/simple-forms/21-0845/sass/0845-auth-disclose.scss
@@ -15,10 +15,6 @@ $font-family-sans-serif: "Source Sans Pro", "Helvetica Neue", "Helvetica",
   margin-top: 1.5rem;
 }
 
-div:has(.schemaform-sip-alert) {
-  margin-top: 4rem;
-}
-
 [href="#start"].vads-c-action-link--green {
   margin-bottom: 2rem;
 }


### PR DESCRIPTION
## Summary

- Remove Third-Party Authorization (21-0845) Intro-page spacing between breadcrumbs and form-H1 
- Team: Platform VA Product Forms
- \[Flipper not implemented yet; disabled in Prod via content-build app-registry\]

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#552

## Testing done

- Local visual testing was successful

## What areas of the site does it impact?

This form ONLY
