### PR TITLE
partial hotfix to  import error

### DIFF
--- a/src/applications/simple-forms/21-0966/config/helpers.js
+++ b/src/applications/simple-forms/21-0966/config/helpers.js
@@ -1,5 +1,5 @@
 import set from '@department-of-veterans-affairs/platform-forms-system/set';
-import { createInitialState } from '@department-of-veterans-affairs/platform-forms-system/exports';
+import { createInitialState } from '@department-of-veterans-affairs/platform-forms-system/state/helpers';
 import {
   preparerIdentifications,
   veteranBenefits,


### PR DESCRIPTION
The 'exports' alias  for platform-forms-system fails to resolve; I have not been able to pin point why exactly, but  fortunately  we should be able to import the same module using a direct alias. 

This is also  partial cause to an error in the cypress stress test. 