### PR TITLE
Check user claims for disability rating api calls in Profile

### DIFF
--- a/src/applications/personalization/components/NameTag.jsx
+++ b/src/applications/personalization/components/NameTag.jsx
@@ -52,11 +52,9 @@ const DisabilityRatingContent = ({ rating }) => {
           style={{ whiteSpace: 'nowrap' }}
         >
           <strong>
-            {rating ? (
-              <>{rating}% service connected </>
-            ) : (
-              <>View disability rating </>
-            )}
+            {rating
+              ? `${rating}% service connected`
+              : 'View disability rating '}
           </strong>
           <i
             aria-hidden="true"

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -314,8 +314,11 @@ const mapStateToProps = state => {
   // 47841 block profile access for deceased, fiduciary flagged, and incompetent veterans
   const isBlocked = selectIsBlocked(state);
 
-  const shouldFetchTotalDisabilityRating =
-    isLOA3 && isInMVI && canAccess(state)?.ratingInfo;
+  const shouldFetchTotalDisabilityRating = !!(
+    isLOA3 &&
+    isInMVI &&
+    canAccess(state)?.ratingInfo
+  );
 
   // this piece of state will be set if the call to load military info succeeds
   // or fails:

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -53,6 +53,7 @@ import getRoutes from '../routes';
 import { PROFILE_PATHS } from '../constants';
 
 import ProfileWrapper from './ProfileWrapper';
+import { canAccess } from '../../common/selectors';
 
 class Profile extends Component {
   componentDidMount() {
@@ -313,7 +314,8 @@ const mapStateToProps = state => {
   // 47841 block profile access for deceased, fiduciary flagged, and incompetent veterans
   const isBlocked = selectIsBlocked(state);
 
-  const shouldFetchTotalDisabilityRating = isLOA3 && isInMVI;
+  const shouldFetchTotalDisabilityRating =
+    isLOA3 && isInMVI && canAccess(state)?.ratingInfo;
 
   // this piece of state will be set if the call to load military info succeeds
   // or fails:

--- a/src/applications/personalization/profile/mocks/endpoints/user/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/user/index.js
@@ -1404,6 +1404,7 @@ const mockErrorResponses = {
   },
 };
 
+// users with various contact info missing
 const loa3UserWithNoMobilePhone = set(
   cloneDeep(baseUserResponses.loa3User72),
   'data.attributes.vet360ContactInformation.mobilePhone',
@@ -1428,6 +1429,20 @@ const loa3UserWithNoHomeAddress = set(
   null,
 );
 
+// users with various data claims missing
+// this user has no rating info claim and therefore should not request the rating_info endpoint
+const loa3UserWithNoRatingInfoClaim = set(
+  cloneDeep(baseUserResponses.loa3User72),
+  'data.attributes.profile.claims.ratingInfo',
+  false,
+);
+
+const loa3UserWithNoMilitaryHistoryClaim = set(
+  cloneDeep(baseUserResponses.loa3User72),
+  'data.attributes.profile.claims.militaryHistory',
+  false,
+);
+
 const responses = {
   ...baseUserResponses,
   ...mockErrorResponses,
@@ -1442,6 +1457,8 @@ const responses = {
     ],
   ),
   loa3UserWithNoHomeAddress,
+  loa3UserWithNoRatingInfoClaim,
+  loa3UserWithNoMilitaryHistoryClaim,
 };
 
 // handler that can be used to customize the user data returned

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -77,7 +77,7 @@ const responses = {
     // example user data cases
     // return res.json(user.loa3User72); // default user (success)
     // return res.json(user.loa1User); // user with loa1
-    return res.json(user.badAddress); // user with bad address
+    // return res.json(user.badAddress); // user with bad address
     // return res.json(user.loa3User); // user with loa3
     // return res.json(user.nonVeteranUser); // non-veteran user
     // return res.json(user.externalServiceError); // external service error
@@ -85,6 +85,10 @@ const responses = {
     // return res.json(user.loa3UserWithNoEmail); // user with no email address
     // return res.json(user.loa3UserWithNoEmailOrMobilePhone); // user without email or mobile phone
     // return res.json(user.loa3UserWithNoHomeAddress); // home address is null
+
+    // data claim users
+    return res.json(user.loa3UserWithNoRatingInfoClaim);
+    // return res.json(user.loa3UserWithNoMilitaryHistoryClaim);
   },
   'GET /v0/profile/status': status.success,
   'OPTIONS /v0/maintenance_windows': 'OK',
@@ -159,6 +163,9 @@ const responses = {
     return res.status(200).json(bankAccounts.saved.success);
   },
   'GET /v0/profile/service_history': (_req, res) => {
+    // user doesnt have any service history or is not authorized
+    // return res.status(403).json(genericErrors.error403);
+
     return res.status(200).json(serviceHistory.airForce);
     // return res
     //   .status(200)

--- a/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
@@ -304,6 +304,28 @@ describe('mapStateToProps', () => {
     });
   });
 
+  describe('#shouldFetchTotalDisabilityRating', () => {
+    it('is falsey when the user is LOA3 and has no claim in user object', () => {
+      const state = makeDefaultState();
+      const props = mapStateToProps(state);
+      expect(props.shouldFetchTotalDisabilityRating).to.not.be.true;
+    });
+
+    it('is falsey when the user is LOA3 and profile.claims.ratingInfo is explicitly false', () => {
+      const state = makeDefaultState();
+      state.user.profile.claims = { ratingInfo: false };
+      const props = mapStateToProps(state);
+      expect(props.shouldFetchTotalDisabilityRating).to.not.be.true;
+    });
+
+    it('is truthy when the user is LOA3 and profile.claims.ratingInfo is explicitly true', () => {
+      const state = makeDefaultState();
+      state.user.profile.claims = { ratingInfo: true };
+      const props = mapStateToProps(state);
+      expect(props.shouldFetchTotalDisabilityRating).to.be.true;
+    });
+  });
+
   describe('#shouldFetchCNPDirectDepositInformation', () => {
     it('is `true` when ID.me user has 2FA set and has access to EVSS', () => {
       const state = makeDefaultState();

--- a/src/applications/personalization/profile/tests/e2e/profile-user-claims.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-user-claims.cypress.spec.js
@@ -1,0 +1,51 @@
+import { success } from '@@profile/mocks/endpoints/rating-info';
+
+import { checkForWebComponentLoadingIndicator } from '~/applications/personalization/common/e2eHelpers';
+import mockUser from '../fixtures/users/user-36.json';
+import { PROFILE_PATHS } from '../../constants';
+import { mockProfileLOA3 } from './helpers';
+
+import user from '../../mocks/endpoints/user';
+
+describe('Profile - Data Claims', () => {
+  beforeEach(() => {
+    cy.login(mockUser);
+    mockProfileLOA3();
+  });
+
+  it('should request rating_info when user claim - ratingInfo is TRUE', () => {
+    cy.intercept('v0/user', user.loa3User72);
+    cy.intercept(
+      '/v0/disability_compensation_form/rating_info',
+      success.serviceConnected40,
+    ).as('getRatingInfo');
+
+    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+    checkForWebComponentLoadingIndicator();
+
+    cy.wait('@getRatingInfo');
+
+    cy.findByText('40% service connected');
+
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('should NOT request rating_info when user claim - ratingInfo is FALSE', () => {
+    cy.intercept('v0/user', user.loa3UserWithNoRatingInfoClaim);
+    cy.intercept(
+      '/v0/disability_compensation_form/rating_info',
+      cy.spy().as('getRatingInfoSpy'),
+    );
+
+    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+    checkForWebComponentLoadingIndicator();
+
+    cy.findByText('40% service connected').should('not.exist');
+
+    cy.get('@getRatingInfoSpy').should('not.have.been.called');
+
+    cy.injectAxeThenAxeCheck();
+  });
+});


### PR DESCRIPTION
## Summary

- To decrease overall api chatter and minimize false errors in our logging tools, we have added a check to determine whether the Profile application should request the `rating_info` api endpoint. Since no check was being done before, then the rating_info endpoint would frequently return a 404 when the user was ineligible for a rating (non-veterans and other use cases)
- The user endpoint will return a claims property, which informs the frontend what endpoints should get hits, and so we are using the `ratingInfo` property from the claims for this logic. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/65019

## Testing done

- E2E test added for claims true and false
- Unit test added for main profile component and map to state logic where claims data is used

## Screenshots

No visual changes, just updates to logic that determines what api calls are made

## What areas of the site does it impact?

Profile

## Acceptance criteria

- `rating_info` endpoint is only called when `claims.ratingInfo` is true.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed