### PR TITLE
MHV-49514 Updated print/download button focus color

### DIFF
--- a/src/applications/mhv/medical-records/sass/print-download.scss
+++ b/src/applications/mhv/medical-records/sass/print-download.scss
@@ -13,10 +13,10 @@
   }
   button:active,
   button:focus {
-    background-color: var(--color-primary-alt-lightest);
+    background-color: var(--color-gray-cool-light);
   }
   button:hover {
-    background-color: var(--color-primary-alt-lightest);
+    background-color: var(--color-gray-cool-light);
     color: var(--color-primary-darker);
   }
   button:hover i::before {

--- a/src/applications/mhv/medications/sass/print-download.scss
+++ b/src/applications/mhv/medications/sass/print-download.scss
@@ -1,94 +1,94 @@
 .print-download {
-    width: 275px;
-    button {
-      background-color: var(--color-white);
-      color: var(--color-primary);
-      width: 100%;
-      box-shadow: none;
-    }
-    button * {
-      margin-top: 0px;
-      margin-bottom: 0px;
-      margin-right: 0px;
-    }
-    button:active,
-    button:focus {
-      background-color: var(--color-primary-alt-lightest);
-    }
-    button:hover {
-      background-color: var(--color-primary-alt-lightest);
-      color: var(--color-primary-darker);
-    }
-    button:hover i::before {
-      color: var(--color-primary-darker);
-    }
-    button:active {
-      color: var(--color-primary);
-      outline: none;
-    }
-    button:active i::before {
-      color: var(--color-primary);
-    }
+  width: 275px;
+  button {
+    background-color: var(--color-white);
+    color: var(--color-primary);
+    width: 100%;
+    box-shadow: none;
+  }
+  button * {
+    margin-top: 0px;
+    margin-bottom: 0px;
+    margin-right: 0px;
+  }
+  button:active,
+  button:focus {
+    background-color: var(--color-gray-cool-light);
+  }
+  button:hover {
+    background-color: var(--color-gray-cool-light);
+    color: var(--color-primary-darker);
+  }
+  button:hover i::before {
+    color: var(--color-primary-darker);
+  }
+  button:active {
+    color: var(--color-primary);
+    outline: none;
+  }
+  button:active i::before {
+    color: var(--color-primary);
+  }
 
-    .toggle-menu-button {
-      display: flex;
-      align-items: center;
-      margin-bottom: 0;
-      border-radius: 5px;
-      border: 2px solid var(--color-primary);
-    }
+  .toggle-menu-button {
+    display: flex;
+    align-items: center;
+    margin-bottom: 0;
+    border-radius: 5px;
+    border: 2px solid var(--color-primary);
+  }
 
-    .menu-options {
+  .menu-options {
+    margin: 0px;
+    padding: 0px;
+    display: none;
+    flex-direction: column;
+
+    li:first-child {
+      margin-top: 4px;
+      border-radius: 5px 5px 0px 0px;
+      border-top: 2px solid var(--color-primary);
+      border-right: 2px solid var(--color-primary);
+      border-bottom: 2px solid var(--color-primary);
+      border-left: 2px solid var(--color-primary);
+
+      button {
+        border-radius: 5px 5px 0px 0px;
+      }
+    }
+    li {
       margin: 0px;
       padding: 0px;
-      display: none;
-      flex-direction: column;
+      border-top: none;
+      border-right: 2px solid var(--color-primary);
+      border-bottom: 2px solid var(--color-primary);
+      border-left: 2px solid var(--color-primary);
+      border-radius: 0px;
 
-      li:first-child {
-        margin-top: 4px;
-        border-radius: 5px 5px 0px 0px;
-        border-top: 2px solid var(--color-primary);
-        border-right: 2px solid var(--color-primary);
-        border-bottom: 2px solid var(--color-primary);
-        border-left: 2px solid var(--color-primary);
-
-        button {
-          border-radius: 5px 5px 0px 0px;
-        }
-      }
-      li {
-        margin: 0px;
-        padding: 0px;
-        border-top: none;
-        border-right: 2px solid var(--color-primary);
-        border-bottom: 2px solid var(--color-primary);
-        border-left: 2px solid var(--color-primary);
+      button {
         border-radius: 0px;
-
-        button {
-          border-radius: 0px;
-          margin: 0px;
-          text-align: left;
-        }
-      }
-      li:last-child {
-        border-radius: 0px 0px 5px 5px;
-        border-top: none;
-        border-right: 2px solid var(--color-primary);
-        border-bottom: 2px solid var(--color-primary);
-        border-left: 2px solid var(--color-primary);
-
-        button {
-          border-radius: 0px 0px 5px 5px;
-        }
+        margin: 0px;
+        text-align: left;
       }
     }
+    li:last-child {
+      border-radius: 0px 0px 5px 5px;
+      border-top: none;
+      border-right: 2px solid var(--color-primary);
+      border-bottom: 2px solid var(--color-primary);
+      border-left: 2px solid var(--color-primary);
 
-    .menu-options-open {
-      width: 275px;
-      position: absolute;
-      z-index: 99;
-      list-style: none;
-      display: flex;
+      button {
+        border-radius: 0px 0px 5px 5px;
+      }
     }
   }
+
+  .menu-options-open {
+    width: 275px;
+    position: absolute;
+    z-index: 99;
+    list-style: none;
+    display: flex;
+  }
+}


### PR DESCRIPTION
## Summary

Updated focus/hover color of Print/Download button in Medical Records.

Original task was to use the latest va-button component. However, because it uses a shadow dom, that button cannot be restyled to match the designs for the print/download dropdown component. For now, it was recommended to update the hover/focus style to be the appropriate color.

Per @BobbyBaileyRB:
> As of now, the focus state (when someone is using the keyboard to tab through) is not passing the color contrast for foreground and background. ...I am recommending to change the focus state to match https://design.va.gov/components/button/ for now.

## Related issue(s)
### [MHV-49514](https://jira.devops.va.gov/browse/MHV-49514) - MUST: UCD - Print and download (dropdown) button, required change for Rx and MR. ###

> At present, the dropdown component for printing and downloading (for both the Medical Records and Medications teams) found on list pages and detail pages, may currently refer to version 1 of the secondary button, but this does not align with the actual VA code in use. If the design system team makes any updates to the component, these changes will not be reflected in this component.
> 
> Action(s) Required:
> 
> Utilize the v3 version of the secondary button, which can be found at https://design.va.gov/storybook/?path=/docs/uswds-va-button--secondary
> Please verify that the code references the correct version to ensure that when updates are applied to the design system, this component will be automatically updated
> The colors for the (background and foreground) text and border must match the component in the given source; including the hover, focus, and active states
> Changes must reflect in both Medical Records and Medications wherever this component displays (list pages and detail pages)

## Testing done

- Manual testing to ensure the hover/focus color changed appropriately.

## Screenshots

### Before ###
<img width="294" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/3a949247-7b1d-4d48-a8fb-2af5289033e7">

### After ###
<img width="288" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/de4f4bdc-2c41-4fbc-aca8-d63fd865ed6d">


## What areas of the site does it impact?

- MHV Medical Records
- MHV Medications

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
