### PR TITLE
64448 toxic exposure migration

### DIFF
--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -341,4 +341,4 @@ export const MAX_HOUSING_STRING_LENGTH = 500;
 export const OMB_CONTROL = '2900-0747';
 
 // used to save feature flag in form data for toxic exposure
-export const SHOW_TOXIC_EXPOSURE = 'view:showToxicExposure';
+export const SHOW_TOXIC_EXPOSURE = 'showToxicExposure';

--- a/src/applications/disability-benefits/all-claims/migrations/09-redirect-toxic-exposure.js
+++ b/src/applications/disability-benefits/all-claims/migrations/09-redirect-toxic-exposure.js
@@ -1,0 +1,36 @@
+import formConfig from '../config/form';
+
+/**
+ * Adding new Toxic Exposure (TE) pages. If user has a return url for a save in
+ * progress form that would skip the new TE pages, redirect to the first TE
+ * page.
+ */
+export default function redirectToxicExposure(savedData) {
+  const { returnUrl } = savedData.metadata;
+
+  const veteranDetailsUrls = [];
+  for (const page of Object.entries(formConfig.chapters.veteranDetails.pages)) {
+    veteranDetailsUrls.push(`/${page[1].path}`);
+  }
+
+  // if user hasn't reached TE pages yet, nothing to do (business as usual)
+  if (veteranDetailsUrls.includes(returnUrl)) {
+    return savedData;
+  }
+
+  const { formData } = savedData;
+  if (
+    returnUrl !== '/toxic-exposure-intro' &&
+    formData['view:exposureStatus'] === undefined
+  ) {
+    return {
+      ...savedData,
+      metadata: {
+        ...savedData.metadata,
+        returnUrl: '/toxic-exposure-intro',
+      },
+    };
+  }
+
+  return savedData;
+}

--- a/src/applications/disability-benefits/all-claims/migrations/index.js
+++ b/src/applications/disability-benefits/all-claims/migrations/index.js
@@ -1,3 +1,4 @@
+import { showToxicExposurePages } from '../utils';
 import redirectToClaimTypePage from './01-require-claim-type';
 import convertCountryCode from './02-convert-country-code';
 import upgradeHasSeparationPay from './03-upgrade-hasSeparationPay';
@@ -6,6 +7,7 @@ import truncateOtherAtRiskHousing from './05-truncate-otherAtRiskHousing';
 import fixTreatedDisabilityNamesKey from './06-fix-treatedDisabilityNames';
 import mapServiceBranches from './07-map-service-branches';
 import reorderHousingIllnessRemoveFdc from './08-paper-sync';
+import redirectToxicExposure from './09-redirect-toxic-exposure';
 
 // We launched at version 1 and not version 0, so the first _real_ migration is at
 //  migrations[1]
@@ -23,5 +25,9 @@ const migrations = [
   mapServiceBranches,
   reorderHousingIllnessRemoveFdc,
 ];
