### PR TITLE
Update HCA performance warning alert content

### DIFF
--- a/src/applications/static-pages/hca-performance-warning/components/App/index.jsx
+++ b/src/applications/static-pages/hca-performance-warning/components/App/index.jsx
@@ -25,11 +25,7 @@ export const App = ({ show }) => {
             <abbr title="Eastern Time">ET</abbr>
           </dfn>
           . Mail us an application postmarked by September 30, 2023. Or bring
-          your application in person to your nearest VA health facility.{' '}
-          <a href="/health-care/how-to-apply/">
-            Learn more about how to apply by phone, mail, or in person
-          </a>
-          .
+          your application in person to your nearest VA health facility.
         </p>
       </div>
     </va-alert>


### PR DESCRIPTION
## Summary
This PR updates the content on the performance warning for the static CMS pages. The alert ended up with a link to the same page the alert was being shown on, so this link has been removed.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#65436

## Acceptance criteria
- Content matches approved writing and does not contain unnecessary links
