### PR TITLE
DR | Set submitted zipcode based on country code

### DIFF
--- a/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
@@ -275,51 +275,105 @@ describe('removeEmptyEntries', () => {
 
 describe('getAddress', () => {
   it('should return a cleaned up address object', () => {
-    const wrap = obj => ({ veteran: { address: obj } });
-    expect(getAddress()).to.deep.equal({});
-    expect(getAddress(wrap({}))).to.deep.equal({});
-    expect(getAddress(wrap({ temp: 'test' }))).to.deep.equal({});
+    // zipCode5 returns 5 zeros if country isn't set to 'US'
+    const result = { zipCode5: '00000' };
+    const wrap = obj => ({
+      // definet countryCodeIso2 to '' until we remove SHOW_PART3 flag
+      veteran: { address: { countryCodeIso2: '', ...obj } },
+    });
+    expect(getAddress()).to.deep.equal(result);
+    expect(getAddress(wrap({}))).to.deep.equal(result);
+    expect(getAddress(wrap({ temp: 'test' }))).to.deep.equal(result);
     expect(getAddress(wrap({ addressLine1: 'test' }))).to.deep.equal({
       addressLine1: 'test',
+      zipCode5: '00000',
     });
     expect(getAddress(wrap({ zipCode: '10101' }))).to.deep.equal({
+      zipCode5: '00000',
+    });
+    expect(
+      getAddress(wrap({ countryCodeIso2: 'US', zipCode: '10101' })),
+    ).to.deep.equal({ zipCode5: '10101' });
+    expect(
+      getAddress({
+        ...wrap({ countryCodeIso2: 'US', zipCode: '10101' }),
+        [SHOW_PART3]: true,
+      }),
+    ).to.deep.equal({
+      countryCodeISO2: 'US',
       zipCode5: '10101',
     });
-    const testAddress = wrap({
+    const testAddress = (country = 'US') =>
+      wrap({
+        addressLine1: '123 test',
+        addressLine2: 'c/o foo',
+        addressLine3: 'suite 99',
+        city: 'Big City',
+        stateCode: 'NV',
+        zipCode: '10101',
+        countryName: 'United States',
+        countryCodeIso2: country, // Iso is camel-case here
+        internationalPostalCode: '12345',
+        extra: 'will not be included',
+      });
+    expect(getAddress(testAddress())).to.deep.equal({
       addressLine1: '123 test',
       addressLine2: 'c/o foo',
       addressLine3: 'suite 99',
       city: 'Big City',
       stateCode: 'NV',
-      zipCode: '10101',
+      zipCode5: '10101',
       countryName: 'United States',
-      countryCodeIso2: 'US', // Iso is camel-case here
       internationalPostalCode: '12345',
-      extra: 'will not be included',
     });
-    expect(getAddress(testAddress)).to.deep.equal({
+    expect(getAddress({ ...testAddress(), [SHOW_PART3]: true })).to.deep.equal({
       addressLine1: '123 test',
       addressLine2: 'c/o foo',
       addressLine3: 'suite 99',
       city: 'Big City',
       stateCode: 'NV',
-      zipCode5: '00000',
-      countryName: 'United States',
-      internationalPostalCode: '12345',
-    });
-    expect(getAddress({ ...testAddress, [SHOW_PART3]: true })).to.deep.equal({
-      addressLine1: '123 test',
-      addressLine2: 'c/o foo',
-      addressLine3: 'suite 99',
-      city: 'Big City',
-      stateCode: 'NV',
-      zipCode5: '00000',
+      zipCode5: '10101',
       countryCodeISO2: 'US', // ISO is all caps here
       internationalPostalCode: '12345',
     });
     expect(
-      getAddress(wrap({ internationalPostalCode: '55555' })),
+      getAddress({ ...testAddress('GB'), [SHOW_PART3]: true }),
     ).to.deep.equal({
+      addressLine1: '123 test',
+      addressLine2: 'c/o foo',
+      addressLine3: 'suite 99',
+      city: 'Big City',
+      stateCode: 'NV',
+      zipCode5: '00000',
+      countryCodeISO2: 'GB',
+      internationalPostalCode: '12345',
+    });
+    expect(
+      getAddress({
+        ...wrap({
+          countryCodeIso2: 'GB',
+          zipCode: '10101',
+          internationalPostalCode: '55555',
+        }),
+        [SHOW_PART3]: true,
+      }),
+    ).to.deep.equal({
+      countryCodeISO2: 'GB',
+      zipCode5: '00000',
+      internationalPostalCode: '55555',
+    });
+    expect(
+      getAddress(
+        wrap({
+          countryName: 'Great Britian',
+          countryCodeIso2: 'GB',
+          zipCode: '10101',
+          internationalPostalCode: '55555',
+        }),
+      ),
+    ).to.deep.equal({
+      // countryCodeISO2: 'GB',
+      countryName: 'Great Britian',
       zipCode5: '00000',
       internationalPostalCode: '55555',
     });

--- a/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
@@ -278,7 +278,7 @@ describe('getAddress', () => {
     // zipCode5 returns 5 zeros if country isn't set to 'US'
     const result = { zipCode5: '00000' };
     const wrap = obj => ({
-      // definet countryCodeIso2 to '' until we remove SHOW_PART3 flag
+      // define countryCodeIso2 to '' until we remove SHOW_PART3 flag
       veteran: { address: { countryCodeIso2: '', ...obj } },
     });
     expect(getAddress()).to.deep.equal(result);
@@ -365,7 +365,7 @@ describe('getAddress', () => {
     expect(
       getAddress(
         wrap({
-          countryName: 'Great Britian',
+          countryName: 'Great Britain',
           countryCodeIso2: 'GB',
           zipCode: '10101',
           internationalPostalCode: '55555',
@@ -373,7 +373,7 @@ describe('getAddress', () => {
       ),
     ).to.deep.equal({
       // countryCodeISO2: 'GB',
-      countryName: 'Great Britian',
+      countryName: 'Great Britain',
       zipCode5: '00000',
       internationalPostalCode: '55555',
     });

--- a/src/applications/appeals/995/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/submit.unit.spec.js
@@ -203,15 +203,21 @@ describe('getAddress', () => {
     veteran: { address: obj },
   });
   it('should return a cleaned up address object', () => {
-    // expect(getAddress({})).to.deep.equal({});
-    // expect(getAddress(wrap({}))).to.deep.equal({});
-    // expect(getAddress(wrap({ temp: 'test' }))).to.deep.equal({});
-    // expect(getAddress(wrap({ addressLine1: 'test' }))).to.deep.equal({
-    //   addressLine1: 'test',
-    // });
-    // expect(getAddress(wrap({ zipCode: '10101' }))).to.deep.equal({
-    //   zipCode5: '10101',
-    // });
+    // zipCode5 returns 5 zeros if country isn't set to 'US'
+    const result = { zipCode5: '00000' };
+    expect(getAddress({})).to.deep.equal(result);
+    expect(getAddress(wrap({}))).to.deep.equal(result);
+    expect(getAddress(wrap({ temp: 'test' }))).to.deep.equal(result);
+    expect(getAddress(wrap({ addressLine1: 'test' }))).to.deep.equal({
+      addressLine1: 'test',
+      zipCode5: '00000',
+    });
+    expect(
+      getAddress(wrap({ countryCodeIso2: 'US', zipCode: '10101' })),
+    ).to.deep.equal({
+      countryCodeISO2: 'US',
+      zipCode5: '10101',
+    });
     expect(
       getAddress(
         wrap({
@@ -232,37 +238,77 @@ describe('getAddress', () => {
       addressLine3: 'suite 99',
       city: 'Big City',
       stateCode: 'NV',
-      zipCode5: '00000',
+      zipCode5: '10101',
       countryCodeISO2: 'US',
       internationalPostalCode: '12345',
     });
-    // expect(
-    //   getAddress(wrap({ internationalPostalCode: '55555' })),
-    // ).to.deep.equal({
-    //   zipCode5: '00000',
-    //   internationalPostalCode: '55555',
-    // });
+    expect(
+      getAddress(
+        wrap({
+          addressLine1: '123 test',
+          addressLine2: 'c/o foo',
+          addressLine3: 'suite 99',
+          city: 'Big City',
+          stateCode: 'NV',
+          zipCode: '10101',
+          countryCodeIso2: 'GB',
+          internationalPostalCode: '12345',
+          extra: 'will not be included',
+        }),
+      ),
+    ).to.deep.equal({
+      addressLine1: '123 test',
+      addressLine2: 'c/o foo',
+      addressLine3: 'suite 99',
+      city: 'Big City',
+      stateCode: 'NV',
+      zipCode5: '00000',
+      countryCodeISO2: 'GB',
+      internationalPostalCode: '12345',
+    });
+    expect(
+      getAddress(
+        wrap({ countryCodeIso2: 'GB', internationalPostalCode: '55555' }),
+      ),
+    ).to.deep.equal({
+      countryCodeISO2: 'GB',
+      zipCode5: '00000',
+      internationalPostalCode: '55555',
+    });
   });
   it('should truncate long address lines', () => {
     expect(getAddress(wrap({ addressLine1: text }))).to.deep.equal({
       addressLine1:
         'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed',
+      zipCode5: '00000',
     });
     expect(getAddress(wrap({ addressLine2: text }))).to.deep.equal({
       addressLine2: 'Lorem ipsum dolor sit amet, co',
+      zipCode5: '00000',
     });
     expect(getAddress(wrap({ addressLine3: text }))).to.deep.equal({
       addressLine3: 'Lorem ipsu',
+      zipCode5: '00000',
     });
     expect(getAddress(wrap({ city: text }))).to.deep.equal({
       city: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed',
+      zipCode5: '00000',
     });
-    expect(getAddress(wrap({ zipCode: '123450000' }))).to.deep.equal({
+    expect(
+      getAddress(wrap({ countryCodeIso2: 'US', zipCode: '123450000' })),
+    ).to.deep.equal({
+      countryCodeISO2: 'US',
       zipCode5: '12345',
     });
     expect(
-      getAddress(wrap({ internationalPostalCode: '12345678901234567890' })),
+      getAddress(
+        wrap({
+          countryCodeIso2: 'GB',
+          internationalPostalCode: '12345678901234567890',
+        }),
+      ),
     ).to.deep.equal({
+      countryCodeISO2: 'GB',
       zipCode5: '00000',
       internationalPostalCode: '1234567890123456',
     });

--- a/src/applications/appeals/996/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/996/tests/utils/submit.unit.spec.js
@@ -305,16 +305,20 @@ describe('getConferenceTime', () => {
 
 describe('getAddress', () => {
   it('should return a cleaned up address object', () => {
-    const wrap = obj => ({
-      veteran: { address: obj },
-    });
-    expect(getAddress({})).to.deep.equal({});
-    expect(getAddress(wrap({}))).to.deep.equal({});
-    expect(getAddress(wrap({ temp: 'test' }))).to.deep.equal({});
+    // zipCode5 returns 5 zeros if country isn't set to 'US'
+    const result = { zipCode5: '00000' };
+    const wrap = obj => ({ veteran: { address: obj } });
+    expect(getAddress({})).to.deep.equal(result);
+    expect(getAddress(wrap({}))).to.deep.equal(result);
+    expect(getAddress(wrap({ temp: 'test' }))).to.deep.equal(result);
     expect(getAddress(wrap({ addressLine1: 'test' }))).to.deep.equal({
       addressLine1: 'test',
+      zipCode5: '00000',
     });
-    expect(getAddress(wrap({ zipCode: '10101' }))).to.deep.equal({
+    expect(
+      getAddress(wrap({ countryCodeIso2: 'US', zipCode: '10101' })),
+    ).to.deep.equal({
+      countryCodeISO2: 'US',
       zipCode5: '10101',
     });
     expect(
@@ -337,13 +341,40 @@ describe('getAddress', () => {
       addressLine3: 'suite 99',
       city: 'Big City',
       stateCode: 'NV',
-      zipCode5: '00000',
+      zipCode5: '10101',
       countryCodeISO2: 'US',
       internationalPostalCode: '12345',
     });
     expect(
-      getAddress(wrap({ internationalPostalCode: '55555' })),
+      getAddress(
+        wrap({
+          addressLine1: '123 test',
+          addressLine2: 'c/o foo',
+          addressLine3: 'suite 99',
+          city: 'Big City',
+          stateCode: 'NV',
+          zipCode: '10101',
+          countryCodeIso2: 'GB',
+          internationalPostalCode: '12345',
+          extra: 'will not be included',
+        }),
+      ),
     ).to.deep.equal({
+      addressLine1: '123 test',
+      addressLine2: 'c/o foo',
+      addressLine3: 'suite 99',
+      city: 'Big City',
+      stateCode: 'NV',
+      zipCode5: '00000',
+      countryCodeISO2: 'GB',
+      internationalPostalCode: '12345',
+    });
+    expect(
+      getAddress(
+        wrap({ countryCodeIso2: 'GB', internationalPostalCode: '55555' }),
+      ),
+    ).to.deep.equal({
+      countryCodeISO2: 'GB',
       zipCode5: '00000',
       internationalPostalCode: '55555',
     });

--- a/src/applications/appeals/996/utils/submit.js
+++ b/src/applications/appeals/996/utils/submit.js
@@ -216,21 +216,30 @@ export const getAddress = formData => {
   const { veteran = {} } = formData || {};
   const truncate = (value, max) =>
     replaceSubmittedData(veteran.address?.[value] || '').substring(0, max);
+  // note "ISO2" is submitted, "Iso2" is from profile address
+  const countryCodeISO2 = truncate(
+    'countryCodeIso2',
+    MAX_LENGTH.ADDRESS_COUNTRY,
+  );
+  // international postal code can be undefined/null
   const internationalPostalCode = truncate(
     'internationalPostalCode',
     MAX_LENGTH.POSTAL_CODE,
   );
+  // zipCode5 is always required, set to 00000 for addresses outside the U.S.
+  // https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/config/schemas/shared/v0/address.json#L34
+  const zipCode5 =
+    countryCodeISO2 !== 'US'
+      ? '00000'
+      : truncate('zipCode', MAX_LENGTH.ZIP_CODE5);
   return removeEmptyEntries({
     addressLine1: truncate('addressLine1', MAX_LENGTH.ADDRESS_LINE1),
     addressLine2: truncate('addressLine2', MAX_LENGTH.ADDRESS_LINE2),
     addressLine3: truncate('addressLine3', MAX_LENGTH.ADDRESS_LINE3),
     city: truncate('city', MAX_LENGTH.CITY),
     stateCode: veteran.address?.stateCode || '',
-    countryCodeISO2: truncate('countryCodeIso2', MAX_LENGTH.ADDRESS_COUNTRY),
-    // https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/appeals_api/config/schemas/v2/200996.json#L145
-    zipCode5: internationalPostalCode
-      ? '00000'
-      : truncate('zipCode', MAX_LENGTH.ZIP_CODE5),
+    countryCodeISO2,
+    zipCode5,
     internationalPostalCode,
   });
 };


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Our code was previously setting a submitted zip code to `'00000'` when an international postal code was provided, but we didn't realize that international postal codes are optional. We discovered this when we noted a Veteran with a failed Higher-Level Review submission. This PR changes the submitted zip code to `'00000'` when the country is not set to the U.S. (using `countryCodeIso2` data provided by the Veteran's profile). We also applied this fix to all 3 of our appeals forms.
- _(If bug, how to reproduce)_
  > Submit any appeal form with an international address and don't provide an international postal code - the submission will be rejected
- _(What is the solution, why is this the solution)_
  > This change should match what Lighthouse is expecting for international addresses
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefit decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#65745](https://github.com/department-of-veterans-affairs/va.gov-team/issues/65745)

## Testing done

- _Describe what the old behavior was prior to the change_
  > See summary
- _Describe the steps required to verify your changes are working as expected_
  > See summary
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

Decision review forms (x3)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
