### PR TITLE
Check in/66707/add aria labels to appointment list

### DIFF
--- a/src/applications/check-in/components/UpcomingAppointmentsList.jsx
+++ b/src/applications/check-in/components/UpcomingAppointmentsList.jsx
@@ -48,31 +48,50 @@ const UpcomingAppointmentsList = props => {
             <h3 data-testid="appointments-list-monthyear-heading">
               {t('date-month-and-year', { date: monthDate })}
             </h3>
-            <ul
-              className="vads-u-margin-bottom--4 check-in--appointment-list appointment-list"
-              data-testid="appointment-list"
-            >
-              {days.map((day, dayIndex) => {
-                const { appointments } = day;
-                return (
-                  <React.Fragment key={dayIndex}>
-                    {appointments.map((appointment, index) => {
-                      return (
-                        <UpcomingAppointmentsListItem
-                          dayKey={index === 0}
-                          key={`${appointment.appointmentIen}-${
-                            appointment.stationNo
-                          }`}
-                          appointment={appointment}
-                          goToDetails={handleDetailClick}
-                          router={router}
-                        />
-                      );
-                    })}
-                  </React.Fragment>
-                );
-              })}
-            </ul>
+            {days.map((day, index) => {
+              const { appointments } = day;
+              const dayStartTime = new Date(appointments[0].startTime);
+              return (
+                <div
+                  className="vads-l-grid-container vads-u-padding-x--0"
+                  key={index}
+                >
+                  <div className="vads-l-row">
+                    <div className="vads-l-col--2 vads-u-border-top--1px">
+                      <h4
+                        className="vads-u-text-align--center vads-u-line-height--2 vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-top--2"
+                        data-testid="day-label"
+                      >
+                        <span className="vads-u-font-size--md vads-u-font-weight--bold">
+                          {`${t('date-day-of-month', { date: dayStartTime })} `}
+                        </span>
+                        <br />
+                        {t('date-day-of-week', { date: dayStartTime })}
+                      </h4>
+                    </div>
+                    <div className="vads-l-col--10 vads-u-border-top--1px">
+                      <ul
+                        className="vads-u-margin-bottom--4 check-in--appointment-list appointment-list"
+                        data-testid="appointment-list"
+                      >
+                        {appointments.map(appointment => {
+                          return (
+                            <UpcomingAppointmentsListItem
+                              key={`${appointment.appointmentIen}-${
+                                appointment.stationNo
+                              }`}
+                              appointment={appointment}
+                              goToDetails={handleDetailClick}
+                              router={router}
+                            />
+                          );
+                        })}
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
           </div>
         );
       })}

--- a/src/applications/check-in/components/UpcomingAppointmentsListItem.jsx
+++ b/src/applications/check-in/components/UpcomingAppointmentsListItem.jsx
@@ -18,6 +18,9 @@ const UpcomingAppointmentsListItem = props => {
     <li
       className="check-in--appointment-item"
       data-testid="appointment-list-item"
+      aria-label={t('appointment-on-date-at-time', {
+        dateTime: appointmentDateTime,
+      })}
     >
       <div className="vads-l-grid-container vads-u-padding-x--0">
         <div className="vads-l-row">
@@ -94,8 +97,8 @@ const UpcomingAppointmentsListItem = props => {
                   router.location.basename
                 }/appointment-details/${getAppointmentId(appointment)}`}
                 onClick={e => goToDetails(e, appointment)}
-                aria-label={t('details-for-appointment', {
-                  time: appointmentDateTime,
+                aria-label={t('details-for-appointment-on-date-at-time', {
+                  dateTime: appointmentDateTime,
                   type: appointment.clinicStopCodeName
                     ? appointment.clinicStopCodeName
                     : 'VA',

--- a/src/applications/check-in/components/UpcomingAppointmentsListItem.jsx
+++ b/src/applications/check-in/components/UpcomingAppointmentsListItem.jsx
@@ -28,7 +28,7 @@ const UpcomingAppointmentsListItem = props => {
           >
             {dayKey && (
               <h4
-                className="vads-u-text-align--center vads-u-line-height--2 vads-u-font-family--sans vads-u-font-weight--normal vads-u-"
+                className="vads-u-text-align--center vads-u-line-height--2 vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-top--2"
                 data-testid="day-label"
               >
                 <span className="vads-u-font-size--md vads-u-font-weight--bold">

--- a/src/applications/check-in/components/UpcomingAppointmentsListItem.jsx
+++ b/src/applications/check-in/components/UpcomingAppointmentsListItem.jsx
@@ -18,9 +18,6 @@ const UpcomingAppointmentsListItem = props => {
     <li
       className="check-in--appointment-item"
       data-testid="appointment-list-item"
-      aria-label={t('appointment-on-date-at-time', {
-        dateTime: appointmentDateTime,
-      })}
     >
       <div className="vads-l-grid-container vads-u-padding-x--0">
         <div className="vads-l-row">
@@ -30,18 +27,16 @@ const UpcomingAppointmentsListItem = props => {
             }`}
           >
             {dayKey && (
-              <div
-                className="vads-u-text-align--center"
+              <h4
+                className="vads-u-text-align--center vads-u-line-height--2 vads-u-font-family--sans vads-u-font-weight--normal vads-u-"
                 data-testid="day-label"
               >
-                <p className="vads-u-line-height--2">
-                  {`${t('date-day-of-week', { date: appointmentDateTime })} `}
-                  <br />
-                  <span className="vads-u-font-size--md vads-u-font-weight--bold">
-                    {t('date-day-of-month', { date: appointmentDateTime })}
-                  </span>
-                </p>
-              </div>
+                <span className="vads-u-font-size--md vads-u-font-weight--bold">
+                  {`${t('date-day-of-month', { date: appointmentDateTime })} `}
+                </span>
+                <br />
+                {t('date-day-of-week', { date: appointmentDateTime })}
+              </h4>
             )}
           </div>
           <div className="vads-l-col--10 vads-u-border-top--1px">

--- a/src/applications/check-in/components/UpcomingAppointmentsListItem.jsx
+++ b/src/applications/check-in/components/UpcomingAppointmentsListItem.jsx
@@ -9,7 +9,7 @@ import {
 } from '../utils/appointment';
 
 const UpcomingAppointmentsListItem = props => {
-  const { appointment, goToDetails, dayKey, router } = props;
+  const { appointment, goToDetails, router } = props;
   const { t } = useTranslation();
   const appointmentDateTime = new Date(appointment.startTime);
   const clinic = clinicName(appointment);
@@ -19,91 +19,63 @@ const UpcomingAppointmentsListItem = props => {
       className="check-in--appointment-item"
       data-testid="appointment-list-item"
     >
-      <div className="vads-l-grid-container vads-u-padding-x--0">
-        <div className="vads-l-row">
-          <div
-            className={`vads-l-col--2${
-              dayKey ? ' vads-u-border-top--1px' : ''
-            }`}
-          >
-            {dayKey && (
-              <h4
-                className="vads-u-text-align--center vads-u-line-height--2 vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-top--2"
-                data-testid="day-label"
-              >
-                <span className="vads-u-font-size--md vads-u-font-weight--bold">
-                  {`${t('date-day-of-month', { date: appointmentDateTime })} `}
-                </span>
-                <br />
-                {t('date-day-of-week', { date: appointmentDateTime })}
-              </h4>
-            )}
-          </div>
-          <div className="vads-l-col--10 vads-u-border-top--1px">
-            <div
-              className="vads-u-margin-top--1p5"
-              data-testid="appointment-time"
-            >
-              {t('date-time', { date: appointmentDateTime })}
-            </div>
-            <div
-              data-testid="appointment-type-and-provider"
-              className="vads-u-font-weight--bold"
-            >
-              {appointment.clinicStopCodeName
-                ? appointment.clinicStopCodeName
-                : t('VA-appointment')}
-              {appointment.doctorName
-                ? ` ${t('with')} ${appointment.doctorName}`
-                : ''}
-            </div>
-            <div className="vads-u-display--flex vads-u-align-items--baseline">
-              <div
-                data-testid="appointment-kind-icon"
-                className="vads-u-margin-right--1 check-in--label"
-              >
-                {appointmentIcon(appointment)}
-              </div>
-              <div
-                data-testid="appointment-kind-and-location"
-                className="vads-u-display--inline"
-              >
-                {appointment?.kind === 'phone' ? (
-                  t('phone')
-                ) : (
-                  <>
-                    {t('in-person')} {appointment.facility}
-                  </>
-                )}
-              </div>
-            </div>
-            <div>
-              {appointment?.kind === 'clinic' && (
-                <>
-                  {t('clinic')}: {clinic}
-                </>
-              )}
-            </div>
-
-            <div className="vads-u-margin-y--1p5">
-              <a
-                data-testid="details-link"
-                href={`${
-                  router.location.basename
-                }/appointment-details/${getAppointmentId(appointment)}`}
-                onClick={e => goToDetails(e, appointment)}
-                aria-label={t('details-for-appointment-on-date-at-time', {
-                  dateTime: appointmentDateTime,
-                  type: appointment.clinicStopCodeName
-                    ? appointment.clinicStopCodeName
-                    : 'VA',
-                })}
-              >
-                {t('details')}
-              </a>
-            </div>
-          </div>
+      <div className="vads-u-margin-top--1p5" data-testid="appointment-time">
+        {t('date-time', { date: appointmentDateTime })}
+      </div>
+      <div
+        data-testid="appointment-type-and-provider"
+        className="vads-u-font-weight--bold"
+      >
+        {appointment.clinicStopCodeName
+          ? appointment.clinicStopCodeName
+          : t('VA-appointment')}
+        {appointment.doctorName
+          ? ` ${t('with')} ${appointment.doctorName}`
+          : ''}
+      </div>
+      <div className="vads-u-display--flex vads-u-align-items--baseline">
+        <div
+          data-testid="appointment-kind-icon"
+          className="vads-u-margin-right--1 check-in--label"
+        >
+          {appointmentIcon(appointment)}
         </div>
+        <div
+          data-testid="appointment-kind-and-location"
+          className="vads-u-display--inline"
+        >
+          {appointment?.kind === 'phone' ? (
+            t('phone')
+          ) : (
+            <>
+              {t('in-person')} {appointment.facility}
+            </>
+          )}
+        </div>
+      </div>
+      <div>
+        {appointment?.kind === 'clinic' && (
+          <>
+            {t('clinic')}: {clinic}
+          </>
+        )}
+      </div>
+      <div className="vads-u-margin-y--1p5">
+        <a
+          data-testid="details-link"
+          href={`${
+            router.location.basename
+          }/appointment-details/${getAppointmentId(appointment)}`}
+          onClick={e => goToDetails(e, appointment)}
+          aria-label={t('details-for-appointment-on-date-at-time', {
+            dateTime: appointmentDateTime,
+            type: appointment.clinicStopCodeName
+              ? appointment.clinicStopCodeName
+              : 'VA',
+          })}
+        >
+          {t('details')}
+        </a>
       </div>
     </li>
   );
@@ -111,7 +83,6 @@ const UpcomingAppointmentsListItem = props => {
 
 UpcomingAppointmentsListItem.propTypes = {
   appointment: PropTypes.object.isRequired,
-  dayKey: PropTypes.bool,
   goToDetails: PropTypes.func,
   router: PropTypes.object,
 };

--- a/src/applications/check-in/components/tests/UpcomingAppointmentsList.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/UpcomingAppointmentsList.unit.spec.jsx
@@ -21,12 +21,11 @@ describe('unified check-in experience', () => {
       expect(getAllByTestId('appointment-list-item').length).to.equal(3);
     });
     it('displays the upcoming appointments list items components with day of the week headings properly', () => {
-      const mockstore = {
-        upcomingAppointments: multipleAppointments,
-      };
       const { getByTestId, getAllByTestId } = render(
-        <CheckInProvider store={mockstore}>
-          <UpcomingAppointmentsList />
+        <CheckInProvider>
+          <UpcomingAppointmentsList
+            upcomingAppointments={multipleAppointments}
+          />
         </CheckInProvider>,
       );
       expect(getAllByTestId('day-label')).to.have.length(1);
@@ -34,22 +33,21 @@ describe('unified check-in experience', () => {
     });
     it('displays the no upcoming appointments info message when there are no appointments', () => {
       const { getByTestId } = render(
-        <CheckInProvider upcomingAppointments={[]}>
-          <UpcomingAppointmentsList />
+        <CheckInProvider>
+          <UpcomingAppointmentsList upcomingAppointments={[]} />
         </CheckInProvider>,
       );
 
       expect(getByTestId('no-upcoming-appointments')).to.exist;
     });
     it('should call handleDetailClick when details link is clicked', () => {
-      const mockstore = {
-        upcomingAppointments: multipleAppointments,
-      };
       const push = sinon.spy();
       const router = { push };
       const { getAllByTestId } = render(
-        <CheckInProvider store={mockstore} router={router}>
-          <UpcomingAppointmentsList />
+        <CheckInProvider router={router}>
+          <UpcomingAppointmentsList
+            upcomingAppointments={multipleAppointments}
+          />
         </CheckInProvider>,
       );
       const detailsLink = getAllByTestId('details-link')[0];

--- a/src/applications/check-in/components/tests/UpcomingAppointmentsList.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/UpcomingAppointmentsList.unit.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
+import sinon from 'sinon';
 import CheckInProvider from '../../tests/unit/utils/CheckInProvider';
 import { multipleAppointments } from '../../tests/unit/mocks/mock-appointments';
 import UpcomingAppointmentsList from '../UpcomingAppointmentsList';
@@ -39,6 +40,21 @@ describe('unified check-in experience', () => {
       );
 
       expect(getByTestId('no-upcoming-appointments')).to.exist;
+    });
+    it('should call handleDetailClick when details link is clicked', () => {
+      const mockstore = {
+        upcomingAppointments: multipleAppointments,
+      };
+      const push = sinon.spy();
+      const router = { push };
+      const { getAllByTestId } = render(
+        <CheckInProvider store={mockstore} router={router}>
+          <UpcomingAppointmentsList />
+        </CheckInProvider>,
+      );
+      const detailsLink = getAllByTestId('details-link')[0];
+      fireEvent.click(detailsLink);
+      sinon.assert.calledOnce(push);
     });
   });
 });

--- a/src/applications/check-in/components/tests/UpcomingAppointmentsList.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/UpcomingAppointmentsList.unit.spec.jsx
@@ -19,6 +19,18 @@ describe('unified check-in experience', () => {
       expect(getByTestId('appointment-list')).to.exist;
       expect(getAllByTestId('appointment-list-item').length).to.equal(3);
     });
+    it('displays the upcoming appointments list items components with day of the week headings properly', () => {
+      const mockstore = {
+        upcomingAppointments: multipleAppointments,
+      };
+      const { getByTestId, getAllByTestId } = render(
+        <CheckInProvider store={mockstore}>
+          <UpcomingAppointmentsList />
+        </CheckInProvider>,
+      );
+      expect(getAllByTestId('day-label')).to.have.length(1);
+      expect(getByTestId('day-label')).to.have.text('3 Mon');
+    });
     it('displays the no upcoming appointments info message when there are no appointments', () => {
       const { getByTestId } = render(
         <CheckInProvider upcomingAppointments={[]}>

--- a/src/applications/check-in/components/tests/UpcomingAppointmentsListItem.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/UpcomingAppointmentsListItem.unit.spec.jsx
@@ -51,7 +51,7 @@ describe('unified check-in experience', () => {
           />
         </CheckInProvider>,
       );
-      expect(screen.getByTestId('day-label')).to.have.text('Tue 16');
+      expect(screen.getByTestId('day-label')).to.have.text('16 Tue');
 
       expect(screen.getByTestId('appointment-time')).to.have.text('9:39 p.m.');
 

--- a/src/applications/check-in/components/tests/UpcomingAppointmentsListItem.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/UpcomingAppointmentsListItem.unit.spec.jsx
@@ -46,12 +46,10 @@ describe('unified check-in experience', () => {
           <UpcomingAppointmentsListItem
             appointment={appointments[0]}
             goToDetails={goToDetails}
-            dayKey
             router={mockRouter}
           />
         </CheckInProvider>,
       );
-      expect(screen.getByTestId('day-label')).to.have.text('16 Tue');
 
       expect(screen.getByTestId('appointment-time')).to.have.text('9:39 p.m.');
 
@@ -65,19 +63,6 @@ describe('unified check-in experience', () => {
 
       fireEvent.click(screen.getByTestId('details-link'));
       expect(goToDetails.calledOnce).to.be.true;
-    });
-    it('should not render a day label if none is provided', () => {
-      const screen = render(
-        <CheckInProvider>
-          <UpcomingAppointmentsListItem
-            appointment={appointments[0]}
-            goToDetails={goToDetails}
-            dayKey=""
-            router={mockRouter}
-          />
-        </CheckInProvider>,
-      );
-      expect(screen.queryByTestId('day-label')).to.not.exist;
     });
     it('should indicate that it is a phone appointment', () => {
       const screen = render(
@@ -100,7 +85,6 @@ describe('unified check-in experience', () => {
           <UpcomingAppointmentsListItem
             appointment={appointments[1]}
             goToDetails={goToDetails}
-            dayKey=""
             router={mockRouter}
           />
         </CheckInProvider>,

--- a/src/applications/check-in/day-of/routes.jsx
+++ b/src/applications/check-in/day-of/routes.jsx
@@ -46,6 +46,7 @@ const routes = [
       requiresForm: true,
       requireAuthorization: true,
     },
+    reloadable: true,
   },
   {
     path: URLS.DEMOGRAPHICS,

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -277,5 +277,7 @@
   "day-of-week-month-day-time": "{{ date, day }}, {{ date, monthDay }}, {{ date, time }}",
   "in-person-appointments": "In-person appointments",
   "phone-appointments": "Phone appointments",
-  "check-in-now-for-your-date-time-appointment": "Check in now for appointment on {{ date, day }}, {{ date, monthDay }} at {{ date, time }}"
+  "check-in-now-for-your-date-time-appointment": "Check in now for appointment on {{ date, day }}, {{ date, monthDay }} at {{ date, time }}",
+  "details-for-appointment-on-date-at-time": "Details for {{ type }} appointment on {{ dateTime, date }} at {{ dateTime, time }}",
+  "appointment-on-date-at-time": "Appointment on {{dateTime, date}} at {{ dateTime, time}}"
 }

--- a/src/applications/check-in/pre-check-in/routes.jsx
+++ b/src/applications/check-in/pre-check-in/routes.jsx
@@ -41,6 +41,7 @@ const routes = [
       requiresForm: true,
       requireAuthorization: true,
     },
+    reloadable: true,
   },
   {
     path: URLS.DEMOGRAPHICS,

--- a/src/applications/check-in/tests/e2e/pages/AppointmentsPage.js
+++ b/src/applications/check-in/tests/e2e/pages/AppointmentsPage.js
@@ -73,7 +73,7 @@ class AppointmentsPage {
   };
 
   validateUpcomingAppointmentsList = () => {
-    const expectedDaySeparators = ['Tue 26', 'Wed 27', 'Sun 26'];
+    const expectedDaySeparators = ['26 Tue', '27 Wed', '26 Sun'];
     const expectedTimeOrder = ['2:00', '3:00', '4:00', '2:00', '2:00'];
     cy.get('[data-testid="appointments-list-monthyear-heading"]', {
       timeout: Timeouts.slow,

--- a/src/applications/check-in/utils/i18n/i18n.js
+++ b/src/applications/check-in/utils/i18n/i18n.js
@@ -74,6 +74,9 @@ i18n
           if (format === 'dayOfMonth') {
             return formatDate(value, 'd', { locale });
           }
+          if (format === 'date') {
+            return formatDate(value, 'E, MMMM do', { locale });
+          }
           return formatDate(value, format, { locale });
         }
         return value;


### PR DESCRIPTION
## Summary

- Changes the way we do aria-labels on the upcoming appointments list
- The only aria-label is on the details link
- Makes the day labels (ex: 23 Mon) heading level 4

## Related issue(s)

- [department-of-veterans-affairs/va.gov-team#66707](https://github.com/department-of-veterans-affairs/va.gov-team/issues/66707)

## Testing done

- Cypress
- Visual
- unit

## Screenshots
![Screenshot 2023-10-23 at 10 52 12 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/2982977/6750e0bc-58e2-46f7-9810-75c1d0495815)

## What areas of the site does it impact?

Check-in -> unified release 2 -> upcoming appointments list

## Acceptance criteria

- Day separators have a heading level of 4
- Use of aria-label is restricted to interactive elements only(details links)
- Detail links have correct aria-label 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)


