### PR TITLE
MHV-49863 Updated fields that have changed in FHIR mapping

### DIFF
--- a/src/applications/mhv/medical-records/reducers/allergies.js
+++ b/src/applications/mhv/medical-records/reducers/allergies.js
@@ -16,8 +16,8 @@ const initialState = {
 };
 
 const interpretObservedOrReported = code => {
-  if (code === 'confirmed') return allergyTypes.OBSERVED;
-  if (code === 'unconfirmed') return allergyTypes.REPORTED;
+  if (code === 'o') return allergyTypes.OBSERVED;
+  if (code === 'h') return allergyTypes.REPORTED;
   return EMPTY_FIELD;
 };
 
@@ -30,12 +30,16 @@ export const convertAllergy = allergy => {
           allergy.category[0].slice(1)) ||
       EMPTY_FIELD,
     name: allergy?.code?.text || EMPTY_FIELD,
-    date: formatDateLong(allergy.onsetDateTime),
+    date: formatDateLong(allergy.recordedDate),
     reaction: getReactions(allergy),
     location: allergy.recorder?.display || EMPTY_FIELD,
     observedOrReported:
-      isArrayAndHasItems(allergy.verificationStatus?.coding) &&
-      interpretObservedOrReported(allergy.verificationStatus.coding[0].code),
+      isArrayAndHasItems(allergy.extension) &&
+      interpretObservedOrReported(
+        allergy.extension.filter(item =>
+          item.url.includes('allergyObservedHistoric'),
+        )[0].valueString,
+      ),
     notes:
       (isArrayAndHasItems(allergy.note) && allergy.note[0].text) || EMPTY_FIELD,
   };

--- a/src/applications/mhv/medical-records/tests/containers/AllergyDetails.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/AllergyDetails.unit.spec.jsx
@@ -45,7 +45,7 @@ describe('Allergy details container', () => {
       exact: false,
       selector: 'h1',
     });
