### PR TITLE
Ensure selected tests exist

### DIFF
--- a/script/github-actions/select-unit-tests.js
+++ b/script/github-actions/select-unit-tests.js
@@ -21,8 +21,10 @@ const CHANGED_APPS = process.env.CHANGED_FILES
     )
   : [];
 
-const TESTS_TO_STRESS_TEST = ALL_SPECS.filter(specPath =>
-  CHANGED_APPS.some(filePath => specPath.includes(filePath)),
+const TESTS_TO_STRESS_TEST = ALL_SPECS.filter(
+  specPath =>
+    CHANGED_APPS.some(filePath => specPath.includes(filePath)) &&
+    fs.existsSync(specPath),
 );
 
 core.exportVariable('TESTS_TO_STRESS_TEST', TESTS_TO_STRESS_TEST);

--- a/src/applications/income-limits/components/Breadcrumbs.jsx
+++ b/src/applications/income-limits/components/Breadcrumbs.jsx
@@ -9,7 +9,7 @@ const Breadcrumbs = () => {
       <a href="/health-care" key="health-care">
         Health Care
       </a>
-      <a href="/health-care/income-limits" key="income-limits">
+      <a href="/health-care/income-limitss" key="income-limits">
         Check income limits
       </a>
     </va-breadcrumbs>

--- a/src/applications/income-limits/components/Breadcrumbs.jsx
+++ b/src/applications/income-limits/components/Breadcrumbs.jsx
@@ -9,7 +9,7 @@ const Breadcrumbs = () => {
       <a href="/health-care" key="health-care">
         Health Care
       </a>
-      <a href="/health-care/income-limitss" key="income-limits">
+      <a href="/health-care/income-limits" key="income-limits">
         Check income limits
       </a>
     </va-breadcrumbs>


### PR DESCRIPTION
## Summary

- Solves for an edge case where the only test change that needs to be stress tested is a deleted test. This caused errors that halted the workflow. Was already implemented for E2E tests so expanding this to Unit Tests as well.

## Related issue(s)

https://app.zenhub.com/workspaces/reliability-team-633b069d2920b776613c93d8/issues/gh/department-of-veterans-affairs/va.gov-team/67379

