### PR TITLE
VACMS-15350 Fix image aspect ratio for Event images

### DIFF
--- a/src/platform/site-wide/sass/modules/facilities/_m-facilities-general.scss
+++ b/src/platform/site-wide/sass/modules/facilities/_m-facilities-general.scss
@@ -133,14 +133,8 @@
 
 .event-detail-img {
   width: 100%;
-  height: 159px;
+  height: 28%;
   object-fit: cover;
-
-  @include media($medium-large-screen) {
-    width: 100%;
-    height: 195px;
-    object-fit: cover;
-  }
 }
 
 .region-grid {


### PR DESCRIPTION
## Summary
The Events pages in the CMS required a 7:2 image to be uploaded to display on an individual event page. The CSS was not respecting this ratio, setting a fixed pixel height on the image with a 100% width. The fixed height has been adjusted to use percentage instead at a 7:2 ratio (28%). This ratio holds at all screen sizes and will respect what the CMS sends over.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15350

## Testing done
Test URL: `/wichita-health-care/events/61317/`

## Screenshots

** BEFORE **
<img width="347" alt="Screenshot 2023-10-02 at 3 00 53 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/b9059df2-1465-4647-8591-1b1173686587">
<img width="1065" alt="Screenshot 2023-10-02 at 3 00 58 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/b637b277-9f9b-4cf1-bb39-62a2cbb52a6e">

** AFTER **
<img width="377" alt="Screenshot 2023-10-02 at 2 42 32 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/a6a1e372-8cad-4193-9f23-90eddcec74de">
<img width="805" alt="Screenshot 2023-10-02 at 2 42 24 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/29cc66bb-1f3c-4620-9d4f-7bb6f425ffc3">
<img width="1075" alt="Screenshot 2023-10-02 at 2 42 15 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/9f792b94-1008-4f47-92a5-c337a76b51bf">
<img width="1250" alt="Screenshot 2023-10-02 at 2 42 07 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/207bee89-05da-4cec-bd4a-59d82d652a16">
