### PR TITLE
VFEP-63 update package.json to use the latest vets-json-schema.

### DIFF
--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2e7fab5f321d02189fa0ecb57dd5659463ed302f"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#be4feabc0b7448db5774dace802204e904bd1120"
   },
   "resolutions": {
     "**/lodash": "4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -20061,9 +20061,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#2e7fab5f321d02189fa0ecb57dd5659463ed302f":
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#be4feabc0b7448db5774dace802204e904bd1120":
   version "20.27.22"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2e7fab5f321d02189fa0ecb57dd5659463ed302f"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#be4feabc0b7448db5774dace802204e904bd1120"
   dependencies:
     minimist "^1.2.3"
 


### PR DESCRIPTION
## Summary
- VFEP-63 update package.json to use the latest vets-json-schema.
- Previous Pull Request was missing this item in vets-json-shema for the backend.


## Related issue(s)
- [Previous Pull Request](https://github.com/department-of-veterans-affairs/vets-website/pull/25609)