+
+if (showToxicExposurePages) {
+  migrations.push(redirectToxicExposure);
+}
 
 export default migrations;

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
@@ -5,7 +5,7 @@ export const toxicExposurePages = {
   toxicExposureIntro: {
     title: 'Toxic Exposure',
     path: 'toxic-exposure-intro',
-    depends: showToxicExposurePages,
+    depends: () => showToxicExposurePages,
     uiSchema: toxicExposureIntro.uiSchema,
     schema: toxicExposureIntro.schema,
   },

--- a/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/migrations/migrations.unit.spec.js
@@ -7,6 +7,7 @@ import truncateOtherAtRiskHousing from '../../migrations/05-truncate-otherAtRisk
 import fixTreatedDisabilityNamesKey from '../../migrations/06-fix-treatedDisabilityNames';
 import mapServiceBranches from '../../migrations/07-map-service-branches';
 import reorderHousingIllnessRemoveFdc from '../../migrations/08-paper-sync';
+import redirectToxicExposure from '../../migrations/09-redirect-toxic-exposure';
 
 import formConfig from '../../config/form';
 import { MAX_HOUSING_STRING_LENGTH } from '../../constants';
@@ -317,6 +318,50 @@ describe('526 v2 migrations', () => {
       expect(migratedData.metadata.returnUrl).to.deep.equal(
         '/review-and-submit',
       );
+    });
+  });
+
+  describe('09-redirect-toxic-exposure', () => {
+    it('should not change returnUrl if user left off on a page before toxic exposure pages', () => {
+      const savedData = {
+        formData: {},
+        metadata: {
+          version: 9,
+          returnUrl: '/contact-information',
+        },
+      };
+      const migratedData = redirectToxicExposure(savedData);
+      expect(migratedData.metadata.returnUrl).to.deep.equal(
+        '/contact-information',
+      );
+    });
+
+    it('should change returnUrl if user left off on a page after toxic exposure pages and has not filled out toxic exposure intro', () => {
+      const savedData = {
+        formData: {},
+        metadata: {
+          version: 9,
+          returnUrl: '/claim-type',
+        },
+      };
+      const migratedData = redirectToxicExposure(savedData);
+      expect(migratedData.metadata.returnUrl).to.deep.equal(
+        '/toxic-exposure-intro',
+      );
+    });
+
+    it('should not change returnUrl if user has filled out toxic exposure intro', () => {
+      const savedData = {
+        formData: {
+          'view:exposureStatus': 'no',
+        },
+        metadata: {
+          version: 9,
+          returnUrl: '/claim-type',
+        },
+      };
+      const migratedData = redirectToxicExposure(savedData);
+      expect(migratedData.metadata.returnUrl).to.deep.equal('/claim-type');
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -318,7 +318,8 @@ export const isDisabilityPtsd = disability => {
 export const hasRatedDisabilities = formData =>
   formData?.ratedDisabilities?.length > 0;
 
-export const showToxicExposurePages = formData => formData[SHOW_TOXIC_EXPOSURE];
+export const showToxicExposurePages =
+  window.sessionStorage.getItem(SHOW_TOXIC_EXPOSURE) === 'true';
 
 export const isClaimingNew = formData =>
   _.get(
@@ -671,9 +672,6 @@ export const show526Wizard = state => toggleValues(state).show526Wizard;
 
 export const showSubform8940And4192 = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.subform89404192];
-
-export const getShowToxicExposure = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.disability526ToxicExposure];
 
 export const show526MaxRating = state =>
   toggleValues(state).disability526MaximumRating;


### PR DESCRIPTION
## Summary
- _(Summarize the changes that have been made to the platform)_
If a user had a 526 form saved in progress, ensure that if they return after the new Toxic Exposure pages are added, that they don't skip the new pages.
Also, discovered that saving the toggle value in form data wouldn't work for migration scripts so moved back to the sessionStorage approach
- _(If bug, how to reproduce)_
-n/a
- _(What is the solution, why is this the solution)_
Solution is to redirect to the new pages if user could have skipped them, following best practices
- _(Which team do you work for, does your team own the maintenance of this component?)_
DBEx, yes
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
[toggle cleanup ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/65089)

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/va.gov-team/issues/64448
- _Link to previous change of the code/bug (if applicable)_
n/a
- _Link to epic if not included in ticket_
n/a

## Testing done

- _Describe what the old behavior was prior to the change_
Old behavior is there was no redirect. User would get to review and submit page and see errors.
- _Describe the steps required to verify your changes are working as expected_
start with toggle off `disability_526_toxic_exposure`
1) start a new claim. save form after new location of TE pages, e.g. after the veteran details chapter
2) enable toggle 
3) reload the app/manually go to 526. click 'Continue your application' button. Verify you are redirected to TE intro page 
4) fill out another page or more of the form 
5) manually go back to intro page /file-disability-claim-form-21-526ez/introduction page 
5) click 'Continue your application'. Verify you are redirected to that page and not TE intro again 
- _Describe the tests completed and the results_
Unit tests added for the migration script. Manual tests were done to verify appropriate redirect and regression test with toggle off.

## Screenshots
n/a. no visual changes made in this pr.

## What areas of the site does it impact?
526ez


## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

