### PR TITLE
Fix undefined disagreementOptions error

### DIFF
--- a/src/applications/appeals/shared/components/AreaOfDisagreement.jsx
+++ b/src/applications/appeals/shared/components/AreaOfDisagreement.jsx
@@ -70,8 +70,8 @@ const AreaOfDisagreement = ({
       const name = event.target.getAttribute('name');
       const { checked } = event.detail;
       if (name && pagePerItemIndex) {
-        const areaOfDisagreement = cloneDeep(data.areaOfDisagreement);
-        const disagreement = areaOfDisagreement[pagePerItemIndex];
+        const areaOfDisagreement = cloneDeep(data.areaOfDisagreement || []);
+        const disagreement = areaOfDisagreement[pagePerItemIndex] || {};
         disagreement.disagreementOptions = {
           ...(disagreement.disagreementOptions || {}),
           [name]: checked,
@@ -84,8 +84,8 @@ const AreaOfDisagreement = ({
     },
     onInput: event => {
       const { value } = event.target;
-      const areaOfDisagreement = cloneDeep(data.areaOfDisagreement);
-      const disagreement = areaOfDisagreement[pagePerItemIndex];
+      const areaOfDisagreement = cloneDeep(data.areaOfDisagreement || []);
+      const disagreement = areaOfDisagreement[pagePerItemIndex] || {};
       disagreement.otherEntry = value;
       setFormData({ ...data, areaOfDisagreement });
       setMaxError(disagreement);

--- a/src/applications/appeals/shared/tests/components/AreaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/AreaOfDisagreement.unit.spec.jsx
@@ -173,4 +173,26 @@ describe('<AreaOfDisagreement>', () => {
       ).to.contain('This field should be less than 34 characters');
     });
   });
+
+  it('should not throw a JS error for undefined disagreementOptions', () => {
+    const goSpy = sinon.spy();
+    const data = {
+      data: {
+        areaOfDisagreement: [{}, { evaluation: undefined }],
+      },
+      pagePerItemIndex: null,
+      goForward: goSpy,
+      setFormData: () => {},
+    };
+    const { container } = render(
+      <div>
+        <AreaOfDisagreement {...data} />
+      </div>,
+    );
+    expect($('va-checkbox-group', container)).to.exist;
+    $('va-checkbox-group').__events.vaChange({
+      target: { getAttribute: () => 'evaluation' },
+      detail: true,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > The errors `Cannot read properties of undefined (reading 'disagreementOptions') TypeError` and `Cannot set properties of undefined (setting 'otherEntry') TypeError` appeared in Sentry on 10/2/2023 and appear to be related. This PR adds a fallback definition & a unit test to catch regressions
- _(If bug, how to reproduce)_
  > I wasn't able to duplicate this bug locally, but I was able to reproduce it in a unit tests
- _(What is the solution, why is this the solution)_
  > Add fallback definition when area of disagreement object isn't defined
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#66792](https://github.com/department-of-veterans-affairs/va.gov-team/issues/66792)

## Testing done

- _Describe what the old behavior was prior to the change_
  > JS error
- _Describe the steps required to verify your changes are working as expected_
  > Unit test passing
- _Describe the tests completed and the results_
  > Test empty area of disagreement object
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

Notice of Disagreement & Higher-Level Review forms

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
