### PR TITLE
Formation to USDWS Conversion Utility

### DIFF
--- a/src/applications/check-in/components/layout/Wrapper.jsx
+++ b/src/applications/check-in/components/layout/Wrapper.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -7,6 +7,8 @@ import {
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
 import { focusElement } from 'platform/utilities/ui';
+
+import { VaSelect } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import { makeSelectApp } from '../../selectors';
 import { APP_NAMES } from '../../utils/appConstants';
@@ -39,12 +41,108 @@ const Wrapper = props => {
   const downtimeDependency =
     app === APP_NAMES.CHECK_IN ? externalServices.cie : externalServices.pcie;
   const appTitle = app === APP_NAMES.CHECK_IN ? 'Check in' : 'Pre-check in';
+
+  const formationSizes =
+    'html { font-size: 10px; } body { font-size: 1.6rem; }';
+
+  const uswdsSizes = 'html { font-size: 100%; } body { font-size: 16px; }';
+
+  const [styleLibrary, setstyleLibrary] = useState('Formation');
+  const [selectedFontSizes, setSelectedFontSizes] = useState(formationSizes);
+
+  const handleChange = event => {
+    const selectedValue = event.detail.value;
+    setstyleLibrary(selectedValue);
+
+    if (selectedValue === 'formation') {
+      document.documentElement.style.fontSize = '10px';
+      document.body.style.fontSize = '1.6rem';
+      setSelectedFontSizes(formationSizes);
+    } else {
+      document.documentElement.style.fontSize = '100%';
+      document.body.style.fontSize = '16px';
+      setSelectedFontSizes(uswdsSizes);
+    }
+  };
   return (
     <>
       <div
         className={`vads-l-grid-container ${classNames} ${topPadding}`}
         data-testid={testID}
       >
+        <div style={{ backgroundColor: `#efefef`, padding: '20px' }}>
+          <VaSelect
+            hint={null}
+            label="Application Base Font Size Toggle"
+            name="base-font-size"
+            value="formation"
+            onVaSelect={handleChange}
+            uswds
+          >
+            <option value="formation">Formation</option>
+            <option value="uswds">USWDS v3</option>
+          </VaSelect>
+          <p>
+            <strong>
+              Font Size:
+              <br /> {selectedFontSizes}
+            </strong>
+          </p>
+        </div>
+
+        <hr />
+
+        <h3>USWDS v3 Component Examples</h3>
+
+        <va-button text="Button" uswds />
+
+        <br /><br />
+
+        <va-alert
+          close-btn-aria-label="Close notification"
+          status="info"
+          uswds
+          visible
+        >
+          <h2 id="track-your-status-on-mobile" slot="headline">
+            Track your claim or appeal on your mobile device
+          </h2>
+          <p className="vads-u-margin-y--0">
+            Lorem ipsum dolor sit amet{' '}
+            <a className="usa-link" href="javascript:void(0);">
+              consectetur adipiscing
+            </a>{' '}
+            elit sed do eiusmod.
+          </p>
+        </va-alert>
+
+        <hr />
+
+        <h3>v1 Component Examples</h3>
+
+        <va-button text="Button" />
+
+        <br /><br />
+
+        <va-alert
+          close-btn-aria-label="Close notification"
+          status="info"
+          visible
+        >
+          <h2 id="track-your-status-on-mobile" slot="headline">
+            Track your claim or appeal on your mobile device
+          </h2>
+          <p className="vads-u-margin-y--0">
+            Lorem ipsum dolor sit amet{' '}
+            <a className="usa-link" href="javascript:void(0);">
+              consectetur adipiscing
+            </a>{' '}
+            elit sed do eiusmod.
+          </p>
+        </va-alert>
+
+        <hr />
+
         <MixedLanguageDisclaimer />
         <LanguagePicker withTopMargin={!withBackButton} />
         {pageTitle && (

--- a/src/applications/check-in/components/layout/Wrapper.jsx
+++ b/src/applications/check-in/components/layout/Wrapper.jsx
@@ -83,10 +83,8 @@ const Wrapper = props => {
             <option value="uswds">USWDS v3</option>
           </VaSelect>
           <p>
-            <strong>
-              Font Size:
-              <br /> {selectedFontSizes}
-            </strong>
+            Font size for {styleLibrary}:<br />{' '}
+            <strong>{selectedFontSizes}</strong>
           </p>
         </div>
 

--- a/src/platform/site-wide/sass/formation-overrides/_buttons.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_buttons.scss
@@ -9,13 +9,17 @@ button,
 [type=submit],
 [type=reset],
 [type=image] {
-  // TO DO #1: I am not sure if i can use the 
+  // TO DO #1: I am not sure if i can use the
   // TO DO #2: Part of above, but conversion function will return a blank for null values
-  @include margin(scale-rem(0.5rem) scale-rem(0.5rem) scale-rem(0.5rem) null);
-  padding: scale-rule(1rem 2rem);
+  // @include margin(scale-rem(0.5rem) scale-rem(0.5rem) scale-rem(0.5rem) null);
+  // padding: scale-rule(1rem 2rem);
+  @include margin( 0.3125rem 0.3125rem 0.3125rem null);
+  padding: 0.625rem 1.25rem;
 
   &.usa-button-big {
-    font-size: scale-rem(2.4rem);
-    padding: scale-rule(1.5rem 3rem);
+    // font-size: scale-rem(2.4rem);
+    // padding: scale-rule(1.5rem 3rem);
+    font-size: 1.5rem;
+    padding: .9375rem 1.875rem;
   }
 }

--- a/src/platform/site-wide/sass/formation-overrides/_buttons.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_buttons.scss
@@ -9,11 +9,13 @@ button,
 [type=submit],
 [type=reset],
 [type=image] {
-  @include margin(uswds-override(0.5rem) uswds-override(0.5rem) uswds-override(0.5rem) null);
-  padding: uswds-override(1rem) uswds-override(2rem);
+  // TO DO #1: I am not sure if i can use the 
+  // TO DO #2: Part of above, but conversion function will return a blank for null values
+  @include margin(scale-rem(0.5rem) scale-rem(0.5rem) scale-rem(0.5rem) null);
+  padding: scale-rule(1rem 2rem);
 
   &.usa-button-big {
-    font-size: uswds-override(2.4rem);
-    padding: uswds-override(1.5rem) uswds-override(3rem);
+    font-size: scale-rem(2.4rem);
+    padding: scale-rule(1.5rem 3rem);
   }
 }

--- a/src/platform/site-wide/sass/formation-overrides/_buttons.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_buttons.scss
@@ -1,0 +1,19 @@
+@import "functions";
+
+.usa-button,
+.usa-button-primary,
+.usa-button:visited,
+.usa-button-primary:visited,
+button,
+[type=button],
+[type=submit],
+[type=reset],
+[type=image] {
+  @include margin(uswds-override(0.5rem) uswds-override(0.5rem) uswds-override(0.5rem) null);
+  padding: uswds-override(1rem) uswds-override(2rem);
+
+  &.usa-button-big {
+    font-size: uswds-override(2.4rem);
+    padding: uswds-override(1.5rem) uswds-override(3rem);
+  }
+}

--- a/src/platform/site-wide/sass/formation-overrides/_functions.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_functions.scss
@@ -13,3 +13,107 @@
   }
   @return $original;
 }
+
+
+// Appended conversion functions
+
+$_USWDS: 16px;                    // USWDS base
+$_FORMATION: 10px;                // Formation base
+
+$_F2U_COEFF: $_FORMATION/$_USWDS; // Formation  to USDWS conversion coeffient
+$_U2F_COEFF: $_USWDS/$_FORMATION; // USDWS to Formation conversion coeffient
+
+
+@function split-value-unit($string) { 
+  // takes a string,  returns a map of
+  // number: number || null
+  // unit: a unit || or null
+  // joint: the number+ its unit  
+  $length: str-length($string);
+  $numeric-value: "";
+  $unit: "";
+  $digits: ( "0":0, "1":1, "2":2, "3":3, "4":4, "5":5, "6":6, "7":7, "8":8, "9":9);
+  $sign : 1;
+  $decimal: 1;
+  $magnitude: 10;
+  $past: false;
+  @for $i from 1 through $length {
+    $char: str-slice($string, $i, $i);
+    @if($char == '-') {
+      $sign :  -1;
+    }
+    @else if($char == ".") {
+      $decimal : 10;
+      $magnitude : 1;
+    }
+    @else if( map-get($digits,$char) and $past == false){
+      @if ($numeric-value == ""){
+            $numeric-value : 0;
+      }
+      $numeric-value: ($numeric-value * $magnitude) +(map-get($digits,$char)/$decimal);
+        @if ($decimal > 1){
+            $decimal : $decimal * 10;
+        }
+    } 
+    @else {
+        $unit: $unit + $char;
+        $past: true;
+    }
+  }
+  $numeric-result: if( $numeric-value =="" , null, $sign * $numeric-value);
+  @return (
+    number: $numeric-result,
+    unit: unquote($unit),
+    joint: $numeric-result+unquote($unit)
+  );
+}
+
+@function str-split($string, $separator: " ") {
+  $split-list: ();
+  $index: str-index($string, $separator);
+
+  @while $index != null {
+    $item: str-slice($string, 1, $index - 1);
+    $split-list: append($split-list, $item);
+    $string: str-slice($string, $index + 1);
+    $index: str-index($string, $separator);
+  }
+
+  @return append($split-list, $string);
+}
+
+@function scale-rem($value, $coeff: $_F2U_COEFF,  $separator: space) {
+  @if (type-of($value) == number and unit($value) == rem) {
+    @return ($value * $coeff) ;
+  }
+  @if (type-of($value) == string ) {
+    $inner-sep: if($separator == comma , ",", " ");
+    $value-set: str-split($value, $inner-sep);
+    $scaled-values: ();
+
+    @each $val in $value-set{
+        $val-parts : split-value-unit($val);
+        @if (map-get($val-parts, unit) == rem) {
+            $rem-number: str-slice($val, 0, -4);
+            $scaled-rem: map-get($val-parts, number) * $coeff ;
+            $scaled-values: append($scaled-values, $scaled-rem + rem);
+        } @else {
+            $scaled-values: append($scaled-values, 
+            map-get($val-parts, joint), $separator);
+        }
+    }
+    @return  $scaled-values;
+  }
+  @else {
+    @return $value;
+  }
+}
+
+@function scale-rule($rule, $separator: space,  $coeff: $_F2U_COEFF   ) {
+  $scaled: ();
+  @each $value in $rule {
+    $scaled-value: scale-rem($value, $coeff, $separator);
+    $scaled: append($scaled, $scaled-value, $separator);
+  }
+  @return $scaled;  
+}

--- a/src/platform/site-wide/sass/formation-overrides/_functions.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_functions.scss
@@ -9,7 +9,7 @@
   @if is-rem($original) {
     $rem-to-px: $original * 10; // Formation base
     $px-to-rem: $rem-to-px / 16; // USWDS base
-    @return $px-to-rem; // return the value back to rem
+    @return ($px-to-rem); // return the value back to rem
   }
   @return $original;
 }

--- a/src/platform/site-wide/sass/formation-overrides/_functions.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_functions.scss
@@ -14,40 +14,40 @@
 // }
 
 ////NEW  FUNCTIONS
-$_USWDS: 16px;                    // USWDS base
-$_FORMATION: 10px;                // Formation base
+$uswds-base: 16px;                    // USWDS base
+$formation-base: 10px;                // Formation base
 
-$_F2U_COEFF: $_FORMATION / $_USWDS; // Formation  to USDWS conversion coeffient
-$_U2F_COEFF: $_USWDS / $_FORMATION; // USDWS to Formation conversion coeffient
+$f2u-coeff: $formation-base / $uswds-base; // Formation  to USDWS conversion coeffient
+$u2f-coeff: $uswds-base / $formation-base; // USDWS to Formation conversion coeffient
 
 
-$_units: (
-    'px': 1px,
-    'cm': 1cm,
-    'mm': 1mm,
-    '%': 1%,
-    'ch': 1ch,
-    'in': 1in,
-    'em': 1em,
-    'rem': 1rem,
-    'pt': 1pt,
-    'pc': 1pc,
-    'ex': 1ex,
-    'vw': 1vw,
-    'vh': 1vh,
-    'vmin': 1vmin,
-    'vmax': 1vmax,
-    'deg': 1deg,
-    'turn': 1turn,
-    'rad': 1rad,
-    'grad': 1grad,
-    's': 1s,
-    'ms': 1ms,
-    'Hz': 1Hz,
-    'kHz': 1kHz,
-    'dppx': 1dppx,
-    'dpcm': 1dpcm,
-    'dpi': 1dpi,
+$unit-types: (
+    "px": 1px,
+    "cm": 1cm,
+    "mm": 1mm,
+    "%": 1%,
+    "ch": 1ch,
+    "in": 1in,
+    "em": 1em,
+    "rem": 1rem,
+    "pt": 1pt,
+    "pc": 1pc,
+    "ex": 1ex,
+    "vw": 1vw,
+    "vh": 1vh,
+    "vmin": 1vmin,
+    "vmax": 1vmax,
+    "deg": 1deg,
+    "turn": 1turn,
+    "rad": 1rad,
+    "grad": 1grad,
+    "s": 1s,
+    "ms": 1ms,
+    "Hz": 1Hz,
+    "kHz": 1kHz,
+    "dppx": 1dppx,
+    "dpcm": 1dpcm,
+    "dpi": 1dpi,
   );
 
 
@@ -55,11 +55,11 @@ $_units: (
   // takes a string,  returns a map of
   // number: number || null
   // unit: a unit || or null
-  // joint: the number+ its unit 
+  // joint: the number+ its unit
   @if(type-of($string) == number){
       @return(
-        number: if(map-has-key($_units, unit($string)),
-            $string / map-get($_units, unit($string))
+        number: if(map-has-key($unit-types, unit($string)),
+            $string / map-get($unit-types, unit($string))
             ,$string),
         unit: unit($string),
         joint: $string
@@ -78,7 +78,7 @@ $_units: (
         unit: null,
         joint: $string
       )
-  }   
+  }
   $length: str-length($string);
   $numeric-value: "";
   $unit: "";
@@ -89,7 +89,7 @@ $_units: (
   $past: false;
   @for $i from 1 through $length {
     $char: str-slice($string, $i, $i);
-    @if($char == '-') {
+    @if($char == "-") {
       $sign :  -1;
     }
     @else if($char == "." and $past == false) {
@@ -104,13 +104,13 @@ $_units: (
         @if ($decimal > 1){
             $decimal : $decimal * 10;
         }
-    } 
+    }
     @else {
         $unit: $unit + $char;
         $past: true;
     }
   }
-  $numeric-result: if( $numeric-value =="" , null, $sign * $numeric-value);
+  $numeric-result: if( $numeric-value == "" , null, $sign * $numeric-value);
   @return (
     number: $numeric-result,
     unit: unquote($unit),
@@ -132,7 +132,7 @@ $_units: (
   @return append($split-list, $string);
 }
 
-@function scale-rem($value, $coeff: $_F2U_COEFF,  $separator: space) {
+@function scale-rem($value, $coeff: $f2u-coeff,  $separator: space) {
   // converts any singular SCSS value with rem units
   // to its scaled equvalent
   // otherwise returns  the orginal value
@@ -151,7 +151,7 @@ $_units: (
             $scaled-rem: map-get($val-parts, number) * $coeff ;
             $scaled-values: append($scaled-values, $scaled-rem + rem);
         } @else {
-            $scaled-values: append($scaled-values, 
+            $scaled-values: append($scaled-values,
             map-get($val-parts, joint), $separator);
         }
     }
@@ -162,12 +162,12 @@ $_units: (
   }
 }
 
-@function scale-rule($rule, $separator: space,  $coeff: $_F2U_COEFF   ) {
+@function scale-rule($rule, $separator: space,  $coeff: $f2u-coeff   ) {
   // converts any plural SCSS value with rem units
   $scaled: ();
   @each $value in $rule {
     $scaled-value: scale-rem($value, $coeff, $separator);
     $scaled: append($scaled, $scaled-value, $separator);
   }
-  @return $scaled;  
+  @return $scaled;
 }

--- a/src/platform/site-wide/sass/formation-overrides/_functions.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_functions.scss
@@ -17,8 +17,8 @@
 $_USWDS: 16px;                    // USWDS base
 $_FORMATION: 10px;                // Formation base
 
-$_F2U_COEFF: $_FORMATION/$_USWDS; // Formation  to USDWS conversion coeffient
-$_U2F_COEFF: $_USWDS/$_FORMATION; // USDWS to Formation conversion coeffient
+$_F2U_COEFF: $_FORMATION / $_USWDS; // Formation  to USDWS conversion coeffient
+$_U2F_COEFF: $_USWDS / $_FORMATION; // USDWS to Formation conversion coeffient
 
 
 $_units: (
@@ -92,7 +92,7 @@ $_units: (
     @if($char == '-') {
       $sign :  -1;
     }
-    @else if($char == ".") {
+    @else if($char == "." and $past == false) {
       $decimal : 10;
       $magnitude : 1;
     }

--- a/src/platform/site-wide/sass/formation-overrides/_functions.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_functions.scss
@@ -9,8 +9,9 @@
 // based on the USWDS 16px base and return it again as rem.
 @function uswds-override($original) {
   @if is-rem($original) {
-    $rem-to-px: ($original / 1rem) * 16;
-    @return ($rem-to-px) + "px";
+    $rem-to-px: $original * 10; // Formation base
+    $px-to-rem: $rem-to-px / 16; // USWDS base
+    @return $px-to-rem; // return the value back to rem
   }
   @return $original;
 }

--- a/src/platform/site-wide/sass/formation-overrides/_functions.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_functions.scss
@@ -24,11 +24,64 @@ $_F2U_COEFF: $_FORMATION/$_USWDS; // Formation  to USDWS conversion coeffient
 $_U2F_COEFF: $_USWDS/$_FORMATION; // USDWS to Formation conversion coeffient
 
 
-@function split-value-unit($string) { 
+$_units: (
+    'px': 1px,
+    'cm': 1cm,
+    'mm': 1mm,
+    '%': 1%,
+    'ch': 1ch,
+    'in': 1in,
+    'em': 1em,
+    'rem': 1rem,
+    'pt': 1pt,
+    'pc': 1pc,
+    'ex': 1ex,
+    'vw': 1vw,
+    'vh': 1vh,
+    'vmin': 1vmin,
+    'vmax': 1vmax,
+    'deg': 1deg,
+    'turn': 1turn,
+    'rad': 1rad,
+    'grad': 1grad,
+    's': 1s,
+    'ms': 1ms,
+    'Hz': 1Hz,
+    'kHz': 1kHz,
+    'dppx': 1dppx,
+    'dpcm': 1dpcm,
+    'dpi': 1dpi,
+  );
+
+
+@function split-value-unit($string) {
   // takes a string,  returns a map of
   // number: number || null
   // unit: a unit || or null
-  // joint: the number+ its unit  
+  // joint: the number+ its unit 
+  @if(type-of($string) == number){
+      @return(
+        number: if(map-has-key($_units, unit($string)),
+            $string / map-get($_units, unit($string))
+            ,$string),
+        unit: unit($string),
+        joint: $string
+      )
+  }
+  @if(type-of($string) == color){
+      @return(
+        number: $string,
+        unit: color,
+        joint: $string
+      )
+  }
+  @if(type-of($string) != string){
+      @return(
+        number: null,
+        unit: null,
+        joint: $string
+      )
+  }   
   $length: str-length($string);
   $numeric-value: "";
   $unit: "";
@@ -83,6 +136,9 @@ $_U2F_COEFF: $_USWDS/$_FORMATION; // USDWS to Formation conversion coeffient
 }
 
 @function scale-rem($value, $coeff: $_F2U_COEFF,  $separator: space) {
+  // converts any singular SCSS value with rem units
+  // to its scaled equvalent
+  // otherwise returns  the orginal value
   @if (type-of($value) == number and unit($value) == rem) {
     @return ($value * $coeff) ;
   }
@@ -110,6 +166,7 @@ $_U2F_COEFF: $_USWDS/$_FORMATION; // USDWS to Formation conversion coeffient
 }
 
 @function scale-rule($rule, $separator: space,  $coeff: $_F2U_COEFF   ) {
+  // converts any plural SCSS value with rem units
   $scaled: ();
   @each $value in $rule {
     $scaled-value: scale-rem($value, $coeff, $separator);

--- a/src/platform/site-wide/sass/formation-overrides/_functions.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_functions.scss
@@ -1,22 +1,19 @@
+// @function is-rem($value) {
+//   @if unit($value) == "rem" {
+//     @return true;
+//   }
+// }
 
-@function is-rem($value) {
-  @if unit($value) == "rem" {
-    @return true;
-  }
-}
+// @function uswds-override($original) {
+//   @if is-rem($original) {
+//     $rem-to-px: $original * 10; // Formation base
+//     $px-to-rem: $rem-to-px / 16; // USWDS base
+//     @return ($px-to-rem); // return the value back to rem
+//   }
+//   @return $original;
+// }
 
-@function uswds-override($original) {
-  @if is-rem($original) {
-    $rem-to-px: $original * 10; // Formation base
-    $px-to-rem: $rem-to-px / 16; // USWDS base
-    @return ($px-to-rem); // return the value back to rem
-  }
-  @return $original;
-}
-
-
-// Appended conversion functions
-
+////NEW  FUNCTIONS
 $_USWDS: 16px;                    // USWDS base
 $_FORMATION: 10px;                // Formation base
 

--- a/src/platform/site-wide/sass/formation-overrides/_functions.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_functions.scss
@@ -1,0 +1,16 @@
+
+@function is-rem($value) {
+  @if unit($value) == "rem" {
+    @return true;
+  }
+}
+
+// TODO: Instead of converting to px, we should calculate the existing rem
+// based on the USWDS 16px base and return it again as rem.
+@function uswds-override($original) {
+  @if is-rem($original) {
+    $rem-to-px: ($original / 1rem) * 16;
+    @return ($rem-to-px) + "px";
+  }
+  @return $original;
+}

--- a/src/platform/site-wide/sass/formation-overrides/_functions.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_functions.scss
@@ -5,8 +5,6 @@
   }
 }
 
-// TODO: Instead of converting to px, we should calculate the existing rem
-// based on the USWDS 16px base and return it again as rem.
 @function uswds-override($original) {
   @if is-rem($original) {
     $rem-to-px: $original * 10; // Formation base

--- a/src/platform/site-wide/sass/formation-overrides/_utilities.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_utilities.scss
@@ -1,0 +1,46 @@
+@import "functions";
+
+// Content size helpers
+@mixin allow-layout-classes {
+  @include margin(null auto);
+  &.align-left {
+    @include media($medium-screen) {
+      margin-right: rem-override(2em) !important;
+      margin-top: rem-override(0.5em) !important;
+    }
+  }
+
+  &.align-right {
+    @include media($medium-screen) {
+      margin-left: rem-override(2em) !important;
+      margin-top: rem-override(0.5em) !important;
+    }
+  }
+}
+
+@mixin usa-sidenav-list {
+  a {
+    padding: rem-override(0.85rem) rem-override(1rem) rem-override(0.85rem) $site-margins-mobile !important;
+  }
+}
+
+@mixin usa-sidenav-sublist {
+  a {
+    padding-left: rem-override(2.8rem) !important;
+
+    &:hover,
+    &.usa-current { /* stylelint-disable-line selector-no-qualifying-type */
+      padding-left: rem-override(2.8rem) !important;
+    }
+  }
+
+  .usa-sidenav-sub_list {
+    a {
+      padding-left: rem-override(3.8rem) !important;
+
+      &:hover {
+        padding-left: rem-override(3.8rem) !important;
+      }
+    }
+  }
+}

--- a/src/platform/site-wide/sass/formation-overrides/_utilities.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_utilities.scss
@@ -5,15 +5,15 @@
   @include margin(null auto);
   &.align-left {
     @include media($medium-screen) {
-      margin-right: rem-override(2em) !important;
-      margin-top: rem-override(0.5em) !important;
+      margin-right: rem-override(2rem) !important;
+      margin-top: rem-override(0.5rem) !important;
     }
   }
 
   &.align-right {
     @include media($medium-screen) {
-      margin-left: rem-override(2em) !important;
-      margin-top: rem-override(0.5em) !important;
+      margin-left: rem-override(2rem) !important;
+      margin-top: rem-override(0.5rem) !important;
     }
   }
 }

--- a/src/platform/site-wide/sass/formation-overrides/_utilities.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_utilities.scss
@@ -5,41 +5,40 @@
   @include margin(null auto);
   &.align-left {
     @include media($medium-screen) {
-      margin-right: rem-override(2rem) !important;
-      margin-top: rem-override(0.5rem) !important;
+      margin-right: scale-rule(2rem !important);
+      margin-top: scale-rule(0.5rem !important);
     }
   }
 
   &.align-right {
     @include media($medium-screen) {
-      margin-left: rem-override(2rem) !important;
-      margin-top: rem-override(0.5rem) !important;
+      margin-left: scale-rule(2rem !important);
+      margin-top: scale-rule(0.5rem !important);
     }
   }
 }
 
 @mixin usa-sidenav-list {
   a {
-    padding: rem-override(0.85rem) rem-override(1rem) rem-override(0.85rem) $site-margins-mobile !important;
+    padding: scale-rule(0.85rem 1rem 0.85rem $site-margins-mobile !important);
   }
 }
 
 @mixin usa-sidenav-sublist {
   a {
-    padding-left: rem-override(2.8rem) !important;
+    padding-left: scale-rule(2.8rem !important);
 
     &:hover,
     &.usa-current { /* stylelint-disable-line selector-no-qualifying-type */
-      padding-left: rem-override(2.8rem) !important;
+      padding-left: scale-rule(2.8rem !important);
     }
   }
 
   .usa-sidenav-sub_list {
     a {
-      padding-left: rem-override(3.8rem) !important;
-
+      padding-left: scale-rule(3.8rem !important);
       &:hover {
-        padding-left: rem-override(3.8rem) !important;
+        padding-left: scale-rule(3.8rem !important);
       }
     }
   }

--- a/src/platform/site-wide/sass/formation-overrides/_variables.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_variables.scss
@@ -2,26 +2,26 @@
 
 $em-base:             100%; // USWDS v3 html value
 $base-font-size:      16px; // USWDS v3 body value
-$small-font-size:     uswds-override(1.4rem) !important;
-$lead-font-size:      uswds-override(2rem) !important;
-$title-font-size:     uswds-override(5.2rem) !important;
+$small-font-size:     uswds-override(1.4rem) !default;
+$lead-font-size:      uswds-override(2rem) !default;
+$title-font-size:     uswds-override(5.2rem) !default;
 $h1-font-size:        uswds-override(4rem) !important;
-$h2-font-size:        uswds-override(3rem) !important;
-$h3-font-size:        uswds-override(2rem) !important;
-$h4-font-size:        uswds-override(1.7rem) !important;
-$h5-font-size:        uswds-override(1.5rem) !important;
-$h6-font-size:        uswds-override(1.3rem) !important;
+$h2-font-size:        uswds-override(3rem) !default;
+$h3-font-size:        uswds-override(2rem) !default;
+$h4-font-size:        uswds-override(1.7rem) !default;
+$h5-font-size:        uswds-override(1.5rem) !default;
+$h6-font-size:        uswds-override(1.3rem) !default;
 
 // Magic Numbers
-$lead-max-width:                uswds-override(77rem) !important;
-$site-margins:                  uswds-override(3rem) !important;
-$site-margins-mobile:           uswds-override(1.5rem) !important;
-$input-max-width:               uswds-override(46rem) !important;
-$sidenav-current-border-width:  0.4rem !important; // must be in rem for math
+$lead-max-width:                uswds-override(77rem) !default;
+$site-margins:                  uswds-override(3rem) !default;
+$site-margins-mobile:           uswds-override(1.5rem) !default;
+$input-max-width:               uswds-override(46rem) !default;
+$sidenav-current-border-width:  0.4rem !default; // must be in rem for math
 
 // 44 x 44 pixels hit target following Apple iOS Human Interface
 // Guidelines
-$hit-area: uswds-override(4.4rem) !important;
+$hit-area: uswds-override(4.4rem) !default;
 
 $spacing-x-small: uswds-override(0.5rem);
 $spacing-small: uswds-override(1rem);

--- a/src/platform/site-wide/sass/formation-overrides/_variables.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_variables.scss
@@ -1,0 +1,30 @@
+@import "functions";
+
+$em-base:             100%; // USWDS v3 html value
+$base-font-size:      16px; // USWDS v3 body value
+$small-font-size:     uswds-override(1.4rem) !important;
+$lead-font-size:      uswds-override(2rem) !important;
+$title-font-size:     uswds-override(5.2rem) !important;
+$h1-font-size:        uswds-override(4rem) !important;
+$h2-font-size:        uswds-override(3rem) !important;
+$h3-font-size:        uswds-override(2rem) !important;
+$h4-font-size:        uswds-override(1.7rem) !important;
+$h5-font-size:        uswds-override(1.5rem) !important;
+$h6-font-size:        uswds-override(1.3rem) !important;
+
+// Magic Numbers
+$lead-max-width:                uswds-override(77rem) !important;
+$site-margins:                  uswds-override(3rem) !important;
+$site-margins-mobile:           uswds-override(1.5rem) !important;
+$input-max-width:               uswds-override(46rem) !important;
+$sidenav-current-border-width:  0.4rem !important; // must be in rem for math
+
+// 44 x 44 pixels hit target following Apple iOS Human Interface
+// Guidelines
+$hit-area: uswds-override(4.4rem) !important;
+
+$spacing-x-small: uswds-override(0.5rem);
+$spacing-small: uswds-override(1rem);
+$spacing-md-small: uswds-override(1.5rem);
+$spacing-medium: uswds-override(2rem);
+$spacing-large: uswds-override(3rem);

--- a/src/platform/site-wide/sass/formation-overrides/_variables.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_variables.scss
@@ -1,7 +1,7 @@
 @import "functions";
 
 $em-base:             100%;     // USWDS v3 html value
-$base-font-size:      $_USWDS; // USWDS v3 body value
+$base-font-size:      $uswds-base; // USWDS v3 body value
 $small-font-size:     scale-rem(1.4rem) !default;
 $lead-font-size:      scale-rem(2rem) !default;
 $title-font-size:     scale-rem(5.2rem) !default;

--- a/src/platform/site-wide/sass/formation-overrides/_variables.scss
+++ b/src/platform/site-wide/sass/formation-overrides/_variables.scss
@@ -1,30 +1,30 @@
 @import "functions";
 
-$em-base:             100%; // USWDS v3 html value
-$base-font-size:      16px; // USWDS v3 body value
-$small-font-size:     uswds-override(1.4rem) !default;
-$lead-font-size:      uswds-override(2rem) !default;
-$title-font-size:     uswds-override(5.2rem) !default;
-$h1-font-size:        uswds-override(4rem) !important;
-$h2-font-size:        uswds-override(3rem) !default;
-$h3-font-size:        uswds-override(2rem) !default;
-$h4-font-size:        uswds-override(1.7rem) !default;
-$h5-font-size:        uswds-override(1.5rem) !default;
-$h6-font-size:        uswds-override(1.3rem) !default;
+$em-base:             100%;     // USWDS v3 html value
+$base-font-size:      $_USWDS; // USWDS v3 body value
+$small-font-size:     scale-rem(1.4rem) !default;
+$lead-font-size:      scale-rem(2rem) !default;
+$title-font-size:     scale-rem(5.2rem) !default;
+$h1-font-size:        scale-rem(4rem) !important;
+$h2-font-size:        scale-rem(3rem) !default;
+$h3-font-size:        scale-rem(2rem) !default;
+$h4-font-size:        scale-rem(1.7rem) !default;
+$h5-font-size:        scale-rem(1.5rem) !default;
+$h6-font-size:        scale-rem(1.3rem) !default;
 
 // Magic Numbers
-$lead-max-width:                uswds-override(77rem) !default;
-$site-margins:                  uswds-override(3rem) !default;
-$site-margins-mobile:           uswds-override(1.5rem) !default;
-$input-max-width:               uswds-override(46rem) !default;
+$lead-max-width:                scale-rem(77rem) !default;
+$site-margins:                  scale-rem(3rem) !default;
+$site-margins-mobile:           scale-rem(1.5rem) !default;
+$input-max-width:               scale-rem(46rem) !default;
 $sidenav-current-border-width:  0.4rem !default; // must be in rem for math
 
 // 44 x 44 pixels hit target following Apple iOS Human Interface
 // Guidelines
-$hit-area: uswds-override(4.4rem) !default;
+$hit-area: scale-rem(4.4rem) !default;
 
-$spacing-x-small: uswds-override(0.5rem);
-$spacing-small: uswds-override(1rem);
-$spacing-md-small: uswds-override(1.5rem);
-$spacing-medium: uswds-override(2rem);
-$spacing-large: uswds-override(3rem);
+$spacing-x-small: scale-rem(0.5rem);
+$spacing-small: scale-rem(1rem);
+$spacing-md-small: scale-rem(1.5rem);
+$spacing-medium: scale-rem(2rem);
+$spacing-large: scale-rem(3rem);

--- a/src/platform/site-wide/sass/minimal.scss
+++ b/src/platform/site-wide/sass/minimal.scss
@@ -2,13 +2,20 @@
 @import "modules/m-overrides";
 
 @import "~uswds/src/stylesheets/core/variables";
+// *** Formation override ***
+@import "formation-overrides/variables";
+
 @import "~uswds/src/stylesheets/core/base";
 @import "~uswds/src/stylesheets/core/fonts";
+
 @import "~uswds/src/stylesheets/core/utilities";
+// *** Formation override ***
+@import "formation-overrides/utilities";
+
 @import "~uswds/src/stylesheets/core/grid";
 @import "~uswds/src/stylesheets/elements/buttons";
 @import "~uswds/src/stylesheets/elements/typography";
-@import "~uswds/src/stylesheets/components/accordions";
+// @import "~uswds/src/stylesheets/components/accordions"; // ** requires rem for calculation
 @import "~uswds/src/stylesheets/components/banner";
 
 //////============ VENDOR PARTIALS ==============//
@@ -24,14 +31,6 @@
 
 @import "~@department-of-veterans-affairs/formation/sass/base/b-font-faces";
 @import "~@department-of-veterans-affairs/formation/sass/base/va";
-
-
-// Add the USWDS html & body font-sizes's to the css-library elements.scss stylesheet with !important
-// and import in here after the `/base/va"` stylesheet.
-
-// html { font-size: 100%!important; }
-// body { font-size: 16px!important; }
-
 @import "~@department-of-veterans-affairs/formation/sass/base/b-utils";
 @import "~@department-of-veterans-affairs/formation/sass/layout/flex-grid";
 

--- a/src/platform/site-wide/sass/minimal.scss
+++ b/src/platform/site-wide/sass/minimal.scss
@@ -24,6 +24,10 @@
 
 @import "~@department-of-veterans-affairs/formation/sass/base/b-font-faces";
 @import "~@department-of-veterans-affairs/formation/sass/base/va";
+
+// html { font-size: 100%!important; }
+// body { font-size: 16px!important; }
+
 @import "~@department-of-veterans-affairs/formation/sass/base/b-utils";
 @import "~@department-of-veterans-affairs/formation/sass/layout/flex-grid";
 

--- a/src/platform/site-wide/sass/minimal.scss
+++ b/src/platform/site-wide/sass/minimal.scss
@@ -25,6 +25,10 @@
 @import "~@department-of-veterans-affairs/formation/sass/base/b-font-faces";
 @import "~@department-of-veterans-affairs/formation/sass/base/va";
 
+
+// Add the USWDS html & body font-sizes's to the css-library elements.scss stylesheet with !important
+// and import in here after the `/base/va"` stylesheet.
+
 // html { font-size: 100%!important; }
 // body { font-size: 16px!important; }
 

--- a/src/platform/site-wide/sass/minimal.scss
+++ b/src/platform/site-wide/sass/minimal.scss
@@ -14,6 +14,8 @@
 
 @import "~uswds/src/stylesheets/core/grid";
 @import "~uswds/src/stylesheets/elements/buttons";
+// *** Formation override ***
+@import "formation-overrides/buttons";
 @import "~uswds/src/stylesheets/elements/typography";
 // @import "~uswds/src/stylesheets/components/accordions"; // ** requires rem for calculation
 @import "~uswds/src/stylesheets/components/banner";


### PR DESCRIPTION
## Summary

This PR is a discovery to see how we might approach converting/overriding existing Formation `rem` values so that they are calculated with the USWDS base font size.

This can be broken down into  four/ five steps steps:

- [x] Calculate a size ratio (coefficient) of change between Formation:USWDS
- [x] Apply ratio to all rem values, leaving others intact
- [ ] Locate and fix exceptions and edge cases
- [ ] Override current rules

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2223

## Testing done

locally