### PR TITLE
MHV-50741 Retry fetching MR allergies

### DIFF
--- a/src/applications/mhv/medical-records/containers/Allergies.jsx
+++ b/src/applications/mhv/medical-records/containers/Allergies.jsx
@@ -137,7 +137,17 @@ const Allergies = props => {
       return <AccessTroubleAlertBox alertType={accessAlertTypes.ALLERGY} />;
     }
     if (allergies?.length > 0) {
-      return <RecordList records={allergies} type={recordType.ALLERGIES} />;
+      return (
+        <>
+          <PrintDownload
+            list
+            download={generateAllergiesPdf}
+            allowTxtDownloads={allowTxtDownloads}
+          />
+          <DownloadingRecordsInfo allowTxtDownloads={allowTxtDownloads} />
+          <RecordList records={allergies} type={recordType.ALLERGIES} />
+        </>
+      );
     }
     if (allergies?.length === 0) {
       return (
@@ -149,12 +159,14 @@ const Allergies = props => {
       );
     }
     return (
-      <va-loading-indicator
-        message="Loading..."
-        setFocus
-        data-testid="loading-indicator"
-        class="loading-indicator"
-      />
+      <div className="vads-u-margin-top--8 vads-u-margin-bottom--8">
+        <va-loading-indicator
+          message="We’re loading your records. This could take up to a minute."
+          setFocus
+          data-testid="loading-indicator"
+          // class="loading-indicator"
+        />
+      </div>
     );
   };
 
@@ -171,16 +183,6 @@ const Allergies = props => {
         If you have allergies that are missing from this list, tell your care
         team at your next appointment.
       </p>
-      {!accessAlert && (
-        <>
-          <PrintDownload
-            list
-            download={generateAllergiesPdf}
-            allowTxtDownloads={allowTxtDownloads}
-          />
-          <DownloadingRecordsInfo allowTxtDownloads={allowTxtDownloads} />
-        </>
-      )}
       {content()}
     </div>
   );

--- a/src/applications/mhv/medical-records/tests/api/MrApi.unit.spec.js
+++ b/src/applications/mhv/medical-records/tests/api/MrApi.unit.spec.js
@@ -12,6 +12,7 @@ import allergy from '../fixtures/allergy.json';
 import vaccines from '../fixtures/vaccines.json';
 import vaccine from '../fixtures/vaccine.json';
 import {
+  testableApiRequestWithRetry,
   getAllergies,
   getAllergy,
   getCondition,
@@ -25,6 +26,55 @@ import {
   getVitalsList,
   postSharingUpdateStatus,
 } from '../../api/MrApi';
+
+describe('apiRequestWithRetry', () => {
+  let callCount = 0;
+
+  const mockApiRequest = async () => {
+    callCount += 1;
+    if (callCount < 3) {
+      // We are throwing a very specific object here that has an "errors" property,
+      // unlike the JS errors object.
+      // eslint-disable-next-line no-throw-literal
+      throw { errors: [{ code: '404' }] };
+    }
+    return 'success';
+  };
+
+  beforeEach(() => {
+    callCount = 0;
+  });
+
+  it('times out if success is not returned quickly enough', async () => {
+    try {
+      const shortEndTime = Date.now() + 1000; // 1 second from now
+      await testableApiRequestWithRetry(mockApiRequest)(
+        'http://example.com/api',
+        {},
+        shortEndTime,
+      );
+      expect.fail('Function should have thrown an error due to timeout');
+    } catch (error) {
+      expect(error).to.exist;
+      expect(callCount).to.be.lessThan(3);
+    }
+  });
+
+  it('retries several times before returning successfully', async () => {
+    try {
+      const endTime = Date.now() + 5000; // 5 seconds from now
+      const result = await testableApiRequestWithRetry(mockApiRequest)(
+        'http://example.com/api',
+        {},
+        endTime,
+      );
+      expect(result).to.equal('success');
+      expect(callCount).to.equal(3);
+    } catch (error) {
+      expect.fail('Function should not have thrown an error');
+    }
+  });
+});
 
 describe('Get labs and tests api call', () => {
   it('should make an api call to get all labs and tests', () => {

--- a/src/applications/mhv/medical-records/tests/api/MrApi.unit.spec.js
+++ b/src/applications/mhv/medical-records/tests/api/MrApi.unit.spec.js
@@ -30,7 +30,8 @@ import {
 describe('apiRequestWithRetry', () => {
   let callCount = 0;
 
-  const mockApiRequest = async () => {
+  const mockedApiRequest = async () => {
+    // Throw a 404 error twice, then return success on the third try.
     callCount += 1;
     if (callCount < 3) {
       // We are throwing a very specific object here that has an "errors" property,
@@ -47,11 +48,11 @@ describe('apiRequestWithRetry', () => {
 
   it('times out if success is not returned quickly enough', async () => {
     try {
-      const shortEndTime = Date.now() + 1000; // 1 second from now
-      await testableApiRequestWithRetry(mockApiRequest)(
+      const endTime = Date.now() + 100;
+      await testableApiRequestWithRetry(200, mockedApiRequest)(
         'http://example.com/api',
         {},
-        shortEndTime,
+        endTime,
       );
       expect.fail('Function should have thrown an error due to timeout');
     } catch (error) {
@@ -62,8 +63,8 @@ describe('apiRequestWithRetry', () => {
 
   it('retries several times before returning successfully', async () => {
     try {
-      const endTime = Date.now() + 5000; // 5 seconds from now
-      const result = await testableApiRequestWithRetry(mockApiRequest)(
+      const endTime = Date.now() + 500;
+      const result = await testableApiRequestWithRetry(200, mockedApiRequest)(
         'http://example.com/api',
         {},
         endTime,


### PR DESCRIPTION
## Summary

- If the `/allergies` endpoints return a 404 (indicating patient record not found), continue polling the endpoint for 90 seconds while displaying a loading spinner and relevant message.
- Rearranged some JSX in Allergies.jsx to avoid multiple conditional checks.

## Related issue(s)

### [MHV-50741](https://jira.devops.va.gov/browse/MHV-50741) - If a user's allergies records are not ready, display a spinner ###

> When a user browses to MR for the very first time, their patient record may not yet be ready in time to display their allergies records. Currently we display an error message.
> 
> Instead, poll the endpoint and continue to fetch the API until we have data (meaning the patient record was created).
> 
> It may be desirable to have a cutoff period rather than poll indefinitely.
> 

## Testing done

- Added unit tests to test both success and timeout of the retry function.

## Screenshots

<img width="638" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/d304e298-6751-419e-bf89-02bd2c8027f4">

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
  - The console prints an error for each failed polling of the backend, but this appears to be built into the browser and cannot be overridden, even by catching and swallowing the exception.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
