### PR TITLE
[AVS] content updates

### DIFF
--- a/src/applications/avs/components/YourHealthInformation.jsx
+++ b/src/applications/avs/components/YourHealthInformation.jsx
@@ -241,7 +241,6 @@ const YourHealthInformation = props => {
       {primaryCareProvider(avs)}
       {primaryCareTeam(avs)}
       {appointments(avs)}
-      <ParagraphBlock heading="Appointment notes" content={avs.comments} />
       {/* TODO: add problem list */}
       <ParagraphBlock
         heading="Smoking status"

--- a/src/applications/avs/containers/Avs.jsx
+++ b/src/applications/avs/containers/Avs.jsx
@@ -89,7 +89,10 @@ const Avs = props => {
         <h1>After-visit Summary</h1>
 
         <va-accordion>
-          <va-accordion-item header={generateAppointmentHeader(avs)}>
+          <va-accordion-item
+            header={generateAppointmentHeader(avs)}
+            open="true"
+          >
             <YourAppointment avs={avs} />
           </va-accordion-item>
           <va-accordion-item header="Your treatment plan from this appointment">

--- a/src/applications/avs/tests/components/YourHealthInformation.unit.spec.jsx
+++ b/src/applications/avs/tests/components/YourHealthInformation.unit.spec.jsx
@@ -28,9 +28,6 @@ describe('Avs: Your Health Information', () => {
     expect(screen.getByTestId('recall-appointments').firstChild).to.have.text(
       'March 15, 2024TEST CLINIC (VETERANS LOCATION VIDEO )Clinic location: LOMA LINDA VA CLINIC',
     );
-    expect(screen.getByTestId('appointment-notes')).to.have.text(
-      'Test appointment notes.',
-    );
     expect(screen.getByTestId('smoking-status')).to.have.text('Current smoker');
     expect(screen.getByTestId('immunizations').children[2]).to.contain.text(
       'COVID-19 (PFIZER)',
@@ -59,7 +56,6 @@ describe('Avs: Your Health Information', () => {
     expect(screen.queryByTestId('primary-care-team')).to.not.exist;
     expect(screen.queryByTestId('scheduled-appointments')).to.not.exist;
     expect(screen.queryByTestId('recall-appointments')).to.not.exist;
-    expect(screen.queryByTestId('appointment-notes')).to.not.exist;
     expect(screen.queryByTestId('smoking-status')).to.not.exist;
     expect(screen.queryByTestId('immunizations')).to.not.exist;
     expect(screen.queryByTestId('allergies-reactions')).to.not.exist;

--- a/src/applications/avs/tests/fixtures/9A7AF40B2BC2471EA116891839113252.json
+++ b/src/applications/avs/tests/fixtures/9A7AF40B2BC2471EA116891839113252.json
@@ -379,7 +379,6 @@
           "physicalLocation": "VETERANS LOCATION VIDEO "
         }
       ],
-      "comments": "Test appointment notes.",
       "patientInstructions": "Recommend acetaminophen 500 mg, take 1000 mg 3 times daily not to exceed<br>3000 mg per day.<br>Recommend acetaminophen 500 mg, take 1000 mg 3 times daily not to exceed<br>3000 mg per day.<br>",
       "patientEducation": "None",
       "primaryCareProviders": [


### PR DESCRIPTION
## Summary

- Changes:
  - makes first accordion item open by default
  - removes "Appointment notes" section - this turns to be a duplicate of "Other instructions"

## Testing done
- local testing
- updated unit tests

## Screenshots

Open by default:

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/101649/ffff4541-a406-4835-9e57-12a1fb0088d1)

Appointment notes removed, were between appointments and smoking status:

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/101649/f91bc946-d8eb-4302-995b-dd5c5b2e43de)