-    const allergyName = screen.getByText('FISH', {
+    const allergyName = screen.getByText('NUTS', {
       exact: true,
       selector: 'span',
     });
@@ -54,7 +54,7 @@ describe('Allergy details container', () => {
   });
 
   it('displays the date entered', () => {
-    expect(screen.getByText('July', { exact: false })).to.exist;
+    expect(screen.getByText('August', { exact: false })).to.exist;
   });
 
   it('displays the reaction', () => {
@@ -67,7 +67,7 @@ describe('Allergy details container', () => {
 
   it('displays the location', () => {
     expect(
-      screen.getByText('SLC4.FO-BAYPINES.MED.VA.GOV', {
+      screen.getByText('SLC10.FO-BAYPINES.MED.VA.GOV', {
         exact: true,
         selector: 'p',
       }),
@@ -75,6 +75,6 @@ describe('Allergy details container', () => {
   });
 
   it('displays provider notes', () => {
-    expect(screen.getByText("maruf's test comment", { exact: false })).to.exist;
+    expect(screen.getByText("Maruf's test", { exact: false })).to.exist;
   });
 });

--- a/src/applications/mhv/medical-records/tests/fixtures/allergies.json
+++ b/src/applications/mhv/medical-records/tests/fixtures/allergies.json
@@ -1,48 +1,59 @@
 {
-  "id": "e226c36e-8aa6-46ab-8327-8259ac1729a4",
+  "resourceType": "Bundle",
+  "id": "27b154d8-18c6-41b3-a988-8474bacd19a8",
   "meta": {
-    "lastUpdated": "2023-09-07T14:15:09.445-04:00"
+    "lastUpdated": "2023-09-29T11:04:31.316-04:00"
   },
   "type": "searchset",
-  "total": 5,
   "link": [
     {
       "relation": "self",
-      "url": "https://mhv-intb-api.myhealth.va.gov/fhir/AllergyIntolerance?_count=9999&patient=7005"
+      "url": "https://mhv-sysb-api.myhealth.va.gov/fhir/AllergyIntolerance?_count=5&patient=3102"
+    },
+    {
+      "relation": "next",
+      "url": "https://mhv-sysb-api.myhealth.va.gov/fhir?_getpages=27b154d8-18c6-41b3-a988-8474bacd19a8&_getpagesoffset=5&_count=5&_pretty=true&_bundletype=searchset"
     }
   ],
   "entry": [
     {
-      "fullUrl": "https://mhv-intb-api.myhealth.va.gov/fhir/AllergyIntolerance/10502",
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/AllergyIntolerance/3106",
       "resource": {
-        "id": "10502",
+        "resourceType": "AllergyIntolerance",
+        "id": "3106",
         "meta": {
-          "versionId": "1",
-          "lastUpdated": "2023-09-05T17:04:33.367-04:00",
-          "source": "#8M2G0uODmzly9BVt",
+          "versionId": "38",
+          "lastUpdated": "2023-09-29T09:32:09.177-04:00",
+          "source": "#EAedTZrjAfUfmoab",
           "profile": [
             "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.allergyIntolerance"
           ]
         },
         "contained": [
           {
+            "resourceType": "Organization",
             "id": "Organization-0",
             "identifier": [
               {
                 "use": "usual",
                 "system": "urn:oid:2.16.840.1.113883.4.349",
-                "value": "991"
+                "value": "979"
               }
             ],
-            "name": "SLC4.FO-BAYPINES.MED.VA.GOV",
-            "resourceType": "Organization"
+            "name": "SLC10.FO-BAYPINES.MED.VA.GOV"
+          }
+        ],
+        "extension": [
+          {
+            "url": "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/allergyObservedHistoric",
+            "valueString": "o"
           }
         ],
         "identifier": [
           {
             "use": "official",
-            "system": "http://va.gov/systems/991_120.8",
-            "value": "69143"
+            "system": "http://va.gov/systems/979_120.8",
+            "value": "69171"
           }
         ],
         "clinicalStatus": {
@@ -50,25 +61,17 @@
             {
               "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
               "code": "active"
-            }
-          ]
-        },
-        "verificationStatus": {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
-              "code": "confirmed"
             }
           ]
         },
         "category": ["food"],
         "code": {
-          "text": "FISH"
+          "text": "NUTS"
         },
         "patient": {
-          "reference": "Patient/7005"
+          "reference": "Patient/3102"
         },
-        "onsetDateTime": "2023-07-27T17:06:00-06:00",
+        "recordedDate": "2023-08-23T23:15:00-06:00",
         "recorder": {
           "extension": [
             {
@@ -78,12 +81,12 @@
               }
             }
           ],
-          "display": "SLC4.FO-BAYPINES.MED.VA.GOV"
+          "display": "SLC10.FO-BAYPINES.MED.VA.GOV"
         },
         "note": [
           {
-            "time": "2023-07-27T17:07:21-06:00",
-            "text": "maruf's test comment "
+            "time": "2023-08-23T23:16:00-06:00",
+            "text": "Maruf's test "
           }
         ],
         "reaction": [
@@ -100,44 +103,50 @@
               }
             ]
           }
-        ],
-        "resourceType": "AllergyIntolerance"
+        ]
       },
       "search": {
         "mode": "match"
       }
     },
     {
-      "fullUrl": "https://mhv-intb-api.myhealth.va.gov/fhir/AllergyIntolerance/10503",
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/AllergyIntolerance/3108",
       "resource": {
-        "id": "10503",
+        "resourceType": "AllergyIntolerance",
+        "id": "3108",
         "meta": {
-          "versionId": "1",
-          "lastUpdated": "2023-09-05T17:04:33.367-04:00",
-          "source": "#8M2G0uODmzly9BVt",
+          "versionId": "38",
+          "lastUpdated": "2023-09-29T09:32:09.177-04:00",
+          "source": "#EAedTZrjAfUfmoab",
           "profile": [
             "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.allergyIntolerance"
           ]
         },
         "contained": [
           {
+            "resourceType": "Organization",
             "id": "Organization-0",
             "identifier": [
               {
                 "use": "usual",
                 "system": "urn:oid:2.16.840.1.113883.4.349",
-                "value": "991"
+                "value": "979"
               }
             ],
-            "name": "SLC4.FO-BAYPINES.MED.VA.GOV",
-            "resourceType": "Organization"
+            "name": "SLC10.FO-BAYPINES.MED.VA.GOV"
+          }
+        ],
+        "extension": [
+          {
+            "url": "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/allergyObservedHistoric",
+            "valueString": "o"
           }
         ],
         "identifier": [
           {
             "use": "official",
-            "system": "http://va.gov/systems/991_120.8",
-            "value": "69144"
+            "system": "http://va.gov/systems/979_120.8",
+            "value": "69173"
           }
         ],
         "clinicalStatus": {
@@ -145,259 +154,17 @@
             {
               "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
               "code": "active"
-            }
-          ]
-        },
-        "verificationStatus": {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
-              "code": "confirmed"
-            }
-          ]
-        },
-        "category": ["Food"],
-        "code": {
-          "text": "RED MEAT"
-        },
-        "patient": {
-          "reference": "Patient/7005"
-        },
-        "onsetDateTime": "2023-07-27T17:08:00-06:00",
-        "recorder": {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/alternate-reference",
-              "valueReference": {
-                "reference": "#Organization-0"
-              }
-            }
-          ],
-          "display": "SLC4.FO-BAYPINES.MED.VA.GOV"
-        },
-        "note": [
-          {
-            "time": "2023-07-27T17:08:49-06:00",
-            "text": "maruf's test data "
-          }
-        ],
-        "reaction": [
-          {
-            "manifestation": [
-              {
-                "coding": [
-                  {
-                    "system": "urn:oid:2.16.840.1.113883.6.233",
-                    "code": "4538635"
-                  }
-                ],
-                "text": "RASH"
-              }
-            ]
-          },
-          {
-            "manifestation": [
-              {
-                "coding": [
-                  {
-                    "system": "urn:oid:2.16.840.1.113883.6.233",
-                    "code": "4637164"
-                  }
-                ],
-                "text": "SWELLING"
-              }
-            ]
-          },
-          {
-            "manifestation": [
-              {
-                "coding": [
-                  {
-                    "system": "urn:oid:2.16.840.1.113883.6.233",
-                    "code": "4637156"
-                  }
-                ],
-                "text": "URTICARIA"
-              }
-            ]
-          }
-        ],
-        "resourceType": "AllergyIntolerance"
-      },
-      "search": {
-        "mode": "match"
-      }
-    },
-    {
-      "fullUrl": "https://mhv-intb-api.myhealth.va.gov/fhir/AllergyIntolerance/10504",
-      "resource": {
-        "id": "10504",
-        "meta": {
-          "versionId": "1",
-          "lastUpdated": "2023-09-05T17:04:33.367-04:00",
-          "source": "#8M2G0uODmzly9BVt",
-          "profile": [
-            "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.allergyIntolerance"
-          ]
-        },
-        "contained": [
-          {
-            "id": "Organization-0",
-            "identifier": [
-              {
-                "use": "usual",
-                "system": "urn:oid:2.16.840.1.113883.4.349",
-                "value": "991"
-              }
-            ],
-            "name": "SLC4.FO-BAYPINES.MED.VA.GOV",
-            "resourceType": "Organization"
-          }
-        ],
-        "identifier": [
-          {
-            "use": "official",
-            "system": "http://va.gov/systems/991_120.8",
-            "value": "69145"
-          }
-        ],
-        "clinicalStatus": {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
-              "code": "active"
-            }
-          ]
-        },
-        "verificationStatus": {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
-              "code": "unconfirmed"
-            }
-          ]
-        },
-        "category": ["environment"],
-        "code": {
-          "text": "POLLEN"
-        },
-        "patient": {
-          "reference": "Patient/7005"
-        },
-        "onsetDateTime": "2023-07-27T17:09:00-06:00",
-        "recorder": {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/alternate-reference",
-              "valueReference": {
-                "reference": "#Organization-0"
-              }
-            }
-          ],
-          "display": "SLC4.FO-BAYPINES.MED.VA.GOV"
-        },
-        "note": [
-          {
-            "time": "2023-07-27T17:10:21-06:00",
-            "text": "maruf's test comment intb "
-          }
-        ],
-        "reaction": [
-          {
-            "manifestation": [
-              {
-                "coding": [
-                  {
-                    "system": "urn:oid:2.16.840.1.113883.6.233",
-                    "code": "4637183"
-                  }
-                ],
-                "text": "RESPIRATORY DISTRESS"
-              }
-            ]
-          },
-          {
-            "manifestation": [
-              {
-                "coding": [
-                  {
-                    "system": "urn:oid:2.16.840.1.113883.6.233",
-                    "code": "4637164"
-                  }
-                ],
-                "text": "SWELLING"
-              }
-            ]
-          }
-        ],
-        "resourceType": "AllergyIntolerance"
-      },
-      "search": {
-        "mode": "match"
-      }
-    },
-    {
-      "fullUrl": "https://mhv-intb-api.myhealth.va.gov/fhir/AllergyIntolerance/10506",
-      "resource": {
-        "id": "10506",
-        "meta": {
-          "versionId": "1",
-          "lastUpdated": "2023-09-05T17:04:33.367-04:00",
-          "source": "#8M2G0uODmzly9BVt",
-          "profile": [
-            "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.allergyIntolerance"
-          ]
-        },
-        "contained": [
-          {
-            "id": "Organization-0",
-            "identifier": [
-              {
-                "use": "usual",
-                "system": "urn:oid:2.16.840.1.113883.4.349",
-                "value": "991"
-              }
-            ],
-            "name": "SLC4.FO-BAYPINES.MED.VA.GOV",
-            "resourceType": "Organization"
-          }
-        ],
-        "identifier": [
-          {
-            "use": "official",
-            "system": "http://va.gov/systems/991_120.8",
-            "value": "69149"
-          }
-        ],
-        "clinicalStatus": {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
-              "code": "active"
-            }
-          ]
-        },
-        "verificationStatus": {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
-              "code": "confirmed"
             }
           ]
         },
         "category": ["medication"],
         "code": {
-          "coding": [
-            {
-              "display": "HERBS/ALTERNATIVE THERAPIES"
-            }
-          ],
-          "text": "PENNYROYAL"
+          "text": "PENNSAID"
         },
         "patient": {
-          "reference": "Patient/7005"
+          "reference": "Patient/3102"
         },
