### PR TITLE
VACMS-15288 Cypress additions for results pages

### DIFF
--- a/src/applications/pact-act/tests/cypress/helpers.js
+++ b/src/applications/pact-act/tests/cypress/helpers.js
@@ -18,6 +18,11 @@ export const RADIATION_2_3_B_INPUT = 'paw-radiation2_3_B';
 
 export const LEJEUNE_2_4_INPUT = 'paw-lejeune2_4';
 
+export const RESULTS_1_P1_HEADER = 'paw-results-1-p1';
+export const RESULTS_1_P2_HEADER = 'paw-results-1-p2';
+export const RESULTS_2_HEADER = 'paw-results-2';
+export const RESULTS_3_HEADER = 'paw-results-3';
+
 export const clickStart = () =>
   cy
     .findByTestId(START_LINK)
@@ -61,6 +66,18 @@ export const clickContinue = () =>
     .shadow()
     .get('va-button')
     .eq(1)
+    .should('be.visible')
+    .click();
+
+export const clickResultsContinue = () =>
+  cy
+    .findByTestId('paw-results-1-p1-continue')
+    .should('be.visible')
+    .click();
+
+export const clickResultsBack = () =>
+  cy
+    .findByTestId('paw-results-back')
     .should('be.visible')
     .click();
 

