### PR TITLE
Hub page build pt1

### DIFF
--- a/src/applications/personalization/common/helpers.js
+++ b/src/applications/personalization/common/helpers.js
@@ -100,7 +100,17 @@ export function formatFullName({
 }
 
 export const normalizePath = path => {
-  // Remove slashes and trim whitespace
-  const pathStripped = path.endsWith('/') ? path.slice(0, -1) : path;
-  return pathStripped.trim();
+  // trim whitespace and remove trailing slash
+  const pathTrimmed = path.trim();
+  return pathTrimmed.endsWith('/') ? path.slice(0, -1) : path;
+};
+
+export const getRouteInfoFromPath = (path, routes) => {
+  const returnRouteInfo = routes.find(({ path: routePath }) => {
+    return routePath === path;
+  });
+  if (!returnRouteInfo) {
+    return { ...routes[0], name: 'profile' };
+  }
+  return returnRouteInfo;
 };

--- a/src/applications/personalization/profile/components/ProfileBreadcrumbs.jsx
+++ b/src/applications/personalization/profile/components/ProfileBreadcrumbs.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useLocation, Link } from 'react-router-dom';
 import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
@@ -9,12 +9,10 @@ import {
 
 import { PROFILE_PATHS_WITH_NAMES, PROFILE_PATHS } from '../constants';
 
-const BreadcrumbContent = () => {
+const BreadcrumbItems = () => {
   const location = useLocation();
 
-  const [breadcrumbs, setBreadcrumbs] = useState([]);
-
-  useEffect(
+  const breadcrumbs = useMemo(
     () => {
       const baseBreadCrumbs = [
         { href: '/', label: 'Home' },
@@ -29,34 +27,44 @@ const BreadcrumbContent = () => {
 
       const routeInfo = getRouteInfoFromPath(path, PROFILE_PATHS_WITH_NAMES);
 
-      setBreadcrumbs([
+      return [
         ...baseBreadCrumbs,
         {
           href: path,
           label: routeInfo.name,
         },
-      ]);
-      return null;
+      ];
     },
-    [location, setBreadcrumbs],
+    [location],
   );
 
-  if (breadcrumbs.length === 0) {
-    return null;
-  }
+  return breadcrumbs.map(crumb => {
+    const Element =
+      crumb.href === '/'
+        ? {
+            Type: 'a',
+            linkProp: 'href',
+          }
+        : {
+            Type: Link,
+            linkProp: 'to',
+          };
 
-  return breadcrumbs.map(crumb => (
-    <li key={crumb.href}>
-      <Link to={crumb.href}>{crumb.label}</Link>
-    </li>
-  ));
+    return (
+      <li key={crumb.href}>
+        <Element.Type {...{ [Element.linkProp]: crumb.href }}>
+          {crumb.label}
+        </Element.Type>
+      </li>
+    );
+  });
 };
 
 export const ProfileBreadcrumbs = () => {
   return (
     <div className="vads-u-padding-left--3">
       <VaBreadcrumbs>
-        <BreadcrumbContent />
+        <BreadcrumbItems />
       </VaBreadcrumbs>
     </div>
   );

--- a/src/applications/personalization/profile/components/ProfileBreadcrumbs.jsx
+++ b/src/applications/personalization/profile/components/ProfileBreadcrumbs.jsx
@@ -1,13 +1,14 @@
 import React, { useMemo } from 'react';
 import { useLocation, Link } from 'react-router-dom';
-import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import PropTypes from 'prop-types';
 
+import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import {
   getRouteInfoFromPath,
   normalizePath,
 } from '~/applications/personalization/common/helpers';
-
 import { PROFILE_PATHS_WITH_NAMES, PROFILE_PATHS } from '../constants';
+import { Toggler } from '~/platform/utilities/feature-toggles';
 
 const BreadcrumbItems = () => {
   const location = useLocation();
@@ -62,10 +63,18 @@ const BreadcrumbItems = () => {
 
 export const ProfileBreadcrumbs = ({ className }) => {
   return (
-    <div className={className}>
-      <VaBreadcrumbs>
-        <BreadcrumbItems />
-      </VaBreadcrumbs>
-    </div>
+    <Toggler toggleName={Toggler.TOGGLE_NAMES.profileUseHubPage}>
+      <Toggler.Enabled>
+        <div className={className}>
+          <VaBreadcrumbs>
+            <BreadcrumbItems />
+          </VaBreadcrumbs>
+        </div>
+      </Toggler.Enabled>
+    </Toggler>
   );
+};
+
+ProfileBreadcrumbs.propTypes = {
+  className: PropTypes.string,
 };

--- a/src/applications/personalization/profile/components/ProfileBreadcrumbs.jsx
+++ b/src/applications/personalization/profile/components/ProfileBreadcrumbs.jsx
@@ -60,9 +60,9 @@ const BreadcrumbItems = () => {
   });
 };
 
-export const ProfileBreadcrumbs = () => {
+export const ProfileBreadcrumbs = ({ className }) => {
   return (
-    <div className="vads-u-padding-left--3">
+    <div className={className}>
       <VaBreadcrumbs>
         <BreadcrumbItems />
       </VaBreadcrumbs>

--- a/src/applications/personalization/profile/components/ProfileBreadcrumbs.jsx
+++ b/src/applications/personalization/profile/components/ProfileBreadcrumbs.jsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import { useLocation, Link } from 'react-router-dom';
+import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+import {
+  getRouteInfoFromPath,
+  normalizePath,
+} from '~/applications/personalization/common/helpers';
+
+import { PROFILE_PATHS_WITH_NAMES, PROFILE_PATHS } from '../constants';
+
+const BreadcrumbContent = () => {
+  const location = useLocation();
+
+  const [breadcrumbs, setBreadcrumbs] = useState([]);
+
+  useEffect(
+    () => {
+      const baseBreadCrumbs = [
+        { href: '/', label: 'Home' },
+        { href: '/profile', label: 'Profile' },
+      ];
+
+      const path = normalizePath(location.pathname);
+
+      if (path === PROFILE_PATHS.PROFILE_ROOT) {
+        return baseBreadCrumbs;
+      }
+
+      const routeInfo = getRouteInfoFromPath(path, PROFILE_PATHS_WITH_NAMES);
+
+      setBreadcrumbs([
+        ...baseBreadCrumbs,
+        {
+          href: path,
+          label: routeInfo.name,
+        },
+      ]);
+      return null;
+    },
+    [location, setBreadcrumbs],
+  );
+
+  if (breadcrumbs.length === 0) {
+    return null;
+  }
+
+  return breadcrumbs.map(crumb => (
+    <li key={crumb.href}>
+      <Link to={crumb.href}>{crumb.label}</Link>
+    </li>
+  ));
+};
+
+export const ProfileBreadcrumbs = () => {
+  return (
+    <div className="vads-u-padding-left--3">
+      <VaBreadcrumbs>
+        <BreadcrumbContent />
+      </VaBreadcrumbs>
+    </div>
+  );
+};

--- a/src/applications/personalization/profile/components/ProfileFullWidthContainer.jsx
+++ b/src/applications/personalization/profile/components/ProfileFullWidthContainer.jsx
@@ -5,7 +5,7 @@ export const ProfileFullWidthContainer = ({ children }) => {
   return (
     <div className="vads-l-grid-container vads-u-padding-x--0">
       <div className="vads-l-row">
-        <div className="vads-l-col--12 vads-u-padding-bottom--4 vads-u-padding-x--1 medium-screen:vads-l-col--9 medium-screen:vads-u-padding-x--2 medium-screen:vads-u-padding-bottom--6 small-desktop-screen:vads-l-col--8">
+        <div className="vads-l-col--12 vads-u-padding-bottom--4 vads-u-padding-x--1 medium-screen:vads-u-padding-x--2 medium-screen:vads-u-padding-bottom--6">
           {/* children will be passed in from React Router one level up */}
           {children}
         </div>

--- a/src/applications/personalization/profile/components/ProfileLink.jsx
+++ b/src/applications/personalization/profile/components/ProfileLink.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import classNames from 'classnames';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+import { PROFILE_PATHS } from '../constants';
+import { normalizePath } from '../../common/helpers';
+
+// sets up same styles for icon as va-link with active prop
+const StyledRouterLink = styled(Link)`
+  i {
+    &:before {
+      content: '\f105';
+      display: inline-block;
+      margin-bottom: 0.1rem;
+      margin-left: 0.8rem;
+      margin-right: 0;
+      vertical-align: middle;
+      moz-osx-font-smoothing: grayscale;
+      -webkit-font-smoothing: antialiased;
+      font-family: 'Font Awesome 5 Free';
+      font-size: 1.6rem;
+      font-style: normal;
+      font-variant: normal;
+      font-weight: 900;
+      line-height: 1;
+      text-rendering: auto;
+    }
+  }
+
+  &:hover,
+  &:focus {
+    i {
+      &:before {
+        margin-left: 1.2rem;
+        transition-duration: 0.3s;
+        transition-timing-function: ease-in-out;
+        transition-property: margin;
+      }
+    }
+  }
+`;
+
+export const ProfileLink = ({ href, active = true, className = '', text }) => {
+  const path = normalizePath(href);
+
+  const isProfilePath = Object.values(PROFILE_PATHS).includes(path);
+
+  const classes = classNames(className, {
+    'vads-u-font-weight--bold': active,
+  });
+
+  return isProfilePath ? (
+    <StyledRouterLink
+      className={classes}
+      to={path}
+      data-testid="profile-link-internal"
+    >
+      {text}
+      {active && <i />}
+    </StyledRouterLink>
+  ) : (
+    <va-link
+      active={active}
+      text={text}
+      href={href}
+      className={className}
+      data-testid="profile-link-external"
+    />
+  );
+};
+
+ProfileLink.propTypes = {
+  href: PropTypes.string.isRequired,
+  text: PropTypes.string.isRequired,
+  active: PropTypes.bool,
+  className: PropTypes.string,
+};

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -14,6 +14,7 @@ import { ProfileFullWidthContainer } from './ProfileFullWidthContainer';
 import { getRoutesForNav } from '../routesForNav';
 import { selectProfileToggles } from '../selectors';
 import { normalizePath } from '../../common/helpers';
+import { ProfileBreadcrumbs } from './ProfileBreadcrumbs';
 
 const LAYOUTS = {
   SIDEBAR: 'sidebar',
@@ -82,6 +83,7 @@ const ProfileWrapper = ({
           </div>
 
           <div className="vads-l-grid-container vads-u-padding-x--0">
+            <ProfileBreadcrumbs />
             <div className="vads-l-row">
               <div className="vads-u-display--none medium-screen:vads-u-display--block vads-l-col--3 vads-u-padding-left--2">
                 <ProfileSubNav

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { connect, useSelector } from 'react-redux';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
 
@@ -11,8 +11,7 @@ import ProfileSubNav from './ProfileSubNav';
 import ProfileMobileSubNav from './ProfileMobileSubNav';
 import { PROFILE_PATHS } from '../constants';
 import { ProfileFullWidthContainer } from './ProfileFullWidthContainer';
-import { getRoutesForNav } from '../routesForNav';
-import { selectProfileToggles } from '../selectors';
+import { routesForNav } from '../routesForNav';
 import { normalizePath } from '../../common/helpers';
 import { ProfileBreadcrumbs } from './ProfileBreadcrumbs';
 
@@ -57,11 +56,6 @@ const ProfileWrapper = ({
     },
     [location.pathname, profileUseHubPage],
   );
-
-  const toggles = useSelector(selectProfileToggles);
-  const routesForNav = getRoutesForNav({
-    profileUseHubPage: toggles.profileUseHubPage,
-  });
 
   return (
     <>

--- a/src/applications/personalization/profile/components/edit/Edit.jsx
+++ b/src/applications/personalization/profile/components/edit/Edit.jsx
@@ -11,28 +11,20 @@ import ProfileInformationFieldController from '~/platform/user/profile/vap-svc/c
 import { Toggler } from '~/platform/utilities/feature-toggles';
 import { hasVAPServiceConnectionError } from '~/platform/user/selectors';
 
-import { getRoutesForNav } from '../../routesForNav';
 import { EditFallbackContent } from './EditFallbackContent';
 import { EditContext } from './EditContext';
 import { EditConfirmCancelModal } from './EditConfirmCancelModal';
 import { EditBreadcrumb } from './EditBreadcrumb';
+
+import { getRoutesForNav } from '../../routesForNav';
 import getProfileInfoFieldAttributes from '../../util/getProfileInfoFieldAttributes';
 import { getInitialFormValues } from '../../util/contact-information/formValues';
 import { selectProfileToggles } from '../../selectors';
+import { getRouteInfoFromPath } from '~/applications/personalization/common/helpers';
 
 const useQuery = () => {
   const { search } = useLocation();
   return useMemo(() => new URLSearchParams(search), [search]);
-};
-
-const getReturnRouteInfo = (path, routes) => {
-  const returnRouteInfo = routes.find(({ path: routePath }) => {
-    return routePath === path;
-  });
-  if (!returnRouteInfo) {
-    return { ...routes[0], name: 'profile' };
-  }
-  return returnRouteInfo;
 };
 
 const getFieldInfo = fieldName => {
@@ -74,7 +66,7 @@ export const Edit = () => {
 
   const fieldInfo = getFieldInfo(query.get('fieldName'));
 
-  const returnRouteInfo = getReturnRouteInfo(
+  const returnRouteInfo = getRouteInfoFromPath(
     query.get('returnPath'),
     routesForNav,
   );

--- a/src/applications/personalization/profile/components/edit/Edit.jsx
+++ b/src/applications/personalization/profile/components/edit/Edit.jsx
@@ -16,10 +16,9 @@ import { EditContext } from './EditContext';
 import { EditConfirmCancelModal } from './EditConfirmCancelModal';
 import { EditBreadcrumb } from './EditBreadcrumb';
 
-import { getRoutesForNav } from '../../routesForNav';
+import { routesForNav } from '../../routesForNav';
 import getProfileInfoFieldAttributes from '../../util/getProfileInfoFieldAttributes';
 import { getInitialFormValues } from '../../util/contact-information/formValues';
-import { selectProfileToggles } from '../../selectors';
 import { getRouteInfoFromPath } from '~/applications/personalization/common/helpers';
 
 const useQuery = () => {
@@ -55,11 +54,6 @@ export const Edit = () => {
   const dispatch = useDispatch();
   const history = useHistory();
   const query = useQuery();
-
-  const toggles = useSelector(selectProfileToggles);
-  const routesForNav = getRoutesForNav({
-    profileUseHubPage: toggles.profileUseHubPage,
-  });
 
   const [showConfirmCancelModal, setShowConfirmCancelModal] = useState(false);
   const [hasBeforeUnloadListener, setHasBeforeUnloadListener] = useState(false);

--- a/src/applications/personalization/profile/components/hub/Hub.jsx
+++ b/src/applications/personalization/profile/components/hub/Hub.jsx
@@ -1,11 +1,134 @@
 import React from 'react';
+
+import { PROFILE_PATHS } from '../../constants';
+
 import { ProfileBreadcrumbs } from '../ProfileBreadcrumbs';
+import { HubCard } from './HubCard';
+import { ProfileLink } from '../ProfileLink';
 
 export const Hub = () => {
   return (
-    <div>
+    <>
       <ProfileBreadcrumbs />
-      <h1>Profile Hub Page Here</h1>
-    </div>
+
+      <div className="vads-l-grid-container">
+        <h1>Profile</h1>
+      </div>
+
+      <div className="vads-l-grid-container">
+        <div className="vads-l-row vads-u-margin-bottom--4">
+          <HubCard
+            className="vads-u-padding-right--3"
+            heading="Personal information"
+            content="Review your legal name, date of birth, and disability rating. And
+              manage your preferred name and gender identity."
+            Links={() => (
+              <ProfileLink
+                text="Manage your personal information"
+                href={PROFILE_PATHS.PERSONAL_INFORMATION}
+              />
+            )}
+          />
+
+          <HubCard
+            heading="Contact information"
+            content="Manage your addresses, phone numbers, and contact email address."
+            Links={() => (
+              <ProfileLink
+                text="Manage your contact information"
+                href={PROFILE_PATHS.CONTACT_INFORMATION}
+              />
+            )}
+          />
+        </div>
+
+        <div className="vads-l-row vads-u-margin-bottom--4">
+          <HubCard
+            className="vads-u-padding-right--3"
+            heading="Military information"
+            content="Review your military branches and dates of service."
+            Links={() => (
+              <>
+                <div className="vads-u-display--block">
+                  <ProfileLink
+                    text="Review your military information"
+                    href={PROFILE_PATHS.MILITARY_INFORMATION}
+                  />
+                </div>
+                <div className="vads-u-display--block vads-u-margin-top--1p5">
+                  <ProfileLink
+                    text="Learn how to request your DD214 and other military records"
+                    href="/records/get-military-service-records/"
+                  />
+                </div>
+              </>
+            )}
+          />
+
+          <HubCard
+            heading="Direct deposit information"
+            content="Manage direct deposit information for disability compensation, pension, and education benefits."
+            Links={() => (
+              <ProfileLink
+                text="Manage your direct deposit"
+                href={PROFILE_PATHS.DIRECT_DEPOSIT}
+              />
+            )}
+          />
+        </div>
+
+        <div className="vads-l-row vads-u-margin-bottom--4">
+          <HubCard
+            className="vads-u-padding-right--3 vads-u-padding-bottom--2"
+            heading="Notification settings"
+            content="Manage the text and email notifications you get from VA."
+            Links={() => (
+              <ProfileLink
+                text="Manage notification settings"
+                href={PROFILE_PATHS.NOTIFICATION_SETTINGS}
+              />
+            )}
+          />
+
+          <HubCard
+            heading="Account security"
+            content="Review your sign-in information and account setup."
+            Links={() => (
+              <>
+                <div className="vads-u-display--block">
+                  <ProfileLink
+                    text="Update your sign-in info on the [credential] website"
+                    href="/coming-soon-cred-url"
+                  />
+                </div>
+
+                <div className="vads-u-display--block vads-u-margin-top--1p5">
+                  <ProfileLink
+                    text="Manage your account security"
+                    href={PROFILE_PATHS.ACCOUNT_SECURITY}
+                  />
+                </div>
+              </>
+            )}
+          />
+        </div>
+
+        <div className="vads-l-row vads-u-margin-bottom--4 ">
+          <HubCard
+            className="vads-u-padding-right--3"
+            heading="Connected apps"
+            content="Manage the 3rd-party apps that have access to your VA.gov profile."
+            Links={() => (
+              <>
+                <ProfileLink
+                  href={PROFILE_PATHS.CONNECTED_APPLICATIONS}
+                  text="Manage your connected apps"
+                />
+              </>
+            )}
+          />
+        </div>
+      </div>
+    </>
   );
 };

--- a/src/applications/personalization/profile/components/hub/Hub.jsx
+++ b/src/applications/personalization/profile/components/hub/Hub.jsx
@@ -21,28 +21,26 @@ export const Hub = () => {
           heading="Personal information"
           content="Review your legal name, date of birth, and disability rating. And
               manage your preferred name and gender identity."
-          Links={() => (
-            <div className="vads-u-margin-bottom--0p5">
-              <ProfileLink
-                text="Manage your personal information"
-                href={PROFILE_PATHS.PERSONAL_INFORMATION}
-              />
-            </div>
-          )}
-        />
+        >
+          <div className="vads-u-margin-bottom--0p5">
+            <ProfileLink
+              text="Manage your personal information"
+              href={PROFILE_PATHS.PERSONAL_INFORMATION}
+            />
+          </div>
+        </HubCard>
 
         <HubCard
           heading="Contact information"
           content="Manage your addresses, phone numbers, and contact email address."
-          Links={() => (
-            <div className="vads-u-margin-bottom--3">
-              <ProfileLink
-                text="Manage your contact information"
-                href={PROFILE_PATHS.CONTACT_INFORMATION}
-              />
-            </div>
-          )}
-        />
+        >
+          <div className="vads-u-margin-bottom--0p5">
+            <ProfileLink
+              text="Manage your contact information"
+              href={PROFILE_PATHS.CONTACT_INFORMATION}
+            />
+          </div>
+        </HubCard>
       </div>
 
       <div className="vads-l-row vads-u-margin-bottom--4">
@@ -50,36 +48,34 @@ export const Hub = () => {
           className="vads-u-padding-right--4"
           heading="Military information"
           content="Review your military branches and dates of service."
-          Links={() => (
-            <>
-              <div className="vads-u-display--block">
-                <ProfileLink
-                  text="Review your military information"
-                  href={PROFILE_PATHS.MILITARY_INFORMATION}
-                />
-              </div>
-              <div className="vads-u-display--block vads-u-margin-top--1p5 vads-u-margin-bottom--0p5">
-                <ProfileLink
-                  text="Learn how to request your DD214 and other military records"
-                  href="/records/get-military-service-records/"
-                />
-              </div>
-            </>
-          )}
-        />
+        >
+          <>
+            <div className="vads-u-display--block">
+              <ProfileLink
+                text="Review your military information"
+                href={PROFILE_PATHS.MILITARY_INFORMATION}
+              />
+            </div>
+            <div className="vads-u-display--block vads-u-margin-top--1p5 vads-u-margin-bottom--0p5">
+              <ProfileLink
+                text="Learn how to request your DD214 and other military records"
+                href="/records/get-military-service-records/"
+              />
+            </div>
+          </>
+        </HubCard>
 
         <HubCard
           heading="Direct deposit information"
           content="Manage direct deposit information for disability compensation, pension, and education benefits."
-          Links={() => (
-            <div className="vads-u-display--block vads-u-margin-bottom--5">
-              <ProfileLink
-                text="Manage your direct deposit information"
-                href={PROFILE_PATHS.DIRECT_DEPOSIT}
-              />
-            </div>
-          )}
-        />
+        >
+          <div className="vads-u-display--block vads-u-margin-bottom--5">
+            <ProfileLink
+              text="Manage your direct deposit information"
+              href={PROFILE_PATHS.DIRECT_DEPOSIT}
+            />
+          </div>
+        </HubCard>
       </div>
 
       <div className="vads-l-row vads-u-margin-bottom--4">
@@ -87,37 +83,35 @@ export const Hub = () => {
           className="vads-u-padding-right--4"
           heading="Notification settings"
           content="Manage the text and email notifications you get from VA."
-          Links={() => (
-            <div className="vads-u-margin-bottom--5">
-              <ProfileLink
-                text="Manage notification settings"
-                href={PROFILE_PATHS.NOTIFICATION_SETTINGS}
-              />
-            </div>
-          )}
-        />
+        >
+          <div className="vads-u-margin-bottom--5">
+            <ProfileLink
+              text="Manage notification settings"
+              href={PROFILE_PATHS.NOTIFICATION_SETTINGS}
+            />
+          </div>
+        </HubCard>
 
         <HubCard
           heading="Account security"
           content="Review your sign-in information and account setup."
-          Links={() => (
-            <>
-              <div className="vads-u-display--block">
-                <ProfileLink
-                  text="Review account security"
-                  href={PROFILE_PATHS.ACCOUNT_SECURITY}
-                />
-              </div>
+        >
+          <>
+            <div className="vads-u-display--block">
+              <ProfileLink
+                text="Review account security"
+                href={PROFILE_PATHS.ACCOUNT_SECURITY}
+              />
+            </div>
 
-              <div className="vads-u-display--block vads-u-margin-top--1p5 vads-u-margin-bottom--0p5">
-                <ProfileLink
-                  text="Update your sign-in info on the [credential] website"
-                  href="/coming-soon-cred-url"
-                />
-              </div>
-            </>
-          )}
-        />
+            <div className="vads-u-display--block vads-u-margin-top--1p5 vads-u-margin-bottom--0p5">
+              <ProfileLink
+                text="Update your sign-in info on the [credential] website"
+                href="/coming-soon-cred-url"
+              />
+            </div>
+          </>
+        </HubCard>
       </div>
 
       <div className="vads-l-row vads-u-margin-bottom--4 ">
@@ -125,15 +119,14 @@ export const Hub = () => {
           className="vads-u-padding-right--4"
           heading="Connected apps"
           content="Manage the 3rd-party apps that have access to your VA.gov profile."
-          Links={() => (
-            <div className="vads-u-display--block vads-u-margin-top--1p5 vads-u-margin-bottom--0p5">
-              <ProfileLink
-                href={PROFILE_PATHS.CONNECTED_APPLICATIONS}
-                text="Manage connected apps"
-              />
-            </div>
-          )}
-        />
+        >
+          <div className="vads-u-display--block vads-u-margin-top--1p5 vads-u-margin-bottom--0p5">
+            <ProfileLink
+              href={PROFILE_PATHS.CONNECTED_APPLICATIONS}
+              text="Manage connected apps"
+            />
+          </div>
+        </HubCard>
       </div>
     </>
   );

--- a/src/applications/personalization/profile/components/hub/Hub.jsx
+++ b/src/applications/personalization/profile/components/hub/Hub.jsx
@@ -1,5 +1,11 @@
 import React from 'react';
+import { ProfileBreadcrumbs } from '../ProfileBreadcrumbs';
 
 export const Hub = () => {
-  return <div>Profile Hub Page Here</div>;
+  return (
+    <div>
+      <ProfileBreadcrumbs />
+      <h1>Profile Hub Page Here</h1>
+    </div>
+  );
 };

--- a/src/applications/personalization/profile/components/hub/Hub.jsx
+++ b/src/applications/personalization/profile/components/hub/Hub.jsx
@@ -9,125 +9,131 @@ import { ProfileLink } from '../ProfileLink';
 export const Hub = () => {
   return (
     <>
-      <ProfileBreadcrumbs />
+      <ProfileBreadcrumbs className="vads-u-margin-left--neg1 vads-u-margin-top--neg2" />
 
-      <div className="vads-l-grid-container">
-        <h1>Profile</h1>
+      <div className="vads-l-row">
+        <h1 className="vads-u-padding-bottom--3">Profile</h1>
       </div>
 
-      <div className="vads-l-grid-container">
-        <div className="vads-l-row vads-u-margin-bottom--4">
-          <HubCard
-            className="vads-u-padding-right--3"
-            heading="Personal information"
-            content="Review your legal name, date of birth, and disability rating. And
+      <div className="vads-l-row vads-u-margin-bottom--4">
+        <HubCard
+          className="vads-u-padding-right--4"
+          heading="Personal information"
+          content="Review your legal name, date of birth, and disability rating. And
               manage your preferred name and gender identity."
-            Links={() => (
+          Links={() => (
+            <div className="vads-u-margin-bottom--0p5">
               <ProfileLink
                 text="Manage your personal information"
                 href={PROFILE_PATHS.PERSONAL_INFORMATION}
               />
-            )}
-          />
+            </div>
+          )}
+        />
 
-          <HubCard
-            heading="Contact information"
-            content="Manage your addresses, phone numbers, and contact email address."
-            Links={() => (
+        <HubCard
+          heading="Contact information"
+          content="Manage your addresses, phone numbers, and contact email address."
+          Links={() => (
+            <div className="vads-u-margin-bottom--3">
               <ProfileLink
                 text="Manage your contact information"
                 href={PROFILE_PATHS.CONTACT_INFORMATION}
               />
-            )}
-          />
-        </div>
+            </div>
+          )}
+        />
+      </div>
 
-        <div className="vads-l-row vads-u-margin-bottom--4">
-          <HubCard
-            className="vads-u-padding-right--3"
-            heading="Military information"
-            content="Review your military branches and dates of service."
-            Links={() => (
-              <>
-                <div className="vads-u-display--block">
-                  <ProfileLink
-                    text="Review your military information"
-                    href={PROFILE_PATHS.MILITARY_INFORMATION}
-                  />
-                </div>
-                <div className="vads-u-display--block vads-u-margin-top--1p5">
-                  <ProfileLink
-                    text="Learn how to request your DD214 and other military records"
-                    href="/records/get-military-service-records/"
-                  />
-                </div>
-              </>
-            )}
-          />
+      <div className="vads-l-row vads-u-margin-bottom--4">
+        <HubCard
+          className="vads-u-padding-right--4"
+          heading="Military information"
+          content="Review your military branches and dates of service."
+          Links={() => (
+            <>
+              <div className="vads-u-display--block">
+                <ProfileLink
+                  text="Review your military information"
+                  href={PROFILE_PATHS.MILITARY_INFORMATION}
+                />
+              </div>
+              <div className="vads-u-display--block vads-u-margin-top--1p5 vads-u-margin-bottom--0p5">
+                <ProfileLink
+                  text="Learn how to request your DD214 and other military records"
+                  href="/records/get-military-service-records/"
+                />
+              </div>
+            </>
+          )}
+        />
 
-          <HubCard
-            heading="Direct deposit information"
-            content="Manage direct deposit information for disability compensation, pension, and education benefits."
-            Links={() => (
+        <HubCard
+          heading="Direct deposit information"
+          content="Manage direct deposit information for disability compensation, pension, and education benefits."
+          Links={() => (
+            <div className="vads-u-display--block vads-u-margin-bottom--5">
               <ProfileLink
-                text="Manage your direct deposit"
+                text="Manage your direct deposit information"
                 href={PROFILE_PATHS.DIRECT_DEPOSIT}
               />
-            )}
-          />
-        </div>
+            </div>
+          )}
+        />
+      </div>
 
-        <div className="vads-l-row vads-u-margin-bottom--4">
-          <HubCard
-            className="vads-u-padding-right--3 vads-u-padding-bottom--2"
-            heading="Notification settings"
-            content="Manage the text and email notifications you get from VA."
-            Links={() => (
+      <div className="vads-l-row vads-u-margin-bottom--4">
+        <HubCard
+          className="vads-u-padding-right--4"
+          heading="Notification settings"
+          content="Manage the text and email notifications you get from VA."
+          Links={() => (
+            <div className="vads-u-margin-bottom--5">
               <ProfileLink
                 text="Manage notification settings"
                 href={PROFILE_PATHS.NOTIFICATION_SETTINGS}
               />
-            )}
-          />
+            </div>
+          )}
+        />
 
-          <HubCard
-            heading="Account security"
-            content="Review your sign-in information and account setup."
-            Links={() => (
-              <>
-                <div className="vads-u-display--block">
-                  <ProfileLink
-                    text="Update your sign-in info on the [credential] website"
-                    href="/coming-soon-cred-url"
-                  />
-                </div>
-
-                <div className="vads-u-display--block vads-u-margin-top--1p5">
-                  <ProfileLink
-                    text="Manage your account security"
-                    href={PROFILE_PATHS.ACCOUNT_SECURITY}
-                  />
-                </div>
-              </>
-            )}
-          />
-        </div>
-
-        <div className="vads-l-row vads-u-margin-bottom--4 ">
-          <HubCard
-            className="vads-u-padding-right--3"
-            heading="Connected apps"
-            content="Manage the 3rd-party apps that have access to your VA.gov profile."
-            Links={() => (
-              <>
+        <HubCard
+          heading="Account security"
+          content="Review your sign-in information and account setup."
+          Links={() => (
+            <>
+              <div className="vads-u-display--block">
                 <ProfileLink
-                  href={PROFILE_PATHS.CONNECTED_APPLICATIONS}
-                  text="Manage your connected apps"
+                  text="Review account security"
+                  href={PROFILE_PATHS.ACCOUNT_SECURITY}
                 />
-              </>
-            )}
-          />
-        </div>
+              </div>
+
+              <div className="vads-u-display--block vads-u-margin-top--1p5 vads-u-margin-bottom--0p5">
+                <ProfileLink
+                  text="Update your sign-in info on the [credential] website"
+                  href="/coming-soon-cred-url"
+                />
+              </div>
+            </>
+          )}
+        />
+      </div>
+
+      <div className="vads-l-row vads-u-margin-bottom--4 ">
+        <HubCard
+          className="vads-u-padding-right--4"
+          heading="Connected apps"
+          content="Manage the 3rd-party apps that have access to your VA.gov profile."
+          Links={() => (
+            <div className="vads-u-display--block vads-u-margin-top--1p5 vads-u-margin-bottom--0p5">
+              <ProfileLink
+                href={PROFILE_PATHS.CONNECTED_APPLICATIONS}
+                text="Manage connected apps"
+              />
+            </div>
+          )}
+        />
       </div>
     </>
   );

--- a/src/applications/personalization/profile/components/hub/HubCard.jsx
+++ b/src/applications/personalization/profile/components/hub/HubCard.jsx
@@ -1,7 +1,8 @@
-import classNames from 'classnames';
 import React from 'react';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
 
-export const HubCard = ({ heading, content, Links, className }) => {
+export const HubCard = ({ heading, content, children, className }) => {
   const classes = classNames('vads-l-col--6', className);
   return (
     <div className={classes}>
@@ -9,9 +10,19 @@ export const HubCard = ({ heading, content, Links, className }) => {
         <div>
           <h3 className="vads-u-margin--0">{heading}</h3>
           <p>{content}</p>
-          {Links && Links()}
+          {children}
         </div>
       </va-card>
     </div>
   );
+};
+
+HubCard.propTypes = {
+  content: PropTypes.string.isRequired,
+  heading: PropTypes.string.isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]),
+  className: PropTypes.string,
 };

--- a/src/applications/personalization/profile/components/hub/HubCard.jsx
+++ b/src/applications/personalization/profile/components/hub/HubCard.jsx
@@ -8,7 +8,7 @@ export const HubCard = ({ heading, content, children, className }) => {
     <div className={classes}>
       <va-card>
         <div>
-          <h3 className="vads-u-margin--0">{heading}</h3>
+          <h2 className="vads-u-margin--0">{heading}</h2>
           <p>{content}</p>
           {children}
         </div>

--- a/src/applications/personalization/profile/components/hub/HubCard.jsx
+++ b/src/applications/personalization/profile/components/hub/HubCard.jsx
@@ -1,0 +1,17 @@
+import classNames from 'classnames';
+import React from 'react';
+
+export const HubCard = ({ heading, content, Links, className }) => {
+  const classes = classNames('vads-l-col--6', className);
+  return (
+    <div className={classes}>
+      <va-card>
+        <div>
+          <h3 className="vads-u-margin--0">{heading}</h3>
+          <p>{content}</p>
+          {Links && Links()}
+        </div>
+      </va-card>
+    </div>
+  );
+};

--- a/src/applications/personalization/profile/constants.js
+++ b/src/applications/personalization/profile/constants.js
@@ -56,6 +56,12 @@ export const PROFILE_PATH_NAMES = Object.freeze({
   EDIT: 'Edit your information',
 });
 
+export const PROFILE_PATHS_WITH_NAMES = Object.entries(PROFILE_PATHS).map(
+  ([key, path]) => {
+    return { path, name: PROFILE_PATH_NAMES[key] };
+  },
+);
+
 export const ACCOUNT_TYPES_OPTIONS = {
   checking: 'Checking',
   savings: 'Savings',

--- a/src/applications/personalization/profile/routes.js
+++ b/src/applications/personalization/profile/routes.js
@@ -1,6 +1,7 @@
 import { PROFILE_PATHS, PROFILE_PATH_NAMES } from './constants';
 import { Edit } from './components/edit/Edit';
-import { getRoutesForNav } from './routesForNav';
+import { routesForNav } from './routesForNav';
+import { Hub } from './components/hub/Hub';
 
 // conditionally add the edit route based on feature toggle
 // conditionally add the profile hub route based on feature toggle
@@ -11,7 +12,7 @@ const getRoutes = (
   },
 ) => {
   return [
-    ...getRoutesForNav({ profileUseHubPage }),
+    ...routesForNav,
     ...(useFieldEditingPage
       ? [
           {
@@ -20,6 +21,17 @@ const getRoutes = (
             path: PROFILE_PATHS.EDIT,
             requiresLOA3: true,
             requiresMVI: true,
+          },
+        ]
+      : []),
+    ...(profileUseHubPage
+      ? [
+          {
+            component: Hub,
+            name: PROFILE_PATH_NAMES.PROFILE_ROOT,
+            path: PROFILE_PATHS.PROFILE_ROOT,
+            requiresLOA3: false,
+            requiresMVI: false,
           },
         ]
       : []),

--- a/src/applications/personalization/profile/routesForNav.js
+++ b/src/applications/personalization/profile/routesForNav.js
@@ -6,12 +6,11 @@ import DirectDeposit from './components/direct-deposit/DirectDeposit';
 import ConnectedApplications from './components/connected-apps/ConnectedApps';
 import NotificationSettings from './components/notification-settings/NotificationSettings';
 import { PROFILE_PATHS, PROFILE_PATH_NAMES } from './constants';
-import { Hub } from './components/hub/Hub';
 
 // the routesForNav array is used in the routes file to build the routes
-// the edit route is not present in the routesForNav array because
-// it is never used within the nav UI itself
-const routesForNav = [
+// the edit and hub routes are not present in the routesForNav array because
+// they are not shown in nav UI
+export const routesForNav = [
   {
     component: PersonalInformation,
     name: PROFILE_PATH_NAMES.PERSONAL_INFORMATION,
@@ -62,24 +61,3 @@ const routesForNav = [
     requiresMVI: true,
   },
 ];
-
-export const getRoutesForNav = (
-  { profileUseHubPage } = {
-    profileUseHubPage: false,
-  },
-) => {
-  return [
-    ...(profileUseHubPage
-      ? [
-          {
-            component: Hub,
-            name: PROFILE_PATH_NAMES.PROFILE_ROOT,
-            path: PROFILE_PATHS.PROFILE_ROOT,
-            requiresLOA3: false,
-            requiresMVI: false,
-          },
-        ]
-      : []),
-    ...routesForNav,
-  ];
-};

--- a/src/applications/personalization/profile/tests/components/ProfileBreadcrumbs.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/ProfileBreadcrumbs.unit.spec.jsx
@@ -1,17 +1,30 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import { MemoryRouter } from 'react-router-dom';
 import { ProfileBreadcrumbs } from '../../components/ProfileBreadcrumbs';
 import { PROFILE_PATHS } from '../../constants';
+import { renderInReduxProvider } from '~/platform/testing/unit/react-testing-library-helpers';
+import { Toggler } from '~/platform/utilities/feature-toggles';
+
+const setup = path => {
+  return renderInReduxProvider(
+    <MemoryRouter initialEntries={[path]}>
+      <ProfileBreadcrumbs />
+    </MemoryRouter>,
+    {
+      initialState: {
+        featureToggles: {
+          loading: false,
+          [Toggler.TOGGLE_NAMES.profileUseHubPage]: true,
+        },
+      },
+    },
+  );
+};
 
 describe('<ProfileBreadcrumbs />', () => {
   it('should render "Home" and "Profile" as base breadcrumbs', () => {
-    const { getByText } = render(
-      <MemoryRouter initialEntries={[PROFILE_PATHS.PROFILE_ROOT]}>
-        <ProfileBreadcrumbs />
-      </MemoryRouter>,
-    );
+    const { getByText } = setup(PROFILE_PATHS.PROFILE_ROOT);
 
     expect(getByText('Home')).to.exist;
     expect(getByText('Profile')).to.exist;
@@ -19,11 +32,7 @@ describe('<ProfileBreadcrumbs />', () => {
 
   describe('should render additional breadcrumb based on route', () => {
     it('renders personal information breadcrumb', () => {
-      const { getByText } = render(
-        <MemoryRouter initialEntries={[PROFILE_PATHS.PERSONAL_INFORMATION]}>
-          <ProfileBreadcrumbs />
-        </MemoryRouter>,
-      );
+      const { getByText } = setup(PROFILE_PATHS.PERSONAL_INFORMATION);
 
       expect(getByText('Home')).to.exist;
       expect(getByText('Profile')).to.exist;
@@ -31,11 +40,7 @@ describe('<ProfileBreadcrumbs />', () => {
     });
 
     it('renders contact information breadcrumb', () => {
-      const { getByText } = render(
-        <MemoryRouter initialEntries={[PROFILE_PATHS.CONTACT_INFORMATION]}>
-          <ProfileBreadcrumbs />
-        </MemoryRouter>,
-      );
+      const { getByText } = setup(PROFILE_PATHS.CONTACT_INFORMATION);
 
       expect(getByText('Home')).to.exist;
       expect(getByText('Profile')).to.exist;
@@ -43,11 +48,7 @@ describe('<ProfileBreadcrumbs />', () => {
     });
 
     it('renders military information breadcrumb', () => {
-      const { getByText } = render(
-        <MemoryRouter initialEntries={[PROFILE_PATHS.MILITARY_INFORMATION]}>
-          <ProfileBreadcrumbs />
-        </MemoryRouter>,
-      );
+      const { getByText } = setup(PROFILE_PATHS.MILITARY_INFORMATION);
 
       expect(getByText('Home')).to.exist;
       expect(getByText('Profile')).to.exist;
@@ -55,11 +56,7 @@ describe('<ProfileBreadcrumbs />', () => {
     });
 
     it('renders direct deposit breadcrumb', () => {
-      const { getByText } = render(
-        <MemoryRouter initialEntries={[PROFILE_PATHS.DIRECT_DEPOSIT]}>
-          <ProfileBreadcrumbs />
-        </MemoryRouter>,
-      );
+      const { getByText } = setup(PROFILE_PATHS.DIRECT_DEPOSIT);
 
       expect(getByText('Home')).to.exist;
       expect(getByText('Profile')).to.exist;
@@ -67,11 +64,7 @@ describe('<ProfileBreadcrumbs />', () => {
     });
 
     it('renders notification settings breadcrumb', () => {
-      const { getByText } = render(
-        <MemoryRouter initialEntries={[PROFILE_PATHS.NOTIFICATION_SETTINGS]}>
-          <ProfileBreadcrumbs />
-        </MemoryRouter>,
-      );
+      const { getByText } = setup(PROFILE_PATHS.NOTIFICATION_SETTINGS);
 
       expect(getByText('Home')).to.exist;
       expect(getByText('Profile')).to.exist;
@@ -79,11 +72,7 @@ describe('<ProfileBreadcrumbs />', () => {
     });
 
     it('renders connected apps breadcrumb', () => {
-      const { getByText } = render(
-        <MemoryRouter initialEntries={[PROFILE_PATHS.CONNECTED_APPLICATIONS]}>
-          <ProfileBreadcrumbs />
-        </MemoryRouter>,
-      );
+      const { getByText } = setup(PROFILE_PATHS.CONNECTED_APPLICATIONS);
 
       expect(getByText('Home')).to.exist;
       expect(getByText('Profile')).to.exist;

--- a/src/applications/personalization/profile/tests/components/ProfileBreadcrumbs.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/ProfileBreadcrumbs.unit.spec.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import { MemoryRouter } from 'react-router-dom';
+import { ProfileBreadcrumbs } from '../../components/ProfileBreadcrumbs';
+import { PROFILE_PATHS } from '../../constants';
+
+describe('<ProfileBreadcrumbs />', () => {
+  it('should render "Home" and "Profile" as base breadcrumbs', () => {
+    const { getByText } = render(
+      <MemoryRouter initialEntries={[PROFILE_PATHS.PROFILE_ROOT]}>
+        <ProfileBreadcrumbs />
+      </MemoryRouter>,
+    );
+
+    expect(getByText('Home')).to.exist;
+    expect(getByText('Profile')).to.exist;
+  });
+
+  describe('should render additional breadcrumb based on route', () => {
+    it('renders personal information breadcrumb', () => {
+      const { getByText } = render(
+        <MemoryRouter initialEntries={[PROFILE_PATHS.PERSONAL_INFORMATION]}>
+          <ProfileBreadcrumbs />
+        </MemoryRouter>,
+      );
+
+      expect(getByText('Home')).to.exist;
+      expect(getByText('Profile')).to.exist;
+      expect(getByText('Personal information')).to.exist;
+    });
+
+    it('renders contact information breadcrumb', () => {
+      const { getByText } = render(
+        <MemoryRouter initialEntries={[PROFILE_PATHS.CONTACT_INFORMATION]}>
+          <ProfileBreadcrumbs />
+        </MemoryRouter>,
+      );
+
+      expect(getByText('Home')).to.exist;
+      expect(getByText('Profile')).to.exist;
+      expect(getByText('Contact information')).to.exist;
+    });
+
+    it('renders military information breadcrumb', () => {
+      const { getByText } = render(
+        <MemoryRouter initialEntries={[PROFILE_PATHS.MILITARY_INFORMATION]}>
+          <ProfileBreadcrumbs />
+        </MemoryRouter>,
+      );
+
+      expect(getByText('Home')).to.exist;
+      expect(getByText('Profile')).to.exist;
+      expect(getByText('Military information')).to.exist;
+    });
+
+    it('renders direct deposit breadcrumb', () => {
+      const { getByText } = render(
+        <MemoryRouter initialEntries={[PROFILE_PATHS.DIRECT_DEPOSIT]}>
+          <ProfileBreadcrumbs />
+        </MemoryRouter>,
+      );
+
+      expect(getByText('Home')).to.exist;
+      expect(getByText('Profile')).to.exist;
+      expect(getByText('Direct deposit information')).to.exist;
+    });
+
+    it('renders notification settings breadcrumb', () => {
+      const { getByText } = render(
+        <MemoryRouter initialEntries={[PROFILE_PATHS.NOTIFICATION_SETTINGS]}>
+          <ProfileBreadcrumbs />
+        </MemoryRouter>,
+      );
+
+      expect(getByText('Home')).to.exist;
+      expect(getByText('Profile')).to.exist;
+      expect(getByText('Notification settings')).to.exist;
+    });
+
+    it('renders connected apps breadcrumb', () => {
+      const { getByText } = render(
+        <MemoryRouter initialEntries={[PROFILE_PATHS.CONNECTED_APPLICATIONS]}>
+          <ProfileBreadcrumbs />
+        </MemoryRouter>,
+      );
+
+      expect(getByText('Home')).to.exist;
+      expect(getByText('Profile')).to.exist;
+      expect(getByText('Connected apps')).to.exist;
+    });
+  });
+});

--- a/src/applications/personalization/profile/tests/components/hub/HubCard.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/hub/HubCard.unit.spec.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import { HubCard } from '../../../components/hub/HubCard';
+
+describe('<HubCard />', () => {
+  it('should render the correct heading', () => {
+    const { getByText } = render(
+      <HubCard heading="Test Heading" content="Test Content" />,
+    );
+
+    expect(getByText('Test Heading')).to.exist;
+  });
+
+  it('should render the correct content', () => {
+    const { getByText } = render(
+      <HubCard heading="Test Heading" content="Test Content" />,
+    );
+
+    expect(getByText('Test Content')).to.exist;
+  });
+
+  it('should render children when passed in', () => {
+    const { getByText } = render(
+      <HubCard heading="Test Heading" content="Test Content">
+        <div>Child Component</div>
+      </HubCard>,
+    );
+
+    expect(getByText('Child Component')).to.exist;
+  });
+
+  it('should apply custom classes when passed', () => {
+    const { container } = render(
+      <HubCard
+        heading="Test Heading"
+        content="Test Content"
+        className="custom-class"
+      />,
+    );
+
+    expect(container.firstChild).to.have.class('custom-class');
+  });
+});

--- a/src/applications/personalization/profile/tests/e2e/profile-hub.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-hub.cypress.spec.js
@@ -18,8 +18,17 @@ describe('Profile - Hub page', () => {
 
     checkForLegacyLoadingIndicator();
 
-    cy.findByText('Profile Hub Page Here').should('exist');
+    cy.findByText('Profile', { selector: 'h1' }).should('exist');
+    cy.findByText('Personal information', { selector: 'h2' }).should('exist');
+    cy.findByText('Contact information', { selector: 'h2' }).should('exist');
+    cy.findByText('Military information', { selector: 'h2' }).should('exist');
+    cy.findByText('Direct deposit information', { selector: 'h2' }).should(
+      'exist',
+    );
+    cy.findByText('Notification settings', { selector: 'h2' }).should('exist');
 
+    cy.findByText('Account security', { selector: 'h2' }).should('exist');
+    cy.findByText('Connected apps', { selector: 'h2' }).should('exist');
     cy.injectAxeThenAxeCheck();
   });
 


### PR DESCRIPTION
## Summary

- Adds main content cards to new `/profile` route, and is all behind `profile_use_hub_page` toggle
- `ProfileBreadcrumbs` component that uses current location to determine breadcrumbs to display
   - The breadcrumbs will appear throughout all profile pages except `/edit` as it has its own unique breadcrumb 
- `ProfileLink` component which allows React Router links or va-links to be rendered depending on the href that it is given to the component.
- Updates some helper functions

Work not completed _yet_:
- Mobile styling
- Making the `Update your sign-in info on the [credential] website` to be dynamic link
- Adding alert for when Bad Address Indicator data is present

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/64160

- NOTE: This is PR part 1 as there will be a secondary PR to add further testing, and adjust styling. This is mostly for getting the content in and setting up the links for the Hub.

## Testing done

- Unit test added for breadcrumbs and hub card.
- Content and links tested locally.
- More unit tests coming on pt2 PR

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | ![Screenshot 2023-09-19 at 10 58 18 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/65227e2b-be3f-42fd-b9a9-5d3ced298196) | ![Screenshot 2023-09-19 at 10 57 45 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/4d5f79b4-577f-4eb1-bb5e-3fda94ef6dd4) | 

## What areas of the site does it impact?

Profile

## Acceptance criteria

- Page content present
- Links work except for `Update your sign-in info on the [credential] website`
- Breadcrumbs are visible when toggle is on

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user