### PR TITLE
[Rated Disabilities] Adding new feature toggle for rated disabilities discrepancy detection

### DIFF
--- a/src/applications/personalization/rated-disabilities/selectors.js
+++ b/src/applications/personalization/rated-disabilities/selectors.js
@@ -27,3 +27,6 @@ export const hasTotalDisabilityServerError = state => {
 // 'rated_disabilities_use_lighthouse`
 export const rdUseLighthouse = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.ratedDisabilitiesUseLighthouse];
+
+export const rdDetectDiscrepancies = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.ratedDisabilitiesDetectDiscrepancies];

--- a/src/applications/rated-disabilities/selectors.js
+++ b/src/applications/rated-disabilities/selectors.js
@@ -27,3 +27,6 @@ export const hasTotalDisabilityServerError = state => {
 // 'rated_disabilities_use_lighthouse`
 export const rdUseLighthouse = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.ratedDisabilitiesUseLighthouse];
+
+export const rdDetectDiscrepancies = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.ratedDisabilitiesDetectDiscrepancies];

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -137,6 +137,7 @@ export default Object.freeze({
   profileUseNotificationSettingsCheckboxes: 'profile_use_notification_settings_checkboxes',
   pwEhrCtaUseSlo: 'pw_ehr_cta_use_slo',
   ratedDisabilitiesSortAbTest: 'rated_disabilities_sort_ab_test',
+  ratedDisabilitiesDetectDiscrepancies: 'rated_disabilities_detect_discrepancies',
   ratedDisabilitiesUseLighthouse: 'rated_disabilities_use_lighthouse',
   scBrowserMonitoringEnabled: 'sc_browser_monitoring_enabled',
   searchRepresentative: 'search_representative',


### PR DESCRIPTION
## Summary
Adding a new feature toggle for detecting rated disabilities discrepancies between the LH and EVSS responses.

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#68409

## Related PR(s)
- department-of-veterans-affairs/vets-api/pull/14293

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
