### PR TITLE
64140 removing header from widget

### DIFF
--- a/src/applications/static-pages/burial-how-do-i-apply-widget/components/App/index.js
+++ b/src/applications/static-pages/burial-how-do-i-apply-widget/components/App/index.js
@@ -13,67 +13,64 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
     );
   };
   return (
-    <section aria-labelledby="section-heading">
-      <h2 id="section-heading">How do I apply?</h2>
-      <va-alert
-        close-btn-aria-label="Close notification"
-        status="info"
-        visible
-        aria-labelledby="alert-heading"
-        aria-describedby="alert-description"
-      >
-        <h3 id="alert-heading" slot="headline">
-          Our online burial form isn’t working right now
-        </h3>
-        <div id="alert-description">
-          {loggedIn ? (
-            <>
-              <p>
-                You can still apply for a VA burial allowance by mail. Download
-                the PDF form we provide on this page.
-              </p>
-              <h4>If you started your form online already</h4>
-              <p>
-                You’ll need to start over using a PDF form. But you can still
-                refer to the information you saved in your online form.
-              </p>
-              <a href="/burials-and-memorials/application/530/introduction">
-                Refer to your saved form
-              </a>
-            </>
-          ) : (
-            <>
-              <p>
-                You can still apply for VA pension benefits by mail, in person
-                at a VA regional office, or with the help of a Veterans Service
-                Officer (VSO) or another accredited representative. Download the
-                PDF form we provide on this page.
-              </p>
-              <h4>If you started your form online already</h4>
-              <p>
-                You’ll need to start over using a PDF form. But you can still
-                sign in to VA.gov to refer to the information you saved in your
-                online form.
-              </p>
-              <p>
-                <strong>Note: </strong>
-                We’ll record the potential start date for your benefits as the
-                date you first saved your online form. You have 1 year from this
-                date to submit your application. If we approve your claim, you
-                may be able to get retroactive payments.
-              </p>
-              <va-button
-                onClick={() => {
-                  setReturnUrl();
-                  toggleLoginModal(true);
-                }}
-                text="Sign in to VA.gov"
-              />
-            </>
-          )}
-        </div>
-      </va-alert>
-    </section>
+    <va-alert
+      close-btn-aria-label="Close notification"
+      status="info"
+      visible
+      aria-labelledby="alert-heading"
+      aria-describedby="alert-description"
+    >
+      <h3 id="alert-heading" slot="headline">
+        Our online burial form isn’t working right now
+      </h3>
+      <div id="alert-description">
+        {loggedIn ? (
+          <>
+            <p>
+              You can still apply for a VA burial allowance by mail. Download
+              the PDF form we provide on this page.
+            </p>
+            <h4>If you started your form online already</h4>
+            <p>
+              You’ll need to start over using a PDF form. But you can still
+              refer to the information you saved in your online form.
+            </p>
+            <a href="/burials-and-memorials/application/530/introduction">
+              Refer to your saved form
+            </a>
+          </>
+        ) : (
+          <>
+            <p>
+              You can still apply for VA pension benefits by mail, in person at
+              a VA regional office, or with the help of a Veterans Service
+              Officer (VSO) or another accredited representative. Download the
+              PDF form we provide on this page.
+            </p>
+            <h4>If you started your form online already</h4>
+            <p>
+              You’ll need to start over using a PDF form. But you can still sign
+              in to VA.gov to refer to the information you saved in your online
+              form.
+            </p>
+            <p>
+              <strong>Note: </strong>
+              We’ll record the potential start date for your benefits as the
+              date you first saved your online form. You have 1 year from this
+              date to submit your application. If we approve your claim, you may
+              be able to get retroactive payments.
+            </p>
+            <va-button
+              onClick={() => {
+                setReturnUrl();
+                toggleLoginModal(true);
+              }}
+              text="Sign in to VA.gov"
+            />
+          </>
+        )}
+      </div>
+    </va-alert>
   );
 };
 

