### PR TITLE
MHV-49509 Force MR users to be logged in

### DIFF
--- a/src/applications/mhv/medical-records/containers/App.jsx
+++ b/src/applications/mhv/medical-records/containers/App.jsx
@@ -1,12 +1,18 @@
 import React, { useEffect, useState, useRef } from 'react';
+import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom/cjs/react-router-dom.min';
 import PropTypes from 'prop-types';
+import { selectUser } from '@department-of-veterans-affairs/platform-user/selectors';
+import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
+import { RequiredLoginView } from '@department-of-veterans-affairs/platform-user/RequiredLoginView';
 import MrBreadcrumbs from '../components/MrBreadcrumbs';
 import ScrollToTop from '../components/shared/ScrollToTop';
 // import Navigation from '../components/Navigation';
 import { useDatadogRum } from '../hooks/useDatadogRum';
 
 const App = ({ children }) => {
+  const user = useSelector(selectUser);
+
   const [isHidden, setIsHidden] = useState(true);
   const [height, setHeight] = useState(0);
   const location = useLocation();
@@ -43,20 +49,25 @@ const App = ({ children }) => {
   }, []);
 
   return (
-    <div
-      ref={measuredRef}
-      className="vads-l-grid-container vads-u-padding-left--2"
+    <RequiredLoginView
+      user={user}
+      // serviceRequired={[backendServices.HEALTH_RECORDS]}
     >
-      <MrBreadcrumbs />
-      <div className="medical-records-container">
-        {/* <Navigation /> */}
-        <div className="vads-l-grid-container main-content">
-          <ScrollToTop />
-          {children}
-          <va-back-to-top hidden={isHidden} />
+      <div
+        ref={measuredRef}
+        className="vads-l-grid-container vads-u-padding-left--2"
+      >
+        <MrBreadcrumbs />
+        <div className="medical-records-container">
+          {/* <Navigation /> */}
+          <div className="vads-l-grid-container main-content">
+            <ScrollToTop />
+            {children}
+            <va-back-to-top hidden={isHidden} />
+          </div>
         </div>
       </div>
-    </div>
+    </RequiredLoginView>
   );
 };
 

--- a/src/applications/mhv/medical-records/containers/App.jsx
+++ b/src/applications/mhv/medical-records/containers/App.jsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom/cjs/react-router-dom.min';
 import PropTypes from 'prop-types';
 import { selectUser } from '@department-of-veterans-affairs/platform-user/selectors';
-import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
 import { RequiredLoginView } from '@department-of-veterans-affairs/platform-user/RequiredLoginView';
 import MrBreadcrumbs from '../components/MrBreadcrumbs';
 import ScrollToTop from '../components/shared/ScrollToTop';
@@ -49,10 +48,7 @@ const App = ({ children }) => {
   }, []);
 
   return (
-    <RequiredLoginView
-      user={user}
-      // serviceRequired={[backendServices.HEALTH_RECORDS]}
-    >
+    <RequiredLoginView user={user}>
       <div
         ref={measuredRef}
         className="vads-l-grid-container vads-u-padding-left--2"


### PR DESCRIPTION
## Summary

When users browse to the Medical Records application, force them to log in if they are unauthenticated.

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-49509 - MUST:  This error shows when you navigate to allergies list before signing in, but you shouldn’t be able to access the landing page or list page without signing in:

## Testing done

- Validated that users can access the MR page only when authenticated in VA.gov.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
