### PR TITLE
Profile/aw/65407/conditional heading in edit page

### DIFF
--- a/src/applications/personalization/profile/components/edit/Edit.jsx
+++ b/src/applications/personalization/profile/components/edit/Edit.jsx
@@ -20,6 +20,7 @@ import { routesForNav } from '../../routesForNav';
 import getProfileInfoFieldAttributes from '../../util/getProfileInfoFieldAttributes';
 import { getInitialFormValues } from '../../util/contact-information/formValues';
 import { getRouteInfoFromPath } from '~/applications/personalization/common/helpers';
+import { isFieldEmpty } from '../../util';
 
 const useQuery = () => {
   const { search } = useLocation();
@@ -78,6 +79,16 @@ export const Edit = () => {
 
   const fieldData = useSelector(state =>
     selectVAPContactInfoField(state, fieldInfo?.fieldName),
+  );
+
+  const editPageHeadingString = useMemo(
+    () => {
+      const useAdd = isFieldEmpty(fieldData, fieldInfo?.fieldName);
+      return `${
+        useAdd ? 'Add' : 'Update'
+      } your ${fieldInfo?.title.toLowerCase()}`;
+    },
+    [fieldData, fieldInfo],
   );
 
   useEffect(() => {
@@ -187,7 +198,7 @@ export const Edit = () => {
                 </p>
 
                 <h1 className="vads-u-font-size--h2 vads-u-margin-bottom--2">
-                  {`Add or update your ${fieldInfo.title.toLowerCase()}`}
+                  {editPageHeadingString}
                 </h1>
 
                 <InitializeVAPServiceIDContainer>

--- a/src/applications/personalization/profile/mocks/endpoints/user/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/user/index.js
@@ -1422,6 +1422,12 @@ const loa3UserWithNoEmailOrMobilePhone = set(
   null,
 );
 
+const loa3UserWithNoHomeAddress = set(
+  cloneDeep(baseUserResponses.loa3User72),
+  'data.attributes.vet360ContactInformation.residentialAddress',
+  null,
+);
+
 const responses = {
   ...baseUserResponses,
   ...mockErrorResponses,
@@ -1435,6 +1441,7 @@ const responses = {
       { name: 'ratingInfo', value: false },
     ],
   ),
+  loa3UserWithNoHomeAddress,
 };
 
 // handler that can be used to customize the user data returned

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -75,15 +75,16 @@ const responses = {
   },
   'GET /v0/user': (_req, res) => {
     // example user data cases
-    // return res.json(user.loa3User72); // default user (success)
+    return res.json(user.loa3User72); // default user (success)
     // return res.json(user.loa1User); // user with loa1
-    return res.json(user.badAddress); // user with bad address
+    // return res.json(user.badAddress); // user with bad address
     // return res.json(user.loa3User); // user with loa3
     // return res.json(user.nonVeteranUser); // non-veteran user
     // return res.json(user.externalServiceError); // external service error
     // return res.json(user.loa3UserWithNoMobilePhone); // user with no mobile phone number
     // return res.json(user.loa3UserWithNoEmail); // user with no email address
     // return res.json(user.loa3UserWithNoEmailOrMobilePhone); // user without email or mobile phone
+    // return res.json(user.loa3UserWithNoHomeAddress); // home address is null
   },
   'GET /v0/profile/status': status.success,
   'OPTIONS /v0/maintenance_windows': 'OK',

--- a/src/applications/personalization/profile/tests/components/edit/Edit.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/edit/Edit.unit.spec.jsx
@@ -19,8 +19,7 @@ describe('<Edit>', () => {
         '/profile/edit?fieldName=mobilePhone&returnPath=%2Fprofile%2Fnotifications',
     });
 
-    expect(await view.findByText('Add or update your mobile phone number')).to
-      .exist;
+    expect(await view.findByText('Add your mobile phone number')).to.exist;
 
     expect(await view.findByText('Mobile phone number (U.S. numbers only)')).to
       .exist;
@@ -74,7 +73,35 @@ describe('<Edit>', () => {
     expect(await view.findByText(/Back to profile/i)).to.exist;
 
     // since the fieldName is valid, we should still render the correct form
-    expect(await view.findByText('Add or update your mobile phone number')).to
+    expect(await view.findByText('Add your mobile phone number')).to.exist;
+  });
+
+  it('renders the "Update" heading when there is field data', async () => {
+    const initialStateWithData = {
+      featureToggles: {
+        [Toggler.TOGGLE_NAMES.profileUseFieldEditingPage]: true,
+      },
+      user: {
+        profile: {
+          vapContactInfo: {
+            mobilePhone: {
+              areaCode: '123',
+              phoneNumber: '4567890',
+            },
+          },
+        },
+      },
+    };
+
+    const viewWithData = renderWithStoreAndRouter(<Edit />, {
+      initialState: initialStateWithData,
+      reducers: { vapService },
+      path:
+        '/profile/edit?fieldName=mobilePhone&returnPath=%2Fprofile%2Fnotifications',
+    });
+
+    // Assuming fieldData is not empty, heading should start with 'Update'
+    expect(await viewWithData.findByText('Update your mobile phone number')).to
       .exist;
   });
 });


### PR DESCRIPTION
## Summary

- Modify the heading of the /edit route, to display Add or Update depending on if there is existing field data present for the user

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/65407

## Testing done

- Updated existing unit tests for new heading
- Added unit tests for when field data is present

## Screenshots

| Before | After | After without data
| ------- | ------ | ----- |
| ![Screenshot 2023-09-25 at 10 05 31 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/14debba2-eb45-4550-8805-2b77abf0b34d) | ![Screenshot 2023-09-25 at 10 04 41 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/f7ac9871-d866-4bf9-a891-8ce19ca2c242) | ![Screenshot 2023-09-25 at 10 08 04 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/47469c3a-3b76-40ac-b3c8-c1a512244bcc) |


## What areas of the site does it impact?

Profile -> Edit page

## Acceptance criteria

- [x] Heading is dynamic based on field data being present

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)