### PR TITLE
Create CTA widget for 10-10EZR static content page

### DIFF
--- a/src/applications/static-pages/cta-widget/ctaWidgets.js
+++ b/src/applications/static-pages/cta-widget/ctaWidgets.js
@@ -21,6 +21,8 @@ export const CTA_WIDGET_TYPES = {
   DIRECT_DEPOSIT: 'direct-deposit',
   DISABILITY_BENEFITS: 'disability-benefits',
   DISABILITY_RATINGS: 'disability-ratings',
+  EDUCATION_LETTERS: 'education-letters',
+  ENROLLMENT_VERIFICATION: 'enrollment-verification',
   GI_BILL_BENEFITS: 'gi-bill-benefits',
   HEALTH_RECORDS: 'health-records',
   HEARING_AID_SUPPLIES: 'hearing-aid-supplies',
@@ -32,14 +34,13 @@ export const CTA_WIDGET_TYPES = {
   MESSAGING: 'messaging',
   RX: 'rx',
   SCHEDULE_APPOINTMENTS: 'schedule-appointments',
+  UPDATE_HEALTH_BENEFITS_INFO: 'update-health-benefits-info',
   VETERAN_ID_CARD: 'vic',
   VET_TEC: 'vet-tec',
   VIEW_APPOINTMENTS: 'view-appointments',
   VIEW_DEPENDENTS: 'view-dependents',
   VIEW_PAYMENT_HISTORY: 'view-payment-history',
   VRRAP: 'vrrap',
-  EDUCATION_LETTERS: 'education-letters',
-  ENROLLMENT_VERIFICATION: 'enrollment-verification',
 };
 
 export const ctaWidgetsLookup = {
@@ -263,6 +264,18 @@ export const ctaWidgetsLookup = {
     mhvToolName: 'VA Appointments',
     requiredServices: null,
     serviceDescription: 'view, schedule, or cancel your appointment online',
+  },
+  [CTA_WIDGET_TYPES.UPDATE_HEALTH_BENEFITS_INFO]: {
+    id: CTA_WIDGET_TYPES.UPDATE_HEALTH_BENEFITS_INFO,
+    deriveToolUrlDetails: () => ({
+      url: '/my-health/update-benefits-information-form-10-10ezr',
+      redirect: true,
+    }),
+    hasRequiredMhvAccount: () => false,
+    isHealthTool: false,
+    mhvToolName: null,
+    requiredServices: null,
+    serviceDescription: 'update your health benefits information',
   },
   [CTA_WIDGET_TYPES.VETERAN_ID_CARD]: {
     id: CTA_WIDGET_TYPES.VETERAN_ID_CARD,


### PR DESCRIPTION
## Summary
This PR creates a new Call to Action widget for the content folks to use on the 10-10EZR static page. The widget is the canned CTA that encourages the Veteran to sign in to complete a task.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#64019

## Acceptance criteria
- Widget is successfully available for use by CMS

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed