### PR TITLE
Discovery: USWDS Formation REM conversion minimal stylesheet

### DIFF
--- a/src/applications/check-in/components/layout/Wrapper.jsx
+++ b/src/applications/check-in/components/layout/Wrapper.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -42,59 +42,23 @@ const Wrapper = props => {
     app === APP_NAMES.CHECK_IN ? externalServices.cie : externalServices.pcie;
   const appTitle = app === APP_NAMES.CHECK_IN ? 'Check in' : 'Pre-check in';
 
-  const formationSizes =
-    'html { font-size: 10px; } body { font-size: 1.6rem; }';
-
-  const uswdsSizes = 'html { font-size: 100%; } body { font-size: 16px; }';
-
-  const [styleLibrary, setstyleLibrary] = useState('Formation');
-  const [selectedFontSizes, setSelectedFontSizes] = useState(formationSizes);
-
-  const handleChange = event => {
-    const selectedValue = event.detail.value;
-    setstyleLibrary(selectedValue);
-
-    if (selectedValue === 'formation') {
-      document.documentElement.style.fontSize = '10px';
-      document.body.style.fontSize = '1.6rem';
-      setSelectedFontSizes(formationSizes);
-    } else {
-      document.documentElement.style.fontSize = '100%';
-      document.body.style.fontSize = '16px';
-      setSelectedFontSizes(uswdsSizes);
-    }
-  };
   return (
     <>
       <div
         className={`vads-l-grid-container ${classNames} ${topPadding}`}
         data-testid={testID}
       >
-        <div style={{ backgroundColor: `#efefef`, padding: '20px' }}>
-          <VaSelect
-            hint={null}
-            label="Application Base Font Size Toggle"
-            name="base-font-size"
-            value="formation"
-            onVaSelect={handleChange}
-            uswds
-          >
-            <option value="formation">Formation</option>
-            <option value="uswds">USWDS v3</option>
-          </VaSelect>
-          <p>
-            Font size for {styleLibrary}:<br />{' '}
-            <strong>{selectedFontSizes}</strong>
-          </p>
-        </div>
-
-        <hr />
+        <va-featured-content>
+          <h3 slot="headline">Demo for USWDS Base Font Size</h3>
+          <code>html: font-size: 100%; body: font-size: 16px;</code>
+        </va-featured-content>
 
         <h3>USWDS v3 Component Examples</h3>
 
         <va-button text="Button" uswds />
 
-        <br /><br />
+        <br />
+        <br />
 
         <va-alert
           close-btn-aria-label="Close notification"
@@ -120,7 +84,8 @@ const Wrapper = props => {
 
         <va-button text="Button" />
 
-        <br /><br />
+        <br />
+        <br />
 
         <va-alert
           close-btn-aria-label="Close notification"

--- a/src/platform/site-wide/sass/formation-overrides/_buttons.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_buttons.scss
@@ -1,0 +1,19 @@
+@import "functions";
+
+.usa-button,
+.usa-button-primary,
+.usa-button:visited,
+.usa-button-primary:visited,
+button,
+[type=button],
+[type=submit],
+[type=reset],
+[type=image] {
+  @include margin(uswds-override(0.5rem) uswds-override(0.5rem) uswds-override(0.5rem) null);
+  padding: uswds-override(1rem) uswds-override(2rem);
+
+  &.usa-button-big {
+    font-size: uswds-override(2.4rem);
+    padding: uswds-override(1.5rem) uswds-override(3rem);
+  }
+}

--- a/src/platform/site-wide/sass/formation-overrides/_functions.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_functions.scss
@@ -1,15 +1,173 @@
+// @function is-rem($value) {
+//   @if unit($value) == "rem" {
+//     @return true;
+//   }
+// }
 
-@function is-rem($value) {
-  @if unit($value) == "rem" {
-    @return true;
+// @function uswds-override($original) {
+//   @if is-rem($original) {
+//     $rem-to-px: $original * 10; // Formation base
+//     $px-to-rem: $rem-to-px / 16; // USWDS base
+//     @return ($px-to-rem); // return the value back to rem
+//   }
+//   @return $original;
+// }
+
+////NEW  FUNCTIONS
+$uswds-base: 16px;                    // USWDS base
+$formation-base: 10px;                // Formation base
+
+$f2u-coeff: $formation-base / $uswds-base; // Formation  to USDWS conversion coeffient
+$u2f-coeff: $uswds-base / $formation-base; // USDWS to Formation conversion coeffient
+
+
+$unit-types: (
+    "px": 1px,
+    "cm": 1cm,
+    "mm": 1mm,
+    "%": 1%,
+    "ch": 1ch,
+    "in": 1in,
+    "em": 1em,
+    "rem": 1rem,
+    "pt": 1pt,
+    "pc": 1pc,
+    "ex": 1ex,
+    "vw": 1vw,
+    "vh": 1vh,
+    "vmin": 1vmin,
+    "vmax": 1vmax,
+    "deg": 1deg,
+    "turn": 1turn,
+    "rad": 1rad,
+    "grad": 1grad,
+    "s": 1s,
+    "ms": 1ms,
+    "Hz": 1Hz,
+    "kHz": 1kHz,
+    "dppx": 1dppx,
+    "dpcm": 1dpcm,
+    "dpi": 1dpi,
+  );
+
+
+@function split-value-unit($string) {
+  // takes a string,  returns a map of
+  // number: number || null
+  // unit: a unit || or null
+  // joint: the number+ its unit
+  @if(type-of($string) == number){
+      @return(
+        number: if(map-has-key($unit-types, unit($string)),
+            $string / map-get($unit-types, unit($string))
+            ,$string),
+        unit: unit($string),
+        joint: $string
+      )
+  }
+  @if(type-of($string) == color){
+      @return(
+        number: $string,
+        unit: color,
+        joint: $string
+      )
+  }
+  @if(type-of($string) != string){
+      @return(
+        number: null,
+        unit: null,
+        joint: $string
+      )
+  }
+  $length: str-length($string);
+  $numeric-value: "";
+  $unit: "";
+  $digits: ( "0":0, "1":1, "2":2, "3":3, "4":4, "5":5, "6":6, "7":7, "8":8, "9":9);
+  $sign : 1;
+  $decimal: 1;
+  $magnitude: 10;
+  $past: false;
+  @for $i from 1 through $length {
+    $char: str-slice($string, $i, $i);
+    @if($char == "-") {
+      $sign :  -1;
+    }
+    @else if($char == "." and $past == false) {
+      $decimal : 10;
+      $magnitude : 1;
+    }
+    @else if( map-get($digits,$char) and $past == false){
+      @if ($numeric-value == ""){
+            $numeric-value : 0;
+      }
+      $numeric-value: ($numeric-value * $magnitude) +(map-get($digits,$char)/$decimal);
+        @if ($decimal > 1){
+            $decimal : $decimal * 10;
+        }
+    }
+    @else {
+        $unit: $unit + $char;
+        $past: true;
+    }
+  }
+  $numeric-result: if( $numeric-value == "" , null, $sign * $numeric-value);
+  @return (
+    number: $numeric-result,
+    unit: unquote($unit),
+    joint: $numeric-result+unquote($unit)
+  );
+}
+
+@function str-split($string, $separator: " ") {
+  $split-list: ();
+  $index: str-index($string, $separator);
+
+  @while $index != null {
+    $item: str-slice($string, 1, $index - 1);
+    $split-list: append($split-list, $item);
+    $string: str-slice($string, $index + 1);
+    $index: str-index($string, $separator);
+  }
+
+  @return append($split-list, $string);
+}
+
+@function uswds-override($value, $coeff: $f2u-coeff,  $separator: space) {
+  // converts any singular SCSS value with rem units
+  // to its scaled equvalent
+  // otherwise returns  the orginal value
+  @if (type-of($value) == number and unit($value) == rem) {
+    @return ($value * $coeff) ;
+  }
+  @if (type-of($value) == string ) {
+    $inner-sep: if($separator == comma , ",", " ");
+    $value-set: str-split($value, $inner-sep);
+    $scaled-values: ();
+
+    @each $val in $value-set{
+        $val-parts : split-value-unit($val);
+        @if (map-get($val-parts, unit) == rem) {
+            $rem-number: str-slice($val, 0, -4);
+            $scaled-rem: map-get($val-parts, number) * $coeff ;
+            $scaled-values: append($scaled-values, $scaled-rem + rem);
+        } @else {
+            $scaled-values: append($scaled-values,
+            map-get($val-parts, joint), $separator);
+        }
+    }
+    @return  $scaled-values;
+  }
+  @else {
+    @return $value;
   }
 }
 
-@function uswds-override($original) {
-  @if is-rem($original) {
-    $rem-to-px: $original * 10; // Formation base
-    $px-to-rem: $rem-to-px / 16; // USWDS base
-    @return ($px-to-rem); // return the value back to rem
+@function scale-rule($rule, $separator: space,  $coeff: $f2u-coeff   ) {
+  // converts any plural SCSS value with rem units
+  $scaled: ();
+  @each $value in $rule {
+    $scaled-value: scale-rem($value, $coeff, $separator);
+    $scaled: append($scaled, $scaled-value, $separator);
   }
-  @return $original;
+  @return $scaled;
 }

--- a/src/platform/site-wide/sass/formation-overrides/_functions.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_functions.scss
@@ -9,7 +9,7 @@
   @if is-rem($original) {
     $rem-to-px: $original * 10; // Formation base
     $px-to-rem: $rem-to-px / 16; // USWDS base
-    @return $px-to-rem; // return the value back to rem
+    @return ($px-to-rem); // return the value back to rem
   }
   @return $original;
 }

--- a/src/platform/site-wide/sass/formation-overrides/_functions.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_functions.scss
@@ -9,8 +9,9 @@
 // based on the USWDS 16px base and return it again as rem.
 @function uswds-override($original) {
   @if is-rem($original) {
-    $rem-to-px: ($original / 1rem) * 16;
-    @return ($rem-to-px) + "px";
+    $rem-to-px: $original * 10; // Formation base
+    $px-to-rem: $rem-to-px / 16; // USWDS base
+    @return $px-to-rem; // return the value back to rem
   }
   @return $original;
 }

--- a/src/platform/site-wide/sass/formation-overrides/_functions.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_functions.scss
@@ -1,0 +1,16 @@
+
+@function is-rem($value) {
+  @if unit($value) == "rem" {
+    @return true;
+  }
+}
+
+// TODO: Instead of converting to px, we should calculate the existing rem
+// based on the USWDS 16px base and return it again as rem.
+@function uswds-override($original) {
+  @if is-rem($original) {
+    $rem-to-px: ($original / 1rem) * 16;
+    @return ($rem-to-px) + "px";
+  }
+  @return $original;
+}

--- a/src/platform/site-wide/sass/formation-overrides/_functions.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_functions.scss
@@ -5,8 +5,6 @@
   }
 }
 
-// TODO: Instead of converting to px, we should calculate the existing rem
-// based on the USWDS 16px base and return it again as rem.
 @function uswds-override($original) {
   @if is-rem($original) {
     $rem-to-px: $original * 10; // Formation base

--- a/src/platform/site-wide/sass/formation-overrides/_shared-variables.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_shared-variables.scss
@@ -1,0 +1,4 @@
+@import "functions";
+
+$text-max-width:      uswds-override(70rem); // Note: USWDS value is 53rem;
+$site-max-width:      uswds-override(100rem); // Worksout to about 1000px. USWDS value is 1040px

--- a/src/platform/site-wide/sass/formation-overrides/_utilities.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_utilities.scss
@@ -1,0 +1,46 @@
+@import "functions";
+
+// Content size helpers
+@mixin allow-layout-classes {
+  @include margin(null auto);
+  &.align-left {
+    @include media($medium-screen) {
+      margin-right: rem-override(2em) !important;
+      margin-top: rem-override(0.5em) !important;
+    }
+  }
+
+  &.align-right {
+    @include media($medium-screen) {
+      margin-left: rem-override(2em) !important;
+      margin-top: rem-override(0.5em) !important;
+    }
+  }
+}
+
+@mixin usa-sidenav-list {
+  a {
+    padding: rem-override(0.85rem) rem-override(1rem) rem-override(0.85rem) $site-margins-mobile !important;
+  }
+}
+
+@mixin usa-sidenav-sublist {
+  a {
+    padding-left: rem-override(2.8rem) !important;
+
+    &:hover,
+    &.usa-current { /* stylelint-disable-line selector-no-qualifying-type */
+      padding-left: rem-override(2.8rem) !important;
+    }
+  }
+
+  .usa-sidenav-sub_list {
+    a {
+      padding-left: rem-override(3.8rem) !important;
+
+      &:hover {
+        padding-left: rem-override(3.8rem) !important;
+      }
+    }
+  }
+}

--- a/src/platform/site-wide/sass/formation-overrides/_utilities.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_utilities.scss
@@ -5,15 +5,15 @@
   @include margin(null auto);
   &.align-left {
     @include media($medium-screen) {
-      margin-right: rem-override(2em) !important;
-      margin-top: rem-override(0.5em) !important;
+      margin-right: rem-override(2rem) !important;
+      margin-top: rem-override(0.5rem) !important;
     }
   }
 
   &.align-right {
     @include media($medium-screen) {
-      margin-left: rem-override(2em) !important;
-      margin-top: rem-override(0.5em) !important;
+      margin-left: rem-override(2rem) !important;
+      margin-top: rem-override(0.5rem) !important;
     }
   }
 }

--- a/src/platform/site-wide/sass/formation-overrides/_variables.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_variables.scss
@@ -2,26 +2,26 @@
 
 $em-base:             100%; // USWDS v3 html value
 $base-font-size:      16px; // USWDS v3 body value
-$small-font-size:     uswds-override(1.4rem) !important;
-$lead-font-size:      uswds-override(2rem) !important;
-$title-font-size:     uswds-override(5.2rem) !important;
+$small-font-size:     uswds-override(1.4rem) !default;
+$lead-font-size:      uswds-override(2rem) !default;
+$title-font-size:     uswds-override(5.2rem) !default;
 $h1-font-size:        uswds-override(4rem) !important;
-$h2-font-size:        uswds-override(3rem) !important;
-$h3-font-size:        uswds-override(2rem) !important;
-$h4-font-size:        uswds-override(1.7rem) !important;
-$h5-font-size:        uswds-override(1.5rem) !important;
-$h6-font-size:        uswds-override(1.3rem) !important;
+$h2-font-size:        uswds-override(3rem) !default;
+$h3-font-size:        uswds-override(2rem) !default;
+$h4-font-size:        uswds-override(1.7rem) !default;
+$h5-font-size:        uswds-override(1.5rem) !default;
+$h6-font-size:        uswds-override(1.3rem) !default;
 
 // Magic Numbers
-$lead-max-width:                uswds-override(77rem) !important;
-$site-margins:                  uswds-override(3rem) !important;
-$site-margins-mobile:           uswds-override(1.5rem) !important;
-$input-max-width:               uswds-override(46rem) !important;
-$sidenav-current-border-width:  0.4rem !important; // must be in rem for math
+$lead-max-width:                uswds-override(77rem) !default;
+$site-margins:                  uswds-override(3rem) !default;
+$site-margins-mobile:           uswds-override(1.5rem) !default;
+$input-max-width:               uswds-override(46rem) !default;
+$sidenav-current-border-width:  0.4rem !default; // must be in rem for math
 
 // 44 x 44 pixels hit target following Apple iOS Human Interface
 // Guidelines
-$hit-area: uswds-override(4.4rem) !important;
+$hit-area: uswds-override(4.4rem) !default;
 
 $spacing-x-small: uswds-override(0.5rem);
 $spacing-small: uswds-override(1rem);

--- a/src/platform/site-wide/sass/formation-overrides/_variables.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_variables.scss
@@ -1,0 +1,30 @@
+@import "functions";
+
+$em-base:             100%; // USWDS v3 html value
+$base-font-size:      16px; // USWDS v3 body value
+$small-font-size:     uswds-override(1.4rem) !important;
+$lead-font-size:      uswds-override(2rem) !important;
+$title-font-size:     uswds-override(5.2rem) !important;
+$h1-font-size:        uswds-override(4rem) !important;
+$h2-font-size:        uswds-override(3rem) !important;
+$h3-font-size:        uswds-override(2rem) !important;
+$h4-font-size:        uswds-override(1.7rem) !important;
+$h5-font-size:        uswds-override(1.5rem) !important;
+$h6-font-size:        uswds-override(1.3rem) !important;
+
+// Magic Numbers
+$lead-max-width:                uswds-override(77rem) !important;
+$site-margins:                  uswds-override(3rem) !important;
+$site-margins-mobile:           uswds-override(1.5rem) !important;
+$input-max-width:               uswds-override(46rem) !important;
+$sidenav-current-border-width:  0.4rem !important; // must be in rem for math
+
+// 44 x 44 pixels hit target following Apple iOS Human Interface
+// Guidelines
+$hit-area: uswds-override(4.4rem) !important;
+
+$spacing-x-small: uswds-override(0.5rem);
+$spacing-small: uswds-override(1rem);
+$spacing-md-small: uswds-override(1.5rem);
+$spacing-medium: uswds-override(2rem);
+$spacing-large: uswds-override(3rem);

--- a/src/platform/site-wide/sass/minimal.scss
+++ b/src/platform/site-wide/sass/minimal.scss
@@ -2,13 +2,20 @@
 @import "modules/m-overrides";
 
 @import "~uswds/src/stylesheets/core/variables";
+// *** Formation override ***
+@import "formation-overrides/variables";
+
 @import "~uswds/src/stylesheets/core/base";
 @import "~uswds/src/stylesheets/core/fonts";
+
 @import "~uswds/src/stylesheets/core/utilities";
+// *** Formation override ***
+@import "formation-overrides/utilities";
+
 @import "~uswds/src/stylesheets/core/grid";
 @import "~uswds/src/stylesheets/elements/buttons";
 @import "~uswds/src/stylesheets/elements/typography";
-@import "~uswds/src/stylesheets/components/accordions";
+// @import "~uswds/src/stylesheets/components/accordions"; // ** requires rem for calculation
 @import "~uswds/src/stylesheets/components/banner";
 
 //////============ VENDOR PARTIALS ==============//
@@ -24,14 +31,6 @@
 
 @import "~@department-of-veterans-affairs/formation/sass/base/b-font-faces";
 @import "~@department-of-veterans-affairs/formation/sass/base/va";
-
-
-// Add the USWDS html & body font-sizes's to the css-library elements.scss stylesheet with !important
-// and import in here after the `/base/va"` stylesheet.
-
-// html { font-size: 100%!important; }
-// body { font-size: 16px!important; }
-
 @import "~@department-of-veterans-affairs/formation/sass/base/b-utils";
 @import "~@department-of-veterans-affairs/formation/sass/layout/flex-grid";
 

--- a/src/platform/site-wide/sass/minimal.scss
+++ b/src/platform/site-wide/sass/minimal.scss
@@ -1,4 +1,5 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+@import "formation-overrides/shared-variables";
 @import "modules/m-overrides";
 
 @import "~uswds/src/stylesheets/core/variables";

--- a/src/platform/site-wide/sass/minimal.scss
+++ b/src/platform/site-wide/sass/minimal.scss
@@ -14,6 +14,8 @@
 
 @import "~uswds/src/stylesheets/core/grid";
 @import "~uswds/src/stylesheets/elements/buttons";
+// *** Formation override ***
+@import "formation-overrides/buttons";
 @import "~uswds/src/stylesheets/elements/typography";
 // @import "~uswds/src/stylesheets/components/accordions"; // ** requires rem for calculation
 @import "~uswds/src/stylesheets/components/banner";


### PR DESCRIPTION
## Summary

This PR is a discovery to see how we might approach converting/overriding existing Formation `rem` values in the minimal stylesheet so that they are calculated with the USWDS base font size.

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2223

## Testing done

locally

## Screenshots

When USWDS base font is applied: 

```
html { font-size: 100%; }
body { font-size: 16px; }
```

**Before REM overrides**

<img width="1283" alt="Screenshot 2023-10-24 at 3 49 50 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/872479/2226edc1-8cf6-4960-90e8-3f792a1ab897">


**After REM overrides applied**

<img width="1286" alt="after" src="https://github.com/department-of-veterans-affairs/vets-website/assets/872479/1f910658-e3c2-4097-9f50-09c05cb59bb9">

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
