### PR TITLE
MHV-49886 The-Date-The-Allergy-Was-Entered-Is-Coded-As-An-H2

### DIFF
--- a/src/applications/mhv/medical-records/containers/AllergyDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/AllergyDetails.jsx
@@ -165,7 +165,7 @@ const AllergyDetails = () => {
           </h1>
           <div className="condition-subheader vads-u-margin-bottom--4">
             <div className="time-header">
-              <h2
+              <p
                 className="vads-u-font-size--base vads-u-font-family--sans"
                 id="allergy-date"
               >
@@ -176,7 +176,7 @@ const AllergyDetails = () => {
                 >
                   {allergy.date}
                 </span>
-              </h2>
+              </p>
             </div>
             <PrintDownload
               download={generateAllergyPdf}

--- a/src/applications/mhv/medical-records/containers/AllergyDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/AllergyDetails.jsx
@@ -166,7 +166,7 @@ const AllergyDetails = () => {
           <div className="condition-subheader vads-u-margin-bottom--4">
             <div className="time-header">
               <p
-                className="vads-u-font-size--base vads-u-font-family--sans"
+                className="vads-u-font-size--base vads-u-font-family--sans vads-u-font-weight--bold"
                 id="allergy-date"
               >
                 Date entered:{' '}


### PR DESCRIPTION
## Summary
Changed the `<h2>` tag to a `<p>` tag to adhere to the Platform Issue heading hierarchy. The headings were not properly nested, and the headings and/or labels are not relevant to the page.
## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/66641

[MHV-49886](https://jira.devops.va.gov/browse/MHV-49886) - The date the allergy was entered is coded as an H2 


## Testing done
- Used a test user to conduct a manual website test and utilized Google Inspect to verify the presence of the `<p>` tag.
- No new unit tests need for minor tag change

## What areas of the site does it impact?
The modification affects the "Date entered" section on the Medical Records details page.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
