### PR TITLE
MHV-49977: Unit test coverage improved

### DIFF
--- a/src/applications/mhv/medical-records/api/MrApi.js
+++ b/src/applications/mhv/medical-records/api/MrApi.js
@@ -15,11 +15,14 @@ const headers = {
   'Content-Type': 'application/json',
 };
 
+const hitApi = runningUnitTest => {
+  return (
+    (environment.BUILDTYPE === 'localhost' && IS_TESTING) || runningUnitTest
+  );
+};
+
 export const getLabsAndTests = runningUnitTest => {
-  if (
-    (environment.BUILDTYPE === 'localhost' && IS_TESTING) ||
-    runningUnitTest
-  ) {
+  if (hitApi(runningUnitTest)) {
     return apiRequest(`${apiBasePath}/medical_records/labs_and_tests`, {
       headers,
     });
@@ -32,10 +35,7 @@ export const getLabsAndTests = runningUnitTest => {
 };
 
 export const getLabOrTest = (id, runningUnitTest) => {
-  if (
-    (environment.BUILDTYPE === 'localhost' && IS_TESTING) ||
-    runningUnitTest
-  ) {
+  if (hitApi(runningUnitTest)) {
     return apiRequest(`${apiBasePath}/medical_records/labs_and_tests/${id}`, {
       headers,
     });
@@ -49,10 +49,7 @@ export const getLabOrTest = (id, runningUnitTest) => {
 };
 
 export const getNotes = runningUnitTest => {
-  if (
-    (environment.BUILDTYPE === 'localhost' && IS_TESTING) ||
-    runningUnitTest
-  ) {
+  if (hitApi(runningUnitTest)) {
     return apiRequest(`${apiBasePath}/medical_records/clinical_notes`, {
       headers,
     });
@@ -65,10 +62,7 @@ export const getNotes = runningUnitTest => {
 };
 
 export const getNote = (id, runningUnitTest) => {
-  if (
-    (environment.BUILDTYPE === 'localhost' && IS_TESTING) ||
-    runningUnitTest
-  ) {
+  if (hitApi(runningUnitTest)) {
     return apiRequest(`${apiBasePath}/medical_records/clinical_notes/${id}`, {
       headers,
     });
@@ -81,10 +75,7 @@ export const getNote = (id, runningUnitTest) => {
 };
 
 export const getVitalsList = runningUnitTest => {
-  if (
-    (environment.BUILDTYPE === 'localhost' && IS_TESTING) ||
-    runningUnitTest
-  ) {
+  if (hitApi(runningUnitTest)) {
     return apiRequest(`${apiBasePath}/medical_records/vitals`, {
       headers,
     });
@@ -97,10 +88,7 @@ export const getVitalsList = runningUnitTest => {
 };
 
 export const getConditions = runningUnitTest => {
-  if (
-    (environment.BUILDTYPE === 'localhost' && IS_TESTING) ||
-    runningUnitTest
-  ) {
+  if (hitApi(runningUnitTest)) {
     return apiRequest(`${apiBasePath}/medical_records/conditions`, {
       headers,
     });
@@ -113,10 +101,7 @@ export const getConditions = runningUnitTest => {
 };
 
 export const getCondition = (id, runningUnitTest) => {
-  if (
-    (environment.BUILDTYPE === 'localhost' && IS_TESTING) ||
-    runningUnitTest
-  ) {
+  if (hitApi(runningUnitTest)) {
     return apiRequest(`${apiBasePath}/medical_records/conditions/${id}`, {
       headers,
     });
@@ -146,10 +131,7 @@ export const getAllergy = id => {
  * @returns list of patient's vaccines in FHIR format
  */
 export const getVaccineList = runningUnitTest => {
-  if (
-    (environment.BUILDTYPE === 'localhost' && IS_TESTING) ||
-    runningUnitTest
-  ) {
+  if (hitApi(runningUnitTest)) {
     return apiRequest(`${apiBasePath}/medical_records/vaccines`, {
       headers,
     });
@@ -167,10 +149,7 @@ export const getVaccineList = runningUnitTest => {
  * @returns vaccine details in FHIR format
  */
 export const getVaccine = (id, runningUnitTest) => {
-  if (
-    (environment.BUILDTYPE === 'localhost' && IS_TESTING) ||
-    runningUnitTest
-  ) {
+  if (hitApi(runningUnitTest)) {
     return apiRequest(`${apiBasePath}/medical_records/vaccines/${id}`, {
       headers,
     });

--- a/src/applications/mhv/medical-records/components/CareSummaries/AdmissionAndDischargeDetails.jsx
+++ b/src/applications/mhv/medical-records/components/CareSummaries/AdmissionAndDischargeDetails.jsx
@@ -1,14 +1,13 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import { generatePdf } from '@department-of-veterans-affairs/platform-pdf/exports';
 import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import PrintHeader from '../shared/PrintHeader';
 import PrintDownload from '../shared/PrintDownload';
 import DownloadingRecordsInfo from '../shared/DownloadingRecordsInfo';
-import { sendErrorToSentry } from '../../util/helpers';
+import { makePdf } from '../../util/helpers';
 import {
   generatePdfScaffold,
   updatePageTitle,
@@ -93,13 +92,12 @@ const AdmissionAndDischargeDetails = props => {
       ],
     };
 
-    try {
-      if (!runningUnitTest) {
-        await generatePdf('medicalRecords', 'care_summaries_report', scaffold);
-      }
-    } catch (error) {
-      sendErrorToSentry(error, 'Care Summary details');
-    }
+    makePdf(
+      'care_summaries_report',
+      scaffold,
+      'Care Summary details',
+      runningUnitTest,
+    );
   };
 
   const content = () => {

--- a/src/applications/mhv/medical-records/components/CareSummaries/ProgressNoteDetails.jsx
+++ b/src/applications/mhv/medical-records/components/CareSummaries/ProgressNoteDetails.jsx
@@ -1,14 +1,13 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import { generatePdf } from '@department-of-veterans-affairs/platform-pdf/exports';
 import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import PrintHeader from '../shared/PrintHeader';
 import PrintDownload from '../shared/PrintDownload';
 import DownloadingRecordsInfo from '../shared/DownloadingRecordsInfo';
-import { sendErrorToSentry } from '../../util/helpers';
+import { makePdf } from '../../util/helpers';
 import {
   generatePdfScaffold,
   updatePageTitle,
@@ -84,13 +83,12 @@ const ProgressNoteDetails = props => {
       ],
     };
 
-    try {
-      if (!runningUnitTest) {
-        await generatePdf('medicalRecords', 'care_notes_report', scaffold);
-      }
-    } catch (error) {
-      sendErrorToSentry(error, 'Care Note details');
-    }
+    makePdf(
+      'care_notes_report',
+      scaffold,
+      'Care Note details',
+      runningUnitTest,
+    );
   };
 
   const download = () => {

--- a/src/applications/mhv/medical-records/components/LabsAndTests/ChemHemDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/ChemHemDetails.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
-import { generatePdf } from '@department-of-veterans-affairs/platform-pdf/exports';
 import { useSelector } from 'react-redux';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
@@ -12,12 +11,12 @@ import ItemList from '../shared/ItemList';
 import ChemHemResults from './ChemHemResults';
 import PrintDownload from '../shared/PrintDownload';
 import DownloadingRecordsInfo from '../shared/DownloadingRecordsInfo';
-import { processList, sendErrorToSentry } from '../../util/helpers';
+import { makePdf, processList } from '../../util/helpers';
 import {
   generatePdfScaffold,
   updatePageTitle,
 } from '../../../shared/util/helpers';
-import { pageTitles } from '../../util/constants';
+import { EMPTY_FIELD, pageTitles } from '../../util/constants';
 
 const ChemHemDetails = props => {
   const { record, fullState, runningUnitTest } = props;
@@ -32,7 +31,7 @@ const ChemHemDetails = props => {
   useEffect(
     () => {
       focusElement(document.querySelector('h1'));
-      const titleDate = record.date ? `${record.date} - ` : '';
+      const titleDate = record.date !== EMPTY_FIELD ? `${record.date} - ` : '';
       updatePageTitle(
         `${titleDate}${record.name} - ${
           pageTitles.LAB_AND_TEST_RESULTS_PAGE_TITLE
@@ -122,13 +121,13 @@ const ChemHemDetails = props => {
         ],
       })),
     };
-    try {
-      if (!runningUnitTest) {
-        await generatePdf('medicalRecords', 'microbiology_report', scaffold);
-      }
-    } catch (error) {
-      sendErrorToSentry(error, 'Microbiology details');
-    }
+
+    makePdf(
+      'microbiology_report',
+      scaffold,
+      'Microbiology details',
+      runningUnitTest,
+    );
   };
 
   const content = () => {

--- a/src/applications/mhv/medical-records/components/LabsAndTests/EkgDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/EkgDetails.jsx
@@ -2,14 +2,13 @@ import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
-import { generatePdf } from '@department-of-veterans-affairs/platform-pdf/exports';
 import moment from 'moment';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import PrintHeader from '../shared/PrintHeader';
 import PrintDownload from '../shared/PrintDownload';
 import DownloadingRecordsInfo from '../shared/DownloadingRecordsInfo';
-import { sendErrorToSentry } from '../../util/helpers';
+import { makePdf } from '../../util/helpers';
 import { updatePageTitle } from '../../../shared/util/helpers';
 import { pageTitles } from '../../util/constants';
 
@@ -69,17 +68,17 @@ const EkgDetails = props => {
             items: [
               {
                 title: 'Date',
-                value: moment(record.date).format('LL') || ' ',
+                value: record.date,
                 inline: true,
               },
               {
                 title: 'Location',
-                value: record.facility || ' ',
+                value: record.facility,
                 inline: true,
               },
               {
                 title: 'Provider',
-                value: record.orderedBy || ' ',
+                value: record.orderedBy,
                 inline: true,
               },
             ],
@@ -88,17 +87,7 @@ const EkgDetails = props => {
       },
     };
 
-    try {
-      if (!runningUnitTest) {
-        await generatePdf(
-          'medicalRecords',
-          'electrocardiogram_report',
-          pdfData,
-        );
-      }
-    } catch (error) {
-      sendErrorToSentry(error, 'EKG');
-    }
+    makePdf('electrocardiogram_report', pdfData, 'EKG', runningUnitTest);
   };
 
   const content = () => {

--- a/src/applications/mhv/medical-records/components/LabsAndTests/GenerateRadiologyPdf.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/GenerateRadiologyPdf.jsx
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
-import { generatePdf } from '@department-of-veterans-affairs/platform-pdf/exports';
 import moment from 'moment';
-import { sendErrorToSentry } from '../../util/helpers';
+import { makePdf } from '../../util/helpers';
 
 const GenerateRadiologyPdf = async (record, runningUnitTest) => {
   const formattedDate = formatDateLong(record?.date);
@@ -68,13 +67,7 @@ const GenerateRadiologyPdf = async (record, runningUnitTest) => {
     },
   };
 
-  try {
-    if (!runningUnitTest) {
-      await generatePdf('medicalRecords', 'radiology_report', pdfData);
-    }
-  } catch (error) {
-    sendErrorToSentry(error, 'Radiology');
-  }
+  makePdf('radiology_report', pdfData, 'Radiology', runningUnitTest);
 };
 
 export default GenerateRadiologyPdf;

--- a/src/applications/mhv/medical-records/components/LabsAndTests/MicroDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/MicroDetails.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
 import { useSelector } from 'react-redux';
 import moment from 'moment';
-import { generatePdf } from '@department-of-veterans-affairs/platform-pdf/exports';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import PrintHeader from '../shared/PrintHeader';
@@ -11,12 +10,12 @@ import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
 import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selectors';
 import PrintDownload from '../shared/PrintDownload';
 import DownloadingRecordsInfo from '../shared/DownloadingRecordsInfo';
-import { dateFormat, nameFormat, sendErrorToSentry } from '../../util/helpers';
+import { makePdf, nameFormat } from '../../util/helpers';
 import { updatePageTitle } from '../../../shared/util/helpers';
-import { pageTitles } from '../../util/constants';
+import { EMPTY_FIELD, pageTitles } from '../../util/constants';
 
 const MicroDetails = props => {
-  const { record, fullState } = props;
+  const { record, fullState, runningUnitTest } = props;
   const user = useSelector(state => state.user.profile);
   const allowTxtDownloads = useSelector(
     state =>
@@ -25,20 +24,19 @@ const MicroDetails = props => {
       ],
   );
   const name = nameFormat(user.userFullName);
-  const dob = dateFormat(user.dob, 'LL');
-  const formattedDate = formatDateLong(record?.date);
+  const dob = formatDateLong(user.dob, 'LL');
 
   useEffect(
     () => {
       focusElement(document.querySelector('h1'));
-      const titleDate = formattedDate ? `${formattedDate} - ` : '';
+      const titleDate = record.date !== EMPTY_FIELD ? `${record.date} - ` : '';
       updatePageTitle(
         `${titleDate}${record.name} - ${
           pageTitles.LAB_AND_TEST_RESULTS_PAGE_TITLE
         }`,
       );
     },
-    [formattedDate, record.name],
+    [record],
   );
 
   const generateMicrobiologyPdf = async () => {
@@ -55,9 +53,7 @@ const MicroDetails = props => {
         'LL',
       )}`,
       footerRight: 'Page %PAGE_NUMBER% of %TOTAL_PAGES%',
-      title: `Lab and test results: Microbiology on ${formatDateLong(
-        record.date,
-      )}`,
+      title: `Lab and test results: Microbiology on ${record.date}`,
       subject: 'VA Medical Record',
       preface:
         'If you have any questions about these results, send a secure message to your care team.',
@@ -99,7 +95,7 @@ const MicroDetails = props => {
               },
               {
                 title: 'Date completed',
-                value: formatDateLong(record.date),
+                value: record.date,
                 inline: true,
               },
             ],
@@ -118,109 +114,105 @@ const MicroDetails = props => {
       },
     };
 
-    try {
-      await generatePdf('medicalRecords', 'microbiology_report', pdfData);
-    } catch (error) {
-      sendErrorToSentry(error, 'Microbiology details');
-    }
+    makePdf(
+      'microbiology_report',
+      pdfData,
+      'Microbiology details',
+      runningUnitTest,
+    );
   };
 
   const content = () => {
-    if (record) {
-      return (
-        <>
-          <PrintHeader />
-          <h1
-            className="vads-u-margin-bottom--0"
-            aria-describedby="microbio-date"
+    return (
+      <>
+        <PrintHeader />
+        <h1
+          className="vads-u-margin-bottom--0"
+          aria-describedby="microbio-date"
+        >
+          {record.name}
+        </h1>
+        <div className="time-header">
+          <h2
+            className="vads-u-font-size--base vads-u-font-family--sans"
+            id="microbio-date"
           >
-            {record.name}
-          </h1>
-          <div className="time-header">
-            <h2
-              className="vads-u-font-size--base vads-u-font-family--sans"
-              id="microbio-date"
-            >
-              Date:{' '}
-              <span className="vads-u-font-weight--normal">
-                {formattedDate}
-              </span>
-            </h2>
-          </div>
-          <div className="no-print">
-            <PrintDownload
-              download={generateMicrobiologyPdf}
-              allowTxtDownloads={allowTxtDownloads}
-            />
-            <DownloadingRecordsInfo allowTxtDownloads={allowTxtDownloads} />
-          </div>
-          <div className="test-details-container max-80">
-            <h2>Details about this test</h2>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Sample tested
-            </h3>
-            <p>{record.sampleTested}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Sample from
-            </h3>
-            <p>{record.sampleFrom}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Ordered by
-            </h3>
-            <p>{record.orderedBy}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Ordering location
-            </h3>
-            <p>{record.orderingLocation}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Collecting location
-            </h3>
-            <p>{record.collectingLocation}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Lab location
-            </h3>
-            <p>{record.labLocation}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Date completed
-            </h3>
-            <p>{formattedDate}</p>
-          </div>
+            Date:{' '}
+            <span className="vads-u-font-weight--normal">{record.date}</span>
+          </h2>
+        </div>
+        <div className="no-print">
+          <PrintDownload
+            download={generateMicrobiologyPdf}
+            allowTxtDownloads={allowTxtDownloads}
+          />
+          <DownloadingRecordsInfo allowTxtDownloads={allowTxtDownloads} />
+        </div>
+        <div className="test-details-container max-80">
+          <h2>Details about this test</h2>
+          <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+            Sample tested
+          </h3>
+          <p>{record.sampleTested}</p>
+          <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+            Sample from
+          </h3>
+          <p>{record.sampleFrom}</p>
+          <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+            Ordered by
+          </h3>
+          <p>{record.orderedBy}</p>
+          <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+            Ordering location
+          </h3>
+          <p>{record.orderingLocation}</p>
+          <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+            Collecting location
+          </h3>
+          <p>{record.collectingLocation}</p>
+          <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+            Lab location
+          </h3>
+          <p>{record.labLocation}</p>
+          <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+            Date completed
+          </h3>
+          <p>{record.date}</p>
+        </div>
 
-          <div className="test-results-container">
-            <h2>Results</h2>
-            <va-additional-info
-              trigger="Need help understanding your results?"
-              class="no-print"
-            >
-              <p>
-                Your provider will review your results and explain what they
-                mean for your health. To ask a question now, send a secure
-                message to your care team.
-              </p>
-              <p>
-                <a
-                  href={mhvUrl(
-                    isAuthenticatedWithSSOe(fullState),
-                    'secure-messaging',
-                  )}
-                >
-                  Start a new message
-                </a>
-              </p>
-            </va-additional-info>
-            <p className="vads-u-font-size--base make-monospace">
-              {record.results}
-            </p>{' '}
-          </div>
-        </>
-      );
-    }
-    return <></>;
+        <div className="test-results-container">
+          <h2>Results</h2>
+          <va-additional-info
+            trigger="Need help understanding your results?"
+            class="no-print"
+          >
+            <p>
+              Your provider will review your results and explain what they mean
+              for your health. To ask a question now, send a secure message to
+              your care team.
+            </p>
+            <p>
+              <a
+                href={mhvUrl(
+                  isAuthenticatedWithSSOe(fullState),
+                  'secure-messaging',
+                )}
+              >
+                Start a new message
+              </a>
+            </p>
+          </va-additional-info>
+          <p className="vads-u-font-size--base make-monospace">
+            {record.results}
+          </p>{' '}
+        </div>
+      </>
+    );
   };
 
   return (
     <div className="vads-l-grid-container vads-u-padding-x--0 vads-u-margin-bottom--5">
-      {content()}
+      {record && content()}
     </div>
   );
 };
@@ -230,4 +222,5 @@ export default MicroDetails;
 MicroDetails.propTypes = {
   fullState: PropTypes.object,
   record: PropTypes.object,
+  runningUnitTest: PropTypes.bool,
 };

--- a/src/applications/mhv/medical-records/components/LabsAndTests/PathologyDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/PathologyDetails.jsx
@@ -1,7 +1,5 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
-import { generatePdf } from '@department-of-veterans-affairs/platform-pdf/exports';
 import moment from 'moment';
 import { useSelector } from 'react-redux';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
@@ -11,13 +9,12 @@ import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
 import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selectors';
 import PrintDownload from '../shared/PrintDownload';
 import DownloadingRecordsInfo from '../shared/DownloadingRecordsInfo';
-import { nameFormat, dateFormat, sendErrorToSentry } from '../../util/helpers';
+import { nameFormat, dateFormat, makePdf } from '../../util/helpers';
 import { updatePageTitle } from '../../../shared/util/helpers';
-import { pageTitles } from '../../util/constants';
+import { EMPTY_FIELD, pageTitles } from '../../util/constants';
 
 const PathologyDetails = props => {
-  const { record, fullState } = props;
-  const formattedDate = formatDateLong(record?.date);
+  const { record, fullState, runningUnitTest } = props;
   const user = useSelector(state => state.user.profile);
   const allowTxtDownloads = useSelector(
     state =>
@@ -31,14 +28,14 @@ const PathologyDetails = props => {
   useEffect(
     () => {
       focusElement(document.querySelector('h1'));
-      const titleDate = formattedDate ? `${formattedDate} - ` : '';
+      const titleDate = record.date !== EMPTY_FIELD ? `${record.date} - ` : '';
       updatePageTitle(
         `${titleDate}${record.name} - ${
           pageTitles.LAB_AND_TEST_RESULTS_PAGE_TITLE
         }`,
       );
     },
-    [formattedDate, record.name],
+    [record],
   );
 
   const generatePathologyPdf = async () => {
@@ -70,17 +67,17 @@ const PathologyDetails = props => {
             items: [
               {
                 title: 'Sample tested',
-                value: record.sampleFrom || ' ',
+                value: record.sampleTested,
                 inline: true,
               },
               {
                 title: 'Lab location',
-                value: record.labLocation || ' ',
+                value: record.labLocation,
                 inline: true,
               },
               {
                 title: 'Date completed',
-                value: moment(record.date).format('LL') || ' ',
+                value: record.date,
                 inline: true,
               },
             ],
@@ -99,90 +96,81 @@ const PathologyDetails = props => {
       },
     };
 
-    try {
-      await generatePdf('medicalRecords', 'Pathology_report', pdfData);
-    } catch (error) {
-      sendErrorToSentry(error, 'Pathology details');
-    }
+    makePdf('Pathology_report', pdfData, 'Pathology details', runningUnitTest);
   };
 
   const content = () => {
-    if (record) {
-      return (
-        <>
-          <PrintHeader />
-          <h1
-            className="vads-u-margin-bottom--0"
-            aria-describedby="pathology-date"
+    return (
+      <>
+        <PrintHeader />
+        <h1
+          className="vads-u-margin-bottom--0"
+          aria-describedby="pathology-date"
+        >
+          {record.name}
+        </h1>
+        <div className="time-header">
+          <h2
+            className="vads-u-font-size--base vads-u-font-family--sans"
+            id="pathology-date"
           >
-            {record.name}
-          </h1>
-          <div className="time-header">
-            <h2
-              className="vads-u-font-size--base vads-u-font-family--sans"
-              id="pathology-date"
-            >
-              Date:{' '}
-              <span className="vads-u-font-weight--normal">
-                {formattedDate}
-              </span>
-            </h2>
-          </div>
-          <div className="no-print">
-            <PrintDownload
-              download={generatePathologyPdf}
-              allowTxtDownloads={allowTxtDownloads}
-            />
-            <DownloadingRecordsInfo allowTxtDownloads={allowTxtDownloads} />
-          </div>
-          <div className="test-details-container max-80">
-            <h4>Details about this test</h4>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Sample tested
-            </h3>
-            <p>{record.sampleTested}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Lab location
-            </h3>
-            <p>{record.labLocation}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              Date completed
-            </h3>
-            <p>{formattedDate}</p>
-          </div>
-          <div className="test-results-container">
-            <h4>Results</h4>
-            <va-additional-info
-              trigger="Need help understanding your results?"
-              class="no-print"
-            >
-              <p>
-                Your provider will review your results and explain what they
-                mean for your health. To ask a question now, send a secure
-                message to your care team.
-              </p>
-              <p>
-                <a
-                  href={mhvUrl(
-                    isAuthenticatedWithSSOe(fullState),
-                    'secure-messaging',
-                  )}
-                >
-                  Start a new message
-                </a>
-              </p>
-            </va-additional-info>
-            <p>{record.results}</p>
-          </div>
-        </>
-      );
-    }
-    return <></>;
+            Date:{' '}
+            <span className="vads-u-font-weight--normal">{record.date}</span>
+          </h2>
+        </div>
+        <div className="no-print">
+          <PrintDownload
+            download={generatePathologyPdf}
+            allowTxtDownloads={allowTxtDownloads}
+          />
+          <DownloadingRecordsInfo allowTxtDownloads={allowTxtDownloads} />
+        </div>
+        <div className="test-details-container max-80">
+          <h4>Details about this test</h4>
+          <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+            Sample tested
+          </h3>
+          <p>{record.sampleTested}</p>
+          <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+            Lab location
+          </h3>
+          <p>{record.labLocation}</p>
+          <h3 className="vads-u-font-size--base vads-u-font-family--sans">
+            Date completed
+          </h3>
+          <p>{record.date}</p>
+        </div>
+        <div className="test-results-container">
+          <h4>Results</h4>
+          <va-additional-info
+            trigger="Need help understanding your results?"
+            class="no-print"
+          >
+            <p>
+              Your provider will review your results and explain what they mean
+              for your health. To ask a question now, send a secure message to
+              your care team.
+            </p>
+            <p>
+              <a
+                href={mhvUrl(
+                  isAuthenticatedWithSSOe(fullState),
+                  'secure-messaging',
+                )}
+              >
+                Start a new message
+              </a>
+            </p>
+          </va-additional-info>
+          <p>{record.results}</p>
+        </div>
+      </>
+    );
   };
 
   return (
     <div className="vads-l-grid-container vads-u-padding-x--0 vads-u-margin-bottom--5">
-      {content()}
+      {record && content()}
     </div>
   );
 };
@@ -192,4 +180,5 @@ export default PathologyDetails;
 PathologyDetails.propTypes = {
   fullState: PropTypes.object,
   record: PropTypes.object,
+  runningUnitTest: PropTypes.bool,
 };

--- a/src/applications/mhv/medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import PrintHeader from '../shared/PrintHeader';
@@ -11,7 +10,7 @@ import PrintDownload from '../shared/PrintDownload';
 import DownloadingRecordsInfo from '../shared/DownloadingRecordsInfo';
 import GenerateRadiologyPdf from './GenerateRadiologyPdf';
 import { updatePageTitle } from '../../../shared/util/helpers';
-import { pageTitles } from '../../util/constants';
+import { EMPTY_FIELD, pageTitles } from '../../util/constants';
 
 const RadiologyDetails = props => {
   const { record, fullState, runningUnitTest } = props;
@@ -21,19 +20,18 @@ const RadiologyDetails = props => {
         FEATURE_FLAG_NAMES.mhvMedicalRecordsAllowTxtDownloads
       ],
   );
-  const formattedDate = record?.date ? formatDateLong(record?.date) : '';
 
   useEffect(
     () => {
       focusElement(document.querySelector('h1'));
-      const titleDate = formattedDate ? `${formattedDate} - ` : '';
+      const titleDate = record.date !== EMPTY_FIELD ? `${record.date} - ` : '';
       updatePageTitle(
         `${titleDate}${record.name} - ${
           pageTitles.LAB_AND_TEST_RESULTS_PAGE_TITLE
         }`,
       );
     },
-    [formattedDate, record.name],
+    [record],
   );
 
   const download = () => {
@@ -60,7 +58,7 @@ const RadiologyDetails = props => {
               className="vads-u-font-weight--normal"
               data-testid="header-time"
             >
-              {formattedDate}
+              {record.date}
             </span>
           </h2>
         </div>

--- a/src/applications/mhv/medical-records/components/MrBreadcrumbs.jsx
+++ b/src/applications/mhv/medical-records/components/MrBreadcrumbs.jsx
@@ -11,7 +11,10 @@ const MrBreadcrumbs = () => {
   return (
     <>
       {crumbs.length > 0 && crumbs[0]?.url ? (
-        <div className="vads-l-row breadcrumbs-container no-print">
+        <div
+          className="vads-l-row breadcrumbs-container no-print"
+          data-testid="breadcrumbs"
+        >
           {/* per exisiting issue found here https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1296 */}
           {/* eslint-disable-next-line @department-of-veterans-affairs/prefer-web-component-library */}
           <Breadcrumbs label="Breadcrumb" mobileFirstProp>
@@ -24,7 +27,7 @@ const MrBreadcrumbs = () => {
           </Breadcrumbs>
         </div>
       ) : (
-        <div className="breadcrumbs-container" />
+        <div className="breadcrumbs-container" data-testid="no-breadcrumbs" />
       )}
     </>
   );

--- a/src/applications/mhv/medical-records/components/RecordList/AllergyListItem.jsx
+++ b/src/applications/mhv/medical-records/components/RecordList/AllergyListItem.jsx
@@ -6,87 +6,65 @@ import ItemList from '../shared/ItemList';
 const AllergyListItem = props => {
   const { record } = props;
 
-  const content = () => {
-    if (record) {
-      return (
-        <div
-          className="record-list-item vads-u-border-color--gray-light vads-u-border--0 vads-u-background-color--gray-lightest card"
-          data-testid="record-list-item"
+  return (
+    <div
+      className="record-list-item vads-u-border-color--gray-light vads-u-border--0 vads-u-background-color--gray-lightest card"
+      data-testid="record-list-item"
+    >
+      <h3 className="vads-u-font-size--h4 vads-u-margin--0 vads-u-line-height--4 no-print">
+        <Link
+          to={`/allergies/${record.id}`}
+          className="vads-u-margin--0"
+          aria-label={`${record.name} on ${record.date}`}
         >
-          <h3 className="vads-u-font-size--h4 vads-u-margin--0 vads-u-line-height--4 no-print">
-            <Link
-              to={`/allergies/${record.id}`}
-              className="vads-u-margin--0"
-              aria-label={`${record.name} on ${record.date}`}
-            >
-              {record.name}
-            </Link>
-          </h3>
-          <h3
-            className="vads-u-font-size--h4 vads-u-line-height--4 print-only"
-            aria-label={`${record.name} ${record.date}`}
-          >
-            {record.name}
-          </h3>
+          {record.name}
+        </Link>
+      </h3>
+      <h3
+        className="vads-u-font-size--h4 vads-u-line-height--4 print-only"
+        aria-label={`${record.name} ${record.date}`}
+      >
+        {record.name}
+      </h3>
 
-          <div className="fields">
-            <div>
-              <span className="field-label">Date entered:</span>{' '}
-              <span
-                className="vads-u-display--inline-block"
-                data-dd-privacy="mask"
-              >
-                {record.date}
-              </span>
-            </div>
-            <div className="print-only">
-              <span className="field-label">Reaction:</span>{' '}
-              <ItemList list={record.reaction} />
-            </div>
-            <div className="print-only">
-              <span className="field-label">Type of allergy:</span>{' '}
-              <span
-                className="vads-u-display--inline-block"
-                data-dd-privacy="mask"
-              >
-                {record.type}
-              </span>
-            </div>
-            <div className="print-only">
-              <span className="field-label">Location:</span>{' '}
-              <span
-                className="vads-u-display--inline-block"
-                data-dd-privacy="mask"
-              >
-                {record.location}
-              </span>
-            </div>
-            <div className="print-only">
-              <span className="field-label">Observed or reported:</span>{' '}
-              <span
-                className="vads-u-display--inline-block"
-                data-dd-privacy="mask"
-              >
-                {record.observedOrReported}
-              </span>
-            </div>
-            <div className="print-only">
-              <span className="field-label">Provider notes:</span>{' '}
-              <span
-                className="vads-u-display--inline-block"
-                data-dd-privacy="mask"
-              >
-                {record.notes}
-              </span>
-            </div>
-          </div>
+      <div className="fields">
+        <div>
+          <span className="field-label">Date entered:</span>{' '}
+          <span className="vads-u-display--inline-block" data-dd-privacy="mask">
+            {record.date}
+          </span>
         </div>
-      );
-    }
-    return <></>;
-  };
-
-  return content();
+        <div className="print-only">
+          <span className="field-label">Reaction:</span>{' '}
+          <ItemList list={record.reaction} />
+        </div>
+        <div className="print-only">
+          <span className="field-label">Type of allergy:</span>{' '}
+          <span className="vads-u-display--inline-block" data-dd-privacy="mask">
+            {record.type}
+          </span>
+        </div>
+        <div className="print-only">
+          <span className="field-label">Location:</span>{' '}
+          <span className="vads-u-display--inline-block" data-dd-privacy="mask">
+            {record.location}
+          </span>
+        </div>
+        <div className="print-only">
+          <span className="field-label">Observed or reported:</span>{' '}
+          <span className="vads-u-display--inline-block" data-dd-privacy="mask">
+            {record.observedOrReported}
+          </span>
+        </div>
+        <div className="print-only">
+          <span className="field-label">Provider notes:</span>{' '}
+          <span className="vads-u-display--inline-block" data-dd-privacy="mask">
+            {record.notes}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default AllergyListItem;

--- a/src/applications/mhv/medical-records/components/RecordList/CareSummariesAndNotesListItem.jsx
+++ b/src/applications/mhv/medical-records/components/RecordList/CareSummariesAndNotesListItem.jsx
@@ -31,7 +31,7 @@ const CareSummariesAndNotesListItem = props => {
         {record.location !== EMPTY_FIELD && <div>{record.location}</div>}
         <div>
           <span className="field-label">
-            {record.isDischargeSummary ? 'Signed by ' : 'Admitted by '}
+            {isDischargeSummary ? 'Signed by ' : 'Admitted by '}
           </span>{' '}
           {record.physician}
         </div>

--- a/src/applications/mhv/medical-records/components/RecordList/ConditionListItem.jsx
+++ b/src/applications/mhv/medical-records/components/RecordList/ConditionListItem.jsx
@@ -7,39 +7,32 @@ const ConditionListItem = props => {
   const { record } = props;
   const formattedDate = formatDateLong(record?.date);
 
-  const content = () => {
-    if (record) {
-      return (
-        <div
-          className="record-list-item vads-u-padding--3 vads-u-border-color--gray-light vads-u-border--0 vads-u-background-color--gray-lightest card"
-          data-testid="record-list-item"
+  return (
+    <div
+      className="record-list-item vads-u-padding--3 vads-u-border-color--gray-light vads-u-border--0 vads-u-background-color--gray-lightest card"
+      data-testid="record-list-item"
+    >
+      <h3 className="vads-u-font-size--h4 vads-u-margin--0 vads-u-line-height--4 no-print">
+        <Link
+          to={`/conditions/${record.id}`}
+          className="vads-u-margin--0"
+          data-dd-privacy="mask"
+          aria-label={`${record.name} on ${formattedDate}`}
         >
-          <h3 className="vads-u-font-size--h4 vads-u-margin--0 vads-u-line-height--4 no-print">
-            <Link
-              to={`/conditions/${record.id}`}
-              className="vads-u-margin--0"
-              data-dd-privacy="mask"
-              aria-label={`${record.name} on ${formattedDate}`}
-            >
-              {record.name}
-            </Link>
-          </h3>
-          <h3
-            className="vads-u-font-size--h4 vads-u-line-height--4 print-only"
-            data-dd-privacy="mask"
-            aria-label={`${record.name} ${formattedDate}`}
-          >
-            {record.name}
-          </h3>
+          {record.name}
+        </Link>
+      </h3>
+      <h3
+        className="vads-u-font-size--h4 vads-u-line-height--4 print-only"
+        data-dd-privacy="mask"
+        aria-label={`${record.name} ${formattedDate}`}
+      >
+        {record.name}
+      </h3>
 
-          <p className="vads-u-margin--0">Date entered: {formattedDate}</p>
-        </div>
-      );
-    }
-    return <></>;
-  };
-
-  return content();
+      <p className="vads-u-margin--0">Date entered: {formattedDate}</p>
+    </div>
+  );
 };
 
 export default ConditionListItem;

--- a/src/applications/mhv/medical-records/components/RecordList/LabsAndTestsListItem.jsx
+++ b/src/applications/mhv/medical-records/components/RecordList/LabsAndTestsListItem.jsx
@@ -8,17 +8,6 @@ const LabsAndTestsListItem = props => {
   const { record } = props;
   const formattedDate = formatDateLong(record.date);
 
-  const orderedOrRequested = () => {
-    return (
-      <>
-        <span className="field-label">
-          {record.orderedBy ? 'Ordered by ' : 'Requested by '}
-        </span>{' '}
-        {record.orderedBy || record.requestedBy}
-      </>
-    );
-  };
-
   return (
     <div
       className="record-list-item vads-u-padding--3 vads-u-border-color--gray-light vads-u-border--0 vads-u-background-color--gray-lightest card"
@@ -39,9 +28,9 @@ const LabsAndTestsListItem = props => {
         {record.type === labTypes.CHEM_HEM && (
           <div>Type of test: Chemistry and hematology</div>
         )}
-        {(record.orderedBy || record.requestedBy) && (
-          <div>{orderedOrRequested()}</div>
-        )}
+        <div>
+          <span className="field-label">Ordered by:</span> {record.orderedBy}
+        </div>
       </div>
       <Link
         to={`/labs-and-tests/${record.id}`}

--- a/src/applications/mhv/medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv/medical-records/containers/Allergies.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import moment from 'moment';
-import { generatePdf } from '@department-of-veterans-affairs/platform-pdf/exports';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import PropTypes from 'prop-types';
@@ -12,7 +11,7 @@ import { getAllergiesList } from '../actions/allergies';
 import PrintHeader from '../components/shared/PrintHeader';
 import PrintDownload from '../components/shared/PrintDownload';
 import DownloadingRecordsInfo from '../components/shared/DownloadingRecordsInfo';
-import { processList, sendErrorToSentry } from '../util/helpers';
+import { makePdf, processList } from '../util/helpers';
 import AccessTroubleAlertBox from '../components/shared/AccessTroubleAlertBox';
 import {
   updatePageTitle,
@@ -118,21 +117,12 @@ const Allergies = props => {
       });
     });
 
-    try {
-      if (!runningUnitTest) {
-        await generatePdf(
-          'medicalRecords',
-          `VA-Allergies-list-${user.userFullName.first}-${
-            user.userFullName.last
-          }-${moment()
-            .format('M-D-YYYY_hhmmssa')
-            .replace(/\./g, '')}`,
-          pdfData,
-        );
-      }
-    } catch (error) {
-      sendErrorToSentry(error, 'Allergies');
-    }
+    const pdfName = `VA-Allergies-list-${user.userFullName.first}-${
+      user.userFullName.last
+    }-${moment()
+      .format('M-D-YYYY_hhmmssa')
+      .replace(/\./g, '')}`;
+    makePdf(pdfName, pdfData, 'Allergies', runningUnitTest);
   };
 
   const accessAlert = activeAlert && activeAlert.type === ALERT_TYPE_ERROR;

--- a/src/applications/mhv/medical-records/containers/AllergyDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/AllergyDetails.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
-import { generatePdf } from '@department-of-veterans-affairs/platform-pdf/exports';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import ItemList from '../components/shared/ItemList';
@@ -12,7 +11,7 @@ import { setBreadcrumbs } from '../actions/breadcrumbs';
 import PrintHeader from '../components/shared/PrintHeader';
 import PrintDownload from '../components/shared/PrintDownload';
 import DownloadingRecordsInfo from '../components/shared/DownloadingRecordsInfo';
-import { processList, sendErrorToSentry } from '../util/helpers';
+import { makePdf, processList } from '../util/helpers';
 import { ALERT_TYPE_ERROR, pageTitles } from '../util/constants';
 import AccessTroubleAlertBox from '../components/shared/AccessTroubleAlertBox';
 import {
@@ -127,21 +126,13 @@ const AllergyDetails = props => {
       ],
     };
 
-    try {
-      if (!runningUnitTest) {
-        await generatePdf(
-          'medicalRecords',
-          `VA-Allergies-details-${user.userFullName.first}-${
-            user.userFullName.last
-          }-${moment()
-            .format('M-D-YYYY_hhmmssa')
-            .replace(/\./g, '')}`,
-          scaffold,
-        );
-      }
-    } catch (error) {
-      sendErrorToSentry(error, 'Allergy details');
-    }
+    const pdfName = `VA-Allergies-details-${user.userFullName.first}-${
+      user.userFullName.last
+    }-${moment()
+      .format('M-D-YYYY_hhmmssa')
+      .replace(/\./g, '')}`;
+
+    makePdf(pdfName, scaffold, 'Allergy details', runningUnitTest);
   };
 
   const content = () => {
@@ -225,6 +216,5 @@ const AllergyDetails = props => {
 export default AllergyDetails;
 
 AllergyDetails.propTypes = {
-  print: PropTypes.func,
   runningUnitTest: PropTypes.bool,
 };

--- a/src/applications/mhv/medical-records/containers/CareSummariesDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/CareSummariesDetails.jsx
@@ -43,25 +43,20 @@ const CareSummariesDetails = () => {
     [summaryId, dispatch],
   );
 
-  if (careSummary?.name) {
-    switch (careSummary.type) {
-      case loincCodes.DISCHARGE_SUMMARY:
-        return <AdmissionAndDischargeDetails record={careSummary} />;
-      case loincCodes.PHYSICIAN_PROCEDURE_NOTE:
-        return <ProgressNoteDetails record={careSummary} />;
-      default:
-        return <p>Something else</p>;
-    }
-  } else {
-    return (
-      <va-loading-indicator
-        message="Loading..."
-        setFocus
-        data-testid="loading-indicator"
-        class="loading-indicator"
-      />
-    );
+  if (careSummary?.type === loincCodes.DISCHARGE_SUMMARY) {
+    return <AdmissionAndDischargeDetails record={careSummary} />;
   }
+  if (careSummary?.type === loincCodes.PHYSICIAN_PROCEDURE_NOTE) {
+    return <ProgressNoteDetails record={careSummary} />;
+  }
+  return (
+    <va-loading-indicator
+      message="Loading..."
+      setFocus
+      data-testid="loading-indicator"
+      class="loading-indicator"
+    />
+  );
 };
 
 export default CareSummariesDetails;

--- a/src/applications/mhv/medical-records/containers/HealthConditions.jsx
+++ b/src/applications/mhv/medical-records/containers/HealthConditions.jsx
@@ -40,7 +40,7 @@ const HealthConditions = () => {
       return (
         <div className="vads-u-margin-bottom--3">
           <va-alert background-only status="info">
-            You don’t have any records in Vitals
+            You don’t have any records in Health conditions
           </va-alert>
         </div>
       );

--- a/src/applications/mhv/medical-records/containers/LabAndTestDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/LabAndTestDetails.jsx
@@ -47,39 +47,33 @@ const LabAndTestDetails = () => {
     [labId, dispatch],
   );
 
-  if (labAndTestDetails?.name) {
-    switch (labAndTestDetails.type) {
-      case labTypes.CHEM_HEM:
-        return (
-          <ChemHemDetails record={labAndTestDetails} fullState={fullState} />
-        );
-      case labTypes.MICROBIOLOGY:
-        return (
-          <MicroDetails record={labAndTestDetails} fullState={fullState} />
-        );
-      case labTypes.PATHOLOGY:
-        return (
-          <PathologyDetails record={labAndTestDetails} fullState={fullState} />
-        );
-      case labTypes.EKG:
-        return <EkgDetails record={labAndTestDetails} />;
-      case labTypes.RADIOLOGY:
-        return (
-          <RadiologyDetails record={labAndTestDetails} fullState={fullState} />
-        );
-      default:
-        return <p>something else</p>;
-    }
-  } else {
+  if (labAndTestDetails?.type === labTypes.CHEM_HEM) {
+    return <ChemHemDetails record={labAndTestDetails} fullState={fullState} />;
+  }
+  if (labAndTestDetails?.type === labTypes.MICROBIOLOGY) {
+    return <MicroDetails record={labAndTestDetails} fullState={fullState} />;
+  }
+  if (labAndTestDetails?.type === labTypes.PATHOLOGY) {
     return (
-      <va-loading-indicator
-        message="Loading..."
-        setFocus
-        data-testid="loading-indicator"
-        class="loading-indicator"
-      />
+      <PathologyDetails record={labAndTestDetails} fullState={fullState} />
     );
   }
+  if (labAndTestDetails?.type === labTypes.EKG) {
+    return <EkgDetails record={labAndTestDetails} />;
+  }
+  if (labAndTestDetails?.type === labTypes.RADIOLOGY) {
+    return (
+      <RadiologyDetails record={labAndTestDetails} fullState={fullState} />
+    );
+  }
+  return (
+    <va-loading-indicator
+      message="Loading..."
+      setFocus
+      data-testid="loading-indicator"
+      class="loading-indicator"
+    />
+  );
 };
 
 export default LabAndTestDetails;

--- a/src/applications/mhv/medical-records/containers/VaccineDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/VaccineDetails.jsx
@@ -2,11 +2,10 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
-import { generatePdf } from '@department-of-veterans-affairs/platform-pdf/exports';
 import moment from 'moment';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
-import { processList, sendErrorToSentry } from '../util/helpers';
+import { makePdf, processList } from '../util/helpers';
 import ItemList from '../components/shared/ItemList';
 import { getVaccineDetails, clearVaccineDetails } from '../actions/vaccines';
 import { setBreadcrumbs } from '../actions/breadcrumbs';
@@ -94,21 +93,13 @@ const VaccineDetails = props => {
       ],
     };
 
-    try {
-      if (!runningUnitTest) {
-        await generatePdf(
-          'medicalRecords',
-          `VA-Vaccines-details-${user.userFullName.first}-${
-            user.userFullName.last
-          }-${moment()
-            .format('M-D-YYYY_hhmmssa')
-            .replace(/\./g, '')}`,
-          scaffold,
-        );
-      }
-    } catch (error) {
-      sendErrorToSentry(error, 'Vaccine details');
-    }
+    const pdfName = `VA-Vaccines-details-${user.userFullName.first}-${
+      user.userFullName.last
+    }-${moment()
+      .format('M-D-YYYY_hhmmssa')
+      .replace(/\./g, '')}`;
+
+    makePdf(pdfName, scaffold, 'Vaccine details', runningUnitTest);
   };
 
   const content = () => {
@@ -178,6 +169,5 @@ const VaccineDetails = props => {
 export default VaccineDetails;
 
 VaccineDetails.propTypes = {
-  print: PropTypes.func,
   runningUnitTest: PropTypes.bool,
 };

--- a/src/applications/mhv/medical-records/containers/Vaccines.jsx
+++ b/src/applications/mhv/medical-records/containers/Vaccines.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import moment from 'moment';
-import { generatePdf } from '@department-of-veterans-affairs/platform-pdf/exports';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import { Link } from 'react-router-dom';
@@ -13,7 +12,7 @@ import PrintHeader from '../components/shared/PrintHeader';
 import { recordType, pageTitles } from '../util/constants';
 import PrintDownload from '../components/shared/PrintDownload';
 import DownloadingRecordsInfo from '../components/shared/DownloadingRecordsInfo';
-import { processList, sendErrorToSentry } from '../util/helpers';
+import { makePdf, processList } from '../util/helpers';
 import {
   updatePageTitle,
   generatePdfScaffold,
@@ -91,21 +90,13 @@ const Vaccines = props => {
       });
     });
 
-    try {
-      if (!runningUnitTest) {
-        await generatePdf(
-          'medicalRecords',
-          `VA-Vaccines-list-${user.userFullName.first}-${
-            user.userFullName.last
-          }-${moment()
-            .format('M-D-YYYY_hhmmssa')
-            .replace(/\./g, '')}`,
-          pdfData,
-        );
-      }
-    } catch (error) {
-      sendErrorToSentry(error, 'Vaccines');
-    }
+    const pdfName = `VA-Vaccines-list-${user.userFullName.first}-${
+      user.userFullName.last
+    }-${moment()
+      .format('M-D-YYYY_hhmmssa')
+      .replace(/\./g, '')}`;
+
+    makePdf(pdfName, pdfData, 'Vaccines', runningUnitTest);
   };
 
   const content = () => {

--- a/src/applications/mhv/medical-records/containers/VitalDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/VitalDetails.jsx
@@ -4,7 +4,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { chunk } from 'lodash';
 import { VaPagination } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { generatePdf } from '@department-of-veterans-affairs/platform-pdf/exports';
 import moment from 'moment';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
@@ -12,7 +11,7 @@ import { setBreadcrumbs } from '../actions/breadcrumbs';
 import { clearVitalDetails, getVitalDetails } from '../actions/vitals';
 import PrintHeader from '../components/shared/PrintHeader';
 import PrintDownload from '../components/shared/PrintDownload';
-import { macroCase, sendErrorToSentry } from '../util/helpers';
+import { macroCase, makePdf } from '../util/helpers';
 import { vitalTypeDisplayNames, pageTitles } from '../util/constants';
 import {
   updatePageTitle,
@@ -20,7 +19,8 @@ import {
 } from '../../shared/util/helpers';
 
 const MAX_PAGE_LIST_LENGTH = 5;
-const VitalDetails = () => {
+const VitalDetails = props => {
+  const { runningUnitTest } = props;
   const records = useSelector(state => state.mr.vitals.vitalDetails);
   const user = useSelector(state => state.user.profile);
   const allowTxtDownloads = useSelector(
@@ -130,19 +130,13 @@ const VitalDetails = () => {
       ],
     };
 
-    try {
-      await generatePdf(
-        'medicalRecords',
-        `VA-Vital-details-${user.userFullName.first}-${
-          user.userFullName.last
-        }-${moment()
-          .format('M-D-YYYY_hhmmssa')
-          .replace(/\./g, '')}`,
-        scaffold,
-      );
-    } catch (error) {
-      sendErrorToSentry(error, 'Vital details');
-    }
+    const pdfName = `VA-Vital-details-${user.userFullName.first}-${
+      user.userFullName.last
+    }-${moment()
+      .format('M-D-YYYY_hhmmssa')
+      .replace(/\./g, '')}`;
+
+    makePdf(pdfName, scaffold, 'Vital details', runningUnitTest);
   };
 
   const content = () => {
@@ -250,5 +244,5 @@ const VitalDetails = () => {
 export default VitalDetails;
 
 VitalDetails.propTypes = {
-  print: PropTypes.func,
+  runningUnitTest: PropTypes.bool,
 };

--- a/src/applications/mhv/medical-records/reducers/conditions.js
+++ b/src/applications/mhv/medical-records/reducers/conditions.js
@@ -1,6 +1,6 @@
-import environment from 'platform/utilities/environment';
+import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
 import { Actions } from '../util/actionTypes';
-import { IS_TESTING } from '../util/constants';
+import { EMPTY_FIELD } from '../util/constants';
 
 const initialState = {
   /**
@@ -14,53 +14,36 @@ const initialState = {
   conditionDetails: undefined,
 };
 
-const convertCondition = condition => {
+export const convertCondition = condition => {
   return {
     id: 'SCT161891005',
-    date: condition.recordedDate,
-    name: condition.code.text,
-    clinicalTerm: condition.code.coding.code,
-    active: condition.clinicalStatus.coding.code,
-    provider: condition.asserter,
-    facility: "chiropractor's office",
-    comments: condition.note,
+    date: condition.recordedDate
+      ? formatDateLong(condition.recordedDate)
+      : EMPTY_FIELD,
+    name: condition.code?.text || EMPTY_FIELD,
+    clinicalTerm: condition.code?.coding?.code || EMPTY_FIELD,
+    active: condition.clinicalStatus?.coding?.code || EMPTY_FIELD,
+    provider: condition.asserter || EMPTY_FIELD,
+    facility: condition.facility,
+    comments: condition.note || EMPTY_FIELD,
   };
-};
-
-const convertConditionsList = recordList => {
-  recordList.entry.map(item => {
-    const record = item.resource;
-    return convertCondition(record);
-  });
 };
 
 export const conditionReducer = (state = initialState, action) => {
   switch (action.type) {
     case Actions.Conditions.GET: {
-      let conditionDetails;
-      if (environment.BUILDTYPE === 'localhost' && IS_TESTING) {
-        convertCondition(action.response);
-      } else {
-        conditionDetails = action.response;
-      }
       return {
         ...state,
-        conditionDetails,
+        conditionDetails: convertCondition(action.response),
       };
     }
     case Actions.Conditions.GET_LIST: {
-      const recordList = action.response;
-      let conditionsList;
-      if (environment.BUILDTYPE === 'localhost' && IS_TESTING) {
-        convertConditionsList(recordList);
-      } else {
-        conditionsList = recordList.map(condition => {
-          return { ...condition };
-        });
-      }
       return {
         ...state,
-        conditionsList,
+        conditionsList: action.response.entry.map(item => {
+          const record = item.resource;
+          return convertCondition(record);
+        }),
       };
     }
     case Actions.Conditions.CLEAR_DETAIL: {

--- a/src/applications/mhv/medical-records/reducers/labsAndTests.js
+++ b/src/applications/mhv/medical-records/reducers/labsAndTests.js
@@ -81,7 +81,9 @@ const convertMicrobiologyRecord = record => {
     category: '',
     orderedBy: 'Beth M. Smith',
     requestedBy: 'John J. Lydon',
-    date: record.effectiveDateTime || EMPTY_FIELD,
+    date: record.effectiveDateTime
+      ? formatDateLong(record.effectiveDateTime)
+      : EMPTY_FIELD,
     sampleFrom: record.type?.text || EMPTY_FIELD,
     sampleTested: record.specimen?.text || EMPTY_FIELD,
     orderingLocation:
@@ -154,13 +156,10 @@ const convertRadiologyRecord = record => {
     orderedBy:
       (isArrayAndHasItems(record.author) && record.author[0].display) ||
       EMPTY_FIELD,
-    requestedBy:
-      (isArrayAndHasItems(record.author) && record.author[0].display) ||
-      EMPTY_FIELD,
     clinicalHistory: record.clinicalHistory || EMPTY_FIELD,
     orderingLocation: record.location || EMPTY_FIELD,
     imagingLocation: authorDisplay,
-    date: record.date || EMPTY_FIELD,
+    date: record.date ? formatDateLong(record.data) : EMPTY_FIELD,
     imagingProvider: record.physician || EMPTY_FIELD,
     results: Buffer.from(record.content[0].attachment.data, 'base64').toString(
       'utf-8',

--- a/src/applications/mhv/medical-records/tests/api/MrApi.unit.spec.js
+++ b/src/applications/mhv/medical-records/tests/api/MrApi.unit.spec.js
@@ -23,6 +23,7 @@ import {
   getVaccine,
   getVaccineList,
   getVitalsList,
+  postSharingUpdateStatus,
 } from '../../api/MrApi';
 
 describe('Get labs and tests api call', () => {
@@ -53,7 +54,7 @@ describe('Get notes api call', () => {
     mockApiRequest(mockData);
 
     return getNotes(true).then(res => {
-      expect(res.entry.length).to.equal(2);
+      expect(res.entry.length).to.equal(3);
     });
   });
 });
@@ -142,6 +143,17 @@ describe('Get vaccine details api call', () => {
 
     return getVaccine('123', true).then(res => {
       expect(res.resourceType).to.equal('Immunization');
+    });
+  });
+});
+
+describe('Update sharing status api call', () => {
+  it('should make an api call to update user sharing status', () => {
+    const mockData = { status: 200 };
+    mockApiRequest(mockData);
+
+    return postSharingUpdateStatus().then(res => {
+      expect(res.status).to.equal(200);
     });
   });
 });

--- a/src/applications/mhv/medical-records/tests/components/AdmissionAndDischargeDetails.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/AdmissionAndDischargeDetails.unit.spec.jsx
@@ -38,7 +38,7 @@ describe('Admission and discharge summary details component', () => {
   });
 
   it('should display the summary name', () => {
-    const header = screen.getAllByText('Physician procedure note', {
+    const header = screen.getAllByText('Discharge summary', {
       exact: true,
       selector: 'h1',
     });

--- a/src/applications/mhv/medical-records/tests/components/CareSummariesAndNotesListItem.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/CareSummariesAndNotesListItem.unit.spec.jsx
@@ -1,44 +1,41 @@
 import { expect } from 'chai';
 import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
+import { beforeEach } from 'mocha';
 import RecordListItem from '../../components/RecordList/RecordListItem';
 import reducer from '../../reducers';
-import notes from '../fixtures/notes.json';
+import physicianProcedureNote from '../fixtures/physicianProcedureNote.json';
+import dischargeSummary from '../fixtures/dischargeSummary.json';
 import { convertNote } from '../../reducers/careSummariesAndNotes';
 
-describe('CareSummariesAndNotesListItem', () => {
+describe('CareSummariesAndNotesListItem with clinical note', () => {
+  const record = convertNote(physicianProcedureNote);
   const initialState = {
     mr: {
       careSummariesAndNotes: {
-        careSummariesAndNotesList: notes.entry.map(item =>
-          convertNote(item.resource),
-        ),
+        careSummariesAndNotesDetails: record,
       },
     },
   };
 
-  const setup = (state = initialState) => {
-    return renderWithStoreAndRouter(
-      <RecordListItem
-        record={convertNote(notes.entry[0].resource)}
-        type="care summaries and notes"
-      />,
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(
+      <RecordListItem record={record} type="care summaries and notes" />,
       {
-        initialState: state,
+        initialState,
         reducers: reducer,
-        path: '/summaries-and-notes',
+        path: '/summaries-and-notes/123',
       },
     );
-  };
+  });
 
   it('renders without errors', () => {
-    const screen = setup();
     expect(screen.getByText('Physician procedure note', { exact: true })).to
       .exist;
   });
 
   it('should contain the name of the record', () => {
-    const screen = setup();
     const recordName = screen.getByText('Physician procedure note', {
       exact: true,
     });
@@ -46,13 +43,57 @@ describe('CareSummariesAndNotesListItem', () => {
   });
 
   it('should contain the date of the record', () => {
-    const screen = setup();
     const recordDate = screen.getAllByText('August', { exact: false });
     expect(recordDate).to.exist;
   });
 
   it('should contain a link to view record details', () => {
-    const screen = setup();
+    const recordDetailsLink = screen.getByRole('link', {
+      name: /Details/,
+    });
+    expect(recordDetailsLink).to.exist;
+  });
+});
+
+describe('CareSummariesAndNotesListItem with discharge summary', () => {
+  const record = convertNote(dischargeSummary);
+  const initialState = {
+    mr: {
+      careSummariesAndNotes: {
+        careSummariesAndNotesDetails: record,
+      },
+    },
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(
+      <RecordListItem record={record} type="care summaries and notes" />,
+      {
+        initialState,
+        reducers: reducer,
+        path: '/summaries-and-notes/123',
+      },
+    );
+  });
+
+  it('renders without errors', () => {
+    expect(screen.getByText('Discharge summary', { exact: true })).to.exist;
+  });
+
+  it('should contain the name of the record', () => {
+    const recordName = screen.getByText('Discharge summary', {
+      exact: true,
+    });
+    expect(recordName).to.exist;
+  });
+
+  it('should contain the date of the record', () => {
+    const recordDate = screen.getAllByText('August', { exact: false });
+    expect(recordDate).to.exist;
+  });
+
+  it('should contain a link to view record details', () => {
     const recordDetailsLink = screen.getByRole('link', {
       name: /Details/,
     });

--- a/src/applications/mhv/medical-records/tests/components/ItemList.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/ItemList.unit.spec.jsx
@@ -28,4 +28,9 @@ describe('Record list item component', () => {
     });
     expect(emptyMessageElement).to.exist;
   });
+
+  it('should display the string passed as list arg if a string is passed instead of an array', () => {
+    const screen = render(<ItemList list="test" />);
+    expect(screen.getByText('test')).to.exist;
+  });
 });

--- a/src/applications/mhv/medical-records/tests/components/LabsAndTestsListItem.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/LabsAndTestsListItem.unit.spec.jsx
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
+import { beforeEach } from 'mocha';
 import RecordListItem from '../../components/RecordList/RecordListItem';
 import reducer from '../../reducers';
 import { convertLabsAndTestsRecord } from '../../reducers/labsAndTests';
@@ -17,22 +18,22 @@ describe('LabsAndTestsListItem component', () => {
     },
   };
 
-  const setup = (state = initialState) => {
-    return renderWithStoreAndRouter(
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(
       <RecordListItem
         record={convertLabsAndTestsRecord(labsAndTests.entry[0])}
         type={recordType.LABS_AND_TESTS}
       />,
       {
-        initialState: state,
+        initialState,
         reducers: reducer,
         path: '/labs-and-tests',
       },
     );
-  };
+  });
 
   it('renders without errors', () => {
-    const screen = setup();
     expect(
       screen.getAllByText(
         'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN:',
@@ -42,7 +43,6 @@ describe('LabsAndTestsListItem component', () => {
   });
 
   it('should contain the name and date of the record', () => {
-    const screen = setup();
     const recordName = screen.getAllByText(
       'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN:',
       {
@@ -55,7 +55,6 @@ describe('LabsAndTestsListItem component', () => {
   });
 
   it('should contain a link to view record details', () => {
-    const screen = setup();
     const recordDetailsLink = screen.getByRole('link', {
       name: /Details/,
     });

--- a/src/applications/mhv/medical-records/tests/components/MicroDetails.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/MicroDetails.unit.spec.jsx
@@ -1,54 +1,42 @@
 import { expect } from 'chai';
 import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
+import { fireEvent, waitFor } from '@testing-library/dom';
+import { beforeEach } from 'mocha';
 import reducer from '../../reducers';
 import MicroDetails from '../../components/LabsAndTests/MicroDetails';
+import microbiology from '../fixtures/microbiology.json';
+import microbiologyWithDateMissing from '../fixtures/microbiologyWithDateMissing.json';
+import { convertLabsAndTestsRecord } from '../../reducers/labsAndTests';
 
 describe('Microbiology details component', () => {
-  const mockMicro = {
-    name: 'Microbiology',
-    category: '',
-    orderedBy: 'Beth M. Smith',
-    requestedBy: 'John J. Lydon',
-    id: 124,
-    date: '2018-05-04T17:42:46.000Z',
-    sampleFrom: 'Blood',
-    sampleTested: 'Blood',
-    orderingLocation:
-      '01 DAYTON, OH VAMC 4100 W. THIRD STREET , DAYTON, OH 45428',
-    collectingLocation: 'school parking lot',
-    labLocation: '01 DAYTON, OH VAMC 4100 W. THIRD STREET , DAYTON, OH 45428',
-    results:
-      'Accession [UID]: MI 16 3065 [1216003065] Received: Jul 08, 2016@11:29\nCollection sample: VENOUS BLOOD Collection date: Jul 08, 2016 11:29\nSite/Specimen: BLOOD VENOUS\nProvider: MCNALLY,PEGGY A\n\n\n* BACTERIOLOGY FINAL REPORT => Jul 09, 2016 09:56 TECH CODE: 205931\nCULTURE RESULTS: ESCHERICHIA COLI - Quantity: 2+\nANTIBIOTIC SUSCEPTIBILITY TEST RESULTS:\nESCHERICHIA COLI\n:\nAMPICILLIN.................... S\nAMPICILLIN/SULBACTAM.......... S\nCEFAZOLIN..................... S\nTOBRMCN....................... S\nGENTMCN....................... S\nCEFTRIAXONE................... S\nCIPROFLOXACIN................. S\nAMOXICILLIN/CLAVULANATE....... S\nTRIMETH/SULF.................. S\nLEVOFLOXACIN.................. S\n\n=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--\nPerforming Laboratory:\nBacteriology Report Performed By:\nROSEBURG VA MEDICAL CENTER [CLIA# 38D0988132]\nMHVZZVISNTWENTY, TEST PATIENTR CONFIDENTIAL Page 40 of 98\n913 NW GARDEN VALLEY BLVD. ROSEBURG, OR 97471-6523\n-----------------------------------------------------------------------------\nResult Key:\nSUSC = Susceptibility Result S = Susceptible\nINTP = Interpretation I = Intermediate\nMIC = Minimum Inhibitory Concentration R = Resistant',
-  };
-
+  const record = convertLabsAndTestsRecord(microbiology);
   const initialState = {
     mr: {
       labsAndTests: {
-        labsAndTestsDetails: mockMicro,
+        labsAndTestsDetails: record,
       },
     },
   };
 
-  const setup = (state = initialState) => {
-    return renderWithStoreAndRouter(
-      <MicroDetails record={mockMicro} fullState={state} />,
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(
+      <MicroDetails record={record} fullState={initialState} runningUnitTest />,
       {
-        initialState: state,
+        initialState,
         reducers: reducer,
         path: '/labs-and-tests/124',
       },
     );
-  };
+  });
 
   it('renders without errors', () => {
-    const screen = setup();
     expect(screen).to.exist;
   });
 
   it('should display the test name', () => {
-    const screen = setup();
-    const header = screen.getAllByText(mockMicro.name, {
+    const header = screen.getAllByText(record.name, {
       exact: true,
       selector: 'h1',
     });
@@ -56,22 +44,51 @@ describe('Microbiology details component', () => {
   });
 
   it('should display the formatted date', () => {
-    const screen = setup();
-
-    const formattedDate = screen.getAllByText('May 4, 2018', {
-      exact: true,
+    const formattedDate = screen.getAllByText('May', {
+      exact: false,
       selector: 'p',
     });
     expect(formattedDate).to.exist;
   });
 
   it('should display the lab results', () => {
-    const screen = setup();
-
-    const results = screen.getByText(mockMicro.results.split('\n')[0], {
+    const results = screen.getByText(record.results.split('\n')[0], {
       exact: false,
       selector: 'p',
     });
     expect(results).to.exist;
+  });
+
+  it('should download a pdf', () => {
+    fireEvent.click(screen.getByTestId('printButton-1'));
+    expect(screen).to.exist;
+  });
+});
+
+describe('Microbiology details component with no date', () => {
+  it('should not display the formatted date if effectiveDateTime is missing', () => {
+    const record = convertLabsAndTestsRecord(microbiologyWithDateMissing);
+    const initialState = {
+      mr: {
+        labsAndTests: {
+          labsAndTestsDetails: record,
+        },
+      },
+    };
+
+    const screen = renderWithStoreAndRouter(
+      <MicroDetails record={record} fullState={initialState} runningUnitTest />,
+      {
+        initialState,
+        reducers: reducer,
+        path: '/labs-and-tests/123',
+      },
+    );
+
+    waitFor(() => {
+      expect(screen.queryByTestId('header-time').innerHTML).to.contain(
+        'None noted',
+      );
+    });
   });
 });

--- a/src/applications/mhv/medical-records/tests/components/PathologyDetails.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/PathologyDetails.unit.spec.jsx
@@ -2,9 +2,11 @@ import { expect } from 'chai';
 import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { beforeEach } from 'mocha';
+import { fireEvent, waitFor } from '@testing-library/dom';
 import reducer from '../../reducers';
 import PathologyDetails from '../../components/LabsAndTests/PathologyDetails';
 import pathology from '../fixtures/pathology.json';
+import pathologyWithDateMissing from '../fixtures/pathologyWithDateMissing.json';
 import { convertLabsAndTestsRecord } from '../../reducers/labsAndTests';
 
 describe('Pathology details component', () => {
@@ -22,6 +24,7 @@ describe('Pathology details component', () => {
       <PathologyDetails
         record={convertLabsAndTestsRecord(pathology)}
         fullState={initialState}
+        runningUnitTest
       />,
       {
         initialState,
@@ -57,5 +60,42 @@ describe('Pathology details component', () => {
       selector: 'p',
     });
     expect(results).to.exist;
+  });
+
+  it('should download a pdf', () => {
+    fireEvent.click(screen.getByTestId('printButton-1'));
+    expect(screen).to.exist;
+  });
+});
+
+describe('Pathology details component with no date', () => {
+  it('should not display the formatted date if effectiveDateTime is missing', () => {
+    const record = convertLabsAndTestsRecord(pathologyWithDateMissing);
+    const initialState = {
+      mr: {
+        labsAndTests: {
+          labsAndTestsDetails: record,
+        },
+      },
+    };
+
+    const screen = renderWithStoreAndRouter(
+      <PathologyDetails
+        record={record}
+        fullState={initialState}
+        runningUnitTest
+      />,
+      {
+        initialState,
+        reducers: reducer,
+        path: '/labs-and-tests/123',
+      },
+    );
+
+    waitFor(() => {
+      expect(screen.queryByTestId('header-time').innerHTML).to.contain(
+        'None noted',
+      );
+    });
   });
 });

--- a/src/applications/mhv/medical-records/tests/components/ProgressNoteDetails.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/ProgressNoteDetails.unit.spec.jsx
@@ -33,7 +33,7 @@ describe('Progress Note details component', () => {
   });
 
   it('should display the summary name', () => {
-    const header = screen.getAllByText('Physician procedure note', {
+    const header = screen.getAllByText('Discharge summary', {
       exact: true,
       selector: 'h1',
     });

--- a/src/applications/mhv/medical-records/tests/components/RecordListItem.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/RecordListItem.unit.spec.jsx
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+import React from 'react';
+import { beforeEach } from 'mocha';
+import { render } from '@testing-library/react';
+import RecordListItem from '../../components/RecordList/RecordListItem';
+import vaccine from '../fixtures/vaccine.json';
+import { convertVaccine } from '../../reducers/vaccines';
+
+describe('Record list component', () => {
+  let screen = null;
+  beforeEach(() => {
+    screen = render(
+      <RecordListItem records={convertVaccine(vaccine)} type="invalidType" />,
+    );
+  });
+
+  it('renders without errors', () => {
+    expect(screen).to.exist;
+  });
+
+  it('shows something went wrong when type does not match any record type', () => {
+    const message = screen.getAllByText(
+      'Something went wrong, please try again.',
+      {
+        exact: false,
+        selector: 'p',
+      },
+    );
+    expect(message).to.exist;
+  });
+});

--- a/src/applications/mhv/medical-records/tests/containers/AllergyDetails.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/AllergyDetails.unit.spec.jsx
@@ -108,7 +108,7 @@ describe('Allergy details container with date missing', () => {
     });
   });
 
-  it('should not display the formatted date if startDate or endDate is missing', () => {
+  it('should not display the formatted date if date is missing', () => {
     waitFor(() => {
       expect(screen.queryByTestId('header-time').innerHTML).to.contain(
         'None noted',

--- a/src/applications/mhv/medical-records/tests/containers/CareSummariesAndNotes.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/CareSummariesAndNotes.unit.spec.jsx
@@ -4,12 +4,14 @@ import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platfo
 import { beforeEach } from 'mocha';
 import CareSummariesAndNotes from '../../containers/CareSummariesAndNotes';
 import reducer from '../../reducers';
+import { convertNote } from '../../reducers/careSummariesAndNotes';
+import notes from '../fixtures/notes.json';
 
 describe('CareSummariesAndNotes list container', () => {
   const initialState = {
     mr: {
       careSummariesAndNotes: {
-        careSummariesAndNotesList: null,
+        careSummariesAndNotesList: notes.entry.map(note => convertNote(note)),
       },
     },
   };
@@ -29,5 +31,28 @@ describe('CareSummariesAndNotes list container', () => {
         exact: false,
       }),
     ).to.exist;
+  });
+});
+
+describe('CareSummariesAndNotes list container still loading', () => {
+  const initialState = {
+    mr: {
+      careSummariesAndNotes: {
+        careSummariesAndNotesList: [],
+      },
+    },
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<CareSummariesAndNotes />, {
+      initialState,
+      reducers: reducer,
+      path: '/summaries-and-notes',
+    });
+  });
+
+  it('shows a loading indicator', () => {
+    expect(screen.getByTestId('loading-indicator')).to.exist;
   });
 });

--- a/src/applications/mhv/medical-records/tests/containers/ConditionDetails.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/ConditionDetails.unit.spec.jsx
@@ -1,55 +1,48 @@
 import { expect } from 'chai';
 import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
+import { fireEvent, waitFor } from '@testing-library/dom';
+import { beforeEach } from 'mocha';
 import reducer from '../../reducers';
 import { user } from '../fixtures/user-reducer.json';
 import ConditionDetails from '../../containers/ConditionDetails';
-import { dateFormat } from '../../util/helpers';
+import { convertCondition } from '../../reducers/conditions';
+import condition from '../fixtures/condition.json';
+import conditionWithFieldsMissing from '../fixtures/conditionWithFieldsMissing.json';
 
 describe('Condition details container', () => {
   const initialState = {
     mr: {
       conditions: {
-        conditionDetails: {
-          id: 'SCT161891005',
-          name: 'Back pain (SCT 161891005)',
-          active: true,
-          provider: 'Becky',
-          facility: "chiropractor's office",
-          comments: [],
-        },
+        conditionDetails: convertCondition(condition),
       },
     },
     user,
   };
 
-  const setup = (state = initialState) => {
-    return renderWithStoreAndRouter(<ConditionDetails />, {
-      initialState: state,
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<ConditionDetails runningUnitTest />, {
+      initialState,
       reducers: reducer,
       path: '/conditions/SCT161891005',
     });
-  };
+  });
 
   it('renders without errors', () => {
-    const screen = setup();
     expect(screen).to.exist;
   });
 
   it('displays Date of birth for the print view', () => {
-    const screen = setup();
     expect(screen.getByText('Date of birth:', { exact: false })).to.exist;
   });
 
   it('displays a print button', () => {
-    const screen = setup();
     const printButton = screen.getByTestId('print-records-button');
     expect(printButton).to.exist;
   });
 
   it('displays the condition name', () => {
-    const screen = setup();
-
     const conditionName = screen.getByText(
       initialState.mr.conditions.conditionDetails.name.split(' (')[0],
       {
@@ -61,22 +54,14 @@ describe('Condition details container', () => {
   });
 
   it('displays the formatted received date', () => {
-    const screen = setup();
-    const formattedDate = screen.getAllByText(
-      dateFormat(
-        initialState.mr.conditions.conditionDetails?.date,
-        'MMMM D, YYYY [at] h:mm z',
-      ),
-      {
-        exact: true,
-        selector: 'span',
-      },
-    );
+    const formattedDate = screen.getAllByText('April', {
+      exact: false,
+      selector: 'span',
+    });
     expect(formattedDate).to.exist;
   });
 
   it('displays the location', () => {
-    const screen = setup();
     const location = screen.getAllByText(
       initialState.mr.conditions.conditionDetails.facility,
       {
@@ -85,5 +70,63 @@ describe('Condition details container', () => {
       },
     );
     expect(location).to.exist;
+  });
+
+  it('should download a pdf', () => {
+    fireEvent.click(screen.getByTestId('printButton-1'));
+    expect(screen).to.exist;
+  });
+});
+
+describe('Condition details container with fields missing', () => {
+  const initialState = {
+    mr: {
+      conditions: {
+        conditionDetails: convertCondition(conditionWithFieldsMissing),
+      },
+    },
+    user,
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<ConditionDetails runningUnitTest />, {
+      initialState,
+      reducers: reducer,
+      path: '/conditions/123',
+    });
+  });
+
+  it('should not display the formatted date if date is missing', () => {
+    waitFor(() => {
+      expect(screen.queryByTestId('header-time').innerHTML).to.contain(
+        'None noted',
+      );
+    });
+  });
+});
+
+describe('Condition details container still loading', () => {
+  const initialState = {
+    user,
+    mr: {
+      conditions: {},
+      alerts: {
+        alertList: [],
+      },
+    },
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<ConditionDetails runningUnitTest />, {
+      initialState,
+      reducers: reducer,
+      path: '/allergies/123',
+    });
+  });
+
+  it('displays a loading indicator', () => {
+    expect(screen.getByTestId('loading-indicator')).to.exist;
   });
 });

--- a/src/applications/mhv/medical-records/tests/containers/DownloadRecordsPage.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/DownloadRecordsPage.unit.spec.jsx
@@ -1,27 +1,31 @@
 import { expect } from 'chai';
 import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
+import { beforeEach } from 'mocha';
 import reducer from '../../reducers';
 import DownloadRecordsPage from '../../containers/DownloadRecordsPage';
+import user from '../fixtures/user.json';
 
-describe('Allergy details container', () => {
-  const initialState = {};
+describe('DownloadRecordsPage', () => {
+  const initialState = {
+    user,
+    mr: {},
+  };
 
-  const setup = (state = initialState) => {
-    return renderWithStoreAndRouter(<DownloadRecordsPage />, {
-      initialState: state,
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<DownloadRecordsPage />, {
+      initialState,
       reducers: reducer,
       path: '/download-all',
     });
-  };
+  });
 
   it('renders without errors', () => {
-    const screen = setup();
     expect(screen).to.exist;
   });
 
   it('displays sharing status', () => {
-    const screen = setup();
     expect(screen.getByText('Download all medical records')).to.exist;
   });
 });

--- a/src/applications/mhv/medical-records/tests/containers/HealthConditions.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/HealthConditions.unit.spec.jsx
@@ -5,12 +5,16 @@ import { beforeEach } from 'mocha';
 import HealthConditions from '../../containers/HealthConditions';
 import conditions from '../fixtures/conditions.json';
 import reducer from '../../reducers';
+import { convertCondition } from '../../reducers/conditions';
+import user from '../fixtures/user.json';
 
 describe('Health conditions list container', () => {
   const initialState = {
     mr: {
       conditions: {
-        conditionsList: conditions,
+        conditionsList: conditions.map(condition =>
+          convertCondition(condition),
+        ),
       },
     },
   };
@@ -39,5 +43,61 @@ describe('Health conditions list container', () => {
   it('displays active condition', () => {
     expect(screen.getAllByText('Back pain (SCT 161891005)', { exact: true })).to
       .exist;
+  });
+});
+
+describe('Health conditions list container still loading', () => {
+  const initialState = {
+    user,
+    mr: {
+      conditions: {},
+      alerts: {
+        alertList: [],
+      },
+    },
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<HealthConditions runningUnitTest />, {
+      initialState,
+      reducers: reducer,
+      path: '/conditions',
+    });
+  });
+
+  it('displays a loading indicator', () => {
+    expect(screen.getByTestId('loading-indicator')).to.exist;
+  });
+});
+
+describe('Health conditions list container with no health conditions', () => {
+  const initialState = {
+    user,
+    mr: {
+      conditions: {
+        conditionsList: [],
+      },
+      alerts: {
+        alertList: [],
+      },
+    },
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<HealthConditions runningUnitTest />, {
+      initialState,
+      reducers: reducer,
+      path: '/conditions',
+    });
+  });
+
+  it('displays a no health conditions message', () => {
+    expect(
+      screen.getByText('You don’t have any records in Health conditions', {
+        exact: true,
+      }),
+    ).to.exist;
   });
 });

--- a/src/applications/mhv/medical-records/tests/containers/LabAndTestDetails.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/LabAndTestDetails.unit.spec.jsx
@@ -3,17 +3,21 @@ import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { beforeEach } from 'mocha';
 import reducer from '../../reducers';
-import labsAndTests from '../fixtures/labsAndTests.json';
 import user from '../fixtures/user.json';
 import { convertLabsAndTestsRecord } from '../../reducers/labsAndTests';
 import LabAndTestDetails from '../../containers/LabAndTestDetails';
+import microbiology from '../fixtures/microbiology.json';
+import chemhem from '../fixtures/chemHem.json';
+import pathology from '../fixtures/pathology.json';
+// import ekg from '../fixtures/ekg.json';
+import radiology from '../fixtures/radiology.json';
 
 describe('LabsAndTests details container', () => {
   const initialState = {
     user,
     mr: {
       labsAndTests: {
-        labsAndTestsDetails: convertLabsAndTestsRecord(labsAndTests.entry[0]),
+        labsAndTestsDetails: convertLabsAndTestsRecord(chemhem),
       },
     },
   };
@@ -85,5 +89,141 @@ describe('LabsAndTests details container', () => {
 
   it('displays a list of results', () => {
     expect(screen.getAllByRole('listitem')).to.exist;
+  });
+});
+
+describe('LabAndTestDetails microbiology', () => {
+  const initialState = {
+    user,
+    mr: {
+      labsAndTests: {
+        labsAndTestsDetails: convertLabsAndTestsRecord(microbiology),
+      },
+    },
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<LabAndTestDetails />, {
+      initialState,
+      reducers: reducer,
+      path: '/labs-and-tests/ex-MHV-chReport-1',
+    });
+  });
+
+  it('displays microbiology label', () => {
+    expect(screen.getByText('Microbiology')).to.exist;
+  });
+});
+
+describe('LabAndTestDetails pathology', () => {
+  const initialState = {
+    user,
+    mr: {
+      labsAndTests: {
+        labsAndTestsDetails: convertLabsAndTestsRecord(pathology),
+      },
+    },
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<LabAndTestDetails />, {
+      initialState,
+      reducers: reducer,
+      path: '/labs-and-tests/ex-MHV-chReport-1',
+    });
+  });
+
+  it('displays pathology label', () => {
+    expect(
+      screen.getByText('LR SURGICAL PATHOLOGY REPORT', {
+        exact: true,
+        selector: 'h1',
+      }),
+    ).to.exist;
+  });
+});
+
+// describe('LabAndTestDetails ekg', () => {
+//   const initialState = {
+//     user,
+//     mr: {
+//       labsAndTests: {
+//         labsAndTestsDetails: convertLabsAndTestsRecord(ekg),
+//       },
+//     },
+//   };
+
+//   let screen;
+//   beforeEach(() => {
+//     screen = renderWithStoreAndRouter(<LabAndTestDetails />, {
+//       initialState,
+//       reducers: reducer,
+//       path: '/labs-and-tests/ex-MHV-chReport-1',
+//     });
+//   });
+
+//   it('displays ekg label', () => {
+//     expect(
+//       screen.getByText('Electrocardiogram (EKG)', {
+//         exact: true,
+//         selector: 'h1',
+//       }),
+//     ).to.exist;
+//   });
+// });
+
+describe('LabAndTestDetails radiology', () => {
+  const initialState = {
+    user,
+    mr: {
+      labsAndTests: {
+        labsAndTestsDetails: convertLabsAndTestsRecord(radiology),
+      },
+    },
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<LabAndTestDetails />, {
+      initialState,
+      reducers: reducer,
+      path: '/labs-and-tests/ex-MHV-chReport-1',
+    });
+  });
+
+  it('displays radiology label', () => {
+    expect(
+      screen.getByText(
+        'RADIOLOGIC EXAMINATION, SPINE, LUMBOSACRAL; 2 OR 3 VIEWS',
+        {
+          exact: true,
+          selector: 'h1',
+        },
+      ),
+    ).to.exist;
+  });
+});
+
+describe('LabAndTestDetails loading', () => {
+  const initialState = {
+    user,
+    mr: {
+      labsAndTests: {},
+    },
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<LabAndTestDetails />, {
+      initialState,
+      reducers: reducer,
+      path: '/labs-and-tests/ex-MHV-chReport-1',
+    });
+  });
+
+  it('displays a loading indicator', () => {
+    expect(screen.getByTestId('loading-indicator')).to.exist;
   });
 });

--- a/src/applications/mhv/medical-records/tests/containers/SettingsPage.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/SettingsPage.unit.spec.jsx
@@ -1,27 +1,180 @@
 import { expect } from 'chai';
 import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
+import { beforeEach } from 'mocha';
 import reducer from '../../reducers';
 import SettingsPage from '../../containers/SettingsPage';
 
-describe('Allergy details container', () => {
-  const initialState = {};
+describe('SettingsPage container opted in with status error', () => {
+  const initialState = {
+    mr: {
+      sharing: {
+        statusError: { type: 'optin' },
+      },
+    },
+  };
 
-  const setup = (state = initialState) => {
-    return renderWithStoreAndRouter(<SettingsPage />, {
-      initialState: state,
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<SettingsPage />, {
+      initialState,
       reducers: reducer,
       path: '/settings',
     });
-  };
+  });
 
   it('renders without errors', () => {
-    const screen = setup();
     expect(screen).to.exist;
   });
 
   it('displays sharing status', () => {
-    const screen = setup();
     expect(screen.getByText('Manage your sharing settings')).to.exist;
+  });
+
+  it('displays no action available header', () => {
+    expect(
+      screen.getByText('opt back in', {
+        exact: false,
+        selector: 'h3',
+      }),
+    ).to.exist;
+  });
+});
+
+describe('SettingsPage container opted out', () => {
+  const initialState = {
+    mr: {
+      sharing: {
+        statusError: { type: 'optout' },
+      },
+    },
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<SettingsPage />, {
+      initialState,
+      reducers: reducer,
+      path: '/settings',
+    });
+  });
+
+  it('displays no action available header', () => {
+    expect(
+      screen.getByText('opt out', {
+        exact: false,
+        selector: 'h3',
+      }),
+    ).to.exist;
+  });
+});
+
+describe('SettingsPage container with error', () => {
+  const initialState = {
+    mr: {
+      sharing: {
+        statusError: 'Error',
+      },
+    },
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<SettingsPage />, {
+      initialState,
+      reducers: reducer,
+      path: '/settings',
+    });
+  });
+
+  it('displays an error', () => {
+    const error = screen.getByText(
+      'We’re sorry. Something went wrong in our system. Try again later.',
+      {
+        exact: true,
+        selector: 'p',
+      },
+    );
+    expect(error).to.exist;
+  });
+});
+
+describe('SettingsPage container loading', () => {
+  const initialState = {
+    mr: {
+      sharing: {},
+    },
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<SettingsPage />, {
+      initialState,
+      reducers: reducer,
+      path: '/settings',
+    });
+  });
+
+  it('displays a loading indicator', () => {
+    const loadingIndicator = screen.getByTestId(
+      'sharing-status-loading-indicator',
+    );
+    expect(loadingIndicator).to.exist;
+  });
+});
+
+describe('SettingsPage container automatically included', () => {
+  const initialState = {
+    mr: {
+      sharing: { isSharing: 'test' },
+    },
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<SettingsPage />, {
+      initialState,
+      reducers: reducer,
+      path: '/settings',
+    });
+  });
+
+  it('displays a loading indicator', () => {
+    const autoIncludeMessage = screen.getByText(
+      'We automatically include you in this online sharing program.',
+      {
+        exact: false,
+        selector: 'p',
+      },
+    );
+    expect(autoIncludeMessage).to.exist;
+  });
+});
+
+describe('SettingsPage container not sharing', () => {
+  const initialState = {
+    mr: {
+      sharing: { isSharing: '' },
+    },
+  };
+
+  let screen;
+  beforeEach(() => {
+    screen = renderWithStoreAndRouter(<SettingsPage />, {
+      initialState,
+      reducers: reducer,
+      path: '/settings',
+    });
+  });
+
+  it('displays a loading indicator', () => {
+    const autoIncludeMessage = screen.getByText(
+      'We’re not currently sharing your records online with your community',
+      {
+        exact: false,
+        selector: 'p',
+      },
+    );
+    expect(autoIncludeMessage).to.exist;
   });
 });

--- a/src/applications/mhv/medical-records/tests/fixtures/conditionWithFieldsMissing.json
+++ b/src/applications/mhv/medical-records/tests/fixtures/conditionWithFieldsMissing.json
@@ -1,15 +1,15 @@
 {
   "id": "SCT161891005",
-  "recordedDate": "2022-04-01T17:42:46.000Z",
+  "recordedDate": "",
   "name": "Back pain (SCT 161891005)",
-  "active": true,
+  "active": false,
   "provider": "Becky",
-  "facility": "chiropractor's office",
+  "facility": "",
   "code": {
     "coding": { "code": "asdf" },
     "text": "Back pain (SCT 161891005)"
   },
-  "clinicalStatus": { "coding": { "code": "Active" } },
+  "clinicalStatus": { "coding": { "code": "Inactive" } },
   "asserter": "Dr. John",
   "note": "A note"
 }

--- a/src/applications/mhv/medical-records/tests/fixtures/conditions.json
+++ b/src/applications/mhv/medical-records/tests/fixtures/conditions.json
@@ -1,39 +1,59 @@
-
 [
-    {
-        "id": "SCT161891005",
-        "date": "2022-04-01T17:42:46.000Z",
-        "name": "Back pain (SCT 161891005)",
-        "active": true,
-        "provider": "Becky",
-        "facility": "chiropractor's office",
-        "comments": []
+  {
+    "id": "SCT161891005",
+    "recordedDate": "2022-04-01T17:42:46.000Z",
+    "name": "Back pain (SCT 161891005)",
+    "active": true,
+    "provider": "Becky",
+    "facility": "chiropractor's office",
+    "code": {
+      "coding": { "code": "asdf" },
+      "text": "Back pain (SCT 161891005)"
     },
-    {
-        "id": "SCT867530999",
-        "date": "2021-04-01T17:42:46.000Z",
-        "name": "Sick sinus syndrome (SCT 867530999)",
-        "active": true,
-        "provider": "Becky",
-        "facility": "No one nose",
-        "comments": []
+    "clinicalStatus": { "coding": { "code": "abc123" } },
+    "asserter": "Dr. John",
+    "note": "A note"
+  },
+  {
+    "id": "SCT867530999",
+    "recordedDate": "2021-04-01T17:42:46.000Z",
+    "name": "Sick sinus syndrome (SCT 867530999)",
+    "active": true,
+    "provider": "Becky",
+    "facility": "No one nose",
+    "code": {
+      "coding": { "code": "asdf" },
+      "text": "Sick sinus syndrome (SCT 867530999)"
     },
-    {
-        "id": "SCT525000600",
-        "date": "2019-04-01T17:42:46.000Z",
-        "name": "Asthma (SCT 525000600)",
-        "active": true,
-        "provider": "Becky",
-        "facility": "Lung doctor's office",
-        "comments": []
+    "clinicalStatus": { "coding": { "code": "abc123" } },
+    "asserter": "Dr. John",
+    "note": "A note"
+  },
+  {
+    "id": "SCT525000600",
+    "recordedDate": "2019-04-01T17:42:46.000Z",
+    "name": "Asthma (SCT 525000600)",
+    "active": true,
+    "provider": "Becky",
+    "facility": "Lung doctor's office",
+    "code": { "coding": { "code": "asdf" }, "text": "Asthma (SCT 525000600)" },
+    "clinicalStatus": { "coding": { "code": "abc123" } },
+    "asserter": "Dr. John",
+    "note": "A note"
+  },
+  {
+    "id": "SCT500530505",
+    "recordedDate": "2018-04-01T17:42:46.000Z",
+    "name": "Hypertension (SCT 500530505)",
+    "active": true,
+    "provider": "Becky",
+    "facility": "Cardiologist's office",
+    "code": {
+      "coding": { "code": "asdf" },
+      "text": "Hypertension (SCT 500530505)"
     },
-    {
-        "id": "SCT500530505",
-        "date": "2018-04-01T17:42:46.000Z",
-        "name": "Hypertension (SCT 500530505)",
-        "active": true,
-        "provider": "Becky",
-        "facility": "Cardiologist's office",
-        "comments": []
-    }
+    "clinicalStatus": { "coding": { "code": "abc123" } },
+    "asserter": "Dr. John",
+    "note": "A note"
+  }
 ]

--- a/src/applications/mhv/medical-records/tests/fixtures/dischargeSummary.json
+++ b/src/applications/mhv/medical-records/tests/fixtures/dischargeSummary.json
@@ -16,8 +16,8 @@
         "coding": [
             {
                 "system": "http://loinc.org",
-                "code": "11505-5",
-                "display": "Physician procedure note"
+                "code": "18842-5",
+                "display": "Discharge summary"
             }
         ]
     },
@@ -56,7 +56,8 @@
     "context": {
         "related": [
             {
-                "reference": "Location/953"
+                "reference": "Location/953",
+                "text": "The library"
             }
         ]
     },

--- a/src/applications/mhv/medical-records/tests/fixtures/ekg.json
+++ b/src/applications/mhv/medical-records/tests/fixtures/ekg.json
@@ -5,5 +5,13 @@
   "requestedBy": "John J. Lydon",
   "id": 123,
   "date": "2022-04-13T17:42:46.000Z",
-  "facility": "school parking lot"
+  "facility": "school parking lot",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "11524-6"
+      }
+    ]
+  }
 }

--- a/src/applications/mhv/medical-records/tests/fixtures/microbiology.json
+++ b/src/applications/mhv/medical-records/tests/fixtures/microbiology.json
@@ -1,0 +1,23 @@
+{
+  "resourceType": "DiagnosticReport",
+  "name": "Microbiology",
+  "category": "",
+  "orderedBy": "Beth M. Smith",
+  "requestedBy": "John J. Lydon",
+  "id": 124,
+  "effectiveDateTime": "2018-05-04T17:42:46.000Z",
+  "sampleFrom": "Blood",
+  "sampleTested": "Blood",
+  "orderingLocation": "01 DAYTON, OH VAMC 4100 W. THIRD STREET , DAYTON, OH 45428",
+  "collectingLocation": "school parking lot",
+  "labLocation": "01 DAYTON, OH VAMC 4100 W. THIRD STREET , DAYTON, OH 45428",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "79381-0"
+      }
+    ]
+  },
+  "result": "Accession [UID]: MI 16 3065 [1216003065] Received: Jul 08, 2016@11:29\nCollection sample: VENOUS BLOOD Collection date: Jul 08, 2016 11:29\nSite/Specimen: BLOOD VENOUS\nProvider: MCNALLY,PEGGY A\n\n\n* BACTERIOLOGY FINAL REPORT => Jul 09, 2016 09:56 TECH CODE: 205931\nCULTURE RESULTS: ESCHERICHIA COLI - Quantity: 2+\nANTIBIOTIC SUSCEPTIBILITY TEST RESULTS:\nESCHERICHIA COLI\n:\nAMPICILLIN.................... S\nAMPICILLIN/SULBACTAM.......... S\nCEFAZOLIN..................... S\nTOBRMCN....................... S\nGENTMCN....................... S\nCEFTRIAXONE................... S\nCIPROFLOXACIN................. S\nAMOXICILLIN/CLAVULANATE....... S\nTRIMETH/SULF.................. S\nLEVOFLOXACIN.................. S\n\n=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--\nPerforming Laboratory:\nBacteriology Report Performed By:\nROSEBURG VA MEDICAL CENTER [CLIA# 38D0988132]\nMHVZZVISNTWENTY, TEST PATIENTR CONFIDENTIAL Page 40 of 98\n913 NW GARDEN VALLEY BLVD. ROSEBURG, OR 97471-6523\n-----------------------------------------------------------------------------\nResult Key:\nSUSC = Susceptibility Result S = Susceptible\nINTP = Interpretation I = Intermediate\nMIC = Minimum Inhibitory Concentration R = Resistant"
+}

--- a/src/applications/mhv/medical-records/tests/fixtures/microbiologyWithDateMissing.json
+++ b/src/applications/mhv/medical-records/tests/fixtures/microbiologyWithDateMissing.json
@@ -1,0 +1,23 @@
+{
+  "resourceType": "DiagnosticReport",
+  "name": "Microbiology",
+  "category": "",
+  "orderedBy": "Beth M. Smith",
+  "requestedBy": "John J. Lydon",
+  "id": 124,
+  "effectiveDateTime": "",
+  "sampleFrom": "Blood",
+  "sampleTested": "Blood",
+  "orderingLocation": "01 DAYTON, OH VAMC 4100 W. THIRD STREET , DAYTON, OH 45428",
+  "collectingLocation": "school parking lot",
+  "labLocation": "01 DAYTON, OH VAMC 4100 W. THIRD STREET , DAYTON, OH 45428",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "79381-0"
+      }
+    ]
+  },
+  "result": "Accession [UID]: MI 16 3065 [1216003065] Received: Jul 08, 2016@11:29\nCollection sample: VENOUS BLOOD Collection date: Jul 08, 2016 11:29\nSite/Specimen: BLOOD VENOUS\nProvider: MCNALLY,PEGGY A\n\n\n* BACTERIOLOGY FINAL REPORT => Jul 09, 2016 09:56 TECH CODE: 205931\nCULTURE RESULTS: ESCHERICHIA COLI - Quantity: 2+\nANTIBIOTIC SUSCEPTIBILITY TEST RESULTS:\nESCHERICHIA COLI\n:\nAMPICILLIN.................... S\nAMPICILLIN/SULBACTAM.......... S\nCEFAZOLIN..................... S\nTOBRMCN....................... S\nGENTMCN....................... S\nCEFTRIAXONE................... S\nCIPROFLOXACIN................. S\nAMOXICILLIN/CLAVULANATE....... S\nTRIMETH/SULF.................. S\nLEVOFLOXACIN.................. S\n\n=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--=--\nPerforming Laboratory:\nBacteriology Report Performed By:\nROSEBURG VA MEDICAL CENTER [CLIA# 38D0988132]\nMHVZZVISNTWENTY, TEST PATIENTR CONFIDENTIAL Page 40 of 98\n913 NW GARDEN VALLEY BLVD. ROSEBURG, OR 97471-6523\n-----------------------------------------------------------------------------\nResult Key:\nSUSC = Susceptibility Result S = Susceptible\nINTP = Interpretation I = Intermediate\nMIC = Minimum Inhibitory Concentration R = Resistant"
+}

--- a/src/applications/mhv/medical-records/tests/fixtures/notes.json
+++ b/src/applications/mhv/medical-records/tests/fixtures/notes.json
@@ -151,6 +151,76 @@
             "search": {
                 "mode": "match"
             }
+        },
+        {
+            "fullUrl": "https://mhv-intb-api.myhealth.va.gov/fhir/DocumentReference/955",
+            "resource": {
+                "id": "955",
+                "meta": {
+                    "versionId": "1",
+                    "lastUpdated": "2023-06-02T19:34:57.348-04:00",
+                    "source": "#2618b3839c87279a"
+                },
+                "identifier": [
+                    {
+                        "system": "urn:oid:2.16.840.1.113883.4.349",
+                        "value": "984.5281857"
+                    }
+                ],
+                "status": "current",
+                "type": {
+                    "coding": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "18842-5",
+                            "display": "Discharge Summary"
+                        }
+                    ]
+                },
+                "category": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category",
+                                "code": "discharge-summary",
+                                "display": "Discharge Summary"
+                            }
+                        ]
+                    }
+                ],
+                "subject": {
+                    "reference": "Patient/952"
+                },
+                "date": "2022-08-05T11:29:00.003-04:00",
+                "author": [
+                    {
+                        "display": "AHMED,MARUF"
+                    }
+                ],
+                "authenticator": {
+                    "display": "AHMED,MARUF"
+                },
+                "content": [
+                    {
+                        "attachment": {
+                            "contentType": "text/plain",
+                            "data": "DQogTE9DQUwgVElUTEU6IEFESEMgRElTQ0hBUkdFIE5PVEUgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIA0KREFURSBPRiBOT1RFOiBBVUcgMDUsIDIwMjJAMTE6MjkgICAgIEVOVFJZIERBVEU6IEFVRyAwNSwgMjAyMkAxMToyOTo0NiAgICAgIA0KICAgICAgQVVUSE9SOiBBSE1FRCxNQVJVRiAgICAgICAgICBFWFAgQ09TSUdORVI6ICAgICAgICAgICAgICAgICAgICAgICAgICAgDQogICAgIFVSR0VOQ1k6ICAgICAgICAgICAgICAgICAgICAgICAgICAgIFNUQVRVUzogQ09NUExFVEVEICAgICAgICAgICAgICAgICAgICAgDQoNClRoaXMgaXMgIGEgdGVzdCBub3RlLCBNYXJ1ZiANCiANCi9lcy8gTUFSVUYgQUhNRUQNClBIWVNJQ0lBTg0KU2lnbmVkOiAwOC8wNS8yMDIyIDExOjUwDQo=",
+                            "title": "ADHC DISCHARGE NOTE"
+                        }
+                    }
+                ],
+                "context": {
+                    "related": [
+                        {
+                            "reference": "Location/953"
+                        }
+                    ]
+                },
+                "resourceType": "DocumentReference"
+            },
+            "search": {
+                "mode": "match"
+            }
         }
     ],
     "resourceType": "Bundle"

--- a/src/applications/mhv/medical-records/tests/fixtures/pathologyWithDateMissing.json
+++ b/src/applications/mhv/medical-records/tests/fixtures/pathologyWithDateMissing.json
@@ -1,0 +1,84 @@
+{
+  "resourceType": "DiagnosticReport",
+  "id": "ex-MHV-labReport-4",
+  "meta": {
+    "profile": [
+      "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
+    ]
+  },
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 60567-5}\">LR SURGICAL PATHOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id:\u00a01013699147\u00a0(use:\u00a0OFFICIAL))</td></tr><tr><td>When For</td><td>2000-08-10 15:56:00+0000</td></tr><tr><td>Reported</td><td>2000-08-10 15:56:00+0000</td></tr><tr><td>Identifier:</td><td> id:\u00a0LabReportTo.SP;6999190\u00a0(use:\u00a0USUAL)</td></tr></table><p><b>Report Details</b></p><p>Date Spec taken: Aug 09, 2000        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: Aug 09, 2000 16:14  Resident: \nDate  completed: Aug 10, 2000        Accession #: SP 00 1982\nSubmitted by: MARK MAZUR MD          Practitioner:MARK MAZUR DPM\n-------------------------------------------------------------------------------\nSpecimen: \nOLD HARDWARE LEFT FOOT X2\nBrief Clinical History:\nThis 71 y/o wm presents with painful hardware L 1st metatarsal head. The\npins were inserted 3 years ago for a bunion procedure. The Bunionprocedure\nis well healed and pt is now wanting the pin removed. Will probably need\nk-wire driver and power for this case.\nPreoperative Diagnosis:\nPAINFUL HARDWARE LEFT FIRST METATARSAL \nPostoperative Diagnosis:\nPAINFUL HARDWARE LEFT FIRST METATARSAL \nGross description:\nRECEIVED UNFIXED AND LABELED &quot;OLD HARDWARE LEFT FOOT X 2&quot; CONSISTS OF TWO\n1.7 CM AND 2.5 CM LONG 1 MM WIDE METALLIC PINS.\n|TAB||NOWRAP|\nDIAGNOSIS: HARDWARE (CLINICALLY FROM LEFT FOOT)</p></div>"
+  },
+  "contained": [
+    {
+      "resourceType": "Specimen",
+      "id": "ex-MHV-specimen-4",
+      "meta": {
+        "profile": [
+          "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
+        ]
+      },
+      "identifier": [
+        {
+          "use": "usual"
+        }
+      ],
+      "accessionIdentifier": {
+        "use": "usual",
+        "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+        "value": "SP 00 1982"
+      },
+      "status": "available",
+      "type": {
+        "text": "OLD HARDWARE LEFT FOOT X2"
+      },
+      "collection": {
+        "collectedDateTime": "2000-08-09"
+      }
+    }
+  ],
+  "identifier": [
+    {
+      "use": "usual",
+      "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+      "value": "LabReportTo.SP;6999190"
+    }
+  ],
+  "status": "final",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+          "code": "LAB"
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "60567-5"
+      }
+    ],
+    "text": "LR SURGICAL PATHOLOGY REPORT"
+  },
+  "subject": {
+    "reference": "Patient/ex-MHV-patient-1"
+  },
+  "effectiveDateTime": "",
+  "issued": "2000-08-10T15:56:00Z",
+  "performer": [
+    {
+      "reference": "Organization/ex-MHV-organization-989"
+    }
+  ],
+  "specimen": [
+    {
+      "reference": "#ex-MHV-specimen-4"
+    }
+  ],
+  "conclusion": "Date Spec taken: Aug 09, 2000        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: Aug 09, 2000 16:14  Resident: \nDate  completed: Aug 10, 2000        Accession #: SP 00 1982\nSubmitted by: MARK MAZUR MD          Practitioner:MARK MAZUR DPM\n-------------------------------------------------------------------------------\nSpecimen: \nOLD HARDWARE LEFT FOOT X2\nBrief Clinical History:\nThis 71 y/o wm presents with painful hardware L 1st metatarsal head. The\npins were inserted 3 years ago for a bunion procedure. The Bunionprocedure\nis well healed and pt is now wanting the pin removed. Will probably need\nk-wire driver and power for this case.\nPreoperative Diagnosis:\nPAINFUL HARDWARE LEFT FIRST METATARSAL \nPostoperative Diagnosis:\nPAINFUL HARDWARE LEFT FIRST METATARSAL \nGross description:\nRECEIVED UNFIXED AND LABELED \"OLD HARDWARE LEFT FOOT X 2\" CONSISTS OF TWO\n1.7 CM AND 2.5 CM LONG 1 MM WIDE METALLIC PINS.\n|TAB||NOWRAP|\nDIAGNOSIS: HARDWARE (CLINICALLY FROM LEFT FOOT)"
+}

--- a/src/applications/mhv/medical-records/tests/fixtures/physicianProcedureNote.json
+++ b/src/applications/mhv/medical-records/tests/fixtures/physicianProcedureNote.json
@@ -1,0 +1,64 @@
+{
+  "id": "954",
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "2023-06-02T19:34:57.348-04:00",
+    "source": "#2618b3839c87279a"
+  },
+  "identifier": [
+    {
+      "system": "urn:oid:2.16.840.1.113883.4.349",
+      "value": "984.5281863"
+    }
+  ],
+  "status": "current",
+  "type": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "11505-5",
+        "display": "Physician procedure note"
+      }
+    ]
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category",
+          "code": "clinical-note",
+          "display": "Clinical Note"
+        }
+      ]
+    }
+  ],
+  "subject": {
+    "reference": "Patient/952"
+  },
+  "date": "2022-08-05T16:56:00.003-04:00",
+  "author": [
+    {
+      "display": "AHMED,MARUF"
+    }
+  ],
+  "authenticator": {
+    "display": "AHMED,MARUF"
+  },
+  "content": [
+    {
+      "attachment": {
+        "contentType": "text/plain",
+        "data": "DQogTE9DQUwgVElUTEU6IEMmUCBFWEFNIE5PVEUgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIA0KREFURSBPRiBOT1RFOiBBVUcgMDUsIDIwMjJAMTY6NTYgICAgIEVOVFJZIERBVEU6IEFVRyAwNSwgMjAyMkAxNjo1Njo1MyAgICAgIA0KICAgICAgQVVUSE9SOiBBSE1FRCxNQVJVRiAgICAgICAgICBFWFAgQ09TSUdORVI6ICAgICAgICAgICAgICAgICAgICAgICAgICAgDQogICAgIFVSR0VOQ1k6ICAgICAgICAgICAgICAgICAgICAgICAgICAgIFNUQVRVUzogQ09NUExFVEVEICAgICAgICAgICAgICAgICAgICAgDQoNCnRoaXMgaXMgYSBjbnAgZXhhbSBub3RlICwgc2hvdWxlIGJlIGF2YWlsYWJsZSBpbiBtaHYgaW1tZWRpYXRlbHkgLCBNYXJ1ZiBBLg0KIA0KL2VzLyBNQVJVRiBBSE1FRA0KUEhZU0lDSUFODQpTaWduZWQ6IDA4LzA1LzIwMjIgMTY6NTgNCg==",
+        "title": "C&P EXAM NOTE"
+      }
+    }
+  ],
+  "context": {
+    "related": [
+      {
+        "reference": "Location/953"
+      }
+    ]
+  },
+  "resourceType": "DocumentReference"
+}

--- a/src/applications/mhv/medical-records/util/helpers.js
+++ b/src/applications/mhv/medical-records/util/helpers.js
@@ -1,6 +1,7 @@
 import moment from 'moment-timezone';
 import * as Sentry from '@sentry/browser';
 import { snakeCase } from 'lodash';
+import { generatePdf } from '@department-of-veterans-affairs/platform-pdf/exports';
 import { EMPTY_FIELD, interpretationMap } from './constants';
 
 /**
@@ -123,4 +124,26 @@ export const macroCase = str => {
  */
 export const isArrayAndHasItems = obj => {
   return Array.isArray(obj) && obj.length;
+};
+
+/**
+ * Create a pdf using the platform pdf generator tool
+ * @param {Boolean} pdfName what the pdf file should be named
+ * @param {Object} pdfData data to be passed to pdf generator
+ * @param {String} sentryError name of the app feature where the call originated
+ * @param {Boolean} runningUnitTest pass true when running unit tests because calling generatePdf will break unit tests
+ */
+export const makePdf = async (
+  pdfName,
+  pdfData,
+  sentryError,
+  runningUnitTest,
+) => {
+  try {
+    if (!runningUnitTest) {
+      await generatePdf('medicalRecords', pdfName, pdfData);
+    }
+  } catch (error) {
+    sendErrorToSentry(error, sentryError);
+  }
 };


### PR DESCRIPTION
## Summary

I added unit test coverage to the Medical Records app along with minor tweaks to enable testing of various statements, branches, functions, and lines. 

The changes I made to the code to enable testing include some slight refactoring and removal of unnecessary, redundant, and unreachable branches in the code. This included single if statements within content functions checking for a record being refactored to `{record && content())`. 

I also moved EMPTY_FIELD fill-ins to the reducer so that the data is being completely set up in mapping functions, instead of coming into the component incomplete and then being filled in there. 

I had to add a testing parameter (`runningUnitTest`) to components that call `generatePdf` so that the containing function block could be run, but the actual call to `generatePdf` would not be run, as it cannot be run in a testing environment, and breaks the test. I added the same parameter in the MrApi.js file to enable testing of the API calls. 

I also added additional mock data with varying data to enable testing of specific branches in the code. 

Other changes:
1. Removed "requested by" verbiage option for labs and tests since “ordered by” is the only verbiage used in the latest mockups. 
2. Dried up code in MrApi.js for the sake of reducing repetitive code. 
3. Dried up the pdf creation code processing to reduce repetitive code. 
4. Removed redundant date formatting and moved all data mapping to reducer functions
5. Changed content functions so that they are never called if the record is missing, rather than having them return `<></>`
6. Cleaned up generatePdf calls’ arguments so that they are not being passed a multiline argument directly in the invocation, but rather being passed a variable containing a multiline argument. 
7. Changed switch statements to if else statements to prevent the use of erroneous default cases such as `<p>Something else</p>`. Did this for CareSummariesDetails.jsx and LabAndTestDetails.jsx types. 
8. Fixed fields in jsx to match reducer fields
9. Fixed mock data fields to match fields required by mapping functions in reducers. 
10. Refactored unit tests to use mocha's beforeEach function instead of a 'setup' function, which does the same thing but is non-standard. 

## Related issue(s)
### [MHV-49977](https://jira.devops.va.gov/browse/MHV-49977) - Increase frontend unit test coverage to 80% ###

> Frontend test coverage must be at least 80%. This is a launch-blocking issue.

<img width="948" alt="Screenshot 2023-10-12 at 10 28 42 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/cb2255ac-4321-4fa9-933d-af87a9515511">

## Testing done

- This ticket was entirely based on writing unit tests

## Screenshots
No UI changes made, but here are before and after screenshots of unit test coverage: 

<img width="1728" alt="Screenshot 2023-10-16 at 2 19 29 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/11a7f5dd-c734-4a14-9288-bdd77fbfae58">
<img width="1728" alt="Screenshot 2023-10-16 at 2 18 44 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/7a9f1a15-70ce-4316-87a0-ea0d68851d5e">

## What areas of the site does it impact?
MHV Medical Records

## Acceptance criteria
Increase unit test coverage to 80%. 

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
