### PR TITLE
Add codeowner lines for known apps without explicit owners, assign to…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -202,3 +202,16 @@ src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appoi
 src/applications/dhp-connected-devices @department-of-veterans-affairs/digital-health-platform
 src/applications/virtual-agent @department-of-veterans-affairs/orchid
 src/applications/pre-need @department-of-veterans-affairs/bah-mbs-selfserv
+
+# Need more specific owners
+
+src/applications/ask-a-question @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/ask-va @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/e-folders @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/messages @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/mock-sip-form @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/post-911-gib-status @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/third-party-app-directory @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/static-pages/analytics @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/static-pages/ask-va @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/static-pages/download-1095b @department-of-veterans-affairs/va-platform-cop-frontend


### PR DESCRIPTION
… Plat FE.

**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
Follow up to https://github.com/department-of-veterans-affairs/vets-website/pull/25743. 
Adds 14 apps that were identified as missing codeowners, and adds them to codeowners with Platform FE as team to review. These ideally would get owned by a product team, and reorganized into the file in other ways, so have added a heading comment to keep them identifiable.

Related Slack thread in #vfs-platform-support: https://dsva.slack.com/archives/CBU0KDSB1/p1696266612367689

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/66724
Relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15303