### PR TITLE
63966 Rename more cases of 'document' to 'file'

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/bddConfirmationAlert.jsx
+++ b/src/applications/disability-benefits/all-claims/content/bddConfirmationAlert.jsx
@@ -7,7 +7,7 @@ const alertContent = (
     <p>
       You can submit this form on VA.gov after you file your BDD claim. Go to My
       VA to find your claim. When you upload your Separation Health Assessment,
-      select this for document type:{' '}
+      select this for file type:{' '}
       <strong>Disability Benefits Questionnaire</strong>.
     </p>
   </>

--- a/src/applications/disability-benefits/all-claims/content/selfAssessmentAlert.jsx
+++ b/src/applications/disability-benefits/all-claims/content/selfAssessmentAlert.jsx
@@ -5,8 +5,8 @@ const alertContent = (
   <>
     {bddAlertBegin}
     <p>
-      When you upload your Separation Health Assessment, select this for
-      document type: <strong>Disability Benefits Questionnaire</strong>
+      When you upload your Separation Health Assessment, select this for file
+      type: <strong>Disability Benefits Questionnaire</strong>
     </p>
   </>
 );

--- a/src/applications/disability-benefits/all-claims/pages/additionalDocuments.js
+++ b/src/applications/disability-benefits/all-claims/pages/additionalDocuments.js
@@ -19,7 +19,8 @@ export const uiSchema = {
       'Supporting (lay) statements or other evidence',
       'Adding additional evidence:',
       {
-        addAnotherLabel: 'Add another document',
+        addAnotherLabel: 'Add another file',
+        buttonText: 'Upload file',
       },
     ),
     'ui:description': UploadDescription,

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsAttachments.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsAttachments.js
@@ -12,7 +12,8 @@ const fileUploadUi = ancillaryFormUploadUi(
   ' ',
   {
     attachmentId: '',
-    addAnotherLabel: 'Add another document',
+    addAnotherLabel: 'Add another file',
+    buttonText: 'Upload file',
   },
 );
 


### PR DESCRIPTION
## Summary
Rename 'document' to 'file' to comply with current [content guidelines](https://design.va.gov/patterns/ask-users-for/files#content-considerations). Follow up to https://github.com/department-of-veterans-affairs/vets-website/pull/25253

Changes were made on the following pages
.../supporting-evidence/private-medical-records-upload
.../supporting-evidence/additional-evidence
.../confirmation

team: @department-of-veterans-affairs/dbex-trex 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/63966

## Testing done
- To verify changes, log in and start a new 526 claim
- On the 3 above pages, verify content and buttons are renamed properly (refer to screenshots 
- Manual tests were performed and verified existing unit, e2e test were successful

## Screenshots
page: supporting-evidence/private-medical-records-upload
<img width="1169" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/ed64c492-a731-41fd-8773-245c77fee459">
<img width="1196" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/6fcccd66-41e0-4d4f-9629-ec3e81dce124">

page: supporting-evidence/additional-evidence
<img width="992" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/ac4196a4-daa3-4960-a0a6-9608cb40e077">
<img width="946" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/bdac31f2-62d9-4c2a-9975-4b5fb828ab3c">

page: confirmation
<img width="955" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/8516396c-259e-44e5-84f5-ee6298224195">

## What areas of the site does it impact?
526EZ

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
