### PR TITLE
fix: wrap in div, fix widow on desktop

### DIFF
--- a/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformationSection.jsx
@@ -99,29 +99,32 @@ const PersonalInformationSection = ({
     <div className="vads-u-margin-bottom--6">
       <div className="vads-u-margin-bottom--3">
         <va-additional-info trigger="How to fix an error in your name or date of birth">
-          <p className="vads-u-margin-top--0">
-            If our records have a misspelling or other error in your name or
-            date of birth, you can request a correction. We’ll ask for a current
-            photo ID that shows proof of the correct information. We’ll accept a
-            government-issued photo ID, driver’s license, or passport as proof.
-          </p>
-          <p>Here’s how to request a correction:</p>
-          <p>
-            <span className="vads-u-font-weight--bold vads-u-display--block ">
-              If you’re enrolled in the VA health care program
-            </span>
-            Please contact your nearest VA medical center to update your
-            personal information.
-          </p>
-          <a href="/find-locations/">Find your nearest VA medical center</a>
-          <p className="vads-u-margin-bottom--0">
-            <span className="vads-u-font-weight--bold vads-u-display--block">
-              If you receive VA benefits, but aren’t enrolled in VA health care
-            </span>
-            Call us at <va-telephone contact="8008271000" /> (
-            <va-telephone contact={CONTACTS['711']} tty />
-            ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
-          </p>
+          <div>
+            <p className="vads-u-margin-top--0">
+              If our records have a misspelling or other error in your name or
+              date of birth, you can request a correction. We’ll ask for a
+              current photo ID that shows proof of the correct information.
+              We’ll accept a government-issued photo ID, driver’s license, or
+              passport as proof.
+            </p>
+            <p>Here’s how to request a correction:</p>
+            <p>
+              <span className="vads-u-font-weight--bold vads-u-display--block ">
+                If you’re enrolled in the VA health care program
+              </span>
+              Contact your VA medical center.
+            </p>
+            <a href="/find-locations/">Find your VA medical center</a>
+            <p className="vads-u-margin-bottom--0 vads-u-padding-right--0 small-screen:vads-u-padding-right--6">
+              <span className="vads-u-font-weight--bold vads-u-display--block">
+                If you receive VA benefits, but aren’t enrolled in VA health
+                care
+              </span>
+              Call us at <va-telephone contact="8008271000" /> (
+              <va-telephone contact={CONTACTS['711']} tty />
+              ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
+            </p>
+          </div>
         </va-additional-info>
       </div>
       <ProfileInfoCard data={cardFields} level={1} />


### PR DESCRIPTION
## Summary

- The spacing css that was applied to the FAQ expandable section in the personal information page was not applying due to some sort of css scoping bug with that web component. The design system team is working on an overall fix, but for the time being the contents can be wrapped in a div in order to allow the styling classes to work.

- This PR adds the wrapping div, and also adds some padding to the last line to prevent a widow that was showing up.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/61384

## Testing done

- All changes are visual and don't require additional tests to be added
- Existing 

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
|   | ![Screenshot 2023-10-12 at 8 16 23 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/cbd6481c-84f3-4a53-9996-a8e8ff352841) | ![Screenshot 2023-10-12 at 9 41 48 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/df47b704-adf5-4c52-9327-a63db0b7df1b) |

## What areas of the site does it impact?

Profile

## Acceptance criteria

- [x] styling updated

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

