### PR TITLE
[1178] start recording if params are invalid for webchat

### DIFF
--- a/src/applications/virtual-agent/components/webchat/WebChat.jsx
+++ b/src/applications/virtual-agent/components/webchat/WebChat.jsx
@@ -15,7 +15,10 @@ import {
   clearBotSessionStorage,
   IS_RX_SKILL,
 } from '../chatbox/utils';
-import { cardActionMiddleware } from './helpers/webChat';
+import {
+  cardActionMiddleware,
+  ifMissingParamsCallSentry,
+} from './helpers/webChat';
 
 const renderMarkdown = text => MarkdownRenderer.render(text);
 
@@ -40,8 +43,9 @@ const WebChat = ({ token, WebChatFramework, apiSession }) => {
   );
 
   const store = useMemo(
-    () =>
-      createStore(
+    () => {
+      ifMissingParamsCallSentry(csrfToken, apiSession, userFirstName, userUuid);
+      return createStore(
         {},
         StartConvoAndTrackUtterances.makeBotStartConvoAndTrackUtterances(
           csrfToken,
@@ -51,7 +55,8 @@ const WebChat = ({ token, WebChatFramework, apiSession }) => {
           userFirstName === '' ? 'noFirstNameFound' : userFirstName,
           userUuid === null ? 'noUserUuid' : userUuid, // Because PVA cannot support empty strings or null pass in 'null' if user is not logged in
         ),
-      ),
+      );
+    },
     [createStore],
   );
   let directLineToken = token;

--- a/src/applications/virtual-agent/components/webchat/helpers/webChat.js
+++ b/src/applications/virtual-agent/components/webchat/helpers/webChat.js
@@ -1,4 +1,5 @@
 import recordEvent from 'platform/monitoring/record-event';
+import * as Sentry from '@sentry/browser';
 
 export const cardActionMiddleware = decisionLetterEnabled => () => next => card => {
   const { cardAction } = card;
@@ -14,4 +15,29 @@ export const cardActionMiddleware = decisionLetterEnabled => () => next => card 
     recordDecisionLetterDownload();
   }
   next(card);
+};
+
+export const ifMissingParamsCallSentry = (
+  csrfToken,
+  apiSession,
+  userFirstName,
+  userUuid,
+) => {
+  const missingParams = !(
+    csrfToken &&
+    apiSession &&
+    typeof userFirstName === 'string' &&
+    (userUuid === null || typeof userUuid === 'string')
+  );
+  if (missingParams) {
+    const params = {
+      csrfToken: undefined,
+      apiSession,
+      userFirstName,
+      userUuid,
+    };
+    Sentry.captureException(
+      new TypeError(`Missing required variables: ${JSON.stringify(params)}`),
+    );
+  }
 };