-        "onsetDateTime": "2023-08-04T11:14:00-06:00",
+        "recordedDate": "2023-08-25T12:48:00-06:00",
         "recorder": {
           "extension": [
             {
@@ -407,112 +174,12 @@
               }
             }
           ],
-          "display": "SLC4.FO-BAYPINES.MED.VA.GOV"
+          "display": "SLC10.FO-BAYPINES.MED.VA.GOV"
         },
         "note": [
           {
-            "time": "2023-08-04T11:16:26-06:00",
-            "text": "testing with Dan , -Maruf "
-          }
-        ],
-        "reaction": [
-          {
-            "manifestation": [
-              {
-                "coding": [
-                  {
-                    "system": "urn:oid:2.16.840.1.113883.6.233",
-                    "code": "4637164"
-                  }
-                ],
-                "text": "SWELLING"
-              }
-            ]
-          }
-        ],
-        "resourceType": "AllergyIntolerance"
-      },
-      "search": {
-        "mode": "match"
-      }
-    },
-    {
-      "fullUrl": "https://mhv-intb-api.myhealth.va.gov/fhir/AllergyIntolerance/10505",
-      "resource": {
-        "id": "10505",
-        "meta": {
-          "versionId": "1",
-          "lastUpdated": "2023-09-05T17:04:33.367-04:00",
-          "source": "#8M2G0uODmzly9BVt",
-          "profile": [
-            "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.allergyIntolerance"
-          ]
-        },
-        "contained": [
-          {
-            "id": "Organization-0",
-            "identifier": [
-              {
-                "use": "usual",
-                "system": "urn:oid:2.16.840.1.113883.4.349",
-                "value": "991"
-              }
-            ],
-            "name": "SLC4.FO-BAYPINES.MED.VA.GOV",
-            "resourceType": "Organization"
-          }
-        ],
-        "identifier": [
-          {
-            "use": "official",
-            "system": "http://va.gov/systems/991_120.8",
-            "value": "69146"
-          }
-        ],
-        "clinicalStatus": {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
-              "code": "active"
-            }
-          ]
-        },
-        "verificationStatus": {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
-              "code": "confirmed"
-            }
-          ]
-        },
-        "category": ["medication"],
-        "code": {
-          "coding": [
-            {
-              "display": "SYRINGES/NEEDLES,OTHER"
-            }
-          ],
-          "text": "HUMAPEN"
-        },
-        "patient": {
-          "reference": "Patient/7005"
-        },
-        "onsetDateTime": "2023-07-27T17:10:00-06:00",
-        "recorder": {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/alternate-reference",
-              "valueReference": {
-                "reference": "#Organization-0"
-              }
-            }
-          ],
-          "display": "SLC4.FO-BAYPINES.MED.VA.GOV"
-        },
-        "note": [
-          {
-            "time": "2023-07-27T17:11:37-06:00",
-            "text": "maruf's test comment "
+            "time": "2023-08-25T12:49:44-06:00",
+            "text": "maruf's test "
           }
         ],
         "reaction": [
@@ -528,7 +195,180 @@
                 "text": "RENAL IMPAIRMENT"
               }
             ]
