### PR TITLE
Medications PDFs: removed dots from file namings

### DIFF
--- a/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
@@ -110,7 +110,7 @@ const PrescriptionDetails = () => {
       'medications',
       `${nonVaPrescription ? 'Non-VA' : 'VA'}-medications-details-${
         userName.first ? `${userName.first}-${userName.last}` : userName.last
-      }-${dateFormat(Date.now(), 'MM-DD-YYYY_hmmssa')}`,
+      }-${dateFormat(Date.now(), 'M-D-YYYY_hmmssa').replace(/\./g, '')}`,
       pdfData,
     );
   };

--- a/src/applications/mhv/medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv/medications/containers/Prescriptions.jsx
@@ -204,7 +204,7 @@ const Prescriptions = () => {
       'medications',
       `VA-medications-list-${
         userName.first ? `${userName.first}-${userName.last}` : userName.last
-      }-${dateFormat(Date.now(), 'MM-DD-YYYY_hmmssa')}`,
+      }-${dateFormat(Date.now(), 'M-D-YYYY_hmmssa').replace(/\./g, '')}`,
       pdfData,
     );
   };


### PR DESCRIPTION
## Summary

Apparently momentjs appends dots to am/pm. We have to manually remove them from the PDFs names.

## Related issue(s)

[Jira ticket](https://jira.devops.va.gov/browse/MHV-47089)
[Jira ticket](https://jira.devops.va.gov/browse/MHV-47424)

## What areas of the site does it impact?

my-health/Medications 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
