### PR TITLE
[Rated Disabilities] Moving OnThisPageLink rendering into separate component

### DIFF
--- a/src/applications/rated-disabilities/components/OnThisPage.jsx
+++ b/src/applications/rated-disabilities/components/OnThisPage.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { OnThisPageLink } from './OnThisPageLink';
+
+export default function OnThisPage() {
+  return (
+    <div className="usa-width-one-third">
+      <h2 className="vads-u-font-size--h3">On this page</h2>
+      <OnThisPageLink
+        text="Your combined disability rating"
+        link="#combined-rating"
+      />
+      <OnThisPageLink
+        text="Your individual ratings"
+        link="#individual-ratings"
+      />
+      <OnThisPageLink text="Learn about VA disabilities" link="#learn" />
+    </div>
+  );
+}

--- a/src/applications/rated-disabilities/components/RatedDisabilityView.jsx
+++ b/src/applications/rated-disabilities/components/RatedDisabilityView.jsx
@@ -2,11 +2,10 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
-
-import { getAppUrl } from 'platform/utilities/registry-helpers';
+import { getAppUrl } from '@department-of-veterans-affairs/platform-utilities/exports';
 
 import TotalRatedDisabilities from './TotalRatedDisabilities';
-import { OnThisPageLink } from './OnThisPageLink';
+import OnThisPage from './OnThisPage';
 import RatedDisabilityList from './RatedDisabilityList';
 
 const facilityLocatorUrl = getAppUrl('facilities');
@@ -55,32 +54,8 @@ const RatedDisabilityView = ({
   }, []);
 
   let content;
-  let onThisPageHeader = '';
-  let combinedRatingLink = '';
-  let ratedDisabilitiesLink = '';
-  let learnMoreLink = '';
 
-  // If there are rated disabilites then the page gets long enough to fill these links
-  if (ratedDisabilities?.ratedDisabilities?.length > 0) {
-    onThisPageHeader = <h2 className="vads-u-font-size--h3">On this page</h2>;
-    combinedRatingLink = (
-      <OnThisPageLink
-        text="Your combined disability rating"
-        link="#combined-rating"
-      />
-    );
-
-    ratedDisabilitiesLink = (
-      <OnThisPageLink
-        text="Your individual ratings"
-        link="#individual-ratings"
-      />
-    );
-
-    learnMoreLink = (
-      <OnThisPageLink text="Learn about VA disabilities" link="#learn" />
-    );
-  }
+  const hasRatedDisabilities = ratedDisabilities?.ratedDisabilities?.length > 0;
 
   // Total Disability Calculation and Pending Disabilities should go here.
   if (user.profile.verified) {
@@ -91,12 +66,7 @@ const RatedDisabilityView = ({
             <div className="vads-l-col--12">
               <h1>View your VA disability ratings</h1>
             </div>
-            <div className="usa-width-one-third">
-              {onThisPageHeader}
-              {combinedRatingLink}
-              {ratedDisabilitiesLink}
-              {learnMoreLink}
-            </div>
+            {hasRatedDisabilities && <OnThisPage />}
           </div>
           <TotalRatedDisabilities
             totalDisabilityRating={totalDisabilityRating}

--- a/src/applications/rated-disabilities/tests/e2e/rated-disabilities.cypress.spec.js
+++ b/src/applications/rated-disabilities/tests/e2e/rated-disabilities.cypress.spec.js
@@ -10,11 +10,6 @@ const DISABILITIES_ENDPOINT =
   'v0/disability_compensation_form/rated_disabilities';
 const TOTAL_RATING_ENDPOINT = 'v0/disability_compensation_form/rating_info';
 
-const testAxe = () => {
-  cy.injectAxe();
-  cy.axeCheck();
-};
-
 const testHappyPath = () => {
   cy.intercept('GET', DISABILITIES_ENDPOINT, mockDisabilities).as(
     'mockDisabilities',
@@ -22,7 +17,7 @@ const testHappyPath = () => {
   cy.intercept('GET', TOTAL_RATING_ENDPOINT, mockTotalRating).as(
     'mockTotalRating',
   );
-  testAxe();
+
   cy.findByText(/90%/).should('exist');
   cy.findAllByText(/Diabetes mellitus0/).should('have.length', 2);
 };
@@ -36,7 +31,7 @@ const testErrorStates = () => {
     body: mockErrorResponse,
     statusCode: 404,
   }).as('totalRatingClientError');
-  testAxe();
+
   cy.findByText(
     /We don’t have a combined disability rating on file for you/,
   ).should('exist');
@@ -49,12 +44,16 @@ describe('View rated disabilities', () => {
   beforeEach(() => {
     cy.login();
     cy.visit(RATED_DISABILITIES_PATH);
+    cy.injectAxe();
   });
 
   it('should display a total rating and a list of ratings', () => {
     testHappyPath();
+    cy.axeCheck();
   });
+
   it('should handle response errors by displaying the correct messaging', () => {
     testErrorStates();
+    cy.axeCheck();
   });
 });

--- a/src/applications/rated-disabilities/tests/e2e/rated-disabilities.cypress.spec.js
+++ b/src/applications/rated-disabilities/tests/e2e/rated-disabilities.cypress.spec.js
@@ -2,7 +2,10 @@ import mockDisabilities from '../mockdata/200-response.json';
 import mockTotalRating from '../mockdata/total-rating-response.json';
 import mockErrorResponse from '../mockdata/error-response.json';
 
-const RATED_DISABILITIES_PATH = '/disability/view-disability-rating/rating';
+// NOTE: This is a temporary path, will be switching back to the original as soon as content-build
+// changes are sorted out
+const RATED_DISABILITIES_PATH = '/disability/view-disability-rating/my-rating';
+// const RATED_DISABILITIES_PATH = '/disability/view-disability-rating/rating';
 const DISABILITIES_ENDPOINT =
   'v0/disability_compensation_form/rated_disabilities';
 const TOTAL_RATING_ENDPOINT = 'v0/disability_compensation_form/rating_info';


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
Abstracting rendering logic for the `On This Page` section of the applicaiton to a new component called `OnThisPage`

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#4784

## Testing done
Tests should be unaffected by these changes

## Screenshots
<img width="678" alt="Screenshot 2023-10-25 at 2 48 02 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/f6c96c7c-683c-491f-b3dd-50cbf786eee2">

## What areas of the site does it impact?
The Rated Disabilities application

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
