### PR TITLE
Check in/67417/add api calls for new pre check in flow

### DIFF
--- a/src/applications/check-in/components/ActionItemDisplay.jsx
+++ b/src/applications/check-in/components/ActionItemDisplay.jsx
@@ -1,36 +1,32 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 // eslint-disable-next-line import/no-unresolved
 import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 import { createAnalyticsSlug } from '../utils/analytics';
 import { useFormRouting } from '../hooks/useFormRouting';
+
 import { makeSelectApp, makeSelectVeteranData } from '../selectors';
 import { APP_NAMES } from '../utils/appConstants';
 import {
-  hasPhoneAppointments,
   preCheckinAlreadyCompleted,
   getAppointmentId,
 } from '../utils/appointment';
 
 import WhatToDoNext from './WhatToDoNext';
+import PreCheckInSuccessAlert from './PreCheckInSuccessAlert';
 
 const ActionItemDisplay = props => {
   const { router } = props;
   const selectApp = useMemo(makeSelectApp, []);
   const { app } = useSelector(selectApp);
-  const { goToNextPage, jumpToPage } = useFormRouting(router);
+  const { goToNextPage, jumpToPage, pages } = useFormRouting(router);
   const selectVeteranData = useMemo(makeSelectVeteranData, []);
   const { appointments } = useSelector(selectVeteranData);
-  const { t } = useTranslation();
 
   const displaySuccessAlert =
-    app === APP_NAMES.PRE_CHECK_IN && preCheckinAlreadyCompleted(appointments);
-
-  const successMessage = hasPhoneAppointments(appointments)
-    ? t('your-provider-will-call-you-at-your-appointment-time')
-    : t('you-can-check-in-with-your-smartphone');
+    app === APP_NAMES.PRE_CHECK_IN &&
+    (preCheckinAlreadyCompleted(appointments) || pages.length < 5);
 
   const action = e => {
     e.preventDefault();
@@ -48,19 +44,7 @@ const ActionItemDisplay = props => {
   return (
     <>
       {displaySuccessAlert ? (
-        <section data-testid="pre-check-in-success-alert">
-          <va-alert
-            close-btn-aria-label="Close notification"
-            closeable
-            status="success"
-            visible
-          >
-            <h2 slot="headline">{t('your-information-is-up-to-date')}</h2>
-            <p data-testid="success-message" className="vads-u-margin-y--0">
-              {successMessage}
-            </p>
-          </va-alert>
-        </section>
+        <PreCheckInSuccessAlert />
       ) : (
         <section data-testid="what-to-do-next">
           <WhatToDoNext

--- a/src/applications/check-in/components/PreCheckInSuccessAlert.jsx
+++ b/src/applications/check-in/components/PreCheckInSuccessAlert.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
-import useSendPreCheckInData from '../hooks/useSendPreCheckInData';
+import { useSendPreCheckInData } from '../hooks/useSendPreCheckInData';
 
 import { makeSelectVeteranData } from '../selectors';
 import { hasPhoneAppointments } from '../utils/appointment';
@@ -21,12 +21,10 @@ const PreCheckInSuccessAlert = () => {
 
   if (isLoading) {
     return (
-      <div>
-        <va-loading-indicator
-          data-testid="loading-indicator"
-          message={t('setting-pre-check-in-completed')}
-        />
-      </div>
+      <va-loading-indicator
+        data-testid="loading-indicator"
+        message={t('setting-pre-check-in-completed')}
+      />
     );
   }
 

--- a/src/applications/check-in/components/PreCheckInSuccessAlert.jsx
+++ b/src/applications/check-in/components/PreCheckInSuccessAlert.jsx
@@ -1,0 +1,50 @@
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { useTranslation } from 'react-i18next';
+import useSendPreCheckInData from '../hooks/useSendPreCheckInData';
+
+import { makeSelectVeteranData } from '../selectors';
+import { hasPhoneAppointments } from '../utils/appointment';
+
+const PreCheckInSuccessAlert = () => {
+  const selectVeteranData = useMemo(makeSelectVeteranData, []);
+  const { appointments } = useSelector(selectVeteranData);
+  const { t } = useTranslation();
+
+  const { isLoading } = useSendPreCheckInData();
+
+  const successMessage = hasPhoneAppointments(appointments)
+    ? t('your-provider-will-call-you-at-your-appointment-time')
+    : t('you-can-check-in-with-your-smartphone', {
+        date: new Date(appointments[0].startTime),
+      });
+
+  if (isLoading) {
+    return (
+      <div>
+        <va-loading-indicator
+          data-testid="loading-indicator"
+          message={t('setting-pre-check-in-completed')}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <section data-testid="pre-check-in-success-alert">
+      <va-alert
+        close-btn-aria-label="Close notification"
+        closeable
+        status="success"
+        visible
+      >
+        <h2 slot="headline">{t('your-information-is-up-to-date')}</h2>
+        <p data-testid="success-message" className="vads-u-margin-y--0">
+          {successMessage}
+        </p>
+      </va-alert>
+    </section>
+  );
+};
+
+export default PreCheckInSuccessAlert;

--- a/src/applications/check-in/components/tests/PreCheckInSuccessAlert.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/PreCheckInSuccessAlert.unit.spec.jsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import sinon from 'sinon';
+import CheckInProvider from '../../tests/unit/utils/CheckInProvider';
+import { singleAppointment } from '../../tests/unit/mocks/mock-appointments';
+import PreCheckInSuccessAlert from '../PreCheckInSuccessAlert';
+import * as useSendPreCheckInDataModule from '../../hooks/useSendPreCheckInData';
+import { api } from '../../api';
+import * as useUpdateErrorModule from '../../hooks/useUpdateError';
+
+describe('unified check-in experience', () => {
+  describe('PreCheckInSuccessAlert', () => {
+    const singlePhoneAppointment = [...singleAppointment];
+    singlePhoneAppointment[0] = {
+      ...singlePhoneAppointment[0],
+      kind: 'phone',
+    };
+    const sandbox = sinon.createSandbox();
+    const { v2 } = api;
+    let store;
+    beforeEach(() => {
+      global.XMLHttpRequest = sinon.useFakeXMLHttpRequest();
+      store = {
+        token: '2b87cf8d-aa7d-41a7-805d-d2c0d290a0dc',
+        demographicsUpToDate: 'yes',
+        emergencyContactUpToDate: 'yes',
+        nextOfKinUpToDate: 'yes',
+      };
+    });
+    afterEach(() => {
+      sandbox.restore();
+    });
+    it('displays the pre-check-in-success-alert if the app is pre-check-in and pre check in is complete', () => {
+      const mockstore = {
+        appointments: singleAppointment,
+        app: 'preCheckIn',
+      };
+      const useSendPreCheckInDataStub = sinon
+        .stub(useSendPreCheckInDataModule, 'useSendPreCheckInData')
+        .returns({
+          isLoading: false,
+        });
+      const { getByTestId } = render(
+        <CheckInProvider store={mockstore}>
+          <PreCheckInSuccessAlert />
+        </CheckInProvider>,
+      );
+      expect(getByTestId('pre-check-in-success-alert')).to.exist;
+      useSendPreCheckInDataStub.restore();
+    });
+    it('displays the correct success message for in person appointments', () => {
+      const mockstore = {
+        appointments: singleAppointment,
+        app: 'preCheckIn',
+      };
+      const useSendPreCheckInDataStub = sinon
+        .stub(useSendPreCheckInDataModule, 'useSendPreCheckInData')
+        .returns({
+          isLoading: false,
+        });
+      const { getByTestId } = render(
+        <CheckInProvider store={mockstore}>
+          <PreCheckInSuccessAlert />
+        </CheckInProvider>,
+      );
+      expect(getByTestId('pre-check-in-success-alert')).to.exist;
+      expect(getByTestId('success-message')).to.contain.text(
+        'You can check-in with your smartphone once you arrive for your appointment on',
+      );
+      useSendPreCheckInDataStub.restore();
+    });
+    it('displays the correct success message for phone appointments', () => {
+      const mockstore = {
+        appointments: singlePhoneAppointment,
+        app: 'preCheckIn',
+      };
+      const useSendPreCheckInDataStub = sinon
+        .stub(useSendPreCheckInDataModule, 'useSendPreCheckInData')
+        .returns({
+          isLoading: false,
+        });
+      const { getByTestId } = render(
+        <CheckInProvider store={mockstore}>
+          <PreCheckInSuccessAlert />
+        </CheckInProvider>,
+      );
+      expect(getByTestId('pre-check-in-success-alert')).to.exist;
+      expect(getByTestId('success-message')).to.have.text(
+        'Your provider will call you at your appointment time. You may need to wait about 15 minutes for their call. Thanks for your patience.',
+      );
+      useSendPreCheckInDataStub.restore();
+    });
+    it('displays the loading spinner if isLoading is true', () => {
+      const mockstore = {
+        appointments: singlePhoneAppointment,
+        app: 'preCheckIn',
+      };
+      const useSendPreCheckInDataStub = sinon
+        .stub(useSendPreCheckInDataModule, 'useSendPreCheckInData')
+        .returns({
+          isLoading: true,
+        });
+      const { getByTestId } = render(
+        <CheckInProvider store={mockstore}>
+          <PreCheckInSuccessAlert />
+        </CheckInProvider>,
+      );
+      expect(getByTestId('loading-indicator')).to.exist;
+      useSendPreCheckInDataStub.restore();
+    });
+    it('calls update error if there is a problem completing pre-check-in', () => {
+      sandbox.stub(v2, 'postPreCheckInData').resolves({
+        data: {
+          error: 'foo',
+        },
+      });
+      const updateErrorStub = () => {};
+      const updateError = sandbox
+        .stub(useUpdateErrorModule, 'useUpdateError')
+        .returns({ updateErrorStub });
+      render(
+        <CheckInProvider store={store}>
+          <PreCheckInSuccessAlert />
+        </CheckInProvider>,
+      );
+      sandbox.assert.calledOnce(updateError);
+    });
+    it('calls update error in the catch block', () => {
+      sandbox.stub(v2, 'postPreCheckInData').throws({
+        error: 'foo',
+      });
+      const updateErrorStub = () => {};
+      const updateError = sandbox
+        .stub(useUpdateErrorModule, 'useUpdateError')
+        .returns({ updateErrorStub });
+      render(
+        <CheckInProvider store={store}>
+          <PreCheckInSuccessAlert />
+        </CheckInProvider>,
+      );
+      sandbox.assert.calledOnce(updateError);
+    });
+  });
+});

--- a/src/applications/check-in/hooks/useFormRouting.jsx
+++ b/src/applications/check-in/hooks/useFormRouting.jsx
@@ -64,6 +64,15 @@ const useFormRouting = (router = {}) => {
     [getCurrentPageFromRouter, pages],
   );
 
+  const getNextPageFromRouter = useCallback(
+    () => {
+      const currentPage = getCurrentPageFromRouter();
+      const positionInForm = pages.indexOf(currentPage);
+      return pages[positionInForm + 1];
+    },
+    [getCurrentPageFromRouter, pages],
+  );
+
   const goToNextPage = useCallback(
     () => {
       const here = getCurrentPageFromRouter();
@@ -81,6 +90,7 @@ const useFormRouting = (router = {}) => {
   return {
     getCurrentPageFromRouter,
     getPreviousPageFromRouter,
+    getNextPageFromRouter,
     goToErrorPage,
     jumpToPage,
     goToPreviousPage,

--- a/src/applications/check-in/hooks/useSendPreCheckInData.jsx
+++ b/src/applications/check-in/hooks/useSendPreCheckInData.jsx
@@ -1,0 +1,85 @@
+import { useEffect, useState, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { focusElement } from 'platform/utilities/ui';
+
+import { api } from '../api';
+import { isUUID } from '../utils/token-format-validator';
+
+import { useStorage } from './useStorage';
+import { useUpdateError } from './useUpdateError';
+
+import { makeSelectCurrentContext, makeSelectForm } from '../selectors';
+
+const useSendPreCheckInData = () => {
+  const selectForm = useMemo(makeSelectForm, []);
+  const { data } = useSelector(selectForm);
+  const [isLoading, setIsLoading] = useState(true);
+  const { getPreCheckinComplete, setPreCheckinComplete } = useStorage();
+
+  const { updateError } = useUpdateError();
+
+  const {
+    demographicsUpToDate = null,
+    emergencyContactUpToDate = null,
+    nextOfKinUpToDate = null,
+  } = data;
+
+  const selectCurrentContext = useMemo(makeSelectCurrentContext, []);
+  const { token } = useSelector(selectCurrentContext);
+
+  useEffect(
+    () => {
+      async function sendPreCheckInData() {
+        // Set pre-checkin complete and send demographics flags.
+        const preCheckInData = { uuid: token };
+
+        if (demographicsUpToDate) {
+          preCheckInData.demographicsUpToDate = demographicsUpToDate === 'yes';
+        }
+        if (nextOfKinUpToDate) {
+          preCheckInData.nextOfKinUpToDate = nextOfKinUpToDate === 'yes';
+        }
+        if (emergencyContactUpToDate) {
+          preCheckInData.emergencyContactUpToDate =
+            emergencyContactUpToDate === 'yes';
+        }
+
+        try {
+          const resp = await api.v2.postPreCheckInData({ ...preCheckInData });
+          if (resp.data.error || resp.data.errors) {
+            updateError('pre-check-in-post-error');
+          } else {
+            setPreCheckinComplete(window, true);
+            // hide loading screen
+            setIsLoading(false);
+            focusElement('h1');
+          }
+        } catch (error) {
+          updateError('error-completing-pre-check-in');
+        }
+      }
+
+      if (!getPreCheckinComplete(window)?.complete && isUUID(token)) {
+        sendPreCheckInData();
+      } else {
+        // hide loading screen
+        setIsLoading(false);
+      }
+
+      focusElement('h1');
+    },
+    [
+      demographicsUpToDate,
+      emergencyContactUpToDate,
+      getPreCheckinComplete,
+      updateError,
+      nextOfKinUpToDate,
+      setPreCheckinComplete,
+      token,
+    ],
+  );
+
+  return { isLoading };
+};
+
+export default useSendPreCheckInData;

--- a/src/applications/check-in/hooks/useSendPreCheckInData.jsx
+++ b/src/applications/check-in/hooks/useSendPreCheckInData.jsx
@@ -43,7 +43,6 @@ const useSendPreCheckInData = () => {
           preCheckInData.emergencyContactUpToDate =
             emergencyContactUpToDate === 'yes';
         }
-
         try {
           const resp = await api.v2.postPreCheckInData({ ...preCheckInData });
           if (resp.data.error || resp.data.errors) {
@@ -58,7 +57,6 @@ const useSendPreCheckInData = () => {
           updateError('error-completing-pre-check-in');
         }
       }
-
       if (!getPreCheckinComplete(window)?.complete && isUUID(token)) {
         sendPreCheckInData();
       } else {
@@ -82,4 +80,4 @@ const useSendPreCheckInData = () => {
   return { isLoading };
 };
 
-export default useSendPreCheckInData;
+export { useSendPreCheckInData };

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -279,5 +279,6 @@
   "phone-appointments": "Phone appointments",
   "check-in-now-for-your-date-time-appointment": "Check in now for appointment on {{ date, day }}, {{ date, monthDay }} at {{ date, time }}",
   "details-for-appointment-on-date-at-time": "Details for {{ type }} appointment on {{ dateTime, date }} at {{ dateTime, time }}",
-  "appointment-on-date-at-time": "Appointment on {{dateTime, date}} at {{ dateTime, time}}"
+  "appointment-on-date-at-time": "Appointment on {{dateTime, date}} at {{ dateTime, time}}",
+  "setting-pre-check-in-completed": "Setting Pre-Check-In completed"
 }

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -279,6 +279,5 @@
   "phone-appointments": "Phone appointments",
   "check-in-now-for-your-date-time-appointment": "Check in now for appointment on {{ date, day }}, {{ date, monthDay }} at {{ date, time }}",
   "details-for-appointment-on-date-at-time": "Details for {{ type }} appointment on {{ dateTime, date }} at {{ dateTime, time }}",
-  "appointment-on-date-at-time": "Appointment on {{dateTime, date}} at {{ dateTime, time}}",
-  "setting-pre-check-in-completed": "Setting Pre-Check-In completed"
+  "appointment-on-date-at-time": "Appointment on {{dateTime, date}} at {{ dateTime, time}}"
 }

--- a/src/applications/check-in/pre-check-in/pages/Confirmation/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Confirmation/index.jsx
@@ -1,95 +1,23 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { focusElement } from 'platform/utilities/ui';
-
-import { api } from '../../../api';
 import PreCheckinConfirmation from '../../../components/PreCheckinConfirmation';
-import { useStorage } from '../../../hooks/useStorage';
-import { useUpdateError } from '../../../hooks/useUpdateError';
 
-import { isUUID } from '../../../utils/token-format-validator';
+import useSendPreCheckInData from '../../../hooks/useSendPreCheckInData';
 
-import {
-  makeSelectCurrentContext,
-  makeSelectForm,
-  makeSelectVeteranData,
-} from '../../../selectors';
+import { makeSelectForm, makeSelectVeteranData } from '../../../selectors';
 
 const Confirmation = props => {
   const { router } = props;
-  const [isLoading, setIsLoading] = useState(true);
-  const { getPreCheckinComplete, setPreCheckinComplete } = useStorage();
 
-  const { updateError } = useUpdateError();
+  const { isLoading } = useSendPreCheckInData();
 
-  const selectForm = useMemo(makeSelectForm, []);
-  const { data } = useSelector(selectForm);
-  const {
-    demographicsUpToDate = null,
-    emergencyContactUpToDate = null,
-    nextOfKinUpToDate = null,
-  } = data;
-
-  const selectCurrentContext = useMemo(makeSelectCurrentContext, []);
-  const { token } = useSelector(selectCurrentContext);
-
-  useEffect(
-    () => {
-      async function sendPreCheckInData() {
-        // Set pre-checkin complete and send demographics flags.
-        const preCheckInData = { uuid: token };
-
-        if (demographicsUpToDate) {
-          preCheckInData.demographicsUpToDate = demographicsUpToDate === 'yes';
-        }
-        if (nextOfKinUpToDate) {
-          preCheckInData.nextOfKinUpToDate = nextOfKinUpToDate === 'yes';
-        }
-        if (emergencyContactUpToDate) {
-          preCheckInData.emergencyContactUpToDate =
-            emergencyContactUpToDate === 'yes';
-        }
-
-        try {
-          const resp = await api.v2.postPreCheckInData({ ...preCheckInData });
-          if (resp.data.error || resp.data.errors) {
-            updateError('pre-check-in-post-error');
-          } else {
-            setPreCheckinComplete(window, true);
-            // hide loading screen
-            setIsLoading(false);
-            focusElement('h1');
-          }
-        } catch (error) {
-          updateError('error-completing-pre-check-in');
-        }
-      }
-
-      if (!getPreCheckinComplete(window)?.complete && isUUID(token)) {
-        sendPreCheckInData();
-      } else {
-        // hide loading screen
-        setIsLoading(false);
-      }
-
-      focusElement('h1');
-    },
-    [
-      demographicsUpToDate,
-      emergencyContactUpToDate,
-      getPreCheckinComplete,
-      updateError,
-      nextOfKinUpToDate,
-      setPreCheckinComplete,
-      token,
-    ],
-  );
   const selectVeteranData = useMemo(makeSelectVeteranData, []);
   const { appointments } = useSelector(selectVeteranData);
-  const selectFormData = useMemo(makeSelectForm, []);
-  const { data: formData } = useSelector(selectFormData);
+
+  const selectForm = useMemo(makeSelectForm, []);
+  const { data: formData } = useSelector(selectForm);
 
   return (
     <PreCheckinConfirmation

--- a/src/applications/check-in/pre-check-in/pages/Confirmation/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Confirmation/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import PreCheckinConfirmation from '../../../components/PreCheckinConfirmation';
 
-import useSendPreCheckInData from '../../../hooks/useSendPreCheckInData';
+import { useSendPreCheckInData } from '../../../hooks/useSendPreCheckInData';
 
 import { makeSelectForm, makeSelectVeteranData } from '../../../selectors';
 

--- a/src/applications/check-in/pre-check-in/pages/Confirmation/tests/Confirmation.test.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Confirmation/tests/Confirmation.test.unit.spec.jsx
@@ -1,62 +1,91 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
+import { render } from '@testing-library/react';
+import sinon from 'sinon';
 import { expect } from 'chai';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
-import { I18nextProvider } from 'react-i18next';
-import i18n from '../../../../utils/i18n/i18n';
 import Confirmation from '../index';
 import { singleAppointment } from '../../../../tests/unit/mocks/mock-appointments';
-import { scheduledDowntimeState } from '../../../../tests/unit/utils/initState';
 import PreCheckinConfirmation from '../../../../components/PreCheckinConfirmation';
+import { api } from '../../../../api';
+import * as useUpdateErrorModule from '../../../../hooks/useUpdateError';
+import CheckInProvider from '../../../../tests/unit/utils/CheckInProvider';
 
 describe('pre-check-in', () => {
   describe('Confirmation page', () => {
     describe('redux store without friendly name', () => {
-      const initState = {
-        checkInData: {
-          appointments: singleAppointment,
-          veteranData: { demographics: {} },
-          form: {
-            pages: ['first-page', 'second-page', 'third-page', 'fourth-page'],
-            data: {
-              demographicsUpToDate: 'yes',
-              nextOfKinUpToDate: 'yes',
-              emergencyContactUpToDate: 'yes',
-            },
-          },
-          context: {
-            token: 'token',
-          },
-        },
-        ...scheduledDowntimeState,
+      const formData = {
+        demographicsUpToDate: 'yes',
+        emergencyContactUpToDate: 'yes',
+        nextOfKinUpToDate: 'no',
       };
-      initState.checkInData.appointments[0].clinicFriendlyName = '';
-      const middleware = [];
-      const mockStore = configureStore(middleware);
-      const store = mockStore(initState);
-      const mockRouter = {
-        push: () => {},
-        location: {
-          basename: '/health-care/appointment-pre-check-in',
-        },
+
+      const store = {
+        ...formData,
+        appointments: singleAppointment,
+        veteranData: { demographics: {} },
+        token: '2b87cf8d-aa7d-41a7-805d-d2c0d290a0dc',
       };
+
+      const { v2 } = api;
+      const sandbox = sinon.createSandbox();
+
+      afterEach(() => {
+        sandbox.restore();
+      });
 
       it('passes the correct props to the pre-checkin confirmation component', () => {
         const testRenderer = TestRenderer.create(
-          <Provider store={store}>
-            <I18nextProvider i18n={i18n}>
-              <Confirmation router={mockRouter} />
-            </I18nextProvider>
-          </Provider>,
+          <CheckInProvider store={store}>
+            <Confirmation />
+          </CheckInProvider>,
         );
         const testInstance = testRenderer.root;
         expect(
-          testInstance.findByType(PreCheckinConfirmation).props.formData,
-        ).to.equal(initState.checkInData.form.data);
+          testInstance.findByType(PreCheckinConfirmation).props.formData
+            .demographicsUpToDate,
+        ).to.equal('yes');
+        expect(
+          testInstance.findByType(PreCheckinConfirmation).props.formData
+            .emergencyContactUpToDate,
+        ).to.equal('yes');
+        expect(
+          testInstance.findByType(PreCheckinConfirmation).props.formData
+            .nextOfKinUpToDate,
+        ).to.equal('no');
         expect(
           testInstance.findByType(PreCheckinConfirmation).props.appointments,
-        ).to.equal(initState.checkInData.appointments);
+        ).to.equal(singleAppointment);
+      });
+
+      it('calls updateError if there is a problem with completing pre check in', () => {
+        sandbox.stub(v2, 'postPreCheckInData').resolves({
+          data: {
+            error: 'foo',
+          },
+        });
+        const updateErrorStub = () => {};
+        const updateError = sandbox
+          .stub(useUpdateErrorModule, 'useUpdateError')
+          .returns({ updateErrorStub });
+        render(
+          <CheckInProvider store={store}>
+            <Confirmation />
+          </CheckInProvider>,
+        );
+        sinon.assert.calledOnce(updateError);
+      });
+      it('calls updateError if there is a problem with the api call', () => {
+        sandbox.stub(v2, 'postPreCheckInData').throws();
+        const updateErrorStub = () => {};
+        const updateError = sandbox
+          .stub(useUpdateErrorModule, 'useUpdateError')
+          .returns({ updateErrorStub });
+        render(
+          <CheckInProvider store={store}>
+            <Confirmation />
+          </CheckInProvider>,
+        );
+        sinon.assert.calledOnce(updateError);
       });
     });
   });

--- a/src/applications/check-in/pre-check-in/pages/Landing/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Landing/index.jsx
@@ -85,7 +85,7 @@ const Index = props => {
                 setSession(token, session.permissions);
                 if (session.permissions === SCOPES.READ_FULL) {
                   // redirect if already full access
-                  jumpToPage(URLS.INTRODUCTION);
+                  jumpToPage(URLS.APPOINTMENTS);
                 } else {
                   // TODO: dispatch to redux
                   jumpToPage(URLS.VERIFY);

--- a/src/applications/check-in/tests/unit/utils/initState.js
+++ b/src/applications/check-in/tests/unit/utils/initState.js
@@ -42,6 +42,7 @@ const createStore = ({
   features = {},
   error = null,
   seeStaffMessage = null,
+  token = 'some-token',
 } = {}) => {
   const middleware = [];
   const mockStore = configureStore(middleware);
@@ -49,7 +50,7 @@ const createStore = ({
     checkInData: {
       app,
       context: {
-        token: 'some-token',
+        token,
       },
       form: {
         pages: formPages,


### PR DESCRIPTION
## Summary

- Creates a hook from useEffect in pre check in complete page
- uses the hook on new unified appointment list if demographics are up to date

## Related issue(s)

- [department-of-veterans-affairs/va.gov-team#67417](https://github.com/department-of-veterans-affairs/va.gov-team/issues/67417)

## Testing done

- unit

## Screenshots

## What areas of the site does it impact?


PCI -> Pre-check-in 

## Acceptance criteria

- [ ] It calls the endpoint to set pre check in to complete if demographics are up to date on the complete page and the new appointments page
- [ ] unit tests for new components and hook

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
