### PR TITLE
Fix typo in intent type Survivor

### DIFF
--- a/src/applications/simple-forms/21-0966/definitions/constants.js
+++ b/src/applications/simple-forms/21-0966/definitions/constants.js
@@ -11,12 +11,12 @@ export const veteranBenefits = {
 };
 
 export const survivingDependentBenefits = {
-  SURVIVORS: 'survivors',
+  SURVIVOR: 'survivor',
 };
 
 export const benefitPhrases = {
   COMPENSATION: 'disability compensation claim',
   PENSION: 'pension claim',
-  SURVIVORS: 'pension claim for survivors',
+  SURVIVOR: 'pension claim for survivors',
   COMPENSATION_AND_PENSION: 'disability compensation and pension claims',
 };

--- a/src/applications/simple-forms/21-0966/pages/survivingDependentBenefitSelection.js
+++ b/src/applications/simple-forms/21-0966/pages/survivingDependentBenefitSelection.js
@@ -14,7 +14,7 @@ export default {
       labelHeaderLevel: '3',
       tile: true,
       labels: {
-        [survivingDependentBenefits.SURVIVORS]: {
+        [survivingDependentBenefits.SURVIVOR]: {
           title:
             'Survivors pension and/or dependency and indemnity compensation (DIC)',
           description:

--- a/src/applications/simple-forms/21-0966/pages/thirdPartySurvivingDependentBenefitSelection.js
+++ b/src/applications/simple-forms/21-0966/pages/thirdPartySurvivingDependentBenefitSelection.js
@@ -14,7 +14,7 @@ export default {
       labelHeaderLevel: '3',
       tile: true,
       labels: {
-        [survivingDependentBenefits.SURVIVORS]: {
+        [survivingDependentBenefits.SURVIVOR]: {
           title:
             'Survivors pension and/or dependency and indemnity compensation (DIC)',
           description:

--- a/src/applications/simple-forms/21-0966/tests/config/helpers.unit.spec.js
+++ b/src/applications/simple-forms/21-0966/tests/config/helpers.unit.spec.js
@@ -223,7 +223,7 @@ describe('confirmation page helper functions', () => {
       [
         veteranBenefits.COMPENSATION,
         veteranBenefits.PENSION,
-        survivingDependentBenefits.SURVIVORS,
+        survivingDependentBenefits.SURVIVOR,
       ].forEach(selectedIntent => {
         const data = {
           benefitSelection: {
@@ -335,7 +335,7 @@ describe('confirmation page helper functions', () => {
       [
         veteranBenefits.COMPENSATION,
         veteranBenefits.PENSION,
-        survivingDependentBenefits.SURVIVORS,
+        survivingDependentBenefits.SURVIVOR,
       ].forEach(selectedIntent => {
         const data = {
           benefitSelection: {
@@ -426,7 +426,7 @@ describe('confirmation page helper functions', () => {
       [
         veteranBenefits.COMPENSATION,
         veteranBenefits.PENSION,
-        survivingDependentBenefits.SURVIVORS,
+        survivingDependentBenefits.SURVIVOR,
       ].forEach(selectedIntent => {
         const data = {
           benefitSelection: {
@@ -567,7 +567,7 @@ describe('confirmation page helper functions', () => {
       [
         veteranBenefits.COMPENSATION,
         veteranBenefits.PENSION,
-        survivingDependentBenefits.SURVIVORS,
+        survivingDependentBenefits.SURVIVOR,
       ].forEach(selectedIntent => {
         const data = {
           benefitSelection: {


### PR DESCRIPTION
## Summary
I found a typo which is causing the intent type `survivor` to not show up. `survivors` is not recognized by the API but `survivor` is. Unfortunately I couldn't actually test this locally because mocked auth wasn't working but I *think* this should solve our problem with survivor.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/703
