### PR TITLE
65960-Fixed Link for Copay

### DIFF
--- a/src/applications/mhv/landing-page/utilities/data/index.js
+++ b/src/applications/mhv/landing-page/utilities/data/index.js
@@ -146,7 +146,7 @@ const resolveLandingPageLinks = (authdWithSSOe = false, featureToggles) => {
   const myVaHealthBenefitsLinks = resolveLinkCollection(
     [
       {
-        href: '/manage-va-debt/summary/copay-balances/',
+        href: '/health-care/copay-rates/',
         text: 'Current Veteran copay rates',
       },
       {


### PR DESCRIPTION
## Summary
Changing the link for current veteran copay rates on MHV homepage

## Related issue(s)
department-of-veterans-affairs/va.gov-team#65960
