### PR TITLE
Pre-fill from VA Profile data for each address field with VADIR fallback

### DIFF
--- a/src/applications/my-education-benefits/helpers.js
+++ b/src/applications/my-education-benefits/helpers.js
@@ -408,7 +408,7 @@ export function prefillTransformerV2(pages, formData, metadata, state) {
           contactInfo?.zipcode,
         country: getSchemaCountryCode(
           vapContactInfo.mailingAddress?.countryCode ||
-            vet360ContactInformation?.countryName ||
+            vet360ContactInformation?.countryCodeIso3 ||
             contactInfo?.countryCode,
         ),
       },

--- a/src/applications/my-education-benefits/helpers.js
+++ b/src/applications/my-education-benefits/helpers.js
@@ -204,6 +204,16 @@ function mapNotificaitonMethodV1(notificationMethod) {
   return notificationMethod;
 }
 
+function selectAddressSource(primary, secondary, tertiary) {
+  if (primary?.addressLine1) {
+    return primary;
+  }
+  if (secondary?.addressLine1) {
+    return secondary;
+  }
+  return tertiary || {};
+}
+
 function mapNotificationMethodV2({ notificationMethod }) {
   if (notificationMethod === 'EMAIL') {
     return 'No, just send me email notifications';
@@ -310,6 +320,11 @@ export function prefillTransformerV2(pages, formData, metadata, state) {
   const vapContactInfo = stateUser.profile?.vapContactInfo || {};
   const vet360ContactInformation =
     stateUser.vet360ContactInformation.mailingAddress || {};
+  const address = selectAddressSource(
+    vet360ContactInformation,
+    vapContactInfo.mailingAddress,
+    contactInfo,
+  );
 
   let firstName;
   let middleName;
@@ -388,34 +403,20 @@ export function prefillTransformerV2(pages, formData, metadata, state) {
     },
     [formFields.viewMailingAddress]: {
       [formFields.address]: {
-        street:
-          vapContactInfo.mailingAddress?.addressLine1 ||
-          contactInfo?.addressLine1,
-        street2:
-          vapContactInfo.mailingAddress?.addressLine2 ||
-          contactInfo?.addressLine2 ||
-          undefined,
-        city: vapContactInfo.mailingAddress?.city || contactInfo?.city,
-        state:
-          vapContactInfo.mailingAddress?.stateCode ||
-          vet360ContactInformation?.province ||
-          contactInfo?.stateCode,
+        street: address?.addressLine1,
+        street2: address?.addressLine2 || undefined,
+        city: address?.city,
+        state: address?.stateCode || address?.province,
         postalCode:
-          vapContactInfo.mailingAddress?.zipCode ||
-          vapContactInfo.mailingAddress?.zipcode ||
-          vet360ContactInformation?.InternationalPostalCode ||
-          contactInfo?.zipCode ||
-          contactInfo?.zipcode,
+          address?.zipCode ||
+          address?.zipcode ||
+          address?.InternationalPostalCode,
         country: getSchemaCountryCode(
-          vapContactInfo.mailingAddress?.countryCode ||
-            vet360ContactInformation?.countryCodeIso3 ||
-            contactInfo?.countryCode,
+          address?.countryCode || address?.countryCodeIso3,
         ),
       },
       [formFields.livesOnMilitaryBase]:
-        vapContactInfo.mailingAddress?.addressType === 'MILITARY_OVERSEAS' ||
-        contactInfo?.addressType === 'MILITARY_OVERSEAS' ||
-        vet360ContactInformation?.addressType === 'MILITARY_OVERSEAS',
+        address?.addressType === 'MILITARY_OVERSEAS',
     },
     [formFields.bankAccount]: {
       ...bankInformation,

--- a/src/applications/my-education-benefits/helpers.js
+++ b/src/applications/my-education-benefits/helpers.js
@@ -308,6 +308,8 @@ export function prefillTransformerV2(pages, formData, metadata, state) {
 
   const profile = stateUser?.profile;
   const vapContactInfo = stateUser.profile?.vapContactInfo || {};
+  const vet360ContactInformation =
+    stateUser.vet360ContactInformation.mailingAddress || {};
 
   let firstName;
   let middleName;
@@ -395,20 +397,25 @@ export function prefillTransformerV2(pages, formData, metadata, state) {
           undefined,
         city: vapContactInfo.mailingAddress?.city || contactInfo?.city,
         state:
-          vapContactInfo.mailingAddress?.stateCode || contactInfo?.stateCode,
+          vapContactInfo.mailingAddress?.stateCode ||
+          vet360ContactInformation?.province ||
+          contactInfo?.stateCode,
         postalCode:
           vapContactInfo.mailingAddress?.zipCode ||
           vapContactInfo.mailingAddress?.zipcode ||
+          vet360ContactInformation?.InternationalPostalCode ||
           contactInfo?.zipCode ||
           contactInfo?.zipcode,
         country: getSchemaCountryCode(
           vapContactInfo.mailingAddress?.countryCode ||
+            vet360ContactInformation?.countryName ||
             contactInfo?.countryCode,
         ),
       },
       [formFields.livesOnMilitaryBase]:
         vapContactInfo.mailingAddress?.addressType === 'MILITARY_OVERSEAS' ||
-        contactInfo?.addressType === 'MILITARY_OVERSEAS',
+        contactInfo?.addressType === 'MILITARY_OVERSEAS' ||
+        vet360ContactInformation?.addressType === 'MILITARY_OVERSEAS',
     },
     [formFields.bankAccount]: {
       ...bankInformation,

--- a/src/applications/my-education-benefits/helpers.js
+++ b/src/applications/my-education-benefits/helpers.js
@@ -355,10 +355,6 @@ export function prefillTransformerV2(pages, formData, metadata, state) {
     homePhoneNumber = contactInfo?.homePhoneNumber;
   }
 
-  const address = vapContactInfo.mailingAddress?.addressLine1
-    ? vapContactInfo.mailingAddress
-    : contactInfo;
-
   const newData = {
     ...formData,
     [formFields.formId]: state.data?.formData?.data?.id,
@@ -390,15 +386,29 @@ export function prefillTransformerV2(pages, formData, metadata, state) {
     },
     [formFields.viewMailingAddress]: {
       [formFields.address]: {
-        street: address?.addressLine1,
-        street2: address?.addressLine2 || undefined,
-        city: address?.city,
-        state: address?.stateCode,
-        postalCode: address?.zipCode || address?.zipcode,
-        country: getSchemaCountryCode(address?.countryCode),
+        street:
+          vapContactInfo.mailingAddress?.addressLine1 ||
+          contactInfo?.addressLine1,
+        street2:
+          vapContactInfo.mailingAddress?.addressLine2 ||
+          contactInfo?.addressLine2 ||
+          undefined,
+        city: vapContactInfo.mailingAddress?.city || contactInfo?.city,
+        state:
+          vapContactInfo.mailingAddress?.stateCode || contactInfo?.stateCode,
+        postalCode:
+          vapContactInfo.mailingAddress?.zipCode ||
+          vapContactInfo.mailingAddress?.zipcode ||
+          contactInfo?.zipCode ||
+          contactInfo?.zipcode,
+        country: getSchemaCountryCode(
+          vapContactInfo.mailingAddress?.countryCode ||
+            contactInfo?.countryCode,
+        ),
       },
       [formFields.livesOnMilitaryBase]:
-        address?.addressType === 'MILITARY_OVERSEAS',
+        vapContactInfo.mailingAddress?.addressType === 'MILITARY_OVERSEAS' ||
+        contactInfo?.addressType === 'MILITARY_OVERSEAS',
     },
     [formFields.bankAccount]: {
       ...bankInformation,

--- a/src/applications/my-education-benefits/helpers.js
+++ b/src/applications/my-education-benefits/helpers.js
@@ -317,12 +317,12 @@ export function prefillTransformerV2(pages, formData, metadata, state) {
   const stateUser = state.user || {};
 
   const profile = stateUser?.profile;
-  const vapContactInfo = stateUser.profile?.vapContactInfo || {};
+  const vapContactInfo = stateUser.profile?.vapContactInfo.mailingAddress || {};
   const vet360ContactInformation =
     stateUser.vet360ContactInformation.mailingAddress || {};
   const address = selectAddressSource(
     vet360ContactInformation,
-    vapContactInfo.mailingAddress,
+    vapContactInfo,
     contactInfo,
   );
 

--- a/src/applications/my-education-benefits/tests/fixtures/data/prefill-transformer-test-data.js
+++ b/src/applications/my-education-benefits/tests/fixtures/data/prefill-transformer-test-data.js
@@ -56,3 +56,30 @@ export const claimantInfo = {
     },
   },
 };
+
+export const mockUserState = {
+  user: {
+    profile: {
+      vapContactInfo: {
+        mailingAddress: {
+          addressLine1: '456 Liberty Street',
+          addressLine2: 'Suite 789',
+          city: 'Liberty City',
+          stateCode: 'LC',
+          zipCode: '12345',
+          countryCode: 'US',
+          addressType: 'DOMESTIC',
+        },
+      },
+    },
+    vet360ContactInformation: {
+      addressLine1: '789 Freedom Blvd',
+      addressLine2: 'Apt 101',
+      city: 'Freedom Town',
+      stateCode: 'FT',
+      zipCode: '67890',
+      countryCodeIso3: 'USA',
+      addressType: 'Domestic',
+    },
+  },
+};

--- a/src/applications/my-education-benefits/tests/units/prefill-transformer.unit.spec.js
+++ b/src/applications/my-education-benefits/tests/units/prefill-transformer.unit.spec.js
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
 import { prefillTransformerV1, prefillTransformerV2 } from '../../helpers';
-import { claimantInfo } from '../fixtures/data/prefill-transformer-test-data';
+import {
+  claimantInfo,
+  mockUserState,
+} from '../fixtures/data/prefill-transformer-test-data';
 
 let mockClaimantInfo;
 
@@ -11,12 +14,10 @@ describe('prefillTransformer', () => {
 
   describe('transforms claimantId', () => {
     it('the transformed claimant info includes a claimantId', () => {
-      const transformedClaimantInfo = prefillTransformerV2(
-        null,
-        null,
-        null,
-        mockClaimantInfo,
-      );
+      const transformedClaimantInfo = prefillTransformerV2(null, null, null, {
+        ...mockClaimantInfo,
+        ...mockUserState,
+      });
       // Check the military claimant section
       expect(transformedClaimantInfo?.formData?.claimantId).to.eql(
         '1000000000000246',
@@ -39,12 +40,10 @@ describe('prefillTransformer', () => {
   });
   describe('transforms contact method', () => {
     it('the transformed claimant has the correct contact method in V2', () => {
-      const transformedClaimantInfo = prefillTransformerV2(
-        null,
-        null,
-        null,
-        mockClaimantInfo,
-      );
+      const transformedClaimantInfo = prefillTransformerV2(null, null, null, {
+        ...mockClaimantInfo,
+        ...mockUserState,
+      });
       // Check the military claimant section
       expect(
         transformedClaimantInfo?.formData['view:receiveTextMessages']


### PR DESCRIPTION

## Summary
Assures Pre-fill from VA Profile data for each address field with VADIR fallback o 1990EZ form.

## Related issue(s)


## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