-          },
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/AllergyIntolerance/3109",
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "3109",
+        "meta": {
+          "versionId": "38",
+          "lastUpdated": "2023-09-29T09:32:09.177-04:00",
+          "source": "#EAedTZrjAfUfmoab",
+          "profile": [
+            "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.allergyIntolerance"
+          ]
+        },
+        "contained": [
+          {
+            "resourceType": "Organization",
+            "id": "Organization-0",
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349",
+                "value": "979"
+              }
+            ],
+            "name": "SLC10.FO-BAYPINES.MED.VA.GOV"
+          }
+        ],
+        "extension": [
+          {
+            "url": "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/allergyObservedHistoric",
+            "valueString": "o"
+          }
+        ],
+        "identifier": [
+          {
+            "use": "official",
+            "system": "http://va.gov/systems/979_120.8",
+            "value": "69174"
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "category": ["medication"],
+        "code": {
+          "text": "PENICILLIN"
+        },
+        "patient": {
+          "reference": "Patient/3102"
+        },
+        "recordedDate": "2023-08-25T12:50:00-06:00",
+        "recorder": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/alternate-reference",
+              "valueReference": {
+                "reference": "#Organization-0"
+              }
+            }
+          ],
+          "display": "SLC10.FO-BAYPINES.MED.VA.GOV"
+        },
+        "note": [
+          {
+            "time": "2023-08-25T12:50:59-06:00",
+            "text": "Maruf's test "
+          }
+        ],
+        "reaction": [
+          {
+            "manifestation": [
+              {
+                "coding": [
+                  {
+                    "system": "urn:oid:2.16.840.1.113883.6.233",
+                    "code": "4637177"
+                  }
+                ],
+                "text": "SEDATED"
+              }
+            ]
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/AllergyIntolerance/3104",
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "3104",
+        "meta": {
+          "versionId": "38",
+          "lastUpdated": "2023-09-29T09:32:09.177-04:00",
+          "source": "#EAedTZrjAfUfmoab",
+          "profile": [
+            "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.allergyIntolerance"
+          ]
+        },
+        "contained": [
+          {
+            "resourceType": "Organization",
+            "id": "Organization-0",
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349",
+                "value": "979"
+              }
+            ],
+            "name": "SLC10.FO-BAYPINES.MED.VA.GOV"
+          }
+        ],
+        "extension": [
+          {
+            "url": "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/allergyObservedHistoric",
+            "valueString": "h"
+          }
+        ],
+        "identifier": [
+          {
+            "use": "official",
+            "system": "http://va.gov/systems/979_120.8",
+            "value": "69169"
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "category": ["food"],
+        "code": {
+          "text": "RED MEAT"
+        },
+        "patient": {
+          "reference": "Patient/3102"
+        },
+        "recordedDate": "2023-08-23T23:13:00-06:00",
+        "recorder": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/alternate-reference",
+              "valueReference": {
+                "reference": "#Organization-0"
+              }
+            }
+          ],
+          "display": "SLC10.FO-BAYPINES.MED.VA.GOV"
+        },
+        "note": [
+          {
+            "time": "2023-08-23T23:13:56-06:00",
+            "text": "Maruf's test "
+          }
+        ],
+        "reaction": [
           {
             "manifestation": [
               {
@@ -542,13 +382,117 @@
               }
             ]
           }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/AllergyIntolerance/3107",
+      "resource": {
+        "resourceType": "AllergyIntolerance",
+        "id": "3107",
+        "meta": {
+          "versionId": "38",
+          "lastUpdated": "2023-09-29T09:32:09.177-04:00",
+          "source": "#EAedTZrjAfUfmoab",
+          "profile": [
+            "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.allergyIntolerance"
+          ]
+        },
+        "contained": [
+          {
+            "resourceType": "Organization",
+            "id": "Organization-0",
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349",
+                "value": "979"
+              }
+            ],
+            "name": "SLC10.FO-BAYPINES.MED.VA.GOV"
+          }
         ],
