### PR TITLE
61117 Fix view issue for disabilities and conditions lists

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -3,9 +3,11 @@ import { Link } from 'react-router';
 
 import {
   capitalizeEachWord,
+  isBDD,
+  isClaimingIncrease,
+  isClaimingNew,
   isDisabilityPtsd,
   DISABILITY_SHARED_CONFIG,
-  isClaimingNew,
 } from '../utils';
 import { ptsdTypeEnum } from './ptsdTypeInfo';
 import { NULL_CONDITION_STRING } from '../constants';
@@ -58,16 +60,17 @@ const getRedirectLink = formData => {
 
 export const SummaryOfDisabilitiesDescription = ({ formData }) => {
   const { ratedDisabilities, newDisabilities } = formData;
-  const ratedDisabilityNames = ratedDisabilities
-    ? ratedDisabilities
-        .filter(disability => disability['view:selected'])
-        .map(
-          disability =>
-            typeof disability.name === 'string'
-              ? capitalizeEachWord(disability.name)
-              : NULL_CONDITION_STRING,
-        )
-    : [];
+  const ratedDisabilityNames =
+    ratedDisabilities && isClaimingIncrease(formData) && !isBDD(formData)
+      ? ratedDisabilities
+          .filter(disability => disability['view:selected'])
+          .map(
+            disability =>
+              typeof disability.name === 'string'
+                ? capitalizeEachWord(disability.name)
+                : NULL_CONDITION_STRING,
+          )
+      : [];
   const newDisabilityNames =
     newDisabilities && isClaimingNew(formData)
       ? newDisabilities.map(

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
+import PropTypes from 'prop-types';
 
 import {
   capitalizeEachWord,
@@ -95,4 +96,8 @@ export const SummaryOfDisabilitiesDescription = ({ formData }) => {
       <ul>{selectedDisabilitiesList}</ul>
     </>
   );
+};
+
+SummaryOfDisabilitiesDescription.propTypes = {
+  formData: PropTypes.shape({}),
 };

--- a/src/applications/disability-benefits/all-claims/tests/content/summaryOfDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/summaryOfDisabilities.unit.spec.jsx
@@ -76,4 +76,34 @@ describe('summaryOfDisabilitiesDescription', () => {
     expect(wrapper.find('li').length).to.equal(3);
     wrapper.unmount();
   });
+
+  it('renders both new disabilities and rated disabilities', () => {
+    const formData = {
+      'view:claimType': {
+        'view:claimingIncrease': true,
+        'view:claimingNew': true,
+      },
+      newDisabilities: [
+        { condition: 'Condition 1' },
+        { condition: 'Condition 2' },
+      ],
+      ratedDisabilities: [
+        {
+          'view:selected': false,
+          name: 'Rated Disability 1',
+        },
+        {
+          'view:selected': true,
+          name: 'Rated Disability 2',
+        },
+      ],
+    };
+
+    const wrapper = shallow(
+      <SummaryOfDisabilitiesDescription formData={formData} />,
+    );
+
+    expect(wrapper.find('li').length).to.equal(3);
+    wrapper.unmount();
+  });
 });

--- a/src/applications/disability-benefits/all-claims/tests/content/summaryOfDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/summaryOfDisabilities.unit.spec.jsx
@@ -6,6 +6,10 @@ import { SummaryOfDisabilitiesDescription } from '../../content/summaryOfDisabil
 describe('summaryOfDisabilitiesDescription', () => {
   it('renders selected rated disabilities', () => {
     const formData = {
+      'view:claimType': {
+        'view:claimingIncrease': true,
+        'view:claimingNew': false,
+      },
       ratedDisabilities: [
         {
           'view:selected': true,
@@ -28,6 +32,10 @@ describe('summaryOfDisabilitiesDescription', () => {
 
   it('does not render unselected rated disabilities', () => {
     const formData = {
+      'view:claimType': {
+        'view:claimingIncrease': true,
+        'view:claimingNew': false,
+      },
       ratedDisabilities: [
         {
           'view:selected': true,
@@ -50,6 +58,10 @@ describe('summaryOfDisabilitiesDescription', () => {
 
   it('renders new disabilities', () => {
     const formData = {
+      'view:claimType': {
+        'view:claimingIncrease': false,
+        'view:claimingNew': true,
+      },
       newDisabilities: [
         { condition: 'Condition 1' },
         { condition: 'Condition 2' },

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
@@ -10,7 +10,12 @@ describe('VA Medical Records', () => {
     schema,
     uiSchema,
   } = formConfig.chapters.supportingEvidence.pages.vaMedicalRecords;
-
+  const claimType = {
+    'view:claimType': {
+      'view:claimingIncrease': true,
+      'view:claimingNew': false,
+    },
+  };
   const ratedDisabilities = [
     {
       name: 'Post traumatic stress disorder',
@@ -26,13 +31,22 @@ describe('VA Medical Records', () => {
     },
   ];
 
-  it('should render', () => {
+  const newDisabilities = [
+    {
+      cause: 'NEW',
+      condition: 'asthma',
+      'view:descriptionInfo': {},
+    },
+  ];
+
+  it('should render with rated disabilities', () => {
     const form = mount(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
         schema={schema}
         uiSchema={uiSchema}
         data={{
+          ...claimType,
           ratedDisabilities,
           'view:hasEvidenceFollowUp': {
             'view:selectableEvidenceTypes': {
@@ -48,6 +62,33 @@ describe('VA Medical Records', () => {
     form.unmount();
   });
 
+  it('should render with rated disabilities and new conditions', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          'view:claimType': {
+            'view:claimingIncrease': true,
+            'view:claimingNew': true,
+          },
+          newDisabilities,
+          ratedDisabilities,
+          'view:hasEvidenceFollowUp': {
+            'view:selectableEvidenceTypes': {
+              'view:hasVaMedicalRecords': true,
+            },
+          },
+        }}
+      />,
+    );
+
+    expect(form.find('input').length).to.equal(7);
+    expect(form.find('select').length).to.equal(3);
+    form.unmount();
+  });
+
   // Ignore empty vaTreatmentFacilities when not selected, see
   // va.gov-team/issues/34289
   it('should allow submit if VA medical records not selected', () => {
@@ -58,6 +99,7 @@ describe('VA Medical Records', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
+          ...claimType,
           ratedDisabilities,
           'view:hasEvidenceFollowUp': {
             'view:selectableEvidenceTypes': {
@@ -85,6 +127,7 @@ describe('VA Medical Records', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
+          ...claimType,
           ratedDisabilities,
           'view:hasEvidenceFollowUp': {
             'view:selectableEvidenceTypes': {
@@ -112,6 +155,7 @@ describe('VA Medical Records', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
+          ...claimType,
           ratedDisabilities,
           vaTreatmentFacilities: [
             {
@@ -154,6 +198,7 @@ describe('VA Medical Records', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
+          ...claimType,
           ratedDisabilities,
           vaTreatmentFacilities: [
             {
@@ -196,6 +241,7 @@ describe('VA Medical Records', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
+          ...claimType,
           ratedDisabilities,
           vaTreatmentFacilities: [
             {
@@ -232,6 +278,7 @@ describe('VA Medical Records', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
+          ...claimType,
           ratedDisabilities,
           vaTreatmentFacilities: [
             {
@@ -268,6 +315,7 @@ describe('VA Medical Records', () => {
         schema={schema}
         uiSchema={uiSchema}
         data={{
+          ...claimType,
           ratedDisabilities,
           vaTreatmentFacilities: [
             {

--- a/src/applications/disability-benefits/all-claims/tests/utils/schemas.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/utils/schemas.unit.spec.js
@@ -9,6 +9,10 @@ import {
 describe('makeSchemaForNewDisabilities', () => {
   it('should return schema with downcased keynames', () => {
     const formData = {
+      'view:claimType': {
+        'view:claimingIncrease': false,
+        'view:claimingNew': true,
+      },
       newDisabilities: [
         {
           condition: 'Ptsd personal trauma',
@@ -27,6 +31,10 @@ describe('makeSchemaForNewDisabilities', () => {
 
   it('should return correct schema when periods used', () => {
     const formData = {
+      'view:claimType': {
+        'view:claimingIncrease': false,
+        'view:claimingNew': true,
+      },
       newDisabilities: [
         {
           condition: 'period. Period.',
@@ -47,6 +55,10 @@ describe('makeSchemaForNewDisabilities', () => {
 describe('makeSchemaForRatedDisabilities', () => {
   it('should return schema for selected disabilities only', () => {
     const formData = {
+      'view:claimType': {
+        'view:claimingIncrease': true,
+        'view:claimingNew': false,
+      },
       ratedDisabilities: [
         {
           name: 'Ptsd personal trauma',
@@ -72,6 +84,10 @@ describe('makeSchemaForRatedDisabilities', () => {
 describe('makeSchemaForAllDisabilities', () => {
   it('should return schema for all (selected) disabilities', () => {
     const formData = {
+      'view:claimType': {
+        'view:claimingIncrease': true,
+        'view:claimingNew': true,
+      },
       ratedDisabilities: [
         {
           name: 'Ptsd personal trauma',

--- a/src/applications/disability-benefits/all-claims/utils/schemas.js
+++ b/src/applications/disability-benefits/all-claims/utils/schemas.js
@@ -30,6 +30,8 @@ import {
 import {
   capitalizeEachWord,
   disabilityIsSelected,
+  isClaimingIncrease,
+  isClaimingNew,
   pathWithIndex,
   sippableId,
 } from './index';
@@ -47,8 +49,12 @@ const createCheckboxSchema = (schema, disabilityName) => {
   );
 };
 
+/**
+ * Create the checkbox schema for new disabilities if user has selected
+ * New claim type
+ */
 export const makeSchemaForNewDisabilities = createSelector(
-  formData => formData.newDisabilities,
+  formData => (isClaimingNew(formData) ? formData.newDisabilities : []),
   (newDisabilities = []) => ({
     properties: newDisabilities
       .map(disability => disability.condition)
@@ -56,8 +62,12 @@ export const makeSchemaForNewDisabilities = createSelector(
   }),
 );
 
+/**
+ * Create the checkbox schema for rated disabilities based if user has selected
+ * Increase claim type
+ */
 export const makeSchemaForRatedDisabilities = createSelector(
-  formData => formData.ratedDisabilities,
+  formData => (isClaimingIncrease(formData) ? formData.ratedDisabilities : []),
   (ratedDisabilities = []) => ({
     properties: ratedDisabilities
       .filter(disabilityIsSelected)
@@ -66,6 +76,10 @@ export const makeSchemaForRatedDisabilities = createSelector(
   }),
 );
 
+/**
+ * Dynamically creates the checkbox schema for new conditions and/or rated
+ * disabilities, based on the claim type user has selected
+ */
 export const makeSchemaForAllDisabilities = createSelector(
   makeSchemaForNewDisabilities,
   makeSchemaForRatedDisabilities,


### PR DESCRIPTION
## Summary
If user selects both claim types, then goes back and selects only one, disability and conditions lists are displaying an incorrect list.

**Steps to reproduce**

1. Start a new 526 claim
2. On the claim-type page, select both types
"A new condition"
"One or more of my rated conditions that have gotten worse"
3. Continue to the rated-disabilities page and select a disability
4. Go back to the claim type page and select only checkbox for "A new condition"
5. continue on in the form until you get to the disabilities/summary and va-medical-records pages

**Expected**
Only new conditions are listed on the summary and va-medical-records pages.

**Actual**
Rated disabilities are displaying on these pages, even though the user changed their claim type

Team: DBex Trex
Toggle: n/a

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/61117

## Testing done
Unit, E2E and manual tests were all successful

## Screenshots
Summaries page
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/7dae7abd-493c-4eee-98b1-c1b6a86344d6)

VA Medical Records page
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/64b1a77b-5c66-4a5f-a4f2-7c2879f81ce7)

## What areas of the site does it impact?
526EZ

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