--- a/src/applications/virtual-agent/components/webchat/helpers/webChat.js
+++ b/src/applications/virtual-agent/components/webchat/helpers/webChat.js
@@ -31,7 +31,7 @@ export const ifMissingParamsCallSentry = (
   );
   if (missingParams) {
     const params = {
-      csrfToken: undefined,
+      csrfToken,
       apiSession,
       userFirstName,
       userUuid,

--- a/src/applications/virtual-agent/components/webchat/helpers/webChat.js
+++ b/src/applications/virtual-agent/components/webchat/helpers/webChat.js
@@ -29,11 +29,25 @@ export const ifMissingParamsCallSentry = (
     typeof userFirstName === 'string' &&
     (userUuid === null || typeof userUuid === 'string');
   if (!hasAllParams) {
+    const sanitizedCsrfToken =
+      typeof csrfToken === 'string' && csrfToken
+        ? 'csrfToken present'
+        : csrfToken;
+    const sanitizedApiSession =
+      typeof apiSession === 'string' && apiSession
+        ? 'apiSession present'
+        : apiSession;
+    const sanitizedUserFirstName =
+      typeof userFirstName === 'string' && userFirstName
+        ? 'userFirstName present'
+        : userFirstName;
+    const sanitizedUserUuid =
+      typeof userUuid === 'string' && userUuid ? 'userUuid present' : userUuid;
     const params = {
-      csrfToken,
-      apiSession,
-      userFirstName,
-      userUuid,
+      sanitizedCsrfToken,
+      sanitizedApiSession,
+      sanitizedUserFirstName,
+      sanitizedUserUuid,
     };
     Sentry.captureException(
       new TypeError(`Missing required variables: ${JSON.stringify(params)}`),

--- a/src/applications/virtual-agent/components/webchat/helpers/webChat.js
+++ b/src/applications/virtual-agent/components/webchat/helpers/webChat.js
@@ -23,13 +23,12 @@ export const ifMissingParamsCallSentry = (
   userFirstName,
   userUuid,
 ) => {
-  const missingParams = !(
+  const hasAllParams =
     csrfToken &&
     apiSession &&
     typeof userFirstName === 'string' &&
-    (userUuid === null || typeof userUuid === 'string')
-  );
-  if (missingParams) {
+    (userUuid === null || typeof userUuid === 'string');
+  if (!hasAllParams) {
     const params = {
       csrfToken,
       apiSession,

--- a/src/applications/virtual-agent/components/webchat/helpers/webChat.js
+++ b/src/applications/virtual-agent/components/webchat/helpers/webChat.js
@@ -28,26 +28,29 @@ export const ifMissingParamsCallSentry = (
     apiSession &&
     typeof userFirstName === 'string' &&
     (userUuid === null || typeof userUuid === 'string');
+  const getSanitizedVariable = (variable, variableName) => {
+    if (variable === undefined) {
+      return `${variableName} was undefined`;
+    }
+    if (typeof variable === 'string' && variable) {
+      return `${variableName} present`;
+    }
+    return variable;
+  };
+
   if (!hasAllParams) {
-    const sanitizedCsrfToken =
-      typeof csrfToken === 'string' && csrfToken
-        ? 'csrfToken present'
-        : csrfToken;
-    const sanitizedApiSession =
-      typeof apiSession === 'string' && apiSession
-        ? 'apiSession present'
-        : apiSession;
-    const sanitizedUserFirstName =
-      typeof userFirstName === 'string' && userFirstName
-        ? 'userFirstName present'
-        : userFirstName;
-    const sanitizedUserUuid =
-      typeof userUuid === 'string' && userUuid ? 'userUuid present' : userUuid;
+    const sanitizedCsrfToken = getSanitizedVariable(csrfToken, 'csrfToken');
+    const sanitizedApiSession = getSanitizedVariable(apiSession, 'apiSession');
+    const sanitizedUserFirstName = getSanitizedVariable(
+      userFirstName,
+      'userFirstName',
+    );
+    const sanitizedUserUuid = getSanitizedVariable(userUuid, 'userUuid');
     const params = {
-      sanitizedCsrfToken,
-      sanitizedApiSession,
-      sanitizedUserFirstName,
-      sanitizedUserUuid,
+      csrfToken: sanitizedCsrfToken,
+      apiSession: sanitizedApiSession,
+      userFirstName: sanitizedUserFirstName,
+      userUuid: sanitizedUserUuid,
     };
     Sentry.captureException(
       new TypeError(`Missing required variables: ${JSON.stringify(params)}`),

--- a/src/applications/virtual-agent/tests/components/webchat/helpers/webchat.unit.spec.js
+++ b/src/applications/virtual-agent/tests/components/webchat/helpers/webchat.unit.spec.js
@@ -107,9 +107,81 @@ describe('Webchat.jsx Helpers', () => {
       it('should call sentry when csrfToken is null', () => {
         const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
         const csrfToken = null;
+        const apiSession = 'apiSession';
+        const userFirstName = 'userFirstName';
+        const userUuid = 'userUuid';
+        ifMissingParamsCallSentry(
+          csrfToken,
+          apiSession,
+          userFirstName,
+          userUuid,
+        );
+        expect(captureExceptionStub.calledOnce).to.be.true;
+      });
+      it('should call sentry when csrfToken is undefined', () => {
+        const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+        const csrfToken = undefined;
+        const apiSession = 'apiSession';
+        const userFirstName = 'userFirstName';
+        const userUuid = 'userUuid';
+        ifMissingParamsCallSentry(
+          csrfToken,
+          apiSession,
+          userFirstName,
+          userUuid,
+        );
+        expect(captureExceptionStub.calledOnce).to.be.true;
+      });
+      it('should call sentry when csrfToken is an empty string', () => {
+        const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+        const csrfToken = '';
+        const apiSession = 'apiSession';
+        const userFirstName = 'userFirstName';
+        const userUuid = 'userUuid';
+        ifMissingParamsCallSentry(
+          csrfToken,
+          apiSession,
+          userFirstName,
+          userUuid,
+        );
+        expect(captureExceptionStub.calledOnce).to.be.true;
+      });
+    });
+    describe('call sentry when the apiSession is invalid', () => {
+      it('should call sentry when apiSession is null', () => {
+        const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+        const csrfToken = 'csrfToken';
+        const apiSession = null;
+        const userFirstName = 'userFirstName';
+        const userUuid = 'userUuid';
+        ifMissingParamsCallSentry(
+          csrfToken,
+          apiSession,
+          userFirstName,
+          userUuid,
+        );
+        expect(captureExceptionStub.calledOnce).to.be.true;
+      });
+      it('should call sentry when apiSession is undefined', () => {
+        const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+        const csrfToken = 'csrfToken';
+        const apiSession = undefined;
+        const userFirstName = 'userFirstName';
+        const userUuid = 'userUuid';
+        ifMissingParamsCallSentry(
+          csrfToken,
+          apiSession,
+          userFirstName,
+          userUuid,
+        );
+        expect(captureExceptionStub.calledOnce).to.be.true;
+      });
+      it('should call sentry when apiSession is an empty string', () => {
+        const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+        const csrfToken = 'csrfToken';
         const apiSession = '';
-        const userFirstName = '';
-        const userUuid = '';
+        const userFirstName = 'userFirstName';
+        const userUuid = 'userUuid';
         ifMissingParamsCallSentry(
           csrfToken,
           apiSession,

--- a/src/applications/virtual-agent/tests/components/webchat/helpers/webchat.unit.spec.js
+++ b/src/applications/virtual-agent/tests/components/webchat/helpers/webchat.unit.spec.js
@@ -2,7 +2,11 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import * as recordEventObject from 'platform/monitoring/record-event';
 import { describe } from 'mocha';
-import { cardActionMiddleware } from '../../../../components/webchat/helpers/webChat';
+import * as Sentry from '@sentry/browser';
+import {
+  cardActionMiddleware,
+  ifMissingParamsCallSentry,
+} from '../../../../components/webchat/helpers/webChat';
 
 const sandbox = sinon.createSandbox();
 
@@ -95,6 +99,24 @@ describe('Webchat.jsx Helpers', () => {
         expect(recordEventStub.notCalled).to.be.true;
         expect(nextSpy.calledOnce).to.be.true;
         expect(nextSpy.firstCall.args[0]).to.eql(nonDecisionLetterCard);
+      });
+    });
+  });
+  describe('ifMissingParamsCallSentry', () => {
+    describe('call sentry when the csrfToken is invalid', () => {
+      it('should call sentry when csrfToken is null', () => {
+        const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+        const csrfToken = null;
+        const apiSession = '';
+        const userFirstName = '';
+        const userUuid = '';
+        ifMissingParamsCallSentry(
+          csrfToken,
+          apiSession,
+          userFirstName,
+          userUuid,
+        );
+        expect(captureExceptionStub.calledOnce).to.be.true;
       });
     });
   });

--- a/src/applications/virtual-agent/tests/components/webchat/helpers/webchat.unit.spec.js
+++ b/src/applications/virtual-agent/tests/components/webchat/helpers/webchat.unit.spec.js
@@ -191,5 +191,53 @@ describe('Webchat.jsx Helpers', () => {
         expect(captureExceptionStub.calledOnce).to.be.true;
       });
     });
+    describe('call sentry when the apiSession is invalid', () => {
+      it('should call sentry when userFirstName is null', () => {
+        const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+        const csrfToken = 'csrfToken';
+        const apiSession = 'apiSession';
+        const userFirstName = null;
+        const userUuid = 'userUuid';
+        ifMissingParamsCallSentry(
+          csrfToken,
+          apiSession,
+          userFirstName,
+          userUuid,
+        );
+        expect(captureExceptionStub.calledOnce).to.be.true;
+      });
+      it('should call sentry when userFirstName is undefined', () => {
+        const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+        const csrfToken = 'csrfToken';
+        const apiSession = 'apiSession';
+        const userFirstName = undefined;
+        const userUuid = 'userUuid';
+        ifMissingParamsCallSentry(
+          csrfToken,
+          apiSession,
+          userFirstName,
+          userUuid,
+        );
+        expect(captureExceptionStub.calledOnce).to.be.true;
+      });
+    });
+    it('should call sentry when userUuid is undefined', () => {
+      const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+      const csrfToken = 'csrfToken';
+      const apiSession = 'apiSession';
+      const userFirstName = 'userFirstName';
+      const userUuid = undefined;
+      ifMissingParamsCallSentry(csrfToken, apiSession, userFirstName, userUuid);
+      expect(captureExceptionStub.calledOnce).to.be.true;
+    });
+    it('should not call sentry when parameters are valid', () => {
+      const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+      const csrfToken = 'csrfToken';
+      const apiSession = 'apiSession';
+      const userFirstName = 'userFirstName';
+      const userUuid = 'userUuid';
+      ifMissingParamsCallSentry(csrfToken, apiSession, userFirstName, userUuid);
+      expect(captureExceptionStub.notCalled).to.be.true;
+    });
   });
 });

--- a/src/applications/virtual-agent/tests/components/webchat/helpers/webchat.unit.spec.js
+++ b/src/applications/virtual-agent/tests/components/webchat/helpers/webchat.unit.spec.js
@@ -239,5 +239,18 @@ describe('Webchat.jsx Helpers', () => {
       ifMissingParamsCallSentry(csrfToken, apiSession, userFirstName, userUuid);
       expect(captureExceptionStub.notCalled).to.be.true;
     });
+    it('should not log the value of the csrfToken to Sentry', () => {
+      const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+      const csrfToken = undefined;
+      const apiSession = 'apiSession';
+      const userFirstName = 'userFirstName';
+      const userUuid = 'userUuid';
+      ifMissingParamsCallSentry(csrfToken, apiSession, userFirstName, userUuid);
+      const expectedError = captureExceptionStub.firstCall.args[0];
+      expect(expectedError.name).to.equal('TypeError');
+      expect(expectedError.message).to.equal(
+        'Missing required variables: {"csrfToken": "csrfToken was undefined","apiSession":"apiSession present","userFirstName":"userFirstName present","userUuid":"userUuid present"}',
+      );
+    });
   });
 });

--- a/src/applications/virtual-agent/tests/components/webchat/helpers/webchat.unit.spec.js
+++ b/src/applications/virtual-agent/tests/components/webchat/helpers/webchat.unit.spec.js
@@ -103,22 +103,212 @@ describe('Webchat.jsx Helpers', () => {
     });
   });
   describe('ifMissingParamsCallSentry', () => {
-    describe('call sentry when the csrfToken is invalid', () => {
-      it('should call sentry when csrfToken is null', () => {
-        const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
-        const csrfToken = null;
-        const apiSession = 'apiSession';
-        const userFirstName = 'userFirstName';
-        const userUuid = 'userUuid';
-        ifMissingParamsCallSentry(
-          csrfToken,
-          apiSession,
-          userFirstName,
-          userUuid,
-        );
-        expect(captureExceptionStub.calledOnce).to.be.true;
+    describe('Invalid params', () => {
+      describe('call sentry when the csrfToken is invalid', () => {
+        it('should call sentry when csrfToken is null', () => {
+          const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+          const csrfToken = null;
+          const apiSession = 'apiSession';
+          const userFirstName = 'userFirstName';
+          const userUuid = 'userUuid';
+          ifMissingParamsCallSentry(
+            csrfToken,
+            apiSession,
+            userFirstName,
+            userUuid,
+          );
+          expect(captureExceptionStub.calledOnce).to.be.true;
+        });
+        it('should call sentry when csrfToken is undefined', () => {
+          const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+          const csrfToken = undefined;
+          const apiSession = 'apiSession';
+          const userFirstName = 'userFirstName';
+          const userUuid = 'userUuid';
+          ifMissingParamsCallSentry(
+            csrfToken,
+            apiSession,
+            userFirstName,
+            userUuid,
+          );
+          expect(captureExceptionStub.calledOnce).to.be.true;
+        });
+        it('should call sentry when csrfToken is an empty string', () => {
+          const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+          const csrfToken = '';
+          const apiSession = 'apiSession';
+          const userFirstName = 'userFirstName';
+          const userUuid = 'userUuid';
+          ifMissingParamsCallSentry(
+            csrfToken,
+            apiSession,
+            userFirstName,
+            userUuid,
+          );
+          expect(captureExceptionStub.calledOnce).to.be.true;
+        });
       });
-      it('should call sentry when csrfToken is undefined', () => {
+      describe('call sentry when the apiSession is invalid', () => {
+        it('should call sentry when apiSession is null', () => {
+          const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+          const csrfToken = 'csrfToken';
+          const apiSession = null;
+          const userFirstName = 'userFirstName';
+          const userUuid = 'userUuid';
+          ifMissingParamsCallSentry(
+            csrfToken,
+            apiSession,
+            userFirstName,
+            userUuid,
+          );
+          expect(captureExceptionStub.calledOnce).to.be.true;
+        });
+        it('should call sentry when apiSession is undefined', () => {
+          const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+          const csrfToken = 'csrfToken';
+          const apiSession = undefined;
+          const userFirstName = 'userFirstName';
+          const userUuid = 'userUuid';
+          ifMissingParamsCallSentry(
+            csrfToken,
+            apiSession,
+            userFirstName,
+            userUuid,
+          );
+          expect(captureExceptionStub.calledOnce).to.be.true;
+        });
+        it('should call sentry when apiSession is an empty string', () => {
+          const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+          const csrfToken = 'csrfToken';
+          const apiSession = '';
+          const userFirstName = 'userFirstName';
+          const userUuid = 'userUuid';
+          ifMissingParamsCallSentry(
+            csrfToken,
+            apiSession,
+            userFirstName,
+            userUuid,
+          );
+          expect(captureExceptionStub.calledOnce).to.be.true;
+        });
+      });
+      describe('call sentry when the apiSession is invalid', () => {
+        it('should call sentry when userFirstName is null', () => {
+          const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+          const csrfToken = 'csrfToken';
+          const apiSession = 'apiSession';
+          const userFirstName = null;
+          const userUuid = 'userUuid';
+          ifMissingParamsCallSentry(
+            csrfToken,
+            apiSession,
+            userFirstName,
+            userUuid,
+          );
+          expect(captureExceptionStub.calledOnce).to.be.true;
+        });
+        it('should call sentry when userFirstName is undefined', () => {
+          const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+          const csrfToken = 'csrfToken';
+          const apiSession = 'apiSession';
+          const userFirstName = undefined;
+          const userUuid = 'userUuid';
+          ifMissingParamsCallSentry(
+            csrfToken,
+            apiSession,
+            userFirstName,
+            userUuid,
+          );
+          expect(captureExceptionStub.calledOnce).to.be.true;
+        });
+      });
+      describe('should indicate if a variable is undefined', () => {
+        it('should indicate when userUuid is undefined', () => {
+          const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+          const csrfToken = 'csrfToken';
+          const apiSession = 'apiSession';
+          const userFirstName = 'userFirstName';
+          const userUuid = undefined;
+          ifMissingParamsCallSentry(
+            csrfToken,
+            apiSession,
+            userFirstName,
+            userUuid,
+          );
+
+          const expectedError = captureExceptionStub.firstCall.args[0];
+          expect(expectedError.name).to.equal('TypeError');
+          expect(expectedError.message).to.equal(
+            'Missing required variables: {"csrfToken":"csrfToken present","apiSession":"apiSession present","userFirstName":"userFirstName present","userUuid":"userUuid was undefined"}',
+          );
+        });
+        it('Should indicate when csrfToke is undefined', () => {
+          const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+          const csrfToken = undefined;
+          const apiSession = 'apiSession';
+          const userFirstName = 'userFirstName';
+          const userUuid = 'userUuid';
+          ifMissingParamsCallSentry(
+            csrfToken,
+            apiSession,
+            userFirstName,
+            userUuid,
+          );
+          const expectedError = captureExceptionStub.firstCall.args[0];
+          expect(expectedError.name).to.equal('TypeError');
+          expect(expectedError.message).to.equal(
+            'Missing required variables: {"csrfToken":"csrfToken was undefined","apiSession":"apiSession present","userFirstName":"userFirstName present","userUuid":"userUuid present"}',
+          );
+        });
+        it('Should indicate when apiSession is undefined', () => {
+          const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+          const csrfToken = 'csrfToken';
+          const apiSession = undefined;
+          const userFirstName = 'userFirstName';
+          const userUuid = 'userUuid';
+          ifMissingParamsCallSentry(
+            csrfToken,
+            apiSession,
+            userFirstName,
+            userUuid,
+          );
+          const expectedError = captureExceptionStub.firstCall.args[0];
+          expect(expectedError.name).to.equal('TypeError');
+          expect(expectedError.message).to.equal(
+            'Missing required variables: {"csrfToken":"csrfToken present","apiSession":"apiSession was undefined","userFirstName":"userFirstName present","userUuid":"userUuid present"}',
+          );
+        });
+        it('Should indicate when userFirstName is undefined', () => {
+          const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+          const csrfToken = 'csrfToken';
+          const apiSession = 'apiSession';
+          const userFirstName = undefined;
+          const userUuid = 'userUuid';
+          ifMissingParamsCallSentry(
+            csrfToken,
+            apiSession,
+            userFirstName,
+            userUuid,
+          );
+          const expectedError = captureExceptionStub.firstCall.args[0];
+          expect(expectedError.name).to.equal('TypeError');
+          expect(expectedError.message).to.equal(
+            'Missing required variables: {"csrfToken":"csrfToken present","apiSession":"apiSession present","userFirstName":"userFirstName was undefined","userUuid":"userUuid present"}',
+          );
+        });
+      });
+    });
+    it('should not call sentry when parameters are valid', () => {
+      const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
+      const csrfToken = 'csrfToken';
+      const apiSession = 'apiSession';
+      const userFirstName = 'userFirstName';
+      const userUuid = 'userUuid';
+      ifMissingParamsCallSentry(csrfToken, apiSession, userFirstName, userUuid);
+      expect(captureExceptionStub.notCalled).to.be.true;
+    });
+    describe('variables should be obfuscated', () => {
+      it('should not log the value of the apiSession, userFirstName, and userUuid to Sentry', () => {
         const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
         const csrfToken = undefined;
         const apiSession = 'apiSession';
@@ -130,39 +320,13 @@ describe('Webchat.jsx Helpers', () => {
           userFirstName,
           userUuid,
         );
-        expect(captureExceptionStub.calledOnce).to.be.true;
-      });
-      it('should call sentry when csrfToken is an empty string', () => {
-        const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
-        const csrfToken = '';
-        const apiSession = 'apiSession';
-        const userFirstName = 'userFirstName';
-        const userUuid = 'userUuid';
-        ifMissingParamsCallSentry(
-          csrfToken,
-          apiSession,
-          userFirstName,
-          userUuid,
+        const expectedError = captureExceptionStub.firstCall.args[0];
+        expect(expectedError.name).to.equal('TypeError');
+        expect(expectedError.message).to.equal(
+          'Missing required variables: {"csrfToken":"csrfToken was undefined","apiSession":"apiSession present","userFirstName":"userFirstName present","userUuid":"userUuid present"}',
         );
-        expect(captureExceptionStub.calledOnce).to.be.true;
       });
-    });
-    describe('call sentry when the apiSession is invalid', () => {
-      it('should call sentry when apiSession is null', () => {
-        const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
-        const csrfToken = 'csrfToken';
-        const apiSession = null;
-        const userFirstName = 'userFirstName';
-        const userUuid = 'userUuid';
-        ifMissingParamsCallSentry(
-          csrfToken,
-          apiSession,
-          userFirstName,
-          userUuid,
-        );
-        expect(captureExceptionStub.calledOnce).to.be.true;
-      });
-      it('should call sentry when apiSession is undefined', () => {
+      it('should not log the value of the csrfToken, userFirstName, and userUuid to Sentry', () => {
         const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
         const csrfToken = 'csrfToken';
         const apiSession = undefined;
@@ -174,83 +338,12 @@ describe('Webchat.jsx Helpers', () => {
           userFirstName,
           userUuid,
         );
-        expect(captureExceptionStub.calledOnce).to.be.true;
-      });
-      it('should call sentry when apiSession is an empty string', () => {
-        const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
-        const csrfToken = 'csrfToken';
-        const apiSession = '';
-        const userFirstName = 'userFirstName';
-        const userUuid = 'userUuid';
-        ifMissingParamsCallSentry(
-          csrfToken,
-          apiSession,
-          userFirstName,
-          userUuid,
+        const expectedError = captureExceptionStub.firstCall.args[0];
+        expect(expectedError.name).to.equal('TypeError');
+        expect(expectedError.message).to.equal(
+          'Missing required variables: {"csrfToken":"csrfToken present","apiSession":"apiSession was undefined","userFirstName":"userFirstName present","userUuid":"userUuid present"}',
         );
-        expect(captureExceptionStub.calledOnce).to.be.true;
       });
-    });
-    describe('call sentry when the apiSession is invalid', () => {
-      it('should call sentry when userFirstName is null', () => {
-        const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
-        const csrfToken = 'csrfToken';
-        const apiSession = 'apiSession';
-        const userFirstName = null;
-        const userUuid = 'userUuid';
-        ifMissingParamsCallSentry(
-          csrfToken,
-          apiSession,
-          userFirstName,
-          userUuid,
-        );
-        expect(captureExceptionStub.calledOnce).to.be.true;
-      });
-      it('should call sentry when userFirstName is undefined', () => {
-        const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
-        const csrfToken = 'csrfToken';
-        const apiSession = 'apiSession';
-        const userFirstName = undefined;
-        const userUuid = 'userUuid';
-        ifMissingParamsCallSentry(
-          csrfToken,
-          apiSession,
-          userFirstName,
-          userUuid,
-        );
-        expect(captureExceptionStub.calledOnce).to.be.true;
-      });
-    });
-    it('should call sentry when userUuid is undefined', () => {
-      const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
-      const csrfToken = 'csrfToken';
-      const apiSession = 'apiSession';
-      const userFirstName = 'userFirstName';
-      const userUuid = undefined;
-      ifMissingParamsCallSentry(csrfToken, apiSession, userFirstName, userUuid);
-      expect(captureExceptionStub.calledOnce).to.be.true;
-    });
-    it('should not call sentry when parameters are valid', () => {
-      const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
-      const csrfToken = 'csrfToken';
-      const apiSession = 'apiSession';
-      const userFirstName = 'userFirstName';
-      const userUuid = 'userUuid';
-      ifMissingParamsCallSentry(csrfToken, apiSession, userFirstName, userUuid);
-      expect(captureExceptionStub.notCalled).to.be.true;
-    });
-    it('should not log the value of the csrfToken to Sentry', () => {
-      const captureExceptionStub = sandbox.stub(Sentry, 'captureException');
-      const csrfToken = undefined;
-      const apiSession = 'apiSession';
-      const userFirstName = 'userFirstName';
-      const userUuid = 'userUuid';
-      ifMissingParamsCallSentry(csrfToken, apiSession, userFirstName, userUuid);
-      const expectedError = captureExceptionStub.firstCall.args[0];
-      expect(expectedError.name).to.equal('TypeError');
-      expect(expectedError.message).to.equal(
-        'Missing required variables: {"csrfToken": "csrfToken was undefined","apiSession":"apiSession present","userFirstName":"userFirstName present","userUuid":"userUuid present"}',
-      );
     });
   });
 });


### PR DESCRIPTION
Co-authored-by: Aaron Young <aaron.young@thoughtworks.com>

## Summary

- _(Summarize the changes that have been made to the platform)_
  - We added a function to check that parameters passed to our function `StartConvoAndTrackUtterances.makeBotStartConvoAndTrackUtterances` are valid values otherwise send the exception to Sentry for monitoring.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - We work with the virtual-agent chatbot team which is responsible for maintaining this component.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#0000
https://app.zenhub.com/workspaces/va-virtual-agent-6011826e423fcf000eb231cb/issues/gh/department-of-veterans-affairs/va-virtual-agent/1178

## Testing done

- _Describe what the old behavior was prior to the change_
  - Before the change, we were unaware whenever invalid parameters were passed to `StartConvoAndTrackUtterances.makeBotStartConvoAndTrackUtterances`, now we should be able to monitor this issue in Sentry
- _Describe the tests completed and the results_
  - We wrote several unit tests validating that the function would return the correct value depending on all possible parameter formats. We also manually tested that the webchat still works as expected. 

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user
