### PR TITLE
40-0247 - Require Veteran Personal Info dates

### DIFF
--- a/src/applications/simple-forms/40-0247/pages/veteranPersonalInfo.js
+++ b/src/applications/simple-forms/40-0247/pages/veteranPersonalInfo.js
@@ -18,8 +18,16 @@ export default {
       </h3>
     ),
     veteranFullName: fullNameNoSuffixUI(),
-    veteranDateOfBirth: dateOfBirthUI(),
-    veteranDateOfDeath: dateOfDeathUI(),
+    veteranDateOfBirth: dateOfBirthUI({
+      errorMessages: {
+        required: 'Please provide the date of birth',
+      },
+    }),
+    veteranDateOfDeath: dateOfDeathUI({
+      errorMessages: {
+        required: 'Please provide the date of death',
+      },
+    }),
   },
   schema: {
     type: 'object',
@@ -28,6 +36,6 @@ export default {
       veteranDateOfBirth: dateOfBirthSchema,
       veteranDateOfDeath: dateOfDeathSchema,
     },
-    required: ['veteranFullName'],
+    required: ['veteranFullName', 'veteranDateOfBirth', 'veteranDateOfDeath'],
   },
 };

--- a/src/applications/simple-forms/40-0247/pages/veteranPersonalInfo.js
+++ b/src/applications/simple-forms/40-0247/pages/veteranPersonalInfo.js
@@ -18,16 +18,8 @@ export default {
       </h3>
     ),
     veteranFullName: fullNameNoSuffixUI(),
-    veteranDateOfBirth: dateOfBirthUI({
-      errorMessages: {
-        required: 'Please provide the date of birth',
-      },
-    }),
-    veteranDateOfDeath: dateOfDeathUI({
-      errorMessages: {
-        required: 'Please provide the date of death',
-      },
-    }),
+    veteranDateOfBirth: dateOfBirthUI(),
+    veteranDateOfDeath: dateOfDeathUI(),
   },
   schema: {
     type: 'object',

--- a/src/platform/forms-system/src/js/web-component-patterns/datePatterns.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/datePatterns.jsx
@@ -95,7 +95,7 @@ const dateOfBirthUI = options => {
     title: title || 'Date of birth',
     errorMessages: {
       pattern: 'Please provide a valid date',
-      required: 'Please enter date of birth',
+      required: 'Please provide the date of birth',
     },
     ...uiOptions,
   });
@@ -126,7 +126,7 @@ const dateOfDeathUI = options => {
     title: title || 'Date of death',
     errorMessages: {
       pattern: 'Please provide a valid date',
-      required: 'Please enter date of death',
+      required: 'Please provide the date of death',
     },
     ...uiOptions,
   });


### PR DESCRIPTION
## Summary

- Make Date of birth and Date of death required on Pres. Mem. Cert. (40-0247) Veteran Personal Information page
- Team: Veteran Facing Forms
- Flipper not implemented yet

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#592

## Testing done

- Local manual-UI testing was successful
- Automated tests to follow via separate ticket & PR

## What areas of the site does it impact?

This form ONLY
