### PR TITLE
Fix local development version of cross app imports script

### DIFF
--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -14,9 +14,15 @@ const {
 const CHANGED_FILE_PATHS = process.env.CHANGED_FILE_PATHS
   ? process.env.CHANGED_FILE_PATHS.split(' ')
   : [];
-const ALLOW_LIST = JSON.parse(
-  fs.readFileSync(path.resolve(`${process.env.TEST_TYPE}_allow_list.json`)),
-);
+const ALLOW_LIST =
+  process.env.TEST_TYPE &&
+  fs.existsSync(path.resolve(`${process.env.TEST_TYPE}_allow_list.json`))
+    ? JSON.parse(
+        fs.readFileSync(
+          path.resolve(`${process.env.TEST_TYPE}_allow_list.json`),
+        ),
+      )
+    : [];
 const IS_CHANGED_APPS_BUILD = Boolean(process.env.APP_ENTRIES);
 const RUN_FULL_SUITE = process.env.RUN_FULL_SUITE === 'true';
 const APPS_HAVE_URLS = Boolean(process.env.APP_URLS);


### PR DESCRIPTION
## Summary

- Adds fallback for when environmental variable is not set or the allow list file does not exist, to avoid the script breaking and to support local development.