-        "resourceType": "AllergyIntolerance"
+        "extension": [
+          {
+            "url": "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/allergyObservedHistoric",
+            "valueString": "o"
+          }
+        ],
+        "identifier": [
+          {
+            "use": "official",
+            "system": "http://va.gov/systems/979_120.8",
+            "value": "69172"
+          }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+              "code": "active"
+            }
+          ]
+        },
+        "category": ["medication"],
+        "code": {
+          "text": "MEDIPLAST"
+        },
+        "patient": {
+          "reference": "Patient/3102"
+        },
+        "recordedDate": "2023-08-25T12:47:00-06:00",
+        "recorder": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/alternate-reference",
+              "valueReference": {
+                "reference": "#Organization-0"
+              }
+            }
+          ],
+          "display": "SLC10.FO-BAYPINES.MED.VA.GOV"
+        },
+        "note": [
+          {
+            "time": "2023-08-25T12:47:57-06:00",
+            "text": "Maruf's test "
+          }
+        ],
+        "reaction": [
+          {
+            "manifestation": [
+              {
+                "coding": [
+                  {
+                    "system": "urn:oid:2.16.840.1.113883.6.233",
+                    "code": "4637015"
+                  }
+                ],
+                "text": "DELIRIUM"
+              }
+            ]
+          },
+          {
+            "manifestation": [
+              {
+                "coding": [
+                  {
+                    "system": "urn:oid:2.16.840.1.113883.6.233",
+                    "code": "4538635"
+                  }
+                ],
+                "text": "RASH"
+              }
+            ]
+          }
+        ]
       },
       "search": {
         "mode": "match"
       }
     }
