### PR TITLE
[FSR] 66245 fix - Asset review page and content fixes

### DIFF
--- a/src/applications/financial-status-report/components/monetary/CashInBank.jsx
+++ b/src/applications/financial-status-report/components/monetary/CashInBank.jsx
@@ -89,7 +89,7 @@ const CashInBank = ({
           hint={null}
           id="cash"
           inputmode="decimal"
-          label="What is the dollar amount of all checkings and savings accounts?"
+          label="What is the total amount you have in all checking and savings accounts?"
           name="cash"
           onBlur={onBlur}
           onInput={({ target }) => setCash(target.value)}
@@ -132,7 +132,16 @@ const CashInBankReview = formData => {
   const { assets } = data;
   const { monetaryAssets = [] } = assets;
 
-  return isStreamlinedShortForm(data) ? (
+  // we want this to show if a short form exited early and they have no other monetary assets where it
+  //  would normally render the monetary asset list
+  const noOtherMonetaryAssets =
+    monetaryAssets.filter(
+      asset =>
+        asset?.name?.toLowerCase() !== 'cash on hand (not in bank)' &&
+        asset?.name?.toLowerCase() !== 'cash in a bank (savings and checkings)',
+    ).length === 0;
+
+  return isStreamlinedShortForm(data) || noOtherMonetaryAssets ? (
     <div className="form-review-panel-page">
       <div className="form-review-panel-page-header-row">
         <h4 className="form-review-panel-page-header vads-u-font-size--h5">


### PR DESCRIPTION
## Summary
This PR fixes a bug where if a user is sent down a streamlined path, and they don't select any additional monetary assets (U.S. Savings bonds, Retirement accounts, etc) they don't see the Cash in bank or Cash on hand values populated on the review page. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#66245

## Testing done
Manual testing completed 

## Screenshots
Prior to fix, if only cash in bank and on hand were populated, they would not display on the review page. 
| Before | After |
| ------ | ----- |
| ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/25368370/4a342f1b-79b0-4378-94fb-750e50e34e91) | <img width="466" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/25368370/e2a3a30a-a1b0-4877-a785-9aa4c1bc67b3">  |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
