### PR TITLE
Terms of Use | Integration with vets-api

### DIFF
--- a/src/applications/terms-of-use/components/Declined.jsx
+++ b/src/applications/terms-of-use/components/Declined.jsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import SubmitSignInForm from 'platform/static-data/SubmitSignInForm';
 
-export default function Placeholder() {
+export default function Declined() {
   const dispatch = useDispatch();
   const openSignInModal = useCallback(() => dispatch(toggleLoginModal(true)), [
     dispatch,
@@ -12,7 +12,7 @@ export default function Placeholder() {
   return (
     <div className="vads-l-grid-container vads-u-padding-y--5">
       <div className="usa-content">
-        <h1>We’ve signed you out of VA.gov</h1>
+        <h1>We’ve signed you out</h1>
         <va-alert visible status="error">
           You didn’t accept VA online services terms of use, so we signed you
           out of the site.
@@ -20,7 +20,7 @@ export default function Placeholder() {
         <h2>What you can do:</h2>
         <p>
           If you want to change your answer and accept the terms, sign in again.
-          We’ll take you back to the terms of use.{' '}
+          We’ll take you back to the terms of use.
         </p>
         <p>
           <strong>Note:</strong> You can still get VA benefits in-person without

--- a/src/applications/terms-of-use/tests/Declined.unit.spec.jsx
+++ b/src/applications/terms-of-use/tests/Declined.unit.spec.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render, fireEvent } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
+import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
+import Declined from '../components/Declined';
+
+const generateStore = dispatch => ({
+  getState: () => ({
+    navigation: {
+      showLoginModal: false,
+    },
+  }),
+  subscribe: sinon.stub(),
+  dispatch,
+});
+
+describe('Declined', () => {
+  let store;
+  let dispatchStub;
+
+  beforeEach(() => {
+    dispatchStub = sinon.stub();
+
+    store = generateStore(dispatchStub);
+  });
+  it('should render', () => {
+    const { container } = render(
+      <Provider store={store}>
+        <Declined />
+      </Provider>,
+    );
+    expect($('h1', container).textContent).to.eql('We’ve signed you out');
+    expect($('button', container).textContent).to.eql('Sign in');
+  });
+
+  it('should render', () => {
+    const { container } = render(
+      <Provider store={store}>
+        <Declined />
+      </Provider>,
+    );
+
+    const signInButton = $('button', container);
+    fireEvent.click(signInButton);
+
+    expect(dispatchStub.calledOnce).to.be.true;
+    expect(dispatchStub.calledWith(toggleLoginModal(true))).to.be.true;
+  });
+});

--- a/src/applications/terms-of-use/tests/TermsOfUse.unit.spec.jsx
+++ b/src/applications/terms-of-use/tests/TermsOfUse.unit.spec.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+
+import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
+import TermsOfUse, { parseRedirectUrl } from '../containers/TermsOfUse';
+
+const store = ({ isLoggedIn = false, termsOfUseEnabled = true } = {}) => ({
+  getState: () => ({
+    user: {
+      login: {
+        currentlyLoggedIn: isLoggedIn,
+      },
+    },
+    featureToggles: {
+      // eslint-disable-next-line camelcase
+      terms_of_use: termsOfUseEnabled,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+});
+
+describe('TermsOfUse', () => {
+  it('should render', () => {
+    const mockStore = store();
+    const { container } = render(
+      <Provider store={mockStore}>
+        <TermsOfUse />
+      </Provider>,
+    );
+    expect($('h1', container).textContent).to.eql(
+      'VA online services terms of use',
+    );
+    expect($('va-on-this-page', container)).to.exist;
+    expect($('va-accordion', container)).to.exist;
+    expect($('va-alert', container)).to.exist;
+  });
+  it('should display content if not signed in', () => {
+    const mockStore = store();
+    const { container } = render(
+      <Provider store={mockStore}>
+        <TermsOfUse />
+      </Provider>,
+    );
+    expect($$('va-button', container).length).to.eql(2);
+  });
+  it('should NOT display Accept or Decline buttons termsOfUse Flipper is disabled', () => {
+    const mockStore = store({ isLoggedIn: true, termsOfUseEnabled: false });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <TermsOfUse />
+      </Provider>,
+    );
+
+    expect($$('va-button', container).length).to.eql(0);
+  });
+});
+
+describe('parseRedirectUrl', () => {
+  it('should return the proper url', () => {
+    expect(
+      parseRedirectUrl(
+        'https%3A%2F%2Fdev.va.gov%2Fauth%2Flogin%2Fcallback%2F%3Ftype%3Didme',
+      ),
+    ).to.eql('https://dev.va.gov/auth/login/callback/?type=idme');
+    expect(
+      parseRedirectUrl('https://staging-patientportal.myhealth.va.gov'),
+    ).to.eql('https://staging-patientportal.myhealth.va.gov');
+    expect(
+      parseRedirectUrl('https://int.eauth.va.gov/mhv-portal-web/eauth'),
+    ).to.eql('https://int.eauth.va.gov/mhv-portal-web/eauth');
+    expect(parseRedirectUrl('https://google.com?q=https://va.gov')).to.eql(
+      'https://dev.va.gov',
+    );
+  });
+});

--- a/src/applications/terms-of-use/touData.jsx
+++ b/src/applications/terms-of-use/touData.jsx
@@ -1,0 +1,379 @@
+import React from 'react';
+import SubmitSignInForm from 'platform/static-data/SubmitSignInForm';
+
+export default [
+  {
+    header: `General Disclaimer`,
+    content: (
+      <>
+        <p>
+          To sign in to VA.gov and most other VA online services, you must
+          accept the VA online services terms of use.
+        </p>
+        <p>
+          <strong>Note:</strong> In these terms of use, “we,” "our,” and “us”
+          refer to VA. “You” and “your” refer to you as the person signing in to
+          VA online services to manage your benefits and health care.
+        </p>
+        <p>
+          When you sign in to VA.gov or another Department of Veteran Affairs
+          (VA) online service, you’re using a United States federal government
+          information system.
+        </p>
+        <p>
+          When you accept these terms, you confirm that you understand the rules
+          for using this system:
+        </p>
+        <ul>
+          <li>
+            You must only access and use information you have the legal
+            authority to access and use. We monitor and record your activity on
+            the system. And we share this information with auditors and law
+            enforcement officials as required.
+          </li>
+          <li>
+            Federal law and VA policy prohibit unauthorized use of this system.
+            Unauthorized use may result in criminal, civil, or administrative
+            penalties. The related federal laws include{' '}
+            <a
+              href="https://uscode.house.gov/view.xhtml?req=granuleid:USC-1994-title18-section1030&num=0&edition=1994"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              18 U.S.C. 1030 (Fraud and Related Activity in Connection with
+              Computers)
+            </a>{' '}
+            and{' '}
+            <a
+              href="https://uscode.house.gov/view.xhtml?req=(title:18%20section:2701%20edition:prelim"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              18 U.S.C. 2701 (Unlawful Access to Stored Communications)
+            </a>
+            .
+          </li>
+        </ul>
+        <p>Unauthorized or prohibited use includes these actions:</p>
+        <ul>
+          <li>
+            Gaining unauthorized access or making unauthorized changes to the
+            system or its data.
+          </li>
+          <li>Harming, destroying, or misusing the system or its data.</li>
+          <li>
+            Impersonating another person (signing in as or pretending to be
+            another person). (<strong>Note:</strong> This does not restrict
+            authorized use by a VA-documented representative.)
+          </li>
+          <li>
+            Using secure messaging to promote your personal agenda, for
+            solicitation, or to transmit prohibited material. (
+            <strong>Note:</strong> You may use messaging only to communicate
+            with your VA health care team about your health care and VA benefits
+            and services, and VA staff about your privacy rights.)
+          </li>
+          <li>
+            Sending material that infringes on the patents, trademarks,
+            copyrights, trade secrets, privacy, or publicity rights of others.
+          </li>
+          <li>
+            Transmitting material that is excessive, illegal, offensive,
+            intimidating, harmful, or threatening to any person (including VA
+            staff) or entity as we determine using our discretion.
+          </li>
+          <li>
+            Using deep-links, page-scrapes, spidering, or applications that
+            gather, copy, change, replicate, or monitor any portion of VA
+            websites or mobile applications.
+          </li>
+        </ul>
+        <p>
+          If we suspect any unauthorized use or violation of these terms, we may
+          suspend or block your access to this system. If you suspect
+          unauthorized or inappropriate use of the system, report it to us.
+        </p>
+        <p>
+          If you don’t accept these terms, you won’t be able to sign in to
+          VA.gov or other VA online services covered by these terms. If you have
+          concerns or questions, or want to report an issue,{' '}
+          <SubmitSignInForm />
+        </p>
+        <p>
+          We take the responsibility of protecting your information seriously.
+          To learn more about how we collect and use your information, read the
+          sections titled <strong>Privacy Act statement</strong> and{' '}
+          <strong>Sharing of your information and data</strong>.
+        </p>
+      </>
+    ),
+  },
+  {
+    header: `Use of VA online services`,
+    content: (
+      <>
+        <p>
+          Groups of people who use VA.gov and other VA online tools and services
+          include those who sign in with an account (such as Login.gov or ID.me)
+          and those who don’t sign in. These groups include Veterans, VA
+          patients, beneficiaries, Veteran advocates, caregivers, personal legal
+          representatives, and the general public.
+        </p>
+        <p>
+          These groups use a range of VA online services, including health
+          tools, benefit applications, and information services.
+        </p>
+      </>
+    ),
+  },
+  {
+    header: `Right of access`,
+    content: (
+      <>
+        <p>
+          By accepting these terms, you give us permission to release{' '}
+          <strong>to you</strong> all or a portion of your personal information
+          that we maintain in a Privacy Act System of Records.
+        </p>
+        <p>
+          In other words, you’re giving us permission to give you the personal
+          information you request. We deliver your personal information to you
+          through secure federal computer systems and networks. We may also
+          partner with select external resources to provide additional
+          information and services. When you select an external service or
+          resource, we’ll tell you that we’re sending you to that partner’s
+          secured environment.
+        </p>
+        <p>
+          If you disagree with the content included in your VA records, or you
+          suspect an error in your record, <SubmitSignInForm />
+        </p>
+      </>
+    ),
+  },
+  {
+    header: `Privacy Act statement`,
+    content: (
+      <>
+        <p>
+          <a
+            href="https://www.va.gov/privacy-policy/#on-this-page-76"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Read our VA.gov privacy policy
+          </a>
+          <br />
+          <a
+            href="https://www.oprm.va.gov/privacy/systems_of_records.aspx"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Read our VA systems of records notices
+          </a>
+        </p>
+        <p>
+          Federal law authorizes us to collect certain information (38 U.S.C.
+          Section 501). The information may be subject to the Privacy Act of
+          1974 (5 U.S.C. 552a). As such, VA employees may use it only in the
+          performance of their duties. We can disclose the information outside
+          of VA only with the proper authority (5 U.S.C. 552a(b)). This includes
+          "routine use" disclosures in applicable Privacy Act Systems of
+          Records.
+        </p>
+        <p>Examples of system of records notices includes these notices:</p>
+        <ul>
+          <li>"My HealtheVet Administrative System of Records" - 130VA10P2</li>
+          <li>
+            "VA Enterprise Cloud – Mobile Application Platform (VAEC-MAP)" - VA
+            173VA005OP2
+          </li>
+          <li>
+            “Compensation, Pension, Education, and Vocational Rehabilitation and
+            Employment Records” - VA 58VA21/22/28
+          </li>
+        </ul>
+      </>
+    ),
+  },
+  {
+    header: `Sharing of your information and data`,
+    content: (
+      <>
+        <p>
+          We may store personal and self-entered information and data that you
+          choose to share with us. VA online services use encryption to securely
+          store and transmit all data, including personal and self-entered
+          information.
+        </p>
+        <p>
+          Our use and release of your information, including your health
+          information, must comply with federal laws and regulations. These are
+          some ways we may use or share your information:
+        </p>
+        <ul>
+          <li>
+            We may do statistical analysis of characteristics of people who use
+            our online services to assess areas of interest.
+          </li>
+          <li>
+            We may use data for quality control, approved research, population
+            health monitoring, or other VA program needs to improve the system.
+          </li>
+          <li>
+            We may access, share, or use your information as permitted by the
+            Principle-Based Ethics Framework for Access to and Use of Veteran
+            Data.{' '}
+            <a
+              href="https://www.regulations.gov/document/VA-2022-OTHER-0017-0001"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Read the Veteran data access and use framework
+            </a>
+          </li>
+          <li>
+            We may give access to your health information only to an agency or
+            an individual as permitted by law and as outlined in the Veterans
+            Health Administration (VHA) notice of privacy practices.{' '}
+            {/* Insert anchor tag once link href is available */}
+            Read the VHA notice of privacy practices
+          </li>
+        </ul>
+        <p>We never share your information for marketing purposes.</p>
+      </>
+    ),
+  },
+  {
+    header: `Text messaging and short message services (SMS)`,
+    content: (
+      <>
+        <p>
+          Some VA programs and services may provide text messaging or short
+          message services (SMS). When you agree to get SMS texts from us, you
+          confirm that you understand that SMS text messages sent to a mobile
+          device are not encrypted.
+        </p>
+        <p>
+          Anyone can read and forward unencrypted text messages. These messages
+          remain unencrypted on telecommunication providers' servers and stay
+          forever on senders' and receivers' devices. Senders can’t authenticate
+          the recipient of text messages. So, the sender can’t be certain that
+          the message has been sent to, received by, or opened by the right
+          person.
+        </p>
+        <p>
+          We automatically opt you in to some types of text message
+          notifications. You can opt out of getting text messages at any time.
+        </p>
+      </>
+    ),
+  },
+  {
+    header: `Medical disclaimer`,
+    content: (
+      <>
+        <p>
+          Some VA online services offer interaction with other VA services and
+          are intended as Veteran self-management tools. The purpose of these
+          self-management tools is to provide individual Veterans with the
+          ability to use data to manage their own care. These data include data
+          that you enter into mobile health apps to create graphs, charts, and
+          dashboards.
+        </p>
+        <p>
+          Self-management tools are not intended to be and should not be used in
+          any way as a substitute for professional medical advice or training.
+          We can’t guarantee the accuracy of data that you enter yourself or
+          that we collect through mobile health apps, wearable devices, or
+          Bluetooth devices. When you access your health data, you acknowledge
+          that the information is not necessarily meant to diagnose a health
+          condition or to develop a health treatment plan.
+        </p>
+        <p>
+          <strong>If you think your life or health is in danger,</strong> call
+          the emergency number (911 in the U.S.) or go to the nearest emergency
+          room.
+        </p>
+        <p>
+          <strong>If you’re a Veteran in crisis or concerned about one,</strong>{' '}
+          connect with our caring, qualified responders for confidential help.
+          Call the Veterans Crisis Line at 988. Then select 1.
+        </p>
+      </>
+    ),
+  },
+  {
+    header: `Use of contact information`,
+    content: (
+      <>
+        <p>
+          We may contact you at the email address, phone numbers, or addresses
+          you provide to us. We may contact you for official VA operations,
+          including customer support, outreach, care, and eligibility.
+        </p>
+        <p>
+          Some Internet Service Providers (ISPs) or third-party email providers
+          may block email messages from sources that aren’t on their
+          pre-approved list. This is a security measure to control spam and
+          potentially malicious email. It’s your responsibility to make sure
+          that VA.gov is on your ISP pre-approved list. We’re not responsible
+          for any consequences resulting from our emails being blocked by your
+          ISP. This includes junk mail folders, spam-blocking software, or other
+          similar products.
+        </p>
+      </>
+    ),
+  },
+  {
+    header: `Feedback`,
+    content: (
+      <>
+        <p>
+          We encourage feedback from the people who use our online services. We
+          may use a variety of tools to gather user feedback. We may use this
+          information to measure performance, determine how people use our
+          services and identify what they want from those services, improve
+          designs, and for other authorized uses.
+        </p>
+        <p>
+          We may also ask you to take part in field testing of new VA online
+          services. Your participation in testing is voluntary. You don’t have
+          to respond to these requests to continue using VA online services.
+        </p>
+      </>
+    ),
+  },
+  {
+    header: `Changes to these terms of use`,
+    content: (
+      <>
+        <p>
+          We may revise these terms of use at any time at our discretion. When
+          we make a change that affects the collection and use of your personal
+          information or when there is a change in law, we’ll provide a summary
+          of the changes. We’ll also create a new version of these terms with
+          the changes included.
+        </p>
+        <p>
+          When you sign in, we’ll prompt you to read and accept the new terms.
+          You’ll have a grace period to review the terms and to download any of
+          your information, if necessary. If you choose not to accept the new
+          terms after the grace period, you’ll no longer be able to sign in to
+          VA.gov or other VA online services.
+        </p>
+      </>
+    ),
+  },
+  {
+    header: `Acceptance of terms`,
+    content: (
+      <p>
+        When you accept these terms, you confirm that the personally
+        identifiable information you provide to sign in to VA.gov or another VA
+        online service is your information or the information of a person you
+        legally represent or are legally authorized to act on behalf of.
+      </p>
+    ),
+  },
+];

--- a/src/platform/user/authentication/selectors.js
+++ b/src/platform/user/authentication/selectors.js
@@ -23,3 +23,6 @@ export const transitionMHVAccount = state =>
 
 export const signInServiceEnabled = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.signInServiceEnabled];
+
+export const termsOfUseEnabled = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.termsOfUse];

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -347,11 +347,11 @@ export async function verify({
   return isLink ? url : redirect(url, `${type}-${clickedEvent}`);
 }
 
-export function logout(
+export function logout({
   version = API_VERSION,
   clickedEvent = AUTH_EVENTS.LOGOUT,
   queryParams = {},
-) {
+}) {
   clearSentryLoginType();
   return redirect(
     sessionTypeUrl({ type: POLICY_TYPES.SLO, version, queryParams }),

--- a/src/platform/user/exportsFile.js
+++ b/src/platform/user/exportsFile.js
@@ -130,6 +130,7 @@ export {
   isAuthenticatedWithSSOe,
   ssoeTransactionId,
   transitionMHVAccount,
+  termsOfUseEnabled,
 } from './authentication/selectors';
 export { externalApplicationsConfig } from './authentication/usip-config';
 export { OAuthEnabledApplications } from './authentication/config/constants';

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -169,6 +169,7 @@ export default Object.freeze({
   subform89404192: 'subform_8940_4192',
   supplementalClaim: 'supplemental_claim',
   supplyReorderingSleepApneaEnabled: 'supply_reordering_sleep_apnea_enabled',
+  termsOfUse: 'terms_of_use',
   useLighthouseFormsSearchLogic: 'new_va_forms_search',
   vaOnlineScheduling: 'va_online_scheduling',
   vaOnlineSchedulingCancel: 'va_online_scheduling_cancel',


### PR DESCRIPTION
## Summary
This PR adds the API integration for users to integrate with the Terms of Use actions of Accepting or Declining.
*Note: this will not include the auto-signout after decline button interaction nor redirecting to the `/decline` page

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#63995

## Testing done
- Unit testing + manual testing

## Screenshots


## What areas of the site does it impact?
This will affect just the Terms of Use page `/terms-of-use` in staging & below

## Acceptance criteria

### Quality Assurance & Testing

- [x] I added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
1. Pull down latest in `vets-api` and start the server
2. Pull down this branch `tou/flipper`
3. Run `yarn` then `yarn watch` 
4. Navigate to `localhost:3001/terms-of-use`
    1. Confirm there are no buttons (Accept or Decline) to click because you are not signed in
5. Sign into VA.gov using any available CSP
6. After authenticating navigate to `localhost:3001/terms-of-use`
7. Open up your DevTools on the Network tab
    1.  Click Accept button confirm the API URL includes the `terms_of_use_agreements/v1/accept`
    2. Click Decline button confirm the API URL includes the `terms_of_use_agreeemnts/v1/decline`
8. Stop the `vets-api` server by running Ctrl + C
9. Try to click the Accept/Decline button
10. Confirm there is an error message asking for them to try again.
