### PR TITLE
VACMS-14939 Add non-functionality code for Agent Orange

### DIFF
--- a/src/applications/pact-act/actions/index.js
+++ b/src/applications/pact-act/actions/index.js
@@ -1,4 +1,10 @@
 import {
+  PAW_UPDATE_ORANGE_2_2_A,
+  PAW_UPDATE_ORANGE_2_2_B,
+  PAW_UPDATE_ORANGE_2_2_1_A,
+  PAW_UPDATE_ORANGE_2_2_1_B,
+  PAW_UPDATE_ORANGE_2_2_2,
+  PAW_UPDATE_ORANGE_2_2_3,
   PAW_UPDATE_BURN_PIT_2_1,
   PAW_UPDATE_BURN_PIT_2_1_1,
   PAW_UPDATE_BURN_PIT_2_1_2,
@@ -45,6 +51,48 @@ export const updateBurnPit211 = value => {
 export const updateBurnPit212 = value => {
   return {
     type: PAW_UPDATE_BURN_PIT_2_1_2,
+    payload: value,
+  };
+};
+
+export const updateOrange22A = value => {
+  return {
+    type: PAW_UPDATE_ORANGE_2_2_A,
+    payload: value,
+  };
+};
+
+export const updateOrange22B = value => {
+  return {
+    type: PAW_UPDATE_ORANGE_2_2_B,
+    payload: value,
+  };
+};
+
+export const updateOrange221A = value => {
+  return {
+    type: PAW_UPDATE_ORANGE_2_2_1_A,
+    payload: value,
+  };
+};
+
+export const updateOrange221B = value => {
+  return {
+    type: PAW_UPDATE_ORANGE_2_2_1_B,
+    payload: value,
+  };
+};
+
+export const updateOrange222 = value => {
+  return {
+    type: PAW_UPDATE_ORANGE_2_2_2,
+    payload: value,
+  };
+};
+
+export const updateOrange223 = value => {
+  return {
+    type: PAW_UPDATE_ORANGE_2_2_3,
     payload: value,
   };
 };

--- a/src/applications/pact-act/constants/index.js
+++ b/src/applications/pact-act/constants/index.js
@@ -1,3 +1,9 @@
+export const PAW_UPDATE_ORANGE_2_2_A = 'pact-act/PAW_UPDATE_ORANGE_2_2_A';
+export const PAW_UPDATE_ORANGE_2_2_B = 'pact-act/PAW_UPDATE_ORANGE_2_2_B';
+export const PAW_UPDATE_ORANGE_2_2_1_A = 'pact-act/PAW_UPDATE_ORANGE_2_2_1_A';
+export const PAW_UPDATE_ORANGE_2_2_1_B = 'pact-act/PAW_UPDATE_ORANGE_2_2_1_B';
+export const PAW_UPDATE_ORANGE_2_2_2 = 'pact-act/PAW_UPDATE_ORANGE_2_2_2';
+export const PAW_UPDATE_ORANGE_2_2_3 = 'pact-act/PAW_UPDATE_ORANGE_2_2_3';
 export const PAW_UPDATE_BURN_PIT_2_1 = 'pact-act/PAW_UPDATE_BURN_PIT_2_1';
 export const PAW_UPDATE_BURN_PIT_2_1_1 = 'pact-act/PAW_UPDATE_BURN_PIT_2_1_1';
 export const PAW_UPDATE_BURN_PIT_2_1_2 = 'pact-act/PAW_UPDATE_BURN_PIT_2_1_2';
@@ -8,6 +14,12 @@ export const PAW_VIEWED_RESULTS_PAGE_1 = 'pact-act/PAW_VIEWED_RESULTS_PAGE_1';
 // Except for HOME and results pages, left side must match
 // short name codes in utilities/question-data-map
 export const ROUTES = {
+  ORANGE_2_2_A: 'agent-orange-2-2-A',
+  ORANGE_2_2_B: 'agent-orange-2-2-B',
+  ORANGE_2_2_1_A: 'agent-orange-2-2-1-A',
+  ORANGE_2_2_1_B: 'agent-orange-2-2-1-B',
+  ORANGE_2_2_2: 'agent-orange-2-2-2',
+  ORANGE_2_2_3: 'agent-orange-2-2-3',
   BURN_PIT_2_1: 'burn-pit-2-1',
   BURN_PIT_2_1_1: 'burn-pit-2-1-1',
   BURN_PIT_2_1_2: 'burn-pit-2-1-2',

--- a/src/applications/pact-act/containers/questions/ServicePeriod.jsx
+++ b/src/applications/pact-act/containers/questions/ServicePeriod.jsx
@@ -5,10 +5,6 @@ import TernaryRadios from './TernaryRadios';
 import { updateServicePeriod } from '../../actions';
 import { RESPONSES, SHORT_NAME_MAP } from '../../utilities/question-data-map';
 import { ROUTES } from '../../constants';
-import {
-  navigateBackward,
-  navigateForward,
-} from '../../utilities/display-logic';
 import { pageSetup } from '../../utilities/page-setup';
 
 const ServicePeriod = ({
@@ -43,54 +39,19 @@ const ServicePeriod = ({
     [router, viewedIntroPage],
   );
 
-  const onContinueClick = () => {
-    if (!servicePeriod) {
-      setFormError(true);
-    } else {
-      setFormError(false);
-      navigateForward(shortName, formResponses, router);
-    }
-  };
-
-  const onBackClick = () => {
-    navigateBackward(shortName, formResponses, router);
-  };
-
-  const onValueChange = event => {
-    const { value } = event?.detail;
-    setServicePeriod(value);
-
-    if (value) {
-      setFormError(false);
-    }
-  };
-
-  const onBlurInput = () => {
-    if (servicePeriod) {
-      setFormError(false);
-    }
-  };
-
   return (
-    <>
-      <h1>{H1}</h1>
-      <TernaryRadios
-        formError={formError}
-        formValue={servicePeriod}
-        h1={H1}
-        onBackClick={onBackClick}
-        onBlurInput={onBlurInput}
-        onContinueClick={onContinueClick}
-        onValueChange={onValueChange}
-        responses={[
-          NINETY_OR_LATER,
-          EIGHTYNINE_OR_EARLIER,
-          DURING_BOTH_PERIODS,
-        ]}
-        shortName={shortName}
-        testId="paw-servicePeriod"
-      />
-    </>
+    <TernaryRadios
+      formError={formError}
+      formResponses={formResponses}
+      formValue={servicePeriod}
+      h1={H1}
+      responses={[NINETY_OR_LATER, EIGHTYNINE_OR_EARLIER, DURING_BOTH_PERIODS]}
+      router={router}
+      setFormError={setFormError}
+      shortName={shortName}
+      testId="paw-servicePeriod"
+      valueSetter={setServicePeriod}
+    />
   );
 };
 

--- a/src/applications/pact-act/containers/questions/TernaryRadios.jsx
+++ b/src/applications/pact-act/containers/questions/TernaryRadios.jsx
@@ -5,6 +5,10 @@ import {
   VaRadio,
   VaRadioOption,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import {
+  navigateBackward,
+  navigateForward,
+} from '../../utilities/display-logic';
 
 /**
  * Produces a set of 3 radio options
@@ -14,17 +18,45 @@ import {
  */
 const TernaryRadios = ({
   formError,
+  formResponses,
   formValue,
   h1,
   locationList,
-  onBackClick,
-  onBlurInput,
-  onContinueClick,
-  onValueChange,
   responses,
+  router,
+  setFormError,
   shortName,
   testId,
+  valueSetter,
 }) => {
+  const onContinueClick = () => {
+    if (!formValue) {
+      setFormError(true);
+    } else {
+      setFormError(false);
+      navigateForward(shortName, formResponses, router);
+    }
+  };
+
+  const onBackClick = () => {
+    navigateBackward(shortName, formResponses, router);
+  };
+
+  const onBlurInput = () => {
+    if (formValue) {
+      setFormError(false);
+    }
+  };
+
+  const onValueChange = event => {
+    const { value } = event?.detail;
+    valueSetter(value);
+
+    if (value) {
+      setFormError(false);
+    }
+  };
+
   return (
     <>
       <VaRadio
@@ -34,6 +66,7 @@ const TernaryRadios = ({
         error={(formError && 'Please select a response.') || null}
         hint=""
         label={h1}
+        label-header-level="1"
         onVaValueChange={onValueChange}
       >
         {locationList}
@@ -68,14 +101,14 @@ const TernaryRadios = ({
 
 TernaryRadios.propTypes = {
   formError: PropTypes.bool.isRequired,
+  formResponses: PropTypes.object.isRequired,
   h1: PropTypes.string.isRequired,
   responses: PropTypes.arrayOf(PropTypes.string).isRequired,
+  router: PropTypes.object.isRequired,
+  setFormError: PropTypes.func.isRequired,
   shortName: PropTypes.string.isRequired,
   testId: PropTypes.string.isRequired,
-  onBackClick: PropTypes.func.isRequired,
-  onBlurInput: PropTypes.func.isRequired,
-  onContinueClick: PropTypes.func.isRequired,
-  onValueChange: PropTypes.func.isRequired,
+  valueSetter: PropTypes.func.isRequired,
   formValue: PropTypes.string,
   locationList: PropTypes.node,
 };

--- a/src/applications/pact-act/containers/questions/burn-pit/BurnPit-2-1-1.jsx
+++ b/src/applications/pact-act/containers/questions/burn-pit/BurnPit-2-1-1.jsx
@@ -9,11 +9,6 @@ import {
   SHORT_NAME_MAP,
 } from '../../../utilities/question-data-map';
 import { ROUTES } from '../../../constants';
-import {
-  displayConditionsMet,
-  navigateBackward,
-  navigateForward,
-} from '../../../utilities/display-logic';
 import { pageSetup } from '../../../utilities/page-setup';
 
 const BurnPit211 = ({
@@ -37,40 +32,12 @@ const BurnPit211 = ({
 
   useEffect(
     () => {
-      if (!viewedIntroPage || !displayConditionsMet(shortName, formResponses)) {
+      if (!viewedIntroPage) {
         router.push(ROUTES.HOME);
       }
     },
-    [formResponses, router, shortName, viewedIntroPage],
+    [router, viewedIntroPage],
   );
-
-  const onContinueClick = () => {
-    if (!burnPit211) {
-      setFormError(true);
-    } else {
-      setFormError(false);
-      navigateForward(shortName, formResponses, router);
-    }
-  };
-
-  const onBackClick = () => {
-    navigateBackward(shortName, formResponses, router);
-  };
-
-  const onValueChange = event => {
-    const { value } = event?.detail;
-    setBurnPit211(value);
-
-    if (value) {
-      setFormError(false);
-    }
-  };
-
-  const onBlurInput = () => {
-    if (burnPit211) {
-      setFormError(false);
-    }
-  };
 
   const locationList = (
     <ul>
@@ -84,22 +51,19 @@ const BurnPit211 = ({
   );
 
   return (
-    <>
-      <h1>{H1}</h1>
-      <TernaryRadios
-        formError={formError}
-        formValue={burnPit211}
-        h1={H1}
-        locationList={locationList}
-        onBackClick={onBackClick}
-        onBlurInput={onBlurInput}
-        onContinueClick={onContinueClick}
-        onValueChange={onValueChange}
-        responses={[YES, NO, NOT_SURE]}
-        shortName={shortName}
-        testId="paw-burnPit2_1_1"
-      />
-    </>
+    <TernaryRadios
+      formError={formError}
+      formResponses={formResponses}
+      formValue={burnPit211}
+      h1={H1}
+      locationList={locationList}
+      responses={[YES, NO, NOT_SURE]}
+      router={router}
+      setFormError={setFormError}
+      shortName={shortName}
+      testId="paw-burnPit2_1_1"
+      valueSetter={setBurnPit211}
+    />
   );
 };
 

--- a/src/applications/pact-act/containers/questions/burn-pit/BurnPit-2-1-2.jsx
+++ b/src/applications/pact-act/containers/questions/burn-pit/BurnPit-2-1-2.jsx
@@ -9,11 +9,6 @@ import {
   SHORT_NAME_MAP,
 } from '../../../utilities/question-data-map';
 import { ROUTES } from '../../../constants';
-import {
-  displayConditionsMet,
-  navigateBackward,
-  navigateForward,
-} from '../../../utilities/display-logic';
 import { pageSetup } from '../../../utilities/page-setup';
 
 const BurnPit212 = ({
@@ -37,40 +32,12 @@ const BurnPit212 = ({
 
   useEffect(
     () => {
-      if (!viewedIntroPage || !displayConditionsMet(shortName, formResponses)) {
+      if (!viewedIntroPage) {
         router.push(ROUTES.HOME);
       }
     },
-    [formResponses, router, shortName, viewedIntroPage],
+    [router, viewedIntroPage],
   );
-
-  const onContinueClick = () => {
-    if (!burnPit212) {
-      setFormError(true);
-    } else {
-      setFormError(false);
-      navigateForward(shortName, formResponses, router);
-    }
-  };
-
-  const onBackClick = () => {
-    navigateBackward(shortName, formResponses, router);
-  };
-
-  const onValueChange = event => {
-    const { value } = event?.detail;
-    setBurnPit212(value);
-
-    if (value) {
-      setFormError(false);
-    }
-  };
-
-  const onBlurInput = () => {
-    if (burnPit212) {
-      setFormError(false);
-    }
-  };
 
   const locationList = (
     <ul>
@@ -87,22 +54,19 @@ const BurnPit212 = ({
   );
 
   return (
-    <>
-      <h1>{H1}</h1>
-      <TernaryRadios
-        formError={formError}
-        formValue={burnPit212}
-        h1={H1}
-        locationList={locationList}
-        onBackClick={onBackClick}
-        onBlurInput={onBlurInput}
-        onContinueClick={onContinueClick}
-        onValueChange={onValueChange}
-        responses={[YES, NO, NOT_SURE]}
-        shortName={shortName}
-        testId="paw-burnPit2_1_2"
-      />
-    </>
+    <TernaryRadios
+      formError={formError}
+      formResponses={formResponses}
+      formValue={burnPit212}
+      h1={H1}
+      locationList={locationList}
+      responses={[YES, NO, NOT_SURE]}
+      router={router}
+      setFormError={setFormError}
+      shortName={shortName}
+      testId="paw-burnPit2_1_2"
+      valueSetter={setBurnPit212}
+    />
   );
 };
 

--- a/src/applications/pact-act/containers/questions/burn-pit/BurnPit-2-1.jsx
+++ b/src/applications/pact-act/containers/questions/burn-pit/BurnPit-2-1.jsx
@@ -9,11 +9,6 @@ import {
   SHORT_NAME_MAP,
 } from '../../../utilities/question-data-map';
 import { ROUTES } from '../../../constants';
-import {
-  displayConditionsMet,
-  navigateBackward,
-  navigateForward,
-} from '../../../utilities/display-logic';
 import { pageSetup } from '../../../utilities/page-setup';
 
 const BurnPit21 = ({
@@ -37,40 +32,12 @@ const BurnPit21 = ({
 
   useEffect(
     () => {
-      if (!viewedIntroPage || !displayConditionsMet(shortName, formResponses)) {
+      if (!viewedIntroPage) {
         router.push(ROUTES.HOME);
       }
     },
-    [formResponses, router, shortName, viewedIntroPage],
+    [router, viewedIntroPage],
   );
-
-  const onContinueClick = () => {
-    if (!burnPit21) {
-      setFormError(true);
-    } else {
-      setFormError(false);
-      navigateForward(shortName, formResponses, router);
-    }
-  };
-
-  const onBackClick = () => {
-    navigateBackward(shortName, formResponses, router);
-  };
-
-  const onValueChange = event => {
-    const { value } = event?.detail;
-    setBurnPit21(value);
-
-    if (value) {
-      setFormError(false);
-    }
-  };
-
-  const onBlurInput = () => {
-    if (burnPit21) {
-      setFormError(false);
-    }
-  };
 
   const locationList = (
     <ul>
@@ -87,22 +54,19 @@ const BurnPit21 = ({
   );
 
   return (
-    <>
-      <h1>{H1}</h1>
-      <TernaryRadios
-        formError={formError}
-        formValue={burnPit21}
-        h1={H1}
-        locationList={locationList}
-        onBackClick={onBackClick}
-        onBlurInput={onBlurInput}
-        onContinueClick={onContinueClick}
-        onValueChange={onValueChange}
-        responses={[YES, NO, NOT_SURE]}
-        shortName={shortName}
-        testId="paw-burnPit2_1"
-      />
-    </>
+    <TernaryRadios
+      formError={formError}
+      formResponses={formResponses}
+      formValue={burnPit21}
+      h1={H1}
+      locationList={locationList}
+      responses={[YES, NO, NOT_SURE]}
+      router={router}
+      setFormError={setFormError}
+      shortName={shortName}
+      testId="paw-burnPit2_1"
+      valueSetter={setBurnPit21}
+    />
   );
 };
 

--- a/src/applications/pact-act/tests/burn-pit/BurnPit-2-1-1.unit.spec.js
+++ b/src/applications/pact-act/tests/burn-pit/BurnPit-2-1-1.unit.spec.js
@@ -3,16 +3,16 @@ import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { RESPONSES } from '../utilities/question-data-map';
-import { ROUTES } from '../constants';
+import { RESPONSES } from '../../utilities/question-data-map';
+import { ROUTES } from '../../constants';
 
-import BurnPit21 from '../containers/questions/burn-pit/BurnPit-2-1';
+import BurnPit211 from '../../containers/questions/burn-pit/BurnPit-2-1-1';
 
 const mockStoreStandard = {
   getState: () => ({
     pactAct: {
       form: {
-        BURN_PIT_2_1_0: null,
+        BURN_PIT_2_1: null,
         SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
       },
       viewedIntroPage: true,
@@ -26,24 +26,10 @@ const mockStoreNoIntroPage = {
   getState: () => ({
     pactAct: {
       form: {
-        BURN_PIT_2_1_0: null,
+        BURN_PIT_2_1: null,
         SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
       },
       viewedIntroPage: false,
-    },
-  }),
-  subscribe: () => {},
-  dispatch: () => {},
-};
-
-const mockStoreDCsNotMet = {
-  getState: () => ({
-    pactAct: {
-      form: {
-        BURN_PIT_2_1_0: null,
-        SERVICE_PERIOD: null,
-      },
-      viewedIntroPage: true,
     },
   }),
   subscribe: () => {},
@@ -55,10 +41,11 @@ const pushStub = sinon.stub();
 
 const propsStandard = {
   formResponses: {
-    BURN_PIT_2_1_0: null,
+    BURN_PIT_2_1: null,
+    BURN_PIT_2_1_1: null,
     SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
   },
-  setBurnPit21: setBurnPitStub,
+  setBurnPit211: setBurnPitStub,
   router: {
     push: pushStub,
   },
@@ -67,26 +54,15 @@ const propsStandard = {
 
 const propsNoIntroPage = {
   formResponses: {
-    BURN_PIT_2_1_0: null,
+    BURN_PIT_2_1: null,
+    BURN_PIT_2_1_1: null,
     SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
   },
-  setBurnPit21: setBurnPitStub,
+  setBurnPit211: setBurnPitStub,
   router: {
     push: pushStub,
   },
   viewedIntroPage: false,
-};
-
-const propsDCsNotMet = {
-  formResponses: {
-    BURN_PIT_2_1_0: null,
-    SERVICE_PERIOD: null,
-  },
-  setBurnPit21: setBurnPitStub,
-  router: {
-    push: pushStub,
-  },
-  viewedIntroPage: true,
 };
 
 describe('Burn Pit 2.1 Page', () => {
@@ -98,28 +74,18 @@ describe('Burn Pit 2.1 Page', () => {
   it('should correctly load the burn pit page in the standard flow', () => {
     const screen = render(
       <Provider store={mockStoreStandard}>
-        <BurnPit21 {...propsStandard} />
+        <BurnPit211 {...propsStandard} />
       </Provider>,
     );
 
-    expect(screen.getByTestId('paw-burnPit2_1')).to.exist;
+    expect(screen.getByTestId('paw-burnPit2_1_1')).to.exist;
   });
 
   describe('redirects', () => {
     it('should redirect to home when the intro page has not been viewed', () => {
       render(
         <Provider store={mockStoreNoIntroPage}>
-          <BurnPit21 {...propsNoIntroPage} />
-        </Provider>,
-      );
-
-      expect(pushStub.withArgs(ROUTES.HOME).called).to.be.true;
-    });
-
-    it('should redirect to home when the display conditions are not met', () => {
-      render(
-        <Provider store={mockStoreDCsNotMet}>
-          <BurnPit21 {...propsDCsNotMet} />
+          <BurnPit211 {...propsNoIntroPage} />
         </Provider>,
       );
 

--- a/src/applications/pact-act/tests/burn-pit/BurnPit-2-1-2.unit.spec.js
+++ b/src/applications/pact-act/tests/burn-pit/BurnPit-2-1-2.unit.spec.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { RESPONSES } from '../../utilities/question-data-map';
+import { ROUTES } from '../../constants';
+
+import BurnPit212 from '../../containers/questions/burn-pit/BurnPit-2-1-2';
+
+const mockStoreStandard = {
+  getState: () => ({
+    pactAct: {
+      form: {
+        BURN_PIT_2_1: null,
+        BURN_PIT_2_1_1: null,
+        BURN_PIT_2_1_2: null,
+        SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
+      },
+      viewedIntroPage: true,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const mockStoreNoIntroPage = {
+  getState: () => ({
+    pactAct: {
+      form: {
+        BURN_PIT_2_1: null,
+        BURN_PIT_2_1_1: null,
+        BURN_PIT_2_1_2: null,
+        SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
+      },
+      viewedIntroPage: false,
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const setBurnPitStub = sinon.stub();
+const pushStub = sinon.stub();
+
+const propsStandard = {
+  formResponses: {
+    BURN_PIT_2_1: null,
+    BURN_PIT_2_1_1: null,
+    BURN_PIT_2_1_2: null,
+    SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
+  },
+  setBurnPit212: setBurnPitStub,
+  router: {
+    push: pushStub,
+  },
+  viewedIntroPage: true,
+};
+
+const propsNoIntroPage = {
+  formResponses: {
+    BURN_PIT_2_1: null,
+    BURN_PIT_2_1_1: null,
+    BURN_PIT_2_1_2: null,
+    SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
+  },
+  setBurnPit212: setBurnPitStub,
+  router: {
+    push: pushStub,
+  },
+  viewedIntroPage: false,
+};
+
+describe('Burn Pit 2.1 Page', () => {
+  afterEach(() => {
+    setBurnPitStub.resetHistory();
+    pushStub.resetHistory();
+  });
+
+  it('should correctly load the burn pit page in the standard flow', () => {
+    const screen = render(
+      <Provider store={mockStoreStandard}>
+        <BurnPit212 {...propsStandard} />
+      </Provider>,
+    );
+
+    expect(screen.getByTestId('paw-burnPit2_1_2')).to.exist;
+  });
+
+  describe('redirects', () => {
+    it('should redirect to home when the intro page has not been viewed', () => {
+      render(
+        <Provider store={mockStoreNoIntroPage}>
+          <BurnPit212 {...propsNoIntroPage} />
+        </Provider>,
+      );
+
+      expect(pushStub.withArgs(ROUTES.HOME).called).to.be.true;
+    });
+  });
+});

--- a/src/applications/pact-act/tests/burn-pit/BurnPit-2-1.unit.spec.js
+++ b/src/applications/pact-act/tests/burn-pit/BurnPit-2-1.unit.spec.js
@@ -3,17 +3,17 @@ import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { RESPONSES } from '../utilities/question-data-map';
-import { ROUTES } from '../constants';
+import { RESPONSES } from '../../utilities/question-data-map';
+import { ROUTES } from '../../constants';
 
-import ServicePeriod from '../containers/questions/ServicePeriod';
+import BurnPit21 from '../../containers/questions/burn-pit/BurnPit-2-1';
 
 const mockStoreStandard = {
   getState: () => ({
     pactAct: {
       form: {
         BURN_PIT_2_1: null,
-        SERVICE_PERIOD: null,
+        SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
       },
       viewedIntroPage: true,
     },
@@ -27,7 +27,7 @@ const mockStoreNoIntroPage = {
     pactAct: {
       form: {
         BURN_PIT_2_1: null,
-        SERVICE_PERIOD: null,
+        SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
       },
       viewedIntroPage: false,
     },
@@ -36,14 +36,15 @@ const mockStoreNoIntroPage = {
   dispatch: () => {},
 };
 
+const setBurnPitStub = sinon.stub();
 const pushStub = sinon.stub();
 
 const propsStandard = {
   formResponses: {
     BURN_PIT_2_1: null,
-    SERVICE_PERIOD: null,
+    SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
   },
-  setServicePeriod: () => {},
+  setBurnPit21: setBurnPitStub,
   router: {
     push: pushStub,
   },
@@ -55,35 +56,38 @@ const propsNoIntroPage = {
     BURN_PIT_2_1: null,
     SERVICE_PERIOD: RESPONSES.NINETY_OR_LATER,
   },
-  setServicePeriod: () => {},
+  setBurnPit21: setBurnPitStub,
   router: {
     push: pushStub,
   },
   viewedIntroPage: false,
 };
 
-describe('Service Period Page', () => {
+describe('Burn Pit 2.1 Page', () => {
   afterEach(() => {
+    setBurnPitStub.resetHistory();
     pushStub.resetHistory();
   });
 
-  it('should correctly load the service period page in the standard flow', () => {
+  it('should correctly load the burn pit page in the standard flow', () => {
     const screen = render(
       <Provider store={mockStoreStandard}>
-        <ServicePeriod {...propsStandard} />
+        <BurnPit21 {...propsStandard} />
       </Provider>,
     );
 
-    expect(screen.getByTestId('paw-servicePeriod')).to.exist;
+    expect(screen.getByTestId('paw-burnPit2_1')).to.exist;
   });
 
-  it('should redirect to home when the intro page has not been viewed', () => {
-    render(
-      <Provider store={mockStoreNoIntroPage}>
-        <ServicePeriod {...propsNoIntroPage} />
-      </Provider>,
-    );
+  describe('redirects', () => {
+    it('should redirect to home when the intro page has not been viewed', () => {
+      render(
+        <Provider store={mockStoreNoIntroPage}>
+          <BurnPit21 {...propsNoIntroPage} />
+        </Provider>,
+      );
 
-    expect(pushStub.withArgs(ROUTES.HOME).called).to.be.true;
+      expect(pushStub.withArgs(ROUTES.HOME).called).to.be.true;
+    });
   });
 });

--- a/src/applications/pact-act/utilities/question-batches.js
+++ b/src/applications/pact-act/utilities/question-batches.js
@@ -1,7 +1,7 @@
 // These are the question categories in the PACT Act flow
 // https://app.mural.co/t/departmentofveteransaffairs9999/m/departmentofveteransaffairs9999/1692989444688/0044b9825c82d8d23920601f68c41a61d047d681?sender=ue51e6049230e03c1248b5078
 export const BATCHES = {
-  AGENT_ORANGE: 'Agent Orange',
+  ORANGE: 'Agent Orange',
   BURN_PITS: 'Burn pits',
   CAMP_LEJEUNE: 'Lejeune',
   RADIATION: 'Radiation',

--- a/src/applications/pact-act/utilities/question-component-map.js
+++ b/src/applications/pact-act/utilities/question-component-map.js
@@ -1,7 +1,21 @@
 import { BATCHES } from './question-batches';
+import { SHORT_NAME_MAP } from './question-data-map';
+
+const { ORANGE, BURN_PITS } = BATCHES;
 
 // This maps SNAKE_CASE name for a question to the batch (category) for results screen branching
-export const QUESTIONS = {
-  SERVICE_PERIOD: null,
-  BURN_PIT_2_1: BATCHES.BURN_PITS,
+export const BATCH_MAP = {
+  [ORANGE]: [
+    SHORT_NAME_MAP.ORANGE_2_2_A,
+    SHORT_NAME_MAP.ORANGE_2_2_B,
+    SHORT_NAME_MAP.ORANGE_2_2_1_A,
+    SHORT_NAME_MAP.ORANGE_2_2_1_B,
+    SHORT_NAME_MAP.ORANGE_2_2_2,
+    SHORT_NAME_MAP.ORANGE_2_2_3,
+  ],
+  [BURN_PITS]: [
+    SHORT_NAME_MAP.BURN_PIT_2_1,
+    SHORT_NAME_MAP.BURN_PIT_2_1_1,
+    SHORT_NAME_MAP.BURN_PIT_2_1_2,
+  ],
 };

--- a/src/applications/pact-act/utilities/question-data-map.js
+++ b/src/applications/pact-act/utilities/question-data-map.js
@@ -5,6 +5,15 @@ export const QUESTION_MAP = {
   BURN_PIT_2_1: 'Burn pit S2.1, did you serve in any of these locations?',
   BURN_PIT_2_1_1: 'Burn pit S2.1.1, did you serve in any of these locations?',
   BURN_PIT_2_1_2: 'Burn pit S2.1.2, did you serve in any of these locations?',
+  ORANGE_2_2_A: 'Agent orange S2.2A, did you serve in any of these locations?',
+  ORANGE_2_2_B: 'Agent orange S2.2B, which locations did you serve in?',
+  ORANGE_2_2_1_A:
+    'Agent orange S2.2.1A, did you serve in any of these locations?',
+  ORANGE_2_2_1_B: 'Agent orange S2.2.1B, which locations did you serve in?',
+  ORANGE_2_2_2:
+    'Agent orange S2.2.2, did you have repeated contact with C-123 airplanes?',
+  ORANGE_2_2_3:
+    'Agent orange S2.2.3, did you help transport, test, store, or use Agent Orange?',
 };
 
 // Left side must match routes in constants/index.js (ROUTES)
@@ -13,6 +22,11 @@ export const SHORT_NAME_MAP = {
   BURN_PIT_2_1: 'BURN_PIT_2_1',
   BURN_PIT_2_1_1: 'BURN_PIT_2_1_1',
   BURN_PIT_2_1_2: 'BURN_PIT_2_1_2',
+  ORANGE_2_2_B: 'ORANGE_2_2_B',
+  ORANGE_2_2_1_A: 'ORANGE_2_2_1_A',
+  ORANGE_2_2_1_B: 'ORANGE_2_2_1_B',
+  ORANGE_2_2_2: 'ORANGE_2_2_2',
+  ORANGE_2_2_3: 'ORANGE_2_2_3',
 };
 
 export const RESPONSES = {


### PR DESCRIPTION
## Summary
Picking off more pieces from the Agent Orange code coming soon. None of this affects visible functionality; it's mostly setting up for Agent Orange to come and refactoring a few things.

Specifics: 
- Adding actions to cover updating the Agent Orange inputs in the Redux store
- Adding constants for the actions and application routes for Agent Orange
- Refactored TernaryRadios to take care of the event listeners (`onContinueClick`, `onBackClick`, `onBlurInput` and `onValueChange`. Removed all of this functionality from Service Period and Burn Pit questions.
- Removed the `displayConditionsMet` check for deep-linking to the Burn Pit questions. If you deep-link to any question in the flow, you won't have viewed the introduction page. The `viewedIntroPage` check covers it.
- Added unit tests for Burn Pit 2.1.1 and Burn Pit 2.1.2 that I missed when adding the BP questions previously
- Added Agent Orange info to the question component map (to be used for Results screen display)
- Added Agent Orange info to the question data map (used for question display)

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14939

## Testing done
- Ran all Cypress tests; they are passing locally
- Manually tested all Burn Pit flows