### PR TITLE
MHV-50139: NON-VA medications on list page PDF

### DIFF
--- a/src/applications/mhv/medications/util/constants.js
+++ b/src/applications/mhv/medications/util/constants.js
@@ -31,7 +31,7 @@ export const imageRootUri = 'https://www.myhealth.va.gov/static/MILDrugImages/';
 
 export const pdfStatusDefinitions = {
   active: `This is a current prescription. If you have refills left, you can request a refill now.
-Note: If you have not refills left, you’ll need to request a renewal instead.`,
+Note: If you have no refills left, you’ll need to request a renewal instead.`,
 
   activeParked: `Your VA provider prescribed this medication or supply to you.But we won’t send any shipments until you request to fill or refill it.
 We may use this status for either of these reasons:

--- a/src/applications/mhv/medications/util/pdfConfigs.js
+++ b/src/applications/mhv/medications/util/pdfConfigs.js
@@ -209,7 +209,7 @@ export const buildAllergiesPDFList = allergies => {
               inline: true,
             },
             {
-              title: 'Observed or reported',
+              title: 'Observed or historical',
               value: validateField(item.observedOrReported),
               inline: true,
             },

--- a/src/applications/mhv/medications/util/pdfConfigs.js
+++ b/src/applications/mhv/medications/util/pdfConfigs.js
@@ -7,12 +7,83 @@ import {
 } from './constants';
 
 /**
+ * Return Non-VA prescription PDF list
+ */
+export const buildNonVAPrescriptionPDFList = prescription => {
+  return [
+    {
+      sections: [
+        {
+          items: [
+            {
+              title: 'Instructions',
+              value: validateField(prescription.sig),
+              inline: true,
+            },
+            {
+              title: 'Reason for use',
+              value: validateField(prescription.indicationForUse),
+              inline: true,
+            },
+            {
+              title: 'Status',
+              value: validateField(prescription.dispStatus?.toString()),
+              inline: true,
+            },
+            {
+              value:
+                'A VA provider added this medication record in your VA medical records. But this isn’t a prescription you filled through a VA pharmacy. You can’t request refills or manage this medication through this online tool.',
+            },
+            {
+              title: 'Non-VA medications include these types:',
+              value: nonVAMedicationTypes,
+              inline: false,
+            },
+            {
+              title: 'When you started taking this medication',
+              value: dateFormat(prescription.dispensedDate, 'MMMM D, YYYY'),
+              inline: true,
+            },
+            {
+              title: 'Documented by',
+              value: prescription.providerLastName
+                ? `${
+                    prescription.providerLastName
+                  }, ${prescription.providerFirstName || ''}`
+                : 'None noted',
+              inline: true,
+            },
+            {
+              title: 'Documented at this facility',
+              value: validateField(prescription.facilityName),
+              inline: true,
+            },
+            {
+              title: 'Provider notes',
+              value: validateField(prescription.remarks),
+              inline: true,
+            },
+          ],
+        },
+      ],
+    },
+  ];
+};
+
+/**
  * Return prescriptions PDF list
  */
 export const buildPrescriptionsPDFList = prescriptions => {
   return prescriptions?.map(rx => {
     // Image (to be added later)
     // const cmopNdcNumber = rx.rxRfRecords.length && rx.rxRfRecords[0][1]?.[0]?.cmopNdcNumber || rx.cmopNdcNumber;
+    if (rx?.prescriptionSource === 'NV') {
+      return {
+        ...buildNonVAPrescriptionPDFList(rx)[0],
+        header: rx.prescriptionName,
+      };
+    }
+
     return {
       header: rx.prescriptionName,
       sections: [
@@ -246,70 +317,6 @@ export const buildVAPrescriptionPDFList = prescription => {
             {
               title: 'Quantity',
               value: validateField(prescription.quantity),
-              inline: true,
-            },
-          ],
-        },
-      ],
-    },
-  ];
-};
-
-/**
- * Return Non-VA prescription PDF list
- */
-export const buildNonVAPrescriptionPDFList = prescription => {
-  return [
-    {
-      sections: [
-        {
-          items: [
-            {
-              title: 'Instructions',
-              value: validateField(prescription.sig),
-              inline: true,
-            },
-            {
-              title: 'Reason for use',
-              value: validateField(prescription.indicationForUse),
-              inline: true,
-            },
-            {
-              title: 'Status',
-              value: validateField(prescription.dispStatus?.toString()),
-              inline: true,
-            },
-            {
-              value:
-                'A VA provider added this medication record in your VA medical records. But this isn’t a prescription you filled through a VA pharmacy. You can’t request refills or manage this medication through this online tool.',
-            },
-            {
-              title: 'Non-VA medications include these types:',
-              value: nonVAMedicationTypes,
-              inline: false,
-            },
-            {
-              title: 'When you started taking this medication',
-              value: dateFormat(prescription.dispensedDate, 'MMMM D, YYYY'),
-              inline: true,
-            },
-            {
-              title: 'Documented by',
-              value: prescription.providerLastName
-                ? `${
-                    prescription.providerLastName
-                  }, ${prescription.providerFirstName || ''}`
-                : 'None noted',
-              inline: true,
-            },
-            {
-              title: 'Documented at this facility',
-              value: validateField(prescription.facilityName),
-              inline: true,
-            },
-            {
-              title: 'Provider notes',
-              value: validateField(prescription.remarks),
               inline: true,
             },
           ],


### PR DESCRIPTION
## Summary

Medications List PDF used to show the same data/format for both VA and NON-VA prescriptions. This PR updates NON-VA prescription config for Medications List PDF.

## Related issue(s)

[Jira ticket](https://jira.devops.va.gov/browse/MHV-50139)

<img width="865" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/ed274e34-9ca2-4912-a011-db86ff61340a">


Before:

<img width="730" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/0a0ebe08-be03-4589-8704-e84aacedc880">


After:

<img width="740" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/e15427aa-5ee9-46f1-b767-bd9ddfbfbe7d">

## Acceptance Criteria

Non-va meds show different information than VA meds on PDF

## Testing done

- Verified update by downloading the PDF
- This is just a data configuration therefore no unit tests were updated

## What areas of the site does it impact?

my-health/Medications 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
