### PR TITLE
Tiny change to add a comma after the day in the itfWrapper.jsx file

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
@@ -7,7 +7,7 @@ import { recordEventOnce } from 'platform/monitoring/record-event';
 
 // EVSS returns dates like '2014-07-28T19:53:45.810+0000'
 const evssDateFormat = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
-const outputDateFormat = 'dddd MMMM Do[,] Y [at] h[:]mm a';
+const outputDateFormat = 'dddd[,] MMMM Do[,] Y [at] h[:]mm a';
 // Adding 1 hour to the displayDate output will display the time in the ET timezone as the returned time and date
 // is in the central timezone
 const displayDate = dateString =>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- A comma is being added after the day when showing the expiration date in the ITF success banner
- Added in a [,] in the time string interpolation
- On DBex 2: Team Carbs

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- Old date was shown without a comma after the day of expiration
- View a successful ITF fetch or creation when starting a 526 form

## Screenshots

<img width="707" alt="Screenshot 2023-09-18 at 10 17 38 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/6454840/ef0c11ce-8a88-45dc-9dc1-5e50ca39b760">



## What areas of the site does it impact?

ITF success page when starting a 526 form

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback


