### PR TITLE
MHV-50632 Fixed verbiage

### DIFF
--- a/src/applications/mhv/medical-records/components/RecordList/AllergyListItem.jsx
+++ b/src/applications/mhv/medical-records/components/RecordList/AllergyListItem.jsx
@@ -51,7 +51,7 @@ const AllergyListItem = props => {
           </span>
         </div>
         <div className="print-only">
-          <span className="field-label">Observed or reported:</span>{' '}
+          <span className="field-label">Observed or historical:</span>{' '}
           <span className="vads-u-display--inline-block" data-dd-privacy="mask">
             {record.observedOrReported}
           </span>


### PR DESCRIPTION
## Summary

Single-word word change in Allergies List print view. Reported should be Historical.

## Related issue(s)

### [MHV-50632](https://jira.devops.va.gov/browse/MHV-50632) - Fix Historical-vs-Reported in Allergies print list view ###

> In allergies list print view, we are still using the term "reported" instead of "historical" for the field "Observed or historical"
> 
> Please correct the terminology.
> 
> It is located in AllergyListItem.jsx

## Testing done

- No testing for single-word content change

## Screenshots

<img width="527" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/84e42f51-9c93-4b3d-ad4c-c482fed61aff">

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
