### PR TITLE
[department-of-veterans-affairs/va-virtual-agent#1105] Decision Letters

### DIFF
--- a/src/applications/virtual-agent/components/webchat/WebChat.jsx
+++ b/src/applications/virtual-agent/components/webchat/WebChat.jsx
@@ -213,17 +213,17 @@ const WebChat = ({ token, WebChatFramework, apiSession }) => {
       sendBox.setAttribute('placeholder', 'Type your message');
     }
   }
-  const urls = new Set();
+  const decisionLetterUrls = new Set();
   return (
     <div data-testid="webchat" style={{ height: '550px', width: '100%' }}>
       <ReactWebChat
         cardActionMiddleware={cardActionMiddleware(
           virtualAgentDecisionLetterDownloadTracking,
-          urls,
+          decisionLetterUrls,
         )}
         activityMiddleware={activityMiddleware(
           virtualAgentDecisionLetterDownloadTracking,
-          urls,
+          decisionLetterUrls,
         )}
         styleOptions={styleOptions}
         directLine={directLine}

--- a/src/applications/virtual-agent/components/webchat/WebChat.jsx
+++ b/src/applications/virtual-agent/components/webchat/WebChat.jsx
@@ -213,15 +213,17 @@ const WebChat = ({ token, WebChatFramework, apiSession }) => {
       sendBox.setAttribute('placeholder', 'Type your message');
     }
   }
+  const urls = new Set();
   return (
     <div data-testid="webchat" style={{ height: '550px', width: '100%' }}>
       <ReactWebChat
         cardActionMiddleware={cardActionMiddleware(
           virtualAgentDecisionLetterDownloadTracking,
+          urls,
         )}
         activityMiddleware={activityMiddleware(
           virtualAgentDecisionLetterDownloadTracking,
-          new Set(),
+          urls,
         )}
         styleOptions={styleOptions}
         directLine={directLine}

--- a/src/applications/virtual-agent/components/webchat/WebChat.jsx
+++ b/src/applications/virtual-agent/components/webchat/WebChat.jsx
@@ -15,7 +15,7 @@ import {
   clearBotSessionStorage,
   IS_RX_SKILL,
 } from '../chatbox/utils';
-import { cardActionMiddleware, activityMiddleware } from './helpers/webChat';
+import { cardActionMiddleware } from './helpers/webChat';
 
 const renderMarkdown = text => MarkdownRenderer.render(text);
 
@@ -213,17 +213,11 @@ const WebChat = ({ token, WebChatFramework, apiSession }) => {
       sendBox.setAttribute('placeholder', 'Type your message');
     }
   }
