### PR TITLE
My VA - minor copy fix for Benefit application drafts section

### DIFF
--- a/src/applications/personalization/dashboard/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard/components/Dashboard.jsx
@@ -106,7 +106,7 @@ const LOA1Content = ({ isLOA1, isVAPatient, useLighthouseClaims }) => {
 
           <HealthCare isVAPatient={isVAPatient} isLOA1={isLOA1} />
           <EducationAndTraining isLOA1={isLOA1} />
-          <SavedApplications />
+          <SavedApplications isLOA1={isLOA1} />
         </>
       </Toggler.Enabled>
 

--- a/src/applications/personalization/dashboard/components/apply-for-benefits/ApplicationsInProgress.jsx
+++ b/src/applications/personalization/dashboard/components/apply-for-benefits/ApplicationsInProgress.jsx
@@ -2,10 +2,7 @@ import React, { useMemo } from 'react';
 import { connect } from 'react-redux';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import {
-  isLOA3 as isLOA3Selector,
-  selectProfile,
-} from '~/platform/user/selectors';
+import { selectProfile } from '~/platform/user/selectors';
 
 import {
   filterOutExpiredForms,
@@ -18,7 +15,7 @@ import {
 
 import ApplicationInProgress from './ApplicationInProgress';
 
-const ApplicationsInProgress = ({ savedForms, hideH3, isLOA3 }) => {
+const ApplicationsInProgress = ({ savedForms, hideH3, isLOA1 }) => {
   // Filter out non-SIP-enabled applications and expired applications
   const verifiedSavedForms = useMemo(
     () =>
@@ -29,8 +26,8 @@ const ApplicationsInProgress = ({ savedForms, hideH3, isLOA3 }) => {
     [savedForms],
   );
 
-  // if LOA3 then show 'You have no benefit application drafts to show.', otherwise show 'You have no applications in progress.'
-  const emptyStateText = isLOA3
+  // if LOA1 then show 'You have no benefit application drafts to show.', otherwise show 'You have no applications in progress.'
+  const emptyStateText = isLOA1
     ? 'You have no benefit application drafts to show.'
     : 'You have no applications in progress.';
 
@@ -83,16 +80,13 @@ const ApplicationsInProgress = ({ savedForms, hideH3, isLOA3 }) => {
 
 ApplicationsInProgress.propTypes = {
   hideH3: PropTypes.bool,
-  isLOA3: PropTypes.bool,
+  isLOA1: PropTypes.bool,
   savedForms: PropTypes.array,
 };
 
 const mapStateToProps = state => {
-  const isLOA3 = isLOA3Selector(state);
-
   return {
     savedForms: selectProfile(state).savedForms || [],
-    isLOA3,
   };
 };
 

--- a/src/applications/personalization/dashboard/components/apply-for-benefits/SavedApplications.jsx
+++ b/src/applications/personalization/dashboard/components/apply-for-benefits/SavedApplications.jsx
@@ -54,7 +54,11 @@ const AllBenefits = () => (
   </div>
 );
 
-const SavedApplications = ({ getESREnrollmentStatus, shouldGetESRStatus }) => {
+const SavedApplications = ({
+  getESREnrollmentStatus,
+  isLOA1,
+  shouldGetESRStatus,
+}) => {
   useEffect(
     () => {
       if (shouldGetESRStatus) {
@@ -72,7 +76,7 @@ const SavedApplications = ({ getESREnrollmentStatus, shouldGetESRStatus }) => {
           <AllBenefits />
         </Toggler.Disabled>
       </Toggler>
-      <ApplicationsInProgress hideH3 />
+      <ApplicationsInProgress hideH3 isLOA1={isLOA1} />
     </div>
   );
 };
@@ -94,6 +98,7 @@ const mapStateToProps = state => {
 
 SavedApplications.propTypes = {
   getESREnrollmentStatus: PropTypes.func,
+  isLOA1: PropTypes.bool,
   shouldGetESRStatus: PropTypes.bool,
 };
 

--- a/src/applications/personalization/dashboard/tests/components/apply-for-benefits/ApplicationsInProgress.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/apply-for-benefits/ApplicationsInProgress.unit.spec.jsx
@@ -172,7 +172,7 @@ describe('ApplicationsInProgress component', () => {
 
     expect(view.getByTestId('applications-in-progress-header')).to.exist;
     expect(
-      view.getByText('You have no benefit application drafts to show', {
+      view.getByText('You have no applications in progress', {
         exact: false,
       }),
     ).to.exist;

--- a/src/applications/personalization/dashboard/tests/e2e/in-progress-forms.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/in-progress-forms.cypress.spec.js
@@ -114,7 +114,7 @@ describe('The My VA Dashboard', () => {
       cy.axeCheck();
     });
   });
-  describe('when there are no-progress forms', () => {
+  describe('when there are no in-progress forms', () => {
     beforeEach(() => {
       // a single form that fails the `isSIPEnabledForm()` check so none will be
       // shown
@@ -150,9 +150,7 @@ describe('The My VA Dashboard', () => {
         'exist',
       );
       cy.findAllByTestId('application-in-progress').should('have.length', 0);
-      cy.findByText(/you have no benefit application drafts to show/i).should(
-        'exist',
-      );
+      cy.findByText(/you have no applications in progress/i).should('exist');
       cy.injectAxe();
       cy.axeCheck();
     });


### PR DESCRIPTION
## Summary
This PR fixes the empty state copy for Benefit application draft section on My VA for LOA1 users, and updates the unit tests for the section.

The changes currently live behind the `myVaUseExperimentalFrontendfeature` flag, but all [LOA1 UX updates will be launched](https://github.com/department-of-veterans-affairs/va.gov-team/issues/66186) after this PR is merged. 

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/66009
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/66187
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/66186

- Epic: https://github.com/department-of-veterans-affairs/va.gov-team/issues/63424

## Testing done
- locally, visually
- all unit tests still pass

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

 | Before | After |
| ------ | ----- |
 |      ![localhost_3001_my-va_ (1)](https://github.com/department-of-veterans-affairs/vets-website/assets/8542413/a0f888d4-009f-4e9a-ae78-f27cd32dcd79)  |    ![localhost_3001_my-va_](https://github.com/department-of-veterans-affairs/vets-website/assets/8542413/90fe8565-8651-4b68-b083-0cb0c954e4fb)   |

## What areas of the site does it impact?
My VA - Benefit application drafts (LOA1 users who have no applications in progress only)

## Acceptance criteria
- [ ] BAD LOA1 empty state copy updated to **You have no benefit application drafts to show.**

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added

### Error Handling

- [x] Browser console contains no warnings or errors.

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user