### PR TITLE
MHV-49514 Update focus text color to be darker

### DIFF
--- a/src/applications/mhv/medical-records/sass/print-download.scss
+++ b/src/applications/mhv/medical-records/sass/print-download.scss
@@ -14,6 +14,7 @@
   button:active,
   button:focus {
     background-color: var(--color-gray-cool-light);
+    color: var(--color-primary-darker);
   }
   button:hover {
     background-color: var(--color-gray-cool-light);

--- a/src/applications/mhv/medications/sass/print-download.scss
+++ b/src/applications/mhv/medications/sass/print-download.scss
@@ -14,6 +14,7 @@
   button:active,
   button:focus {
     background-color: var(--color-gray-cool-light);
+    color: var(--color-primary-darker);
   }
   button:hover {
     background-color: var(--color-gray-cool-light);


### PR DESCRIPTION
## Summary

Quick validation change from previous PR https://github.com/department-of-veterans-affairs/vets-website/pull/25742
The onFocus color must match the onHover color (darker text).

## Related issue(s)

[MHV-49514](https://jira.devops.va.gov/browse/MHV-49514)

## Testing done

- Visual Confirmation of focus color change

## Screenshots

<img width="294" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/ffbeed32-259a-4f58-b3bf-fca84a08d709">

## What areas of the site does it impact?

MHV MR

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
