### PR TITLE
HLR | Fix no loaded alert visibility

### DIFF
--- a/src/applications/appeals/10182/tests/components/ContestableIssuesWidget.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ContestableIssuesWidget.unit.spec.jsx
@@ -6,11 +6,12 @@ import sinon from 'sinon';
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import { ContestableIssuesWidget } from '../../components/ContestableIssuesWidget';
-import { SELECTED } from '../../../shared/constants';
 import {
   FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
   FETCH_CONTESTABLE_ISSUES_FAILED,
 } from '../../actions';
+
+import { SELECTED } from '../../../shared/constants';
 
 describe('<ContestableIssuesWidget>', () => {
   const getProps = ({

--- a/src/applications/appeals/996/components/ContestableIssuesWidget.jsx
+++ b/src/applications/appeals/996/components/ContestableIssuesWidget.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
@@ -7,6 +7,7 @@ import { VaModal } from '@department-of-veterans-affairs/component-library/dist/
 import set from 'platform/utilities/data/set';
 import { setData } from 'platform/forms-system/src/js/actions';
 
+import { FETCH_CONTESTABLE_ISSUES_FAILED } from '../actions';
 import { APP_NAME } from '../constants';
 
 import { IssueCard } from '../../shared/components/IssueCard';
@@ -55,6 +56,7 @@ const ContestableIssuesWidget = props => {
     id,
     options,
     formContext = {},
+    apiLoadStatus, // API loaded status
     additionalIssues,
     setFormData,
     formData,
@@ -64,6 +66,19 @@ const ContestableIssuesWidget = props => {
   const [showRemoveModal, setShowRemoveModal] = useState(false);
   const [removeIndex, setRemoveIndex] = useState(null);
   const [editState] = useState(window.sessionStorage.getItem(LAST_ISSUE));
+  const hasChecked = useRef(false);
+
+  useEffect(
+    () => {
+      if (
+        !hasChecked.current &&
+        apiLoadStatus === FETCH_CONTESTABLE_ISSUES_FAILED
+      ) {
+        hasChecked.current = true;
+      }
+    },
+    [apiLoadStatus, hasChecked],
+  );
 
   useEffect(
     () => {
@@ -92,8 +107,6 @@ const ContestableIssuesWidget = props => {
     .concat((additionalIssues || []).filter(Boolean));
 
   const hasSelected = someSelected(items);
-  // Only show alert initially when no issues loaded
-  const [showNoLoadedIssues] = useState(items.length === 0);
 
   if (onReviewPage && inReviewMode && items.length && !hasSelected) {
     return (
@@ -182,7 +195,8 @@ const ContestableIssuesWidget = props => {
     return hideCard ? null : <IssueCard {...cardProps} />;
   });
 
-  const showNoIssues = showNoLoadedIssues && !onReviewPage;
+  const showNoIssues =
+    !onReviewPage && apiLoadStatus === FETCH_CONTESTABLE_ISSUES_FAILED;
 
   return (
     <>
@@ -249,6 +263,7 @@ const ContestableIssuesWidget = props => {
 
 ContestableIssuesWidget.propTypes = {
   additionalIssues: PropTypes.array,
+  apiLoadStatus: PropTypes.string,
   formContext: PropTypes.shape({
     onReviewPage: PropTypes.bool,
     reviewMode: PropTypes.bool,
@@ -266,6 +281,7 @@ ContestableIssuesWidget.propTypes = {
 
 const mapStateToProps = state => ({
   formData: state.form?.data || {},
+  apiLoadStatus: state.contestableIssues?.status || '',
   additionalIssues: state.form?.data.additionalIssues || [],
 });
 const mapDispatchToProps = {

--- a/src/applications/appeals/996/tests/components/ContestableIssuesWidget.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/components/ContestableIssuesWidget.unit.spec.jsx
@@ -6,6 +6,8 @@ import sinon from 'sinon';
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import { ContestableIssuesWidget } from '../../components/ContestableIssuesWidget';
+import { FETCH_CONTESTABLE_ISSUES_FAILED } from '../../actions';
+
 import { SELECTED } from '../../../shared/constants';
 
 describe('<ContestableIssuesWidget>', () => {
@@ -14,6 +16,7 @@ describe('<ContestableIssuesWidget>', () => {
     submitted = false,
     onChange = () => {},
     setFormData = () => {},
+    apiLoadStatus = '',
   } = {}) => ({
     id: 'id',
     value: [
@@ -28,6 +31,7 @@ describe('<ContestableIssuesWidget>', () => {
       submitted,
     },
     setFormData,
+    apiLoadStatus,
   });
 
   it('should render a list of check boxes (IssueCard component)', () => {
@@ -142,8 +146,8 @@ describe('<ContestableIssuesWidget>', () => {
     });
   });
 
-  it('should not show no loaded issues alert after remove all additional items', async () => {
-    const props = getProps();
+  it('should show "no loaded issues" alert when api fails', async () => {
+    const props = getProps({ apiLoadStatus: FETCH_CONTESTABLE_ISSUES_FAILED });
     const { container } = render(
       <ContestableIssuesWidget {...props} additionalIssues={[]} value={[]} />,
     );


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > No loaded issues alert would show 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#66478](https://github.com/department-of-veterans-affairs/va.gov-team/issues/66478)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
  > Disable contestable issue endpoint and reload the app
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

Higher-Level Review

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
