### PR TITLE
MHV-49732 Card-Links-Not-Recieving-Focus

### DIFF
--- a/src/applications/mhv/medical-records/components/RecordList/AllergyListItem.jsx
+++ b/src/applications/mhv/medical-records/components/RecordList/AllergyListItem.jsx
@@ -13,15 +13,15 @@ const AllergyListItem = props => {
           className="record-list-item vads-u-border-color--gray-light vads-u-border--0 vads-u-background-color--gray-lightest card"
           data-testid="record-list-item"
         >
-          <Link
-            to={`/allergies/${record.id}`}
-            className="vads-u-margin--0 no-print"
-            aria-label={`View details for ${record.name} on ${record.date}`}
-          >
-            <h3 className="vads-u-font-size--h4 vads-u-line-height--4">
+          <h3 className="vads-u-font-size--h4 vads-u-margin--0 vads-u-line-height--4">
+            <Link
+              to={`/allergies/${record.id}`}
+              className="vads-u-margin--0 no-print"
+              aria-label={`${record.name} on ${record.date}`}
+            >
               {record.name}
-            </h3>
-          </Link>
+            </Link>
+          </h3>
 
           <div className="fields">
             <div>


### PR DESCRIPTION
## Summary
To ensure a seamless experience for keyboard users who navigate using the Tab key, it's crucial to implement focus states on interactive elements. In the Allergies List View, it has been observed that links within the cards are not currently receiving focus.  I resolved the focus issue by repositioning the H3 tag to the outer level and nesting the Link tag within it.

## Related issue(s)
[MHV-49732](https://jira.devops.va.gov/browse/MHV-49732) - Accessibility - Card links not receiving focus

## Testing done

User Story: As a Medical Records User who relies on keyboard navigation using the Tab key, I require proper focus states on all interactive elements. I have thoroughly tested all card elements to ensure they receive focus and can be selected.



## What areas of the site does it impact?

The provided code for the Allergies card layout.

## Acceptance criteria

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ x] Browser console contains no warnings or errors.
- [ x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x ] Did you login to a local build and verify all authenticated routes work as expected with a test user

