### PR TITLE
Medication details PDF: Fixed date formatting

### DIFF
--- a/src/applications/mhv/medications/util/pdfConfigs.js
+++ b/src/applications/mhv/medications/util/pdfConfigs.js
@@ -167,10 +167,11 @@ export const buildVAPrescriptionPDFList = prescription => {
           items: [
             {
               title: 'Last filled on',
-              value: validateField(
+              value: dateFormat(
                 (prescription.rxRfRecords?.length &&
                   prescription.rxRfRecords?.[0]?.[1].dispensedDate) ||
                   prescription.dispensedDate,
+                'MMMM D, YYYY',
               ),
               inline: true,
             },
@@ -191,7 +192,7 @@ export const buildVAPrescriptionPDFList = prescription => {
             },
             {
               title: 'Request refills by this prescription expiration date',
-              value: dateFormat(prescription.expirationDate),
+              value: dateFormat(prescription.expirationDate, 'MMMM D, YYYY'),
               inline: true,
             },
             {
@@ -201,7 +202,7 @@ export const buildVAPrescriptionPDFList = prescription => {
             },
             {
               title: 'Prescribed on',
-              value: dateFormat(prescription.orderedDate),
+              value: dateFormat(prescription.orderedDate, 'MMMM D, YYYY'),
               inline: true,
             },
             {
@@ -290,7 +291,7 @@ export const buildNonVAPrescriptionPDFList = prescription => {
             },
             {
               title: 'When you started taking this medication',
-              value: dateFormat(prescription.dispensedDate),
+              value: dateFormat(prescription.dispensedDate, 'MMMM D, YYYY'),
               inline: true,
             },
             {


### PR DESCRIPTION
## Summary

This a bug fix for story MHV-47424 covered in #25959 
Fixed isolated dates formatting on Medication Details PDF

## Related issue(s)

[Jira ticket](https://jira.devops.va.gov/browse/MHV-47424)

<img width="965" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/46433838-918b-4b33-a86e-6e5e444acc1c">

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/f9add296-638c-44fc-abaa-991c8ed22492)

## What areas of the site does it impact?

my-health/Medications 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
