### PR TITLE
Fix file upload URL for form 40-0247

### DIFF
--- a/src/applications/simple-forms/40-0247/helpers.js
+++ b/src/applications/simple-forms/40-0247/helpers.js
@@ -36,16 +36,18 @@ export const supportingDocsDescription = (
   </>
 );
 
-export const createPayload = (file, _formId, password) => {
+export const createPayload = (file, formId, password) => {
   const payload = new FormData();
-  payload.append('files_attachment[file_data]', file);
+  payload.set('form_id', formId);
+  payload.append('file', file);
   if (password) {
-    payload.append('files_attachment[password]', password);
+    payload.append('password', password);
   }
   return payload;
 };
 
-export function parseResponse({ data }, { name }) {
+export function parseResponse({ data }) {
+  const { name } = data.attributes;
   const focusFileCard = () => {
     const target = $$('.schemaform-file-list li').find(entry =>
       entry.textContent?.trim().includes(name),
@@ -62,7 +64,7 @@ export function parseResponse({ data }, { name }) {
 
   return {
     name,
-    confirmationCode: data.attributes.confirmation_code,
+    confirmationCode: data.attributes.confirmationCode,
   };
 }
 

--- a/src/applications/simple-forms/40-0247/pages/veteranSupportDocs.js
+++ b/src/applications/simple-forms/40-0247/pages/veteranSupportDocs.js
@@ -28,11 +28,21 @@ export default {
         attachmentDescription: {
           'ui:title': 'Document description',
         },
-        // TODO: Sync with b/e to determine proper URL
-        fileUploadUrl: `${environment.API_URL}/v0/simple-forms/40-0247/files`,
-        fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
-        createPayload,
-        parseResponse,
+        fileUploadUrl: `${
+          environment.API_URL
+        }/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
+        fileTypes: ['jpg', 'jpeg', 'png'],
+        createPayload: file => {
+          const payload = new FormData();
+          payload.append('file', file);
+          payload.set('form_id', '40-0247');
+          return payload;
+        },
+        parseResponse: fileInfo => ({
+          name: fileInfo.data.attributes.name,
+          size: fileInfo.data.attributes.size,
+          confirmationCode: fileInfo.data.attributes.confirmationCode,
+        }),
         classNames: 'schemaform-file-upload',
       },
     },

--- a/src/applications/simple-forms/40-0247/pages/veteranSupportDocs.js
+++ b/src/applications/simple-forms/40-0247/pages/veteranSupportDocs.js
@@ -31,7 +31,7 @@ export default {
         fileUploadUrl: `${
           environment.API_URL
         }/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
-        fileTypes: ['jpg', 'jpeg', 'png'],
+        fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
         createPayload,
         parseResponse,
         classNames: 'schemaform-file-upload',

--- a/src/applications/simple-forms/40-0247/pages/veteranSupportDocs.js
+++ b/src/applications/simple-forms/40-0247/pages/veteranSupportDocs.js
@@ -32,17 +32,8 @@ export default {
           environment.API_URL
         }/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
         fileTypes: ['jpg', 'jpeg', 'png'],
-        createPayload: file => {
-          const payload = new FormData();
-          payload.append('file', file);
-          payload.set('form_id', '40-0247');
-          return payload;
-        },
-        parseResponse: fileInfo => ({
-          name: fileInfo.data.attributes.name,
-          size: fileInfo.data.attributes.size,
-          confirmationCode: fileInfo.data.attributes.confirmationCode,
-        }),
+        createPayload,
+        parseResponse,
         classNames: 'schemaform-file-upload',
       },
     },

--- a/src/applications/simple-forms/40-0247/tests/unit/helpers.unit.spec.js
+++ b/src/applications/simple-forms/40-0247/tests/unit/helpers.unit.spec.js
@@ -45,8 +45,8 @@ describe('createPayload', () => {
     const password = 'test-password';
     const payload = createPayload(file, formId, password);
 
-    expect(payload.get('files_attachment[file_data]')).to.equal(file);
-    expect(payload.get('files_attachment[password]')).to.equal(password);
+    expect(payload.get('file')).to.equal(file);
+    expect(payload.get('password')).to.equal(password);
   });
 
   it('should create a FormData object with only the file if no password is provided', () => {
@@ -54,8 +54,8 @@ describe('createPayload', () => {
     const formId = 'test-form';
     const payload = createPayload(file, formId);
 
-    expect(payload.get('files_attachment[file_data]')).to.equal(file);
-    expect(payload.get('files_attachment[password]')).to.be.null;
+    expect(payload.get('file')).to.equal(file);
+    expect(payload.get('password')).to.be.null;
   });
 });
 
@@ -64,8 +64,7 @@ describe('parseResponse', () => {
     const response = {
       data: {
         attributes: {
-          // eslint-disable-next-line camelcase
-          confirmation_code: 'test-guid',
+          confirmationCode: 'test-guid',
         },
       },
     };

--- a/src/applications/simple-forms/40-0247/tests/unit/helpers.unit.spec.js
+++ b/src/applications/simple-forms/40-0247/tests/unit/helpers.unit.spec.js
@@ -65,14 +65,14 @@ describe('parseResponse', () => {
       data: {
         attributes: {
           confirmationCode: 'test-guid',
+          name: 'test-file.txt',
         },
       },
     };
-    const name = 'test-file.txt';
-    const result = parseResponse(response, { name });
+    const result = parseResponse(response);
 
     expect(result).to.deep.equal({
-      name,
+      name: 'test-file.txt',
       confirmationCode: 'test-guid',
     });
   });


### PR DESCRIPTION
## Summary

This PR changes the file upload URL in form 40-0247 to match what the back end expects. It also adds the `form_id` to the payload and removed the `pdf` filetype, which I believe the back end cannot support. If that is an issue, I can look into it some more.

## Related issue(s)

This is not tracked as an issue afaik.