### PR TITLE
Switch to using stationNo

### DIFF
--- a/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
@@ -68,9 +68,9 @@ const CheckInConfirmation = props => {
   useEffect(
     () => {
       if (travelPayClaimSent) {
-        const { facility } = selectedAppointment;
+        const { stationNo } = selectedAppointment;
         const travelPaySent = getTravelPaySent(window);
-        travelPaySent[facility] = new Date();
+        travelPaySent[stationNo] = new Date();
         setShouldSendTravelPayClaim(window, false);
         setTravelPaySent(window, travelPaySent);
       }

--- a/src/applications/check-in/utils/navigation/index.js
+++ b/src/applications/check-in/utils/navigation/index.js
@@ -67,10 +67,10 @@ const updateFormPages = (
   let skipLogic = appointments.length > 1;
 
   if (isTravelLogicEnabled) {
-    const { facility } = appointments[0];
+    const { stationNo } = appointments[0];
     skipLogic =
-      facility in travelPaySent &&
-      !differenceInCalendarDays(Date.now(), parseISO(travelPaySent[facility]));
+      stationNo in travelPaySent &&
+      !differenceInCalendarDays(Date.now(), parseISO(travelPaySent[stationNo]));
   }
 
   if (

--- a/src/applications/check-in/utils/navigation/navigation.unit.spec.js
+++ b/src/applications/check-in/utils/navigation/navigation.unit.spec.js
@@ -259,7 +259,7 @@ describe('Global check in', () => {
           isTravelReimbursementEnabled,
           appointments,
           true,
-          { testId: new Date().toISOString() },
+          { '0001': new Date().toISOString() },
         );
         expect(form.find(page => page === URLS.TRAVEL_PAY)).to.be.undefined;
         expect(form.find(page => page === URLS.TRAVEL_VEHICLE)).to.be.undefined;
@@ -287,7 +287,7 @@ describe('Global check in', () => {
           isTravelReimbursementEnabled,
           appointments,
           true,
-          { testId: new Date('2023-01-01T03:24:00').toISOString() },
+          { '0001': new Date('2023-01-01T03:24:00').toISOString() },
         );
         expect(form.find(page => page === URLS.TRAVEL_QUESTION)).to.exist;
         expect(form.find(page => page === URLS.TRAVEL_VEHICLE)).to.exist;
@@ -344,7 +344,7 @@ describe('Global check in', () => {
           isTravelReimbursementEnabled,
           appointments,
           true,
-          { testId2: new Date().toISOString() },
+          { '0002': new Date().toISOString() },
         );
         expect(form.find(page => page === URLS.TRAVEL_QUESTION)).to.exist;
         expect(form.find(page => page === URLS.TRAVEL_VEHICLE)).to.exist;


### PR DESCRIPTION
## Summary

- Switch to use stationNo as identifier for new travel logic

## Related issue(s)

- [department-of-veterans-affairs/va.gov-team#65628](https://github.com/department-of-veterans-affairs/va.gov-team/issues/65628)
