### PR TITLE
My VA: Wait for feature toggles to load before rendering dashboard

### DIFF
--- a/src/applications/personalization/dashboard/components/Dashboard.jsx
+++ b/src/applications/personalization/dashboard/components/Dashboard.jsx
@@ -341,7 +341,10 @@ const mapStateToProps = state => {
       hasLoadedFullName &&
       hasLoadedDisabilityRating);
 
-  const showLoader = !hasLoadedScheduledDowntime || !hasLoadedAllData;
+  const togglesAreLoaded = !toggleValues(state)?.loading;
+
+  const showLoader =
+    !hasLoadedScheduledDowntime || !hasLoadedAllData || !togglesAreLoaded;
   const showValidateIdentityAlert = isLOA1;
   const showNameTag = isLOA3 && isEmpty(hero?.errors);
   const showMPIConnectionError = hasMPIConnectionError(state);

--- a/src/applications/personalization/dashboard/tests/components/Dashboard.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/Dashboard.unit.spec.jsx
@@ -140,4 +140,20 @@ describe('<Dashboard />', () => {
         .exist;
     });
   });
+
+  it("should show the loader if feature toggles aren't loaded", async () => {
+    mockFetch();
+    initialState.featureToggles = { loading: true };
+    let tree;
+    await act(async () => {
+      tree = renderInReduxProvider(<Dashboard />, {
+        initialState,
+        reducers,
+      });
+    });
+
+    await waitFor(() => {
+      expect(tree.getByTestId('req-loader')).to.exist;
+    });
+  });
 });


### PR DESCRIPTION
Wait for feature toggles to load before rendering the dashboard components.

## Summary

We are seeing race conditions that results in us rendering components before the feature toggles are loaded. This made it seem as if the feature toggle value was being ignored.

## Related issue(s)

- [66660](https://github.com/department-of-veterans-affairs/va.gov-team/issues/66660)

## Testing done

- Specs updated and passing
- Visual confirmation locally

## What areas of the site does it impact?

My VA

## Acceptance criteria
- [ ] Loading indicator displays until feature toggles are loaded

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
