### PR TITLE
40-0247 - Front-end follow up: Part 1

### DIFF
--- a/src/applications/simple-forms/40-0247/pages/additionalCertificatesRequest.js
+++ b/src/applications/simple-forms/40-0247/pages/additionalCertificatesRequest.js
@@ -35,7 +35,11 @@ export default {
         </>
       ),
       'ui:errorMessages': {
-        required: 'Please enter the number of certificates you’d like',
+        required: 'Please provide the number of certificates you would like',
+        minimum:
+          'Please raise the number of certificates to at least 1, you can request up to 99',
+        maximum:
+          'Please lower the number of certificates, you can only request up to 99',
       },
       'ui:reviewField': ({ children }) => (
         <div className="review-row">

--- a/src/applications/simple-forms/40-0247/pages/certificates.js
+++ b/src/applications/simple-forms/40-0247/pages/certificates.js
@@ -18,9 +18,9 @@ export default {
       'ui:errorMessages': {
         required: 'Please provide the number of certificates you would like',
         minimum:
-          'Please raise the number to at least 1, you can request up to 99',
+          'Please raise the number of certificates to at least 1, you can request up to 99',
         maximum:
-          'Please lower the number of requests, you can only request up to 99',
+          'Please lower the number of certificates, you can only request up to 99',
       },
       'ui:reviewField': ({ children }) => (
         <div className="review-row">

--- a/src/platform/forms/components/review/PreSubmitSection.jsx
+++ b/src/platform/forms/components/review/PreSubmitSection.jsx
@@ -141,13 +141,12 @@ export function PreSubmitSection(props) {
             {statementOfTruthBodyElement(form?.data, statementOfTruth.body)}
             <p>
               I have read and accept the{' '}
-              <a href="/privacy-policy/" target="_blank">
+              <a
+                href="/privacy-policy/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 privacy policy
-                <i
-                  className="fas fa-arrow-up-right-from-square"
-                  aria-hidden="true"
-                  role="img"
-                />
                 <span className="sr-only">opens in a new window</span>
               </a>
               .


### PR DESCRIPTION
**\[DRAFT: Do NOT merge!\]**

## Summary

- Make follow-up front-end changes to PMC (40-0247):
    - Fix certificate-quantity fields’ maximum error-message
    - Remove new-window icon from Review-page Stmt-of-Truth privacy-policy external-link
- Team: Veteran Facing Forms
- No Flipper yet

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#585

## Testing done

- Local manual-UI testing was successful
- Automated tests to follow, via separate ticket & PR

## What areas of the site does it impact?

This form only, EXCEPT removing new-window icon from Review-page SoT privacy-policy link which impacts all forms.
