### PR TITLE
Fix confirmation page in direct schedule flow

### DIFF
--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -368,6 +368,10 @@ export default function getNewAppointmentFlow(state) {
         ? 'request-date'
         : '/new-appointment/request-date',
     },
+    review: {
+      ...flow.review,
+      url: featureBreadcrumbUrlUpdate ? 'review' : '/new-appointment/review',
+    },
     scheduleCerner: {
       ...flow.scheduleCerner,
       url: featureBreadcrumbUrlUpdate

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -14,6 +14,7 @@ import {
   selectFeatureVAOSServiceVAAppointments,
   selectFeatureClinicFilter,
   selectFeatureAcheronService,
+  selectFeatureBreadcrumbUrlUpdate,
 } from '../../redux/selectors';
 import {
   getTypeOfCare,
@@ -732,6 +733,7 @@ export function submitAppointmentOrRequest(history) {
     const featureAcheronVAOSServiceRequests = selectFeatureAcheronService(
       state,
     );
+    const featureBreadcrumbUrlUpdate = selectFeatureBreadcrumbUrlUpdate(state);
     const newAppointment = getNewAppointment(state);
     const data = newAppointment?.data;
     const typeOfCare = getTypeOfCare(getFormData(state))?.name;
@@ -775,7 +777,11 @@ export function submitAppointmentOrRequest(history) {
         resetDataLayer();
 
         if (featureVAOSServiceVAAppointments) {
-          history.push(`/va/${appointment.id}?confirmMsg=true`);
+          if (featureBreadcrumbUrlUpdate) {
+            history.push(`/${appointment.id}?confirmMsg=true`);
+          } else {
+            history.push(`/va/${appointment.id}?confirmMsg=true`);
+          }
         } else {
           history.push('/new-appointment/confirmation');
         }

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -39,6 +39,7 @@ const confirmedV2 = require('./v2/confirmed.json');
 
 // Returns the meta object without any backend service errors
 const meta = require('./v2/meta.json');
+const momentTz = require('../../lib/moment-tz');
 
 varSlots.data[0].attributes.appointmentTimeSlot = generateMockSlots();
 const mockAppts = [];
@@ -220,11 +221,15 @@ const responses = {
     const selectedTime = appointmentSlotsV2.data
       .filter(slot => slot.id === req.body.slot?.id)
       .map(slot => slot.attributes.start);
+    // convert to local time in America/Denver timezone
+    const localTime = momentTz(selectedTime[0])
+      .tz('America/Denver')
+      .format('YYYY-MM-DDTHH:mm:ss');
     const submittedAppt = {
       id: `mock${currentMockId}`,
       attributes: {
         ...req.body,
-        start: req.body.slot?.id ? selectedTime[0] : null,
+        localStartTime: req.body.slot?.id ? localTime : null,
         preferredProviderName: providerNpi ? providerMock[providerNpi] : null,
       },
     };


### PR DESCRIPTION
## Summary
This PR fixes the confirmation page in the direct schedule flow. 

## Acceptance criteria
Background: the `va_online_scheduling_breadcrumb_url_update` toggle is on

- [ ] Given the user is on `Upcoming VA appointments` landing page, 
        And the user clicks on `Start Scheduling` button and books an appointment
        Then the URL will be updated to: https://va.gov/my-health/appointments/[ID]?confirmMsg=true

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#66477


## Testing done

n/a

## Screenshots

![Screenshot 2023-09-27 at 11 09 41 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/dd6df23b-c180-4a48-b219-c6270ccb77b4)


## What areas of the site does it impact?

DS confirmation page