-  ],
-  "resourceType": "Bundle"
+  ]
 }

--- a/src/applications/mhv/medical-records/tests/fixtures/allergy.json
+++ b/src/applications/mhv/medical-records/tests/fixtures/allergy.json
@@ -1,91 +1,87 @@
 {
-    "id": "10502",
-    "meta": {
-        "versionId": "1",
-        "lastUpdated": "2023-09-05T17:04:33.367-04:00",
-        "source": "#8M2G0uODmzly9BVt",
-        "profile": [
-            "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.allergyIntolerance"
-        ]
-    },
-    "contained": [
+  "resourceType": "AllergyIntolerance",
+  "id": "3106",
+  "meta": {
+    "versionId": "38",
+    "lastUpdated": "2023-09-29T09:32:09.177-04:00",
+    "source": "#EAedTZrjAfUfmoab",
+    "profile": [
+      "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.allergyIntolerance"
+    ]
+  },
+  "contained": [
+    {
+      "resourceType": "Organization",
+      "id": "Organization-0",
+      "identifier": [
         {
-            "id": "Organization-0",
-            "identifier": [
-                {
-                    "use": "usual",
-                    "system": "urn:oid:2.16.840.1.113883.4.349",
-                    "value": "991"
-                }
-            ],
-            "name": "SLC4.FO-BAYPINES.MED.VA.GOV",
-            "resourceType": "Organization"
+          "use": "usual",
+          "system": "urn:oid:2.16.840.1.113883.4.349",
+          "value": "979"
         }
+      ],
+      "name": "SLC10.FO-BAYPINES.MED.VA.GOV"
+    }
+  ],
+  "extension": [
+    {
+      "url": "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/allergyObservedHistoric",
+      "valueString": "o"
+    }
+  ],
+  "identifier": [
+    {
+      "use": "official",
+      "system": "http://va.gov/systems/979_120.8",
+      "value": "69171"
+    }
+  ],
+  "clinicalStatus": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+        "code": "active"
+      }
+    ]
+  },
+  "category": ["food"],
+  "code": {
+    "text": "NUTS"
+  },
+  "patient": {
+    "reference": "Patient/3102"
+  },
+  "recordedDate": "2023-08-23T23:15:00-06:00",
+  "recorder": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/alternate-reference",
+        "valueReference": {
+          "reference": "#Organization-0"
+        }
+      }
     ],
