### PR TITLE
VFE-864 A future date is a valid ActiveDuty Date.

### DIFF
--- a/src/applications/edu-benefits/1995/containers/PreSubmitInfo.jsx
+++ b/src/applications/edu-benefits/1995/containers/PreSubmitInfo.jsx
@@ -1,12 +1,27 @@
 import React from 'react';
 import PreSubmitInfo from '../../containers/PreSubmitInfo';
 
+function isNoToDate(to) {
+  return to == null;
+}
+
+function isFutureDate(to) {
+  const toDate = new Date(to);
+  const now = new Date();
+  //  To Date is in the past.
+  return toDate > now;
+}
+
+function inValidToDate(to) {
+  return isFutureDate(to) || isNoToDate(to);
+}
+
 export function isActiveDuty(formData) {
   try {
     let result = false;
     const toursOfDuty = formData?.toursOfDuty || [];
     toursOfDuty.map(data => {
-      if (data && data.dateRange && data?.dateRange?.to == null) {
+      if (data && data.dateRange && inValidToDate(data?.dateRange?.to)) {
         result = true;
       }
       return data;


### PR DESCRIPTION
## Summary

- VFE-864 A future date is a valid Active  Duty Date.

## Jira Ticket

As a...

VFEP Business User

I want...

a note to display when applicant has indicated that they are currently on Active Duty by entering a new service period with an end date in the future.

So that...

the Veteran is aware of all possible education benefits allowed for them

Acceptance Criteria:

Display As an active-duty service member, you have consulted with an Education Service Officer (ESO) regarding your education program. in signature/certification block when applicant as indicated in Service History section that they are "Active Duty", which is derived based on entering new service with an end date in the future (as well as the current empty end date).   

<img width="377" alt="image-2023-09-26-15-49-15-133" src="https://github.com/department-of-veterans-affairs/vets-website/assets/95312667/e5e58cc6-f326-4bdf-917f-c25dc76312e5">

