### PR TITLE
[DRAFT] 40-0247 - Add date-of-death custom-validation to Vet Personal Info page

### DIFF
--- a/src/applications/simple-forms/40-0247/helpers.js
+++ b/src/applications/simple-forms/40-0247/helpers.js
@@ -1,5 +1,19 @@
+import moment from 'moment';
+
 export function getInitialData({ mockData, environment }) {
   return !!mockData && environment.isLocalhost() && !window.Cypress
     ? mockData
     : undefined;
+}
+
+export function dateOfDeathValidation(errors, fields) {
+  const { veteranDateOfBirth, veteranDateOfDeath } = fields;
+  const dob = moment(veteranDateOfBirth);
+  const dod = moment(veteranDateOfDeath);
+
+  if (dod.isBefore(dob)) {
+    errors.veteranDateOfDeath.addError(
+      'Provide a date that is after the date of birth',
+    );
+  }
 }

--- a/src/applications/simple-forms/40-0247/pages/veteranPersonalInfo.js
+++ b/src/applications/simple-forms/40-0247/pages/veteranPersonalInfo.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import moment from 'moment';
+
 import {
   dateOfBirthUI,
   dateOfDeathUI,
@@ -20,6 +22,22 @@ export default {
     veteranFullName: fullNameNoSuffixUI(),
     veteranDateOfBirth: dateOfBirthUI(),
     veteranDateOfDeath: dateOfDeathUI(),
+    // can't move this validation to Forms-Library web-component-patterns
+    // since one pattern can't detect presence of the other
+    'ui:validations': [
+      // date of death should be after date of birth
+      (errors, fields) => {
+        const { veteranDateOfBirth, veteranDateOfDeath } = fields;
+        const dob = moment(veteranDateOfBirth);
+        const dod = moment(veteranDateOfDeath);
+
+        if (dod.isBefore(dob)) {
+          errors.veteranDateOfDeath.addError(
+            'Provide a date that is after the date of birth',
+          );
+        }
+      },
+    ],
   },
   schema: {
     type: 'object',

--- a/src/applications/simple-forms/40-0247/pages/veteranPersonalInfo.js
+++ b/src/applications/simple-forms/40-0247/pages/veteranPersonalInfo.js
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import moment from 'moment';
-
 import {
   dateOfBirthUI,
   dateOfDeathUI,
@@ -10,6 +8,8 @@ import {
   fullNameNoSuffixSchema,
   fullNameNoSuffixUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
+
+import { dateOfDeathValidation } from '../helpers';
 
 /** @type {PageSchema} */
 export default {
@@ -24,20 +24,7 @@ export default {
     veteranDateOfDeath: dateOfDeathUI(),
     // can't move this validation to Forms-Library web-component-patterns
     // since one pattern can't detect presence of the other
-    'ui:validations': [
-      // date of death should be after date of birth
-      (errors, fields) => {
-        const { veteranDateOfBirth, veteranDateOfDeath } = fields;
-        const dob = moment(veteranDateOfBirth);
-        const dod = moment(veteranDateOfDeath);
-
-        if (dod.isBefore(dob)) {
-          errors.veteranDateOfDeath.addError(
-            'Provide a date that is after the date of birth',
-          );
-        }
-      },
-    ],
+    'ui:validations': [dateOfDeathValidation],
   },
   schema: {
     type: 'object',

--- a/src/applications/simple-forms/40-0247/tests/unit/helpers.unit.spec.js
+++ b/src/applications/simple-forms/40-0247/tests/unit/helpers.unit.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { getInitialData } from '../../helpers';
+import { getInitialData, dateOfDeathValidation } from '../../helpers';
 
 describe('getInitialData', () => {
   it('returns mockData if environment is localhost and Cypress is not running', () => {
@@ -30,5 +30,50 @@ describe('getInitialData', () => {
     const result = getInitialData({ mockData, environment });
     expect(result).to.be.undefined;
     window.Cypress = undefined;
+  });
+});
+
+describe('dateOfDeathValidation', () => {
+  let errors;
+
+  beforeEach(() => {
+    errors = {
+      veteranDateOfDeath: {
+        addError: error => {
+          errors.veteranDateOfDeath.errors.push(error);
+        },
+        errors: [],
+      },
+    };
+  });
+
+  it('should add an error if date of death is before date of birth', () => {
+    const fields = {
+      veteranDateOfBirth: '1950-01-01',
+      veteranDateOfDeath: '1940-01-01',
+    };
+
+    dateOfDeathValidation(errors, fields);
+    expect(errors.veteranDateOfDeath.errors).to.have.lengthOf(1);
+  });
+
+  it('should not add an error if date of death is after date of birth', () => {
+    const fields = {
+      veteranDateOfBirth: '1950-01-01',
+      veteranDateOfDeath: '1960-01-01',
+    };
+
+    dateOfDeathValidation(errors, fields);
+    expect(errors.veteranDateOfDeath.errors).to.have.lengthOf(0);
+  });
+
+  it('should not add an error if date of death is the same as date of birth', () => {
+    const fields = {
+      veteranDateOfBirth: '1950-01-01',
+      veteranDateOfDeath: '1950-01-01',
+    };
+
+    dateOfDeathValidation(errors, fields);
+    expect(errors.veteranDateOfDeath.errors).to.have.lengthOf(0);
   });
 });


### PR DESCRIPTION
**\[DRAFT: Do NOT merge!\]**

## Summary

- Add custom data-of-death validation to PMC (40-0247) Veteran Personal Information page, to catch when death-date precedes birth-date.
- Team: Veteran Facing Forms
- Flipper not implemented yet

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#659

## Testing done

- Local browser-testing was successful

## What areas of the site does it impact?

This form ONLY

## Requested Feedback

I don't think my newly-added custom validation (currently in my helpers file) can be moved to v3-web-component patterns, since one pattern can't detect presence of another on a form-page, but...

Do let me know if there's another way this can be made reusable.  Time permitting, maybe a follow-up ticket to add a "DoB-DoD-group" pattern?  I have no idea how often this need would come up.

