### PR TITLE
MHV-48949: Medication Details Updates

### DIFF
--- a/src/applications/mhv/medications/components/PrescriptionDetails/NonVaPrescription.jsx
+++ b/src/applications/mhv/medications/components/PrescriptionDetails/NonVaPrescription.jsx
@@ -58,7 +58,7 @@ const NonVaPrescription = prescription => {
           <h3 className="vads-u-font-size--base vads-u-font-family--sans">
             Reason for use
           </h3>
-          <p>{validateField(prescription.reason)}</p>
+          <p>{validateField(prescription.indicationForUse)}</p>
         </section>
         <section>
           <h3 className="vads-u-font-size--base vads-u-font-family--sans">

--- a/src/applications/mhv/medications/components/PrescriptionDetails/VaPrescription.jsx
+++ b/src/applications/mhv/medications/components/PrescriptionDetails/VaPrescription.jsx
@@ -6,7 +6,13 @@ import FillRefillButton from '../shared/FillRefillButton';
 import StatusDropdown from '../shared/StatusDropdown';
 
 const VaPrescription = prescription => {
-  const refillHistory = prescription?.rxRfRecords?.[0]?.[1];
+  const refillHistory = [...prescription?.rxRfRecords?.[0]?.[1]];
+  refillHistory.push({
+    dispensedDate: prescription?.dispensedDate,
+    cmopNdcNumber: prescription?.cmopNdcNumber,
+    id: prescription?.prescriptionId,
+  });
+
   const shippedOn = prescription?.trackingList?.[0]?.[1];
   const content = () => {
     if (prescription) {
@@ -35,7 +41,7 @@ const VaPrescription = prescription => {
               {validateField(prescription.refillRemaining)}
             </p>
             <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Request refills by this prescription expiration date
+              Order refills by this prescription expiration date
             </h3>
             <p data-testid="expiration-date">
               {validateField(prescription.expirationDate, 'date')}
@@ -94,7 +100,7 @@ const VaPrescription = prescription => {
             <h3 className="vads-u-font-size--base vads-u-font-family--sans">
               Reason for use
             </h3>
-            <p>{validateField(prescription?.reason)}</p>
+            <p>{validateField(prescription?.indicationForUse)}</p>
             <h3 className="vads-u-font-size--base vads-u-font-family--sans">
               Quantity
             </h3>
@@ -110,60 +116,56 @@ const VaPrescription = prescription => {
 
           <div className="medication-details-div">
             <h2 className="vads-u-margin-top--3">Refill history</h2>
-            {refillHistory && refillHistory.length > 0 ? (
-              refillHistory.map((entry, i) => (
-                <div
-                  key={entry.id}
-                  className={
-                    i + 1 < refillHistory.length && 'vads-u-margin-bottom--3'
-                  }
-                >
-                  <h3 className="vads-u-font-size--lg vads-u-font-family--sans vads-u-margin-bottom--2">
-                    {i + 1 === refillHistory.length
-                      ? 'Original Fill'
-                      : `Refill ${refillHistory.length - i - 1}`}
-                  </h3>
-                  <h4 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-top--2 vads-u-margin--0">
-                    Filled by pharmacy on
-                  </h4>
-                  <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
-                    {validateField(entry.dispensedDate, 'date')}
-                  </p>
-                  <h4 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-top--2 vads-u-margin--0">
-                    Shipped on
-                  </h4>
-                  <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
-                    {validateField(shippedOn?.[i]?.completeDateTime, 'date')}
-                  </p>
-                  <h4 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-top--2 vads-u-margin--0">
-                    Description of the medication or supply
-                  </h4>
-                  <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
-                    {/* TODO: Not yet available */}
-                    None noted
-                  </p>
-                  <h4 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-top--2 vads-u-margin--0">
-                    Image of the medication or supply
-                  </h4>
-                  <div className="no-print">
-                    <va-additional-info trigger="Review image">
-                      {entry.cmopNdcNumber ? (
-                        <img
-                          src={getImageUri(entry.cmopNdcNumber)}
-                          alt="Not Available"
-                          width="350"
-                          height="350"
-                        />
-                      ) : (
-                        <p>(Image not available)</p>
-                      )}
-                    </va-additional-info>
-                  </div>
+            {refillHistory.map((entry, i) => (
+              <div
+                key={entry.id}
+                className={
+                  i + 1 < refillHistory.length ? 'vads-u-margin-bottom--3' : ''
+                }
+              >
+                <h3 className="vads-u-font-size--lg vads-u-font-family--sans vads-u-margin-bottom--2">
+                  {i + 1 === refillHistory.length
+                    ? 'Original Fill'
+                    : `Refill ${refillHistory.length - i - 1}`}
+                </h3>
+                <h4 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-top--2 vads-u-margin--0">
+                  Filled by pharmacy on
+                </h4>
+                <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
+                  {validateField(entry.dispensedDate, 'date')}
+                </p>
+                <h4 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-top--2 vads-u-margin--0">
+                  Shipped on
+                </h4>
+                <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
+                  {validateField(shippedOn?.[i]?.completeDateTime, 'date')}
+                </p>
+                <h4 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-top--2 vads-u-margin--0">
+                  Description of the medication or supply
+                </h4>
+                <p className="vads-u-margin-top--0 vads-u-margin-bottom--1">
+                  {/* TODO: Not yet available */}
+                  None noted
+                </p>
+                <h4 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-top--2 vads-u-margin--0">
+                  Image of the medication or supply
+                </h4>
+                <div className="no-print">
+                  <va-additional-info trigger="Review image">
+                    {entry.cmopNdcNumber ? (
+                      <img
+                        src={getImageUri(entry.cmopNdcNumber)}
+                        alt="Not Available"
+                        width="350"
+                        height="350"
+                      />
+                    ) : (
+                      <p>(Image not available)</p>
+                    )}
+                  </va-additional-info>
                 </div>
-              ))
-            ) : (
-              <p>No recorded history for this medication.</p>
-            )}
+              </div>
+            ))}
           </div>
         </>
       );

--- a/src/applications/mhv/medications/components/PrescriptionDetails/VaPrescription.jsx
+++ b/src/applications/mhv/medications/components/PrescriptionDetails/VaPrescription.jsx
@@ -6,7 +6,7 @@ import FillRefillButton from '../shared/FillRefillButton';
 import StatusDropdown from '../shared/StatusDropdown';
 
 const VaPrescription = prescription => {
-  const refillHistory = [...prescription?.rxRfRecords?.[0]?.[1]];
+  const refillHistory = [...(prescription?.rxRfRecords?.[0]?.[1] || [])];
   refillHistory.push({
     dispensedDate: prescription?.dispensedDate,
     cmopNdcNumber: prescription?.cmopNdcNumber,

--- a/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
@@ -228,7 +228,7 @@ const PrescriptionDetails = () => {
     );
   };
 
-  return <div className="medium-screen:vads-l-col--8">{content()}</div>;
+  return <div>{content()}</div>;
 };
 
 export default PrescriptionDetails;


### PR DESCRIPTION
## Summary

Original fill now comes directly from `attributes`, not from `rxRfRecords`
"Reason for use" field has been remapped from `reason` to `indicationForUse`
Minor verbiage updates
Minor styling updates

## Related issue(s)

[Jira ticket](https://jira.devops.va.gov/browse/MHV-48949)
[Jira ticket](https://jira.devops.va.gov/browse/MHV-45002)

## What areas of the site does it impact?

my-health/Medications 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
