### PR TITLE
Profile/aw/66403/profile hub revisions title bai alert

### DIFF
--- a/src/applications/personalization/common/helpers.js
+++ b/src/applications/personalization/common/helpers.js
@@ -106,11 +106,12 @@ export const normalizePath = path => {
 };
 
 export const getRouteInfoFromPath = (path, routes) => {
+  const normalizedPath = normalizePath(path);
   const returnRouteInfo = routes.find(({ path: routePath }) => {
-    return routePath === path;
+    return routePath === normalizedPath;
   });
   if (!returnRouteInfo) {
-    return { ...routes[0], name: 'profile' };
+    throw new Error('No route found for path');
   }
   return returnRouteInfo;
 };

--- a/src/applications/personalization/profile/components/alerts/bad-address/ProfileAlert.jsx
+++ b/src/applications/personalization/profile/components/alerts/bad-address/ProfileAlert.jsx
@@ -2,19 +2,23 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 import { recordCustomProfileEvent } from '../../../util/analytics';
+import { useProfileRouteMetaData } from '../../../hooks';
+import { PROFILE_PATH_NAMES } from '../../../constants';
 
 const handlers = {
-  recordView() {
-    recordCustomProfileEvent({
-      title: 'Personal Info',
-      status: 'BAI Views',
-    });
+  recordView(pageName) {
+    return () =>
+      recordCustomProfileEvent({
+        title: pageName,
+        status: 'BAI Views',
+      });
   },
-  recordLinkClick(linkText) {
+  recordLinkClick(linkText, pageName) {
     return () => {
       recordCustomProfileEvent({
-        title: 'Personal Info',
+        title: pageName,
         status: 'BAI Link Click',
         primaryButtonText: linkText,
       });
@@ -25,12 +29,24 @@ const handlers = {
 export default function ProfileAlert({ className = 'vads-u-margin-top--4' }) {
   const heading = 'Review your mailing address';
   const linkText = 'Go to your contact information to review your address';
+  const pageName = useProfileRouteMetaData().name;
+
+  const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
+  const profileUseHubPage = useToggleValue(TOGGLE_NAMES.profileUseHubPage);
+
+  // dont show the alert if the hub page is being used and we are on the personal information page
+  if (
+    profileUseHubPage &&
+    pageName === PROFILE_PATH_NAMES.PERSONAL_INFORMATION
+  ) {
+    return null;
+  }
 
   return (
     <VaAlert
       status="warning"
       data-testid="bad-address-profile-alert"
-      onVa-component-did-load={handlers.recordView}
+      onVa-component-did-load={handlers.recordView(pageName)}
       className={className}
       role="alert"
       aria-live="polite"
@@ -49,7 +65,7 @@ export default function ProfileAlert({ className = 'vads-u-margin-top--4' }) {
       <p>
         <Link
           to="contact-information/#mailing-address"
-          onClick={handlers.recordLinkClick(linkText)}
+          onClick={handlers.recordLinkClick(linkText, pageName)}
         >
           {linkText}
         </Link>

--- a/src/applications/personalization/profile/components/edit/Edit.jsx
+++ b/src/applications/personalization/profile/components/edit/Edit.jsx
@@ -21,6 +21,7 @@ import getProfileInfoFieldAttributes from '../../util/getProfileInfoFieldAttribu
 import { getInitialFormValues } from '../../util/contact-information/formValues';
 import { getRouteInfoFromPath } from '~/applications/personalization/common/helpers';
 import { isFieldEmpty } from '../../util';
+import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '../../constants';
 
 const useQuery = () => {
   const { search } = useLocation();
@@ -61,10 +62,17 @@ export const Edit = () => {
 
   const fieldInfo = getFieldInfo(query.get('fieldName'));
 
-  const returnRouteInfo = getRouteInfoFromPath(
-    query.get('returnPath'),
-    routesForNav,
-  );
+  const returnRouteInfo = (() => {
+    try {
+      return getRouteInfoFromPath(query.get('returnPath'), routesForNav);
+    } catch (e) {
+      // default to using the root route if the returnPath is invalid
+      return {
+        path: PROFILE_PATHS.PROFILE_ROOT,
+        name: PROFILE_PATH_NAMES.PROFILE_ROOT,
+      };
+    }
+  })();
 
   const returnPath = returnRouteInfo?.path;
   const returnPathName = returnRouteInfo?.name;

--- a/src/applications/personalization/profile/components/hub/Hub.jsx
+++ b/src/applications/personalization/profile/components/hub/Hub.jsx
@@ -16,7 +16,7 @@ export const Hub = () => {
   const hasBadAddress = useSelector(hasBadAddressSelector);
 
   useEffect(() => {
-    document.title = `Your Profile | Veterans Affairs`;
+    document.title = `Profile | Veterans Affairs`;
   }, []);
 
   return (

--- a/src/applications/personalization/profile/components/hub/Hub.jsx
+++ b/src/applications/personalization/profile/components/hub/Hub.jsx
@@ -50,7 +50,7 @@ export const Hub = () => {
 
         <HubCard
           heading="Contact information"
-          content="Manage your addresses, phone numbers, and contact email address."
+          content="Manage your addresses, phone numbers, and the email address we'll use to contact you."
         >
           <div className="vads-u-margin-bottom--0p5">
             <ProfileLink
@@ -114,7 +114,7 @@ export const Hub = () => {
 
         <HubCard
           heading="Account security"
-          content="Review your sign-in information and account setup."
+          content="Review your sign-in and account information."
         >
           <>
             <div className="vads-u-display--block">

--- a/src/applications/personalization/profile/hooks/index.js
+++ b/src/applications/personalization/profile/hooks/index.js
@@ -2,3 +2,4 @@ export * from './useProfileTransaction';
 export * from './useContactInfoDeepLink';
 export * from './useNotificationSettingsUtils';
 export * from './useSignInServiceProvider';
+export * from './useProfileRouteMetaData';

--- a/src/applications/personalization/profile/hooks/useProfileRouteMetaData.js
+++ b/src/applications/personalization/profile/hooks/useProfileRouteMetaData.js
@@ -4,5 +4,11 @@ import { getRouteInfoFromPath } from '../../common/helpers';
 
 export const useProfileRouteMetaData = () => {
   const { pathname } = useLocation();
-  return getRouteInfoFromPath(pathname, PROFILE_PATHS_WITH_NAMES);
+  return (() => {
+    try {
+      return getRouteInfoFromPath(pathname, PROFILE_PATHS_WITH_NAMES);
+    } catch (e) {
+      return PROFILE_PATHS_WITH_NAMES.PROFILE_ROOT;
+    }
+  })();
 };

--- a/src/applications/personalization/profile/hooks/useProfileRouteMetaData.js
+++ b/src/applications/personalization/profile/hooks/useProfileRouteMetaData.js
@@ -1,0 +1,8 @@
+import { useLocation } from 'react-router-dom';
+import { PROFILE_PATHS_WITH_NAMES } from '../constants';
+import { getRouteInfoFromPath } from '../../common/helpers';
+
+export const useProfileRouteMetaData = () => {
+  const { pathname } = useLocation();
+  return getRouteInfoFromPath(pathname, PROFILE_PATHS_WITH_NAMES);
+};

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -75,9 +75,9 @@ const responses = {
   },
   'GET /v0/user': (_req, res) => {
     // example user data cases
-    return res.json(user.loa3User72); // default user (success)
+    // return res.json(user.loa3User72); // default user (success)
     // return res.json(user.loa1User); // user with loa1
-    // return res.json(user.badAddress); // user with bad address
+    return res.json(user.badAddress); // user with bad address
     // return res.json(user.loa3User); // user with loa3
     // return res.json(user.nonVeteranUser); // non-veteran user
     // return res.json(user.externalServiceError); // external service error

--- a/src/applications/personalization/profile/tests/components/alerts/bad-address/bad-address-alerts.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/alerts/bad-address/bad-address-alerts.unit.spec.jsx
@@ -1,28 +1,64 @@
 import React from 'react';
 import { axeCheck } from 'platform/forms-system/test/config/helpers';
-import { MemoryRouter as Router } from 'react-router-dom';
-import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import FormAlert from '../../../../components/alerts/bad-address/FormAlert';
 import ProfileAlert from '../../../../components/alerts/bad-address/ProfileAlert';
+import { renderWithStoreAndRouter } from '~/platform/testing/unit/react-testing-library-helpers';
+import { PROFILE_PATHS } from '~/applications/personalization/profile/constants';
+import { Toggler } from '~/platform/utilities/feature-toggles';
 
 describe('authenticated experience -- profile -- bad address alert', () => {
   describe('ProfileAlert', () => {
     it('passes axeCheck', () => {
-      axeCheck(
-        <Router>
-          <ProfileAlert />
-        </Router>,
-      );
+      const { container } = renderWithStoreAndRouter(<ProfileAlert />, {
+        initialState: {
+          featureToggles: {
+            [Toggler.TOGGLE_NAMES.profileUseHubPage]: false,
+          },
+        },
+        path: PROFILE_PATHS.PERSONAL_INFORMATION,
+      });
+
+      return axeCheck(<container />);
     });
     it('has accessibility considerations including alert role and aria-live', async () => {
-      const { findByRole } = render(
-        <Router>
-          <ProfileAlert />
-        </Router>,
-      );
+      const { findByRole } = renderWithStoreAndRouter(<ProfileAlert />, {
+        initialState: {
+          featureToggles: {
+            [Toggler.TOGGLE_NAMES.profileUseHubPage]: false,
+          },
+        },
+        path: PROFILE_PATHS.PERSONAL_INFORMATION,
+      });
+
       const alert = await findByRole('alert');
       expect(alert.getAttribute('aria-live')).to.equal('polite');
+    });
+
+    it('does not render on personal information page when hub toggle is ON', async () => {
+      const { queryByRole } = renderWithStoreAndRouter(<ProfileAlert />, {
+        initialState: {
+          featureToggles: {
+            [Toggler.TOGGLE_NAMES.profileUseHubPage]: true,
+          },
+        },
+        path: PROFILE_PATHS.PERSONAL_INFORMATION,
+      });
+
+      expect(queryByRole('alert')).to.not.exist;
+    });
+
+    it('render on profile root page when hub toggle is ON', async () => {
+      const { queryByRole } = renderWithStoreAndRouter(<ProfileAlert />, {
+        initialState: {
+          featureToggles: {
+            [Toggler.TOGGLE_NAMES.profileUseHubPage]: true,
+          },
+        },
+        path: PROFILE_PATHS.PROFILE_ROOT,
+      });
+
+      expect(queryByRole('alert')).to.exist;
     });
   });
   describe('FormAlert', () => {


### PR DESCRIPTION
## Summary

- Updates some content on the Profile Hub cards from the midpoint review feedback.
- Updates page title to be 'Profile' instead of "Your profile"
- Hide the Bad Address Indicator on the Personal Information page when it is being shown/used on the Hub page, since the Hub is the root page of profile.
- makes the helper `getRouteInfoFromPath` more generic and throws error is a route match is not found
- introduces a small hook to get route info from the current route that uses the above helper

## Related issue(s)

This covers two tickets, one of which was minor content updates, so that is why I combined them

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/66371 (content ticket)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/66403 (revisions ticket)

## Testing done

All tests passing, no new drastic behavior changes introduced.

## Screenshots

No ui changes other than content.

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)