### PR TITLE
Adjust 10-10EZR Enrollment Status Fetch

### DIFF
--- a/src/applications/ezr/components/IntroductionPage/SaveInProgressInfo.jsx
+++ b/src/applications/ezr/components/IntroductionPage/SaveInProgressInfo.jsx
@@ -1,18 +1,16 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { connect, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
-import { fetchEnrollmentStatus as fetchEnrollmentStatusAction } from '../../utils/actions/enrollment-status';
 import { selectEnrollmentStatus } from '../../utils/selectors/entrollment-status';
 import { selectAuthStatus } from '../../utils/selectors/auth-status';
 import EnrollmentStatusAlert from '../FormAlerts/EnrollmentStatusAlert';
 import VerifiedPrefillAlert from '../FormAlerts/VerifiedPrefillAlert';
 import content from '../../locales/en/content.json';
 
-const SaveInProgressInfo = props => {
-  const { fetchEnrollmentStatus, formConfig, pageList } = props;
-  const { isLoggedOut, isUserLOA3 } = useSelector(selectAuthStatus);
+const SaveInProgressInfo = ({ formConfig, pageList }) => {
+  const { isLoggedOut } = useSelector(selectAuthStatus);
   const { isEnrolledinESR, hasServerError } = useSelector(
     selectEnrollmentStatus,
   );
@@ -22,13 +20,6 @@ const SaveInProgressInfo = props => {
     savedFormMessages,
     customText,
   } = formConfig;
-
-  useEffect(() => {
-    if (isUserLOA3) {
-      fetchEnrollmentStatus();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   // set the props to use for the SaveInProgressIntro components
   const sipProps = {
@@ -82,16 +73,8 @@ const SaveInProgressInfo = props => {
 };
 
 SaveInProgressInfo.propTypes = {
-  fetchEnrollmentStatus: PropTypes.func,
   formConfig: PropTypes.object,
   pageList: PropTypes.array,
 };
 
-const mapDispatchToProps = {
-  fetchEnrollmentStatus: fetchEnrollmentStatusAction,
-};
-
-export default connect(
-  null,
-  mapDispatchToProps,
-)(SaveInProgressInfo);
+export default SaveInProgressInfo;

--- a/src/applications/ezr/config/form.js
+++ b/src/applications/ezr/config/form.js
@@ -141,7 +141,7 @@ const formConfig = {
           path: 'veteran-information/gender-identity',
           title: 'Veteran\u2019s gender identity',
           initialData: {},
-          depends: formData => !formData['view:isSigiEnabled'],
+          depends: formData => formData['view:isSigiEnabled'],
           uiSchema: veteranGenderIdentity.uiSchema,
           schema: veteranGenderIdentity.schema,
         },

--- a/src/applications/ezr/containers/IntroductionPage.jsx
+++ b/src/applications/ezr/containers/IntroductionPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
+import { connect, useSelector } from 'react-redux';
 
 import { AUTH_EVENTS } from 'platform/user/authentication/constants';
 import recordEvent from 'platform/monitoring/record-event';
@@ -10,6 +10,7 @@ import {
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
 
+import { fetchEnrollmentStatus as fetchEnrollmentStatusAction } from '../utils/actions/enrollment-status';
 import { selectEnrollmentStatus } from '../utils/selectors/entrollment-status';
 import { selectAuthStatus } from '../utils/selectors/auth-status';
 import IdentityVerificationAlert from '../components/FormAlerts/IdentityVerificationAlert';
@@ -18,9 +19,9 @@ import SaveInProgressInfo from '../components/IntroductionPage/SaveInProgressInf
 import OMBInfo from '../components/IntroductionPage/OMBInfo';
 import content from '../locales/en/content.json';
 
-const IntroductionPage = ({ route }) => {
+const IntroductionPage = ({ fetchEnrollmentStatus, route }) => {
   const { isLoading } = useSelector(selectEnrollmentStatus);
-  const { isUserLOA1 } = useSelector(selectAuthStatus);
+  const { isUserLOA1, isUserLOA3 } = useSelector(selectAuthStatus);
   const { formConfig, pageList } = route;
   const sipProps = { formConfig, pageList };
 
@@ -28,6 +29,10 @@ const IntroductionPage = ({ route }) => {
 
   useEffect(() => {
     focusElement('.va-nav-breadcrumbs-list');
+    if (isUserLOA3) {
+      fetchEnrollmentStatus();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -57,7 +62,15 @@ const IntroductionPage = ({ route }) => {
 };
 
 IntroductionPage.propTypes = {
+  fetchEnrollmentStatus: PropTypes.func,
   route: PropTypes.object,
 };
 
-export default IntroductionPage;
+const mapDispatchToProps = {
+  fetchEnrollmentStatus: fetchEnrollmentStatusAction,
+};
+
+export default connect(
+  null,
+  mapDispatchToProps,
+)(IntroductionPage);


### PR DESCRIPTION
## Summary
This PR addresses an issue with the enrollment status fetch on the 10-10EZR. The fetch was running in an infinite loop inside the child component and not resolving to allow the user to proceed. The fix moves the fetch to the Introduction page on the form and ensures that it only runs once on mount of the Intro page component.

## Acceptance criteria
- Fetch runs on initial render of the Intro page and on no subsequent renders.
- Fetch returns appropriate data.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution