### PR TITLE
Allow for Military base address for 10-10EZR form

### DIFF
--- a/src/applications/ezr/config/chapters/insuranceInformation/policyInformation.js
+++ b/src/applications/ezr/config/chapters/insuranceInformation/policyInformation.js
@@ -64,8 +64,8 @@ export default {
         type: 'object',
         properties: {
           insurancePolicyNumber,
-          insuranceGroupCode,
           'view:or': VIEW_FIELD_SCHEMA,
+          insuranceGroupCode,
         },
       },
     },

--- a/src/applications/ezr/config/chapters/veteranInformation/homeAddress.js
+++ b/src/applications/ezr/config/chapters/veteranInformation/homeAddress.js
@@ -18,13 +18,13 @@ export default {
   uiSchema: {
     ...descriptionUI(PrefillMessage, { hideOnReview: true }),
     'view:pageTitle': inlineTitleUI(content['vet-home-address-title']),
-    veteranHomeAddress: addressUI({ omit: ['isMilitary'] }),
+    veteranHomeAddress: addressUI(),
   },
   schema: {
     type: 'object',
     properties: {
       'view:pageTitle': inlineTitleSchema,
-      veteranHomeAddress: merge({}, addressSchema({ omit: ['isMilitary'] }), {
+      veteranHomeAddress: merge({}, addressSchema(), {
         properties: schemaOverride,
       }),
     },

--- a/src/applications/ezr/config/chapters/veteranInformation/mailingAddress.js
+++ b/src/applications/ezr/config/chapters/veteranInformation/mailingAddress.js
@@ -23,7 +23,7 @@ export default {
       content['vet-mailing-address-title'],
       content['vet-mailing-address-description'],
     ),
-    veteranAddress: addressUI({ omit: ['isMilitary'] }),
+    veteranAddress: addressUI(),
     'view:doesMailingMatchHomeAddress': yesNoUI(
       content['vet-address-match-title'],
     ),
@@ -33,7 +33,7 @@ export default {
     required: ['view:doesMailingMatchHomeAddress'],
     properties: {
       'view:pageTitle': inlineTitleSchema,
-      veteranAddress: merge({}, addressSchema({ omit: ['isMilitary'] }), {
+      veteranAddress: merge({}, addressSchema(), {
         properties: schemaOverride,
       }),
       'view:doesMailingMatchHomeAddress': yesNoSchema,

--- a/src/applications/ezr/tests/unit/config/veteranInformation/homeAddress.unit.spec.js
+++ b/src/applications/ezr/tests/unit/config/veteranInformation/homeAddress.unit.spec.js
@@ -14,21 +14,21 @@ const {
 const { title: pageTitle, schema, uiSchema } = homeAddress;
 
 // run test for correct number of fields on the page
-const expectedNumberOfFields = 7;
+const expectedNumberOfWebComponentFields = 8;
 testNumberOfWebComponentFields(
   formConfig,
   schema,
   uiSchema,
-  expectedNumberOfFields,
+  expectedNumberOfWebComponentFields,
   pageTitle,
 );
 
 // run test for correct number of error messages on submit
-const expectedNumberOfErrors = 4;
+const expectedNumberOfWebComponentErrors = 4;
 testNumberOfErrorsOnSubmitForWebComponents(
   formConfig,
   schema,
   uiSchema,
-  expectedNumberOfErrors,
+  expectedNumberOfWebComponentErrors,
   pageTitle,
 );

--- a/src/applications/ezr/tests/unit/config/veteranInformation/mailingAddress.unit.spec.js
+++ b/src/applications/ezr/tests/unit/config/veteranInformation/mailingAddress.unit.spec.js
@@ -14,7 +14,7 @@ const {
 const { title: pageTitle, schema, uiSchema } = mailingAddress;
 
 // run test for correct number of fields on the page
-const expectedNumberOfWebComponentFields = 8;
+const expectedNumberOfWebComponentFields = 9;
 testNumberOfWebComponentFields(
   formConfig,
   schema,


### PR DESCRIPTION
## Summary
This PR updates the address schema for the Veteran Information section of the 10-10EZR form. Since we are getting addresses from Eligibility & Enrollment that are on Military bases, we need to account for that in the UI.

## Testing done
- [x] Updated unit tests to account for correct number of form fields

## Related issue(s)
department-of-veterans-affairs/va.gov-team#68620

## Acceptance criteria
- Vets can use Military bases as their address location

### Quality Assurance & Testing

- [x] I updated unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution