### PR TITLE
Use currentOrPastDateUI instead of dateUI in form 21-4142

### DIFF
--- a/src/applications/simple-forms/21-4142/pages/recordsRequested.js
+++ b/src/applications/simple-forms/21-4142/pages/recordsRequested.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import dateUI from 'platform/forms-system/src/js/definitions/date';
+import { currentOrPastDateUI } from 'platform/forms-system/src/js/web-component-patterns';
 import * as address from 'platform/forms-system/src/js/definitions/address';
 import fullSchema from 'vets-json-schema/dist/21-4142-schema.json';
 
@@ -93,8 +93,8 @@ export default {
           },
         },
         [providerFacilityFields.treatmentDateRange]: {
-          from: dateUI('First treatment date (you can estimate)'),
-          to: dateUI('Last treatment date (you can estimate)'),
+          from: currentOrPastDateUI('First treatment date (you can estimate)'),
+          to: currentOrPastDateUI('Last treatment date (you can estimate)'),
         },
         'ui:validations': [
           (errors, field) => {


### PR DESCRIPTION
## Summary

We have two date input fields that provide error message which are not specific enough. If, for example, the day is missing we want to specifically tell the user that the day is missing. This PR uses `currentOrPastDateUI` instead of `dateUI` because it has better error messaging (see screenshots).

I'm not sure if this PR fully addresses the issue raised in the ticket below since it still doesn't specifically say which part of the date is missing, but it's at least an improvement. Do we want/need to modify an existing component (or make a new one??) for these error messages to come through? (This PR just represents my path-of-least-resistance approach to the problem!)

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/63437


## Screenshots

**Before**
<img width="395" alt="Screenshot 2023-10-16 at 9 25 14 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/10481391/12955228-f292-4c85-910d-c077802944e9">

**After**
<img width="452" alt="Screenshot 2023-10-16 at 9 24 12 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/10481391/4c965102-e31d-435a-a4a2-8e821dc34d8d">



## What areas of the site does it impact?
This form only.