### PR TITLE
Removing "view:" fields that are rendering titles and descriptions

### DIFF
--- a/src/applications/simple-forms/21-4142/pages/authorization.js
+++ b/src/applications/simple-forms/21-4142/pages/authorization.js
@@ -5,106 +5,99 @@ import { schemaFields } from '../definitions/constants';
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'view:legalText': {
-      'ui:title': (
-        <h3 className="vads-u-color--gray-dark vads-u-margin-top--0">
-          Provide your authorization to request the medical records
-        </h3>
-      ),
-      'ui:description': (
-        <>
-          <h4 className="vads-u-color--gray-dark vads-u-margin-top--0">
-            Authorization
-          </h4>
-          <p>
-            I voluntarily authorize and request disclosure (including paper,
-            oral, and electronic interchange) of: All my medical records;
-            including information related to my ability to perform tasks of
-            daily living. This includes specific permission to release:
-          </p>
-          <ol className="vads-u-margin-left--neg2">
-            <li>
-              All records and other information regarding my treatment,
-              hospitalization, and outpatient care for my impairment(s)
-              including, but not limited to:
-              <ul>
-                <li>
-                  Psychological, psychiatric, or other mental impairment(s)
-                  excluding “psychotherapy notes” as defined in 45 C.F.R.
-                  §164.501
-                </li>
-                <li>Drug abuse, alcoholism, or other substance abuse</li>
-                <li>Sickle cell anemia</li>
-                <li>
-                  Records which may indicate the presence of a communicable or
-                  non-communicable disease; and tests for or records of HIV/AIDS
-                </li>
-                <li>
-                  Gene-related impairments (including genetic test results)
-                </li>
-              </ul>
-            </li>
+    'ui:title': (
+      <h3 className="vads-u-color--gray-dark vads-u-margin-top--0">
+        Provide your authorization to request the medical records
+      </h3>
+    ),
+    'ui:description': (
+      <>
+        <h4 className="vads-u-color--gray-dark vads-u-margin-top--0">
+          Authorization
+        </h4>
+        <p>
+          I voluntarily authorize and request disclosure (including paper, oral,
+          and electronic interchange) of: All my medical records; including
+          information related to my ability to perform tasks of daily living.
+          This includes specific permission to release:
+        </p>
+        <ol className="vads-u-margin-left--neg2">
+          <li>
+            All records and other information regarding my treatment,
+            hospitalization, and outpatient care for my impairment(s) including,
+            but not limited to:
+            <ul>
+              <li>
+                Psychological, psychiatric, or other mental impairment(s)
+                excluding “psychotherapy notes” as defined in 45 C.F.R. §164.501
+              </li>
+              <li>Drug abuse, alcoholism, or other substance abuse</li>
+              <li>Sickle cell anemia</li>
+              <li>
+                Records which may indicate the presence of a communicable or
+                non-communicable disease; and tests for or records of HIV/AIDS
+              </li>
+              <li>Gene-related impairments (including genetic test results)</li>
+            </ul>
+          </li>
 
-            <li>
-              Information about how my impairment(s) affects my ability to
-              complete tasks and activities of daily living, and affects my
-              ability to work.
-            </li>
-            <li>
-              Information created within 12 months after the date this
-              authorization is signed, as well as past information.
-            </li>
-          </ol>
-          <p>
-            You should not complete this form unless you want the VA to obtain
-            private treatment records on your behalf. If you have already
-            provided these records or intend to obtain them yourself, there is
-            no need to fill out this form. Doing so will lengthen your claim
-            processing time.
-          </p>
-          <h4 className="vads-u-color--gray-dark">Important</h4>
-          <p>
-            In accordance with 38 C.F.R. §3.159(c), "VA will not pay any fees
-            charged by a custodian to provide records requested."
-          </p>
-          <h4 className="vads-u-color--gray-dark">Acknowledgment</h4>
-          <p>
-            I hereby authorize the sources listed in this form, to release any
-            information that may have been obtained in connection with a
-            physical, psychological or psychiatric examination or treatment,
-            with the understanding that VA will use this information in
-            determining my eligibility to veterans benefits I have claimed.
-          </p>
-          <p>
-            I understand that the source being asked to provide the Veterans
-            Benefits Administration with records under this authorization may
-            not require me to execute this authorization before it provides me
-            with treatment, payment for health care, enrollment in a health
-            plan, or eligibility for benefits provided by it.
-          </p>
-          <p>
-            I understand that once my source sends this information to VA under
-            this authorization, the information will no longer be protected by
-            the HIPAA Privacy Rule, but will be protected by the Federal Privacy
-            Act, 5 USC 552a, and VA may disclose this information as authorized
-            by law.
-          </p>
-          <p>
-            I also understand that I may revoke this authorization in writing,
-            at any time except to the extent a source of information has already
-            relied on it to take an action. To revoke, I must send a written
-            statement to the VA Regional Office handling my claim or the Board
-            of Veterans' Appeals (if my claim is related to an appeal) and also
-            send a copy directly to any of my sources that I no longer wish to
-            disclose information about me.
-          </p>
-          <p>
-            I understand that VA may use information disclosed prior to
-            revocation to decide my claim.
-          </p>
-        </>
-      ),
-    },
+          <li>
+            Information about how my impairment(s) affects my ability to
+            complete tasks and activities of daily living, and affects my
+            ability to work.
+          </li>
+          <li>
+            Information created within 12 months after the date this
+            authorization is signed, as well as past information.
+          </li>
+        </ol>
+        <p>
+          You should not complete this form unless you want the VA to obtain
+          private treatment records on your behalf. If you have already provided
+          these records or intend to obtain them yourself, there is no need to
+          fill out this form. Doing so will lengthen your claim processing time.
+        </p>
+        <h4 className="vads-u-color--gray-dark">Important</h4>
+        <p>
+          In accordance with 38 C.F.R. §3.159(c), "VA will not pay any fees
+          charged by a custodian to provide records requested."
+        </p>
+        <h4 className="vads-u-color--gray-dark">Acknowledgment</h4>
+        <p>
+          I hereby authorize the sources listed in this form, to release any
+          information that may have been obtained in connection with a physical,
+          psychological or psychiatric examination or treatment, with the
+          understanding that VA will use this information in determining my
+          eligibility to veterans benefits I have claimed.
+        </p>
+        <p>
+          I understand that the source being asked to provide the Veterans
+          Benefits Administration with records under this authorization may not
+          require me to execute this authorization before it provides me with
+          treatment, payment for health care, enrollment in a health plan, or
+          eligibility for benefits provided by it.
+        </p>
+        <p>
+          I understand that once my source sends this information to VA under
+          this authorization, the information will no longer be protected by the
+          HIPAA Privacy Rule, but will be protected by the Federal Privacy Act,
+          5 USC 552a, and VA may disclose this information as authorized by law.
+        </p>
+        <p>
+          I also understand that I may revoke this authorization in writing, at
+          any time except to the extent a source of information has already
+          relied on it to take an action. To revoke, I must send a written
+          statement to the VA Regional Office handling my claim or the Board of
+          Veterans' Appeals (if my claim is related to an appeal) and also send
+          a copy directly to any of my sources that I no longer wish to disclose
+          information about me.
+        </p>
+        <p>
+          I understand that VA may use information disclosed prior to revocation
+          to decide my claim.
+        </p>
+      </>
+    ),
     [schemaFields.acknowledgeToReleaseInformation]: {
       'ui:title': 'I acknowledge and authorize this release of information',
       'ui:widget': 'checkbox',
@@ -123,10 +116,6 @@ export default {
     type: 'object',
     required: [schemaFields.acknowledgeToReleaseInformation],
     properties: {
-      'view:legalText': {
-        type: 'object',
-        properties: {},
-      },
       [schemaFields.acknowledgeToReleaseInformation]:
         fullSchema.properties[schemaFields.acknowledgeToReleaseInformation],
     },

--- a/src/applications/simple-forms/21P-0847/pages/deceasedClaimantPersonalInformation.js
+++ b/src/applications/simple-forms/21P-0847/pages/deceasedClaimantPersonalInformation.js
@@ -3,14 +3,13 @@ import {
   dateOfDeathUI,
   fullNameNoSuffixSchema,
   fullNameNoSuffixUI,
-  titleSchema,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'view:deceasedClaimantPersonalInfoTitle': titleUI(
+    ...titleUI(
       'Deceased Claimant',
       'Now, we’ll ask for information about the person whose claim you’re requesting to continue.',
     ),
@@ -20,7 +19,6 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      'view:deceasedClaimantPersonalInfoTitle': titleSchema,
       deceasedClaimantFullName: fullNameNoSuffixSchema,
       deceasedClaimantDateOfDeath: currentOrPastDateSchema,
     },

--- a/src/applications/simple-forms/21P-0847/pages/preparerPersonalInformation.js
+++ b/src/applications/simple-forms/21P-0847/pages/preparerPersonalInformation.js
@@ -1,14 +1,13 @@
 import {
   fullNameNoSuffixSchema,
   fullNameNoSuffixUI,
-  titleSchema,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'view:preparerPersonalInfoTitle': titleUI(
+    ...titleUI(
       'Substitute Claimant',
       'First, we’ll ask for your information as the person requesting to be the substitute claimant.',
     ),
@@ -17,7 +16,6 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      'view:preparerPersonalInfoTitle': titleSchema,
       preparerName: fullNameNoSuffixSchema,
     },
   },

--- a/src/applications/simple-forms/21P-0847/pages/veteranIdentificationInformation.js
+++ b/src/applications/simple-forms/21P-0847/pages/veteranIdentificationInformation.js
@@ -3,7 +3,6 @@ import {
   dateOfBirthUI,
   ssnSchema,
   ssnUI,
-  titleSchema,
   titleUI,
   vaFileNumberSchema,
   vaFileNumberUI,
@@ -12,7 +11,7 @@ import {
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'view:veteranInfoTitle': titleUI(
+    ...titleUI(
       'Veteran’s information',
       'We need to know information about the Veteran whose benefits you’re connected to. In some cases, this Veteran may also be the deceased claimant.',
     ),
@@ -23,7 +22,6 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      'view:veteranInfoTitle': titleSchema,
       veteranSsn: ssnSchema,
       veteranDateOfBirth: dateOfBirthSchema,
       veteranVaFileNumber: vaFileNumberSchema,

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/pages/identificationInformation.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/pages/identificationInformation.js
@@ -6,12 +6,12 @@ import {
   serviceNumberUI,
   serviceNumberSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { titleH1Schema, titleH1UI } from '../components/customTitlePattern';
+import { titleH1UI } from '../components/customTitlePattern';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'view:title': titleH1UI('Your identification information'),
+    ...titleH1UI('Your identification information'),
     veteranSSN: ssnUI(),
     veteranVaFileNumber: vaFileNumberUI(),
     veteranServiceNumber: serviceNumberUI(),
@@ -20,7 +20,6 @@ export default {
     type: 'object',
     required: ['veteranSSN'],
     properties: {
-      'view:title': titleH1Schema,
       veteranSSN: ssnSchema,
       veteranVaFileNumber: vaFileNumberSchema,
       veteranServiceNumber: serviceNumberSchema,

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/pages/mailingAddress.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/pages/mailingAddress.js
@@ -2,19 +2,18 @@ import {
   addressNoMilitaryUI,
   addressNoMilitarySchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { titleH1Schema, titleH1UI } from '../components/customTitlePattern';
+import { titleH1UI } from '../components/customTitlePattern';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'view:title': titleH1UI('Your mailing address'),
+    ...titleH1UI('Your mailing address'),
     address: addressNoMilitaryUI(),
   },
   schema: {
     type: 'object',
     required: ['address'],
     properties: {
-      'view:title': titleH1Schema,
       address: addressNoMilitarySchema(),
     },
   },

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/pages/nameAndDate.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/pages/nameAndDate.js
@@ -4,12 +4,12 @@ import {
   fullNameNoSuffixUI,
   fullNameNoSuffixSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { titleH1Schema, titleH1UI } from '../components/customTitlePattern';
+import { titleH1UI } from '../components/customTitlePattern';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'view:title': titleH1UI('Your name and date of birth'),
+    ...titleH1UI('Your name and date of birth'),
     veteranFullName: fullNameNoSuffixUI(),
     veteranDateOfBirth: dateOfBirthUI(),
   },
@@ -17,7 +17,6 @@ export default {
     type: 'object',
     required: ['veteranFullName'],
     properties: {
-      'view:title': titleH1Schema,
       veteranFullName: fullNameNoSuffixSchema,
       veteranDateOfBirth: dateOfBirthSchema,
     },

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/pages/organizationInfo.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/pages/organizationInfo.js
@@ -3,12 +3,12 @@ import {
   addressNoMilitarySchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import VaTextInputField from 'platform/forms-system/src/js/web-component-fields/VaTextInputField';
-import { titleH1Schema, titleH1UI } from '../components/customTitlePattern';
+import { titleH1UI } from '../components/customTitlePattern';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'view:title': titleH1UI("Organization's information"),
+    ...titleH1UI("Organization's information"),
     organizationName: {
       'ui:title': 'Name of organization',
       'ui:webComponentField': VaTextInputField,
@@ -19,7 +19,6 @@ export default {
     type: 'object',
     required: ['organizationName', 'organizationAddress'],
     properties: {
-      'view:title': titleH1Schema,
       organizationName: {
         type: 'string',
       },

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/pages/phoneAndEmail.js
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/pages/phoneAndEmail.js
@@ -4,12 +4,12 @@ import {
   phoneSchema,
   emailSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { titleH1Schema, titleH1UI } from '../components/customTitlePattern';
+import { titleH1UI } from '../components/customTitlePattern';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'view:title': titleH1UI('Your phone and email'),
+    ...titleH1UI('Your phone and email'),
     phone: phoneUI(),
     email: emailUI(),
   },
@@ -17,7 +17,6 @@ export default {
     type: 'object',
     required: ['phone'],
     properties: {
-      'view:title': titleH1Schema,
       phone: phoneSchema,
       email: emailSchema,
     },

--- a/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/identificationInformation.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/identificationInformation.js
@@ -1,5 +1,4 @@
 import {
-  titleSchema,
   titleUI,
   ssnOrVaFileNumberSchema,
   ssnOrVaFileNumberUI,
@@ -8,13 +7,12 @@ import {
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'view:title': titleUI('Identification information'),
+    ...titleUI('Identification information'),
     veteranId: ssnOrVaFileNumberUI(),
   },
   schema: {
     type: 'object',
     properties: {
-      'view:title': titleSchema,
       veteranId: ssnOrVaFileNumberSchema,
     },
   },

--- a/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/mailingAddress.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/mailingAddress.js
@@ -1,14 +1,13 @@
 import {
   addressSchema,
   addressUI,
-  titleSchema,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'view:title': titleUI(
+    ...titleUI(
       'Mailing address',
       "We'll send any important information about your application to this address.",
     ),
@@ -17,7 +16,6 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      'view:title': titleSchema,
       address: addressSchema(),
     },
   },

--- a/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/nameAndDateOfBirth.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/nameAndDateOfBirth.js
@@ -3,21 +3,19 @@ import {
   fullNameUI,
   dateOfBirthSchema,
   dateOfBirthUI,
-  titleSchema,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'view:title': titleUI('Name and date of birth'),
+    ...titleUI('Name and date of birth'),
     fullName: fullNameUI(),
     dateOfBirth: dateOfBirthUI(),
   },
   schema: {
     type: 'object',
     properties: {
-      'view:title': titleSchema,
       fullName: fullNameSchema,
       dateOfBirth: dateOfBirthSchema,
     },

--- a/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/phoneAndEmailAddress.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/phoneAndEmailAddress.js
@@ -3,14 +3,13 @@ import {
   emailUI,
   phoneSchema,
   phoneUI,
-  titleSchema,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'view:title': titleUI('Phone and email address'),
+    ...titleUI('Phone and email address'),
     homePhone: phoneUI('Home phone number'),
     mobilePhone: phoneUI('Mobile phone number'),
     emailAddress: emailUI(),
@@ -18,7 +17,6 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      'view:title': titleSchema,
       homePhone: phoneSchema,
       mobilePhone: phoneSchema,
       emailAddress: emailSchema,

--- a/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/relationshipToVeteran.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns-v3/pages/relationshipToVeteran.js
@@ -1,6 +1,5 @@
 import {
   titleUI,
-  titleSchema,
   relationshipToVeteranUI,
   relationshipToVeteranSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
@@ -8,13 +7,12 @@ import {
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'view:title': titleUI('Relationship to Veteran'),
+    ...titleUI('Relationship to Veteran'),
     relationshipToVeteran: relationshipToVeteranUI(),
   },
   schema: {
     type: 'object',
     properties: {
-      'view:title': titleSchema,
       relationshipToVeteran: relationshipToVeteranSchema,
     },
   },

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockArrayMultiplePageStart.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockArrayMultiplePageStart.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   fullNameSchema,
   fullNameUI,
-  titleSchema,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
@@ -20,7 +19,7 @@ export function childViewCard({ formData }) {
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'view:title': titleUI('Child Information'),
+    ...titleUI('Child Information'),
     exampleArrayData: {
       'ui:options': {
         itemName: 'Child',
@@ -40,7 +39,6 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      'view:title': titleSchema,
       exampleArrayData: {
         type: 'array',
         minItems: 1,

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockArraySinglePage.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockArraySinglePage.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {
   currentOrPastDateSchema,
   currentOrPastDateUI,
-  titleSchema,
   titleUI,
   yesNoSchema,
   yesNoUI,
@@ -13,7 +12,7 @@ import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/V
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'view:arrayTitle': titleUI('Array Field Title', 'Array Description'),
+    ...titleUI('Array Field Title', 'Array Description'),
     exampleArrayOne: {
       'ui:options': {
         itemName: 'Facility',
@@ -81,7 +80,6 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      'view:arrayTitle': titleSchema,
       exampleArrayOne: {
         type: 'array',
         minItems: 1,


### PR DESCRIPTION
## Summary
This pull request addresses an issue found with using `view:` fields combined with `ui:title` and `ui:description`. We had many locations inside our simple forms directory that were leveraging the `titleUI` pattern combined with `view:` fields and schema properties. This has the unfortunate side effect of wrapping the title and description inside a `fieldset` tag and wrapping the title in a `legend` tag. The `fieldset` tag is supposed to wrap around all of the fields on the page, but inserting a dummy object `view:` field is triggering some logic inside RJSF to wrap the nested object in the `fieldset`. 

This PR addresses all the locations that use `ui:title`, but some were leftover that only use `ui:description` because these are trickier to deal with. In those instances, we are using the `view:` field to place a description in a specific location. We'll need to investigate these further to figure out a better way of moving the description around and also figure out if the way `fieldset` gets used in those instances breaks accessibility rules. 

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#432