### PR TITLE
[#mhv-50220] fixed content issue

### DIFF
--- a/src/applications/mhv/medications/components/PrescriptionDetails/VaPrescription.jsx
+++ b/src/applications/mhv/medications/components/PrescriptionDetails/VaPrescription.jsx
@@ -106,13 +106,6 @@ const VaPrescription = prescription => {
               Quantity
             </h3>
             <p>{validateField(prescription.quantity)}</p>
-            <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-              What it looks like
-            </h3>
-            <p>
-              Your medication may look different when you get a refill. Find the
-              most recent image in your refill history.
-            </p>
           </div>
 
           <div className="vads-u-border-top--1px vads-u-border-color--gray-lighter">
@@ -147,18 +140,18 @@ const VaPrescription = prescription => {
                   Image of the medication or supply
                 </h4>
                 <div className="no-print">
-                  <va-additional-info trigger="Review image">
-                    {entry.cmopNdcNumber ? (
+                  {entry.cmopNdcNumber ? (
+                    <va-additional-info trigger="Review image">
                       <img
                         src={getImageUri(entry.cmopNdcNumber)}
                         alt={entry.prescriptionName}
                         width="350"
                         height="350"
                       />
-                    ) : (
-                      <p>No Image Available</p>
-                    )}
-                  </va-additional-info>
+                    </va-additional-info>
+                  ) : (
+                    <p className="vads-u-margin--0">No Image Available</p>
+                  )}
                 </div>
                 <div className="print-only">
                   {entry.cmopNdcNumber ? (


### PR DESCRIPTION
## Summary
Removes "what does it look like" field and makes the "No image available" appear without the dropdown (dropdown only appears if there is an image inside it).

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-50220

> Link to staging ticket: [[Content styleguide] The content has incorrect information. (05.06.1) · Issue #67301 · department-of-veterans-affairs/va.gov-team · GitHub](https://github.com/department-of-veterans-affairs/va.gov-team/issues/67301)
> 
> Sketch link to solution: [Sketch - Details page/Desktop/Tacrolimus 1MG refillable](https://www.sketch.com/s/11f59942-a697-451c-ac26-6624754b2616/a/YZvrZML#Version)
> 
> About Medications, >Medications, >[name of medication] >About this medication or supply >What it looks like:
> 
> ISSUE: In all cases for all medications filled through the VA, the content that appears beneath the subheading "what it looks like" is neither an image nor a description of the medication.
> SOLUTION:
> Get rid of "what it looks like field"
> Also when no image available it should not be a drop down but just shown as plain text.
> 

## Testing done
All unit tests passing locally, behavior is as expected locally.

## Screenshots
![Screen Shot 2023-10-19 at 1 18 07 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/108146636/273e18c8-1010-467d-a395-410bf06f4cc3)

## What areas of the site does it impact?
my-health/medications

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
