### PR TITLE
MHV-50827: none note for when a field value is 0

### DIFF
--- a/src/applications/mhv/medications/tests/util/helpers.unit.spec.jsx
+++ b/src/applications/mhv/medications/tests/util/helpers.unit.spec.jsx
@@ -28,6 +28,10 @@ describe('Validate Field function', () => {
   it("should return 'None noted'", () => {
     expect(helpers.validateField()).to.equal('None noted');
   });
+
+  it('should return 0', () => {
+    expect(helpers.validateField(0)).to.equal(0);
+  });
 });
 
 describe('Image URI function', () => {

--- a/src/applications/mhv/medications/util/helpers.js
+++ b/src/applications/mhv/medications/util/helpers.js
@@ -41,7 +41,7 @@ export const generateMedicationsPDF = async (
  * @param {String} fieldValue value that is being validated
  */
 export const validateField = fieldValue => {
-  if (fieldValue) {
+  if (fieldValue || fieldValue === 0) {
     return fieldValue;
   }
   return 'None noted';


### PR DESCRIPTION
## Summary

- VA Medication Details: when `refillRemaining` field value was `0` it was showing `'None noted'` instead. The corresponding validation function has been updated to account for such situations

## Acceptance criteria

- Refills left show 0 instead of none noted

## Related issue(s)

[Jira ticket](https://jira.devops.va.gov/browse/MHV-50827)

<img width="929" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/984fffde-dd82-49f0-83ef-33e7be1903df">

## Before

<img width="1033" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/26b02810-6102-4240-a90d-af8a992db166">

## After

<img width="1066" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/cb5fe872-44a5-4967-9b1b-f20906e094fe">

## What areas of the site does it impact?

my-health/Medications 

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
