### PR TITLE
Remove PACT deadline content from Health Care Application

### DIFF
--- a/src/applications/hca/components/FormAlerts/LoginRequiredAlert.jsx
+++ b/src/applications/hca/components/FormAlerts/LoginRequiredAlert.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const LoginRequiredAlert = ({ handleLogin }) => (
-  <va-alert status="error" uswds>
+  <va-alert status="error">
     <h2 slot="headline">Please sign in to review your information</h2>
     <p>
       We’re sorry for the interruption, but we’ve found some more information

--- a/src/applications/hca/components/FormAlerts/SubmissionErrorAlert.jsx
+++ b/src/applications/hca/components/FormAlerts/SubmissionErrorAlert.jsx
@@ -9,45 +9,67 @@ const SubmissionErrorAlert = () => {
 
   return (
     <div className="hca-error-message vads-u-margin-bottom--4">
-      <va-alert status="error" uswds>
+      <va-alert status="error">
         <h3 slot="headline">We didn’t receive your online application</h3>
-        <p>
-          We’re sorry. Something went wrong when you tried to submit your
-          application. Try again later.
-        </p>
+        <div>
+          <p className="vads-u-margin-top--0">
+            We’re sorry. Something went wrong when you tried to submit your
+            application. If you were signed in, you can try to submit your
+            application again later. If you were not signed in, you may need to
+            fill out and submit the online application again.
+          </p>
 
-        <p>
-          <strong>
-            If you’re trying to apply by the September 30th special enrollment
-            deadline for certain combat Veterans
-          </strong>
-          , you can also apply in other ways:
-        </p>
-        <ul>
-          <li>
-            Call us at <va-telephone contact={CONTACTS['222_VETS']} />. We’re
-            here Friday, September 29, 7:00 a.m. to 9:00 p.m.{' '}
+          <h4 className="vads-u-font-size--h5">Other ways to apply</h4>
+          <ul>
+            <li>
+              You can call our toll-free hotline at{' '}
+              <va-telephone contact={CONTACTS['222_VETS']} /> to apply by phone,
+              Monday through Friday, 8:00 a.m. to 8:00 p.m.{' '}
+              <dfn>
+                <abbr title="Eastern Time">ET</abbr>
+              </dfn>
+              , <strong>or</strong>
+            </li>
+            <li>
+              You can download and fill out the application. Send your completed
+              application here:
+            </li>
+          </ul>
+          <p className="va-address-block vads-u-margin-bottom--2 vads-u-margin-x--0">
+            Health Eligibility Center <br />
+            2957 Clairmont Road NE, Ste 200 <br />
+            Atlanta, GA 30329-1647 <br />
+          </p>
+          <p>
+            If you have trouble downloading your application, call us at{' '}
+            <va-telephone contact={CONTACTS.HELP_DESK} /> (
+            <va-telephone contact={CONTACTS['711']} tty />
+            ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m.{' '}
             <dfn>
-              <abbr title="Central Time">CT</abbr>
-            </dfn>
-            , and Saturday, September 30, 7:00 a.m. to 11:59 p.m.{' '}
-            <dfn>
-              <abbr title="Central Time">CT</abbr>
+              <abbr title="Eastern Time">ET</abbr>
             </dfn>
             .
-          </li>
-          <li>Mail us an application postmarked by September 30, 2023.</li>
-          <li>
-            Or bring your application in person to your nearest VA health
-            facility.
-          </li>
-        </ul>
-        <p>
-          <a href="/health-care/how-to-apply/">
-            Learn more about how to apply by phone, mail, or in person
+          </p>
+
+          <a
+            href="https://www.va.gov/vaforms/medical/pdf/10-10EZ-fillable.pdf"
+            aria-label="Download VA Form 10-10EZ - Opens in new window"
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="hca-fillable-pdf-link"
+          >
+            <i
+              className="fas fa-download vads-u-margin-right--1"
+              aria-hidden="true"
+              role="img"
+            />
+            Download VA Form 10-10EZ (
+            <dfn>
+              <abbr title="Portable Document Format">PDF</abbr>
+            </dfn>
+            )
           </a>
-          .
-        </p>
+        </div>
       </va-alert>
     </div>
   );

--- a/src/applications/hca/components/FormAlerts/index.jsx
+++ b/src/applications/hca/components/FormAlerts/index.jsx
@@ -5,107 +5,28 @@ import recordEvent from 'platform/monitoring/record-event';
 
 /** Global */
 export const DowntimeWarning = () => (
-  <va-alert status="warning" uswds>
+  <va-alert status="warning">
     <h2 slot="headline">The health care application is down for maintenance</h2>
     <p>
       We’re sorry. The health care application is currently down while we fix a
       few things. We’ll be back up as soon as we can.
     </p>
     <p>
-      <strong>
-        If you’re trying to apply by the September 30th special enrollment
-        deadline for certain combat Veterans
-      </strong>
-      , you can also apply in other ways. Call us at{' '}
-      <va-telephone contact={CONTACTS['222_VETS']} />. We’re here Friday,
-      September 29, 7:00 a.m. to 9:00 p.m.{' '}
+      In the meantime, you can call{' '}
+      <va-telephone contact={CONTACTS['222_VETS']} />, Monday through Friday,
+      8:00 a.m. to 8:00 p.m.{' '}
       <dfn>
-        <abbr title="Central Time">CT</abbr>
-      </dfn>
-      , and Saturday, September 30, 7:00 a.m. to 11:59 p.m.{' '}
-      <dfn>
-        <abbr title="Central Time">CT</abbr>
-      </dfn>
-      . Mail us an application postmarked by September 30, 2023. Or bring your
-      application in person to your nearest VA health facility.{' '}
-      <a href="/health-care/how-to-apply/">
-        Learn more about how to apply by phone, mail, or in person
-      </a>
-      .
+        <abbr title="Eastern Time">ET</abbr>
+      </dfn>{' '}
+      and press 2 to complete this application over the phone.
     </p>
-  </va-alert>
-);
-
-export const PerformanceWarning = () => (
-  <va-alert status="warning" class="vads-u-margin-bottom--4" uswds>
-    <h3 slot="headline">This application may not be working right now</h3>
-    <div>
-      <p className="vads-u-margin-top--0">
-        You may have trouble using this application at this time. We’re working
-        to fix the problem. If you have trouble, you can try again or check back
-        later.
-      </p>
-      <p>
-        <strong>
-          If you’re trying to apply by the September 30th special enrollment
-          deadline for certain combat Veterans
-        </strong>
-        , you can also apply in other ways. Call us at{' '}
-        <va-telephone contact={CONTACTS['222_VETS']} />. We’re here Friday,
-        September 29, 7:00 a.m. to 9:00 p.m.{' '}
-        <dfn>
-          <abbr title="Central Time">CT</abbr>
-        </dfn>
-        , and Saturday, September 30, 7:00 a.m. to 11:59 p.m.{' '}
-        <dfn>
-          <abbr title="Central Time">CT</abbr>
-        </dfn>
-        . Mail us an application postmarked by September 30, 2023. Or bring your
-        application in person to your nearest VA health facility.{' '}
-        <a href="/health-care/how-to-apply/">
-          Learn more about how to apply by phone, mail, or in person
-        </a>
-        .
-      </p>
-    </div>
   </va-alert>
 );
 
 export const ServerErrorAlert = () => (
-  <va-alert status="error" uswds>
+  <va-alert status="error">
     <h2 slot="headline">Something went wrong on our end</h2>
     <p>We’re sorry. Something went wrong on our end. Please try again.</p>
-    <p>
-      <strong>
-        If you’re trying to apply by the September 30th special enrollment
-        deadline for certain combat Veterans
-      </strong>
-      , you can also apply in other ways:
-    </p>
-    <ul>
-      <li>
-        Call us at <va-telephone contact={CONTACTS['222_VETS']} />. We’re here
-        Friday, September 29, 7:00 a.m. to 9:00 p.m.{' '}
-        <dfn>
-          <abbr title="Central Time">CT</abbr>
-        </dfn>
-        , and Saturday, September 30, 7:00 a.m. to 11:59 p.m.{' '}
-        <dfn>
-          <abbr title="Central Time">CT</abbr>
-        </dfn>
-        .
-      </li>
-      <li>Mail us an application postmarked by September 30, 2023.</li>
-      <li>
-        Or bring your application in person to your nearest VA health facility.
-      </li>
-    </ul>
-    <p>
-      <a href="/health-care/how-to-apply/">
-        Learn more about how to apply by phone, mail, or in person
-      </a>
-      .
-    </p>
   </va-alert>
 );
 
@@ -124,7 +45,7 @@ export const ShortFormAlert = () => (
 
 /** CHAPTER 1: Veteran Information */
 export const IdentityVerificationAlert = () => (
-  <va-alert status="continue" data-testid="hca-identity-alert" uswds>
+  <va-alert status="continue" data-testid="hca-identity-alert">
     <h4 slot="headline">
       Please verify your identity before applying for VA health care
     </h4>

--- a/src/applications/hca/components/GetHelp.jsx
+++ b/src/applications/hca/components/GetHelp.jsx
@@ -12,28 +12,6 @@ const GetHelp = () => (
     </p>
     <p className="help-talk">
       <strong>
-        If you’re trying to apply by the September 30th special enrollment
-        deadline for certain combat Veterans
-      </strong>
-      , you can also apply in other ways. Call us at{' '}
-      <va-telephone contact={CONTACTS['222_VETS']} />. We’re here Friday,
-      September 29, 7:00 a.m. to 9:00 p.m.{' '}
-      <dfn>
-        <abbr title="Central Time">CT</abbr>
-      </dfn>
-      , and Saturday, September 30, 7:00 a.m. to 11:59 p.m.{' '}
-      <dfn>
-        <abbr title="Central Time">CT</abbr>
-      </dfn>
-      . Mail us an application postmarked by September 30, 2023. Or bring your
-      application in person to your nearest VA health facility.{' '}
-      <a href="/health-care/how-to-apply/">
-        Learn more about how to apply by phone, mail, or in person
-      </a>
-      .
-    </p>
-    <p className="help-talk">
-      <strong>
         If you need help to gather your information or fill out your
         application,{' '}
       </strong>

--- a/src/applications/hca/components/IntroductionPage/GetStarted/index.jsx
+++ b/src/applications/hca/components/IntroductionPage/GetStarted/index.jsx
@@ -13,7 +13,7 @@ const GetStartedContent = ({ route, showLoginAlert, toggleLoginModal }) => {
   return (
     <>
       {showLoginAlert ? (
-        <va-alert status="info" uswds>
+        <va-alert status="info" background-only>
           <h2 className="vads-u-font-size--h4 vads-u-margin-top--0 vads-u-margin-bottom--2">
             Have you applied for VA health care before?
           </h2>
@@ -37,7 +37,7 @@ const GetStartedContent = ({ route, showLoginAlert, toggleLoginModal }) => {
       <ProcessTimeline />
 
       {showLoginAlert ? (
-        <va-alert status="info" class="vads-u-margin-bottom--5" uswds>
+        <va-alert status="info" class="vads-u-margin-bottom--5">
           <h2 slot="headline">Save time and save your work in progress</h2>
           <p>Here’s how signing in now helps you:</p>
           <ul>

--- a/src/applications/hca/containers/IntroductionPage.jsx
+++ b/src/applications/hca/containers/IntroductionPage.jsx
@@ -11,10 +11,7 @@ import {
 
 import EnrollmentStatus from '../components/IntroductionPage/EnrollmentStatus';
 import GetStartedContent from '../components/IntroductionPage/GetStarted';
-import {
-  IdentityVerificationAlert,
-  PerformanceWarning,
-} from '../components/FormAlerts';
+import { IdentityVerificationAlert } from '../components/FormAlerts';
 
 import {
   isLoading,
@@ -33,7 +30,7 @@ const IntroductionPage = props => {
     showLOA3Content,
     showGetStartedContent,
   } = displayConditions;
-  const { enrollmentOverrideEnabled, performanceAlertEnabled } = features;
+  const { enrollmentOverrideEnabled } = features;
 
   useEffect(() => {
     focusElement('.va-nav-breadcrumbs-list');
@@ -54,8 +51,6 @@ const IntroductionPage = props => {
         appTitle="Application for VA health care"
         dependencies={[externalServices.es]}
       >
-        {performanceAlertEnabled && <PerformanceWarning />}
-
         {!showLoader &&
           !showLOA3Content && (
             <p data-testid="hca-loa1-description">
@@ -103,7 +98,6 @@ const mapStateToProps = state => ({
   features: {
     enrollmentOverrideEnabled:
       state.featureToggles.hcaEnrollmentStatusOverrideEnabled,
-    performanceAlertEnabled: state.featureToggles.hcaPerformanceAlertEnabled,
   },
 });
 

--- a/src/applications/hca/tests/components/FormAlerts/FormAlerts.unit.spec.js
+++ b/src/applications/hca/tests/components/FormAlerts/FormAlerts.unit.spec.js
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 
 import {
   DowntimeWarning,
-  PerformanceWarning,
   ServerErrorAlert,
   ShortFormAlert,
   IdentityVerificationAlert,
@@ -17,17 +16,6 @@ describe('hca <DowntimeWarning>', () => {
     expect(selector).to.exist;
     expect(selector).to.contain.text(
       'The health care application is down for maintenance',
-    );
-  });
-});
-
-describe('hca <PerformanceWarning>', () => {
-  it('should render', () => {
-    const { container } = render(<PerformanceWarning />);
-    const selector = container.querySelector('va-alert');
-    expect(selector).to.exist;
-    expect(selector).to.contain.text(
-      'This application may not be working right now',
     );
   });
 });

--- a/src/applications/hca/tests/components/FormAlerts/SubmissionErrorAlert.unit.spec.js
+++ b/src/applications/hca/tests/components/FormAlerts/SubmissionErrorAlert.unit.spec.js
@@ -14,5 +14,17 @@ describe('hca <SubmissionErrorAlert>', () => {
         'We didn’t receive your online application',
       );
     });
+
+    it('should render PDF form download link', () => {
+      const { container } = render(<SubmissionErrorAlert />);
+      const selector = container.querySelector(
+        '[data-testid="hca-fillable-pdf-link"]',
+      );
+      expect(selector).to.exist;
+      expect(selector).to.have.attribute(
+        'href',
+        'https://www.va.gov/vaforms/medical/pdf/10-10EZ-fillable.pdf',
+      );
+    });
   });
 });

--- a/src/applications/hca/tests/components/GetHelp.unit.spec.js
+++ b/src/applications/hca/tests/components/GetHelp.unit.spec.js
@@ -9,7 +9,7 @@ describe('hca <GetHelp>', () => {
     it('should render with the correct number of sections', () => {
       const { container } = render(<GetHelp />);
       const selector = container.querySelectorAll('.help-talk');
-      expect(selector).to.have.lengthOf(4);
+      expect(selector).to.have.lengthOf(3);
     });
   });
 });


### PR DESCRIPTION
## Summary
With the PACT deadline passed, we need to remove content from the Health Care Application that references steps to take in order to meet that deadline. This PR reverts all messaging and component changes that were made for the PACT deadline.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#65565

## Testing done
- [x] Unit tested affected component

## Acceptance criteria
- HCA content does not reference PACT deadline requirements