### PR TITLE
Add Identity Verification Alert to 10-10EZR Intro Page

### DIFF
--- a/src/applications/ezr/components/FormAlerts/EnrollmentStatusAlert.jsx
+++ b/src/applications/ezr/components/FormAlerts/EnrollmentStatusAlert.jsx
@@ -5,12 +5,7 @@ import ServerErrorAlert from './ServerErrorAlert';
 
 const EnrollmentStatusAlert = ({ showError }) => {
   return !showError ? (
-    <va-alert
-      status="warning"
-      class="vads-u-margin-y--4"
-      data-testid="ezr-enrollment-status-alert"
-      uswds
-    >
+    <va-alert status="warning" data-testid="ezr-enrollment-status-alert" uswds>
       <h3 slot="headline">{content['alert-enrollment-title']}</h3>
       <p>{content['alert-enrollment-message']}</p>
       <a

--- a/src/applications/ezr/components/FormAlerts/IdentityVerificationAlert.jsx
+++ b/src/applications/ezr/components/FormAlerts/IdentityVerificationAlert.jsx
@@ -4,7 +4,12 @@ import { AUTH_EVENTS } from 'platform/user/authentication/constants';
 import recordEvent from 'platform/monitoring/record-event';
 
 export const IdentityVerificationAlert = () => (
-  <va-alert status="continue" data-testid="ezr-identity-alert" uswds>
+  <va-alert
+    status="continue"
+    class="vads-u-margin-y--4"
+    data-testid="ezr-identity-alert"
+    uswds
+  >
     <h3 slot="headline">
       Please verify your identity before updating your health benefits
       information

--- a/src/applications/ezr/components/FormAlerts/IdentityVerificationAlert.jsx
+++ b/src/applications/ezr/components/FormAlerts/IdentityVerificationAlert.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import { AUTH_EVENTS } from 'platform/user/authentication/constants';
+import recordEvent from 'platform/monitoring/record-event';
+
+export const IdentityVerificationAlert = () => (
+  <va-alert status="continue" data-testid="ezr-identity-alert" uswds>
+    <h3 slot="headline">
+      Please verify your identity before updating your health benefits
+      information
+    </h3>
+    <p>This process should take about 5 to 10 minutes.</p>
+    <p>
+      <strong>
+        If you need more information or help with verifying your identity:
+      </strong>
+    </p>
+    <ul>
+      <li>
+        <va-link
+          href="/resources/verifying-your-identity-on-vagov/"
+          text="Read our identity verification FAQs"
+        />
+      </li>
+      <li>
+        Or call us at <va-telephone contact={CONTACTS['222_VETS']} />. If you
+        have hearing hearing loss, call{' '}
+        <va-telephone contact={CONTACTS['711']} tty />. We’re here Monday
+        through Friday, 8:00 a.m. to 8:00 p.m.{' '}
+        <dfn>
+          <abbr title="Eastern Time">ET</abbr>
+        </dfn>
+        .
+      </li>
+    </ul>
+    <p>
+      <a
+        href="/verify"
+        className="usa-button"
+        onClick={() => {
+          recordEvent({ event: AUTH_EVENTS.VERIFY });
+        }}
+      >
+        Verify your identity
+      </a>
+    </p>
+  </va-alert>
+);
+
+export default IdentityVerificationAlert;

--- a/src/applications/ezr/components/IntroductionPage/SaveInProgressInfo.jsx
+++ b/src/applications/ezr/components/IntroductionPage/SaveInProgressInfo.jsx
@@ -45,7 +45,12 @@ const SaveInProgressInfo = ({ formConfig, pageList }) => {
 
   return isLoggedOut ? (
     <>
-      <va-alert status="info" data-testid="ezr-login-alert" uswds>
+      <va-alert
+        status="info"
+        class="vads-u-margin-y--4"
+        data-testid="ezr-login-alert"
+        uswds
+      >
         <h3 slot="headline">{content['sip-alert-title']}</h3>
         <div>
           <ul className="vads-u-margin-top--0">
@@ -63,7 +68,7 @@ const SaveInProgressInfo = ({ formConfig, pageList }) => {
       </va-alert>
     </>
   ) : (
-    <>{LoggedInAlertToRender}</>
+    <div className="vads-u-margin-y--4">{LoggedInAlertToRender}</div>
   );
 };
 

--- a/src/applications/ezr/config/form.js
+++ b/src/applications/ezr/config/form.js
@@ -2,6 +2,7 @@
 import environment from 'platform/utilities/environment';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 import { externalServices } from 'platform/monitoring/DowntimeNotification';
+import ezrSchema from 'vets-json-schema/dist/10-10EZ-schema.json';
 
 // internal app imports
 import manifest from '../manifest.json';
@@ -36,6 +37,9 @@ import InsurancePolicyReviewPage from '../components/FormReview/InsurancePolicyR
 
 // declare shared paths for custom form page navigation
 const { insurance: INSURANCE_PATHS } = SHARED_PATHS;
+
+// declare schema definitions
+const { provider } = ezrSchema.definitions;
 
 // declare form config object
 const formConfig = {
@@ -84,7 +88,7 @@ const formConfig = {
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   getHelp: GetFormHelp,
-  defaultDefinitions: {},
+  defaultDefinitions: { provider },
   chapters: {
     veteranInformation: {
       title: 'Veteran information',

--- a/src/applications/ezr/containers/IntroductionPage.jsx
+++ b/src/applications/ezr/containers/IntroductionPage.jsx
@@ -9,13 +9,16 @@ import {
 } from 'platform/monitoring/DowntimeNotification';
 
 import { selectEnrollmentStatus } from '../utils/selectors/entrollment-status';
-import content from '../locales/en/content.json';
+import { selectAuthStatus } from '../utils/selectors/auth-status';
+import IdentityVerificationAlert from '../components/FormAlerts/IdentityVerificationAlert';
 import ProcessDescription from '../components/IntroductionPage/ProcessDescription';
 import SaveInProgressInfo from '../components/IntroductionPage/SaveInProgressInfo';
 import OMBInfo from '../components/IntroductionPage/OMBInfo';
+import content from '../locales/en/content.json';
 
 const IntroductionPage = ({ route }) => {
   const { isLoading } = useSelector(selectEnrollmentStatus);
+  const { isUserLOA1 } = useSelector(selectAuthStatus);
   const { formConfig, pageList } = route;
   const sipProps = { formConfig, pageList };
 
@@ -35,7 +38,11 @@ const IntroductionPage = ({ route }) => {
           ) : (
             <>
               <ProcessDescription />
-              <SaveInProgressInfo {...sipProps} />
+              {isUserLOA1 ? (
+                <IdentityVerificationAlert />
+              ) : (
+                <SaveInProgressInfo {...sipProps} />
+              )}
               <OMBInfo />
             </>
           )}

--- a/src/applications/ezr/tests/unit/utils/selectors/auth-status.unit.spec.js
+++ b/src/applications/ezr/tests/unit/utils/selectors/auth-status.unit.spec.js
@@ -40,7 +40,7 @@ describe('ezr auth status selectors', () => {
     });
 
     context('when the user is logged in', () => {
-      context('when the user is not LOA3', () => {
+      context('when the user is LOA1', () => {
         it('should set the correct part of the state', () => {
           const state = {
             user: {
@@ -52,9 +52,12 @@ describe('ezr auth status selectors', () => {
               },
             },
           };
-          const { isLoggedOut, isUserLOA3 } = selectAuthStatus(state);
+          const { isLoggedOut, isUserLOA1, isUserLOA3 } = selectAuthStatus(
+            state,
+          );
           expect(isLoggedOut).to.be.false;
           expect(isUserLOA3).to.be.false;
+          expect(isUserLOA1).to.be.true;
         });
       });
 
@@ -71,9 +74,12 @@ describe('ezr auth status selectors', () => {
               },
             },
           };
-          const { isLoggedOut, isUserLOA3 } = selectAuthStatus(state);
+          const { isLoggedOut, isUserLOA1, isUserLOA3 } = selectAuthStatus(
+            state,
+          );
           expect(isLoggedOut).to.be.false;
           expect(isUserLOA3).to.be.true;
+          expect(isUserLOA1).to.be.false;
         });
       });
     });

--- a/src/applications/ezr/utils/selectors/auth-status.js
+++ b/src/applications/ezr/utils/selectors/auth-status.js
@@ -1,4 +1,9 @@
-import { isLOA3, isLoggedIn, isProfileLoading } from 'platform/user/selectors';
+import {
+  isLOA1,
+  isLOA3,
+  isLoggedIn,
+  isProfileLoading,
+} from 'platform/user/selectors';
 
 /**
  * Map state values to create selector for user authentication properties
@@ -8,6 +13,7 @@ import { isLOA3, isLoggedIn, isProfileLoading } from 'platform/user/selectors';
 export function selectAuthStatus(state) {
   const isLoggedOut = !isProfileLoading(state) && !isLoggedIn(state);
   return {
+    isUserLOA1: !isLoggedOut && isLOA1(state),
     isUserLOA3: !isLoggedOut && isLOA3(state),
     isLoggedOut,
   };


### PR DESCRIPTION
## Summary
For the Introduction page, we need to limit access to the API calls and form start button for users who have an account status of LOA1 on VA.gov. This PR adds an alert that will take the place of the Save-In-Progress components that control form entry and enrollment status verification to ensure only verified users can access the form.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#68292

## Testing done
- [x] Unit testing all components and conditionals

## Acceptance criteria
- LOA1 users must verify their identity before gaining access to the form
- LOA3 or guest users will see the traditional SIP components rendered

### Quality Assurance & Testing

- [x] I added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
