### PR TITLE
Add unit test coverage for VideoVisitProvider.jsx

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitProvider.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoVisitProvider.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default function VideoVisitProvider({ appointment }) {
-  const providers = appointment.videoData.providers;
+  const { providers } = appointment.videoData;
 
   if (!providers?.length) {
     return null;
@@ -23,3 +24,27 @@ export default function VideoVisitProvider({ appointment }) {
     </div>
   );
 }
+
+VideoVisitProvider.propTypes = {
+  appointment: PropTypes.shape({
+    status: PropTypes.string.isRequired,
+    vaos: PropTypes.shape({
+      isPastAppointment: PropTypes.bool.isRequired,
+    }),
+    videoData: PropTypes.shape({
+      providers: PropTypes.arrayOf(PropTypes.object).isRequired,
+    }),
+  }),
+};
+
+VideoVisitProvider.defaultProps = {
+  appointment: {
+    status: '',
+    vaos: {
+      isPastAppointment: false,
+    },
+    videoData: {
+      providers: [],
+    },
+  },
+};

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/tests/VideoVisitProvider.unit.spec.js
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/tests/VideoVisitProvider.unit.spec.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import VideoVisitProvider from '../VideoVisitProvider';
+
+const appointmentData = {
+  status: 'Booked',
+};
+
+describe('VideoVisitProvider', () => {
+  it('should return null', async () => {
+    const appointment = {
+      ...appointmentData,
+      vaos: {
+        isPastAppointment: true,
+      },
+      videoData: {
+        providers: [],
+      },
+    };
+
+    const props = { appointment };
+    const wrapper = render(<VideoVisitProvider {...props} />);
+    expect(await wrapper.queryByText('You met with')).to.not.exist;
+  });
+  it('should return you met with text and provider name', async () => {
+    const appointment = {
+      ...appointmentData,
+      vaos: {
+        isPastAppointment: true,
+      },
+      videoData: {
+        providers: [
+          {
+            name: {
+              firstName: ['Test', 'PhD'],
+              lastName: 'Provider',
+            },
+            display: 'Test,PhD Provider',
+          },
+        ],
+      },
+    };
+
+    const props = { appointment };
+    const wrapper = render(<VideoVisitProvider {...props} />);
+    expect(await wrapper.queryByText('You met with')).to.exist;
+    expect(await wrapper.queryByText('Test,PhD Provider')).to.exist;
+  });
+  it("should return you'll be meeting with text and provider name", async () => {
+    const appointment = {
+      ...appointmentData,
+      vaos: {
+        isPastAppointment: false,
+      },
+      videoData: {
+        providers: [
+          {
+            name: {
+              firstName: ['Test', 'PhD'],
+              lastName: 'Provider',
+            },
+            display: 'Test,PhD Provider',
+          },
+        ],
+      },
+    };
+
+    const props = { appointment };
+    const wrapper = render(<VideoVisitProvider {...props} />);
+    expect(
+      wrapper.getByText('You’ll be meeting with', {
+        exact: true,
+        selector: 'h2',
+      }),
+    ).to.exist;
+    expect(await wrapper.queryByText('Test,PhD Provider')).to.exist;
+  });
+});


### PR DESCRIPTION
## Summary
Added unit test coverage for `VideoVisitProvider.jsx`.



## Related issue(s)

- https://app.zenhub.com/workspaces/appointments-team-603fdef281af6500110a1691/issues/gh/department-of-veterans-affairs/va.gov-team/67686

## Testing done
Checked file coverage and confirmed it was 100% covered.

<img width="1350" alt="Screenshot 2023-10-24 at 5 12 51 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/47654119/79da276c-07c5-4805-98cc-c900afa552a9">





## Acceptance criteria
- [x] file coverage for Branches, functions, lines and statements is 100%
