### PR TITLE
Display the date correctly for next steps paragraph in 21-0966

### DIFF
--- a/src/applications/simple-forms/21-0966/config/helpers.js
+++ b/src/applications/simple-forms/21-0966/config/helpers.js
@@ -267,27 +267,29 @@ export const getNextStepsTextSecondParagraph = (
   alreadySubmittedIntents,
   newExpirationDate,
 ) => {
-  const benefitSelection = benefitSelections(data)[0].toLowerCase();
-  if (benefitSelections(data).length > 1) {
-    if (
-      alreadySubmittedIntents?.compensation &&
-      alreadySubmittedIntents?.pension
-    ) {
-      return `Your intent to file for disability compensation expires on ${
-        alreadySubmittedIntents.compensation.expirationDate
-      } and your intent to file for pension claims expires on ${
-        alreadySubmittedIntents.pension.expirationDate
-      }. You’ll need to file your claims by these dates to get retroactive payments (payments for the time between when you submit your intent to file and when we approve your claim).`;
-    }
-    return 'You’ll need to file your claims within 1 year to get retroactive payments (payments for the time between when you submit your intent to file and when we approve your claim).';
-  }
-
   const dateOptions = {
     weekday: 'long',
     year: 'numeric',
     month: 'long',
     day: 'numeric',
   };
+  const benefitSelection = benefitSelections(data)[0].toLowerCase();
+  if (benefitSelections(data).length > 1) {
+    if (
+      alreadySubmittedIntents?.compensation &&
+      alreadySubmittedIntents?.pension
+    ) {
+      const compensationExpirationDate = new Date(
+        alreadySubmittedIntents.compensation.expirationDate,
+      ).toLocaleDateString('en-US', dateOptions);
+      const pensionExpirationDate = new Date(
+        alreadySubmittedIntents.pension.expirationDate,
+      ).toLocaleDateString('en-US', dateOptions);
+      return `Your intent to file for disability compensation expires on ${compensationExpirationDate} and your intent to file for pension claims expires on ${pensionExpirationDate}. You’ll need to file your claims by these dates to get retroactive payments (payments for the time between when you submit your intent to file and when we approve your claim).`;
+    }
+    return 'You’ll need to file your claims within 1 year to get retroactive payments (payments for the time between when you submit your intent to file and when we approve your claim).';
+  }
+
   let expirationDate = newExpirationDate;
   const oldExpirationDate =
     alreadySubmittedIntents[benefitSelection]?.expirationDate;

--- a/src/applications/simple-forms/21-0966/tests/config/helpers.unit.spec.js
+++ b/src/applications/simple-forms/21-0966/tests/config/helpers.unit.spec.js
@@ -583,7 +583,16 @@ describe('confirmation page helper functions', () => {
           [veteranBenefits.pension]: true,
         },
       };
-      const expirationDate = 'expiration-date';
+      const dateOptions = {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      };
+      const expirationDate = '2022-03-16T19:15:21.000-05:00';
+      const formattedExpirationDate = new Date(
+        expirationDate,
+      ).toLocaleDateString('en-us', dateOptions);
       const alreadySubmittedIntents = {
         compensation: {
           creationDate: '2021-03-16T19:15:21.000-05:00',
@@ -611,11 +620,7 @@ describe('confirmation page helper functions', () => {
         expect(
           getNextStepsTextSecondParagraph(data, alreadySubmittedIntents),
         ).to.equal(
-          `Your intent to file for disability compensation expires on ${
-            alreadySubmittedIntents.compensation.expirationDate
-          } and your intent to file for pension claims expires on ${
-            alreadySubmittedIntents.pension.expirationDate
-          }. You’ll need to file your claims by these dates to get retroactive payments (payments for the time between when you submit your intent to file and when we approve your claim).`,
+          `Your intent to file for disability compensation expires on ${formattedExpirationDate} and your intent to file for pension claims expires on ${formattedExpirationDate}. You’ll need to file your claims by these dates to get retroactive payments (payments for the time between when you submit your intent to file and when we approve your claim).`,
         );
       });
 


### PR DESCRIPTION
## Summary
More bug-squashing on 21-0966, this time a date display error because I missed converting a date to the right format before displaying it.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/713

## Testing done
Test updated

## Screenshots

Before:
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/10481391/1fcae24c-af78-4367-8eaf-7ee040bf0c5f)

After:
<img width="716" alt="Screenshot 2023-10-24 at 9 12 20 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/10481391/79c4d44d-2f69-4dc5-aaca-019fdd691c5d">

