### PR TITLE
PR for NOD | Update "addIssue" content

### DIFF
--- a/src/applications/appeals/10182/content/addIssue.jsx
+++ b/src/applications/appeals/10182/content/addIssue.jsx
@@ -17,9 +17,9 @@ export const issueErrorMessages = {
   invalidDateRange: (min, max) =>
     `You must enter a year between ${min} and ${max}`,
   pastDate: 'You must add a decision date that’s in the past',
-  newerDate:
-    'You must add an issue with a decision date that’s less than a year old',
   recentDate:
+    'You must add an issue with a decision date that’s less than a year old',
+  newerDate:
     'You must add an issue with a decision date that’s less than 100 years old',
 };
 

--- a/src/applications/appeals/10182/content/addIssue.jsx
+++ b/src/applications/appeals/10182/content/addIssue.jsx
@@ -6,20 +6,21 @@ const hintText =
   'You can only add an issue that you’ve received a VA decision notice for.';
 
 export const issueErrorMessages = {
-  missingIssue: 'Add the name of an issue',
-  uniqueIssue: 'Enter a unique condition name',
-  maxLength: `Enter less than ${
+  missingIssue: 'You must add an issue',
+  uniqueIssue: 'You must enter an issue you haven’t already entered',
+  maxLength: `You can enter a maximum of ${
     MAX_LENGTH.NOD_ISSUE_NAME
-  } characters for this issue name`,
+  } characters`,
 
-  invalidDate: 'Provide a valid date',
-  blankDecisionDate: 'Enter a decision date',
-  invalidDateRange: (min, max) => `Enter a year between ${min} and ${max}`,
-  pastDate: 'Add a past decision date',
-  // date must be < 1 year old
-  newerDate: 'Add an issue with a decision date less than a year old',
-  // date must be more recent (set to 100 years max)
-  recentDate: 'You must add a more recent decision date',
+  invalidDate: 'You must provide a date that includes a month, day, and year',
+  blankDecisionDate: 'You must enter a decision date',
+  invalidDateRange: (min, max) =>
+    `You must enter a year between ${min} and ${max}`,
+  pastDate: 'You must add a decision date that’s in the past',
+  newerDate:
+    'You must add an issue with a decision date that’s less than a year old',
+  recentDate:
+    'You must add an issue with a decision date that’s less than 100 years old',
 };
 
 export const content = {

--- a/src/applications/appeals/10182/tests/components/AddIssue.unit.spec.js
+++ b/src/applications/appeals/10182/tests/components/AddIssue.unit.spec.js
@@ -54,6 +54,7 @@ describe('<AddIssue>', () => {
 
   it('should render', () => {
     const { container } = render(setup());
+    expect($('h3', container)).to.exist;
     expect($('va-text-input')).to.exist;
     expect($('va-memorable-date', container)).to.exist;
   });

--- a/src/applications/appeals/10182/tests/components/AddIssue.unit.spec.js
+++ b/src/applications/appeals/10182/tests/components/AddIssue.unit.spec.js
@@ -102,7 +102,7 @@ describe('<AddIssue>', () => {
     fireEvent.click($('#submit', container));
 
     const date = $('va-memorable-date', container);
-    expect(date.error).to.contain('past decision date');
+    expect(date.error).to.contain('decision date that’s in the past');
     expect(date.invalidMonth).to.be.false;
     expect(date.invalidDay).to.be.false;
     expect(date.invalidYear).to.be.true;
@@ -134,7 +134,7 @@ describe('<AddIssue>', () => {
     fireEvent.click($('#submit', container));
 
     const date = $('va-memorable-date', container);
-    expect(date.error).to.contain(issueErrorMessages.newerDate);
+    expect(date.error).to.contain(issueErrorMessages.recentDate);
     expect(date.invalidMonth).to.be.false;
     expect(date.invalidDay).to.be.false;
     expect(date.invalidYear).to.be.true;

--- a/src/applications/appeals/10182/tests/validations/date.unit.spec.js
+++ b/src/applications/appeals/10182/tests/validations/date.unit.spec.js
@@ -54,7 +54,7 @@ describe('validateDate & isValidDate', () => {
   });
   it('should throw a range error for dates too old', () => {
     validateDate(errors, '1899-01-01');
-    expect(errorMessage[0]).to.eq(issueErrorMessages.newerDate);
+    expect(errorMessage[0]).to.eq(issueErrorMessages.recentDate);
     expect(errorMessage[1]).to.not.contain('month');
     expect(errorMessage[1]).to.not.contain('day');
     expect(errorMessage[1]).to.contain('year');
@@ -84,7 +84,7 @@ describe('validateDate & isValidDate', () => {
   it('should throw an error for dates in the distant past', () => {
     const date = getDate({ offset: { years: -2 } });
     validateDate(errors, date);
-    expect(errorMessage[0]).to.eq(issueErrorMessages.newerDate);
+    expect(errorMessage[0]).to.eq(issueErrorMessages.recentDate);
     expect(errorMessage[1]).to.not.contain('month');
     expect(errorMessage[1]).to.not.contain('day');
     expect(errorMessage[1]).to.contain('year');
@@ -121,7 +121,7 @@ describe('validateDate & isValidDate', () => {
   it('should throw an error for dates in the distant past when feature toggle is set to support the new form', () => {
     const date = getDate({ offset: { years: -110 } });
     validateDate(errors, date, { [SHOW_PART3]: true });
-    expect(errorMessage[0]).to.eq(issueErrorMessages.recentDate);
+    expect(errorMessage[0]).to.eq(issueErrorMessages.newerDate);
     expect(errorMessage[1]).to.not.contain('month');
     expect(errorMessage[1]).to.not.contain('day');
     expect(errorMessage[1]).to.contain('year');

--- a/src/applications/appeals/10182/validations/date.js
+++ b/src/applications/appeals/10182/validations/date.js
@@ -34,11 +34,11 @@ export const validateDate = (
   const hasMessages = addDateErrorMessages(errors, issueErrorMessages, date);
   if (!hasMessages) {
     if (!data[SHOW_PART3] && date.momentDate.isBefore(minDate1)) {
-      errors.addError(issueErrorMessages.newerDate);
+      errors.addError(issueErrorMessages.recentDate);
       date.errors.year = true;
     } else if (date.momentDate.isBefore(minDate100)) {
       // max 1 year for old form or 100 years for newer form
-      errors.addError(issueErrorMessages.recentDate);
+      errors.addError(issueErrorMessages.newerDate);
       date.errors.year = true; // only the year is invalid at this point
     }
   }

--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -68,7 +68,8 @@ export const errorMessages = {
   decisions: {
     blankDate: 'You must enter a decision date',
     pastDate: 'You must add a decision date that’s in the past',
-    newerDate: 'You must add a more recent decision date',
+    newerDate:
+      'You must add an issue with a decision date that’s less than 100 years old',
   },
   evidence: {
     // VA evidence

--- a/src/applications/appeals/995/tests/components/AddIssue.unit.spec.js
+++ b/src/applications/appeals/995/tests/components/AddIssue.unit.spec.js
@@ -72,7 +72,6 @@ describe('<AddIssue>', () => {
     expect(elems[1].invalidMonth).to.be.true;
     expect(elems[1].invalidDay).to.be.true;
     expect(elems[1].invalidYear).to.be.true;
-
     expect(goToPathSpy.called).to.be.false;
   });
   it('should navigate on cancel', () => {


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  - `newerDate` updated to `recentDate` to match `recentDate` in 995 since they're the same error message
  - language in error messages updated for NOD to match Supplemental Claim's error messages
  - added `expect($('h3', container)).to.exist;` to unit test to match 995's unit test
- _(If bug, how to reproduce)_
  - not a bug (content matching that of 995-Supplemental Claims
- _(What is the solution, why is this the solution)_
  - Content team has reviewed and approved specific language to be used when errors occur related to contestable issues
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - Benefits Management and Decision Reviews

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#64708

## Testing done

- _Describe what the old behavior was prior to the change_
  - Outdated language was still being used
- _Describe the steps required to verify your changes are working as expected_
  - No logical change - only content updates
- _Describe the tests completed and the results_
  - Already existing and updated to match 995's

## What areas of the site does it impact?
Appeals

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed