### PR TITLE
VFEP-819 On the Search by Name field. If you do not enter information an error message appears “Please fill in a city, state or Postal Code” and it is read by the screen reader so that part is correct

### DIFF
--- a/src/applications/gi/components/search/KeywordSearch.jsx
+++ b/src/applications/gi/components/search/KeywordSearch.jsx
@@ -116,6 +116,8 @@ export function KeywordSearch({
             className="usa-input-error-message"
             role="alert"
             id="search-error-message"
+            aria-live="assertive"
+            aria-relevant="additions removals"
           >
             <span className="sr-only">Error</span>
             {error}
@@ -150,7 +152,8 @@ export function KeywordSearch({
                   onChange: handleChange,
                   onKeyUp: handleEnterPress,
                   onFocus: handleFocus,
-                  'aria-labelledby': 'institution-search-label',
+                  'aria-labelledby':
+                    'search-error-message institution-search-label',
                 })}
               />
               {/* eslint-disable-next-line no-nested-ternary */}


### PR DESCRIPTION
## Summary

- VFEP-819 On the Search by Name field. If you do not enter information an error message appears “Please fill in a city, state or Postal Code” and it is read by the screen reader so that part is correct

## Jira

 Example 1. On the Search by Name field. If you do not enter information an error message appears “Please fill in a city, state or Postal Code” and it is read by the screen reader so that part is correct.  If you tab out of the field and then shift tab back in the combo box, the error message is still visible but is not read to the user. If there is a visible error message on a component, that error message must be read when focus is placed on the component. New (8/18/2023):

## Image

![Screenshot 2023-10-12 at 10 38 11 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/95312667/3fb72065-135f-4890-8087-2f6a58b7924f)
