### PR TITLE
MHV-50423 Moved screen/print classes one level down

### DIFF
--- a/src/applications/mhv/medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv/medical-records/containers/Allergies.jsx
@@ -137,7 +137,35 @@ const Allergies = props => {
 
   const accessAlert = activeAlert && activeAlert.type === ALERT_TYPE_ERROR;
 
-  const content = () => {
+  const headerContent = () => {
+    return (
+      <>
+        <PrintHeader />
+        <h1 className="vads-u-margin--0">Allergies and reactions</h1>
+        <p className="page-description">
+          Review allergies, reactions, and side effects in your VA medical
+          records. This includes medication side effects (also called adverse
+          drug reactions).
+        </p>
+        <p className="page-description">
+          If you have allergies that are missing from this list, tell your care
+          team at your next appointment.
+        </p>
+        {!accessAlert && (
+          <>
+            <PrintDownload
+              list
+              download={generateAllergiesPdf}
+              allowTxtDownloads={allowTxtDownloads}
+            />
+            <DownloadingRecordsInfo allowTxtDownloads={allowTxtDownloads} />
+          </>
+        )}
+      </>
+    );
+  };
+
+  const listContent = () => {
     if (accessAlert) {
       return <AccessTroubleAlertBox />;
     }
@@ -164,30 +192,19 @@ const Allergies = props => {
   };
 
   return (
-    <div id="allergies">
-      <PrintHeader />
-      <h1 className="vads-u-margin--0">Allergies and reactions</h1>
-      <p className="page-description">
-        Review allergies, reactions, and side effects in your VA medical
-        records. This includes medication side effects (also called adverse drug
-        reactions).
-      </p>
-      <p className="page-description">
-        If you have allergies that are missing from this list, tell your care
-        team at your next appointment.
-      </p>
-      {!accessAlert && (
-        <>
-          <PrintDownload
-            list
-            download={generateAllergiesPdf}
-            allowTxtDownloads={allowTxtDownloads}
-          />
-          <DownloadingRecordsInfo allowTxtDownloads={allowTxtDownloads} />
-        </>
-      )}
-      {content()}
-    </div>
+    <>
+      <div
+        id="allergies"
+        className="vads-l-col--12 medium-screen:vads-l-col--8 no-print"
+      >
+        {headerContent()}
+        {listContent()}
+      </div>
+      <div id="allergies-print" className="vads-l-col--12 print-only">
+        {headerContent()}
+        {listContent()}
+      </div>
+    </>
   );
 };
 

--- a/src/applications/mhv/medical-records/containers/AllergyDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/AllergyDetails.jsx
@@ -219,7 +219,14 @@ const AllergyDetails = props => {
     );
   };
 
-  return <div className="vads-u-margin-bottom--5">{content()}</div>;
+  return (
+    <div className="vads-u-margin-bottom--5">
+      <div className="vads-l-col--12 medium-screen:vads-l-col--8 no-print">
+        {content()}
+      </div>
+      <div className="vads-l-col--12 print-only">{content()}</div>
+    </div>
+  );
 };
 
 export default AllergyDetails;

--- a/src/applications/mhv/medical-records/containers/App.jsx
+++ b/src/applications/mhv/medical-records/containers/App.jsx
@@ -98,12 +98,9 @@ const App = ({ children }) => {
         <MrBreadcrumbs />
         {/* <Navigation /> */}
         <div className="vads-l-grid-container vads-u-padding-left--0">
-          <div className="vads-l-col--12 medium-screen:vads-l-col--8 no-print">
-            <ScrollToTop />
-            {children}
-            <va-back-to-top hidden={isHidden} />
-          </div>
-          <div className="vads-l-col--12 print-only">{children}</div>
+          <ScrollToTop />
+          {children}
+          <va-back-to-top hidden={isHidden} />
         </div>
       </div>
     </RequiredLoginView>


### PR DESCRIPTION
## Summary

I moved the classes that specify print-only/no-print down one level, from App to Allergies/AllergyDetails. This prevents the component from being mounted twice (and thus calling the API twice).

## Related issue(s)

### [MHV-50423](https://jira.devops.va.gov/browse/MHV-50423) - Allergy API call is being fired twice ###

> Currently, when browsing to the Allergies list page, the API call to the backend is fired twice in rapid succession. This will propagate all the way to the FHIR server and may cause an error if two Patient records are created simultaneously.
> 
> It is occurring because of the screen/print views CSS in side App.jsx. While one view is always hidden to the user, BOTH are apparently always mounted and execute in parallel.
> 
> See this Slack thread for details: https://dsva.slack.com/archives/C04ER7MHX5E/p1697219592426079?thread_ts=1697035646.078659&cid=C04ER7MHX5E

## Testing done

- To verify, check the network tab while loading the Allergies and AllergiesDetails pages. You should see that only one call to the backend API is being fired.
- Manually tested that the component is being mounted only once, and is firing the API only once.
- Manually verified that the print view for the pages still works in both Chrome and Safari.
- I did not add any unit tests for this, as I do not believe there is a good way to test CSS media queries in unit tests.

## Screenshots

### Safari Print View - content fills width as before ###
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/cae7e720-cb3f-4805-8256-6490773e706a)

### Only one API request is fired

<img width="416" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/04a2a5d3-031c-4422-b282-6b8aaff538b5">


## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
