### PR TITLE
Update 10-10EZR prefill transformer to set isMilitary address flag

### DIFF
--- a/src/applications/ezr/components/FormPages/InsuranceSummary.jsx
+++ b/src/applications/ezr/components/FormPages/InsuranceSummary.jsx
@@ -9,7 +9,7 @@ import { INSURANCE_VIEW_FIELDS, SHARED_PATHS } from '../../utils/constants';
 import content from '../../locales/en/content.json';
 
 // declare shared data & route attrs from the form
-const { providers: INSURANCE_PATHS } = SHARED_PATHS;
+const { insurance: INSURANCE_PATHS } = SHARED_PATHS;
 
 // declare default component
 const InsuranceSummary = props => {

--- a/src/applications/ezr/components/PreSubmitNotice/index.jsx
+++ b/src/applications/ezr/components/PreSubmitNotice/index.jsx
@@ -45,7 +45,6 @@ const PreSubmitNotice = props => {
         error={error}
         onVaChange={event => setAccepted(event.target.checked)}
         label={content['presubmit-checkbox-label']}
-        uswds
       />
     </>
   );

--- a/src/applications/ezr/tests/unit/utils/helpers/prefill-transformer.unit.spec.js
+++ b/src/applications/ezr/tests/unit/utils/helpers/prefill-transformer.unit.spec.js
@@ -15,6 +15,7 @@ describe('ezr prefill transformer', () => {
         countryCodeIso3: 'USA',
       };
       const desiredOutput = JSON.stringify({
+        isMilitary: false,
         street: '123 Apple Lane',
         street2: undefined,
         street3: undefined,
@@ -38,12 +39,33 @@ describe('ezr prefill transformer', () => {
         countryCodeIso3: 'USA',
       };
       const desiredOutput = JSON.stringify({
+        isMilitary: false,
         street: '123 Apple Lane',
         street2: 'Apt 1',
         street3: 'c/o homeowner',
         city: 'Plymouth',
         postalCode: '46563',
         state: 'IN',
+        country: 'USA',
+      });
+      const output = JSON.stringify(sanitizeAddress(addressToSanitize));
+      expect(output).to.equal(desiredOutput);
+    });
+
+    it('should set `isMilitary` to true when a military city code is provided', () => {
+      const addressToSanitize = {
+        addressLine1: 'PSC 808 Box 37',
+        city: 'FPO',
+        zipCode: '09618',
+        stateCode: 'AA',
+        countryCodeIso3: 'USA',
+      };
+      const desiredOutput = JSON.stringify({
+        isMilitary: true,
+        street: 'PSC 808 Box 37',
+        city: 'FPO',
+        postalCode: '09618',
+        state: 'AA',
         country: 'USA',
       });
       const output = JSON.stringify(sanitizeAddress(addressToSanitize));
@@ -141,7 +163,7 @@ describe('ezr prefill transformer', () => {
         );
         expect(Object.keys(prefillData)).to.have.lengthOf(15);
         expect(prefillData.veteranAddress).to.equal(undefined);
-        expect(Object.keys(prefillData.veteranHomeAddress)).to.have.lengthOf(7);
+        expect(Object.keys(prefillData.veteranHomeAddress)).to.have.lengthOf(8);
         expect(prefillData['view:doesMailingMatchHomeAddress']).to.equal(
           undefined,
         );
@@ -216,9 +238,9 @@ describe('ezr prefill transformer', () => {
             state,
           );
           expect(Object.keys(prefillData)).to.have.lengthOf(16);
-          expect(Object.keys(prefillData.veteranAddress)).to.have.lengthOf(7);
+          expect(Object.keys(prefillData.veteranAddress)).to.have.lengthOf(8);
           expect(Object.keys(prefillData.veteranHomeAddress)).to.have.lengthOf(
-            7,
+            8,
           );
           expect(prefillData['view:doesMailingMatchHomeAddress']).to.be.false;
         });
@@ -294,7 +316,7 @@ describe('ezr prefill transformer', () => {
           );
           expect(Object.keys(prefillData)).to.have.lengthOf(15);
           expect(Object.keys(prefillData).veteranHomeAddress).to.not.exist;
-          expect(Object.keys(prefillData.veteranAddress)).to.have.lengthOf(7);
+          expect(Object.keys(prefillData.veteranAddress)).to.have.lengthOf(8);
           expect(prefillData['view:doesMailingMatchHomeAddress']).to.be.true;
         });
       },

--- a/src/applications/ezr/utils/constants.js
+++ b/src/applications/ezr/utils/constants.js
@@ -82,6 +82,8 @@ export const INSURANCE_VIEW_FIELDS = {
   skip: 'view:skipInsuranceInfo',
 };
 
+export const MILITARY_CITIES = ['APO', 'FPO', 'DPO'];
+
 export const MOCK_ENROLLMENT_REPSONSE = {
   applicationDate: '2019-04-24T00:00:00.000-06:00',
   enrollmentDate: '2019-04-30T00:00:00.000-06:00',

--- a/src/applications/ezr/utils/constants.js
+++ b/src/applications/ezr/utils/constants.js
@@ -82,8 +82,10 @@ export const INSURANCE_VIEW_FIELDS = {
   skip: 'view:skipInsuranceInfo',
 };
 
+// declare military city codes to use for prefill transformer
 export const MILITARY_CITIES = ['APO', 'FPO', 'DPO'];
 
+// declare mock response for enrollment status API to use for simulated testing
 export const MOCK_ENROLLMENT_REPSONSE = {
   applicationDate: '2019-04-24T00:00:00.000-06:00',
   enrollmentDate: '2019-04-30T00:00:00.000-06:00',

--- a/src/applications/ezr/utils/helpers/prefill-transformer.js
+++ b/src/applications/ezr/utils/helpers/prefill-transformer.js
@@ -1,3 +1,5 @@
+import { MILITARY_CITIES } from '../constants';
+
 /**
  * Map address object to match the key names in the schema
  * @param {Array} address - an array of arrays that defines the keys/values to map
@@ -15,6 +17,7 @@ export function sanitizeAddress(address) {
     countryCodeIso3,
   } = address;
   return {
+    isMilitary: MILITARY_CITIES.includes(city),
     street: addressLine1,
     street2: addressLine2 || undefined,
     street3: addressLine3 || undefined,


### PR DESCRIPTION
## Summary
This PR primarily updates the prefill transform function for the 10-10EZR form to account for military city codes to set the `isMilitary` checkbox to true for the home/mailing address fields. The PR also includes two minor styling/bug fixes for other sections of the form

## Related issue(s)
department-of-veterans-affairs/va.gov-team#68620

## Testing done

- [x] Updated unit tests to account for the additional `isMilitary` data key and field

## Acceptance criteria
- All prefilled addresses that contain military city codes will allow for the `isMilitary` checkbox to be selected and for proper data selections to able to be made

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution