### PR TITLE
Fix the back button on the calendar page in the request flow

### DIFF
--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -342,7 +342,9 @@ export default function getNewAppointmentFlow(state) {
     },
     clinicChoice: {
       ...flow.clinicChoice,
-      url: featureBreadcrumbUrlUpdate ? 'clinic' : '/new-appointment/clinics',
+      url: featureBreadcrumbUrlUpdate
+        ? '/schedule/clinic'
+        : '/new-appointment/clinics',
     },
     contactInfo: {
       ...flow.contactInfo,


### PR DESCRIPTION
## Summary

This PR fixes the appointment flow so the back button on the calendar page goes to the previous page

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#68338

## Acceptance criteria

- [ ] It should go to the Choose a VA clinic page with the URL `https://staging.va.gov/my-health/appointments/schedule/clinic`

## Testing done

manual

## Screenshots

At the request flow on calendar page
![Screenshot 2023-10-25 at 1 12 56 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/7c4445aa-d0f4-4b15-9892-4f39a057f28a)

___
Result after clicking the back button on calendar page
![Screenshot 2023-10-25 at 1 13 12 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/094bef64-5495-4895-9b0e-2732e800e287)


## What areas of the site does it impact?

VA request flow



