### PR TITLE
MHV-49975 Page-Title-tag-for-Allergy-Details-Page-Has-Extra-Information

### DIFF
--- a/src/applications/mhv/medical-records/containers/AllergyDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/AllergyDetails.jsx
@@ -62,10 +62,7 @@ const AllergyDetails = () => {
     () => {
       if (allergy) {
         focusElement(document.querySelector('h1'));
-        const titleDate = allergy.date ? `${allergy.date} - ` : '';
-        updatePageTitle(
-          `${titleDate}${allergy.name} - ${pageTitles.ALLERGIES_PAGE_TITLE}`,
-        );
+        updatePageTitle(`${allergy.name} - ${pageTitles.ALLERGIES_PAGE_TITLE}`);
       }
     },
     [dispatch, allergy, allergyId],


### PR DESCRIPTION
## Summary
Eliminated the date object from the `<title>`  tag on the Allergies Detail page. This additional information does not align with the page title #66636.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/66636

[MHV-49975](https://jira.devops.va.gov/browse/MHV-49975) - Page title tag for Allergy details pages has extra information and does not match the page title #66636

## Testing done
- Used a test user to conduct a manual website test and utilized Google Inspect to verify the removal of the Date object from `<title>` tag.
- No new unit tests need for minor tag change

## What areas of the site does it impact?
The modification affects the `<title>` section on the Medical Records details page.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
