### PR TITLE
Simple forms/instructional text

### DIFF
--- a/src/applications/simple-forms/21-0845/pages/authorizerType.js
+++ b/src/applications/simple-forms/21-0845/pages/authorizerType.js
@@ -12,7 +12,7 @@ export default {
       'ui:title': (
         <>
           <h2 className="vads-u-font-size--h3">{labelString}</h2>
-          <p>Select the description that fits you.</p>
+          Select the description that fits you.
         </>
       ),
       'ui:widget': 'radio',

--- a/src/applications/simple-forms/21-0845/pages/limitedInfo.js
+++ b/src/applications/simple-forms/21-0845/pages/limitedInfo.js
@@ -18,10 +18,10 @@ export default {
               (*Required)
             </span>
           </h3>
-          <p>
+          <span className="vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-weight--normal vads-u-font-size--base vads-u-line-height--4 vads-u-display--block">
             Select the items we can share with your third-party source. You can
             select more than one.
-          </p>
+          </span>
         </>
       ),
       'ui:widget': GroupCheckboxWidget,

--- a/src/applications/simple-forms/21-0845/pages/organizationReps.js
+++ b/src/applications/simple-forms/21-0845/pages/organizationReps.js
@@ -7,10 +7,10 @@ export default {
     'ui:title': (
       <>
         <h3>Organization’s representatives</h3>
-        <p className="vads-u-margin-top--4 vads-u-margin-bottom--2 vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal vads-u-color--gray-dark">
+        <span className="vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-weight--normal vads-u-font-size--base vads-u-line-height--4 vads-u-display--block">
           List at least one person from the organization who we can release your
           information to.
-        </p>
+        </span>
       </>
     ),
     organizationRepresentative: {

--- a/src/applications/simple-forms/21-0845/pages/securityQuestion.js
+++ b/src/applications/simple-forms/21-0845/pages/securityQuestion.js
@@ -58,17 +58,15 @@ export default {
                     (*Required)
                   </span>
                 </h3>
-                <div>
-                  <p>
-                    Select a security question. We’ll ask you to enter the
-                    answer on the next screen. You’ll then need to give the
-                    answer to your designated third-party source.
-                  </p>
-                  <p>
-                    We’ll ask this question each time your designated
-                    third-party source contacts us.
-                  </p>
-                </div>
+                <span className="vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-weight--normal vads-u-font-size--base vads-u-line-height--4 vads-u-display--block">
+                  Select a security question. We’ll ask you to enter the answer
+                  on the next screen. You’ll then need to give the answer to
+                  your designated third-party source.
+                  <br />
+                  <br />
+                  We’ll ask this question each time your designated third-party
+                  source contacts us.
+                </span>
               </>
             ),
             uiSchema,

--- a/src/platform/forms-system/src/js/web-component-patterns/titlePattern.js
+++ b/src/platform/forms-system/src/js/web-component-patterns/titlePattern.js
@@ -23,11 +23,17 @@ import React from 'react';
 export const titleUI = (title, description) => {
   return {
     'ui:title': (
-      <h3 className="vads-u-color--gray-dark vads-u-margin-y--0">{title}</h3>
+      <>
+        <h3 className="vads-u-color--gray-dark vads-u-margin-top--0 vads-u-margin-bottom--3">
+          {title}
+        </h3>
+        {description && (
+          <span className="vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-weight--normal vads-u-font-size--base vads-u-line-height--4 vads-u-display--block">
+            {description}
+          </span>
+        )}
+      </>
     ),
-    'ui:description': description ? (
-      <p className="vads-u-margin-bottom--0">{description}</p>
-    ) : null,
   };
 };
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

Working with @ndsprinkle, we figured out how to also get ui:description to load in the legend on forms where there is a ui:title, and a ui:description. For forms that had ui:title/description recently updated like 21P-0847, no code changes are needed in order for this to work, and the descriptions load in the legend. I did do some HTML cleanup in 0845 to help the legend be more valid.

Team: Veteran facing forms

no flipper



## Related issue(s)

-  https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/636
- related to Fieldset/Legend/Headings work: https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/556

## Testing done

**Describe what the old behavior was prior to the change**

Instructional text was not loading in the `<legend>`

**Describe the steps required to verify your changes are working as expected**

- Load each form page in the browser, inspect the code to see instructional text moved from outside of the `<legend>` to inside the legend
 - Test the page with a screen reader and hear the text readout by a screen reader


## Screenshots

Visually nothing changes with this work. 


## What areas of the site does it impact?

Only impacts simple forms

## Acceptance criteria

- Instructional text is read by screen readers
- HTML is valid

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

I do wonder if some of our other simple-forms `ui:title` should be updated to match what was done on 21P-0847
```
  uiSchema: {
    ...titleUI(
      'Substitute Claimant',
      'First, we’ll ask for your information as the person requesting to be the substitute claimant.',
    ),
    preparerName: fullNameNoSuffixUI(),
  },
```
