### PR TITLE
update med supply reorder intro page

### DIFF
--- a/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
@@ -55,6 +55,7 @@ const IntroductionPage = props => {
                 <li>Shipping address</li>
                 <li>Email address</li>
                 <li>Hearing aid information</li>
+                <li>CPAP machine information</li>
               </ul>
               <p className="vads-u-font-weight--bold">
                 What if I need help with my order?


### PR DESCRIPTION

## Summary

- adds bullet to "prepare" section to call out need for cpap machine info


![screencapture-localhost-3001-health-care-order-hearing-aid-batteries-and-accessories-order-form-2346-introduction-2023-09-26-09_31_11](https://github.com/department-of-veterans-affairs/vets-website/assets/7645362/baae3c68-1211-48c5-855c-242a821e5b3b)
