### PR TITLE
MHV-49885 IF-A-User-Has-No-Records-Of-Allergies-They-Get-An-Empty-State-That-Is-Styled-With-A-Slim-Info-Alert

### DIFF
--- a/src/applications/mhv/medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv/medical-records/containers/Allergies.jsx
@@ -133,10 +133,13 @@ const Allergies = props => {
     }
     if (allergies?.length === 0) {
       return (
-        <div className="vads-u-margin-bottom--3">
-          <va-alert background-only status="info">
-            You don’t have any records in Allergies
-          </va-alert>
+        <div
+          className="record-list-item vads-u-border-color--gray-light vads-u-border--0 vads-u-background-color--gray-lightest card"
+          data-testid="record-list-item"
+        >
+          <h2 className="vads-u-font-size--base vads-u-font-weight--normal vads-u-font-family--sans vads-u-margin-top--0 vads-u-margin-bottom--0">
+            There are no allergies or reactions in your VA medical records.
+          </h2>
         </div>
       );
     }

--- a/src/applications/mhv/medical-records/sass/medical-records.scss
+++ b/src/applications/mhv/medical-records/sass/medical-records.scss
@@ -125,3 +125,7 @@
     margin: 16px 0px;
   }
 }
+
+.no-margin-top {
+  margin-top: 0;
+}

--- a/src/applications/mhv/medical-records/sass/medical-records.scss
+++ b/src/applications/mhv/medical-records/sass/medical-records.scss
@@ -125,7 +125,3 @@
     margin: 16px 0px;
   }
 }
-
-.no-margin-top {
-  margin-top: 0;
-}

--- a/src/applications/mhv/medical-records/tests/containers/Allergies.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/Allergies.unit.spec.jsx
@@ -58,6 +58,33 @@ describe('Allergies list container', () => {
       .exist;
   });
 
+  it('displays a list of records when allergies are present', async () => {
+    // Ensure there are allergies in the state
+    expect(
+      screen.getByText('Allergies and reactions', {
+        exact: true,
+      }),
+    ).to.exist;
+
+    // Check if the count of records is displayed
+    await waitFor(() => {
+      expect(
+        screen.getByText('Showing 1 to 5 of 5 records', {
+          exact: false,
+        }),
+      ).to.exist;
+    });
+
+    // Check if the list of records is displayed
+    await waitFor(() => {
+      expect(screen.getAllByTestId('record-list-item').length).to.eq(10);
+    });
+
+    // Check for other elements that should be displayed when allergies are present
+    expect(screen.getByText('Date of birth:', { exact: false })).to.exist;
+    expect(screen.getByTestId('print-records-button')).to.exist;
+  });
+
   it('displays a list of records', async () => {
     await waitFor(() => {
       expect(screen.getAllByTestId('record-list-item').length).to.eq(10);

--- a/src/applications/mhv/medical-records/tests/containers/Allergies.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/Allergies.unit.spec.jsx
@@ -58,33 +58,6 @@ describe('Allergies list container', () => {
       .exist;
   });
 
-  it('displays a list of records when allergies are present', async () => {
-    // Ensure there are allergies in the state
-    expect(
-      screen.getByText('Allergies and reactions', {
-        exact: true,
-      }),
-    ).to.exist;
-
-    // Check if the count of records is displayed
-    await waitFor(() => {
-      expect(
-        screen.getByText('Showing 1 to 5 of 5 records', {
-          exact: false,
-        }),
-      ).to.exist;
-    });
-
-    // Check if the list of records is displayed
-    await waitFor(() => {
-      expect(screen.getAllByTestId('record-list-item').length).to.eq(10);
-    });
-
-    // Check for other elements that should be displayed when allergies are present
-    expect(screen.getByText('Date of birth:', { exact: false })).to.exist;
-    expect(screen.getByTestId('print-records-button')).to.exist;
-  });
-
   it('displays a list of records', async () => {
     await waitFor(() => {
       expect(screen.getAllByTestId('record-list-item').length).to.eq(10);
@@ -101,8 +74,8 @@ describe('Allergies list container', () => {
   });
 
   it('should download a pdf', () => {
-    const printButton = screen.getByTestId('printButton-1');
-    fireEvent.click(printButton);
+    fireEvent.click(screen.getByTestId('printButton-1'));
+    expect(screen).to.exist;
   });
 });
 
@@ -162,7 +135,6 @@ describe('Allergies list container with no allergies', () => {
         },
       ),
     ).to.exist;
-    expect(screen.queryByTestId('print-records-button')).to.not.exist;
   });
 });
 

--- a/src/applications/mhv/medical-records/tests/containers/Allergies.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/Allergies.unit.spec.jsx
@@ -162,6 +162,7 @@ describe('Allergies list container with no allergies', () => {
         },
       ),
     ).to.exist;
+    expect(screen.queryByTestId('print-records-button')).to.not.exist;
   });
 });
 

--- a/src/applications/mhv/medical-records/tests/containers/Allergies.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/Allergies.unit.spec.jsx
@@ -74,8 +74,8 @@ describe('Allergies list container', () => {
   });
 
   it('should download a pdf', () => {
-    fireEvent.click(screen.getByTestId('printButton-1'));
-    expect(screen).to.exist;
+    const printButton = screen.getByTestId('printButton-1');
+    fireEvent.click(printButton);
   });
 });
 
@@ -128,9 +128,12 @@ describe('Allergies list container with no allergies', () => {
 
   it('displays a no allergies message', () => {
     expect(
-      screen.getByText('You don’t have any records in Allergies', {
-        exact: true,
-      }),
+      screen.getByText(
+        'There are no allergies or reactions in your VA medical records.',
+        {
+          exact: true,
+        },
+      ),
     ).to.exist;
   });
 });


### PR DESCRIPTION
## Summary
Revised the download button behavior to only appear when there are records available, and also transformed the notification for cases where no records are found into a card-based layout.

[MHV-49885](https://jira.devops.va.gov/browse/MHV-49885) - If a user has no records of allergies they get an empty state that is styled with a slim info

User Story: As a Secure Messaging User, I want to

Given:
When:
Then:

Links to UCD:
Sketch Link:
Other Design Notes

Architectural Notes:

## Testing done
Conducted UI testing to ensure the expected behavior. I updated existing unit test for new components.

![Screenshot 2023-10-26 at 1 36 09 PM (2)](https://github.com/department-of-veterans-affairs/vets-website/assets/8038703/7bdaec9d-a9a9-4422-88a2-356fec4df5cf)




## What areas of the site does it impact?
The modification affects the Vaccine section of the Medical Records page.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
