### PR TITLE
MHV-50422: Follow up - hid Medications behind the toggle (in addition…

### DIFF
--- a/src/applications/mhv/medications/containers/App.jsx
+++ b/src/applications/mhv/medications/containers/App.jsx
@@ -1,13 +1,42 @@
 import React from 'react';
-import Prescriptions from './Prescriptions';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 
-const App = () => {
-  return (
-    <div>
-      <Prescriptions />
-      <va-back-to-top />
-    </div>
+const App = ({ children }) => {
+  const { featureTogglesLoading, appEnabled } = useSelector(
+    state => {
+      return {
+        featureTogglesLoading: state.featureToggles.loading,
+        appEnabled:
+          state.featureToggles[FEATURE_FLAG_NAMES.mhvMedicationsToVaGovRelease],
+      };
+    },
+    state => state.featureToggles,
   );
+
+  if (featureTogglesLoading) {
+    return (
+      <div className="vads-l-grid-container">
+        <va-loading-indicator
+          message="Loading your medications..."
+          setFocus
+          data-testid="rx-feature-flag-loading-indicator"
+        />
+      </div>
+    );
+  }
+
+  if (!appEnabled) {
+    window.location.replace('/health-care/refill-track-prescriptions');
+    return <></>;
+  }
+
+  return children;
+};
+
+App.propTypes = {
+  children: PropTypes.object,
 };
 
 export default App;

--- a/src/applications/mhv/medications/containers/PrintBottom.jsx
+++ b/src/applications/mhv/medications/containers/PrintBottom.jsx
@@ -5,7 +5,7 @@ const PrintBottom = () => {
   return (
     <div className="print-only print-bottom vads-u-padding-bottom--0">
       <span>{window.location.href}</span>
-      <span>{dateFormat(Date())}</span>
+      <span>{dateFormat(Date.now())}</span>
     </div>
   );
 };

--- a/src/applications/mhv/medications/routes.jsx
+++ b/src/applications/mhv/medications/routes.jsx
@@ -3,25 +3,31 @@ import { Switch, Route } from 'react-router-dom';
 import App from './containers/App';
 import PrescriptionDetails from './containers/PrescriptionDetails';
 import RxBreadcrumbs from './containers/RxBreadcrumbs';
+import Prescriptions from './containers/Prescriptions';
 
 const routes = (
   <div className="vads-l-grid-container">
     <div className="main-content vads-l-col--12 medium-screen:vads-l-col--8 medium-screen:vads-u-margin-left--neg2 vads-u-max-width--100">
-      <RxBreadcrumbs />
-      <div>
-        <Switch>
-          <Route exact path={['/', '/:page']} key="App">
-            <App />
-          </Route>
-          <Route
-            exact
-            path="/prescription/:prescriptionId"
-            key="prescriptionDetails"
-          >
-            <PrescriptionDetails />
-          </Route>
-        </Switch>
-      </div>
+      <App>
+        <RxBreadcrumbs />
+        <div>
+          <Switch>
+            <Route exact path={['/', '/:page']} key="App">
+              <div>
+                <Prescriptions />
+                <va-back-to-top />
+              </div>
+            </Route>
+            <Route
+              exact
+              path="/prescription/:prescriptionId"
+              key="prescriptionDetails"
+            >
+              <PrescriptionDetails />
+            </Route>
+          </Switch>
+        </div>
+      </App>
     </div>
   </div>
 );

--- a/src/applications/mhv/medications/tests/containers/App.unit.spec.jsx
+++ b/src/applications/mhv/medications/tests/containers/App.unit.spec.jsx
@@ -37,8 +37,6 @@ describe('Medications <App>', () => {
       </App>,
       initialStateFeatureFlag(false, false),
     );
-    expect(screenFeatureToggle.getByTestId('rx-feature-flag-loading-indicator'))
-      .to.not.exist;
     expect(screenFeatureToggle.queryByText('unit test paragraph')).to.be.null;
   });
 
@@ -49,8 +47,6 @@ describe('Medications <App>', () => {
       </App>,
       initialStateFeatureFlag(false, true),
     );
-    expect(screenFeatureToggle.getByTestId('rx-feature-flag-loading-indicator'))
-      .to.not.exist;
     expect(screenFeatureToggle.queryByText('unit test paragraph')).to.exist;
   });
 });

