### PR TITLE
MHV-49868 Pull location from the new name field in FHIR

### DIFF
--- a/src/applications/mhv/medical-records/reducers/allergies.js
+++ b/src/applications/mhv/medical-records/reducers/allergies.js
@@ -21,6 +21,28 @@ const interpretObservedOrReported = code => {
   return EMPTY_FIELD;
 };
 
+export const extractLocation = allergy => {
+  if (
+    allergy?.recorder?.extension &&
+    isArrayAndHasItems(allergy.recorder.extension)
+  ) {
+    // Strip the leading "#" from the reference.
+    const ref = allergy.recorder.extension[0].valueReference?.reference?.substring(
+      1,
+    );
+    // Use the reference inside "recorder" to get the value from "contained".
+    if (ref && isArrayAndHasItems(allergy.contained)) {
+      const org = allergy.contained.filter(
+        containedItem => containedItem.id === ref,
+      );
+      if (org.length > 0 && org[0].name) {
+        return org[0].name;
+      }
+    }
+  }
+  return EMPTY_FIELD;
+};
+
 export const convertAllergy = allergy => {
   return {
     id: allergy.id,
@@ -32,7 +54,7 @@ export const convertAllergy = allergy => {
     name: allergy?.code?.text || EMPTY_FIELD,
     date: formatDateLong(allergy.recordedDate),
     reaction: getReactions(allergy),
-    location: allergy.recorder?.display || EMPTY_FIELD,
+    location: extractLocation(allergy),
     observedOrReported:
       isArrayAndHasItems(allergy.extension) &&
       interpretObservedOrReported(

--- a/src/applications/mhv/medical-records/tests/reducers/allergies.unit.spec.js
+++ b/src/applications/mhv/medical-records/tests/reducers/allergies.unit.spec.js
@@ -1,0 +1,83 @@
+import { expect } from 'chai';
+import { extractLocation } from '../../reducers/allergies';
+import { EMPTY_FIELD } from '../../util/constants';
+
+describe('extractLocation function', () => {
+  it('should return the name when all properties exist and conditions are met', () => {
+    const allergyExample = {
+      recorder: {
+        extension: [
+          {
+            valueReference: {
+              reference: '#org1',
+            },
+          },
+        ],
+      },
+      contained: [
+        {
+          id: 'org1',
+          name: 'LocationName',
+        },
+      ],
+    };
+    expect(extractLocation(allergyExample)).to.equal('LocationName');
+  });
+
+  it('should return EMPTY_FIELD when recorder or extension is undefined', () => {
+    const allergyExample = {
+      recorder: {
+        // extension is missing
+      },
+      contained: [
+        {
+          id: 'org1',
+          name: 'LocationName',
+        },
+      ],
+    };
+    expect(extractLocation(allergyExample)).to.equal(EMPTY_FIELD);
+  });
+
+  it('should return EMPTY_FIELD when reference is incorrect', () => {
+    const allergyExample = {
+      recorder: {
+        extension: [
+          {
+            valueReference: {
+              reference: '#org2', // mismatched reference
+            },
+          },
+        ],
+      },
+      contained: [
+        {
+          id: 'org1',
+          name: 'LocationName',
+        },
+      ],
+    };
+    expect(extractLocation(allergyExample)).to.equal(EMPTY_FIELD);
+  });
+
+  it('should return EMPTY_FIELD when contained item does not have a name', () => {
+    const allergyExample = {
+      recorder: {
+        extension: [
+          {
+            valueReference: {
+              reference: '#org1',
+            },
+          },
+        ],
+      },
+      contained: [
+        {
+          id: 'org1',
+          // name is missing
+        },
+      ],
+    };
+    expect(extractLocation(allergyExample)).to.equal(EMPTY_FIELD);
+  });
+});


### PR DESCRIPTION
## Summary

Changed to use the new updated field in the FHIR data

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-49868 - Convert Allergy location data to be more user friendly (Dark Deploy)

## Testing done

- 4 new unit tests to test various branches of the function

## Screenshots

None

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
