### PR TITLE
Hides the My VA link in header

### DIFF
--- a/src/applications/static-pages/homepage/tests/mocks/features.js
+++ b/src/applications/static-pages/homepage/tests/mocks/features.js
@@ -23,6 +23,7 @@ const features = {
       { name: 'edu_section_103', value: true },
       { name: 'vaViewDependentsAccess', value: false },
       { name: 'gibctEybBottomSheet', value: true },
+      { name: 'my_va_show_header_link', value: true },
     ],
   },
 };

--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -6,6 +6,8 @@ import { connect } from 'react-redux';
 
 // Relative imports.
 import { isLandingPageEnabled } from 'applications/mhv/landing-page/selectors';
+import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
+import { toggleValues } from '@department-of-veterans-affairs/platform-site-wide/selectors';
 import MY_VA_LINK from '../constants/MY_VA_LINK';
 import MY_HEALTH_LINK from '../constants/MY_HEALTH_LINK';
 import MegaMenu from '../components/MegaMenu';
@@ -185,12 +187,14 @@ const mapStateToProps = (state, ownProps) => {
 
   // If user is not logged in, open login modal on current page with a redirect param to my-va
   if (!loggedIn) {
-    MY_VA_LINK.href = `${
-      window.location.href.split('?')[0]
-    }?next=%2Fmy-va%2F${useOAuth}`;
+    const urlWithoutParams = window.location.href.split('?')[0];
+    MY_VA_LINK.href = `${urlWithoutParams}?next=%2Fmy-va%2F${useOAuth}`;
   }
 
-  defaultLinks.push(MY_VA_LINK);
+  const showMyVALink = toggleValues(state)[
+    FEATURE_FLAG_NAMES.myVaShowHeaderLink
+  ];
+  if (showMyVALink) defaultLinks.push(MY_VA_LINK);
 
   const authenticatedLinks = isLandingPageEnabled(state)
     ? [{ ...MY_HEALTH_LINK }]

--- a/src/platform/site-wide/mega-menu/tests/megaMenu.cypress.spec.js
+++ b/src/platform/site-wide/mega-menu/tests/megaMenu.cypress.spec.js
@@ -7,6 +7,7 @@
  */
 // Relative imports.
 import { mockUser } from 'applications/personalization/profile/tests/fixtures/users/user.js';
+import featureFlagNames from '~/platform/utilities/feature-toggles/featureFlagNames';
 
 Cypress.Commands.add(
   'checkMenuItem',
@@ -188,6 +189,20 @@ const testUrl = Cypress.env('app_url') || '/';
 const usingHomepageUrl = testUrl === '/';
 
 describe('Mega Menu', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/v0/feature_toggles*', {
+      data: {
+        type: 'feature_toggles',
+        features: [
+          {
+            name: featureFlagNames.myVaShowHeaderLink,
+            value: true,
+          },
+        ],
+      },
+    });
+  });
+
   context('on desktop', () => {
     beforeEach(() => {
       cy.viewport(1280, 720);

--- a/src/platform/site-wide/mega-menu/tests/my-health-link/mega-menu.my-health.cypress.spec.js
+++ b/src/platform/site-wide/mega-menu/tests/my-health-link/mega-menu.my-health.cypress.spec.js
@@ -10,10 +10,10 @@ describe(manifest.appName, () => {
     ApiInitializer.initializeUserData.withDefaultUser();
     LandingPage.visitPage({ serviceProvider: CSP_IDS.ID_ME });
     cy.injectAxeThenAxeCheck();
-    cy.get('[data-e2e-id="my-healthe-vet-4"]')
+    cy.get('[data-e2e-id^="my-healthe-vet-"]')
       .should('be.visible')
       .and('have.text', 'My HealtheVet');
-    cy.get('[data-e2e-id="my-healthe-vet-4"]').should(
+    cy.get('[data-e2e-id^="my-healthe-vet-"]').should(
       'have.attr',
       'href',
       '/my-health/',
@@ -25,10 +25,10 @@ describe(manifest.appName, () => {
     cy.login();
     cy.visit('/');
     cy.injectAxeThenAxeCheck();
-    cy.get('[data-e2e-id="my-healthe-vet-4"]')
+    cy.get('[data-e2e-id^="my-healthe-vet-"]')
       .should('be.visible')
       .and('have.text', 'My HealtheVet');
-    cy.get('[data-e2e-id="my-healthe-vet-4"]')
+    cy.get('[data-e2e-id^="my-healthe-vet-"]')
       .should('have.attr', 'href')
       .and('include', 'mhv-portal-web/eauth');
   });

--- a/src/platform/site-wide/mega-menu/tests/my-va-link/mega-menu.my-va.cypress.spec.js
+++ b/src/platform/site-wide/mega-menu/tests/my-va-link/mega-menu.my-va.cypress.spec.js
@@ -1,0 +1,40 @@
+import manifest from 'applications/mhv/landing-page/manifest.json';
+import featureFlagNames from '~/platform/utilities/feature-toggles/featureFlagNames';
+
+describe(manifest.appName, () => {
+  it('shows the My VA link when enabled', () => {
+    cy.intercept('GET', '/v0/feature_toggles*', {
+      data: {
+        type: 'feature_toggles',
+        features: [
+          {
+            name: featureFlagNames.myVaShowHeaderLink,
+            value: true,
+          },
+        ],
+      },
+    });
+    cy.visit('/');
+    cy.injectAxeThenAxeCheck();
+
+    cy.get('[data-e2e-id^="my-va-"]').should('exist');
+  });
+
+  it('hides the My VA link when disabled', () => {
+    cy.intercept('GET', '/v0/feature_toggles*', {
+      data: {
+        type: 'feature_toggles',
+        features: [
+          {
+            name: featureFlagNames.myVaShowHeaderLink,
+            value: false,
+          },
+        ],
+      },
+    });
+    cy.visit('/');
+    cy.injectAxeThenAxeCheck();
+
+    cy.get('[data-e2e-id^="my-va-"]').should('not.exist');
+  });
+});

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -113,6 +113,7 @@ export default Object.freeze({
   myVaHideNotificationsSection: 'my_va_hide_notifications_section',
   myVaNotificationDotIndicator: 'my_va_notification_dot_indicator',
   myVaUpdateErrorsWarnings: 'my_va_update_errors_warnings',
+  myVaShowHeaderLink: 'my_va_show_header_link',
   nodBrowserMonitoringEnabled: 'nod_browser_monitoring_enabled',
   nodPart3Update: 'nod_part3_update',
   omniChannelLink: 'omni_channel_link',


### PR DESCRIPTION
Removes the `My VA` link from the site's global header nav.

## Summary

- Adds a feature flag `my_va_show_header_link`
- Removes the `My VA` link from the header nav if the flag is `false`

## Related issue(s)

- [67050](https://github.com/department-of-veterans-affairs/va.gov-team/issues/67050)
- [Backend PR](https://github.com/department-of-veterans-affairs/vets-api/pull/14146)

## Testing done

- Locally tested the proxy rewrite application using [these instructions](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite)
- Created a new cypress e2e test

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![image](https://github.com/department-of-veterans-affairs/vets-website/assets/534756/26e7e111-598f-4976-b549-ddeb6be859ca)|![image](https://github.com/department-of-veterans-affairs/vets-website/assets/534756/8be14d19-decd-49e7-94e7-cc8aeb17a93a)|

## What areas of the site does it impact?

Global Site Header

## Acceptance criteria
- [ ] My VA link isn't in the header if the feature flag `my_va_show_header_link` is `false`
- [ ] My VA link is in the header if the feature flag `my_va_show_header_link` is `true`

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
