### PR TITLE
Fix heading elements on 686c-674 and 28-1900 introduction pages

### DIFF
--- a/src/applications/disability-benefits/686c-674/components/IntroductionPageFormProcess.jsx
+++ b/src/applications/disability-benefits/686c-674/components/IntroductionPageFormProcess.jsx
@@ -89,7 +89,7 @@ export const IntroductionPageFormProcess = () => (
           </p>
         </li>
         <li className="process-step list-two">
-          <h4>Apply</h4>
+          <h3>Apply</h3>
           <p>
             Complete this dependents form and upload additional information if
             needed.
@@ -157,14 +157,14 @@ export const IntroductionPageFormProcess = () => (
           </p>
         </li>
         <li className="process-step list-three">
-          <h4>VA Review</h4>
+          <h3>VA Review</h3>
           <p>
             We process applications in the order we receive them. We may contact
             you if we have questions or need more information.
           </p>
         </li>
         <li className="process-step list-four vads-u-padding-bottom--0p25">
-          <h4>Decision</h4>
+          <h3>Decision</h3>
           <p>
             You’ll get a notice in the mail once we’ve processed your claim.
           </p>

--- a/src/applications/vre/28-1900/containers/IntroductionPage.jsx
+++ b/src/applications/vre/28-1900/containers/IntroductionPage.jsx
@@ -74,7 +74,7 @@ const IntroductionPage = props => {
             </p>
           </li>
           <li className="process-step list-two">
-            <h4>Apply</h4>
+            <h3>Apply</h3>
             <p>Complete this Veteran Readiness and Employment form.</p>
             <p>
               After submitting your application, you’ll get a confirmation
@@ -83,14 +83,14 @@ const IntroductionPage = props => {
             </p>
           </li>
           <li className="process-step list-three">
-            <h4>VA review</h4>
+            <h3>VA review</h3>
             <p>
               We process applications in the order we receive them. We may
               contact you if we have questions or need more information.
             </p>
           </li>
           <li className="process-step list-four">
-            <h4>Decision</h4>
+            <h3>Decision</h3>
             <p>
               If you’re eligible for Veteran Readiness and Employment benefits,
               we’ll schedule a meeting for you with a Vocational Rehabilitation


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/64130

## Summary

- Some headers were using the wrong headings in the form introduction pages, breaking accessibility guidelines.
- This fix changes some `<h4>`s to `<h3>`s to bring us back into compliance.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/64130

## Testing done

- Checked the new headers using HeadingsMap

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|          | Before | After |
| -------- | ------ | ----- |
|686c-674|![dependents-headers-before](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/e021214c-a533-4912-a97f-f18a71197f27)|![deps-headers-after](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/f7961aed-2ccc-49aa-b989-9641f17837e5)|
|28-1900 | ![veteran-readiness-headers-before](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/0b596062-7e28-43d2-9551-aae69f4f6605)|![veteran-readiness-headers-after](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/f10bf0f1-fb03-4674-b07e-0418069f6911)|

## What areas of the site does it impact?

Just these two forms

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
