### PR TITLE
New feature flag for SW assets calculations Frontend

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -75,6 +75,7 @@ export default Object.freeze({
   fileUploadShortWorkflowEnabled: 'file_upload_short_workflow_enabled',
   financialStatusReportDebtsApiModule: 'financial_status_report_debts_api_module',
   financialStatusReportStreamlinedWaiver: 'financial_status_report_streamlined_waiver',
+  financialStatusReportStreamlinedWaiverAssets: 'financial_status_report_streamlined_waiver_assets',
   form10182Nod: 'form10182_nod',
   form2110210: 'form2110210',
   form210845: 'form210845',


### PR DESCRIPTION
## Summary

This PR creates a new feature flag called `financial_status_report_streamlined_waiver_assets ` which Enables a simplified asset calculation flow, including Cash in Bank, for users completing the Financial Status Report (FSR) form.


Companion PR for feature flag on **Vets Api**
https://github.com/department-of-veterans-affairs/vets-api/pull/13964

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#66505

## Testing done

- Verified the financial_status_report_streamlined_waiver_assets feature flag appears in http://localhost:3000/flipper/features
- Followed instructions on https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles
- Tested flag locally

![Screenshot 2023-09-27 at 9 50 23 PM](https://github.com/department-of-veterans-affairs/vets-api/assets/3916436/0301dfde-3c11-49e0-9aef-0b0674845896)


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._



![Screenshot 2023-09-27 at 9 50 46 PM](https://github.com/department-of-veterans-affairs/vets-api/assets/3916436/d716eb23-a5fc-4732-9156-fefae5e81035)


## What areas of the site does it impact?

Financial Status Report  https://va.gov/manage-va-debt/request-debt-help-form-5655/introduction

## Acceptance criteria

-[x] New feature flag has been created for streamlined waiver work

### Quality Assurance & Testing
- [x] Screenshot of the developed feature is added



