### PR TITLE
MHV-49721 Fixed some hard-coding issues with the PrintHeader

### DIFF
--- a/src/applications/mhv/medical-records/components/shared/PrintHeader.jsx
+++ b/src/applications/mhv/medical-records/components/shared/PrintHeader.jsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
+import { formatName } from '../../../shared/util/helpers';
 
 const PrintHeader = () => {
-  const user = useSelector(state => state.user.profile);
-  const { first, last, middle, suffix } = user.userFullName;
-  const name = user.first
-    ? `${last}, ${first} ${middle}, ${suffix}`
-    : 'Doe, John R., Jr.';
-  const dob = user.dob || 'March 15, 1982';
+  const user = useSelector(state => state.user);
+  const name = user?.profile ? formatName(user.profile.userFullName) : '';
 
   return (
     <div className="print-only print-header vads-u-margin-bottom--4">
       <div className="name-dob vads-u-margin-bottom--3">
         <span>{name}</span>
-        <span>Date of birth: {dob}</span>
+        {user?.profile?.dob && (
+          <span>Date of birth: {formatDateLong(user.profile.dob)}</span>
+        )}
       </div>
 
       <div

--- a/src/applications/mhv/medical-records/components/shared/PrintHeader.jsx
+++ b/src/applications/mhv/medical-records/components/shared/PrintHeader.jsx
@@ -5,7 +5,9 @@ import { formatName } from '../../../shared/util/helpers';
 
 const PrintHeader = () => {
   const user = useSelector(state => state.user);
-  const name = user?.profile ? formatName(user.profile.userFullName) : '';
+  const name = user?.profile?.userFullName
+    ? formatName(user.profile.userFullName)
+    : '';
 
   return (
     <div className="print-only print-header vads-u-margin-bottom--4">

--- a/src/applications/mhv/medical-records/tests/containers/Allergies.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/Allergies.unit.spec.jsx
@@ -6,10 +6,12 @@ import { waitFor } from '@testing-library/react';
 import Allergies from '../../containers/Allergies';
 import reducer from '../../reducers';
 import allergies from '../fixtures/allergies.json';
+import user from '../fixtures/user.json';
 import { convertAllergy } from '../../reducers/allergies';
 
 describe('Allergies list container', () => {
   const initialState = {
+    user,
     mr: {
       allergies: {
         allergiesList: allergies.entry.map(item =>

--- a/src/applications/mhv/medical-records/tests/containers/AllergyDetails.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/AllergyDetails.unit.spec.jsx
@@ -5,10 +5,12 @@ import { beforeEach } from 'mocha';
 import AllergyDetails from '../../containers/AllergyDetails';
 import reducer from '../../reducers';
 import allergy from '../fixtures/allergy.json';
+import user from '../fixtures/user.json';
 import { convertAllergy } from '../../reducers/allergies';
 
 describe('Allergy details container', () => {
   const initialState = {
+    user,
     mr: {
       allergies: {
         allergyDetails: convertAllergy(allergy),

--- a/src/applications/mhv/medical-records/tests/containers/LabAndTestDetails.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/LabAndTestDetails.unit.spec.jsx
@@ -4,11 +4,13 @@ import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platfo
 import { beforeEach } from 'mocha';
 import reducer from '../../reducers';
 import labsAndTests from '../fixtures/labsAndTests.json';
+import user from '../fixtures/user.json';
 import { convertLabsAndTestsRecord } from '../../reducers/labsAndTests';
 import LabAndTestDetails from '../../containers/LabAndTestDetails';
 
 describe('LabsAndTests details container', () => {
   const initialState = {
+    user,
     mr: {
       labsAndTests: {
         labsAndTestsDetails: convertLabsAndTestsRecord(labsAndTests.entry[0]),

--- a/src/applications/mhv/medical-records/tests/containers/RadiologyImagesList.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/RadiologyImagesList.unit.spec.jsx
@@ -3,9 +3,11 @@ import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import reducer from '../../reducers';
 import RadiologyImagesList from '../../containers/RadiologyImagesList';
+import user from '../fixtures/user.json';
 
 describe('Radiology Images List container', () => {
   const initialState = {
+    user,
     mr: {
       labsAndTests: {
         labsAndTestsDetails: {

--- a/src/applications/mhv/medical-records/tests/containers/VaccineDetails.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/VaccineDetails.unit.spec.jsx
@@ -4,10 +4,12 @@ import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platfo
 import VaccineDetails from '../../containers/VaccineDetails';
 import reducer from '../../reducers';
 import vaccine from '../fixtures/vaccine.json';
+import user from '../fixtures/user.json';
 import { convertVaccine } from '../../reducers/vaccines';
 
 describe('Vaccines details container', () => {
   const initialState = {
+    user,
     mr: {
       vaccines: {
         vaccineDetails: convertVaccine(vaccine),

--- a/src/applications/mhv/medical-records/tests/containers/Vaccines.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/Vaccines.unit.spec.jsx
@@ -3,9 +3,11 @@ import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import Vaccines from '../../containers/Vaccines';
 import reducer from '../../reducers';
+import user from '../fixtures/user.json';
 
 describe('Vaccines list container', () => {
   const initialState = {
+    user,
     mr: {
       vaccines: {
         vaccinesList: null,

--- a/src/applications/mhv/medical-records/tests/fixtures/user.json
+++ b/src/applications/mhv/medical-records/tests/fixtures/user.json
@@ -1,0 +1,6 @@
+{
+  "profile": {
+    "userFullName": { "first": "John", "last": "Smith" },
+    "dob": "1974-04-06"
+  }
+}


### PR DESCRIPTION
## Summary

- Fixed the implementation of getting name from state and displayed in print header
- Don't hard-code values for Name and DoB under any circumstances
- Don't display an invalid date of birth

## Related issue(s)

### [MHV-49721](https://jira.devops.va.gov/browse/MHV-49721) - In the print view, we are hardcoding John Doe as the user name ###

> This is currently hardcoded in shared/PrintHeader.jsx.
> 
> The PrintHeader component should not pull any state from redux. Instead we should pass the userFullName in as a prop, then deconstruct that.
> 
> Each container that uses PrintHeader should be responsible for pulling the name from the Redux store and passing in to PrintHeader as a prop.
> 
> NOTE: Both medications and medical-records are using this component.

## Testing done

- Manual testing to verify changes

## Screenshots

<img width="518" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/a434ba98-56a6-4935-9170-f2d9b808442f">

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