--- a/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/im-not-sure/im-not-sure-flow-A.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/im-not-sure/im-not-sure-flow-A.cypress.spec.js
@@ -13,8 +13,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe(`1989 or earlier - "I'm not sure" to all Agent Orange, Radiation and Lejeune questions (Results Screen 3)`, () => {
+xdescribe('PACT Act', () => {
+  describe(`1989 or earlier - "I'm not sure" to all questions (Results Screen 3)`, () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -58,7 +58,10 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 2);
       h.clickContinue();
 
-      // TODO add Results screen 3 when it exists
+      // RESULTS 3
+      h.verifyUrl(ROUTES.RESULTS_3);
+      h.verifyElement(h.RESULTS_3_HEADER);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/im-not-sure/im-not-sure-flow-B.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/im-not-sure/im-not-sure-flow-B.cypress.spec.js
@@ -13,8 +13,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe(`1989 or earlier - "I'm not sure" to all Agent Orange (except 1), Radiation and Lejeune questions (Results Screen 1)`, () => {
+xdescribe('PACT Act', () => {
+  describe(`1989 or earlier - "I'm not sure" to all questions except 1 Agent Orange (Results Screen 1)`, () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -58,7 +58,19 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 2);
       h.clickContinue();
 
-      // TODO add Results screen 1 when it exists
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.verifyElement(h.RESULTS_1_P1_HEADER);
+      h.clickResultsContinue();
+
+      // RESULTS 1, P2
+      h.verifyUrl(ROUTES.RESULTS_1_P2);
+      h.verifyElement(h.RESULTS_1_P2_HEADER);
+      h.clickResultsBack();
+
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/mix.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/mix.cypress.spec.js
@@ -17,7 +17,7 @@ import { ROUTES } from '../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
+xdescribe('PACT Act', () => {
   describe('1989 or earlier - Mixed responses (Results screen 1)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
@@ -81,7 +81,19 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 2);
       h.clickContinue();
 
-      // TODO add Results screen 1 when it exists
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.verifyElement(h.RESULTS_1_P1_HEADER);
+      h.clickResultsContinue();
+
+      // RESULTS 1, P2
+      h.verifyUrl(ROUTES.RESULTS_1_P2);
+      h.verifyElement(h.RESULTS_1_P2_HEADER);
+      h.clickResultsBack();
+
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/no/no-flow-A.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/no/no-flow-A.cypress.spec.js
@@ -13,8 +13,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('1989 or earlier - "No" to all Agent Orange, Radiation and Lejeune questions (Results Screen 3)', () => {
+xdescribe('PACT Act', () => {
+  describe('1989 or earlier - "No" to all questions (Results Screen 3)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -58,7 +58,10 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 1);
       h.clickContinue();
 
-      // TODO add Results screen 3 when it exists
+      // RESULTS 3
+      h.verifyUrl(ROUTES.RESULTS_3);
+      h.verifyElement(h.RESULTS_3_HEADER);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/no/no-flow-B.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/no/no-flow-B.cypress.spec.js
@@ -13,8 +13,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('1989 or earlier - "No" to all Agent Orange (except for 1), Radiation and Lejeune questions (Results Screen 1)', () => {
+xdescribe('PACT Act', () => {
+  describe('1989 or earlier - "No" to all questions except 1 Agent Orange (Results Screen 1)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -58,7 +58,19 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 1);
       h.clickContinue();
 
-      // TODO add Results screen 1 when it exists
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.verifyElement(h.RESULTS_1_P1_HEADER);
+      h.clickResultsContinue();
+
+      // RESULTS 1, P2
+      h.verifyUrl(ROUTES.RESULTS_1_P2);
+      h.verifyElement(h.RESULTS_1_P2_HEADER);
+      h.clickResultsBack();
+
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/yes/yes-flow-A.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/yes/yes-flow-A.cypress.spec.js
@@ -12,8 +12,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('1989 or earlier - "Yes" to ORANGE_2_2_A - "Yes" to two or more categories (Results Screen 1)', () => {
+xdescribe('PACT Act', () => {
+  describe('1989 or earlier - "Yes" to two or more question categories (Results Screen 1)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -52,7 +52,19 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 0);
       h.clickContinue();
 
-      // TODO add Results screen 1 when it exists
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.verifyElement(h.RESULTS_1_P1_HEADER);
+      h.clickResultsContinue();
+
+      // RESULTS 1, P2
+      h.verifyUrl(ROUTES.RESULTS_1_P2);
+      h.verifyElement(h.RESULTS_1_P2_HEADER);
+      h.clickResultsBack();
+
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/yes/yes-flow-B.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/yes/yes-flow-B.cypress.spec.js
@@ -13,8 +13,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('1989 or earlier - "Yes" to ORANGE_2_2_1_A - "Yes" to one category (Results Screen 1)', () => {
+xdescribe('PACT Act', () => {
+  describe('1989 or earlier - "Yes" to two or more question categories (Results Screen 1)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -58,7 +58,19 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 0);
       h.clickContinue();
 
-      // TODO add Results screen 1 when it exists
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.verifyElement(h.RESULTS_1_P1_HEADER);
+      h.clickResultsContinue();
+
+      // RESULTS 1, P2
+      h.verifyUrl(ROUTES.RESULTS_1_P2);
+      h.verifyElement(h.RESULTS_1_P2_HEADER);
+      h.clickResultsBack();
+
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/yes/yes-flow-C.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/yes/yes-flow-C.cypress.spec.js
@@ -13,8 +13,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('1989 or earlier - "Yes" to ORANGE_2_2_2 - "Yes" to two or more categories (Results Screen 1)', () => {
+xdescribe('PACT Act', () => {
+  describe('1989 or earlier - "Yes" to two or more question categories (Results Screen 1)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -58,7 +58,19 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 0);
       h.clickContinue();
 
-      // TODO add Results screen 1 when it exists
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.verifyElement(h.RESULTS_1_P1_HEADER);
+      h.clickResultsContinue();
+
+      // RESULTS 1, P2
+      h.verifyUrl(ROUTES.RESULTS_1_P2);
+      h.verifyElement(h.RESULTS_1_P2_HEADER);
+      h.clickResultsBack();
+
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/yes/yes-flow-D.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1989-or-earlier/yes/yes-flow-D.cypress.spec.js
@@ -13,8 +13,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('1989 or earlier - "Yes" to LEJEUNE_2_4 - "Yes" to only Camp Lejeune (Results Screen 2)', () => {
+xdescribe('PACT Act', () => {
+  describe('1989 or earlier - "No" to all questions except 1 Camp Lejeune (Results Screen 2)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -58,7 +58,10 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 0);
       h.clickContinue();
 
-      // TODO add Results screen 2 when it exists
+      // RESULTS 2
+      h.verifyUrl(ROUTES.RESULTS_2);
+      h.verifyElement(h.RESULTS_2_HEADER);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-1990-or-later/im-not-sure.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1990-or-later/im-not-sure.cypress.spec.js
@@ -3,8 +3,8 @@ import { ROUTES } from '../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe(`1990 or later - "I'm not sure" to all Burn Pit questions`, () => {
+xdescribe('PACT Act', () => {
+  describe(`1990 or later - "I'm not sure" to all questions (Results Screen 3)`, () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -34,7 +34,10 @@ describe('PACT Act', () => {
       h.selectRadio(h.BURN_PIT_2_1_2_INPUT, 2);
       h.clickContinue();
 
-      // TODO: test navigation to Results screen 1 when that mapping logic exists
+      // RESULTS 3
+      h.verifyUrl(ROUTES.RESULTS_3);
+      h.verifyElement(h.RESULTS_3_HEADER);
+      h.clickResultsBack();
 
       // BURN_PIT_2_1_2
       h.verifyUrl(ROUTES.BURN_PIT_2_1_2);

--- a/src/applications/pact-act/tests/cypress/service-period-1990-or-later/no.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1990-or-later/no.cypress.spec.js
@@ -3,8 +3,8 @@ import { ROUTES } from '../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('1990 or later - "No" to all Burn Pit questions', () => {
+xdescribe('PACT Act', () => {
+  describe('1990 or later - "No" to all questions (Results Screen 3)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -31,9 +31,16 @@ describe('PACT Act', () => {
       // BURN_PIT_2_1_2
       h.verifyUrl(ROUTES.BURN_PIT_2_1_2);
       h.selectRadio(h.BURN_PIT_2_1_2_INPUT, 1);
-      h.clickBack();
+      h.clickContinue();
 
-      // TODO: test navigation to Results screen 1 when that mapping logic exists
+      // RESULTS 3
+      h.verifyUrl(ROUTES.RESULTS_3);
+      h.verifyElement(h.RESULTS_3_HEADER);
+      h.clickResultsBack();
+
+      // BURN_PIT_2_1_2
+      h.verifyUrl(ROUTES.BURN_PIT_2_1_2);
+      h.clickBack();
 
       // BURN_PIT_2_1_1
       h.verifyUrl(ROUTES.BURN_PIT_2_1_1);

--- a/src/applications/pact-act/tests/cypress/service-period-1990-or-later/yes/yes-flow-A.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1990-or-later/yes/yes-flow-A.cypress.spec.js
@@ -8,8 +8,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('1990 or later - "Yes" to BURN_PIT_2_1', () => {
+xdescribe('PACT Act', () => {
+  describe('1990 or later -  "Yes" to one question category (Results Screen 1)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -28,7 +28,19 @@ describe('PACT Act', () => {
       h.selectRadio(h.BURN_PIT_2_1_INPUT, 0);
       h.clickContinue();
 
-      // TODO: test navigation to Results screen 1 when that mapping logic exists
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.verifyElement(h.RESULTS_1_P1_HEADER);
+      h.clickResultsContinue();
+
+      // RESULTS 1, P2
+      h.verifyUrl(ROUTES.RESULTS_1_P2);
+      h.verifyElement(h.RESULTS_1_P2_HEADER);
+      h.clickResultsBack();
+
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.clickResultsBack();
 
       // BURN_PIT_2_1
       h.verifyUrl(ROUTES.BURN_PIT_2_1);

--- a/src/applications/pact-act/tests/cypress/service-period-1990-or-later/yes/yes-flow-B.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1990-or-later/yes/yes-flow-B.cypress.spec.js
@@ -9,8 +9,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('1990 or later - "Yes" to BURN_PIT_2_1_1', () => {
+xdescribe('PACT Act', () => {
+  describe('1990 or later -  "Yes" to one question category (Results Screen 1)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -34,7 +34,19 @@ describe('PACT Act', () => {
       h.selectRadio(h.BURN_PIT_2_1_1_INPUT, 0);
       h.clickContinue();
 
-      // TODO: test navigation to Results screen 1 when that mapping logic exists
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.verifyElement(h.RESULTS_1_P1_HEADER);
+      h.clickResultsContinue();
+
+      // RESULTS 1, P2
+      h.verifyUrl(ROUTES.RESULTS_1_P2);
+      h.verifyElement(h.RESULTS_1_P2_HEADER);
+      h.clickResultsBack();
+
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.clickResultsBack();
 
       // BURN_PIT_2_1_1
       h.verifyUrl(ROUTES.BURN_PIT_2_1_1);

--- a/src/applications/pact-act/tests/cypress/service-period-1990-or-later/yes/yes-flow-C.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-1990-or-later/yes/yes-flow-C.cypress.spec.js
@@ -10,8 +10,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('1990 or later - "Yes" to BURN_PIT_2_1_2', () => {
+xdescribe('PACT Act', () => {
+  describe('1990 or later -  "Yes" to one question category (Results Screen 1)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -37,10 +37,22 @@ describe('PACT Act', () => {
 
       // BURN_PIT_2_1_2
       h.verifyUrl(ROUTES.BURN_PIT_2_1_2);
-      h.selectRadio(h.BURN_PIT_2_1_2_INPUT, 1);
+      h.selectRadio(h.BURN_PIT_2_1_2_INPUT, 0);
       h.clickContinue();
 
-      // TODO: test navigation to Results screen 1 when that mapping logic exists
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.verifyElement(h.RESULTS_1_P1_HEADER);
+      h.clickResultsContinue();
+
+      // RESULTS 1, P2
+      h.verifyUrl(ROUTES.RESULTS_1_P2);
+      h.verifyElement(h.RESULTS_1_P2_HEADER);
+      h.clickResultsBack();
+
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.clickResultsBack();
 
       // BURN_PIT_2_1_2
       h.verifyUrl(ROUTES.BURN_PIT_2_1_2);

--- a/src/applications/pact-act/tests/cypress/service-period-during-both/deep-linking.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/deep-linking.cypress.spec.js
@@ -3,7 +3,7 @@ import { ROUTES } from '../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
+xdescribe('PACT Act', () => {
   describe('During both of these time periods - deep linking', () => {
     it('redirects to home when the service period page is loaded without the right criteria', () => {
       cy.visit(`/pact-act-wizard-test/${ROUTES.SERVICE_PERIOD}`);
@@ -127,6 +127,46 @@ describe('PACT Act', () => {
 
     it('redirects to home when the lejeune 2-4 page is loaded without the right criteria', () => {
       cy.visit(`/pact-act-wizard-test/${ROUTES.LEJEUNE_2_4}`);
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+    });
+
+    it('redirects to home when the results 1, p1 page is loaded without the right criteria', () => {
+      cy.visit(`/pact-act-wizard-test/${ROUTES.RESULTS_1_P1}`);
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+    });
+
+    it('redirects to home when the results 1, p2 page is loaded without the right criteria', () => {
+      cy.visit(`/pact-act-wizard-test/${ROUTES.RESULTS_1_P2}`);
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+    });
+
+    it('redirects to home when the results 2 page is loaded without the right criteria', () => {
+      cy.visit(`/pact-act-wizard-test/${ROUTES.RESULTS_2}`);
+
+      h.verifyUrl(ROUTES.HOME);
+
+      // Home
+      h.verifyElement(h.START_LINK);
+      cy.injectAxeThenAxeCheck();
+    });
+
+    it('redirects to home when the results 3page is loaded without the right criteria', () => {
+      cy.visit(`/pact-act-wizard-test/${ROUTES.RESULTS_3}`);
 
       h.verifyUrl(ROUTES.HOME);
 

--- a/src/applications/pact-act/tests/cypress/service-period-during-both/im-not-sure/im-not-sure-flow-A.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/im-not-sure/im-not-sure-flow-A.cypress.spec.js
@@ -16,8 +16,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe(`During both of these time periods - "I'm not sure" to all categories (Results Screen 3)`, () => {
+xdescribe('PACT Act', () => {
+  describe(`During both of these time periods - "I'm not sure" to all questions (Results Screen 3)`, () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -76,7 +76,10 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 2);
       h.clickContinue();
 
-      // TODO Add Results 3 when it exists
+      // RESULTS 3
+      h.verifyUrl(ROUTES.RESULTS_3);
+      h.verifyElement(h.RESULTS_3_HEADER);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-during-both/im-not-sure/im-not-sure-flow-B.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/im-not-sure/im-not-sure-flow-B.cypress.spec.js
@@ -16,8 +16,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('During both of these time periods - "Yes" to one category (not Camp Lejeune), no to all else (Results Screen 1)', () => {
+xdescribe('PACT Act', () => {
+  describe(`During both of these time periods - "I'm not sure" to all questions except 1 Burn Pit (Results Screen 1)`, () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -76,7 +76,19 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 2);
       h.clickContinue();
 
-      // TODO add Results screen 1
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.verifyElement(h.RESULTS_1_P1_HEADER);
+      h.clickResultsContinue();
+
+      // RESULTS 1, P2
+      h.verifyUrl(ROUTES.RESULTS_1_P2);
+      h.verifyElement(h.RESULTS_1_P2_HEADER);
+      h.clickResultsBack();
+
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-during-both/mix.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/mix.cypress.spec.js
@@ -23,7 +23,7 @@ import { ROUTES } from '../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
+xdescribe('PACT Act', () => {
   describe('During both of these time periods - Mixed responses (Results screen 1)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
@@ -106,7 +106,19 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 0);
       h.clickContinue();
 
-      // TODO add Results screen 1
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.verifyElement(h.RESULTS_1_P1_HEADER);
+      h.clickResultsContinue();
+
+      // RESULTS 1, P2
+      h.verifyUrl(ROUTES.RESULTS_1_P2);
+      h.verifyElement(h.RESULTS_1_P2_HEADER);
+      h.clickResultsBack();
+
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-during-both/no/no-flow-A.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/no/no-flow-A.cypress.spec.js
@@ -16,8 +16,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('During both of these time periods - "No" to all categories (Results Screen 3)', () => {
+xdescribe('PACT Act', () => {
+  describe('During both of these time periods - "No" to all questions (Results Screen 3)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -76,7 +76,10 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 1);
       h.clickContinue();
 
-      // TODO add Results screen 3
+      // RESULTS 3
+      h.verifyUrl(ROUTES.RESULTS_3);
+      h.verifyElement(h.RESULTS_3_HEADER);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-during-both/no/no-flow-B.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/no/no-flow-B.cypress.spec.js
@@ -16,8 +16,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('During both of these time periods - "Yes" to one category (not Camp Lejeune), no to all else (Results Screen 1)', () => {
+xdescribe('PACT Act', () => {
+  describe('During both of these time periods -  "No" to all questions except 1 Burn Pit (Results Screen 1)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -76,7 +76,19 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 1);
       h.clickContinue();
 
-      // TODO add Results screen 1
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.verifyElement(h.RESULTS_1_P1_HEADER);
+      h.clickResultsContinue();
+
+      // RESULTS 1, P2
+      h.verifyUrl(ROUTES.RESULTS_1_P2);
+      h.verifyElement(h.RESULTS_1_P2_HEADER);
+      h.clickResultsBack();
+
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-during-both/yes/yes-flow-A.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/yes/yes-flow-A.cypress.spec.js
@@ -13,8 +13,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('During both of these time periods - "Yes" to two or more categories (Results Screen 1)', () => {
+xdescribe('PACT Act', () => {
+  describe('During both of these time periods - "Yes" to two or more question categories (Results Screen 1)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -58,7 +58,19 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 0);
       h.clickContinue();
 
-      // TODO add Results screen 1
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.verifyElement(h.RESULTS_1_P1_HEADER);
+      h.clickResultsContinue();
+
+      // RESULTS 1, P2
+      h.verifyUrl(ROUTES.RESULTS_1_P2);
+      h.verifyElement(h.RESULTS_1_P2_HEADER);
+      h.clickResultsBack();
+
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-during-both/yes/yes-flow-B.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/yes/yes-flow-B.cypress.spec.js
@@ -15,8 +15,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('During both of these time periods - "Yes" to two or more categories (Results Screen 1)', () => {
+xdescribe('PACT Act', () => {
+  describe('During both of these time periods - "Yes" to two or more question categories (Results Screen 1)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -70,7 +70,19 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 0);
       h.clickContinue();
 
-      // TODO add Results screen 1
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.verifyElement(h.RESULTS_1_P1_HEADER);
+      h.clickResultsContinue();
+
+      // RESULTS 1, P2
+      h.verifyUrl(ROUTES.RESULTS_1_P2);
+      h.verifyElement(h.RESULTS_1_P2_HEADER);
+      h.clickResultsBack();
+
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-during-both/yes/yes-flow-C.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/yes/yes-flow-C.cypress.spec.js
@@ -15,8 +15,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('During both of these time periods - "Yes" to two or more categories (Results Screen 1)', () => {
+xdescribe('PACT Act', () => {
+  describe('During both of these time periods - "Yes" to two or more question categories (Results Screen 1)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -70,7 +70,19 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 0);
       h.clickContinue();
 
-      // TODO add Results screen 1
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.verifyElement(h.RESULTS_1_P1_HEADER);
+      h.clickResultsContinue();
+
+      // RESULTS 1, P2
+      h.verifyUrl(ROUTES.RESULTS_1_P2);
+      h.verifyElement(h.RESULTS_1_P2_HEADER);
+      h.clickResultsBack();
+
+      // RESULTS 1, P1
+      h.verifyUrl(ROUTES.RESULTS_1_P1);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);

--- a/src/applications/pact-act/tests/cypress/service-period-during-both/yes/yes-flow-D.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/yes/yes-flow-D.cypress.spec.js
@@ -16,8 +16,8 @@ import { ROUTES } from '../../../../constants';
 
 // Note: anything requiring a VA button click is tested here as unit tests cannot
 // target the shadow DOM
-describe('PACT Act', () => {
-  describe('During both of these time periods - "Yes" to Camp Lejeune only (Results Screen 2)', () => {
+xdescribe('PACT Act', () => {
+  describe('During both of these time periods - "No" to all questions except 1 Camp Lejeune (Results Screen 2)', () => {
     it('navigates through the flow forward and backward successfully', () => {
       cy.visit('/pact-act-wizard-test');
 
@@ -76,7 +76,10 @@ describe('PACT Act', () => {
       h.selectRadio(h.LEJEUNE_2_4_INPUT, 0);
       h.clickContinue();
 
-      // TODO add Results screen 2
+      // RESULTS 2
+      h.verifyUrl(ROUTES.RESULTS_2);
+      h.verifyElement(h.RESULTS_2_HEADER);
+      h.clickResultsBack();
 
       // LEJEUNE_2_4
       h.verifyUrl(ROUTES.LEJEUNE_2_4);


### PR DESCRIPTION
## Summary
The placeholder results pages for PACT Act wizard are coming in a future pull request, but I'd like to get some Cypress test changes through to reduce the cognitive load of reviewing the results screens PR.

All Cypress tests except for form validation are skipped as they are asserting on results pages that do not exist yet (in this branch). They pass locally with the correct code in place, and will be re-enabled with the results screen PR.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15288

## Testing done
All Cypress tests ran locally and passed when running with the results screen code.