### PR TITLE
Profile/aw/65410/disallow letters in phone fields

### DIFF
--- a/src/applications/personalization/profile/util/contact-information/phoneUtils.js
+++ b/src/applications/personalization/profile/util/contact-information/phoneUtils.js
@@ -1,5 +1,4 @@
 import { PHONE_TYPE, USA } from '@@vap-svc/constants';
-import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
 import pickBy from 'lodash/pickBy';
 
 export const phoneFormSchema = {
@@ -11,7 +10,8 @@ export const phoneFormSchema = {
     },
     inputPhoneNumber: {
       type: 'string',
-      pattern: '^\\d{10}$',
+      pattern: '^[0-9-]+$',
+      maxLength: 14,
     },
     extension: {
       type: 'string',
@@ -25,10 +25,9 @@ export const phoneFormSchema = {
 export const phoneUiSchema = fieldName => {
   return {
     inputPhoneNumber: {
-      'ui:widget': PhoneNumberWidget,
       'ui:title': `${fieldName} (U.S. numbers only)`,
       'ui:errorMessages': {
-        pattern: 'Please enter a valid 10-digit U.S. phone number.',
+        pattern: 'Enter a 10 digit phone number',
       },
       'ui:options': {
         ariaDescribedby: 'error-message-details',

--- a/src/applications/personalization/profile/util/contact-information/phoneUtils.js
+++ b/src/applications/personalization/profile/util/contact-information/phoneUtils.js
@@ -10,7 +10,7 @@ export const phoneFormSchema = {
     },
     inputPhoneNumber: {
       type: 'string',
-      pattern: '^[0-9-]+$',
+      pattern: '^[0-9- ]+$',
       maxLength: 14,
     },
     extension: {

--- a/src/applications/personalization/profile/util/contact-information/phoneUtils.js
+++ b/src/applications/personalization/profile/util/contact-information/phoneUtils.js
@@ -10,7 +10,7 @@ export const phoneFormSchema = {
     },
     inputPhoneNumber: {
       type: 'string',
-      pattern: '^[0-9- ]+$',
+      pattern: '^[0-9-() ]+$',
       maxLength: 14,
     },
     extension: {


### PR DESCRIPTION
## Summary

- Changes the validation rules of the phone field to only allow numbers, -, and spaces in the field. This was the field will show a validation error if any invalid characters are input

- Error message content was updated per the ticket as well 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/65410

## Testing done

- Existing tests function appropriately

## Screenshots

No UI changes

## What areas of the site does it impact?

Profile

## Acceptance criteria

- [x] Validation regex updated for allowing only numbers, dashes, and spaces

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
