### PR TITLE
Profile/aw/67073/focus fix notification settings checkboxes

### DIFF
--- a/src/applications/personalization/profile/components/notification-settings/NotificationCheckbox.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationCheckbox.jsx
@@ -40,7 +40,6 @@ export const NotificationCheckbox = ({
       <NotificationStatusMessage
         id={errorSpanId}
         classes="vads-u-background-color--secondary-lightest vads-u-font-weight--bold"
-        alert
       >
         <i
           className="fas fa-exclamation-circle vads-u-margin-right--1"
@@ -59,7 +58,6 @@ export const NotificationCheckbox = ({
       <NotificationStatusMessage
         id={loadingSpanId}
         classes="vads-u-font-weight--normal"
-        alert
       >
         <i
           className="fas fa-spinner fa-spin vads-u-margin-right--1"
@@ -78,7 +76,6 @@ export const NotificationCheckbox = ({
       <NotificationStatusMessage
         id={successSpanId}
         classes="vads-u-background-color--green-lightest vads-u-font-weight--bold"
-        alert
       >
         <i className="fas fa-check vads-u-margin-right--1" aria-hidden="true" />{' '}
         <span className="sr-only">Success</span> {successMessage}
@@ -96,16 +93,27 @@ export const NotificationCheckbox = ({
       {!loadingMessage && !successMessage && errorSpan}
       {!loadingMessage && !errorMessage && successSpan}
       {!errorMessage && !successMessage && loadingSpan}
-      <VaCheckbox
-        checked={checked}
-        label={label}
-        onVaChange={handleChange}
-        data-testid={checkboxId}
-        id={checkboxId}
-        disabled={disabled}
-        uswds
-        className={className}
-      />{' '}
+      {disabled ? (
+        <VaCheckbox
+          checked={checked}
+          label={label}
+          data-testid={checkboxId}
+          id={checkboxId}
+          disabled
+          uswds
+          className={className}
+        />
+      ) : (
+        <VaCheckbox
+          checked={checked}
+          label={label}
+          onVaChange={handleChange}
+          data-testid={checkboxId}
+          id={checkboxId}
+          uswds
+          className={className}
+        />
+      )}{' '}
     </div>
   );
 };

--- a/src/applications/personalization/profile/components/notification-settings/NotificationStatusMessage.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationStatusMessage.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -6,7 +6,6 @@ export const NotificationStatusMessage = ({
   children,
   classes,
   id,
-  alert,
   legacy = false,
 }) => {
   // legacy can be removed as a prop when the radio buttons are removed
@@ -24,6 +23,7 @@ export const NotificationStatusMessage = ({
               'vads-u-padding-y--1p5',
               'vads-u-padding-x--2',
               'vads-u-margin-left--neg1p5',
+              'focus-ring',
               classes,
             ],
       );
@@ -31,14 +31,19 @@ export const NotificationStatusMessage = ({
     [classes, legacy],
   );
 
+  const statusMessage = useRef(null);
+
+  useEffect(() => {
+    if (statusMessage.current) {
+      statusMessage.current.focus();
+    }
+  }, []);
+
   return (
-    <div
-      id={id}
-      role={alert ? 'alert' : undefined}
-      aria-live={alert ? 'polite' : undefined}
-      className="vads-u-display--flex"
-    >
-      <span className={computedClasses}>{children}</span>
+    <div id={id} className="vads-u-display--flex">
+      <div ref={statusMessage} tabIndex="-1" className={computedClasses}>
+        {children}
+      </div>
     </div>
   );
 };

--- a/src/applications/personalization/profile/mocks/endpoints/rating-info/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/rating-info/index.js
@@ -8,6 +8,15 @@ const success = {
       },
     },
   },
+  serviceConnected0: {
+    data: {
+      id: '',
+      type: 'evss_disability_compensation_form_rating_info_responses',
+      attributes: {
+        userPercentOfDisability: 0,
+      },
+    },
+  },
 };
 
 const error = {

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -276,6 +276,9 @@ const responses = {
       },
     });
 
+    // uncomment to test 500 error
+    // return res.status(500).json(error500);
+
     delaySingleResponse(() => res.json(mockedRes), 1);
   },
 

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -78,7 +78,7 @@ const responses = {
   },
   'GET /v0/user': (_req, res) => {
     // example user data cases
-    // return res.json(user.loa3User72); // default user (success)
+    return res.json(user.loa3User72); // default user (success)
     // return res.json(user.loa1User); // user with loa1
     // return res.json(user.badAddress); // user with bad address
     // return res.json(user.loa3User); // user with loa3
@@ -90,7 +90,7 @@ const responses = {
     // return res.json(user.loa3UserWithNoHomeAddress); // home address is null
 
     // data claim users
-    return res.json(user.loa3UserWithNoRatingInfoClaim);
+    // return res.json(user.loa3UserWithNoRatingInfoClaim);
     // return res.json(user.loa3UserWithNoMilitaryHistoryClaim);
   },
   'GET /v0/profile/status': status.success,
@@ -175,7 +175,7 @@ const responses = {
     //   .json(serviceHistory.generateServiceHistoryError('403'));
   },
   'GET /v0/disability_compensation_form/rating_info':
-    ratingInfo.success.serviceConnected40,
+    ratingInfo.success.serviceConnected0,
   'PUT /v0/profile/telephones': (req, res) => {
     if (req?.body?.phoneNumber === '1111111') {
       return res.json(phoneNumber.transactions.receivedNoChangesDetected);

--- a/src/applications/personalization/profile/sass/_shared.scss
+++ b/src/applications/personalization/profile/sass/_shared.scss
@@ -27,3 +27,10 @@ $nav-item-padding: units-px(1) units-px(2) units-px(1) units-px(1.5);
     }
   }
 }
+
+// util to make sure a focus ring is visible
+.focus-ring:focus {
+  outline: 2px solid !important;
+  outline-color: $color-gold-light !important;
+  outline-offset: 0;
+}


### PR DESCRIPTION
## Summary

- Adds focus to the notification when a setting saves / fails saving. This ensures that the alert is read to screen readers. 
- There is also a visual indicator of focus as well, and tabbing now returns the user to the previous checkbox as requested by the related issue.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/67073

## Testing done

- Tested locally. To verify behavior you can save a notification setting and verify that the alert is focused and the focus ring is present.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| | ![Screenshot 2023-11-01 at 10 08 18 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/0cf7de6a-cfcb-427e-9a2c-5a79c4759665) | ![Screenshot 2023-11-01 at 10 07 55 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/27a0ffa8-74c9-43d8-96c6-2e5b11223163) |

## What areas of the site does it impact?

Profile -> Notification Settings

## Acceptance criteria

- Focus is set on alert

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
