### PR TITLE
Sa 79899 additional considerations

### DIFF
--- a/src/applications/my-education-benefits/config/form.js
+++ b/src/applications/my-education-benefits/config/form.js
@@ -275,7 +275,9 @@ function AdditionalConsiderationTemplate(page, formField) {
     path: page.name,
     title: data => {
       return additionalConsiderationsQuestionTitleText(
-        data[formFields.viewBenefitSelection][formFields.benefitRelinquished],
+        data[(formFields?.viewBenefitSelection)][
+          (formFields?.benefitRelinquished)
+        ] || 'NotEligible',
         page.order,
       );
     },

--- a/src/applications/my-education-benefits/config/form.js
+++ b/src/applications/my-education-benefits/config/form.js
@@ -275,9 +275,11 @@ function AdditionalConsiderationTemplate(page, formField) {
     path: page.name,
     title: data => {
       return additionalConsiderationsQuestionTitleText(
-        data[(formFields?.viewBenefitSelection)][
-          (formFields?.benefitRelinquished)
-        ] || 'NotEligible',
+        (data[(formFields?.viewBenefitSelection)] &&
+          data[(formFields?.viewBenefitSelection)][
+            (formFields?.benefitRelinquished)
+          ]) ||
+          'NotEligible',
         page.order,
       );
     },


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- Check for existence of values 


Description: 

From the Application Review page, when the users selects the “+” next to the Additional Considerations the line does not expand and takes the user to an erroneous va page. Users can not update the additional consideration questions from the application review page.  

Descriptive Analysis: 

[SA-1491](https://jira.np.afsp.io/browse/SA-1491) WHEN the applicant continues from the "Additional Considerations" page 

THEN the applicant is presented with a "Review & Submit" page 

AND the page is presented an expandable Additional Considerations sections with a plus sign 

Pressing the plus sign will 

Present each of the questions answered previously for Additional Considerations. 

Each question will have an Edit button right next to it. 

Pressing the Edit button on any give button will show: 

Title: "Question x of 4" where x will depend on the number of the question. 

Sentence: "If you’d like to update your answer to Question x of 4, edit your answer to to the question below." where x will depend on the number of the question. 

Sentence that will be the question to be answered. This depends on the selected question and can be one of these: 

Do you qualify for an active duty kicker, sometimes called a College Fund?(*Required) 

Did you graduate and receive a commission from the United States Military Academy, Naval Academy, Air Force Academy, or Coast Guard Academy?(*Required) 

Were you commissioned as a result of Senior ROTC?(*Required) 

Do you have a period of service that the Department of Defense counts towards an education loan payment? (*Required) 

Show Yes/No radio buttons to change the answer to the Additional Consideration. 

An "Update page" button. 

Pressing the "Update Page" button will store the answer and return to read only version of the Additional Consideration question. 

Presently users can not update the Additional Considerations questions from the Application review page.  Users can still log back in and submit the application without reviewing.   

Expected Outcome: 

From the Application Review page, when the users selects the “+” next to the Additional Considerations the line should expand and display each of the questions.   

Do you qualify for an active duty kicker, sometimes called a College Fund? 

Did you graduate and receive a commission from the United States Military Academy, Naval Academy, Air Force Academy, or Coast Guard Academy? 

Were you commissioned as a result of Senior ROTC? 

Do you have a period of service that the Department of Defense counts towards an education loan payment? And the user should be able to update the answers to the questions.  

Actual Outcome: 

The user is unable to view or update the answers to the  additional considerations questions and is routed to an erroneous page.  

Type: 

Automation  

Test Case Number: 

ADHOC 

Person Email Account if MEB & WP Key for DGIB: 

ALL STAGED USERS  

vets.dgib.user+255@gmail.com 

vets.dgib.user+361@gmail.com personKey=607236266 

vets.dgib.user+378@gmail.com