### PR TITLE
PR for Refactoring "helper" functions into shared file - DR

### DIFF
--- a/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
+++ b/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
@@ -15,7 +15,6 @@ import debounce from 'platform/utilities/data/debounce';
 
 import { EVIDENCE_PRIVATE_PATH, NO_ISSUES_SELECTED } from '../constants';
 import { content } from '../content/evidencePrivateRecords';
-import { getIssueName } from '../utils/helpers';
 import { getIndex, hasErrors } from '../utils/evidence';
 import { checkValidations } from '../validations';
 import {
@@ -33,7 +32,7 @@ import {
 } from '../validations/evidence';
 import { focusEvidence } from '../utils/focus';
 
-import { getSelected } from '../../shared/utils/issues';
+import { getIssueName, getSelected } from '../../shared/utils/issues';
 
 const PRIVATE_PATH = `/${EVIDENCE_PRIVATE_PATH}`;
 // const REVIEW_AND_SUBMIT = '/review-and-submit';

--- a/src/applications/appeals/995/components/EvidenceVaRecords.jsx
+++ b/src/applications/appeals/995/components/EvidenceVaRecords.jsx
@@ -13,7 +13,6 @@ import debounce from 'platform/utilities/data/debounce';
 
 import { EVIDENCE_VA_PATH, NO_ISSUES_SELECTED } from '../constants';
 import { content } from '../content/evidenceVaRecords';
-import { getIssueName } from '../utils/helpers';
 import { getIndex, hasErrors } from '../utils/evidence';
 import { checkValidations } from '../validations';
 import {
@@ -26,7 +25,7 @@ import {
 } from '../validations/evidence';
 import { focusEvidence } from '../utils/focus';
 
-import { getSelected } from '../../shared/utils/issues';
+import { getIssueName, getSelected } from '../../shared/utils/issues';
 
 const VA_PATH = `/${EVIDENCE_VA_PATH}`;
 // const REVIEW_AND_SUBMIT = '/review-and-submit';

--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -38,7 +38,7 @@ import evidenceWillUpload from '../pages/evidenceWillUpload';
 import evidenceUpload from '../pages/evidenceUpload';
 import evidenceSummary from '../pages/evidenceSummary';
 
-import { appStateSelector, mayHaveLegacyAppeals } from '../utils/helpers';
+import { mayHaveLegacyAppeals } from '../utils/helpers';
 import {
   hasVAEvidence,
   hasPrivateEvidence,
@@ -70,6 +70,7 @@ import { focusEvidence, focusUploads } from '../utils/focus';
 
 import { CONTESTABLE_ISSUES_PATH } from '../../shared/constants';
 import { focusAlertH3, focusRadioH3 } from '../../shared/utils/focus';
+import { appStateSelector } from '../../shared/utils/issues';
 
 // const { } = fullSchema.properties;
 const blankUiSchema = { 'ui:options': { hideOnReview: true } };

--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -127,7 +127,6 @@ export const SUPPORTED_BENEFIT_TYPES_LIST = [
   // 'nationalCemeteryAdministration',
 ];
 
-export const LEGACY_TYPE = 'legacyAppeal';
 export const AMA_DATE = '2019-02-19'; // Appeals Modernization Act in effect
 
 export const SUPPORTED_BENEFIT_TYPES = constants.benefitTypes.map(type => ({

--- a/src/applications/appeals/995/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/995/containers/ConfirmationPage.jsx
@@ -8,11 +8,10 @@ import scrollTo from 'platform/utilities/ui/scrollTo';
 import { waitForRenderThenFocus } from 'platform/utilities/ui';
 import { resetStoredSubTask } from 'platform/forms/sub-task';
 
-import { getIssueName } from '../utils/helpers';
 import GetFormHelp from '../content/GetFormHelp';
 
 import { FORMAT_READABLE } from '../../shared/constants';
-import { getSelected } from '../../shared/utils/issues';
+import { getIssueName, getSelected } from '../../shared/utils/issues';
 
 export const ConfirmationPage = () => {
   const alertRef = useRef(null);

--- a/src/applications/appeals/995/reducers/contestableIssues.js
+++ b/src/applications/appeals/995/reducers/contestableIssues.js
@@ -3,10 +3,9 @@ import {
   FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
   FETCH_CONTESTABLE_ISSUES_FAILED,
 } from '../actions';
-import {
-  getEligibleContestableIssues,
-  getLegacyAppealsLength,
-} from '../utils/helpers';
+import { getEligibleContestableIssues } from '../utils/helpers';
+
+import { getLegacyAppealsLength } from '../../shared/utils/issues';
 
 const initialState = {
   issues: [],

--- a/src/applications/appeals/995/tests/utils/contactInfo.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/contactInfo.unit.spec.js
@@ -8,8 +8,6 @@ import {
   hasHomeAndMobilePhone,
 } from '../../utils/contactInfo';
 
-import { returnPhoneObject } from '../../../shared/utils/helpers';
-
 const getPhone = ({
   country = '1',
   area = '800',

--- a/src/applications/appeals/995/tests/utils/contactInfo.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/contactInfo.unit.spec.js
@@ -8,6 +8,8 @@ import {
   hasHomeAndMobilePhone,
 } from '../../utils/contactInfo';
 
+import { returnPhoneObject } from '../../../shared/utils/helpers';
+
 const getPhone = ({
   country = '1',
   area = '800',

--- a/src/applications/appeals/995/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/helpers.unit.spec.js
@@ -9,7 +9,6 @@ import {
   getIssueName,
   getIssueDate,
   getIssueNameAndDate,
-  hasDuplicates,
   isEmptyObject,
   calculateIndexOffset,
 } from '../../utils/helpers';
@@ -18,6 +17,7 @@ import { LEGACY_TYPE, SELECTED } from '../../../shared/constants';
 import { getItemSchema } from '../../../shared/utils/helpers';
 import {
   appStateSelector,
+  hasDuplicates,
   hasSomeSelected,
   getLegacyAppealsLength,
   getSelected,

--- a/src/applications/appeals/995/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/helpers.unit.spec.js
@@ -13,13 +13,13 @@ import {
   getIssueNameAndDate,
   hasDuplicates,
   isEmptyObject,
-  appStateSelector,
   calculateIndexOffset,
 } from '../../utils/helpers';
 
 import { SELECTED } from '../../../shared/constants';
 import { getItemSchema } from '../../../shared/utils/helpers';
 import {
+  appStateSelector,
   someSelected,
   hasSomeSelected,
   getSelected,

--- a/src/applications/appeals/995/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/helpers.unit.spec.js
@@ -9,12 +9,11 @@ import {
   getIssueName,
   getIssueDate,
   getIssueNameAndDate,
-  isEmptyObject,
   calculateIndexOffset,
 } from '../../utils/helpers';
 
 import { LEGACY_TYPE, SELECTED } from '../../../shared/constants';
-import { getItemSchema } from '../../../shared/utils/helpers';
+import { getItemSchema, isEmptyObject } from '../../../shared/utils/helpers';
 import {
   appStateSelector,
   hasDuplicates,

--- a/src/applications/appeals/995/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/helpers.unit.spec.js
@@ -1,11 +1,9 @@
 import moment from 'moment';
 import { expect } from 'chai';
 
-import { LEGACY_TYPE } from '../../constants';
 import { getDate } from '../../utils/dates';
 import {
   getEligibleContestableIssues,
-  getLegacyAppealsLength,
   mayHaveLegacyAppeals,
   getSelectedCount,
   getIssueName,
@@ -16,13 +14,14 @@ import {
   calculateIndexOffset,
 } from '../../utils/helpers';
 
-import { SELECTED } from '../../../shared/constants';
+import { LEGACY_TYPE, SELECTED } from '../../../shared/constants';
 import { getItemSchema } from '../../../shared/utils/helpers';
 import {
   appStateSelector,
-  someSelected,
   hasSomeSelected,
+  getLegacyAppealsLength,
   getSelected,
+  someSelected,
 } from '../../../shared/utils/issues';
 
 describe('getEligibleContestableIssues', () => {

--- a/src/applications/appeals/995/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/helpers.unit.spec.js
@@ -6,9 +6,6 @@ import {
   getEligibleContestableIssues,
   mayHaveLegacyAppeals,
   getSelectedCount,
-  getIssueName,
-  getIssueDate,
-  getIssueNameAndDate,
   calculateIndexOffset,
 } from '../../utils/helpers';
 
@@ -18,6 +15,9 @@ import {
   appStateSelector,
   hasDuplicates,
   hasSomeSelected,
+  getIssueDate,
+  getIssueName,
+  getIssueNameAndDate,
   getLegacyAppealsLength,
   getSelected,
   someSelected,

--- a/src/applications/appeals/995/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/helpers.unit.spec.js
@@ -14,11 +14,11 @@ import {
   hasDuplicates,
   isEmptyObject,
   appStateSelector,
-  getItemSchema,
   calculateIndexOffset,
 } from '../../utils/helpers';
 
 import { SELECTED } from '../../../shared/constants';
+import { getItemSchema } from '../../../shared/utils/helpers';
 import {
   someSelected,
   hasSomeSelected,

--- a/src/applications/appeals/995/utils/evidence.js
+++ b/src/applications/appeals/995/utils/evidence.js
@@ -1,7 +1,6 @@
-import { getIssueName } from './helpers';
 import { EVIDENCE_VA, EVIDENCE_PRIVATE, EVIDENCE_OTHER } from '../constants';
 
-import { getSelected } from '../../shared/utils/issues';
+import { getIssueName, getSelected } from '../../shared/utils/issues';
 
 export const hasVAEvidence = formData => formData?.[EVIDENCE_VA];
 export const hasPrivateEvidence = formData => formData?.[EVIDENCE_PRIVATE];

--- a/src/applications/appeals/995/utils/helpers.js
+++ b/src/applications/appeals/995/utils/helpers.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-import { LEGACY_TYPE, AMA_DATE } from '../constants';
+import { AMA_DATE } from '../constants';
 
 import { FORMAT_YMD } from '../../shared/constants';
 import {
@@ -37,24 +37,6 @@ export const getEligibleContestableIssues = issues => {
   });
   return processContestableIssues(result);
 };
-
-/**
- * Find legacy appeal array included with contestable issues & return length
- * Note: we are using the length of this array instead of trying to do a 1:1
- * coorelation of contestable issues to legacy issues since we're only getting a
- * summary and not a matching name or date (at least in the mock data).
- * @param {ContestableIssues} issues - Array of both eligible & ineligible
- *  contestable issues, plus legacy issues
- * @return {Number} - length of legacy array
- */
-export const getLegacyAppealsLength = issues =>
-  (issues || []).reduce((count, issue) => {
-    if (issue.type === LEGACY_TYPE) {
-      // add just-in-case there is more than one legacy type entry
-      return count + (issue.attributes?.issues?.length || 0);
-    }
-    return count;
-  }, 0);
 
 const amaCutoff = moment(AMA_DATE).startOf('day');
 /**

--- a/src/applications/appeals/995/utils/helpers.js
+++ b/src/applications/appeals/995/utils/helpers.js
@@ -67,22 +67,6 @@ export const getSelectedCount = (formData, items) =>
   getSelected({ ...formData, additionalIssues: items }).length;
 
 /**
- * Get issue name/title from either a manually added issue or issue loaded from
- * the API
- * @param {AdditionalIssueItem|ContestableIssueItem}
- */
-export const getIssueName = (entry = {}) =>
-  entry.issue || entry.attributes?.ratingIssueSubjectText;
-
-export const getIssueDate = (entry = {}) =>
-  entry.decisionDate || entry.attributes?.approxDecisionDate || '';
-
-export const getIssueNameAndDate = (entry = {}) =>
-  `${(getIssueName(entry) || '').toLowerCase()}${entry.decisionDate ||
-    entry.attributes?.approxDecisionDate ||
-    ''}`;
-
-/**
  * Calculate the index offset for the additional issue
  * @param {Number} index - index of data in combined array of contestable issues
  *   and additional issues

--- a/src/applications/appeals/995/utils/helpers.js
+++ b/src/applications/appeals/995/utils/helpers.js
@@ -120,14 +120,6 @@ export const isEmptyObject = obj =>
     ? Object.keys(obj)?.length === 0 || false
     : false;
 
-export const appStateSelector = state => ({
-  // Validation functions are provided the pageData and not the
-  // formData on the review & submit page. For more details
-  // see https://dsva.slack.com/archives/CBU0KDSB1/p1614182869206900
-  contestedIssues: state.form?.data?.contestedIssues || [],
-  additionalIssues: state.form?.data?.additionalIssues || [],
-});
-
 /**
  * Calculate the index offset for the additional issue
  * @param {Number} index - index of data in combined array of contestable issues

--- a/src/applications/appeals/995/utils/helpers.js
+++ b/src/applications/appeals/995/utils/helpers.js
@@ -82,26 +82,6 @@ export const getIssueNameAndDate = (entry = {}) =>
     entry.attributes?.approxDecisionDate ||
     ''}`;
 
-const processIssues = (array = []) =>
-  array
-    .filter(entry => getIssueName(entry) && getIssueDate(entry))
-    .map(entry => getIssueNameAndDate(entry));
-
-export const hasDuplicates = (data = {}) => {
-  const contestedIssues = processIssues(data.contestedIssues);
-  const additionalIssues = processIssues(data.additionalIssues);
-  // ignore duplicate contestable issues (if any)
-  const fullList = [...new Set(contestedIssues)].concat(additionalIssues);
-
-  return fullList.length !== new Set(fullList).size;
-};
-
-// Simple one level deep check
-export const isEmptyObject = obj =>
-  obj && typeof obj === 'object' && !Array.isArray(obj)
-    ? Object.keys(obj)?.length === 0 || false
-    : false;
-
 /**
  * Calculate the index offset for the additional issue
  * @param {Number} index - index of data in combined array of contestable issues

--- a/src/applications/appeals/995/utils/helpers.js
+++ b/src/applications/appeals/995/utils/helpers.js
@@ -128,14 +128,6 @@ export const appStateSelector = state => ({
   additionalIssues: state.form?.data?.additionalIssues || [],
 });
 
-export const getItemSchema = (schema, index) => {
-  const itemSchema = schema;
-  if (itemSchema.items.length > index) {
-    return itemSchema.items[index];
-  }
-  return itemSchema.additionalItems;
-};
-
 /**
  * Calculate the index offset for the additional issue
  * @param {Number} index - index of data in combined array of contestable issues

--- a/src/applications/appeals/995/validations/issues.js
+++ b/src/applications/appeals/995/validations/issues.js
@@ -1,10 +1,13 @@
-import { getIssueName, getIssueDate } from '../utils/helpers';
 import { errorMessages } from '../constants';
 import { validateDate } from './date';
 
 import { maxSelectedErrorMessage } from '../../shared/content/contestableIssues';
 import { MAX_LENGTH } from '../../shared/constants';
-import { getSelected } from '../../shared/utils/issues';
+import {
+  getIssueDate,
+  getIssueName,
+  getSelected,
+} from '../../shared/utils/issues';
 import { addUniqueIssueErrorMessage } from '../../shared/validations/issues';
 
 // Alert Veteran to duplicates based on name & decision date

--- a/src/applications/appeals/996/config/form.js
+++ b/src/applications/appeals/996/config/form.js
@@ -30,10 +30,11 @@ import informalConferenceTime from '../pages/informalConferenceTime';
 import informalConferenceTimeRep from '../pages/informalConferenceTimeRep';
 
 import { errorMessages, WIZARD_STATUS, ADD_ISSUE_PATH } from '../constants';
-import { appStateSelector, mayHaveLegacyAppeals } from '../utils/helpers';
+import { mayHaveLegacyAppeals } from '../utils/helpers';
 import { getIssueTitle } from '../content/areaOfDisagreement';
 
 import { CONTESTABLE_ISSUES_PATH } from '../../shared/constants';
+import { appStateSelector } from '../../shared/utils/issues';
 
 // import initialData from '../tests/schema/initialData';
 

--- a/src/applications/appeals/996/constants.js
+++ b/src/applications/appeals/996/constants.js
@@ -74,8 +74,6 @@ const supportedBenefitTypes = [
   // 'nca',
 ];
 
-export const LEGACY_TYPE = 'legacyAppeal';
-
 export const SUPPORTED_BENEFIT_TYPES = constants.benefitTypes.map(type => ({
   ...type,
   isSupported: supportedBenefitTypes.includes(type.value),

--- a/src/applications/appeals/996/containers/Form0996App.jsx
+++ b/src/applications/appeals/996/containers/Form0996App.jsx
@@ -198,9 +198,6 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   setFormData: setData,
-  formData: PropTypes.shape({
-    informalConferenceRep: PropTypes.shape({}),
-  }),
   getContestableIssues: getContestableIssuesAction,
 };
 

--- a/src/applications/appeals/996/containers/Form0996App.jsx
+++ b/src/applications/appeals/996/containers/Form0996App.jsx
@@ -10,7 +10,6 @@ import { setData } from 'platform/forms-system/src/js/actions';
 import formConfig from '../config/form';
 import { SAVED_CLAIM_TYPE } from '../constants';
 import forcedMigrations from '../migrations/forceMigrations';
-import { getIssueNameAndDate } from '../utils/helpers';
 import { getHlrWizardStatus, shouldShowWizard } from '../wizard/utils';
 
 import {
@@ -21,6 +20,7 @@ import {
 import { copyAreaOfDisagreementOptions } from '../../shared/utils/areaOfDisagreement';
 import { useBrowserMonitoring } from '../../shared/utils/useBrowserMonitoring';
 import {
+  getIssueNameAndDate,
   getSelected,
   issuesNeedUpdating,
   processContestableIssues,
@@ -198,6 +198,9 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   setFormData: setData,
+  formData: PropTypes.shape({
+    informalConferenceRep: PropTypes.shape({}),
+  }),
   getContestableIssues: getContestableIssuesAction,
 };
 

--- a/src/applications/appeals/996/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/996/content/areaOfDisagreement.jsx
@@ -1,9 +1,8 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
 
-import { getIssueDate } from '../utils/helpers';
-
-import { getIssueName } from '../../shared/utils/issues';
+import { getIssueDate, getIssueName } from '../../shared/utils/issues';
 import { FORMAT_YMD, FORMAT_READABLE } from '../../shared/constants';
 
 export const missingAreaOfDisagreementErrorMessage =
@@ -109,4 +108,8 @@ export const AreaOfDisagreementReviewField = ({ children }) => {
       </dd>
     </div>
   ) : null;
+};
+
+AreaOfDisagreementReviewField.propTypes = {
+  children: PropTypes.node.isRequired,
 };

--- a/src/applications/appeals/996/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/996/content/areaOfDisagreement.jsx
@@ -111,5 +111,5 @@ export const AreaOfDisagreementReviewField = ({ children }) => {
 };
 
 AreaOfDisagreementReviewField.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
 };

--- a/src/applications/appeals/996/migrations/02-rep-phone-fix.js
+++ b/src/applications/appeals/996/migrations/02-rep-phone-fix.js
@@ -1,4 +1,4 @@
-import { returnPhoneObject } from '../utils/helpers';
+import { returnPhoneObject } from '../../shared/utils/helpers';
 
 export const forceRepPhoneFix = data => {
   const formData = { ...data };

--- a/src/applications/appeals/996/reducers/contestableIssues.js
+++ b/src/applications/appeals/996/reducers/contestableIssues.js
@@ -3,10 +3,9 @@ import {
   FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
   FETCH_CONTESTABLE_ISSUES_FAILED,
 } from '../actions';
-import {
-  getEligibleContestableIssues,
-  getLegacyAppealsLength,
-} from '../utils/helpers';
+import { getEligibleContestableIssues } from '../utils/helpers';
+
+import { getLegacyAppealsLength } from '../../shared/utils/issues';
 
 const initialState = {
   issues: [],

--- a/src/applications/appeals/996/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/996/tests/utils/helpers.unit.spec.js
@@ -8,11 +8,13 @@ import {
   getLegacyAppealsLength,
   mayHaveLegacyAppeals,
   isVersion1Data,
-  returnPhoneObject,
 } from '../../utils/helpers';
 
 import { SELECTED } from '../../../shared/constants';
-import { isEmptyObject } from '../../../shared/utils/helpers';
+import {
+  isEmptyObject,
+  returnPhoneObject,
+} from '../../../shared/utils/helpers';
 import {
   getIssueDate,
   getIssueName,

--- a/src/applications/appeals/996/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/996/tests/utils/helpers.unit.spec.js
@@ -8,18 +8,18 @@ import {
   getLegacyAppealsLength,
   mayHaveLegacyAppeals,
   isVersion1Data,
-  getSelectedCount,
-  getIssueDate,
-  getIssueNameAndDate,
-  hasDuplicates,
-  isEmptyObject,
   returnPhoneObject,
 } from '../../utils/helpers';
 
 import { SELECTED } from '../../../shared/constants';
+import { isEmptyObject } from '../../../shared/utils/helpers';
 import {
+  getIssueDate,
   getIssueName,
+  getIssueNameAndDate,
   getSelected,
+  getSelectedCount,
+  hasDuplicates,
   hasSomeSelected,
   someSelected,
 } from '../../../shared/utils/issues';

--- a/src/applications/appeals/996/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/996/tests/utils/helpers.unit.spec.js
@@ -1,16 +1,14 @@
 import moment from 'moment';
 import { expect } from 'chai';
 
-import { LEGACY_TYPE } from '../../constants';
 import { getDate } from '../../utils/dates';
 import {
   getEligibleContestableIssues,
-  getLegacyAppealsLength,
   mayHaveLegacyAppeals,
   isVersion1Data,
 } from '../../utils/helpers';
 
-import { SELECTED } from '../../../shared/constants';
+import { LEGACY_TYPE, SELECTED } from '../../../shared/constants';
 import {
   isEmptyObject,
   returnPhoneObject,
@@ -19,6 +17,7 @@ import {
   getIssueDate,
   getIssueName,
   getIssueNameAndDate,
+  getLegacyAppealsLength,
   getSelected,
   getSelectedCount,
   hasDuplicates,

--- a/src/applications/appeals/996/utils/helpers.js
+++ b/src/applications/appeals/996/utils/helpers.js
@@ -95,23 +95,3 @@ export const getItemSchema = (schema, index) => {
  */
 export const calculateIndexOffset = (index, contestableIssuesLength) =>
   index - contestableIssuesLength;
-
-/**
- * Return a phone number object
- * @param {String} phone - phone number string to convert to an object
- * @return {phoneObject}
- */
-export const returnPhoneObject = phone => {
-  const result = {
-    countryCode: '',
-    areaCode: '',
-    phoneNumber: '',
-    phoneNumberExt: '',
-  };
-  if (typeof phone === 'string' && phone?.length === 10) {
-    result.countryCode = '1';
-    result.areaCode = phone.slice(0, 3);
-    result.phoneNumber = phone.slice(-7);
-  }
-  return result;
-};

--- a/src/applications/appeals/996/utils/helpers.js
+++ b/src/applications/appeals/996/utils/helpers.js
@@ -1,7 +1,5 @@
 import moment from 'moment';
 
-import { LEGACY_TYPE } from '../constants';
-
 import { processContestableIssues } from '../../shared/utils/issues';
 import '../../shared/definitions';
 
@@ -40,24 +38,6 @@ export const getEligibleContestableIssues = issues => {
   });
   return processContestableIssues(result);
 };
-
-/**
- * Find legacy appeal array included with contestable issues & return length
- * Note: we are using the length of this array instead of trying to do a 1:1
- * coorelation of contestable issues to legacy issues since we're only getting a
- * summary and not a matching name or date (at least in the mock data).
- * @param {ContestableIssues} issues - Array of both eligible & ineligible
- *  contestable issues, plus legacy issues
- * @return {Number} - length of legacy array
- */
-export const getLegacyAppealsLength = issues =>
-  (issues || []).reduce((count, issue) => {
-    if (issue.type === LEGACY_TYPE) {
-      // add just-in-case there is more than one legacy type entry
-      return count + (issue.attributes?.issues?.length || 0);
-    }
-    return count;
-  }, 0);
 
 /**
  * Are there any legacy appeals in the API, or did the Veteran manually add an

--- a/src/applications/appeals/996/utils/helpers.js
+++ b/src/applications/appeals/996/utils/helpers.js
@@ -70,14 +70,6 @@ export const mayHaveLegacyAppeals = ({
   additionalIssues,
 } = {}) => legacyCount > 0 || additionalIssues?.length > 0;
 
-export const appStateSelector = state => ({
-  // Validation functions are provided the pageData and not the
-  // formData on the review & submit page. For more details
-  // see https://dsva.slack.com/archives/CBU0KDSB1/p1614182869206900
-  contestedIssues: state.form?.data?.contestedIssues || [],
-  additionalIssues: state.form?.data?.additionalIssues || [],
-});
-
 /**
  * Calculate the index offset for the additional issue
  * @param {Number} index - index of data in combined array of contestable issues

--- a/src/applications/appeals/996/utils/helpers.js
+++ b/src/applications/appeals/996/utils/helpers.js
@@ -2,11 +2,7 @@ import moment from 'moment';
 
 import { LEGACY_TYPE } from '../constants';
 
-import {
-  getIssueName,
-  getSelected,
-  processContestableIssues,
-} from '../../shared/utils/issues';
+import { processContestableIssues } from '../../shared/utils/issues';
 import '../../shared/definitions';
 
 /**
@@ -73,45 +69,6 @@ export const mayHaveLegacyAppeals = ({
   legacyCount = 0,
   additionalIssues,
 } = {}) => legacyCount > 0 || additionalIssues?.length > 0;
-
-// additionalIssues (items) are separate because we're checking the count before
-// the formData is updated
-export const getSelectedCount = (formData, items) =>
-  getSelected({ ...formData, additionalIssues: items }).length;
-
-/**
- * Get issue name/title from either a manually added issue or issue loaded from
- * the API
- * @param {AdditionalIssueItem|ContestableIssueItem}
- */
-
-export const getIssueDate = (entry = {}) =>
-  entry.decisionDate || entry.attributes?.approxDecisionDate || '';
-
-export const getIssueNameAndDate = (entry = {}) =>
-  `${(getIssueName(entry) || '').toLowerCase()}${entry.decisionDate ||
-    entry.attributes?.approxDecisionDate ||
-    ''}`;
-
-const processIssues = (array = []) =>
-  array
-    .filter(entry => getIssueName(entry) && getIssueDate(entry))
-    .map(entry => getIssueNameAndDate(entry));
-
-export const hasDuplicates = (data = {}) => {
-  const contestedIssues = processIssues(data.contestedIssues);
-  const additionalIssues = processIssues(data.additionalIssues);
-  // ignore duplicate contestable issues (if any)
-  const fullList = [...new Set(contestedIssues)].concat(additionalIssues);
-
-  return fullList.length !== new Set(fullList).size;
-};
-
-// Simple one level deep check
-export const isEmptyObject = obj =>
-  obj && typeof obj === 'object' && !Array.isArray(obj)
-    ? Object.keys(obj)?.length === 0 || false
-    : false;
 
 export const appStateSelector = state => ({
   // Validation functions are provided the pageData and not the

--- a/src/applications/appeals/996/utils/helpers.js
+++ b/src/applications/appeals/996/utils/helpers.js
@@ -78,14 +78,6 @@ export const appStateSelector = state => ({
   additionalIssues: state.form?.data?.additionalIssues || [],
 });
 
-export const getItemSchema = (schema, index) => {
-  const itemSchema = schema;
-  if (itemSchema.items.length > index) {
-    return itemSchema.items[index];
-  }
-  return itemSchema.additionalItems;
-};
-
 /**
  * Calculate the index offset for the additional issue
  * @param {Number} index - index of data in combined array of contestable issues

--- a/src/applications/appeals/shared/constants.js
+++ b/src/applications/appeals/shared/constants.js
@@ -59,7 +59,7 @@ export const FORMAT_COMPACT = 'MMM DD, YYYY';
 // Supplemental Claim allows for past decision dates, but we should limit them.
 // Limit past decision dates to 100 years until told otherwise
 export const MAX_YEARS_PAST = 100;
-
+export const LEGACY_TYPE = 'legacyAppeal';
 export const AMA_DATE = '2019-02-19'; // Appeals Modernization Act in effect
 
 /**

--- a/src/applications/appeals/shared/utils/helpers.js
+++ b/src/applications/appeals/shared/utils/helpers.js
@@ -11,3 +11,23 @@ export const getItemSchema = (schema, index) => {
   }
   return itemSchema.additionalItems;
 };
+
+/**
+ * Return a phone number object
+ * @param {String} phone - phone number string to convert to an object
+ * @return {phoneObject}
+ */
+export const returnPhoneObject = phone => {
+  const result = {
+    countryCode: '',
+    areaCode: '',
+    phoneNumber: '',
+    phoneNumberExt: '',
+  };
+  if (typeof phone === 'string' && phone?.length === 10) {
+    result.countryCode = '1';
+    result.areaCode = phone.slice(0, 3);
+    result.phoneNumber = phone.slice(-7);
+  }
+  return result;
+};

--- a/src/applications/appeals/shared/utils/issues.js
+++ b/src/applications/appeals/shared/utils/issues.js
@@ -1,5 +1,5 @@
 // import the toggleValues helper
-import { SELECTED, REGEXP } from '../constants';
+import { LEGACY_TYPE, REGEXP, SELECTED } from '../constants';
 
 import { replaceDescriptionContent } from './replace';
 import '../definitions';
@@ -157,3 +157,21 @@ export const appStateSelector = state => ({
   contestedIssues: state.form?.data?.contestedIssues || [],
   additionalIssues: state.form?.data?.additionalIssues || [],
 });
+
+/**
+ * Find legacy appeal array included with contestable issues & return length
+ * Note: we are using the length of this array instead of trying to do a 1:1
+ * coorelation of contestable issues to legacy issues since we're only getting a
+ * summary and not a matching name or date (at least in the mock data).
+ * @param {ContestableIssues} issues - Array of both eligible & ineligible
+ *  contestable issues, plus legacy issues
+ * @return {Number} - length of legacy array
+ */
+export const getLegacyAppealsLength = issues =>
+  (issues || []).reduce((count, issue) => {
+    if (issue.type === LEGACY_TYPE) {
+      // add just-in-case there is more than one legacy type entry
+      return count + (issue.attributes?.issues?.length || 0);
+    }
+    return count;
+  }, 0);

--- a/src/applications/appeals/shared/utils/issues.js
+++ b/src/applications/appeals/shared/utils/issues.js
@@ -47,11 +47,10 @@ export const getSelected = formData => {
 export const getSelectedCount = (formData, items) =>
   getSelected({ ...formData, additionalIssues: items }).length;
 
-/*
- * Look for duplicates
- */
 const processIssues = (array = []) =>
-  array.filter(Boolean).map(entry => getIssueNameAndDate(entry));
+  array
+    .filter(entry => getIssueName(entry) && getIssueDate(entry))
+    .map(entry => getIssueNameAndDate(entry));
 
 export const hasDuplicates = (data = {}) => {
   const contestedIssues = processIssues(data.contestedIssues);

--- a/src/applications/appeals/shared/utils/issues.js
+++ b/src/applications/appeals/shared/utils/issues.js
@@ -17,7 +17,9 @@ export const getIssueDate = (entry = {}) =>
 
 // used for string comparison
 export const getIssueNameAndDate = (entry = {}) =>
-  `${(getIssueName(entry) || '').toLowerCase()}${getIssueDate(entry)}`;
+  `${(getIssueName(entry) || '').toLowerCase()}${entry.decisionDate ||
+    entry.attributes?.approxDecisionDate ||
+    ''}`;
 
 /*
  * Selected issues helpers


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  - Several functions moved to shared helper and issues utils into: `src/applications/appeals/shared/utils/helpers.js` and `src/applications/appeals/shared/utils/issues.js`
   

    - >  `hasDuplicates`, `getLegacyAppealsLength`, `getIssueNameAndDate`, `isEmptyObject`, `appStateSelector`, `getItemSchema`, `processIssues`, `returnPhoneObject`, and `readableList`

- _(If bug, how to reproduce)_
  - not a bug
- _(What is the solution, why is this the solution)_
  - these functions are the same for both 995 and 996; therefore don't have to be called twice and be imported from existing shared directory
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - Benefits Management & Decision Reviews

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#65800

## Testing done

- _Describe what the old behavior was prior to the change_
  - no behavior changes

## Screenshots

  - N/A

## What areas of the site does it impact?

Appeals

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed