### PR TITLE
Add enrollment status fetch to 10-10EZR

### DIFF
--- a/src/applications/ezr/components/IntroductionPage/SaveInProgressInfo.jsx
+++ b/src/applications/ezr/components/IntroductionPage/SaveInProgressInfo.jsx
@@ -1,16 +1,18 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import { fetchEnrollmentStatus as fetchEnrollmentStatusAction } from '../../utils/actions/enrollment-status';
 import { selectEnrollmentStatus } from '../../utils/selectors/entrollment-status';
 import { selectAuthStatus } from '../../utils/selectors/auth-status';
 import EnrollmentStatusAlert from '../FormAlerts/EnrollmentStatusAlert';
 import VerifiedPrefillAlert from '../FormAlerts/VerifiedPrefillAlert';
 import content from '../../locales/en/content.json';
 
-const SaveInProgressInfo = ({ formConfig, pageList }) => {
-  const { isLoggedOut } = useSelector(selectAuthStatus);
+const SaveInProgressInfo = props => {
+  const { fetchEnrollmentStatus, formConfig, pageList } = props;
+  const { isLoggedOut, isUserLOA3 } = useSelector(selectAuthStatus);
   const { isEnrolledinESR, hasServerError } = useSelector(
     selectEnrollmentStatus,
   );
@@ -20,6 +22,16 @@ const SaveInProgressInfo = ({ formConfig, pageList }) => {
     savedFormMessages,
     customText,
   } = formConfig;
+
+  useEffect(
+    () => {
+      if (isUserLOA3) {
+        fetchEnrollmentStatus();
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isUserLOA3],
+  );
 
   // set the props to use for the SaveInProgressIntro components
   const sipProps = {
@@ -73,8 +85,16 @@ const SaveInProgressInfo = ({ formConfig, pageList }) => {
 };
 
 SaveInProgressInfo.propTypes = {
+  fetchEnrollmentStatus: PropTypes.func,
   formConfig: PropTypes.object,
   pageList: PropTypes.array,
 };
 
-export default SaveInProgressInfo;
+const mapDispatchToProps = {
+  fetchEnrollmentStatus: fetchEnrollmentStatusAction,
+};
+
+export default connect(
+  null,
+  mapDispatchToProps,
+)(SaveInProgressInfo);

--- a/src/applications/ezr/tests/unit/utils/actions/enrollment-status.unit.spec.js
+++ b/src/applications/ezr/tests/unit/utils/actions/enrollment-status.unit.spec.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-
 import {
   mockApiRequest,
   setFetchJSONResponse,
@@ -19,110 +18,65 @@ describe('ezr enrollment status actions', () => {
   let mockData;
   let thunk;
 
-  describe('when `fetchEnrollmentStatus` executes', () => {
-    beforeEach(() => {
-      dispatch = sinon.spy();
+  beforeEach(() => {
+    dispatch = sinon.spy();
+    getState = () => ({
+      enrollmentStatus: { loading: false },
+    });
+    mockData = { data: 'data' };
+    thunk = fetchEnrollmentStatus();
+  });
+
+  context('when fetch operation starts', () => {
+    it('should dispatch a fetch started action', done => {
+      mockApiRequest(mockData);
+      thunk(dispatch, getState)
+        .then(() => {
+          const action = dispatch.firstCall.args[0];
+          expect(action.type).to.equal(FETCH_ENROLLMENT_STATUS_STARTED);
+        })
+        .then(done, done);
+    });
+  });
+
+  context('when fetch operation succeeds', () => {
+    it('should dispatch a fetch succeeded action with data', done => {
+      mockApiRequest(mockData);
+      thunk(dispatch, getState)
+        .then(() => {
+          const action = dispatch.secondCall.args[0];
+          expect(action.type).to.equal(FETCH_ENROLLMENT_STATUS_SUCCEEDED);
+          expect(action.response).to.equal(mockData);
+        })
+        .then(done, done);
+    });
+  });
+
+  context('when fetch operation fails', () => {
+    it('should dispatch a fetch failed action', done => {
+      mockApiRequest(mockData, false);
+      setFetchJSONResponse(
+        global.fetch.onCall(0),
+        // eslint-disable-next-line prefer-promise-reject-errors
+        Promise.reject({ status: 503, error: 'error' }),
+      );
+      thunk(dispatch, getState)
+        .then(() => {
+          const action = dispatch.secondCall.args[0];
+          expect(action.type).to.equal(FETCH_ENROLLMENT_STATUS_FAILED);
+        })
+        .then(done, done);
+    });
+  });
+
+  context('when fetch operation is already in progress', () => {
+    it('should not dispatch anything', done => {
       getState = () => ({
-        enrollmentStatus: { loading: false },
+        enrollmentStatus: { loading: true },
       });
-      mockData = { data: 'data' };
-      thunk = fetchEnrollmentStatus();
-    });
-
-    context('when fetch operation starts', () => {
-      it('should dispatch a fetch started action', done => {
-        mockApiRequest(mockData);
-        thunk(dispatch, getState)
-          .then(() => {
-            const action = dispatch.firstCall.args[0];
-            expect(action.type).to.equal(FETCH_ENROLLMENT_STATUS_STARTED);
-          })
-          .then(done, done);
-      });
-    });
-
-    context('when fetch operation succeeds', () => {
-      it('should dispatch a fetch succeeded action with data', done => {
-        mockApiRequest(mockData);
-        thunk(dispatch, getState)
-          .then(() => {
-            const action = dispatch.secondCall.args[0];
-            expect(action.type).to.equal(FETCH_ENROLLMENT_STATUS_SUCCEEDED);
-            expect(action.response).to.equal(mockData);
-          })
-          .then(done, done);
-      });
-    });
-
-    context('when fetch operation fails', () => {
-      it('should dispatch a fetch failed action', done => {
-        mockApiRequest(mockData, false);
-        setFetchJSONResponse(
-          global.fetch.onCall(0),
-          // eslint-disable-next-line prefer-promise-reject-errors
-          Promise.reject({ status: 503, error: 'error' }),
-        );
-        thunk(dispatch, getState)
-          .then(() => {
-            const action = dispatch.secondCall.args[0];
-            expect(action.type).to.equal(FETCH_ENROLLMENT_STATUS_FAILED);
-          })
-          .then(done, done);
-      });
-    });
-
-    context('when fetch operation is already in progress', () => {
-      it('should not dispatch anything', done => {
-        getState = () => ({
-          enrollmentStatus: { loading: true },
-        });
-        expect(thunk(dispatch, getState)).to.be.null;
-        expect(dispatch.notCalled).to.be.true;
-        done();
-      });
-    });
-
-    context('when form data is provided to fetch operation', () => {
-      it('should append the form data to the request URL', done => {
-        mockData = {
-          data: {
-            dob: '01-01-00',
-            firstName: 'Pat',
-            lastName: 'Smith',
-            ssn: '123-12-1234',
-          },
-        };
-        thunk = fetchEnrollmentStatus(mockData.data);
-
-        mockApiRequest(mockData);
-        setFetchJSONResponse(global.fetch.onCall(0), { status: 'OK' });
-
-        thunk(dispatch, getState)
-          .then(() => {
-            const fetch = global.fetch.firstCall.args[0];
-            expect(fetch).to.contain(
-              `${encodeURI('userAttributes[veteranDateOfBirth]')}=${
-                mockData.data.dob
-              }`,
-            );
-            expect(fetch).to.contain(
-              `${encodeURI('userAttributes[veteranFullName][first]')}=${
-                mockData.data.firstName
-              }`,
-            );
-            expect(fetch).to.contain(
-              `${encodeURI('userAttributes[veteranFullName][last]')}=${
-                mockData.data.lastName
-              }`,
-            );
-            expect(fetch).to.contain(
-              `${encodeURI('userAttributes[veteranSocialSecurityNumber]')}=${
-                mockData.data.ssn
-              }`,
-            );
-          })
-          .then(done, done);
-      });
+      expect(thunk(dispatch, getState)).to.be.null;
+      expect(dispatch.notCalled).to.be.true;
+      done();
     });
   });
 });

--- a/src/applications/ezr/tests/unit/utils/helpers/enrollment-status.unit.spec.js
+++ b/src/applications/ezr/tests/unit/utils/helpers/enrollment-status.unit.spec.js
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+import { mockApiRequest } from 'platform/testing/unit/helpers';
+import sinon from 'sinon';
+
+import {
+  callAPI,
+  callFakeSuccess,
+} from '../../../../utils/helpers/enrollment-status';
+
+describe('ezr enrollment status helpers', () => {
+  let dispatch;
+
+  beforeEach(() => {
+    dispatch = sinon.spy();
+  });
+
+  context('when `callAPI` executes', done => {
+    it('should execute the dispatch function', () => {
+      mockApiRequest({ data: 'data' });
+      callAPI(dispatch)
+        .then(() => {
+          expect(dispatch).to.be.called;
+        })
+        .then(done, done);
+    });
+  });
+
+  context('when `callFakeSuccess` executes', done => {
+    it('should execute the dispatch function', () => {
+      callFakeSuccess(dispatch)
+        .then(() => {
+          expect(dispatch).to.be.called;
+        })
+        .then(done, done);
+    });
+  });
+});

--- a/src/applications/ezr/utils/actions/enrollment-status.js
+++ b/src/applications/ezr/utils/actions/enrollment-status.js
@@ -1,8 +1,7 @@
-import appendQuery from 'append-query';
-import { apiRequest } from 'platform/utilities/api';
-
+import environment from 'platform/utilities/environment';
 import { selectEnrollmentStatus } from '../selectors/entrollment-status';
 import { ENROLLMENT_STATUS_ACTIONS } from '../constants';
+import { callAPI, callFakeSuccess } from '../helpers/enrollment-status';
 
 /**
  * Action to fetch the current enrollment status based on the provided user data
@@ -10,34 +9,27 @@ import { ENROLLMENT_STATUS_ACTIONS } from '../constants';
  * @returns {Promise} - resolves to calling the reducer to set the correct state variables
  * for enrollment status
  */
-export function fetchEnrollmentStatus(formData = {}) {
+export function fetchEnrollmentStatus() {
   return (dispatch, getState) => {
     const { isLoading } = selectEnrollmentStatus(getState());
     if (isLoading) return null;
 
-    const {
-      FETCH_ENROLLMENT_STATUS_STARTED,
-      FETCH_ENROLLMENT_STATUS_FAILED,
-      FETCH_ENROLLMENT_STATUS_SUCCEEDED,
-    } = ENROLLMENT_STATUS_ACTIONS;
-    const { firstName, lastName, dob, ssn } = formData;
+    // NOTE: flip the `false` to `true` to fake the endpoint when testing locally
+    // eslint-disable-next-line sonarjs/no-redundant-boolean
+    const simulateServerLocally = environment.isLocalhost() && false;
+    const { FETCH_ENROLLMENT_STATUS_STARTED } = ENROLLMENT_STATUS_ACTIONS;
 
     dispatch({ type: FETCH_ENROLLMENT_STATUS_STARTED });
 
-    const baseUrl = `/health_care_applications/enrollment_status`;
-    const requestUrl = appendQuery(baseUrl, {
-      'userAttributes[veteranFullName][first]': firstName,
-      'userAttributes[veteranFullName][last]': lastName,
-      'userAttributes[veteranDateOfBirth]': dob,
-      'userAttributes[veteranSocialSecurityNumber]': ssn,
-    });
+    /*
+    When hitting the API locally, we cannot get responses other than 500s from
+    the endpoint due to the endpoint's need to connect to MVI. To get around this, 
+    confirm that `simulateServerLocally` evals to `true` and then optionally adjust 
+    what the `callFakeSuccess` functions return.
+    */
 
-    return apiRequest(requestUrl)
-      .then(response =>
-        dispatch({ type: FETCH_ENROLLMENT_STATUS_SUCCEEDED, response }),
-      )
-      .catch(({ errors }) =>
-        dispatch({ type: FETCH_ENROLLMENT_STATUS_FAILED, errors }),
-      );
+    return simulateServerLocally
+      ? callFakeSuccess(dispatch)
+      : callAPI(dispatch);
   };
 }

--- a/src/applications/ezr/utils/helpers/enrollment-status.js
+++ b/src/applications/ezr/utils/helpers/enrollment-status.js
@@ -1,0 +1,50 @@
+import { apiRequest } from 'platform/utilities/api';
+import { ENROLLMENT_STATUS_ACTIONS } from '../constants';
+
+/**
+ * Provide a mocked 200 response when calling the API endpoint
+ * @param {Function} dispatch - tells the enrollment status reducer
+ * what dataset to return
+ * @param {String} type - the dispatch type to call
+ */
+export function callFakeSuccess(dispatch) {
+  const { FETCH_ENROLLMENT_STATUS_SUCCEEDED } = ENROLLMENT_STATUS_ACTIONS;
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, 1000);
+  }).then(() => {
+    dispatch({
+      type: FETCH_ENROLLMENT_STATUS_SUCCEEDED,
+      response: {
+        applicationDate: '2019-04-24T00:00:00.000-06:00',
+        enrollmentDate: '2019-04-30T00:00:00.000-06:00',
+        preferredFacility: '463 - CHEY6',
+        parsedStatus: 'enrolled',
+        effectiveDate: '2019-04-25T00:00:00.000-06:00',
+      },
+    });
+  });
+}
+
+/**
+ * Call the `/health_care_applications/enrollment_status` endpoint
+ * @param {Function} dispatch - tells the enrollment status reducer what data
+ * set to return
+ * @param {Object} formData - data object from the ID form fields
+ */
+export function callAPI(dispatch) {
+  const {
+    FETCH_ENROLLMENT_STATUS_SUCCEEDED,
+    FETCH_ENROLLMENT_STATUS_FAILED,
+  } = ENROLLMENT_STATUS_ACTIONS;
+  const requestUrl = `/health_care_applications/enrollment_status`;
+
+  return apiRequest(requestUrl)
+    .then(response =>
+      dispatch({ type: FETCH_ENROLLMENT_STATUS_SUCCEEDED, response }),
+    )
+    .catch(({ errors }) =>
+      dispatch({ type: FETCH_ENROLLMENT_STATUS_FAILED, errors }),
+    );
+}


### PR DESCRIPTION
## Summary
This PR wires up the enrollment status fetch action to the introduction page of the 10-10EZR form. The response data from this fetch controls an array of alerts and conditional action that users can take within the application.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#68413

## Testing done
- [x] Unit tested all fetch actions and associated helper functions

## Acceptance criteria
- Fetch action executes properly to get the users enrollment status
- Fetch action only occurs for LOA3 users

### Quality Assurance & Testing

- [x] I updated & added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
