### PR TITLE
MHV-50892: Number of refills left not showing on some cards

### DIFF
--- a/src/applications/mhv/medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv/medications/tests/e2e/pages/MedicationsListPage.js
@@ -182,6 +182,10 @@ class MedicationsListPage {
     cy.get(
       ':nth-child(2) > .rx-card-detials > :nth-child(2) > [data-testid="active-not-filled-rx"]',
     ).should('have.text', 'Not filled yet');
+    cy.get(':nth-child(2) > .rx-card-detials > :nth-child(3)').should(
+      'contain',
+      `${activeRxRefills.data.attributes.refillRemaining} refills left`,
+    );
   };
 
   verifyInformationBaseOnStatusSubmitted = () => {

--- a/src/applications/mhv/medications/util/constants.js
+++ b/src/applications/mhv/medications/util/constants.js
@@ -24,7 +24,7 @@ export const dispStatusForRefillsLeft = [
   'Active: Parked',
   'Active: On Hold',
   'Active: Submitted',
-  'Active: Refill in process',
+  'Active: Refill in Process',
 ];
 
 export const imageRootUri = 'https://www.myhealth.va.gov/static/MILDrugImages/';


### PR DESCRIPTION
## Summary

- Medications List page: refills left was not showing for Active: Refill in Process cards

## Acceptance criteria

- Number of refills left should show up on all cards in the list except for Non-VA, Expired, Discontinued, and Transferred.

## Related issue(s)

[Jira ticket](https://jira.devops.va.gov/browse/MHV-50892)

<img width="690" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/0a2b50df-7648-4649-a8c0-dfb39d84efd3">

## Before

<img width="467" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/c7591cc3-308c-410f-8296-8859c52e03e4">

## After

<img width="466" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/7b1cfee9-d9e2-43a6-863e-ed950eff67f4">

## What areas of the site does it impact?

my-health/Medications 

### Testing

Only manual testing has been performed. No unit testing since actual code change is verbiage change.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
