### PR TITLE
[DBEX-64149] Update accordion and edit components on forms review page

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -436,7 +436,6 @@ module.exports = async (env = {}) => {
           },
         },
       },
-      runtimeChunk: 'single',
     },
     plugins: [
       new webpack.DefinePlugin({

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -436,6 +436,7 @@ module.exports = async (env = {}) => {
           },
         },
       },
+      runtimeChunk: 'single',
     },
     plugins: [
       new webpack.DefinePlugin({

--- a/src/applications/appeals/shared/components/AreaOfDisagreement.jsx
+++ b/src/applications/appeals/shared/components/AreaOfDisagreement.jsx
@@ -103,7 +103,7 @@ const AreaOfDisagreement = ({
     },
     updatePage: () => {
       waitForRenderThenFocus(
-        `[name="areaOfDisagreementFollowUp${pagePerItemIndex}ScrollElement"] + form .edit-btn`,
+        `[name="areaOfDisagreementFollowUp${pagePerItemIndex}ScrollElement"] + form va-button[text="Edit"]`,
       );
       updatePage();
     },

--- a/src/applications/appeals/testing/components/AreaOfDisagreement.jsx
+++ b/src/applications/appeals/testing/components/AreaOfDisagreement.jsx
@@ -104,7 +104,7 @@ const AreaOfDisagreement = ({
     },
     updatePage: () => {
       waitForRenderThenFocus(
-        `[name="areaOfDisagreementFollowUp${pagePerItemIndex}ScrollElement"] + form .edit-btn`,
+        `[name="areaOfDisagreementFollowUp${pagePerItemIndex}ScrollElement"] + form va-button[text="Edit"]`,
       );
       updatePage();
     },

--- a/src/applications/edu-benefits/1990s/analytics/analytics-events.js
+++ b/src/applications/edu-benefits/1990s/analytics/analytics-events.js
@@ -1,24 +1,6 @@
-import {
-  CLOSE_REVIEW_CHAPTER,
-  OPEN_REVIEW_CHAPTER,
-  SET_EDIT_MODE,
-} from 'platform/forms-system/src/js/actions';
+import { SET_EDIT_MODE } from 'platform/forms-system/src/js/actions';
 
 export const analyticsEvents = [
-  {
-    action: CLOSE_REVIEW_CHAPTER,
-    event: () => ({
-      event: 'int-accordion-collapse',
-      'accordion-header': 'VRRAP application',
-    }),
-  },
-  {
-    action: OPEN_REVIEW_CHAPTER,
-    event: () => ({
-      event: 'int-accordion-expand',
-      'accordion-header': 'VRRAP application',
-    }),
-  },
   {
     action: SET_EDIT_MODE,
     event: (store, action) => {

--- a/src/applications/edu-benefits/feedback-tool/tests/01.feedback-tool-keyboard.cypress.spec.js
+++ b/src/applications/edu-benefits/feedback-tool/tests/01.feedback-tool-keyboard.cypress.spec.js
@@ -180,7 +180,7 @@ describe('Feedback Tool Keyboard Test', () => {
     cy.realPress('Enter');
 
     cy.get('input[type="checkbox"]');
-    cy.repeatKey('Tab', 6);
+    cy.repeatKey('Tab', 7);
     cy.allyEvaluateCheckboxes(['input[type="checkbox"]']);
   });
 });

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-long.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-long.cypress.spec.js
@@ -205,7 +205,7 @@ const testConfig = createTestConfig(
       },
       'review-and-submit': ({ afterHook }) => {
         afterHook(() => {
-          cy.get('.accordion-header').should('have.length', 4);
+          cy.get('va-accordion-item').should('have.length', 4);
           cy.get('#veteran-signature')
             .shadow()
             .find('input')

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-short.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-short.cypress.spec.js
@@ -139,7 +139,7 @@ const testConfig = createTestConfig(
       },
       'review-and-submit': ({ afterHook }) => {
         afterHook(() => {
-          cy.get('.accordion-header').should('have.length', 3);
+          cy.get('va-accordion-item').should('have.length', 3);
           cy.get('#veteran-signature')
             .shadow()
             .find('input')

--- a/src/applications/financial-status-report/tests/e2e/streamlined-waiver-long.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/streamlined-waiver-long.cypress.spec.js
@@ -155,7 +155,7 @@ const testConfig = createTestConfig(
       },
       'review-and-submit': ({ afterHook }) => {
         afterHook(() => {
-          cy.get('.accordion-header').should('have.length', 4);
+          cy.get('va-accordion-item').should('have.length', 4);
           cy.get('#veteran-signature')
             .shadow()
             .find('input')

--- a/src/applications/financial-status-report/tests/e2e/streamlined-waiver-short.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/streamlined-waiver-short.cypress.spec.js
@@ -139,7 +139,7 @@ const testConfig = createTestConfig(
       },
       'review-and-submit': ({ afterHook }) => {
         afterHook(() => {
-          cy.get('.accordion-header').should('have.length', 3);
+          cy.get('va-accordion-item').should('have.length', 3);
           cy.get('#veteran-signature')
             .shadow()
             .find('input')

--- a/src/applications/hca/tests/e2e/utils/index.js
+++ b/src/applications/hca/tests/e2e/utils/index.js
@@ -170,7 +170,7 @@ export const shortFormSelfDisclosureToSubmit = () => {
   goToNextPage('review-and-submit');
 
   // check review page for self disclosure of va compensation type
-  cy.get(`button.usa-button-unstyled`)
+  cy.get('va-accordion-item')
     .contains(/^VA benefits$/)
     .click();
   cy.findByText(/Do you receive VA disability compensation?/i, {

--- a/src/applications/simple-forms/21-0972/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-0972/containers/ConfirmationPage.jsx
@@ -25,7 +25,7 @@ const childContent = (
         value: 'null',
       }}
     >
-      <va-accordion-item header="Accrued benefits" id="first">
+      <va-accordion-item header="Accrued benefits">
         <ul>
           <li>
             Application for Accrued Amounts Due a Deceased Beneficiary (VA Form
@@ -37,7 +37,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item header="Appeals" id="second">
+      <va-accordion-item header="Appeals">
         <ul>
           <li>
             Decision Review Request: Supplemental Claim (VA Form 20-0995)
@@ -63,7 +63,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item header="Auto allowance" id="third">
+      <va-accordion-item header="Auto allowance">
         <ul>
           <li>
             Application for Automobile or Other Conveyance and Adaptive
@@ -75,10 +75,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item
-        header="Benefits for certain children with disabilities"
-        id="fourth"
-      >
+      <va-accordion-item header="Benefits for certain children with disabilities">
         <ul>
           <li>
             Application for Benefits for a Qualifying Veteran’s Child Born with
@@ -90,7 +87,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item header="Compensation" id="fifth">
+      <va-accordion-item header="Compensation">
         <ul>
           <li>
             Application for Disability Compensation and Related Compensation
@@ -102,7 +99,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item header="Compensation or Pension" id="sixth">
+      <va-accordion-item header="Compensation or Pension">
         <ul>
           <li>
             Intent to File a Claim for Compensation and/or Pension, or Survivors
@@ -114,7 +111,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item header="Dependents" id="seventh">
+      <va-accordion-item header="Dependents">
         <ul>
           <li>
             Application Request to Add and/or Remove Dependents (VA Form
@@ -126,7 +123,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item header="Dependent parent(s)" id="eighth">
+      <va-accordion-item header="Dependent parent(s)">
         <ul>
           <li>
             Statement of Dependency of Parent(s) (VA Form 21P-509)
@@ -137,7 +134,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item header="Individual unemployability" id="ninth">
+      <va-accordion-item header="Individual unemployability">
         <ul>
           <li>
             Veteran’s Application for Increased Compensation Based on
@@ -149,7 +146,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item header="Pension" id="tenth">
+      <va-accordion-item header="Pension">
         <ul>
           <li>
             Application for Veterans Pension (VA Form 21P-527EZ)
@@ -211,7 +208,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item header="Posttraumatic stress disorder" id="twelfth">
+      <va-accordion-item header="Posttraumatic stress disorder">
         <ul>
           <li>
             Statement in Support of Claim for Service Connection for
@@ -238,10 +235,7 @@ const childContent = (
           forms are included within the online version of VA Form 21-526EZ.
         </p>
       </va-accordion-item>
-      <va-accordion-item
-        header="School-age children (ages 18 to 23 and in school)"
-        id="thirteenth"
-      >
+      <va-accordion-item header="School-age children (ages 18 to 23 and in school)">
         <ul>
           <li>
             Request for Approval of School Attendance (VA Form 21-674)
@@ -252,10 +246,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item
-        header="Specially adapted housing or special home adaptation"
-        id="fourteenth"
-      >
+      <va-accordion-item header="Specially adapted housing or special home adaptation">
         <ul>
           <li>
             Application in Acquiring Specially Adapted Housing or Special Home
@@ -267,7 +258,7 @@ const childContent = (
           </li>
         </ul>
       </va-accordion-item>
-      <va-accordion-item header="Survivor benefits" id="fifteenth">
+      <va-accordion-item header="Survivor benefits">
         <ul>
           <li>
             Application for DIC, Survivors Pension, and/or Accrued Benefit (VA

--- a/src/applications/toe/tests/e2e/00-toe-prefill.cypress.spec.js
+++ b/src/applications/toe/tests/e2e/00-toe-prefill.cypress.spec.js
@@ -482,22 +482,16 @@ describe('All Field prefilled tests for TOE app', () => {
     );
 
     // verifying your information section in review page
-    cy.get('button[id*="collapsibleButton"]').contains('Your information');
+    cy.get("va-accordion-item[header='Your information']").should('exist');
 
     // verifying Sponsor information section in review page
 
-    cy.get('button[id*="collapsibleButton"]')
-      .contains('Sponsor information')
-      .click();
+    cy.get("va-accordion-item[header='Sponsor information']").click();
     cy.contains('Sponsor 1: Sharon Parker').should('exist');
-    cy.get('button[id*="collapsibleButton"]')
-      .contains('Sponsor information')
-      .click();
+    cy.get("va-accordion-item[header='Sponsor information']").click();
 
     // verifying Contact information, mailing and contact preference section in review page
-    cy.get('button[id*="collapsibleButton"]')
-      .contains('Contact information')
-      .click();
+    cy.get("va-accordion-item[header='Contact information']").click();
     cy.contains(
       toeClaimantTestData.data.attributes.claimant.contactInfo
         .mobilePhoneNumber,
@@ -519,15 +513,11 @@ describe('All Field prefilled tests for TOE app', () => {
     cy.contains(
       toeClaimantTestData.data.attributes.claimant.contactInfo.zipcode,
     ).should('exist');
-    cy.get('button[id*="collapsibleButton"]')
-      .contains('Contact information')
-      .click();
+    cy.get("va-accordion-item[header='Contact information']").click();
 
     // verify direct deposit information on review page
-    cy.get('button[id*="collapsibleButton"]')
-      .contains('Direct deposit')
-      .click();
-    cy.get('button[aria-label="Edit account information"]').click();
+    cy.get("va-accordion-item[header='Direct deposit']").click();
+    cy.get('va-button[aria-label="Edit account information"]').click();
     cy.get(
       'input[id*="root_bankAccount_accountType"][value="checking"]',
     ).should('be.checked');
@@ -540,8 +530,6 @@ describe('All Field prefilled tests for TOE app', () => {
       '123123123',
     );
     cy.get('[aria-label="Update Direct deposit"]').click();
-    cy.get('button[id*="collapsibleButton"]')
-      .contains('Direct deposit')
-      .click();
+    cy.get("va-accordion-item[header='Direct deposit']").click();
   });
 });

--- a/src/applications/toe/tests/fixtures/data/form-submission-test-data.js
+++ b/src/applications/toe/tests/fixtures/data/form-submission-test-data.js
@@ -66,7 +66,6 @@ export const submissionForm = {
     },
   },
   reviewPageView: {
-    openChapters: [],
     viewedPages: {},
   },
   trackingPrefix: 'toe-',

--- a/src/platform/forms-system/exportsFile.js
+++ b/src/platform/forms-system/exportsFile.js
@@ -183,8 +183,6 @@ export { default as TextWidget } from './src/js/widgets/TextWidget';
 export { default as ArrayCountWidget } from './src/js/widgets/ArrayCountWidget';
 
 export {
-  closeReviewChapter,
-  openReviewChapter,
   setData,
   setEditMode,
   setSubmission,

--- a/src/platform/forms-system/exportsFile.js
+++ b/src/platform/forms-system/exportsFile.js
@@ -108,7 +108,6 @@ export {
   getFormData,
   getFormPages,
   getSubmission,
-  getReviewPageOpenChapters,
   getViewedPages,
 } from './src/js/state/selectors';
 

--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -13,24 +13,7 @@ export const SET_VIEWED_PAGES = 'SET_VIEWED_PAGES';
 export const SET_PRE_SUBMIT = 'SET_PRE_SUBMIT';
 export const SET_SUBMISSION = 'SET_SUBMISSION';
 export const SET_SUBMITTED = 'SET_SUBMITTED';
-export const OPEN_REVIEW_CHAPTER = 'OPEN_REVIEW_CHAPTER';
-export const CLOSE_REVIEW_CHAPTER = 'CLOSE_REVIEW_CHAPTER';
 export const SET_FORM_ERRORS = 'SET_FORM_ERRORS';
-
-export function closeReviewChapter(closedChapter, pageKeys = []) {
-  return {
-    type: CLOSE_REVIEW_CHAPTER,
-    closedChapter,
-    pageKeys,
-  };
-}
-
-export function openReviewChapter(openedChapter) {
-  return {
-    type: OPEN_REVIEW_CHAPTER,
-    openedChapter,
-  };
-}
 
 export function setData(data) {
   return {

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -163,13 +163,7 @@ class ObjectField extends React.Component {
       onEdit = formContext?.onEdit,
       text = 'Edit',
     } = {}) => (
-      <va-button
-        secondary
-        role="button"
-        aria-label={label}
-        onClick={onEdit}
-        text={text}
-      />
+      <va-button secondary aria-label={label} onClick={onEdit} text={text} />
     );
 
     if (isReactComponent(ObjectViewField)) {

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -243,6 +243,7 @@ ObjectField.propTypes = {
   }),
   required: PropTypes.bool,
   uiSchema: PropTypes.object,
+  onBlur: PropTypes.func,
   onChange: PropTypes.func,
 };
 

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -163,7 +163,13 @@ class ObjectField extends React.Component {
       onEdit = formContext?.onEdit,
       text = 'Edit',
     } = {}) => (
-      <va-button secondary aria-label={label} onClick={onEdit} text={text} />
+      <va-button
+        className="edit-btn"
+        secondary
+        aria-label={label}
+        onClick={onEdit}
+        text={text}
+      />
     );
 
     if (isReactComponent(ObjectViewField)) {

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -163,7 +163,13 @@ class ObjectField extends React.Component {
       onEdit = formContext?.onEdit,
       text = 'Edit',
     } = {}) => (
-      <va-button secondary aria-label={label} onClick={onEdit} text={text} />
+      <va-button
+        secondary
+        role="button"
+        aria-label={label}
+        onClick={onEdit}
+        text={text}
+      />
     );
 
     if (isReactComponent(ObjectViewField)) {

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -163,13 +163,7 @@ class ObjectField extends React.Component {
       onEdit = formContext?.onEdit,
       text = 'Edit',
     } = {}) => (
-      <va-button
-        className="edit-btn"
-        secondary
-        aria-label={label}
-        onClick={onEdit}
-        text={text}
-      />
+      <va-button secondary aria-label={label} onClick={onEdit} text={text} />
     );
 
     if (isReactComponent(ObjectViewField)) {

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -163,14 +163,7 @@ class ObjectField extends React.Component {
       onEdit = formContext?.onEdit,
       text = 'Edit',
     } = {}) => (
-      <button
-        type="button"
-        className="edit-btn primary-outline"
-        aria-label={label}
-        onClick={onEdit}
-      >
-        {text}
-      </button>
+      <va-button secondary aria-label={label} onClick={onEdit} text={text} />
     );
 
     if (isReactComponent(ObjectViewField)) {
@@ -195,7 +188,9 @@ class ObjectField extends React.Component {
                   {title}
                 </h4>
               )}
-            {defaultEditButton()}
+            <div className="vads-u-width--full vads-u-display--flex vads-u-justify-content--flex-end">
+              {defaultEditButton()}
+            </div>
           </div>
         )}
         {environment.isProduction() && (

--- a/src/platform/forms-system/src/js/review/ReviewChapters.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewChapters.jsx
@@ -91,7 +91,7 @@ class ReviewChapters extends React.Component {
             pageList={pageList}
             setData={(...args) => this.handleSetData(...args)}
             setValid={setValid}
-            hasUnviewedPages // chapter.hasUnviewedPages}
+            hasUnviewedPages={chapter.hasUnviewedPages}
             toggleButtonClicked={() => this.handleToggleChapter(chapter)}
             uploadFile={this.props.uploadFile}
             viewedPages={viewedPages}

--- a/src/platform/forms-system/src/js/review/ReviewChapters.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewChapters.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
-import Scroll from 'react-scroll';
 
 import ReviewCollapsibleChapter from './ReviewCollapsibleChapter';
 import {
@@ -14,28 +13,12 @@ import {
 import { getViewedPages } from '../state/selectors';
 import { setData, setEditMode, setViewedPages, uploadFile } from '../actions';
 
-const { scroller } = Scroll;
 class ReviewChapters extends React.Component {
   componentDidMount() {
     const { formData, pageList } = this.props;
     const viewedPages = new Set(getPageKeys(pageList, formData));
     this.props.setViewedPages(viewedPages);
   }
-
-  handleOpenChapter({ name }) {
-    this.scrollToChapter(name);
-  }
-
-  scrollToChapter = chapterKey => {
-    scroller.scrollTo(
-      `chapter${chapterKey}ScrollElement`,
-      window.Forms?.scroll || {
-        duration: 500,
-        delay: 2,
-        smooth: true,
-      },
-    );
-  };
 
   handleEdit = (pageKey, editing, index = null) => {
     const fullPageKey = `${pageKey}${index === null ? '' : index}`;
@@ -80,7 +63,6 @@ class ReviewChapters extends React.Component {
             setData={(...args) => this.handleSetData(...args)}
             setValid={setValid}
             hasUnviewedPages={chapter.hasUnviewedPages}
-            handleOpenChapter={() => this.handleOpenChapter(chapter)}
             uploadFile={this.props.uploadFile}
             viewedPages={viewedPages}
           />

--- a/src/platform/forms-system/src/js/review/ReviewChapters.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewChapters.jsx
@@ -12,14 +12,7 @@ import {
   getPageKeys,
 } from '../helpers';
 import { getViewedPages } from '../state/selectors';
-import {
-  closeReviewChapter,
-  openReviewChapter,
-  setData,
-  setEditMode,
-  setViewedPages,
-  uploadFile,
-} from '../actions';
+import { setData, setEditMode, setViewedPages, uploadFile } from '../actions';
 
 const { scroller } = Scroll;
 class ReviewChapters extends React.Component {
@@ -29,13 +22,8 @@ class ReviewChapters extends React.Component {
     this.props.setViewedPages(viewedPages);
   }
 
-  handleToggleChapter({ name, open, pageKeys }) {
-    if (open) {
-      this.props.closeReviewChapter(name, pageKeys);
-    } else {
-      this.props.openReviewChapter(name);
-      this.scrollToChapter(name);
-    }
+  handleOpenChapter({ name }) {
+    this.scrollToChapter(name);
   }
 
   scrollToChapter = chapterKey => {
@@ -92,7 +80,7 @@ class ReviewChapters extends React.Component {
             setData={(...args) => this.handleSetData(...args)}
             setValid={setValid}
             hasUnviewedPages={chapter.hasUnviewedPages}
-            toggleButtonClicked={() => this.handleToggleChapter(chapter)}
+            handleOpenChapter={() => this.handleOpenChapter(chapter)}
             uploadFile={this.props.uploadFile}
             viewedPages={viewedPages}
           />
@@ -153,8 +141,6 @@ export function mapStateToProps(state, ownProps) {
 }
 
 const mapDispatchToProps = {
-  closeReviewChapter,
-  openReviewChapter,
   setData,
   setEditMode,
   setViewedPages,
@@ -163,13 +149,11 @@ const mapDispatchToProps = {
 
 ReviewChapters.propTypes = {
   chapters: PropTypes.array.isRequired,
-  closeReviewChapter: PropTypes.func.isRequired,
   form: PropTypes.object.isRequired,
   formData: PropTypes.object.isRequired,
   formConfig: PropTypes.object.isRequired,
   formContext: PropTypes.object,
   onSetData: PropTypes.func,
-  openReviewChapter: PropTypes.func.isRequired,
   pageList: PropTypes.array.isRequired,
   setData: PropTypes.func.isRequired,
   setEditMode: PropTypes.func.isRequired,

--- a/src/platform/forms-system/src/js/review/ReviewChapters.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewChapters.jsx
@@ -11,7 +11,7 @@ import {
   getActiveChapters,
   getPageKeys,
 } from '../helpers';
-import { getReviewPageOpenChapters, getViewedPages } from '../state/selectors';
+import { getViewedPages } from '../state/selectors';
 import {
   closeReviewChapter,
   openReviewChapter,
@@ -21,7 +21,7 @@ import {
   uploadFile,
 } from '../actions';
 
-const scroller = Scroll.scroller;
+const { scroller } = Scroll;
 class ReviewChapters extends React.Component {
   componentDidMount() {
     const { formData, pageList } = this.props;
@@ -76,31 +76,28 @@ class ReviewChapters extends React.Component {
     } = this.props;
 
     return (
-      <div className="input-section">
-        <div>
-          {chapters.map(chapter => (
-            <ReviewCollapsibleChapter
-              expandedPages={chapter.expandedPages}
-              chapterFormConfig={chapter.formConfig}
-              chapterKey={chapter.name}
-              form={form}
-              reviewErrors={formConfig?.reviewErrors}
-              formContext={formContext}
-              key={chapter.name}
-              onEdit={this.handleEdit}
-              open={chapter.open}
-              pageKeys={chapter.pageKeys}
-              pageList={pageList}
-              setData={(...args) => this.handleSetData(...args)}
-              setValid={setValid}
-              hasUnviewedPages={chapter.hasUnviewedPages}
-              toggleButtonClicked={() => this.handleToggleChapter(chapter)}
-              uploadFile={this.props.uploadFile}
-              viewedPages={viewedPages}
-            />
-          ))}
-        </div>
-      </div>
+      <va-accordion bordered>
+        {chapters.map(chapter => (
+          <ReviewCollapsibleChapter
+            expandedPages={chapter.expandedPages}
+            chapterFormConfig={chapter.formConfig}
+            chapterKey={chapter.name}
+            form={form}
+            reviewErrors={formConfig?.reviewErrors}
+            formContext={formContext}
+            key={chapter.name}
+            onEdit={this.handleEdit}
+            pageKeys={chapter.pageKeys}
+            pageList={pageList}
+            setData={(...args) => this.handleSetData(...args)}
+            setValid={setValid}
+            hasUnviewedPages // chapter.hasUnviewedPages}
+            toggleButtonClicked={() => this.handleToggleChapter(chapter)}
+            uploadFile={this.props.uploadFile}
+            viewedPages={viewedPages}
+          />
+        ))}
+      </va-accordion>
     );
   }
 }
@@ -110,9 +107,8 @@ export function mapStateToProps(state, ownProps) {
   const { formConfig, formContext, pageList } = ownProps;
 
   // from redux state
-  const form = state.form;
+  const { form } = state;
   const formData = state.form.data;
-  const openChapters = getReviewPageOpenChapters(state);
   const viewedPages = getViewedPages(state);
 
   const chapterNames = getActiveChapters(formConfig, formData);
@@ -122,7 +118,6 @@ export function mapStateToProps(state, ownProps) {
 
     const expandedPages = getActiveExpandedPages(pages, formData);
     const chapterFormConfig = formConfig.chapters[chapterName];
-    const open = openChapters.includes(chapterName);
     const pageKeys = getPageKeys(pages, formData);
 
     const hasErrors = state.form.formErrors?.errors?.some(err =>

--- a/src/platform/forms-system/src/js/review/ReviewChapters.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewChapters.jsx
@@ -41,7 +41,6 @@ class ReviewChapters extends React.Component {
       form,
       formConfig,
       formContext,
-      setValid,
       viewedPages,
       pageList,
     } = this.props;
@@ -61,7 +60,6 @@ class ReviewChapters extends React.Component {
             pageKeys={chapter.pageKeys}
             pageList={pageList}
             setData={(...args) => this.handleSetData(...args)}
-            setValid={setValid}
             hasUnviewedPages={chapter.hasUnviewedPages}
             uploadFile={this.props.uploadFile}
             viewedPages={viewedPages}
@@ -105,7 +103,6 @@ export function mapStateToProps(state, ownProps) {
       ),
       formConfig: chapterFormConfig,
       name: chapterName,
-      open,
       pageKeys,
       hasUnviewedPages,
     };
@@ -132,16 +129,16 @@ const mapDispatchToProps = {
 ReviewChapters.propTypes = {
   chapters: PropTypes.array.isRequired,
   form: PropTypes.object.isRequired,
-  formData: PropTypes.object.isRequired,
   formConfig: PropTypes.object.isRequired,
-  formContext: PropTypes.object,
-  onSetData: PropTypes.func,
+  formData: PropTypes.object.isRequired,
   pageList: PropTypes.array.isRequired,
   setData: PropTypes.func.isRequired,
   setEditMode: PropTypes.func.isRequired,
   setViewedPages: PropTypes.func.isRequired,
   uploadFile: PropTypes.func.isRequired,
   viewedPages: PropTypes.object.isRequired,
+  formContext: PropTypes.object,
+  onSetData: PropTypes.func,
 };
 
 export default withRouter(

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -408,7 +408,6 @@ class ReviewCollapsibleChapter extends React.Component {
 
     return (
       <va-accordion-item
-        id={this.props.chapterKey}
         data-chapter={this.props.chapterKey}
         header={chapterTitle}
         subHeader={this.props.hasUnviewedPages ? subHeader : ''}

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -5,7 +5,6 @@ import { withRouter } from 'react-router';
 import Scroll from 'react-scroll';
 import uniqueId from 'lodash/uniqueId';
 import classNames from 'classnames';
-import { getScrollOptions } from 'platform/utilities/ui';
 import get from '../../../../utilities/data/get';
 import set from '../../../../utilities/data/set';
 
@@ -20,8 +19,7 @@ import { isValidForm } from '../validation';
 import { reduceErrors } from '../utilities/data/reduceErrors';
 import { setFormErrors } from '../actions';
 
-const { Element, scroller } = Scroll;
-const scrollOffset = -40;
+const { Element } = Scroll;
 
 /*
  * Displays all the pages in a chapter on the review page
@@ -30,11 +28,6 @@ class ReviewCollapsibleChapter extends React.Component {
   constructor(props) {
     super(props);
     this.handleEdit = this.handleEdit.bind(this);
-    this.handleChapterClick = this.handleChapterClick.bind(this);
-
-    this.state = {
-      chapterOpen: false,
-    };
   }
 
   /* eslint-disable-next-line camelcase */
@@ -42,19 +35,8 @@ class ReviewCollapsibleChapter extends React.Component {
     this.id = uniqueId();
   }
 
-  handleChapterClick(name) {
-    if (!this.state.chapterOpen) {
-      this.scrollToChapter(name);
-    }
-
-    this.setState(prevState => ({
-      chapterOpen: !prevState.chapterOpen,
-    }));
-  }
-
   handleEdit(key, editing, index = null) {
     this.props.onEdit(key, editing, index);
-    this.scrollToPage(`${key}${index === null ? '' : index}`);
     if (editing) {
       // pressing "Update page" will call handleSubmit, which moves focus from
       // the edit button to the this target
@@ -69,17 +51,6 @@ class ReviewCollapsibleChapter extends React.Component {
     }
     this.props.setData(newData);
   }
-
-  scrollToChapter = () => {
-    scroller.scrollTo(
-      `chapter${this.props.chapterKey}ScrollElement`,
-      window.Forms?.scroll || {
-        duration: 500,
-        delay: 2,
-        smooth: true,
-      },
-    );
-  };
 
   handleSubmit = (formData, key, path = null, index = null) => {
     // This makes sure defaulted data on a page with no changes is saved
@@ -429,48 +400,39 @@ class ReviewCollapsibleChapter extends React.Component {
     }, 0);
   };
 
-  scrollToPage = key => {
-    scroller.scrollTo(
-      `${key}ScrollElement`,
-      getScrollOptions({ offset: scrollOffset }),
-    );
-  };
-
   render() {
     const chapterTitle = this.getChapterTitle(this.props.chapterFormConfig);
     const subHeader = 'Some information has changed. Please review.';
 
     return (
-      <>
+      <va-accordion-item
+        id={this.props.chapterKey}
+        data-chapter={this.props.chapterKey}
+        header={chapterTitle}
+        subHeader={this.props.hasUnviewedPages ? subHeader : ''}
+        onClick={this.handleChapterClick}
+      >
         <Element name={`chapter${this.props.chapterKey}ScrollElement`} />
-        <va-accordion-item
-          id={this.props.chapterKey}
-          data-chapter={this.props.chapterKey}
-          header={chapterTitle}
-          subHeader={this.props.hasUnviewedPages ? subHeader : ''}
-          onClick={this.handleChapterClick}
-        >
-          {this.props.hasUnviewedPages && (
-            <>
-              <i
-                aria-hidden="true"
-                className="fas fa-exclamation-circle vads-u-color--secondary"
-                slot="subheader-icon"
-              />
-              <va-alert
-                role="alert"
-                status="error"
-                background-only
-                aria-describedby={`collapsibleButton${this.id}`}
-              >
-                <span className="sr-only">Error</span>
-                <span>Some information has changed. Please review.</span>
-              </va-alert>
-            </>
-          )}
-          {this.getChapterContent(this.props)}
-        </va-accordion-item>
-      </>
+        {this.props.hasUnviewedPages && (
+          <>
+            <i
+              aria-hidden="true"
+              className="fas fa-exclamation-circle vads-u-color--secondary"
+              slot="subheader-icon"
+            />
+            <va-alert
+              role="alert"
+              status="error"
+              background-only
+              aria-describedby={`collapsibleButton${this.id}`}
+            >
+              <span className="sr-only">Error</span>
+              <span>Some information has changed. Please review.</span>
+            </va-alert>
+          </>
+        )}
+        {this.getChapterContent(this.props)}
+      </va-accordion-item>
     );
   }
 }

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -408,6 +408,7 @@ class ReviewCollapsibleChapter extends React.Component {
 
     return (
       <va-accordion-item
+        id={this.props.chapterKey}
         data-chapter={this.props.chapterKey}
         header={chapterTitle}
         subHeader={this.props.hasUnviewedPages ? subHeader : ''}

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -428,7 +428,7 @@ class ReviewCollapsibleChapter extends React.Component {
               aria-describedby={`collapsibleButton${this.id}`}
             >
               <span className="sr-only">Error</span>
-              <span>Some information has changed. Please review.</span>
+              <span>{subHeader}</span>
             </va-alert>
           </>
         )}

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -44,7 +44,7 @@ class ReviewCollapsibleChapter extends React.Component {
 
   handleChapterClick(name) {
     if (!this.state.chapterOpen) {
-      this.props.handleOpenChapter(name);
+      this.scrollToChapter(name);
     }
 
     this.setState(prevState => ({
@@ -69,6 +69,17 @@ class ReviewCollapsibleChapter extends React.Component {
     }
     this.props.setData(newData);
   }
+
+  scrollToChapter = () => {
+    scroller.scrollTo(
+      `chapter${this.props.chapterKey}ScrollElement`,
+      window.Forms?.scroll || {
+        duration: 500,
+        delay: 2,
+        smooth: true,
+      },
+    );
+  };
 
   handleSubmit = (formData, key, path = null, index = null) => {
     // This makes sure defaulted data on a page with no changes is saved
@@ -438,9 +449,7 @@ class ReviewCollapsibleChapter extends React.Component {
           data-chapter={this.props.chapterKey}
           header={chapterTitle}
           subHeader={this.props.hasUnviewedPages ? subHeader : ''}
-          onClick={() => {
-            this.handleChapterClick(chapterTitle);
-          }}
+          onClick={this.handleChapterClick}
         >
           {this.props.hasUnviewedPages && (
             <>
@@ -480,7 +489,6 @@ ReviewCollapsibleChapter.propTypes = {
   form: PropTypes.object.isRequired,
   hasUnviewedPages: PropTypes.bool.isRequired,
   pageList: PropTypes.array.isRequired,
-  handleOpenChapter: PropTypes.func.isRequired,
   setData: PropTypes.func.isRequired,
   setFormErrors: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -350,10 +350,7 @@ class ReviewCollapsibleChapter extends React.Component {
     } = props;
     const ChapterDescription = chapterFormConfig.reviewDescription;
     return (
-      <div
-        className="usa-accordion-content schemaform-chapter-accordion-content"
-        aria-hidden="false"
-      >
+      <div data-testid="accordion-item-content">
         {ChapterDescription && (
           <ChapterDescription
             viewedPages={viewedPages}
@@ -363,20 +360,22 @@ class ReviewCollapsibleChapter extends React.Component {
             push
           />
         )}
-        {expandedPages.map(page => {
-          const pageConfig = form.pages[page.pageKey];
-          const editing = pageConfig.showPagePerItem
-            ? pageConfig.editMode[page.index]
-            : pageConfig.editMode;
+        {expandedPages
+          ? expandedPages.map(page => {
+              const pageConfig = form.pages[page.pageKey];
+              const editing = pageConfig.showPagePerItem
+                ? pageConfig.editMode[page.index]
+                : pageConfig.editMode;
 
-          const showCustomPage = editing
-            ? !!pageConfig.CustomPage
-            : !!pageConfig.CustomPageReview;
+              const showCustomPage = editing
+                ? !!pageConfig.CustomPage
+                : !!pageConfig.CustomPageReview;
 
-          return showCustomPage
-            ? this.getCustomPageContent(page, props, editing)
-            : this.getSchemaformPageContent(page, props, editing);
-        })}
+              return showCustomPage
+                ? this.getCustomPageContent(page, props, editing)
+                : this.getSchemaformPageContent(page, props, editing);
+            })
+          : null}
       </div>
     );
   };
@@ -413,63 +412,37 @@ class ReviewCollapsibleChapter extends React.Component {
   };
 
   render() {
-    let pageContent = null;
-
     const chapterTitle = this.getChapterTitle(this.props.chapterFormConfig);
-
-    if (this.props.open) {
-      pageContent = this.getChapterContent(this.props);
-    }
-
-    const classes = classNames('usa-accordion-bordered', 'form-review-panel', {
-      'schemaform-review-chapter-error': this.props.hasUnviewedPages,
-    });
-
-    const headerClasses = classNames(
-      'accordion-header',
-      'clearfix',
-      'schemaform-chapter-accordion-header',
-      'vads-u-font-size--h4',
-      'vads-u-margin-top--0',
-    );
+    const subHeader = 'Some information has changed. Please review.';
 
     return (
-      <div
-        id={`${this.id}-collapsiblePanel`}
-        className={classes}
+      <va-accordion-item
+        id={this.id}
         data-chapter={this.props.chapterKey}
+        header={chapterTitle || ''}
+        subHeader={this.props.hasUnviewedPages ? subHeader : ''}
       >
         <Element name={`chapter${this.props.chapterKey}ScrollElement`} />
-        {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
-        <ul className="usa-unstyled-list" role="list">
-          <li>
-            <h3 className={headerClasses}>
-              <button
-                className="usa-button-unstyled"
-                aria-expanded={this.props.open ? 'true' : 'false'}
-                aria-controls={`collapsible-${this.id}`}
-                onClick={this.props.toggleButtonClicked}
-                id={`collapsibleButton${this.id}`}
-                type="button"
-              >
-                {chapterTitle || ''}
-              </button>
-            </h3>
-            {this.props.hasUnviewedPages && (
-              <va-alert
-                role="alert"
-                status="error"
-                background-only
-                aria-describedby={`collapsibleButton${this.id}`}
-              >
-                <span className="sr-only">Error</span>
-                <span>Some information has changed. Please review.</span>
-              </va-alert>
-            )}
-            <div id={`collapsible-${this.id}`}>{pageContent}</div>
-          </li>
-        </ul>
-      </div>
+        {this.props.hasUnviewedPages && (
+          <>
+            <i
+              aria-hidden="true"
+              className="fas fa-exclamation-circle vads-u-color--secondary"
+              slot="subheader-icon"
+            />
+            <va-alert
+              role="alert"
+              status="error"
+              background-only
+              aria-describedby={`collapsibleButton${this.id}`}
+            >
+              <span className="sr-only">Error</span>
+              <span>Some information has changed. Please review.</span>
+            </va-alert>
+          </>
+        )}
+        {this.getChapterContent(this.props)}
+      </va-accordion-item>
     );
   }
 }
@@ -483,10 +456,13 @@ const mapDispatchToProps = {
 // TODO: refactor to pass form.data instead of the entire form object
 ReviewCollapsibleChapter.propTypes = {
   chapterFormConfig: PropTypes.object.isRequired,
+  chapterKey: PropTypes.string.isRequired,
   form: PropTypes.object.isRequired,
-  onEdit: PropTypes.func.isRequired,
+  hasUnviewedPages: PropTypes.bool.isRequired,
   pageList: PropTypes.array.isRequired,
+  setData: PropTypes.func.isRequired,
   setFormErrors: PropTypes.func.isRequired,
+  onEdit: PropTypes.func.isRequired,
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }),

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -444,8 +444,7 @@ class ReviewCollapsibleChapter extends React.Component {
       <>
         <Element name={`chapter${this.props.chapterKey}ScrollElement`} />
         <va-accordion-item
-          id={this.id}
-          className="test"
+          id={this.props.chapterKey}
           data-chapter={this.props.chapterKey}
           header={chapterTitle}
           subHeader={this.props.hasUnviewedPages ? subHeader : ''}

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -109,7 +109,8 @@ class ReviewCollapsibleChapter extends React.Component {
     if (chapterFormConfig.reviewTitle) {
       chapterTitle = chapterFormConfig.reviewTitle;
     }
-    return chapterTitle;
+
+    return chapterTitle || '';
   };
 
   getPageTitle = rawPageTitle => {
@@ -360,22 +361,20 @@ class ReviewCollapsibleChapter extends React.Component {
             push
           />
         )}
-        {expandedPages
-          ? expandedPages.map(page => {
-              const pageConfig = form.pages[page.pageKey];
-              const editing = pageConfig.showPagePerItem
-                ? pageConfig.editMode[page.index]
-                : pageConfig.editMode;
+        {expandedPages?.map(page => {
+          const pageConfig = form.pages[page.pageKey];
+          const editing = pageConfig.showPagePerItem
+            ? pageConfig.editMode[page.index]
+            : pageConfig.editMode;
 
-              const showCustomPage = editing
-                ? !!pageConfig.CustomPage
-                : !!pageConfig.CustomPageReview;
+          const showCustomPage = editing
+            ? !!pageConfig.CustomPage
+            : !!pageConfig.CustomPageReview;
 
-              return showCustomPage
-                ? this.getCustomPageContent(page, props, editing)
-                : this.getSchemaformPageContent(page, props, editing);
-            })
-          : null}
+          return showCustomPage
+            ? this.getCustomPageContent(page, props, editing)
+            : this.getSchemaformPageContent(page, props, editing);
+        }) ?? null}
       </div>
     );
   };
@@ -419,7 +418,7 @@ class ReviewCollapsibleChapter extends React.Component {
       <va-accordion-item
         id={this.id}
         data-chapter={this.props.chapterKey}
-        header={chapterTitle || ''}
+        header={chapterTitle}
         subHeader={this.props.hasUnviewedPages ? subHeader : ''}
       >
         <Element name={`chapter${this.props.chapterKey}ScrollElement`} />

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -30,11 +30,26 @@ class ReviewCollapsibleChapter extends React.Component {
   constructor(props) {
     super(props);
     this.handleEdit = this.handleEdit.bind(this);
+    this.handleChapterClick = this.handleChapterClick.bind(this);
+
+    this.state = {
+      chapterOpen: false,
+    };
   }
 
   /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillMount() {
     this.id = uniqueId();
+  }
+
+  handleChapterClick(name) {
+    if (!this.state.chapterOpen) {
+      this.props.handleOpenChapter(name);
+    }
+
+    this.setState(prevState => ({
+      chapterOpen: !prevState.chapterOpen,
+    }));
   }
 
   handleEdit(key, editing, index = null) {
@@ -420,6 +435,9 @@ class ReviewCollapsibleChapter extends React.Component {
         data-chapter={this.props.chapterKey}
         header={chapterTitle}
         subHeader={this.props.hasUnviewedPages ? subHeader : ''}
+        onClick={() => {
+          this.handleChapterClick(chapterTitle);
+        }}
       >
         <Element name={`chapter${this.props.chapterKey}ScrollElement`} />
         {this.props.hasUnviewedPages && (
@@ -459,6 +477,7 @@ ReviewCollapsibleChapter.propTypes = {
   form: PropTypes.object.isRequired,
   hasUnviewedPages: PropTypes.bool.isRequired,
   pageList: PropTypes.array.isRequired,
+  handleOpenChapter: PropTypes.func.isRequired,
   setData: PropTypes.func.isRequired,
   setFormErrors: PropTypes.func.isRequired,
   onEdit: PropTypes.func.isRequired,

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -246,6 +246,8 @@ class ReviewCollapsibleChapter extends React.Component {
                   `${page.pageKey}${
                     typeof page.index === 'number' ? page.index : ''
                   }`,
+                  'va-button',
+                  'button',
                 );
               }}
               buttonText="Update page"

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -430,36 +430,39 @@ class ReviewCollapsibleChapter extends React.Component {
     const subHeader = 'Some information has changed. Please review.';
 
     return (
-      <va-accordion-item
-        id={this.id}
-        data-chapter={this.props.chapterKey}
-        header={chapterTitle}
-        subHeader={this.props.hasUnviewedPages ? subHeader : ''}
-        onClick={() => {
-          this.handleChapterClick(chapterTitle);
-        }}
-      >
+      <>
         <Element name={`chapter${this.props.chapterKey}ScrollElement`} />
-        {this.props.hasUnviewedPages && (
-          <>
-            <i
-              aria-hidden="true"
-              className="fas fa-exclamation-circle vads-u-color--secondary"
-              slot="subheader-icon"
-            />
-            <va-alert
-              role="alert"
-              status="error"
-              background-only
-              aria-describedby={`collapsibleButton${this.id}`}
-            >
-              <span className="sr-only">Error</span>
-              <span>Some information has changed. Please review.</span>
-            </va-alert>
-          </>
-        )}
-        {this.getChapterContent(this.props)}
-      </va-accordion-item>
+        <va-accordion-item
+          id={this.id}
+          className="test"
+          data-chapter={this.props.chapterKey}
+          header={chapterTitle}
+          subHeader={this.props.hasUnviewedPages ? subHeader : ''}
+          onClick={() => {
+            this.handleChapterClick(chapterTitle);
+          }}
+        >
+          {this.props.hasUnviewedPages && (
+            <>
+              <i
+                aria-hidden="true"
+                className="fas fa-exclamation-circle vads-u-color--secondary"
+                slot="subheader-icon"
+              />
+              <va-alert
+                role="alert"
+                status="error"
+                background-only
+                aria-describedby={`collapsibleButton${this.id}`}
+              >
+                <span className="sr-only">Error</span>
+                <span>Some information has changed. Please review.</span>
+              </va-alert>
+            </>
+          )}
+          {this.getChapterContent(this.props)}
+        </va-accordion-item>
+      </>
     );
   }
 }

--- a/src/platform/forms-system/src/js/review/submit-states/ErrorLinks.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ErrorLinks.jsx
@@ -80,9 +80,8 @@ const ErrorLinks = props => {
                           );
                           focusAndScrollToReviewElement(error);
                         }}
-                      >
-                        {error.message}
-                      </va-button>
+                        text={error.message}
+                      />
                     ) : (
                       error.message
                     )}

--- a/src/platform/forms-system/src/js/review/submit-states/ErrorLinks.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ErrorLinks.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import { focusAndScrollToReviewElement } from '../../utilities/review';
-import { openReviewChapter, setEditMode } from '../../actions';
+import { setEditMode } from '../../actions';
 
 const ErrorLinks = props => {
   const { appType, testId, errors } = props;
@@ -69,11 +69,10 @@ const ErrorLinks = props => {
                 {errors.map(error => (
                   <li key={error.name}>
                     {error.chapterKey ? (
-                      <a
+                      <va-button
                         href="#"
                         onClick={event => {
                           event.preventDefault();
-                          props.openReviewChapter(error.chapterKey);
                           props.setEditMode(
                             error.pageKey,
                             true, // enable edit mode
@@ -83,7 +82,7 @@ const ErrorLinks = props => {
                         }}
                       >
                         {error.message}
-                      </a>
+                      </va-button>
                     ) : (
                       error.message
                     )}
@@ -103,7 +102,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = {
-  openReviewChapter,
   setEditMode,
 };
 
@@ -111,7 +109,6 @@ ErrorLinks.propTypes = {
   appType: PropTypes.string,
   testId: PropTypes.string,
   errors: PropTypes.array,
-  openReviewChapter: PropTypes.func,
   setEditMode: PropTypes.func,
 };
 

--- a/src/platform/forms-system/src/js/review/submit-states/ErrorLinks.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ErrorLinks.jsx
@@ -2,12 +2,14 @@ import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import { focusAndScrollToReviewElement } from '../../utilities/review';
+import {
+  scrollToReviewElement,
+  openAndEditChapter,
+} from '../../utilities/review';
 import { setEditMode } from '../../actions';
 
 const ErrorLinks = props => {
   const { appType, testId, errors } = props;
-
   const errorRef = useRef(null);
   const [hadErrors, setHadErrors] = useState(false);
 
@@ -69,19 +71,16 @@ const ErrorLinks = props => {
                 {errors.map(error => (
                   <li key={error.name}>
                     {error.chapterKey ? (
-                      <va-button
+                      <a // eslint-disable-line jsx-a11y/anchor-is-valid
                         href="#"
                         onClick={event => {
                           event.preventDefault();
-                          props.setEditMode(
-                            error.pageKey,
-                            true, // enable edit mode
-                            error.index || null,
-                          );
-                          focusAndScrollToReviewElement(error);
+                          openAndEditChapter(error.chapterKey);
+                          scrollToReviewElement(error);
                         }}
-                        text={error.message}
-                      />
+                      >
+                        {error.message}
+                      </a>
                     ) : (
                       error.message
                     )}
@@ -106,9 +105,9 @@ const mapDispatchToProps = {
 
 ErrorLinks.propTypes = {
   appType: PropTypes.string,
-  testId: PropTypes.string,
   errors: PropTypes.array,
   setEditMode: PropTypes.func,
+  testId: PropTypes.string,
 };
 
 export default connect(

--- a/src/platform/forms-system/src/js/review/submit-states/ErrorLinks.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ErrorLinks.jsx
@@ -6,7 +6,6 @@ import {
   scrollToReviewElement,
   openAndEditChapter,
 } from '../../utilities/review';
-import { setEditMode } from '../../actions';
 
 const ErrorLinks = props => {
   const { appType, testId, errors } = props;
@@ -75,8 +74,8 @@ const ErrorLinks = props => {
                         href="#"
                         onClick={event => {
                           event.preventDefault();
-                          openAndEditChapter(error.chapterKey);
                           scrollToReviewElement(error);
+                          openAndEditChapter(error.chapterKey);
                         }}
                       >
                         {error.message}
@@ -99,20 +98,12 @@ const mapStateToProps = state => ({
   errors: state.form?.formErrors?.errors || [],
 });
 
-const mapDispatchToProps = {
-  setEditMode,
-};
-
 ErrorLinks.propTypes = {
   appType: PropTypes.string,
   errors: PropTypes.array,
-  setEditMode: PropTypes.func,
   testId: PropTypes.string,
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ErrorLinks);
+export default connect(mapStateToProps)(ErrorLinks);
 
 export { ErrorLinks };

--- a/src/platform/forms-system/src/js/review/submit-states/ErrorLinks.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ErrorLinks.jsx
@@ -75,7 +75,7 @@ const ErrorLinks = props => {
                         onClick={event => {
                           event.preventDefault();
                           scrollToReviewElement(error);
-                          openAndEditChapter(error.chapterKey);
+                          openAndEditChapter(error);
                         }}
                       >
                         {error.message}

--- a/src/platform/forms-system/src/js/state/helpers.js
+++ b/src/platform/forms-system/src/js/state/helpers.js
@@ -654,7 +654,6 @@ export function createInitialState(formConfig) {
       metadata: {},
     },
     reviewPageView: {
-      openChapters: [],
       viewedPages: new Set(),
     },
     trackingPrefix: formConfig.trackingPrefix,

--- a/src/platform/forms-system/src/js/state/reducers.js
+++ b/src/platform/forms-system/src/js/state/reducers.js
@@ -1,8 +1,6 @@
 import set from '../../../../utilities/data/set';
 
 import {
-  CLOSE_REVIEW_CHAPTER,
-  OPEN_REVIEW_CHAPTER,
   SET_DATA,
   SET_EDIT_MODE,
   SET_PRE_SUBMIT,
@@ -15,27 +13,6 @@ import {
 import { recalculateSchemaAndData } from './helpers';
 
 export default {
-  [OPEN_REVIEW_CHAPTER]: (state, action) => {
-    const openChapters = [
-      ...state.reviewPageView.openChapters,
-      action.openedChapter,
-    ];
-
-    return set('reviewPageView.openChapters', openChapters, state);
-  },
-  [CLOSE_REVIEW_CHAPTER]: (state, action) => {
-    const openChapters = state.reviewPageView.openChapters.filter(
-      value => value !== action.closedChapter,
-    );
-
-    const newState = set('reviewPageView.openChapters', openChapters, state);
-
-    const viewedPages = new Set(state.reviewPageView.viewedPages);
-
-    action.pageKeys.forEach(pageKey => viewedPages.add(pageKey));
-
-    return set('reviewPageView.viewedPages', viewedPages, newState);
-  },
   [SET_DATA]: (state, action) => {
     const newState = set('data', action.data, state);
     return recalculateSchemaAndData(newState);

--- a/src/platform/forms-system/src/js/state/selectors.js
+++ b/src/platform/forms-system/src/js/state/selectors.js
@@ -1,6 +1,4 @@
 export const getFormData = state => state.form.data;
 export const getFormPages = state => state.form.pages;
 export const getSubmission = state => state.form.submission;
-export const getReviewPageOpenChapters = state =>
-  state.form.reviewPageView.openChapters;
 export const getViewedPages = state => state.form.reviewPageView.viewedPages;

--- a/src/platform/forms-system/src/js/utilities/review/index.js
+++ b/src/platform/forms-system/src/js/utilities/review/index.js
@@ -27,9 +27,7 @@ const findTargets = error => {
       `[name$="${error.pageKey}${error.index || ''}${scrollElementName}"]`,
     ].join(','),
   );
-  if (error.pageKey === error.chapterKey) {
-    return { scroll: el };
-  }
+
   return {
     scroll: el,
   };
@@ -41,18 +39,20 @@ const findTargets = error => {
  * interacrtive element in the content.
  * @param {String} chapterKey - a chapter key
  */
-export const openAndEditChapter = chapterKey => {
+export const openAndEditChapter = error => {
   const accordionItem = document.querySelector(
-    `va-accordion-item[data-chapter="${chapterKey}"`,
+    `va-accordion-item[data-chapter="${error.chapterKey}"`,
   );
 
   const accordionItemButton = accordionItem.shadowRoot.querySelector(
     "button[aria-controls='content']",
   );
 
-  const editButton = accordionItem.querySelector('va-button');
-
   accordionItemButton.click();
+
+  const pageTarget = findTargets(error).scroll;
+
+  const editButton = pageTarget.parentNode.querySelector('va-button');
 
   // editButton will be undefined if it's already in the edit state
   editButton?.click();

--- a/src/platform/forms-system/src/js/utilities/review/index.js
+++ b/src/platform/forms-system/src/js/utilities/review/index.js
@@ -1,15 +1,8 @@
-import {
-  $,
-  scrollElementName,
-  getFocusableElements,
-  focusElement,
-  scrollToElement,
-} from '../ui';
+import { $, scrollElementName, scrollToElement } from '../ui';
 
 /**
  * @typedef FormUtility~findTargetsOptions
  * @type {object}
- * @property {boolean} getLabel - if true, return label vs actual element
  */
 /**
  * @typedef FormUtility~findTargetsReturnedValues
@@ -25,7 +18,7 @@ import {
  * @param {FormUtility~findTargetsOptions}
  * @return {FormUtility~findTargetsReturnedValues}
  */
-const findTargets = (error, { getLabel = true } = {}) => {
+const findTargets = error => {
   // find scroll element first
   const el = $(
     [
@@ -35,27 +28,34 @@ const findTargets = (error, { getLabel = true } = {}) => {
     ].join(','),
   );
   if (error.pageKey === error.chapterKey) {
-    return { scroll: el, focus: el };
+    return { scroll: el };
   }
-  // Find all visible elements within the form
-  const form = el?.closest('.form-review-panel-page')?.querySelectorAll('form');
-  const formElements = form
-    ? getFocusableElements(form[error.index] || form[0])
-    : [];
-  // narrow down search to a matching id (if possible)
-  const firstElement =
-    formElements.filter(elm => elm.id.includes(`_${error.name}`))[0] ||
-    // ID may not match the name in an array block (e.g. 526 servicePeriods)
-    formElements[0];
   return {
     scroll: el,
-    focus:
-      (getLabel
-        ? firstElement
-            ?.closest('.schemaform-field-container, .schemaform-field-template')
-            ?.querySelector('legend, label')
-        : firstElement) || el,
   };
+};
+
+/**
+ * Open the accordion for the specified chapter and click on the "Edit" button
+ * to go into edit mode. This will also result in the focusing of the first
+ * interacrtive element in the content.
+ * @param {String} chapterKey - a chapter key
+ */
+export const openAndEditChapter = chapterKey => {
+  const accordionItem = document.querySelector(
+    `va-accordion-item[data-chapter="${chapterKey}"`,
+  );
+
+  const accordionItemButton = accordionItem.shadowRoot.querySelector(
+    "button[aria-controls='content']",
+  );
+
+  const editButton = accordionItem.querySelector('va-button');
+
+  accordionItemButton.click();
+
+  // editButton will be undefined if it's already in the edit state
+  editButton?.click();
 };
 
 /**
@@ -66,13 +66,12 @@ const findTargets = (error, { getLabel = true } = {}) => {
  * The error object is created by ../utilities/data/reduceErrors.js
  * @param {Form~errors} error - single error from `form.formErrors.errors`
  */
-export const focusAndScrollToReviewElement = (error = {}) => {
+export const scrollToReviewElement = (error = {}) => {
   if (error.name) {
     // Ensure DOM updates
     setTimeout(() => {
-      const { focus, scroll } = findTargets(error);
-      if (focus) {
-        focusElement(focus);
+      const { scroll } = findTargets(error);
+      if (scroll) {
         scrollToElement(scroll);
       }
     }, 50);

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -86,7 +86,7 @@ export function focusOnChange(
     const focusTarget = el?.nextElementSibling?.querySelector(target);
 
     if (focusTarget && shadowTarget) {
-      focusElement(focusTarget.shadowRoot.querySelector(shadowTarget));
+      focusElement(focusTarget.shadowRoot?.querySelector(shadowTarget));
     } else if (focusTarget) {
       focusElement(focusTarget);
     }

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -75,11 +75,7 @@ export const getFocusableElements = block => {
 export const scrollElementName = 'ScrollElement';
 
 // Set focus on target _after_ the content has been updated
-export function focusOnChange(
-  name,
-  target = '.edit-btn',
-  shadowTarget = undefined,
-) {
+export function focusOnChange(name, target, shadowTarget = undefined) {
   setTimeout(() => {
     const el = $(`[name="${name}${scrollElementName}"]`);
     // nextElementSibling = page form

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -75,12 +75,19 @@ export const getFocusableElements = block => {
 export const scrollElementName = 'ScrollElement';
 
 // Set focus on target _after_ the content has been updated
-export function focusOnChange(name, target = '.edit-btn') {
+export function focusOnChange(
+  name,
+  target = '.edit-btn',
+  shadowTarget = undefined,
+) {
   setTimeout(() => {
     const el = $(`[name="${name}${scrollElementName}"]`);
     // nextElementSibling = page form
     const focusTarget = el?.nextElementSibling?.querySelector(target);
-    if (focusTarget) {
+
+    if (focusTarget && shadowTarget) {
+      focusElement(focusTarget.shadowRoot.querySelector(shadowTarget));
+    } else if (focusTarget) {
       focusElement(focusTarget);
     }
   });

--- a/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
@@ -920,10 +920,9 @@ describe('Schemaform review: ObjectField', () => {
     expect(testField.value).to.equal('foo');
     expect(testLabel).to.exist;
 
-    const testEdit = within(document.querySelector('.test-edit'));
-    const editButton = testEdit.getByRole('button', { name: 'fooz' });
+    const editButton = document.querySelector('.test-edit va-button');
     expect(editButton).to.exist;
-    expect(editButton.textContent).to.equal('barz');
+    expect(editButton.getAttribute('text')).to.equal('barz');
 
     fireEvent.click(editButton);
     expect(onClick.called).to.be.true;

--- a/src/platform/forms-system/test/js/review/ReviewChapters.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewChapters.unit.spec.jsx
@@ -54,72 +54,6 @@ describe('Schemaform review: ReviewChapters', () => {
     tree.unmount();
   });
 
-  it('should handle toggling', () => {
-    const formConfig = {
-      chapters: {
-        chapter1: {
-          pages: {
-            page1: {},
-          },
-        },
-        chapter2: {
-          pages: {
-            page2: {},
-          },
-        },
-      },
-    };
-
-    const pageList = [
-      {
-        path: 'previous-page',
-      },
-      {
-        path: 'next-page',
-      },
-    ];
-
-    const chapters = [
-      {
-        expandedPages: [],
-        formConfig: {},
-        name: 'chapter1',
-        open: false,
-        pageKeys: ['page1'],
-      },
-      {
-        expandedPages: [],
-        formConfig: {},
-        name: 'chapter2',
-        open: false,
-        pageKeys: ['page2'],
-      },
-    ];
-
-    const openReviewChapter = sinon.spy();
-    const closeReviewChapter = sinon.spy();
-
-    const tree = shallow(
-      <ReviewChapters
-        chapters={chapters}
-        closeReviewChapter={closeReviewChapter}
-        openReviewChapter={openReviewChapter}
-        pageList={pageList}
-        route={{ formConfig, pageList }}
-        viewedPages={['page1', 'page2']}
-        setViewedPages={f => f}
-      />,
-    );
-
-    const instance = tree.instance();
-
-    instance.handleToggleChapter({ name: 'chapter1', open: false });
-    expect(openReviewChapter.calledWith('chapter1')).to.be.true;
-    instance.handleToggleChapter({ name: 'chapter3', open: true, pageKeys: 0 });
-    expect(closeReviewChapter.calledWith('chapter3', 0)).to.be.true;
-    tree.unmount();
-  });
-
   it('should pass index to depends for pagePerItem pages', () => {
     const formData = {
       testArray: [{}],
@@ -134,7 +68,6 @@ describe('Schemaform review: ReviewChapters', () => {
           pages: {},
           submission: {},
           reviewPageView: {
-            openChapters: [],
             viewedPages: new Set(),
           },
           data: formData,

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -9,6 +9,46 @@ import sinon from 'sinon';
 import { ReviewCollapsibleChapter } from '../../../src/js/review/ReviewCollapsibleChapter';
 
 describe('<ReviewCollapsibleChapter>', () => {
+  it('should add a data-attribute with the chapterKey', () => {
+    const onEdit = sinon.spy();
+    const pages = [
+      {
+        title: '',
+        pageKey: 'test',
+      },
+    ];
+    const chapterKey = 'chapterX';
+    const chapter = {};
+    const form = {
+      pages: {
+        test: {
+          title: '',
+          schema: {
+            properties: {},
+          },
+          uiSchema: {},
+          editMode: false,
+        },
+      },
+      data: {},
+    };
+
+    const wrapper = mount(
+      <ReviewCollapsibleChapter
+        viewedPages={new Set()}
+        onEdit={onEdit}
+        expandedPages={pages}
+        chapterKey={chapterKey}
+        chapterFormConfig={chapter}
+        form={form}
+      />,
+    );
+
+    const accordion = wrapper.find('va-accordion-item');
+    expect(accordion.length).to.equal(1);
+    expect(accordion.props()['data-chapter']).to.equal('chapterX');
+    wrapper.unmount();
+  });
   it('should handle editing', () => {
     const onEdit = sinon.spy();
     const pages = [
@@ -182,7 +222,6 @@ describe('<ReviewCollapsibleChapter>', () => {
       <ReviewCollapsibleChapter
         viewedPages={new Set()}
         onEdit={onEdit}
-        open
         expandedPages={pages}
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
@@ -247,7 +286,6 @@ describe('<ReviewCollapsibleChapter>', () => {
       <ReviewCollapsibleChapter
         viewedPages={new Set()}
         onEdit={() => {}}
-        open
         pageKeys={['test1', 'test2', 'test3']}
         expandedPages={pages}
         chapterKey={chapterKey}
@@ -317,7 +355,6 @@ describe('<ReviewCollapsibleChapter>', () => {
       <ReviewCollapsibleChapter
         viewedPages={new Set()}
         onEdit={() => {}}
-        open
         expandedPages={pages}
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
@@ -365,7 +402,6 @@ describe('<ReviewCollapsibleChapter>', () => {
         setPagesViewed={setPagesViewed}
         viewedPages={new Set()}
         onEdit={onEdit}
-        open
         expandedPages={pages}
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
@@ -471,7 +507,6 @@ describe('<ReviewCollapsibleChapter>', () => {
         setPagesViewed={setPagesViewed}
         viewedPages={new Set()}
         onEdit={onEdit}
-        open
         expandedPages={pages}
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
@@ -529,7 +564,6 @@ describe('<ReviewCollapsibleChapter>', () => {
         setPagesViewed={setPagesViewed}
         viewedPages={new Set()}
         onEdit={onEdit}
-        open
         expandedPages={pages}
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
@@ -593,7 +627,6 @@ describe('<ReviewCollapsibleChapter>', () => {
         setPagesViewed={setPagesViewed}
         viewedPages={new Set()}
         onEdit={onEdit}
-        open
         expandedPages={pages}
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
@@ -670,7 +703,6 @@ describe('<ReviewCollapsibleChapter>', () => {
       <ReviewCollapsibleChapter
         viewedPages={new Set()}
         onEdit={() => {}}
-        open
         expandedPages={pages}
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
@@ -723,7 +755,6 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
-          open
         />,
       );
 
@@ -777,7 +808,6 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
-          open
         />,
       );
 
@@ -832,7 +862,6 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
-          open
         />,
       );
 
@@ -895,7 +924,6 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
-          open
         />,
       );
 
@@ -950,7 +978,6 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
-          open
         />,
       );
 
@@ -1008,7 +1035,6 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
-          open
         />,
       );
 
@@ -1026,7 +1052,6 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
-          open
         />,
       );
 
@@ -1085,7 +1110,6 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
-          open
         />,
       );
 
@@ -1113,7 +1137,6 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
-          open
         />,
       );
 
@@ -1131,7 +1154,6 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
-          open
         />,
       );
       expect(queryByTestId('accordion-item-content').children.length).to.equal(
@@ -1153,7 +1175,6 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
-          open
         />,
       );
       expect(container.querySelector('form.rjsf')).to.exist;
@@ -1179,7 +1200,6 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
-          open
           onEdit={onEdit}
         />,
       );
@@ -1208,7 +1228,6 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
-          open
           onEdit={onEdit}
         />,
       );
@@ -1234,7 +1253,6 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
-          open
         />,
       );
 
@@ -1259,7 +1277,6 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
-          open
         />,
       );
 
@@ -1290,7 +1307,6 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
-          open
           setData={onSetData}
         />,
       );

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -9,43 +9,6 @@ import sinon from 'sinon';
 import { ReviewCollapsibleChapter } from '../../../src/js/review/ReviewCollapsibleChapter';
 
 describe('<ReviewCollapsibleChapter>', () => {
-  it('should add a data-attribute with the chapterKey', () => {
-    const pages = [
-      {
-        title: '',
-        pageKey: 'test2',
-      },
-    ];
-    const chapterKey = 'chapterX';
-    const chapter = {};
-    const form = {
-      pages: {
-        test: {
-          title: '',
-          schema: {
-            properties: {},
-          },
-          uiSchema: {},
-        },
-      },
-      data: {},
-    };
-
-    const wrapper = mount(
-      <ReviewCollapsibleChapter
-        viewedPages={new Set()}
-        expandedPages={pages}
-        chapterKey={chapterKey}
-        chapterFormConfig={chapter}
-        form={form}
-      />,
-    );
-
-    const accordion = wrapper.find('.usa-accordion-bordered');
-    expect(accordion.length).to.equal(1);
-    expect(accordion.props()['data-chapter']).to.equal('chapterX');
-    wrapper.unmount();
-  });
   it('should handle editing', () => {
     const onEdit = sinon.spy();
     const pages = [
@@ -411,8 +374,9 @@ describe('<ReviewCollapsibleChapter>', () => {
       />,
     );
 
-    expect(wrapper.find('.schemaform-review-chapter-error').length).to.equal(1);
-    expect(wrapper.find('.schemaform-review-page-error').length).to.equal(1);
+    expect(wrapper.find('va-accordion-item').props().subHeader).to.equal(
+      'Some information has changed. Please review.',
+    );
     wrapper.unmount();
   });
   it('should handle submitting array page', () => {
@@ -515,7 +479,9 @@ describe('<ReviewCollapsibleChapter>', () => {
       />,
     );
 
-    expect(wrapper.find('h3').text()).to.equal(testChapterTitle);
+    expect(wrapper.find('va-accordion-item').props().header).to.equal(
+      testChapterTitle,
+    );
 
     const titleDiv = wrapper.find('h4.form-review-panel-page-header');
     expect(titleDiv.length).to.equal(1);
@@ -571,7 +537,9 @@ describe('<ReviewCollapsibleChapter>', () => {
       />,
     );
 
-    expect(wrapper.find('h3').text()).to.equal(testChapterTitle);
+    expect(wrapper.find('va-accordion-item').props().header).to.equal(
+      testChapterTitle,
+    );
 
     const titleDiv = wrapper.find('.form-review-panel-page-header');
     // Title is not rendered if it contains an empty string
@@ -633,7 +601,7 @@ describe('<ReviewCollapsibleChapter>', () => {
       />,
     );
 
-    expect(wrapper.find('h3.accordion-header').text()).to.equal(
+    expect(wrapper.find('va-accordion-item').props().header).to.equal(
       testChapterTitleFromFunction,
     );
 
@@ -713,44 +681,6 @@ describe('<ReviewCollapsibleChapter>', () => {
     expect(tree.find('.form-review-panel-page').length).to.eq(0);
 
     tree.unmount();
-  });
-
-  it('should render a collapsible button with a unique id attribute', () => {
-    const pages = [
-      {
-        title: '',
-        pageKey: 'test2',
-      },
-    ];
-    const chapterKey = 'chapterX';
-    const chapter = {};
-    const form = {
-      pages: {
-        test: {
-          title: '',
-          schema: {
-            properties: {},
-          },
-          uiSchema: {},
-        },
-      },
-      data: {},
-    };
-
-    const wrapper = mount(
-      <ReviewCollapsibleChapter
-        viewedPages={new Set()}
-        expandedPages={pages}
-        chapterKey={chapterKey}
-        chapterFormConfig={chapter}
-        form={form}
-      />,
-    );
-
-    const button = wrapper.find('.usa-button-unstyled');
-    expect(button.props().id).to.contain('collapsibleButton');
-
-    wrapper.unmount();
   });
 
   describe('updateFormData', () => {
@@ -1194,7 +1124,7 @@ describe('<ReviewCollapsibleChapter>', () => {
       const { pages, chapterKey, chapter, form } = getProps();
       pages[0].CustomPageReview = null;
       form.pages.test.CustomPageReview = null;
-      const { container } = render(
+      const { queryByTestId } = render(
         <ReviewCollapsibleChapter
           viewedPages={new Set()}
           expandedPages={pages}
@@ -1204,9 +1134,9 @@ describe('<ReviewCollapsibleChapter>', () => {
           open
         />,
       );
-      expect(
-        container.querySelector('.usa-accordion-content').children.length,
-      ).to.equal(0);
+      expect(queryByTestId('accordion-item-content').children.length).to.equal(
+        0,
+      );
     });
 
     it('should render SchemaForm in the chapter when CustomPageReview is null but the schema properties are not empty', () => {

--- a/src/platform/forms-system/test/js/review/ReviewPage.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewPage.unit.spec.jsx
@@ -48,7 +48,6 @@ describe('Schemaform review: ReviewPage', () => {
     const tree = shallow(
       <ReviewPage
         form={form}
-        openChapters={[]}
         route={{ formConfig, pageList }}
         setEditMode={f => f}
         setPreSubmit={f => f}

--- a/src/platform/forms-system/test/js/review/submit-states/ErrorLinks.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/ErrorLinks.unit.spec.jsx
@@ -19,6 +19,7 @@ describe('<ErrorLinks />', () => {
       .exist;
     expect(view.getByText(/information before you can submit/)).to.exist;
   });
+
   it('has the expected list of errors', () => {
     const props = {
       appType: 'test',
@@ -39,10 +40,13 @@ describe('<ErrorLinks />', () => {
 
     const view = render(<ErrorLinks {...props} />);
 
-    expect(view.getByRole('link', { name: /Missing test/ })).to.exist;
-    expect(view.getByRole('link', { name: /Zip/ })).to.exist;
+    expect(view.baseElement.querySelector('va-button[text="Missing test"]')).to
+      .exist;
+    expect(view.baseElement.querySelector('va-button[text="Zip"]')).to.exist;
+
     expect(view.getByText(/Property not found/)).to.exist;
   });
+
   it('opens the chapter and enables editing when a link is clicked', () => {
     const props = {
       appType: 'test',
@@ -60,9 +64,10 @@ describe('<ErrorLinks />', () => {
     };
 
     const view = render(<ErrorLinks {...props} />);
-    userEvent.click(view.getByRole('link', { name: /Foo/ }));
+    userEvent.click(view.baseElement.querySelector("va-button[text='Foo']"));
     expect(props.setEditMode.called).to.be.true;
   });
+
   it('changes the alert message once the errors are cleared', () => {
     const props = {
       appType: 'test',
@@ -81,7 +86,8 @@ describe('<ErrorLinks />', () => {
 
     const view = render(<ErrorLinks {...props} />);
     // userEvent.click(view.getByRole('link', { name: /Foo/ }));
-    expect(view.getByRole('link', { name: /Foo/ })).to.exist;
+
+    expect(view.baseElement.querySelector('va-button[text="foo"]')).to.exist;
 
     view.rerender(<ErrorLinks {...props} errors={[]} />);
     expect(view.getByText(/Thank you for completing/)).to.exist;

--- a/src/platform/forms-system/test/js/review/submit-states/ErrorLinks.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/ErrorLinks.unit.spec.jsx
@@ -12,7 +12,6 @@ describe('<ErrorLinks />', () => {
       appType: 'test',
       testId: '1234',
       errors: [],
-      openReviewChapter: () => {},
       setEditMode: () => {},
     };
     const view = render(<ErrorLinks {...props} />);
@@ -35,7 +34,6 @@ describe('<ErrorLinks />', () => {
         // No chapter = no link to open accordion
         { name: 'empty', message: 'Property not found', chapterKey: '' },
       ],
-      openReviewChapter: () => {},
       setEditMode: () => {},
     };
 
@@ -58,13 +56,11 @@ describe('<ErrorLinks />', () => {
           pageKey: 'foo',
         },
       ],
-      openReviewChapter: sinon.spy(),
       setEditMode: sinon.spy(),
     };
 
     const view = render(<ErrorLinks {...props} />);
     userEvent.click(view.getByRole('link', { name: /Foo/ }));
-    expect(props.openReviewChapter.called).to.be.true;
     expect(props.setEditMode.called).to.be.true;
   });
   it('changes the alert message once the errors are cleared', () => {
@@ -80,7 +76,6 @@ describe('<ErrorLinks />', () => {
           pageKey: 'foo',
         },
       ],
-      openReviewChapter: sinon.spy(),
       setEditMode: sinon.spy(),
     };
 

--- a/src/platform/forms-system/test/js/review/submit-states/ErrorLinks.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/ErrorLinks.unit.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
+import * as utilities from '../../../../src/js/utilities/review';
 
 import { ErrorLinks } from '../../../../src/js/review/submit-states/ErrorLinks';
 
@@ -12,7 +13,6 @@ describe('<ErrorLinks />', () => {
       appType: 'test',
       testId: '1234',
       errors: [],
-      setEditMode: () => {},
     };
     const view = render(<ErrorLinks {...props} />);
     expect(view.getAllByRole('heading', { name: /missing some info/ })).to
@@ -35,19 +35,19 @@ describe('<ErrorLinks />', () => {
         // No chapter = no link to open accordion
         { name: 'empty', message: 'Property not found', chapterKey: '' },
       ],
-      setEditMode: () => {},
     };
 
     const view = render(<ErrorLinks {...props} />);
 
-    expect(view.baseElement.querySelector('va-button[text="Missing test"]')).to
-      .exist;
-    expect(view.baseElement.querySelector('va-button[text="Zip"]')).to.exist;
-
+    expect(view.getByRole('link', { name: /Missing test/ })).to.exist;
+    expect(view.getByRole('link', { name: /Zip/ })).to.exist;
     expect(view.getByText(/Property not found/)).to.exist;
   });
 
   it('opens the chapter and enables editing when a link is clicked', () => {
+    const editSpy = sinon.spy(utilities, 'openAndEditChapter');
+    const scrollSpy = sinon.spy(utilities, 'scrollToReviewElement');
+
     const props = {
       appType: 'test',
       testId: '1234',
@@ -60,12 +60,13 @@ describe('<ErrorLinks />', () => {
           pageKey: 'foo',
         },
       ],
-      setEditMode: sinon.spy(),
     };
 
     const view = render(<ErrorLinks {...props} />);
-    userEvent.click(view.baseElement.querySelector("va-button[text='Foo']"));
-    expect(props.setEditMode.called).to.be.true;
+    userEvent.click(view.getByRole('link', { name: /Foo/ }));
+
+    expect(editSpy.called).to.be.true;
+    expect(scrollSpy.called).to.be.true;
   });
 
   it('changes the alert message once the errors are cleared', () => {
@@ -81,13 +82,11 @@ describe('<ErrorLinks />', () => {
           pageKey: 'foo',
         },
       ],
-      setEditMode: sinon.spy(),
     };
 
     const view = render(<ErrorLinks {...props} />);
     // userEvent.click(view.getByRole('link', { name: /Foo/ }));
-
-    expect(view.baseElement.querySelector('va-button[text="foo"]')).to.exist;
+    expect(view.getByRole('link', { name: /Foo/ })).to.exist;
 
     view.rerender(<ErrorLinks {...props} errors={[]} />);
     expect(view.getByText(/Thank you for completing/)).to.exist;

--- a/src/platform/forms-system/test/js/state/index.unit.spec.js
+++ b/src/platform/forms-system/test/js/state/index.unit.spec.js
@@ -1,8 +1,6 @@
 import { expect } from 'chai';
 
 import {
-  CLOSE_REVIEW_CHAPTER,
-  OPEN_REVIEW_CHAPTER,
   SET_DATA,
   SET_EDIT_MODE,
   SET_PRE_SUBMIT,
@@ -68,56 +66,6 @@ describe('schemaform createSchemaFormReducer', () => {
       },
     };
     const reducer = createSchemaFormReducer(formConfig);
-
-    it('adds the chapter name to openChapters on OPEN_REVIEW_CHAPTER', () => {
-      const previousState = {
-        reviewPageView: {
-          openChapters: [],
-        },
-      };
-
-      const expectedState = {
-        reviewPageView: {
-          openChapters: ['chapter2'],
-        },
-      };
-
-      const action = {
-        type: OPEN_REVIEW_CHAPTER,
-        openedChapter: 'chapter2',
-      };
-
-      const testState = reducer(previousState, action);
-
-      expect(testState).to.deep.equal(expectedState);
-    });
-
-    it('removes the chapter name from openChapters on CLOSE_REVIEW_CHAPTER', () => {
-      const viewedPages = new Set();
-      const previousState = {
-        reviewPageView: {
-          openChapters: ['chapter1', 'chapter2', 'chapter3'],
-          viewedPages,
-        },
-      };
-
-      const action = {
-        type: CLOSE_REVIEW_CHAPTER,
-        closedChapter: 'chapter2',
-        pageKeys: ['test'],
-      };
-
-      const testState = reducer(previousState, action);
-
-      const expectedState = {
-        reviewPageView: {
-          openChapters: ['chapter1', 'chapter3'],
-          viewedPages: viewedPages.add('test'),
-        },
-      };
-
-      expect(testState).to.deep.equal(expectedState);
-    });
 
     it('should set data state', () => {
       const state = reducer(

--- a/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
@@ -235,7 +235,7 @@ describe('focus on change', () => {
 
     const dom = findDOMNode(tree);
     global.document = dom;
-    const target = '.edit-btn';
+    const target = 'va-button[text="edit"]';
     const focused = sinon.stub(dom.querySelector(target), 'focus');
     focusOnChange('test', target);
 

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -528,35 +528,6 @@ legend.schemaform-label.schemaform-file-label {
   line-height: 2.2rem;
 }
 
-.schemaform-review-chapter-error {
-  .schemaform-chapter-accordion-header {
-    position: relative;
-    margin-bottom: 0;
-    border-bottom: 0.5rem solid var(--color-secondary-lightest);
-    > button.usa-button-unstyled {
-      padding-left: 5rem;
-      background-color: $color-secondary-lightest;
-    }
-    .schemaform-review-chapter-error-icon {
-      position: absolute;
-      top: calc(50% - 0.6em);
-      left: 1.5rem;
-      display: block;
-      background-image: url("~uswds/dist/img/alerts/error.png");
-      background-image: url("~uswds/dist/img/alerts/error.svg");
-      width: 2em;
-      height: 1.2em;
-      background-size: 1.8em;
-      margin-right: 1em;
-    }
-  }
-  .schemaform-chapter-accordion-content {
-    border-right-color: $color-secondary-lightest;
-    border-left-color: $color-secondary-lightest;
-    border-bottom-color: $color-secondary-lightest;
-  }
-}
-
 #content .panel.saved-success-container {
   background-color: $color-green-lightest;
 }

--- a/src/platform/forms/tests/save-in-progress/01-sip-review.cypress.spec.js
+++ b/src/platform/forms/tests/save-in-progress/01-sip-review.cypress.spec.js
@@ -24,13 +24,11 @@ describe('SIP Review Test', () => {
     cy.get('body').should('be.visible');
     cy.get('.main .usa-button-primary', { timeout: Timeouts.slow });
 
-    cy.get(
-      '.schemaform-chapter-accordion-header:first-child > .usa-button-unstyled',
-    )
+    cy.get('va-accordion-item')
       .first()
       .click()
       .then(() => {
-        cy.get('.edit-btn')
+        cy.get("va-button[text='edit']")
           .first()
           .click();
         cy.fill('input[name="root_veteranFullName_first"]', 'Jane');

--- a/src/platform/forms/tests/save-in-progress/RoutedSavableReviewPage.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/RoutedSavableReviewPage.unit.spec.jsx
@@ -60,7 +60,6 @@ describe('Schemaform save in progress: RoutedSavableReviewPage', () => {
       <RoutedSavableReviewPage
         router={router}
         setData={setData}
-        openChapters={[]}
         form={form}
         user={user}
         onSubmit={onSubmit}
@@ -251,7 +250,6 @@ describe('Schemaform save in progress: RoutedSavableReviewPage', () => {
         <RoutedSavableReviewPage
           router={router}
           setData={setData}
-          openChapters={[]}
           form={form}
           user={user}
           onSubmit={onSubmit}


### PR DESCRIPTION
## Summary

- The review page was using custom components for the "accordion"-style effect. These components need to be migrated to the design system. The specific impetus is a contrast issue.
- The accordion item buttons were not meeting AA accessibility guidelines when in `:active` state.
- The solution is to migrate the components to use `<va-accordion>`.
- This work is being done under the color of the Non-Disability Benefits Experience team. This team owns some forms being impacted by this work, but does not own the system or specific components being modified in this PR.
- This work is not behind Flipper.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/64149

## Testing done

- Unit tests were updated to work with the new changes. Some tests are no longer needed and were removed (these decisions are explained in comments on the PR).
- Manual testing shows the features working properly with the new components (see screenshots).
- Testing can be done by navigating to the end of any form.

## Screenshots

### Accordion Active State

<details>
<summary>
Before
</summary>

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/6e55d138-e7e2-418a-8259-e622279f7198)
</details>

<details>
<summary>
After
</summary>

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/3b204d6a-d014-4703-bd09-639cf9673a8c)
</details>

### Accordion Error State
<details>
<summary>
Before
</summary>

![deps-contrast-forms-error-old](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/6dfb5c5b-944f-433c-b50f-2467654cd7c9)
</details>

<details>
<summary>
After
</summary>

![deps-contrast-forms-error-fixed](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/ac9bf4ac-2a2a-46c0-8018-793392cbd3d8)
</details>

### Accordion scroll and focus behavior
- All autoscrolling has been removed from the page
- Autofocus behavior has been maintained
<details>
<summary>
Video
</summary>

https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/920473a7-d114-4cbc-9f7c-f229885df859
</summary>
</details>

### Button Active State
<details>
<summary>
Before
</summary>

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/ad88f904-6339-4aa5-a883-9b292e25a334)
</details>

<details>
<summary>
After
</summary>

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/0d349f61-2b7e-4efd-8b79-332c1f6a6c06)

</details>

### Video
<details>
<summary>
Final product
</summary>

https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/7f10894a-2332-4bf5-8e14-1b21ee640646
</details>

## What areas of the site does it impact?

**This will impact the "Review" page on every form using Platform's Form System.** 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
