### PR TITLE
Extending travel pilot for 657GB

### DIFF
--- a/src/applications/check-in/utils/pilotFeatures/index.js
+++ b/src/applications/check-in/utils/pilotFeatures/index.js
@@ -17,6 +17,10 @@ const pilotFeatures = {
     pilotStations: {
       ...devStations,
       ...fileTravelClaimWilkesBarre,
+      // Merge 10/30/23 after 5pm EST
+      '657GB': {},
+      // Uncomment and merge 10/31/23 after 5pm EST
+      // '657GA': {},
       // Week 1 658
       // ...fileTravelClaimSalem,
       // Week 2 565


### PR DESCRIPTION
## Summary

Adds 657GB to travel pilot and sets up 657GA to be added later. Don't merge until after 5pm EST on Monday 10/30/2023

## What areas of the site does it impact?

Day-of check-in

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
