### PR TITLE
Adjusts content for Terms of Use pages

### DIFF
--- a/src/applications/terms-of-use/components/Declined.jsx
+++ b/src/applications/terms-of-use/components/Declined.jsx
@@ -13,19 +13,20 @@ export default function Declined() {
     <div className="vads-l-grid-container vads-u-padding-y--5">
       <div className="usa-content">
         <h1>We’ve signed you out</h1>
-        <va-alert visible status="error">
-          You didn’t accept VA online services terms of use, so we signed you
-          out of the site.
-        </va-alert>
-        <h2>What you can do:</h2>
         <p>
-          If you want to change your answer and accept the terms, sign in again.
-          We’ll take you back to the terms of use.
+          You declined the VA online services terms of use, so we've signed you
+          out.
+        </p>
+        <h2>What you can do</h2>
+        <p>
+          <strong>Note:</strong> You can still get VA health care and benefits
+          without using our online services. If you need help or have questions,{' '}
+          <SubmitSignInForm /> We’re here 24/7.
         </p>
         <p>
-          <strong>Note:</strong> You can still get VA benefits in-person without
-          using VA online services. If you need help or have questions,{' '}
-          <SubmitSignInForm /> We’re here 24/7.
+          Or you can change your answer and accept the terms. If you want to
+          accept the terms, sign in again. We’ll take you back to the terms of
+          use. Then you can continue using VA online services.
         </p>
         <button type="button" onClick={openSignInModal}>
           Sign in

--- a/src/applications/terms-of-use/containers/TermsOfUse.jsx
+++ b/src/applications/terms-of-use/containers/TermsOfUse.jsx
@@ -15,7 +15,7 @@ import {
 import touData from '../touData';
 
 const touUpdatedDate = `September 2023`;
-const errorMessages = {
+export const errorMessages = {
   network: `We had a connection issue on our end. Please try again in a few minutes.`,
 };
 
@@ -48,25 +48,38 @@ export default function TermsOfUse() {
   const [isAuthenticated, setIsAuthenticated] = useState(true);
   const [showDeclineModal, setShowDeclineModal] = useState(false);
   const [error, setError] = useState({ isError: false, message: '' });
+  const termsCodeExists =
+    new URL(window.location).searchParams.get('terms_code')?.length > 1;
 
-  useEffect(() => {
-    apiRequest('/terms_of_use_agreements/v1/latest').catch(response => {
-      const [{ code, title }] = response.errors;
-      if (code === '401' || title?.includes('Not authorized')) {
-        setIsAuthenticated(false);
+  useEffect(
+    () => {
+      if (!termsCodeExists) {
+        apiRequest('/terms_of_use_agreements/v1/latest').catch(response => {
+          const [{ code, title }] = response.errors;
+          if (code === '401' || title?.includes('Not authorized')) {
+            setIsAuthenticated(false);
+          }
+        });
       }
-    });
-  }, []);
+    },
+    [termsCodeExists],
+  );
 
   const handleTouClick = async type => {
     const url = new URL(window.location);
     const redirectUrl = parseRedirectUrl(url.searchParams.get('redirect_url'));
+    const termsCode = termsCodeExists
+      ? `?terms_code=${url.searchParams.get('terms_code')}`
+      : '';
     try {
-      const response = await apiRequest(`/terms_of_use_agreements/v1/${type}`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-      });
+      const response = await apiRequest(
+        `/terms_of_use_agreements/v1/${type}${termsCode}`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
 
       if (Object.keys(response?.termsOfUseAgreement).length) {
         // if the type was accept
@@ -84,6 +97,7 @@ export default function TermsOfUse() {
         }
       }
     } catch (err) {
+      if (type === 'decline') setShowDeclineModal(true);
       setError({
         isError: true,
         message: errorMessages.network,
@@ -167,6 +181,18 @@ export default function TermsOfUse() {
           <h2 id="do-you-accept-of-terms-of-use" className={className}>
             Do you accept these terms of use?
           </h2>
+          {error.isError && (
+            <va-alert
+              status="error"
+              slim
+              visible
+              uswds
+              data-testid="error-non-modal"
+              class="vads-u-margin-y--1p5"
+            >
+              {error.message}
+            </va-alert>
+          )}
           {isAuthenticated &&
             termsOfUseAuthorized && (
               <>
@@ -185,12 +211,10 @@ export default function TermsOfUse() {
                 />
               </>
             )}
-          {error.isError && <p>{error.message}</p>}
         </article>
       </div>
       <VaModal
         visible={showDeclineModal}
-        status="warning"
         clickToClose
         onCloseEvent={() => setShowDeclineModal(false)}
         modalTitle="Decline the terms of use and sign out?"
@@ -199,7 +223,19 @@ export default function TermsOfUse() {
         primaryButtonText="Decline and sign out"
         secondaryButtonText="Go back"
         data-testid="modal-show"
-      />
+      >
+        {error.isError && (
+          <va-alert
+            status="error"
+            slim
+            visible
+            uswds
+            class="vads-u-margin-y--1p5"
+          >
+            {error.message}
+          </va-alert>
+        )}
+      </VaModal>
     </section>
   );
 }

--- a/src/applications/terms-of-use/containers/TermsOfUse.jsx
+++ b/src/applications/terms-of-use/containers/TermsOfUse.jsx
@@ -134,23 +134,23 @@ export default function TermsOfUse() {
           <p>
             Your decision to decline these terms won’t affect your eligibility
             for VA health care and benefits in any way. You can still get VA
-            health care and benefits in-person without using online services. If
-            you need help or have questions, <SubmitSignInForm /> We’re here
-            24/7.
+            health care and benefits without using online services. If you need
+            help or have questions, <SubmitSignInForm /> We’re here 24/7.
           </p>
           <va-alert status="warning" visible>
             <h3 slot="headline" id="what-happens-if-you-decline">
               What will happen if you decline
             </h3>
             <p>
-              If you decline these terms, we’ll sign you out and take you back
-              to the VA.gov homepage. And you won’t be able to sign in to use
-              some VA online services, like:
+              If you decline these terms, we’ll sign you out. You can still get
+              VA health care and benefits by phone, by mail, or in person. But
+              you won't be able to use some online services, like:
             </p>
             <ul>
               <li>VA.gov</li>
               <li>My HealtheVet</li>
               <li>My VA Health</li>
+              <li>VA: Health and Benefits</li>
             </ul>
             <p>
               This means you won’t be able to do these types of things using VA

--- a/src/applications/terms-of-use/tests/TermsOfUse.unit.spec.jsx
+++ b/src/applications/terms-of-use/tests/TermsOfUse.unit.spec.jsx
@@ -6,7 +6,10 @@ import { setupServer } from 'msw/node';
 import { rest } from 'msw';
 
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
-import TermsOfUse, { parseRedirectUrl } from '../containers/TermsOfUse';
+import TermsOfUse, {
+  parseRedirectUrl,
+  errorMessages,
+} from '../containers/TermsOfUse';
 
 const store = ({ termsOfUseEnabled = true } = {}) => ({
   getState: () => ({
@@ -58,7 +61,27 @@ describe('TermsOfUse', () => {
       expect($$('va-button', container).length).to.eql(2);
     });
   });
-  it('should NOT display buttons if URL comes back bad', async () => {
+  it('should NOT display buttons if URL comes back as a 401', async () => {
+    const mockStore = store();
+    server.use(
+      rest.get(
+        `https://dev-api.va.gov/v0/terms_of_use_agreements/v1/latest`,
+        (_, res, ctx) => {
+          return res(ctx.status(401), ctx.json({ errors: [{ code: '401' }] }));
+        },
+      ),
+    );
+    const { container } = render(
+      <Provider store={mockStore}>
+        <TermsOfUse />
+      </Provider>,
+    );
+
+    await waitFor(() => {
+      expect($$('va-button', container).length).to.eql(0);
+    });
+  });
+  it('should NOT display buttons if title is `Not authorized`', async () => {
     const mockStore = store();
     server.use(
       rest.get(
@@ -66,7 +89,7 @@ describe('TermsOfUse', () => {
         (_, res, ctx) => {
           return res(
             ctx.status(401),
-            ctx.json({ errors: [{ title: 'Not authorized', code: '401' }] }),
+            ctx.json({ errors: [{ code: '500', title: 'Not authorized' }] }),
           );
         },
       ),
@@ -91,7 +114,7 @@ describe('TermsOfUse', () => {
 
     expect($$('va-button', container).length).to.eql(0);
   });
-  it('should display a Modal if the decline button is clicked', async () => {
+  it('should display the declined modal if the decline button is clicked', async () => {
     const mockStore = store();
     server.use(
       rest.get(
@@ -113,6 +136,47 @@ describe('TermsOfUse', () => {
       const modal = container.querySelector('va-modal');
       expect(modal).to.exist;
       expect(modal).to.have.attribute('visible', 'true');
+    });
+  });
+  it('should call `/decline` when `Decline and sign out button` is clicked', async () => {
+    const redirectUrl = `https://dev.va.gov/auth/login/callback/?type=idme`;
+    const termsCode = `555abc`;
+    global.window.location = `https://dev.va.gov/terms-of-use/?redirect_url=${redirectUrl}&terms_code=${termsCode}`;
+
+    const mockStore = store();
+    server.use(
+      rest.get(
+        `https://dev-api.va.gov/v0/terms_of_use_agreements/v1/latest`,
+        (_, res, ctx) => res(ctx.status(200)),
+      ),
+      rest.post(
+        `https://dev-api.va.gov/v0/terms_of_use_agreements/v1/decline`,
+        (req, res, ctx) => {
+          expect(req.url.searchParams.get('terms_code')).to.eql(termsCode);
+          return res(
+            ctx.status(200),
+            ctx.json({ termsOfUseAgreement: { 'some-key': 'some-value' } }),
+          );
+        },
+      ),
+    );
+    const { container, queryByTestId } = render(
+      <Provider store={mockStore}>
+        <TermsOfUse />
+      </Provider>,
+    );
+
+    await waitFor(() => {
+      const declineButton = queryByTestId('decline');
+
+      fireEvent.click(declineButton);
+
+      const modal = $('va-modal', container);
+      expect(modal).to.exist;
+      expect(modal).to.have.attribute('visible', 'true');
+
+      // click the Decline and sign out button
+      modal.__events.primaryButtonClick();
     });
   });
   it('should redirect to the `redirect_url`', async () => {
@@ -146,6 +210,106 @@ describe('TermsOfUse', () => {
 
       fireEvent.click(acceptButton);
       expect(global.window.location).to.eql(redirectUrl);
+    });
+  });
+  it('should pass along `terms_code` to API', async () => {
+    const redirectUrl = `https://dev.va.gov/auth/login/callback/?type=logingov`;
+    const termsCode = '123456abc';
+    global.window.location = `https://dev.va.gov/terms-of-use/?redirect_url=${redirectUrl}&terms_code=${termsCode}`;
+
+    const mockStore = store();
+    server.use(
+      rest.get(
+        `https://dev-api.va.gov/v0/terms_of_use_agreements/v1/latest`,
+        (_, res, ctx) => res(ctx.status(200)),
+      ),
+      rest.post(
+        `https://dev-api.va.gov/v0/terms_of_use_agreements/v1/accept`,
+        (req, res, ctx) => {
+          expect(req.url.searchParams.get('terms_code')).to.eql(termsCode);
+          return res(
+            ctx.status(200),
+            ctx.json({ termsOfUseAgreement: { 'some-key': 'some-value' } }),
+          );
+        },
+      ),
+    );
+    const { queryByTestId } = render(
+      <Provider store={mockStore}>
+        <TermsOfUse />
+      </Provider>,
+    );
+
+    await waitFor(() => {
+      const acceptButton = queryByTestId('accept');
+      expect(acceptButton).to.exist;
+      fireEvent.click(acceptButton);
+      expect(global.window.location).to.not.eql(redirectUrl);
+    });
+  });
+  it('should show an error state if there is a network error | non-modal', async () => {
+    const redirectUrl = `https://dev.va.gov/auth/login/callback/?type=idme`;
+    global.window.location = `https://dev.va.gov/terms-of-use/?redirect_url=${redirectUrl}`;
+
+    const mockStore = store();
+    server.use(
+      rest.get(
+        `https://dev-api.va.gov/v0/terms_of_use_agreements/v1/latest`,
+        (_, res, ctx) => res(ctx.status(200)),
+      ),
+      rest.post(
+        `https://dev-api.va.gov/v0/terms_of_use_agreements/v1/accept`,
+        (_, res) => res.networkError(),
+      ),
+    );
+    const { queryByTestId } = render(
+      <Provider store={mockStore}>
+        <TermsOfUse />
+      </Provider>,
+    );
+
+    await waitFor(() => {
+      const acceptButton = queryByTestId('accept');
+      expect(acceptButton).to.exist;
+
+      fireEvent.click(acceptButton);
+
+      const nonModalErrorState = queryByTestId('error-non-modal');
+      expect(nonModalErrorState).to.exist;
+      expect(nonModalErrorState.textContent).to.eql(errorMessages.network);
+    });
+  });
+  it('should close the Decline modal when Close or Go Back buttons are clicked', async () => {
+    const mockStore = store();
+    server.use(
+      rest.get(
+        `https://dev-api.va.gov/v0/terms_of_use_agreements/v1/latest`,
+        (_, res, ctx) => res(ctx.status(200)),
+      ),
+    );
+    const { container, queryByTestId } = render(
+      <Provider store={mockStore}>
+        <TermsOfUse />
+      </Provider>,
+    );
+
+    await waitFor(() => {
+      const declineButton = queryByTestId('decline');
+      expect(declineButton).to.exist;
+
+      fireEvent.click(declineButton);
+
+      // click close button on modal
+      const openedModal = $('va-modal[visible="true"]', container);
+      openedModal.__events.closeEvent();
+      expect($('va-modal[visible="false"]', container)).to.be.exist;
+
+      // open the modal again
+      fireEvent.click(declineButton);
+      expect(openedModal).to.exist;
+      // click `Go back` button
+      openedModal.__events.secondaryButtonClick();
+      expect($('va-modal[visible="false"]', container)).to.be.exist;
     });
   });
 });


### PR DESCRIPTION
## Summary
Updates the content language for the Terms of Use pages (default page) and the Decline page. Specifically it fixes the following:

1. Declined page 
- [x] Remove va-alert in favor of suggested content:

> [H1] We've signed you out
> You declined the VA online services terms of use, so we've signed you out.
> [H2] What you can do
> You can still get VA health care and benefits without using our online services. If you need help or have questions, call us at 800-698-2411 (TTY: 711). We’re here 24/7.
> Or you can change your answer and accept the terms. If you want to accept the terms, sign in again. We’ll take you back to the terms of use. Then you can continue using VA online services.
> [button] Sign in

2. Terms of use page updated content:
- The paragraph below the "Getting VA benefits and services if you don’t accept" header
    - [x] Removes "in person" to keep consistent with Declined page messaging
- Paragraph in the va-alert will be updated to:
    - [x] _If you decline these terms, we’ll sign you out. You can still get VA health care and benefits by phone, by mail, or in person. But you won't be able to use some online services, like:_
    - What changed: I removed "websites" in favor of "online services"
    - Why: To keep it more general so we can include the VA: Health and Benefits mobile app

3. Conditionalizes authentication `tou/latest` call
- [x] Only call `tou/latest` when there is not `terms_code` query parameter

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#63260 (Laura's content feedback)
- department-of-veterans-affairs/va.gov-team#66309 (Ticket to implement the above feedback)

## Testing done
- Unit testing & manual testing

## Screenshots
### Declined page
<img width="786" alt="Screenshot 2023-09-26 at 10 15 49 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/67602137/463588d6-c86d-465a-aca4-10d6edf9d576">

### Terms of Use (specifically the va-alert)
<img width="786" alt="Screenshot 2023-09-26 at 10 24 36 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/67602137/018448e9-d702-41a8-9938-c733f37cc3e2">

## What areas of the site does it impact?
This should only impact staging & below for the Terms of Use page

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
