### PR TITLE
Profile/aw/64160/profile hub build pt3

### DIFF
--- a/src/applications/personalization/profile/components/hub/Hub.jsx
+++ b/src/applications/personalization/profile/components/hub/Hub.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { hasBadAddress as hasBadAddressSelector } from '@@profile/selectors';
 import { useSelector } from 'react-redux';
@@ -14,6 +14,11 @@ import { HubCard } from './HubCard';
 export const Hub = () => {
   const { label, link } = useSignInServiceProvider();
   const hasBadAddress = useSelector(hasBadAddressSelector);
+
+  useEffect(() => {
+    document.title = `Your Profile | Veterans Affairs`;
+  }, []);
+
   return (
     <>
       <ProfileBreadcrumbs className="medium-screen:vads-u-margin-left--neg1 medium-screen:vads-u-margin-top--neg2 vads-u-margin-bottom--neg1" />

--- a/src/applications/personalization/profile/routes.js
+++ b/src/applications/personalization/profile/routes.js
@@ -30,8 +30,8 @@ const getRoutes = (
             component: Hub,
             name: PROFILE_PATH_NAMES.PROFILE_ROOT,
             path: PROFILE_PATHS.PROFILE_ROOT,
-            requiresLOA3: false,
-            requiresMVI: false,
+            requiresLOA3: true,
+            requiresMVI: true,
           },
         ]
       : []),

--- a/src/applications/personalization/profile/tests/e2e/profile-hub.blocked.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-hub.blocked.cypress.spec.js
@@ -1,0 +1,68 @@
+import disabilityComps from '@@profile/mocks/endpoints/disability-compensations';
+import { checkForLegacyLoadingIndicator } from '~/applications/personalization/common/e2eHelpers';
+import mockUser from '../fixtures/users/user-36.json';
+import { PROFILE_PATHS } from '../../constants';
+import { mockProfileLOA3 } from './helpers';
+import { generateFeatureToggles } from '../../mocks/endpoints/feature-toggles';
+
+const checkForAccountSecurityAsRedirect = () => {
+  cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+  checkForLegacyLoadingIndicator();
+
+  cy.findByText('We can’t show your information').should('exist');
+
+  cy.url().should('include', 'profile/account-security');
+};
+
+describe('Profile - Hub page', () => {
+  // visits the profile page with useProfileHub toggled on and off
+  // and checks that the correct content is rendered
+
+  beforeEach(() => {
+    cy.login(mockUser);
+
+    mockProfileLOA3();
+
+    cy.intercept(
+      'v0/feature_toggles*',
+      generateFeatureToggles({
+        profileUseHubPage: true,
+        profileLighthouseDirectDeposit: true,
+      }),
+    );
+  });
+
+  it('should render blocked profile content when user is deceased', () => {
+    cy.intercept(
+      '/v0/profile/direct_deposits/disability_compensations',
+      disabilityComps.isDeceased,
+    );
+
+    checkForAccountSecurityAsRedirect();
+
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('should render blocked profile content when user has fiduciary flag', () => {
+    cy.intercept(
+      '/v0/profile/direct_deposits/disability_compensations',
+      disabilityComps.isFiduciary,
+    );
+
+    checkForAccountSecurityAsRedirect();
+
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('should render blocked profile content when user in not competent', () => {
+    cy.intercept(
+      '/v0/profile/direct_deposits/disability_compensations',
+      disabilityComps.isNotCompetent,
+    );
+
+    checkForAccountSecurityAsRedirect();
+
+    cy.injectAxeThenAxeCheck();
+  });
+});

--- a/src/applications/personalization/profile/tests/e2e/profile-hub.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-hub.cypress.spec.js
@@ -1,8 +1,10 @@
+import disabilityComps from '@@profile/mocks/endpoints/disability-compensations';
 import { checkForLegacyLoadingIndicator } from '~/applications/personalization/common/e2eHelpers';
 import mockUser from '../fixtures/users/user-36.json';
 import { PROFILE_PATHS } from '../../constants';
 import { mockProfileLOA3 } from './helpers';
 import { generateFeatureToggles } from '../../mocks/endpoints/feature-toggles';
+import user from '../../mocks/endpoints/user';
 
 describe('Profile - Hub page', () => {
   // visits the profile page with useProfileHub toggled on and off
@@ -26,16 +28,67 @@ describe('Profile - Hub page', () => {
       'exist',
     );
     cy.findByText('Notification settings', { selector: 'h2' }).should('exist');
-
     cy.findByText('Account security', { selector: 'h2' }).should('exist');
     cy.findByText('Connected apps', { selector: 'h2' }).should('exist');
+
+    cy.url().should('not.include', 'personal-information');
+
     cy.injectAxeThenAxeCheck();
   });
 
-  it('should render the correct content with toggle OFF', () => {
+  it('should render the bad address indicator on the Hub, for a user with a bad address', () => {
+    cy.intercept('v0/user', user.badAddress);
+
+    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+    checkForLegacyLoadingIndicator();
+
+    cy.findByText('Profile', { selector: 'h1' }).should('exist');
+
+    // heading of the bad address indicator alert
+    cy.findByText('Review your mailing address').should('exist');
+
+    // link text for the bad address indicator alert
+    cy.findByText(
+      'Go to your contact information to review your address',
+    ).should('exist');
+
+    cy.url().should('not.include', 'personal-information');
+
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('should render blocked profile content when user is deceased', () => {
     cy.intercept(
       'v0/feature_toggles*',
-      generateFeatureToggles({ useProfileHub: false }),
+      generateFeatureToggles({
+        profileUseHubPage: true,
+        profileLighthouseDirectDeposit: true,
+      }),
+    );
+
+    cy.intercept(
+      '/v0/profile/direct_deposits/disability_compensations',
+      disabilityComps.isDeceased,
+    );
+
+    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+    checkForLegacyLoadingIndicator();
+
+    cy.findByText('We can’t show your information').should('exist');
+
+    cy.url().should('include', 'profile/account-security');
+
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('should render the personal information page as the profile root route when toggle is OFF', () => {
+    cy.intercept(
+      'v0/feature_toggles*',
+      generateFeatureToggles({
+        profileUseHubPage: false,
+      }),
     );
     cy.visit(PROFILE_PATHS.PROFILE_ROOT);
 
@@ -48,7 +101,7 @@ describe('Profile - Hub page', () => {
     cy.findByText('Gender identity').should('exist');
     cy.findByText('Disability rating').should('exist');
 
-    cy.url().should('include', '/personal-information');
+    cy.url().should('include', 'profile/personal-information');
 
     cy.injectAxeThenAxeCheck();
   });


### PR DESCRIPTION
## Summary

- Some last little bits of logic for the profile hub main build ticket
  - Display Bad Address Indicator when present
  - Block the Hub and redirect to Account Security when certain flags are present from direct deposit endpoints
- Additionally made sure the document title was set when page loaded to `Your Profile | Veterans Affairs`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/64160

## Testing done

- E2E tests added for all 3 blocked cases
- E2E test added for Bad Address indicator alert

## Screenshots

No real before and after, but here is what the Hub looks like with the bad address indicator present

![Screenshot 2023-09-26 at 9 30 00 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/7d58e758-e3bc-43bb-829f-bf52a53e418c)


## What areas of the site does it impact?

Profile -> Hub

## Acceptance criteria

- [x] Bad address alert shown
- [x] Hub blocked for fiduciary, incompetent, and deceased flags 

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