--- a/src/applications/static-pages/burial-how-do-i-apply-widget/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/burial-how-do-i-apply-widget/components/App/index.unit.spec.js
@@ -17,7 +17,6 @@ describe('Burial Widget <App>', () => {
 
   it('renders the burial widget app', () => {
     const wrapper = shallow(<App />);
-    expect(wrapper.find('h2').text()).to.equal(`How do I apply?`);
     expect(wrapper.find('h3').text()).to.equal(
       `Our online burial form isn’t working right now`,
     );

--- a/src/applications/static-pages/burial-how-do-i-apply-widget/tests/burial-how-do-i-apply-widget.cypress.spec.js
+++ b/src/applications/static-pages/burial-how-do-i-apply-widget/tests/burial-how-do-i-apply-widget.cypress.spec.js
@@ -28,7 +28,6 @@ describe('The Burial Widget unauthenticed Veteran', () => {
   });
 
   it('Displays the correct page content for unauthenticated user', () => {
-    cy.get('h2').contains('How do I apply?');
     cy.get('h3').contains('Our online burial form isn’t working right now');
     cy.get('p').contains(
       'You can still apply for VA pension benefits by mail, in person at a VA regional office, or with the help of a Veterans Service Officer (VSO) or another accredited representative. Download the PDF form we provide on this page.',
@@ -55,7 +54,6 @@ describe('The Burial Widget for authenticed Veteran', () => {
   });
 
   it('Displays the correct page content for authenticated user', () => {
-    cy.get('h2').contains('How do I apply?');
     cy.get('h3').contains('Our online burial form isn’t working right now');
     cy.get('div').contains(
       'You can still apply for a VA burial allowance by mail. Download the PDF form we provide on this page.',


### PR DESCRIPTION
## Summary
 The widget use to have a h2 header that said 'How do I apply?'. We were asked to remove the heading from the widget.  

-Description 
  - Updated react widget to no longer include h2 heading that says 'How do I apply?'

## Related issue(s)

- [_Link to ticket created in va.gov-team repo_](https://github.com/department-of-veterans-affairs/va.gov-team/issues/62445)
- [_Link to github_](https://github.com/department-of-veterans-affairs/va.gov-team/issues/64140)

## Testing done

- Load widget in app and test at scaffolded index page (/burial-how-do-i-apply-widget)
- Manually zoom in to 400% and test
- Tested on mobile
- Screenreader tests with voiceover software
- Removed unit test assertions checking for the h2 element
- Removed cypress assertions checking for the h2 element

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._
### Before
#### Not Logged In
##### Desktop
- 100%
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/be96d5a1-57e6-4697-8729-2b7074826e3d)
- 400%
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/c4eece78-0c49-45fb-acbe-a791e431b645)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/fe6416a7-2256-46f0-8eb8-202987ce9ddb)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/69b4cc0c-b4d0-40d4-b5ab-b29f3e9acc7a)
##### Mobile
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/e500b154-02a2-444c-8351-248b2feec3cc)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/61a3a54b-0772-4f9c-86e9-573840a6b096)
#### Logged In
##### Desktop
-100%
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/9f1f0b3a-a514-4706-998b-d24e6b849fb5)
-400%
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/9d93576d-e640-4eca-8985-8d472c1cb230)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/c663fed4-4373-418a-9d8b-d1966edfa311)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/65bdca37-f343-4b50-927d-5138575aaf3e)
##### Mobile
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/debd36f9-b098-4978-9a1c-f8ca90b4258b)
### After
#### Not Logged In
##### Desktop
- 100%
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/99c6be73-e005-4e0c-b31c-c384593d5368)
- 400%
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/c9341839-0ae6-42a7-85ed-436e44461437)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/9704a07a-5fac-4a93-bba0-42faae15a30d)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/58bc3f61-a9ea-4d2d-a26d-13a18690f992)
##### Mobile
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/56aedb59-9609-4e46-97ec-5916983fff95)
#### Logged In
##### Desktop
-100%
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/a9d3af0b-24ec-4c5c-81a6-ba79bc5b06d9)
-400%
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/ad13d59d-ffba-4b08-87b5-1ff1d6c14616)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/3bbd02c8-b907-4c4c-a48e-046879f532be)
##### Mobile
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/135056639/8122eb58-17f0-4bf6-b6f9-5aadaefdf4ec)

## What areas of the site does it impact?
- This will currently not effect any areas of the site. The page consuming this widget is still in staging review.

## Acceptance criteria

### Quality Assurance & Testing

- [ x ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ x ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ x ] Linting warnings have been addressed
- [ x ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [  x ] Screenshot of the developed feature is added
- [ x ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ x ] Browser console contains no warnings or errors.
- [ x ] Events are being sent to the appropriate logging solution


### Authentication

- [ x ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback