### PR TITLE
Update thirdPartyPreparerFullName and conditionally validate SoT

### DIFF
--- a/src/applications/simple-forms/21-0966/config/form.js
+++ b/src/applications/simple-forms/21-0966/config/form.js
@@ -25,7 +25,7 @@ import {
 import survivingDependantBenefitSelection from '../pages/survivingDependantBenefitSelection';
 import veteranPersonalInformation from '../pages/veteranPersonalInformation';
 import veteranIdentificationInformation from '../pages/veteranIdentificationInformation';
-import preparerName from '../pages/preparerName';
+import thirdPartyPreparerFullName from '../pages/thirdPartyPreparerFullName';
 
 // mock-data import for local development
 import testData from '../tests/e2e/fixtures/data/minimal-test.json';
@@ -72,7 +72,10 @@ const formConfig = {
         'I confirm that the identifying information in this form is accurate and has been represented correctly.',
       messageAriaDescribedby:
         'I confirm that the identifying information in this form is accurate and has been represented correctly.',
-      fullNamePath: 'preparerFullName',
+      fullNamePath: formData =>
+        preparerIsThirdParty({ formData })
+          ? 'thirdPartyPreparerFullName'
+          : 'preparerFullName',
     },
   },
   formId: '21-0966',
@@ -112,13 +115,13 @@ const formConfig = {
           uiSchema: preparerIdentification.uiSchema,
           schema: preparerIdentification.schema,
         },
-        preparerName: {
+        thirdPartyPreparerFullName: {
           path: 'preparer-name',
           // display only if preparer is a third-party
           depends: formData => preparerIsThirdParty({ formData }),
           title: 'Your name',
-          uiSchema: preparerName.uiSchema,
-          schema: preparerName.schema,
+          uiSchema: thirdPartyPreparerFullName.uiSchema,
+          schema: thirdPartyPreparerFullName.schema,
         },
       },
     },

--- a/src/applications/simple-forms/21-0966/pages/thirdPartyPreparerFullName.js
+++ b/src/applications/simple-forms/21-0966/pages/thirdPartyPreparerFullName.js
@@ -17,13 +17,13 @@ export default {
         sign this application for them.
       </p>,
     ),
-    preparerName: fullNameNoSuffixUI(),
+    thirdPartyPreparerFullName: fullNameNoSuffixUI(),
   },
   schema: {
     type: 'object',
     properties: {
       'view:title': titleSchema,
-      preparerName: fullNameNoSuffixSchema,
+      thirdPartyPreparerFullName: fullNameNoSuffixSchema,
     },
   },
 };

--- a/src/applications/simple-forms/21-0966/tests/e2e/21-0966-intent-to-file-a-claim.cypress.spec.js
+++ b/src/applications/simple-forms/21-0966/tests/e2e/21-0966-intent-to-file-a-claim.cypress.spec.js
@@ -44,11 +44,14 @@ const testConfig = createTestConfig(
           });
         });
       },
-      [pagePaths.preparerName]: ({ afterHook }) => {
+      [pagePaths.thirdPartyPreparerFullName]: ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
           cy.get('@testData').then(data => {
-            fillFullNameWebComponentPattern('preparerName', data.preparerName);
+            fillFullNameWebComponentPattern(
+              'thirdPartyPreparerFullName',
+              data.thirdPartyPreparerFullName,
+            );
 
             cy.axeCheck();
             cy.findByText(/continue/i, { selector: 'button' }).click();

--- a/src/applications/simple-forms/21-0966/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/simple-forms/21-0966/tests/e2e/fixtures/data/maximal-test.json
@@ -18,7 +18,7 @@
     "vaFileNumber": "445565612"
   },
   "relationshipToVeteran": "SPOUSE",
-  "preparerName": {
+  "thirdPartyPreparerFullName": {
     "first": "Thierry",
     "middle": "P.",
     "last": "Dependant"

--- a/src/applications/simple-forms/21-0966/tests/e2e/pagePaths.js
+++ b/src/applications/simple-forms/21-0966/tests/e2e/pagePaths.js
@@ -5,8 +5,9 @@ export default {
   preparerIdentification:
     formChapters.preparerIdentificationChapter.pages.preparerIdentification
       .path,
-  preparerName:
-    formChapters.preparerIdentificationChapter.pages.preparerName.path,
+  thirdPartyPreparerFullName:
+    formChapters.preparerIdentificationChapter.pages.thirdPartyPreparerFullName
+      .path,
   veteranBenefitSelection:
     formChapters.benefitSelectionChapter.pages.veteranBenefitSelection.path,
   survivingDependantBenefitSelection:

--- a/src/applications/simple-forms/21-0966/tests/pages/preparerName.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/pages/preparerName.unit.spec.jsx
@@ -7,7 +7,7 @@ import formConfig from '../../config/form';
 const {
   schema,
   uiSchema,
-} = formConfig.chapters.preparerIdentificationChapter.pages.preparerName;
+} = formConfig.chapters.preparerIdentificationChapter.pages.thirdPartyPreparerFullName;
 
 const pageTitle = 'Preparer name';
 


### PR DESCRIPTION
## Summary
This updates form 21-0966 to support conditional logic in the statement of truth based on the identity of the person filling out the form. There is also an update to a property name in here, `thirdPartyPreparerFullName` to distinguish it more from the default `preparerFullName`

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#647