### PR TITLE
MHV-48809 Quick landing page updates

### DIFF
--- a/src/applications/mhv/medical-records/containers/LandingPage.jsx
+++ b/src/applications/mhv/medical-records/containers/LandingPage.jsx
@@ -253,7 +253,7 @@ const LandingPage = () => {
         </section>
         */}
 
-            <section>
+            <section className="vads-u-margin-bottom--4">
               <h2>Questions about this medical records tool</h2>
               <va-accordion bordered>
                 <va-accordion-item>
@@ -375,8 +375,7 @@ const LandingPage = () => {
                       <span className="vads-u-font-weight--bold">
                         If you think your life or health is in danger,
                       </span>{' '}
-                      call <va-telephone contact="911" /> or go to the nearest
-                      emergency room.
+                      call 911 or go to the nearest emergency room.
                     </li>
                   </ul>
                   <p className="vads-u-margin-bottom--2">


### PR DESCRIPTION
## Summary

Fixing validation criteria. 911 is not supposed to be a link.

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-48809 - Research/redesign domains not being released behind a feature flag

Validation comments:

> Please note that the contents of the last question (on the landing page is not showing up right)..please see the attachments for the actual content and the content shown on the reference page (on Sketch). Also call 911 shows 911 as a hyper link which should be changed to plain text.


> Had a discussion with Mike about '911' as hyperlink and we agreed that we need to change this to plain text because on a phone, someone can accidently click it and make an emergency call. (Also, it is not there in the designs)



## Testing done

- Visual confirmation of changes.

## Screenshots

<img width="611" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/41da9174-78b8-41f1-b32d-1e8b563b806d">


## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
