### PR TITLE
Fix accessibility issue on 28-1900 communication preferences options

### DIFF
--- a/src/applications/vre/28-1900/config/chapters/communication-preferences/communicationPreferences.js
+++ b/src/applications/vre/28-1900/config/chapters/communication-preferences/communicationPreferences.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import fullSchema from 'vets-json-schema/dist/28-1900-schema.json';
 import {
-  AppointmentPreferencesInformation,
   VreCommunicationInformation,
   validateAtLeastOneSelected,
 } from './helpers';
@@ -24,10 +23,6 @@ export const schema = {
     },
     useEva,
     useTelecounseling,
-    'view:AppointmentPreferencesInformation': {
-      type: 'object',
-      properties: {},
-    },
     appointmentTimePreferences,
   },
 };
@@ -56,14 +51,13 @@ export const uiSchema = {
       </p>
     ),
   },
-  'view:AppointmentPreferencesInformation': {
-    'ui:options': { showFieldLabel: false },
-    'ui:description': AppointmentPreferencesInformation,
-  },
   appointmentTimePreferences: {
     'ui:title': (
       <p className="vads-u-margin--0 vads-u-margin-top-neg2 vads-u-display--inline-block vads-u-font-weight--normal vads-u-color--base vads-u-font-family--sans vads-u-font-size--base">
-        When are the best times to meet with your counselor?{' '}
+        Please tell us the time you prefer to meet with your counselor. We’ll
+        make every effort to assign a counselor who is available to meet during
+        your preferred hours. When are the best times to meet with your
+        counselor?{' '}
         <span className="schemaform-required-span vads-u-display--block">
           (*Choose at least 1)
         </span>
@@ -78,9 +72,6 @@ export const uiSchema = {
       'ui:title': 'Mornings 6:00 to 10:00 a.m.',
       'ui:options': {
         hideEmptyValueInReview: true,
-        widgetProps: {
-          false: { 'aria-describedby': 'appointment-time-desc' },
-        },
       },
     },
     midDay: {

--- a/src/applications/vre/28-1900/config/chapters/communication-preferences/helpers.js
+++ b/src/applications/vre/28-1900/config/chapters/communication-preferences/helpers.js
@@ -27,16 +27,6 @@ export const VreCommunicationInformation = (
   </section>
 );
 
-export const AppointmentPreferencesInformation = (
-  <section>
-    <p id="appointment-time-desc">
-      Please tell us the time you prefer to meet with your counselor. We’ll make
-      every effort to assign a counselor who is available to meet during your
-      preferred hours.
-    </p>
-  </section>
-);
-
 export const validateAtLeastOneSelected = (errors, fieldData) => {
   if (!Object.values(fieldData).some(val => val === true)) {
     errors.addError('Please select at least one option');

--- a/src/applications/vre/28-1900/tests/e2e/formDataSets/chapter31-maximal.json
+++ b/src/applications/vre/28-1900/tests/e2e/formDataSets/chapter31-maximal.json
@@ -3,7 +3,6 @@
   "useEva": false,
   "view:TeleCounselingInformation": {},
   "useTelecounseling": false,
-  "view:AppointmentPreferencesInformation": {},
   "appointmentTimePreferences": {
     "morning": true,
     "midDay": false,


### PR DESCRIPTION


## Summary

- The checkbox options were not meeting accessibility requirements for screen readers.
- To resolve this issue, the help text was moved into the legend where it would be read by screen readers and still visible to sighted users.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/65505

## Testing done

- Before the change the text was not being read by a screen reader.
- After the change, the text is being read off by the screen reader.

## Screenshots

Please excuse the audio quality - I had to record it using a microphone in front of the speaker.

https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/4595a0ba-495b-4979-a0a7-4e1a63ee72bc

## What areas of the site does it impact?

None

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