--- a/src/applications/mhv/medications/tests/containers/App.unit.spec.jsx
+++ b/src/applications/mhv/medications/tests/containers/App.unit.spec.jsx
@@ -38,7 +38,7 @@ describe('Medications <App>', () => {
       initialStateFeatureFlag(false, false),
     );
     expect(screenFeatureToggle.getByTestId('rx-feature-flag-loading-indicator'))
-      .to.be.null;
+      .to.not.exist;
     expect(screenFeatureToggle.queryByText('unit test paragraph')).to.be.null;
   });
 
@@ -50,7 +50,7 @@ describe('Medications <App>', () => {
       initialStateFeatureFlag(false, true),
     );
     expect(screenFeatureToggle.getByTestId('rx-feature-flag-loading-indicator'))
-      .to.be.null;
+      .to.not.exist;
     expect(screenFeatureToggle.queryByText('unit test paragraph')).to.exist;
   });
 });

--- a/src/applications/mhv/medications/tests/containers/App.unit.spec.jsx
+++ b/src/applications/mhv/medications/tests/containers/App.unit.spec.jsx
@@ -1,0 +1,56 @@
+import { expect } from 'chai';
+import React from 'react';
+import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
+import reducer from '../../reducers';
+import App from '../../containers/App';
+
+describe('Medications <App>', () => {
+  const initialStateFeatureFlag = (loading = true, flag = true) => {
+    return {
+      initialState: {
+        featureToggles: {
+          loading,
+          // eslint-disable-next-line camelcase
+          mhv_medications_to_va_gov_release: flag,
+        },
+      },
+      path: `/`,
+      reducers: reducer,
+    };
+  };
+  it('feature flags are still loading', () => {
+    const screenFeatureToggle = renderWithStoreAndRouter(
+      <App>
+        <p data-testid="app-unit-test-p">unit test paragraph</p>
+      </App>,
+      initialStateFeatureFlag(),
+    );
+    expect(screenFeatureToggle.getByTestId('rx-feature-flag-loading-indicator'))
+      .to.exist;
+    expect(screenFeatureToggle.queryByText('unit test paragraph')).to.be.null;
+  });
+
+  it('feature flag set to false', () => {
+    const screenFeatureToggle = renderWithStoreAndRouter(
+      <App>
+        <p data-testid="app-unit-test-p">unit test paragraph</p>
+      </App>,
+      initialStateFeatureFlag(false, false),
+    );
+    expect(screenFeatureToggle.getByTestId('rx-feature-flag-loading-indicator'))
+      .to.be.null;
+    expect(screenFeatureToggle.queryByText('unit test paragraph')).to.be.null;
+  });
+
+  it('feature flag set to true', () => {
+    const screenFeatureToggle = renderWithStoreAndRouter(
+      <App>
+        <p data-testid="app-unit-test-p">unit test paragraph</p>
+      </App>,
+      initialStateFeatureFlag(false, true),
+    );
+    expect(screenFeatureToggle.getByTestId('rx-feature-flag-loading-indicator'))
+      .to.be.null;
+    expect(screenFeatureToggle.queryByText('unit test paragraph')).to.exist;
+  });
+});


### PR DESCRIPTION
… to About Medications aka Landing Page)

## Summary

- This is a follow up of #26362  
- The same logic implemented for About Medications page has been applied for Medications App (covers Medications List and Medication Details)

## Acceptance criteria

User is redirected to `/health-care/refill-track-prescriptions` from Medications if `mhvMedicationsToVaGovRelease` is turned off.

## Related issue(s)

[Jira ticket](https://jira.devops.va.gov/browse/MHV-50422)

<img width="931" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/6657c7d9-7906-450c-9f05-1297f1652438">

## What areas of the site does it impact?

my-health/Medications 

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