-  const decisionLetterUrls = new Set();
   return (
     <div data-testid="webchat" style={{ height: '550px', width: '100%' }}>
       <ReactWebChat
         cardActionMiddleware={cardActionMiddleware(
           virtualAgentDecisionLetterDownloadTracking,
-          decisionLetterUrls,
-        )}
-        activityMiddleware={activityMiddleware(
-          virtualAgentDecisionLetterDownloadTracking,
-          decisionLetterUrls,
         )}
         styleOptions={styleOptions}
         directLine={directLine}

--- a/src/applications/virtual-agent/components/webchat/WebChat.jsx
+++ b/src/applications/virtual-agent/components/webchat/WebChat.jsx
@@ -15,7 +15,7 @@ import {
   clearBotSessionStorage,
   IS_RX_SKILL,
 } from '../chatbox/utils';
-import { cardActionMiddleware } from './helpers/webChat';
+import { cardActionMiddleware, activityMiddleware } from './helpers/webChat';
 
 const renderMarkdown = text => MarkdownRenderer.render(text);
 
@@ -218,6 +218,10 @@ const WebChat = ({ token, WebChatFramework, apiSession }) => {
       <ReactWebChat
         cardActionMiddleware={cardActionMiddleware(
           virtualAgentDecisionLetterDownloadTracking,
+        )}
+        activityMiddleware={activityMiddleware(
+          virtualAgentDecisionLetterDownloadTracking,
+          new Set(),
         )}
         styleOptions={styleOptions}
         directLine={directLine}

--- a/src/applications/virtual-agent/components/webchat/WebChat.jsx
+++ b/src/applications/virtual-agent/components/webchat/WebChat.jsx
@@ -15,21 +15,9 @@ import {
   clearBotSessionStorage,
   IS_RX_SKILL,
 } from '../chatbox/utils';
+import { cardActionMiddleware } from './helpers/webChat';
 
 const renderMarkdown = text => MarkdownRenderer.render(text);
-
-export const cardActionMiddleware = () => next => card => {
-  const isDecisionLetter = card.cardAction.value.includes('/v0/claim_letters/');
-  if (isDecisionLetter) {
-    // Track decision letter downloads
-    recordEvent({
-      event: 'file_download',
-      'button-click-label': 'Decision Letter',
-      time: new Date(Date.now()),
-    });
-  }
-  next(card);
-};
 
 const WebChat = ({ token, WebChatFramework, apiSession }) => {
   const { ReactWebChat, createDirectLine, createStore } = WebChatFramework;

--- a/src/applications/virtual-agent/components/webchat/WebChat.jsx
+++ b/src/applications/virtual-agent/components/webchat/WebChat.jsx
@@ -18,17 +18,18 @@ import {
 
 const renderMarkdown = text => MarkdownRenderer.render(text);
 
-export function cardActionMiddleware(next, card) {
-  // Track decision letter downloads
-  if (card.cardAction.value.includes('/v0/claim_letters/')) {
+export const cardActionMiddleware = () => next => ({ cardAction }) => {
+  const isDecisionLetter = cardAction.value.includes('/v0/claim_letters/');
+  if (isDecisionLetter) {
+    // Track decision letter downloads
     recordEvent({
       event: 'file_download',
       'button-click-label': 'Decision Letter',
       time: new Date(Date.now()),
     });
   }
-  next(card);
-}
+  next(cardAction);
+};
 
 const WebChat = ({ token, WebChatFramework, apiSession }) => {
   const { ReactWebChat, createDirectLine, createStore } = WebChatFramework;
@@ -230,8 +231,7 @@ const WebChat = ({ token, WebChatFramework, apiSession }) => {
     return (
       <div data-testid="webchat" style={{ height: '550px', width: '100%' }}>
         <ReactWebChat
-          cardActionMiddleware={() => next => card =>
-            cardActionMiddleware(next, card)}
+          cardActionMiddleware={cardActionMiddleware}
           styleOptions={styleOptions}
           directLine={directLine}
           store={store}

--- a/src/applications/virtual-agent/components/webchat/WebChat.jsx
+++ b/src/applications/virtual-agent/components/webchat/WebChat.jsx
@@ -94,9 +94,9 @@ const WebChat = ({ token, WebChatFramework, apiSession }) => {
   const BUTTONS = 49.2;
   const styleOptions = {
     hideUploadButton: true,
-    botAvatarBackgroundColor: '#003e73', // color-primary-darker
+    botAvatarBackgroundColor: '#003e73',
     botAvatarInitials: 'VA',
-    userAvatarBackgroundColor: '#003e73', // color-primary-darker
+    userAvatarBackgroundColor: '#003e73',
     userAvatarInitials: 'You',
     primaryFont: 'Source Sans Pro, sans-serif',
     bubbleBorderRadius: 5,
@@ -117,7 +117,7 @@ const WebChat = ({ token, WebChatFramework, apiSession }) => {
     suggestedActionBorderRadius: 5,
     suggestedActionBorderWidth: 0,
     microphoneButtonColorOnDictate: 'rgb(255, 255, 255)',
-  };
+  }; // color-primary-darker // color-primary-darker
 
   const handleTelemetry = event => {
     const { name } = event;
@@ -138,9 +138,7 @@ const WebChat = ({ token, WebChatFramework, apiSession }) => {
       environment.isDev() || environment.isLocalhost() ? 'eastus' : 'eastus2';
 
     async function callVirtualAgentVoiceTokenApi() {
-      return apiRequest('/virtual_agent_speech_token', {
-        method: 'POST',
-      });
+      return apiRequest('/virtual_agent_speech_token', { method: 'POST' });
     }
     const speechToken = await callVirtualAgentVoiceTokenApi();
     return webchat.createCognitiveServicesSpeechServicesPonyfillFactory({
@@ -215,23 +213,12 @@ const WebChat = ({ token, WebChatFramework, apiSession }) => {
       sendBox.setAttribute('placeholder', 'Type your message');
     }
   }
-  if (virtualAgentDecisionLetterDownloadTracking) {
-    return (
-      <div data-testid="webchat" style={{ height: '550px', width: '100%' }}>
-        <ReactWebChat
-          cardActionMiddleware={cardActionMiddleware}
-          styleOptions={styleOptions}
-          directLine={directLine}
-          store={store}
-          renderMarkdown={renderMarkdown}
-          onTelemetry={handleTelemetry}
-        />
-      </div>
-    );
-  }
   return (
     <div data-testid="webchat" style={{ height: '550px', width: '100%' }}>
       <ReactWebChat
+        cardActionMiddleware={cardActionMiddleware(
+          virtualAgentDecisionLetterDownloadTracking,
+        )}
         styleOptions={styleOptions}
         directLine={directLine}
         store={store}

--- a/src/applications/virtual-agent/components/webchat/WebChat.jsx
+++ b/src/applications/virtual-agent/components/webchat/WebChat.jsx
@@ -18,8 +18,8 @@ import {
 
 const renderMarkdown = text => MarkdownRenderer.render(text);
 
-export const cardActionMiddleware = () => next => ({ cardAction }) => {
-  const isDecisionLetter = cardAction.value.includes('/v0/claim_letters/');
+export const cardActionMiddleware = () => next => card => {
+  const isDecisionLetter = card.cardAction.value.includes('/v0/claim_letters/');
   if (isDecisionLetter) {
     // Track decision letter downloads
     recordEvent({
@@ -28,7 +28,7 @@ export const cardActionMiddleware = () => next => ({ cardAction }) => {
       time: new Date(Date.now()),
     });
   }
-  next(cardAction);
+  next(card);
 };
 
 const WebChat = ({ token, WebChatFramework, apiSession }) => {

--- a/src/applications/virtual-agent/components/webchat/helpers/webChat.js
+++ b/src/applications/virtual-agent/components/webchat/helpers/webChat.js
@@ -1,0 +1,30 @@
+// import recordEvent from 'platform/monitoring/record-event';
+
+// export const cardActionMiddleware = () => next => card => {
+//   const isDecisionLetter = card.cardAction.value.includes('/v0/claim_letters/');
+//   if (isDecisionLetter) {
+//     // Track decision letter downloads
+//     recordEvent({
+//       event: 'file_download',
+//       'button-click-label': 'Decision Letter',
+//       time: new Date(Date.now()),
+//     });
+//   }
+//   next(card);
+// };
+
+import recordEvent from 'platform/monitoring/record-event';
+
+export const cardActionMiddleware = decisionLetterEnabled => () => next => card => {
+  const isDecisionLetter = card.cardAction.value.includes('/v0/claim_letters/');
+  if (decisionLetterEnabled && isDecisionLetter) {
+    const recordDecisionLetterDownload = () =>
+      recordEvent({
+        event: 'file_download',
+        'button-click-label': 'Decision Letter',
+        time: new Date(Date.now()),
+      });
+    recordDecisionLetterDownload();
+  }
+  next(card);
+};

--- a/src/applications/virtual-agent/components/webchat/helpers/webChat.js
+++ b/src/applications/virtual-agent/components/webchat/helpers/webChat.js
@@ -1,10 +1,17 @@
 import recordEvent from 'platform/monitoring/record-event';
 
-export const cardActionMiddleware = decisionLetterEnabled => () => next => card => {
+export const cardActionMiddleware = (
+  decisionLetterEnabled,
+  urls,
+) => () => next => card => {
   const { cardAction } = card;
-  const isDecisionLetter = cardAction.value.includes('/v0/claim_letters/');
+  // const isDecisionLetter = cardAction.value.includes('/v0/claim_letters/');
+  const isDecisionLetter = () => {
+    const url = cardAction.value.replace('https://', '');
+    return urls.has(url);
+  };
   const actionIsOpenUrl = cardAction.type === 'openUrl';
-  if (decisionLetterEnabled && actionIsOpenUrl && isDecisionLetter) {
+  if (decisionLetterEnabled && actionIsOpenUrl && isDecisionLetter()) {
     const recordDecisionLetterDownload = () =>
       recordEvent({
         event: 'file_download',

--- a/src/applications/virtual-agent/components/webchat/helpers/webChat.js
+++ b/src/applications/virtual-agent/components/webchat/helpers/webChat.js
@@ -15,3 +15,26 @@ export const cardActionMiddleware = decisionLetterEnabled => () => next => card 
   }
   next(card);
 };
+
+export const activityMiddleware = (
+  featureFlag,
+  setOfUrls,
+) => () => next => card => children => {
+  const { activity } = card;
+  const isDecisionLetterCard = () =>
+    activity.type === 'message' &&
+    activity.attachments[0]?.content?.body[0]?.text ===
+      'Claims Decision Letters';
+  if (featureFlag && isDecisionLetterCard()) {
+    activity.attachments[0].content.body.forEach(body => {
+      const isOpenUrl = () =>
+        body?.columns?.[0]?.items?.[0]?.actions?.[0]?.type === 'Action.OpenUrl';
+      if (isOpenUrl()) {
+        const { url } = body.columns[0].items[0].actions[0];
+        setOfUrls.add(url);
+      }
+    });
+  }
+
+  return next(card)(children);
+};

--- a/src/applications/virtual-agent/components/webchat/helpers/webChat.js
+++ b/src/applications/virtual-agent/components/webchat/helpers/webChat.js
@@ -1,17 +1,10 @@
 import recordEvent from 'platform/monitoring/record-event';
 
-export const cardActionMiddleware = (
-  decisionLetterEnabled,
-  urls,
-) => () => next => card => {
+export const cardActionMiddleware = decisionLetterEnabled => () => next => card => {
   const { cardAction } = card;
-  // const isDecisionLetter = cardAction.value.includes('/v0/claim_letters/');
-  const isDecisionLetter = () => {
-    const url = cardAction.value.replace('https://', '');
-    return urls.has(url);
-  };
+  const isDecisionLetter = cardAction.value.includes('/v0/claim_letters/');
   const actionIsOpenUrl = cardAction.type === 'openUrl';
-  if (decisionLetterEnabled && actionIsOpenUrl && isDecisionLetter()) {
+  if (decisionLetterEnabled && actionIsOpenUrl && isDecisionLetter) {
     const recordDecisionLetterDownload = () =>
       recordEvent({
         event: 'file_download',
@@ -21,27 +14,4 @@ export const cardActionMiddleware = (
     recordDecisionLetterDownload();
   }
   next(card);
-};
-
-export const activityMiddleware = (
-  featureFlag,
-  setOfUrls,
-) => () => next => card => children => {
-  const { activity } = card;
-  const isDecisionLetterCard = () =>
-    activity.type === 'message' &&
-    activity.attachments[0]?.content?.body[0]?.text ===
-      'Claims Decision Letters';
-  if (featureFlag && isDecisionLetterCard()) {
-    activity.attachments[0].content.body.forEach(body => {
-      const isOpenUrl = () =>
-        body?.columns?.[0]?.items?.[0]?.actions?.[0]?.type === 'Action.OpenUrl';
-      if (isOpenUrl()) {
-        const { url } = body.columns[0].items[0].actions[0];
-        setOfUrls.add(url);
-      }
-    });
-  }
-
-  return next(card)(children);
 };

--- a/src/applications/virtual-agent/components/webchat/helpers/webChat.js
+++ b/src/applications/virtual-agent/components/webchat/helpers/webChat.js
@@ -1,18 +1,3 @@
-// import recordEvent from 'platform/monitoring/record-event';
-
-// export const cardActionMiddleware = () => next => card => {
-//   const isDecisionLetter = card.cardAction.value.includes('/v0/claim_letters/');
-//   if (isDecisionLetter) {
-//     // Track decision letter downloads
-//     recordEvent({
-//       event: 'file_download',
-//       'button-click-label': 'Decision Letter',
-//       time: new Date(Date.now()),
-//     });
-//   }
-//   next(card);
-// };
-
 import recordEvent from 'platform/monitoring/record-event';
 
 export const cardActionMiddleware = decisionLetterEnabled => () => next => card => {

--- a/src/applications/virtual-agent/components/webchat/helpers/webChat.js
+++ b/src/applications/virtual-agent/components/webchat/helpers/webChat.js
@@ -16,8 +16,10 @@
 import recordEvent from 'platform/monitoring/record-event';
 
 export const cardActionMiddleware = decisionLetterEnabled => () => next => card => {
-  const isDecisionLetter = card.cardAction.value.includes('/v0/claim_letters/');
-  if (decisionLetterEnabled && isDecisionLetter) {
+  const { cardAction } = card;
+  const isDecisionLetter = cardAction.value.includes('/v0/claim_letters/');
+  const actionIsOpenUrl = cardAction.type === 'openUrl';
+  if (decisionLetterEnabled && actionIsOpenUrl && isDecisionLetter) {
     const recordDecisionLetterDownload = () =>
       recordEvent({
         event: 'file_download',

--- a/src/applications/virtual-agent/tests/components/webchat/Webchat.unit.spec.js
+++ b/src/applications/virtual-agent/tests/components/webchat/Webchat.unit.spec.js
@@ -47,7 +47,7 @@ describe('Webchat.jsx', () => {
       expect(recordEventStub.firstCall.args[0]).to.eql(recordEventData);
 
       expect(nextSpy.calledOnce).to.be.true;
-      expect(nextSpy.firstCall.args[0]).to.eql(decisionLetterCard.cardAction);
+      expect(nextSpy.firstCall.args[0]).to.eql(decisionLetterCard);
       dateStub.restore();
     });
 

--- a/src/applications/virtual-agent/tests/components/webchat/Webchat.unit.spec.js
+++ b/src/applications/virtual-agent/tests/components/webchat/Webchat.unit.spec.js
@@ -41,12 +41,13 @@ describe('Webchat.jsx', () => {
         time: new Date(Date.now()),
       };
 
-      cardActionMiddleware(nextSpy, decisionLetterCard);
+      cardActionMiddleware()(nextSpy)(decisionLetterCard);
 
       expect(recordEventStub.calledOnce).to.be.true;
       expect(recordEventStub.firstCall.args[0]).to.eql(recordEventData);
 
       expect(nextSpy.calledOnce).to.be.true;
+      expect(nextSpy.firstCall.args[0]).to.eql(decisionLetterCard.cardAction);
       dateStub.restore();
     });
 
@@ -55,7 +56,7 @@ describe('Webchat.jsx', () => {
         'random_thing_we_dont_use',
       );
       const { nextSpy, recordEventStub } = generateSinonFunctions();
-      cardActionMiddleware(nextSpy, nonDecisionLetterCard);
+      cardActionMiddleware()(nextSpy)(nonDecisionLetterCard);
       expect(recordEventStub.notCalled).to.be.true;
       expect(nextSpy.calledOnce).to.be.true;
     });

--- a/src/applications/virtual-agent/tests/components/webchat/Webchat.unit.spec.js
+++ b/src/applications/virtual-agent/tests/components/webchat/Webchat.unit.spec.js
@@ -1,0 +1,63 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import * as recordEventObject from 'platform/monitoring/record-event';
+import { cardActionMiddleware } from '../../../components/webchat/WebChat';
+
+const sandbox = sinon.createSandbox();
+
+describe('Webchat.jsx', () => {
+  describe('decision letter tracking', () => {
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    /**
+     * creates sinon functions for the tests
+     * @returns {{nextSpy: SinonSpy, recordEventStub: SinonStub}}
+     *          an object contianing sinon functions for next and recordEvent
+     */
+    const generateSinonFunctions = () => ({
+      nextSpy: sandbox.spy(),
+      recordEventStub: sandbox.stub(recordEventObject, 'default'),
+    });
+
+    /**
+     * create a fake action card
+     * @param {string} value url for the cardAction
+     * @returns {{cardAction: {value: string}}} fake cardAction card
+     */
+    const generateFakeCard = value => ({ cardAction: { value } });
+
+    it('should call recordEvent and next when card is a decision letter', () => {
+      const decisionLetterCard = generateFakeCard(
+        'https://www.va.gov/v0/claim_letters/abc',
+      );
+      const { nextSpy, recordEventStub } = generateSinonFunctions();
+      const dateStub = sandbox.stub(Date, 'now');
+      dateStub.returns(1234567890);
+      const recordEventData = {
+        event: 'file_download',
+        'button-click-label': 'Decision Letter',
+        time: new Date(Date.now()),
+      };
+
+      cardActionMiddleware(nextSpy, decisionLetterCard);
+
+      expect(recordEventStub.calledOnce).to.be.true;
+      expect(recordEventStub.firstCall.args[0]).to.eql(recordEventData);
+
+      expect(nextSpy.calledOnce).to.be.true;
+      dateStub.restore();
+    });
+
+    it('should only call next when card is not a decision letter', () => {
+      const nonDecisionLetterCard = generateFakeCard(
+        'random_thing_we_dont_use',
+      );
+      const { nextSpy, recordEventStub } = generateSinonFunctions();
+      cardActionMiddleware(nextSpy, nonDecisionLetterCard);
+      expect(recordEventStub.notCalled).to.be.true;
+      expect(nextSpy.calledOnce).to.be.true;
+    });
+  });
+});

--- a/src/applications/virtual-agent/tests/components/webchat/Webchat.unit.spec.js
+++ b/src/applications/virtual-agent/tests/components/webchat/Webchat.unit.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import * as recordEventObject from 'platform/monitoring/record-event';
-import { cardActionMiddleware } from '../../../components/webchat/WebChat';
+import { cardActionMiddleware } from '../../../components/webchat/helpers/webChat';
 
 const sandbox = sinon.createSandbox();
 
@@ -20,7 +20,7 @@ describe('Webchat.jsx', () => {
       nextSpy: sandbox.spy(),
       recordEventStub: sandbox.stub(recordEventObject, 'default'),
     });
-
+    const decisionLetterEnabled = true;
     /**
      * create a fake action card
      * @param {string} value url for the cardAction
@@ -41,7 +41,9 @@ describe('Webchat.jsx', () => {
         time: new Date(Date.now()),
       };
 
-      cardActionMiddleware()(nextSpy)(decisionLetterCard);
+      cardActionMiddleware(decisionLetterEnabled)()(nextSpy)(
+        decisionLetterCard,
+      );
 
       expect(recordEventStub.calledOnce).to.be.true;
       expect(recordEventStub.firstCall.args[0]).to.eql(recordEventData);
@@ -56,7 +58,9 @@ describe('Webchat.jsx', () => {
         'random_thing_we_dont_use',
       );
       const { nextSpy, recordEventStub } = generateSinonFunctions();
-      cardActionMiddleware()(nextSpy)(nonDecisionLetterCard);
+      cardActionMiddleware(decisionLetterEnabled)()(nextSpy)(
+        nonDecisionLetterCard,
+      );
       expect(recordEventStub.notCalled).to.be.true;
       expect(nextSpy.calledOnce).to.be.true;
     });

--- a/src/applications/virtual-agent/tests/components/webchat/Webchat.unit.spec.js
+++ b/src/applications/virtual-agent/tests/components/webchat/Webchat.unit.spec.js
@@ -6,27 +6,27 @@ import { cardActionMiddleware } from '../../../components/webchat/helpers/webCha
 const sandbox = sinon.createSandbox();
 
 describe('Webchat.jsx', () => {
-  describe('decision letter tracking', () => {
-    afterEach(() => {
-      sandbox.restore();
-    });
+  /**
+   * create a fake action card
+   * @param {string} value url for the cardAction
+   * @returns {{cardAction: {value: string}}} fake cardAction card
+   */
+  const generateFakeCard = value => ({ cardAction: { value } });
+  /**
+   * creates sinon functions for the tests
+   * @returns {{nextSpy: SinonSpy, recordEventStub: SinonStub}}
+   *          an object containing sinon functions for next and recordEvent
+   */
 
-    /**
-     * creates sinon functions for the tests
-     * @returns {{nextSpy: SinonSpy, recordEventStub: SinonStub}}
-     *          an object contianing sinon functions for next and recordEvent
-     */
-    const generateSinonFunctions = () => ({
-      nextSpy: sandbox.spy(),
-      recordEventStub: sandbox.stub(recordEventObject, 'default'),
-    });
+  const generateSinonFunctions = () => ({
+    nextSpy: sandbox.spy(),
+    recordEventStub: sandbox.stub(recordEventObject, 'default'),
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+  describe('when decision letter tracking is enabled', () => {
     const decisionLetterEnabled = true;
-    /**
-     * create a fake action card
-     * @param {string} value url for the cardAction
-     * @returns {{cardAction: {value: string}}} fake cardAction card
-     */
-    const generateFakeCard = value => ({ cardAction: { value } });
 
     it('should call recordEvent and next when card is a decision letter', () => {
       const decisionLetterCard = generateFakeCard(
@@ -53,7 +53,7 @@ describe('Webchat.jsx', () => {
       dateStub.restore();
     });
 
-    it('should only call next when card is not a decision letter', () => {
+    it('should not call recordEvent when card is not a decision letter', () => {
       const nonDecisionLetterCard = generateFakeCard(
         'random_thing_we_dont_use',
       );
@@ -63,6 +63,23 @@ describe('Webchat.jsx', () => {
       );
       expect(recordEventStub.notCalled).to.be.true;
       expect(nextSpy.calledOnce).to.be.true;
+      expect(nextSpy.firstCall.args[0]).to.eql(nonDecisionLetterCard);
+    });
+  });
+
+  describe('when decision letter tracking is disabled', () => {
+    it('should not call recordEvent', () => {
+      const decisionLetterEnabled = false;
+      const nonDecisionLetterCard = generateFakeCard(
+        'random_thing_we_dont_use',
+      );
+      const { nextSpy, recordEventStub } = generateSinonFunctions();
+      cardActionMiddleware(decisionLetterEnabled)()(nextSpy)(
+        nonDecisionLetterCard,
+      );
+      expect(recordEventStub.notCalled).to.be.true;
+      expect(nextSpy.calledOnce).to.be.true;
+      expect(nextSpy.firstCall.args[0]).to.eql(nonDecisionLetterCard);
     });
   });
 });

--- a/src/applications/virtual-agent/tests/components/webchat/helpers/webchat.unit.spec.js
+++ b/src/applications/virtual-agent/tests/components/webchat/helpers/webchat.unit.spec.js
@@ -2,10 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import * as recordEventObject from 'platform/monitoring/record-event';
 import { describe } from 'mocha';
-import {
-  cardActionMiddleware,
-  activityMiddleware,
-} from '../../../../components/webchat/helpers/webChat';
+import { cardActionMiddleware } from '../../../../components/webchat/helpers/webChat';
 
 const sandbox = sinon.createSandbox();
 
@@ -13,168 +10,7 @@ describe('Webchat.jsx Helpers', () => {
   afterEach(() => {
     sandbox.restore();
   });
-  describe('activityMiddleware', () => {
-    /**
-     * Pseudo code for the activityMiddleware
-     * 1. Create a curried version of a activityMiddleware that takes in a
-     *    set.
-     * 2. only do main body of function if and only if the feature flag is
-     *    enabled
-     * 3. update the set to contain the urls for the decision letters if and
-     *    only if the card is an decision letter card containing openUrl actions
-     *
-     * Test cases:
-     * 1. when the feature flag is enabled and the card is a decision letter
-     *   - we should add url to set when there is only one decision letter
-     *   - we should add urls to set when there are multiple decision letters
-     */
-
-    describe('When decision letter feature flag is enabled', () => {
-      const generateFakeCard = (text, ...urls) => {
-        const newCard = {
-          activity: {
-            type: 'message',
-            attachments: [
-              {
-                content: {
-                  body: [
-                    {
-                      text,
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-        };
-        return urls.reduce((card, url) => {
-          card.activity.attachments[0].content.body.push({
-            columns: [
-              {
-                items: [
-                  {
-                    actions: [
-                      {
-                        type: 'Action.OpenUrl',
-                        url,
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          });
-          return card;
-        }, newCard);
-      };
-      const featureFlagEnabled = true;
-      it('should call next and not add anything to the set when the card is not a decision letter', () => {
-        const nextStub = sandbox.stub();
-        const card = generateFakeCard('not a decision letter');
-        const setOfDecisionLetterUrls = new Set();
-        const childrenObject = {};
-        const childrenSpy = sandbox.spy();
-
-        nextStub.returns(childrenSpy);
-
-        activityMiddleware(featureFlagEnabled, setOfDecisionLetterUrls)()(
-          nextStub,
-        )(card)(childrenObject);
-
-        expect(nextStub.calledOnce).to.be.true;
-        expect(nextStub.firstCall.args[0]).to.equal(card);
-
-        expect(childrenSpy.calledOnce).to.be.true;
-        expect(childrenSpy.firstCall.args[0]).to.equal(childrenObject);
-
-        expect(setOfDecisionLetterUrls.size).to.equal(0);
-      });
-      it('should add url to set when there is only one decision letter', () => {
-        const nextStub = sandbox.stub();
-        const card = generateFakeCard('Claims Decision Letters', 'url1');
-        const setOfDecisionLetterUrls = new Set();
-        const childrenObject = {};
-        const childrenSpy = sandbox.spy();
-
-        nextStub.returns(childrenSpy);
-
-        activityMiddleware(featureFlagEnabled, setOfDecisionLetterUrls)()(
-          nextStub,
-        )(card)(childrenObject);
-
-        expect(nextStub.calledOnce).to.be.true;
-        expect(nextStub.firstCall.args[0]).to.equal(card);
-
-        expect(childrenSpy.calledOnce).to.be.true;
-        expect(childrenSpy.firstCall.args[0]).to.equal(childrenObject);
-
-        expect(setOfDecisionLetterUrls.size).to.equal(1);
-        expect(setOfDecisionLetterUrls.has('url1')).to.be.true;
-      });
-      it('should add urls to set when there are multiple decision letters', () => {
-        const nextStub = sandbox.stub();
-        const card = generateFakeCard(
-          'Claims Decision Letters',
-          'url1',
-          'url2',
-          'url3',
-        );
-        const setOfDecisionLetterUrls = new Set();
-        const childrenObject = {};
-        const childrenSpy = sandbox.spy();
-
-        nextStub.returns(childrenSpy);
-
-        activityMiddleware(featureFlagEnabled, setOfDecisionLetterUrls)()(
-          nextStub,
-        )(card)(childrenObject);
-
-        expect(nextStub.calledOnce).to.be.true;
-        expect(nextStub.firstCall.args[0]).to.equal(card);
-
-        expect(childrenSpy.calledOnce).to.be.true;
-        expect(childrenSpy.firstCall.args[0]).to.equal(childrenObject);
-
-        expect(setOfDecisionLetterUrls.size).to.equal(3);
-        expect(setOfDecisionLetterUrls.has('url1')).to.be.true;
-        expect(setOfDecisionLetterUrls.has('url2')).to.be.true;
-        expect(setOfDecisionLetterUrls.has('url3')).to.be.true;
-      });
-    });
-    it('should call only next when the feature flag is disabled', () => {
-      //  3. when the feature flag is disabled
-      const nextStub = sandbox.stub();
-      const card = {};
-      const setOfDecisionLetterUrls = new Set();
-      const childrenObject = {};
-      const childrenSpy = sandbox.spy();
-
-      nextStub.returns(childrenSpy);
-
-      activityMiddleware(false, setOfDecisionLetterUrls)()(nextStub)(card)(
-        childrenObject,
-      );
-
-      expect(nextStub.calledOnce).to.be.true;
-      expect(nextStub.firstCall.args[0]).to.equal(card);
-
-      expect(childrenSpy.calledOnce).to.be.true;
-      expect(childrenSpy.firstCall.args[0]).to.equal(childrenObject);
-
-      expect(setOfDecisionLetterUrls.size).to.equal(0);
-    });
-  });
   describe('cardActionMiddleware', () => {
-    /**
-     * Pseudo code for the middleware
-     * 1. update the cardActionMiddleware to take in a Set containing decision
-     *    letter urls
-     * 1.5 strip url to only contain the path and not https://
-     * 2. update the middleware to check if the url to check if the url is in
-     *    the set
-     * 3. if the url is in the set, call recordEvent otherwise skip
-     */
-
     /**
      * create a fake action card
      * @param {string} value url for the cardAction
@@ -209,9 +45,7 @@ describe('Webchat.jsx Helpers', () => {
           'button-click-label': 'Decision Letter',
           time: new Date(Date.now()),
         };
-        const urls = new Set();
-        urls.add('www.va.gov/v0/claim_letters/abc');
-        cardActionMiddleware(decisionLetterEnabled, urls)()(nextSpy)(
+        cardActionMiddleware(decisionLetterEnabled)()(nextSpy)(
           decisionLetterCard,
         );
 
@@ -228,8 +62,7 @@ describe('Webchat.jsx Helpers', () => {
           'random_thing_we_dont_use',
         );
         const { nextSpy, recordEventStub } = generateSinonFunctions();
-        const urls = new Set();
-        cardActionMiddleware(decisionLetterEnabled, urls)()(nextSpy)(
+        cardActionMiddleware(decisionLetterEnabled)()(nextSpy)(
           nonDecisionLetterCard,
         );
         expect(recordEventStub.notCalled).to.be.true;
@@ -242,10 +75,7 @@ describe('Webchat.jsx Helpers', () => {
           'notOpenUrl',
         );
         const { nextSpy, recordEventStub } = generateSinonFunctions();
-        const urls = new Set();
-        cardActionMiddleware(decisionLetterEnabled, urls)()(nextSpy)(
-          notOpenUrl,
-        );
+        cardActionMiddleware(decisionLetterEnabled)()(nextSpy)(notOpenUrl);
         expect(recordEventStub.notCalled).to.be.true;
         expect(nextSpy.calledOnce).to.be.true;
         expect(nextSpy.firstCall.args[0]).to.eql(notOpenUrl);
@@ -259,8 +89,7 @@ describe('Webchat.jsx Helpers', () => {
           'random_thing_we_dont_use',
         );
         const { nextSpy, recordEventStub } = generateSinonFunctions();
-        const urls = new Set();
-        cardActionMiddleware(decisionLetterEnabled, urls)()(nextSpy)(
+        cardActionMiddleware(decisionLetterEnabled)()(nextSpy)(
           nonDecisionLetterCard,
         );
         expect(recordEventStub.notCalled).to.be.true;

--- a/src/applications/virtual-agent/tests/components/webchat/helpers/webchat.unit.spec.js
+++ b/src/applications/virtual-agent/tests/components/webchat/helpers/webchat.unit.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import * as recordEventObject from 'platform/monitoring/record-event';
-import { cardActionMiddleware } from '../../../components/webchat/helpers/webChat';
+import { cardActionMiddleware } from '../../../../components/webchat/helpers/webChat';
 
 const sandbox = sinon.createSandbox();
 
@@ -11,7 +11,9 @@ describe('Webchat.jsx', () => {
    * @param {string} value url for the cardAction
    * @returns {{cardAction: {value: string}}} fake cardAction card
    */
-  const generateFakeCard = value => ({ cardAction: { value } });
+  const generateFakeCard = (value, type = 'openUrl') => ({
+    cardAction: { value, type },
+  });
   /**
    * creates sinon functions for the tests
    * @returns {{nextSpy: SinonSpy, recordEventStub: SinonStub}}
@@ -64,6 +66,17 @@ describe('Webchat.jsx', () => {
       expect(recordEventStub.notCalled).to.be.true;
       expect(nextSpy.calledOnce).to.be.true;
       expect(nextSpy.firstCall.args[0]).to.eql(nonDecisionLetterCard);
+    });
+    it('should not call recordEvent when cardAction.type is not openUrl', () => {
+      const notOpenUrl = generateFakeCard(
+        'https://www.va.gov/v0/claim_letters/abc',
+        'notOpenUrl',
+      );
+      const { nextSpy, recordEventStub } = generateSinonFunctions();
+      cardActionMiddleware(decisionLetterEnabled)()(nextSpy)(notOpenUrl);
+      expect(recordEventStub.notCalled).to.be.true;
+      expect(nextSpy.calledOnce).to.be.true;
+      expect(nextSpy.firstCall.args[0]).to.eql(notOpenUrl);
     });
   });
 

--- a/src/applications/virtual-agent/tests/components/webchat/helpers/webchat.unit.spec.js
+++ b/src/applications/virtual-agent/tests/components/webchat/helpers/webchat.unit.spec.js
@@ -66,7 +66,6 @@ describe('Webchat.jsx Helpers', () => {
           });
           return card;
         }, newCard);
-        // return newCard
       };
       const featureFlagEnabled = true;
       it('should call next and not add anything to the set when the card is not a decision letter', () => {
@@ -170,6 +169,7 @@ describe('Webchat.jsx Helpers', () => {
      * Pseudo code for the middleware
      * 1. update the cardActionMiddleware to take in a Set containing decision
      *    letter urls
+     * 1.5 strip url to only contain the path and not https://
      * 2. update the middleware to check if the url to check if the url is in
      *    the set
      * 3. if the url is in the set, call recordEvent otherwise skip
@@ -209,8 +209,9 @@ describe('Webchat.jsx Helpers', () => {
           'button-click-label': 'Decision Letter',
           time: new Date(Date.now()),
         };
-
-        cardActionMiddleware(decisionLetterEnabled)()(nextSpy)(
+        const urls = new Set();
+        urls.add('www.va.gov/v0/claim_letters/abc');
+        cardActionMiddleware(decisionLetterEnabled, urls)()(nextSpy)(
           decisionLetterCard,
         );
 
@@ -227,7 +228,8 @@ describe('Webchat.jsx Helpers', () => {
           'random_thing_we_dont_use',
         );
         const { nextSpy, recordEventStub } = generateSinonFunctions();
-        cardActionMiddleware(decisionLetterEnabled)()(nextSpy)(
+        const urls = new Set();
+        cardActionMiddleware(decisionLetterEnabled, urls)()(nextSpy)(
           nonDecisionLetterCard,
         );
         expect(recordEventStub.notCalled).to.be.true;
@@ -240,7 +242,10 @@ describe('Webchat.jsx Helpers', () => {
           'notOpenUrl',
         );
         const { nextSpy, recordEventStub } = generateSinonFunctions();
-        cardActionMiddleware(decisionLetterEnabled)()(nextSpy)(notOpenUrl);
+        const urls = new Set();
+        cardActionMiddleware(decisionLetterEnabled, urls)()(nextSpy)(
+          notOpenUrl,
+        );
         expect(recordEventStub.notCalled).to.be.true;
         expect(nextSpy.calledOnce).to.be.true;
         expect(nextSpy.firstCall.args[0]).to.eql(notOpenUrl);
@@ -254,7 +259,8 @@ describe('Webchat.jsx Helpers', () => {
           'random_thing_we_dont_use',
         );
         const { nextSpy, recordEventStub } = generateSinonFunctions();
-        cardActionMiddleware(decisionLetterEnabled)()(nextSpy)(
+        const urls = new Set();
+        cardActionMiddleware(decisionLetterEnabled, urls)()(nextSpy)(
           nonDecisionLetterCard,
         );
         expect(recordEventStub.notCalled).to.be.true;


### PR DESCRIPTION
## Summary
- Add `cardActionMiddleware` & `activityMiddleware` to WebChat rendering if the feature toggle `virtualAgentDecisionLetterDownloadTracking` is on; otherwise, render using original behavior
  - The new `cardActionMiddleware` will post to Google Analytics by calling the `recordEvent` function if the event is determined to be a decision letter download
- Add tests for new `cardActionMiddleware` function
  - Verify that `recordEvent` is called once with expected parameters and `next` is called once when it's a decision letter downloaded
  - Verify that `recordEvent` is not called and `next` is called when it's not a decision letter

Team: Virtual Agent Chatbot
Maintenance Owner: Yes
Flipper End Date: 11/1/23


## Related issue(s)
- `va-virtual-agent` issue: https://github.com/department-of-veterans-affairs/va-virtual-agent/issues/1105
- `vets-website` feature flag: https://github.com/department-of-veterans-affairs/vets-website/pull/25855
- `vets-api` feature flag: https://github.com/department-of-veterans-affairs/vets-api/pull/13943


## Testing done
- Before this change, when a user clicked to download a decision letter from within the Chatbot, there would be no recorded event in Google analytics. With this change, there will be an event recorded.
- To verify this change:
  - Add a console.log message to the new `cardActionMiddleware` function in `Webchat.jsx`. This is needed because the are no visual changes to this this modification and Google Analytics does not track data from local runs.
  - Run `vets-website` and `vets-api` locally.
  - Enable the flipper feature toggle `virtualAgentDecisionLetterDownloadTracking`.
  - Go to http://localhost:3001/contact-us/virtual-agent/ and open your dev console.
  - Click **Start Chat** in the Chatbot and send a message saying "decision letter"
  - The bot will ask if you want to login. Say yes and follow the steps.
  - Once the bot returns and gives you the decision letters, click one of the letters.
  - Look for your message in the console.
  - Click another decision letter and verify that each time you click to download, there is a message.
  - Repeat these steps with the feature flag off and verify that no message is shown.
Test completed:
  - We ran this locally using the steps mentioned above and verified that the message showed up only when the feature flag was on and that the message showed up each time the button was clicked.
  - We created unit tests for the new function to make sure the event recorded only when it was a decision letter download.


## What areas of the site does it impact?
Only the Chatbot located at /contact-us/virtual-agent/.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
We were wondering about the `recordEvent` arguments.
- Is there a standard way to determine what type of `event` to put. In this case, we are tracking every time a user downloads a decision letter through our bot. Right now, we have the event as a `cta-button-click` but technically, this isn't a CTA as we're not asking the user to do anything. Is there an event that says something that makes more sense for this type of event (button click or file download)?
- The label looks like it's normally exactly what's written on the button. In this case, we are looking to track all button clicks total but these button labels are dynamic so we've generalized it to `decisionLetter`. Is that okay?
