### PR TITLE
59260 remove extra left border

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
@@ -36,6 +36,7 @@ const expander = (
   <VaAdditionalInfo
     trigger="What is an Intent to File?"
     disableAnalytics
+    disable-border
     onClick={recordITFHelpEvent}
   >
     <p className="vads-u-font-size--base">


### PR DESCRIPTION
## Summary
The additional info component inside the 'You already have an Intent to File' alert has a left border. Per [our guidance](https://design.va.gov/components/additional-info#choosing-between-variations) you should use the no border additional info when it is inside of an alert.

Team: @department-of-veterans-affairs/dbex-trex 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/59260

## Testing done
**Steps to verify**
1. Log in
2. Start a new 526 claim or continue an existing application
3. Expand the link for "What is an Intent to File?"
4. Verify the left blue border has been removed

**Tests completed**
Manual, visual test completed for desktop and mobile. Verified existing unit and e2e tests are successful.

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/9a420749-8a7d-4be7-a9ca-eaa2280d81b5)

## What areas of the site does it impact?
526EZ

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
