### PR TITLE
VFEP-820 Add Accessibility to remove button in compareDrawer.

### DIFF
--- a/src/applications/gi/containers/CompareDrawer.jsx
+++ b/src/applications/gi/containers/CompareDrawer.jsx
@@ -136,6 +136,9 @@ export function CompareDrawer({
                   onClick={() => {
                     setPromptingFacilityCode(facilityCode);
                   }}
+                  aria-label={`Remove ${
+                    institutions[facilityCode].name
+                  } from comparison`}
                 >
                   Remove
                 </button>


### PR DESCRIPTION
## Summary

- When the users adds schools to compare in the comparison tool, while using a screen reader, the tool read "remove" under the school, and the user may not understand what the remove is referring to. This was listed in the 8/23/2023 audit report as number 5. "Labels or instructions are provided when content requires user input. Ensure the user can understand what will happen if the link is activated."

## JIRA

- VFEP-820


## Image

![Screenshot 2023-10-16 at 10 26 20 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/95312667/a6381df0-51ea-4673-914a-f04a05419103)
