### PR TITLE
Fix YesNoWidget PropTypes

### DIFF
--- a/src/platform/forms-system/src/js/widgets/YesNoWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/YesNoWidget.jsx
@@ -87,7 +87,7 @@ YesNoWidget.propTypes = {
     widgetProps: PropTypes.shape({}),
     selectedProps: PropTypes.shape({}),
     enableAnalytics: PropTypes.bool,
-    title: PropTypes.string,
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     errorMessages: PropTypes.shape({}),
   }),
   value: PropTypes.bool,


### PR DESCRIPTION
## Summary

- Updating the title PropType of the YesNoWidget to expect elements
- Currently, any time an element is passed in (which is expected by the component code) we get a warning in the console.

## Related issue(s)

- None

## Testing done

- All tests continue to pass. Errors stop appearing in the console on forms.

## What areas of the site does it impact?

- Forms code that uses the YesNoWidget.

## Screenshots
<details>
<summary>
Before
</summary>

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/98f8b808-8c00-4343-acbe-a298c0f1e920)

</details>

<details>
<summary>
After
</summary>

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/966cf95f-bb45-4aaa-b09d-53e694dc5660)


</details>

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions