### PR TITLE
Change ToU Warning Text

### DIFF
--- a/src/applications/terms-of-use/containers/TermsOfUse.jsx
+++ b/src/applications/terms-of-use/containers/TermsOfUse.jsx
@@ -164,7 +164,7 @@ export default function TermsOfUse() {
               <li>VA.gov</li>
               <li>My HealtheVet</li>
               <li>My VA Health</li>
-              <li>VA: Health and Benefits</li>
+              <li>VA Health and Benefits Mobile App</li>
             </ul>
             <p>
               This means you won’t be able to do these types of things using VA


### PR DESCRIPTION
## Summary
Changes the line “VA: Health and Benefits” to “VA Health and Benefits Mobile App” in the ToU in the warning box.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/67065

## What areas of the site does it impact?
The ToU page.

## Acceptance criteria
- [x] Update the line of text “VA: Health and Benefits” in the ToU in the warning box to read “VA Health and Benefits Mobile App”.