### PR TITLE
21P-0847 Content Styleguide Updates

### DIFF
--- a/src/applications/simple-forms/21P-0847/config/form.js
+++ b/src/applications/simple-forms/21P-0847/config/form.js
@@ -58,7 +58,7 @@ const formConfig = {
     noAuth:
       'Please sign in again to continue your application for substitute claimant.',
   },
-  title: 'Request to be a substitute for a deceased claimant',
+  title: 'Request to be a substitute claimant for a deceased claimant',
   subTitle:
     'Request for substitution of claimant upon death of claimant (VA Form 21P-0847)',
   defaultDefinitions: {},

--- a/src/applications/simple-forms/21P-0847/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21P-0847/containers/IntroductionPage.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { IntroductionPageView } from '../../shared/components/IntroductionPageView';
 
 const content = {
-  formTitle: 'Request to be a substitute for a deceased claimant',
+  formTitle: 'Request to be a substitute claimant for a deceased claimant',
   formSubTitle:
     'Request for substitution of claimant upon death of claimant (VA Form 21P-0847)',
   authStartFormText: 'Start your request to be a substitute claimant',

--- a/src/applications/simple-forms/21P-0847/manifest.json
+++ b/src/applications/simple-forms/21P-0847/manifest.json
@@ -1,5 +1,5 @@
 {
-  "appName": "Request to be a substitute claimant",
+  "appName": "Request to be a substitute claimant for a deceased claimant",
   "entryFile": "./app-entry.jsx",
   "entryName": "21P-0847-substitute-claimant",
   "rootUrl": "/supporting-forms-for-claims/substitute-claimant-form-21P-0847",

--- a/src/applications/simple-forms/21P-0847/pages/deceasedClaimantPersonalInformation.js
+++ b/src/applications/simple-forms/21P-0847/pages/deceasedClaimantPersonalInformation.js
@@ -1,6 +1,6 @@
 import {
-  currentOrPastDateSchema,
   dateOfDeathUI,
+  dateOfDeathSchema,
   fullNameNoSuffixSchema,
   fullNameNoSuffixUI,
   titleUI,
@@ -20,7 +20,7 @@ export default {
     type: 'object',
     properties: {
       deceasedClaimantFullName: fullNameNoSuffixSchema,
-      deceasedClaimantDateOfDeath: currentOrPastDateSchema,
+      deceasedClaimantDateOfDeath: dateOfDeathSchema,
     },
     required: ['deceasedClaimantDateOfDeath'],
   },

--- a/src/platform/forms-system/src/js/web-component-patterns/datePatterns.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/datePatterns.jsx
@@ -45,9 +45,16 @@ const currentOrPastDateUI = options => {
       <Tag className="review-row">
         <dt>{uiTitle}</dt>
         <dd>
-          {new Date(`${children.props.formData}T00:00:00`).toLocaleDateString(
-            'en-us',
-            { year: 'numeric', month: 'long', day: 'numeric' },
+          {children.props.formData && (
+            <>
+              {new Date(
+                `${children.props.formData}T00:00:00`,
+              ).toLocaleDateString('en-us', {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })}
+            </>
           )}
         </dd>
       </Tag>

--- a/src/platform/forms-system/src/js/web-component-patterns/datePatterns.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/datePatterns.jsx
@@ -26,7 +26,6 @@ const currentOrPastDateUI = options => {
   const { title, errorMessages, ...uiOptions } =
     typeof options === 'object' ? options : { title: options };
 
-  const Tag = uiOptions?.useDlWrap ? 'dl' : 'div';
   const uiTitle = title ?? 'Date';
 
   return {
@@ -42,7 +41,7 @@ const currentOrPastDateUI = options => {
       ...uiOptions,
     },
     'ui:reviewField': ({ children }) => (
-      <Tag className="review-row">
+      <div className="review-row">
         <dt>{uiTitle}</dt>
         <dd>
           {children.props.formData && (
@@ -57,7 +56,7 @@ const currentOrPastDateUI = options => {
             </>
           )}
         </dd>
-      </Tag>
+      </div>
     ),
   };
 };

--- a/src/platform/forms-system/src/js/web-component-patterns/datePatterns.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/datePatterns.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import commonDefinitions from 'vets-json-schema/dist/definitions.json';
 import VaMemorableDateField from '../web-component-fields/VaMemorableDateField';
 import { validateCurrentOrPastMemorableDate } from '../validation';
@@ -25,8 +26,11 @@ const currentOrPastDateUI = options => {
   const { title, errorMessages, ...uiOptions } =
     typeof options === 'object' ? options : { title: options };
 
+  const Tag = uiOptions?.useDlWrap ? 'dl' : 'div';
+  const uiTitle = title ?? 'Date';
+
   return {
-    'ui:title': title ?? 'Date',
+    'ui:title': uiTitle,
     'ui:webComponentField': VaMemorableDateField,
     'ui:validations': [validateCurrentOrPastMemorableDate],
     'ui:errorMessages': {
@@ -37,6 +41,17 @@ const currentOrPastDateUI = options => {
     'ui:options': {
       ...uiOptions,
     },
+    'ui:reviewField': ({ children }) => (
+      <Tag className="review-row">
+        <dt>{uiTitle}</dt>
+        <dd>
+          {new Date(`${children.props.formData}T00:00:00`).toLocaleDateString(
+            'en-us',
+            { year: 'numeric', month: 'long', day: 'numeric' },
+          )}
+        </dd>
+      </Tag>
+    ),
   };
 };
 


### PR DESCRIPTION
## Summary
This pull request addresses two different content styleguide review tickets for 21P-0847. 

One is an update to the browser tab title, app name, breadcrumbs, etc. to all have matching text. A content-build pull request was also required to make this change: https://github.com/department-of-veterans-affairs/content-build/pull/1719

The other is a UI change to how we display memorable date on the review page. This change was made to our base `currentOrPastDateUI` pattern, so it should automatically change all other memorable date patterns as well.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#63093
department-of-veterans-affairs/vets-website#63094

## Screenshots
<img width="455" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/53942725/01a7e809-721b-4104-8745-26a814302d9b">
