### PR TITLE
Fix error message alignemnt on 28-1900 scheduling options

### DIFF
--- a/src/applications/vre/28-1900/config/chapters/communication-preferences/communicationPreferences.js
+++ b/src/applications/vre/28-1900/config/chapters/communication-preferences/communicationPreferences.js
@@ -62,7 +62,7 @@ export const uiSchema = {
   },
   appointmentTimePreferences: {
     'ui:title': (
-      <p className="vads-u-margin--0 vads-u-margin-top--3 vads-u-display--inline-block vads-u-font-weight--normal vads-u-color--base vads-u-font-family--sans vads-u-font-size--base">
+      <p className="vads-u-margin--0 vads-u-margin-top-neg2 vads-u-display--inline-block vads-u-font-weight--normal vads-u-color--base vads-u-font-family--sans vads-u-font-size--base">
         When are the best times to meet with your counselor?{' '}
         <span className="schemaform-required-span vads-u-display--block">
           (*Choose at least 1)
@@ -71,8 +71,6 @@ export const uiSchema = {
     ),
     'ui:validations': [validateAtLeastOneSelected],
     'ui:options': {
-      // this needed because ObjectField adds the schemaform-block class to this, which creates a huge top margin.
-      classNames: 'vads-u-margin-top--neg2',
       showFieldLabel: true,
       forceDivWrapper: true,
     },


### PR DESCRIPTION
## Summary

- One of the error messages on 28-1900 was overlapping the checkbox
- The solution was to fix the margin classes
- I work for DBEX and my team owns this work

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/65394

## Testing done

- See video below.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

<details>
<summary>video: before</summary>

https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/825f304d-ec19-450f-b965-7ed9a696863c

</details>

<details>
<summary>video: after</summary>

https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/01decc47-729f-42a8-9a57-a439a9f3e21c

</details>

## What areas of the site does it impact?

Form 28-1900

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
