### PR TITLE
[Rated Disabilities] va-card headers should be h4s not h3s

### DIFF
--- a/src/applications/rated-disabilities/components/RatedDisabilityListItem.jsx
+++ b/src/applications/rated-disabilities/components/RatedDisabilityListItem.jsx
@@ -18,7 +18,7 @@ const RatedDisabilityListItem = ({ ratedDisability }) => {
 
   return (
     <va-card class="vads-u-margin-bottom--2">
-      <h3 className="vads-u-margin-y--0">{headingText}</h3>
+      <h4 className="vads-u-margin-y--0 vads-u-font-size--h3">{headingText}</h4>
       {effectiveDate !== null && (
         <div className="vads-u-margin-top--2">
           <strong>Effective date:</strong> {effectiveDate.format('MM/DD/YYYY')}

--- a/src/applications/rated-disabilities/tests/components/RatedDisabilityList.unit.spec.jsx
+++ b/src/applications/rated-disabilities/tests/components/RatedDisabilityList.unit.spec.jsx
@@ -55,7 +55,7 @@ describe('<RatedDisabilityList/>', () => {
 
     expect(
       wrapper.getByRole('heading', {
-        level: 3,
+        level: 4,
         name: headingText,
       }),
     ).to.exist;


### PR DESCRIPTION
## Summary
Changing the headers in the `va-card`s to be h4s instead of h3s to improve the accessibility of the application

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#4784

## Screenshots
No visual changes were made

## What areas of the site does it impact?
The Rated Disabilities application

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_