### PR TITLE
40-0247 - Fix Add'l Certs Req page's missing error-message for additionalCopies field

### DIFF
--- a/src/applications/simple-forms/40-0247/pages/additionalCertificatesRequest.js
+++ b/src/applications/simple-forms/40-0247/pages/additionalCertificatesRequest.js
@@ -61,5 +61,6 @@ export default {
         maximum: 99,
       },
     },
+    required: ['additionalAddress', 'additionalCopies'],
   },
 };


### PR DESCRIPTION
## Summary

- Fix missing error-message for PMC (40-0247) Additional Certificates Request page's `additionalCopies` field.
- Team: Veteran Facing Forms
- Flipper not implemented yet &mdash; end-date TBD

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#600

## Testing done

- Local manual-UI testing was successful.
- Automated tests to follow via separate ticket & PR

## What areas of the site does it impact?

This form ONLY