-    "identifier": [
+    "display": "SLC10.FO-BAYPINES.MED.VA.GOV"
+  },
+  "note": [
+    {
+      "time": "2023-08-23T23:16:00-06:00",
+      "text": "Maruf's test "
+    }
+  ],
+  "reaction": [
+    {
+      "manifestation": [
         {
-            "use": "official",
-            "system": "http://va.gov/systems/991_120.8",
-            "value": "69143"
-        }
-    ],
-    "clinicalStatus": {
-        "coding": [
+          "coding": [
             {
-                "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
-                "code": "active"
+              "system": "urn:oid:2.16.840.1.113883.6.233",
+              "code": "4538635"
             }
-        ]
-    },
-    "verificationStatus": {
-        "coding": [
-            {
-                "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-verification",
-                "code": "confirmed"
-            }
-        ]
-    },
-    "category": [
-        "food"
-    ],
-    "code": {
-        "text": "FISH"
-    },
-    "patient": {
-        "reference": "Patient/7005"
-    },
-    "onsetDateTime": "2023-07-27T17:06:00-06:00",
-    "recorder": {
-        "extension": [
-            {
-                "url": "http://hl7.org/fhir/StructureDefinition/alternate-reference",
-                "valueReference": {
-                    "reference": "#Organization-0"
-                }
-            }
-        ],
-        "display": "SLC4.FO-BAYPINES.MED.VA.GOV"
-    },
-    "note": [
-        {
-            "time": "2023-07-27T17:07:21-06:00",
-            "text": "maruf's test comment "
+          ],
+          "text": "RASH"
         }
-    ],
-    "reaction": [
-        {
-            "manifestation": [
-                {
-                    "coding": [
-                        {
-                            "system": "urn:oid:2.16.840.1.113883.6.233",
-                            "code": "4538635"
-                        }
-                    ],
-                    "text": "RASH"
-                }
-            ]
-        }
-    ],
-    "resourceType": "AllergyIntolerance"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Some of the fields in FHIR have been changed. Updated the frontend to reflect this and pull the right fields.

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-49863 - Pull the updated fields from Allergies FHIR data

## Testing done

- Updated tests and fixtures to reflect the changed fields

## Screenshots

Note that the date and observed/reported fields are now filled and correct:
<img width="396" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/3c7872fa-1a92-4923-9853-ec536f9700cc">


## What areas of the site does it impact?

MHV MR

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
