### PR TITLE
Update PACT deadline content for Health Care Application

### DIFF
--- a/src/applications/hca/components/FormAlerts/SubmissionErrorAlert.jsx
+++ b/src/applications/hca/components/FormAlerts/SubmissionErrorAlert.jsx
@@ -25,8 +25,12 @@ const SubmissionErrorAlert = () => {
         </p>
         <ul>
           <li>
-            Call us at <va-telephone contact={CONTACTS['222_VETS']} />, Monday
-            through Friday, 8:00 a.m. to 8:00 p.m.{' '}
+            Call us at <va-telephone contact={CONTACTS['222_VETS']} />. We’re
+            here Friday, September 29, 8:00 a.m. to 10:00 p.m.{' '}
+            <dfn>
+              <abbr title="Eastern Time">ET</abbr>
+            </dfn>
+            , and Saturday, September 30, 8:00 a.m. to 1:00 p.m.{' '}
             <dfn>
               <abbr title="Eastern Time">ET</abbr>
             </dfn>

--- a/src/applications/hca/components/FormAlerts/index.jsx
+++ b/src/applications/hca/components/FormAlerts/index.jsx
@@ -17,8 +17,12 @@ export const DowntimeWarning = () => (
         deadline for certain combat Veterans
       </strong>
       , you can also apply in other ways. Call us at{' '}
-      <va-telephone contact={CONTACTS['222_VETS']} />, Monday through Friday,
-      8:00 a.m. to 8:00 p.m.{' '}
+      <va-telephone contact={CONTACTS['222_VETS']} />. We’re here Friday,
+      September 29, 8:00 a.m. to 10:00 p.m.{' '}
+      <dfn>
+        <abbr title="Eastern Time">ET</abbr>
+      </dfn>
+      , and Saturday, September 30, 8:00 a.m. to 1:00 p.m.{' '}
       <dfn>
         <abbr title="Eastern Time">ET</abbr>
       </dfn>
@@ -47,8 +51,12 @@ export const PerformanceWarning = () => (
           deadline for certain combat Veterans
         </strong>
         , you can also apply in other ways. Call us at{' '}
-        <va-telephone contact={CONTACTS['222_VETS']} />, Monday through Friday,
-        8:00 a.m. to 8:00 p.m.{' '}
+        <va-telephone contact={CONTACTS['222_VETS']} />. We’re here Friday,
+        September 29, 8:00 a.m. to 10:00 p.m.{' '}
+        <dfn>
+          <abbr title="Eastern Time">ET</abbr>
+        </dfn>
+        , and Saturday, September 30, 8:00 a.m. to 1:00 p.m.{' '}
         <dfn>
           <abbr title="Eastern Time">ET</abbr>
         </dfn>
@@ -76,8 +84,12 @@ export const ServerErrorAlert = () => (
     </p>
     <ul>
       <li>
-        Call us at <va-telephone contact={CONTACTS['222_VETS']} />, Monday
-        through Friday, 8:00 a.m. to 8:00 p.m.{' '}
+        Call us at <va-telephone contact={CONTACTS['222_VETS']} />. We’re here
+        Friday, September 29, 8:00 a.m. to 10:00 p.m.{' '}
+        <dfn>
+          <abbr title="Eastern Time">ET</abbr>
+        </dfn>
+        , and Saturday, September 30, 8:00 a.m. to 1:00 p.m.{' '}
         <dfn>
           <abbr title="Eastern Time">ET</abbr>
         </dfn>

--- a/src/applications/hca/components/GetHelp.jsx
+++ b/src/applications/hca/components/GetHelp.jsx
@@ -16,8 +16,12 @@ const GetHelp = () => (
         deadline for certain combat Veterans
       </strong>
       , you can also apply in other ways. Call us at{' '}
-      <va-telephone contact={CONTACTS['222_VETS']} />, Monday through Friday,
-      8:00 a.m. to 8:00 p.m.{' '}
+      <va-telephone contact={CONTACTS['222_VETS']} />. We’re here Friday,
+      September 29, 8:00 a.m. to 10:00 p.m.{' '}
+      <dfn>
+        <abbr title="Eastern Time">ET</abbr>
+      </dfn>
+      , and Saturday, September 30, 8:00 a.m. to 1:00 p.m.{' '}
       <dfn>
         <abbr title="Eastern Time">ET</abbr>
       </dfn>

--- a/src/applications/static-pages/hca-performance-warning/components/App/index.jsx
+++ b/src/applications/static-pages/hca-performance-warning/components/App/index.jsx
@@ -19,8 +19,12 @@ export const App = ({ show }) => {
             deadline for certain combat Veterans
           </strong>
           , you can also apply in other ways. Call us at{' '}
-          <va-telephone contact={CONTACTS['222_VETS']} />, Monday through
-          Friday, 8:00 a.m. to 8:00 p.m.{' '}
+          <va-telephone contact={CONTACTS['222_VETS']} />. We’re here Friday,
+          September 29, 8:00 a.m. to 10:00 p.m.{' '}
+          <dfn>
+            <abbr title="Eastern Time">ET</abbr>
+          </dfn>
+          , and Saturday, September 30, 8:00 a.m. to 1:00 p.m.{' '}
           <dfn>
             <abbr title="Eastern Time">ET</abbr>
           </dfn>


### PR DESCRIPTION
## Summary
To account for expanded support hours, we need to update the content of the various alerts and help text that references the PACT act special enrollment deadline. This PR updates that content to give Veterans the most accurate support hours.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#66615

## Acceptance criteria
- Content reflects expanded support hours