### PR TITLE
VACMS-15699 Clean up code in the header/footer directories

### DIFF
--- a/src/platform/site-wide/header/components/App/index.js
+++ b/src/platform/site-wide/header/components/App/index.js
@@ -1,49 +1,41 @@
-// Node modules.
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-// Relative imports.
-import recordEvent from 'platform/monitoring/record-event';
+import recordEvent from '~/platform/monitoring/record-event';
 import Header from '../Header';
 import { hideLegacyHeader, showLegacyHeader } from '../../helpers';
 
 const MOBILE_BREAKPOINT_PX = 768;
 
 export const App = ({ megaMenuData, show, showMegaMenu, showNavLogin }) => {
-  // Derive if we are on desktop.
   const [isDesktop, setIsDesktop] = useState(
     window.innerWidth >= MOBILE_BREAKPOINT_PX,
   );
 
-  // Derive if we are on desktop and set isDesktop state.
   const deriveIsDesktop = () =>
     setIsDesktop(window.innerWidth >= MOBILE_BREAKPOINT_PX);
 
   useEffect(() => {
-    // Record analytic event.
     recordEvent({
       event: 'phased-roll-out-enabled',
       'product-description': 'Header V2',
     });
 
-    // Set screen size listener.
     window.addEventListener('resize', deriveIsDesktop);
 
-    // Clear listener.
     return () => window.removeEventListener('resize', deriveIsDesktop);
   }, []);
 
-  // Do not render if prop show is falsey.
   if (!show) {
     return null;
   }
 
-  // Render the legacy header if we are on desktop.
   if (isDesktop) {
     showLegacyHeader();
     return null;
   }
 
   hideLegacyHeader();
+
   return (
     <Header
       megaMenuData={megaMenuData}

--- a/src/platform/site-wide/header/components/Header/index.js
+++ b/src/platform/site-wide/header/components/Header/index.js
@@ -1,7 +1,5 @@
-// Node modules.
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-// Relative imports.
 import LogoRow from '../LogoRow';
 import Menu from '../../containers/Menu';
 import OfficialGovtWebsite from '../OfficialGovtWebsite';
@@ -13,28 +11,20 @@ export const Header = ({ megaMenuData, showMegaMenu, showNavLogin }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   useEffect(() => {
-    // Start Veteran Crisis Line modal functionality.
     addFocusBehaviorToCrisisLineModal();
     addOverlayTriggers();
   }, []);
 
   return (
     <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-margin--0 vads-u-padding--0">
-      {/* Official government website banner */}
       <OfficialGovtWebsite />
-
-      {/* Veteran crisis line */}
       <VeteranCrisisLine id="header-crisis-line" />
-
       <nav className="vads-u-display--flex vads-u-flex-direction--column vads-u-margin--0 vads-u-padding--0">
-        {/* Logo row */}
         <LogoRow
           isMenuOpen={isMenuOpen}
           showNavLogin={showNavLogin}
           setIsMenuOpen={setIsMenuOpen}
         />
-
-        {/* Menu */}
         <Menu
           isMenuOpen={isMenuOpen}
           megaMenuData={megaMenuData}

--- a/src/platform/site-wide/header/components/Header/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/Header/index.unit.spec.js
@@ -1,24 +1,18 @@
-// 3rd-party imports
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-
-// 1st-party imports
 import { Header } from '.';
 
 describe('Header <Header>', () => {
   const renderHeader = () => shallow(<Header showMegaMenu showNavLogin />);
 
-  // Component Wrapper
   let wrapper;
 
   beforeEach(() => {
-    // Set up.
     wrapper = renderHeader();
   });
 
   it('renders content', () => {
-    // Assertions.
     expect(wrapper.find('OfficialGovtWebsite')).to.have.lengthOf(1);
     expect(wrapper.find('VeteranCrisisLine')).to.have.lengthOf(1);
     expect(wrapper.find('Connect(LogoRow)')).to.have.lengthOf(1);

--- a/src/platform/site-wide/header/components/Logo/index.js
+++ b/src/platform/site-wide/header/components/Logo/index.js
@@ -1,4 +1,3 @@
-// Node modules.
 import React from 'react';
 
 export const Logo = props => (

--- a/src/platform/site-wide/header/components/Logo/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/Logo/index.unit.spec.js
@@ -1,19 +1,14 @@
-// Node modules.
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-// Relative imports.
 import { Logo } from '.';
 
 describe('Header <Logo>', () => {
   it('renders content', () => {
-    // Set up.
     const wrapper = shallow(<Logo />);
 
-    // Assertions.
     expect(wrapper.find(`svg`)).to.have.lengthOf(1);
 
-    // Clean up.
     wrapper.unmount();
   });
 });

--- a/src/platform/site-wide/header/components/LogoRow/index.js
+++ b/src/platform/site-wide/header/components/LogoRow/index.js
@@ -1,9 +1,7 @@
-// Node modules.
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-// Relative imports.
-import recordEvent from 'platform/monitoring/record-event';
+import recordEvent from '~/platform/monitoring/record-event';
 import Logo from '../Logo';
 import UserNav from '../../../user-nav/containers/Main';
 import { updateExpandedMenuIDAction } from '../../containers/Menu/actions';
@@ -15,17 +13,13 @@ export const LogoRow = ({
   updateExpandedMenuID,
 }) => {
   const onMenuToggle = () => {
-    // Record the analytic event.
     recordEvent({ event: 'nav-header-menu-expand' });
-
-    // Update the state.
     updateExpandedMenuID();
     setIsMenuOpen(!isMenuOpen);
   };
 
   return (
     <div className="header-logo-row vads-u-background-color--primary-darkest vads-u-display--flex vads-u-align-items--center vads-u-justify-content--space-between vads-u-padding-y--1p5 vads-u-padding-left--1p5 vads-u-padding-right--1">
-      {/* Logo */}
       <a
         aria-label="VA logo"
         className="header-logo vads-u-display--flex vads-u-align-items--center vads-u-justify-content--center"
@@ -34,12 +28,8 @@ export const LogoRow = ({
       >
         <Logo />
       </a>
-
       <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-align-items--center">
-        {/* Sign in button */}
         <UserNav isHeaderV2 showNavLogin={showNavLogin} />
-
-        {/* Mobile menu button */}
         {showNavLogin && (
           <button
             aria-controls="header-nav-items"
@@ -48,10 +38,7 @@ export const LogoRow = ({
             onClick={onMenuToggle}
             type="button"
           >
-            {/* Menu | Close */}
             {!isMenuOpen ? 'Menu' : 'Close'}
-
-            {/* Menu bars icon | Close icon */}
             {!isMenuOpen ? (
               <i
                 aria-hidden="true"
@@ -63,8 +50,6 @@ export const LogoRow = ({
                 className="fa fa-times vads-u-margin-left--1 vads-u-font-size--sm"
               />
             )}
-
-            {/* Styling overlay */}
             {isMenuOpen && (
               <div className="header-menu-button-overlay vads-u-background-color--gray-lightest vads-u-position--absolute vads-u-width--full" />
             )}

--- a/src/platform/site-wide/header/components/LogoRow/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/LogoRow/index.unit.spec.js
@@ -1,17 +1,13 @@
-// Node modules.
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-// Relative imports.
 import { LogoRow } from '.';
 
 describe('Header <LogoRow>', () => {
   it('renders correct content with no props', () => {
-    // Set up.
     const wrapper = shallow(<LogoRow />);
 
-    // Assertions.
     expect(wrapper.find('Logo')).to.have.length(1);
     expect(wrapper.find('Connect(Main)')).to.have.length(1);
     expect(wrapper.find('button.header-menu-button')).to.have.length(1);
@@ -21,15 +17,12 @@ describe('Header <LogoRow>', () => {
     expect(wrapper.find('i.fa.fa-times')).to.have.length(0);
     expect(wrapper.find('div.header-menu-button-overlay')).to.have.length(0);
 
-    // Clean up.
     wrapper.unmount();
   });
 
   it('renders correct content with isMenuOpen', () => {
-    // Set up tests.
     const wrapper = shallow(<LogoRow isMenuOpen />);
 
-    // Assertions.
     expect(wrapper.find('Logo')).to.have.length(1);
     expect(wrapper.find('Connect(Main)')).to.have.length(1);
     expect(wrapper.find('button.header-menu-button')).to.have.length(1);
@@ -39,12 +32,10 @@ describe('Header <LogoRow>', () => {
     expect(wrapper.find('i.fa.fa-times')).to.have.length(1);
     expect(wrapper.find('div.header-menu-button-overlay')).to.have.length(1);
 
-    // Clean up.
     wrapper.unmount();
   });
 
   it('toggles the menu', () => {
-    // Set up tests.
     const updateExpandedMenuID = sinon.spy();
     const setIsMenuOpen = sinon.spy();
     const wrapper = shallow(
@@ -56,12 +47,10 @@ describe('Header <LogoRow>', () => {
     );
     wrapper.find('.header-menu-button').simulate('click');
 
-    // Assertions.
     expect(updateExpandedMenuID.called).to.be.true;
     expect(setIsMenuOpen.called).to.be.true;
     expect(setIsMenuOpen.firstCall.args[0]).to.equal(false);
 
-    // Clean up.
     wrapper.unmount();
   });
 });

--- a/src/platform/site-wide/header/components/MenuItemLevel1/index.js
+++ b/src/platform/site-wide/header/components/MenuItemLevel1/index.js
@@ -1,10 +1,8 @@
-// Node modules.
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-// Relative imports.
 import MenuItemLevel2 from '../MenuItemLevel2';
-import recordEvent from 'platform/monitoring/record-event';
+import recordEvent from '~/platform/monitoring/record-event';
 import { deriveMenuItemID, formatMenuItems } from '../../helpers';
 import { updateExpandedMenuIDAction } from '../../containers/Menu/actions';
 
@@ -13,36 +11,27 @@ export const MenuItemLevel1 = ({
   item,
   updateExpandedMenuID,
 }) => {
-  // Derive the menu item's ID.
   const menuItemID = deriveMenuItemID(item, '1');
-
-  // Derive if we the menu item is expanded.
   const isExpanded = menuItemID === expandedMenuID;
 
-  // Do not render if we are missing necessary menu item data.
   if (!item?.menuSections && !item?.href && !item?.title) {
     return null;
   }
 
-  // Format menuSections to be an array if needed.
   if (item?.menuSections) {
     item.menuSections = formatMenuItems(item.menuSections); // eslint-disable-line no-param-reassign
   }
 
   const toggleShowItems = title => () => {
-    // Record event.
     recordEvent({
       event: 'nav-header-top-level',
       'nav-header-action': `Navigation - Header - Open Top Level - ${title}`,
     });
 
-    // Update the expanded menu ID.
     updateExpandedMenuID(isExpanded ? undefined : menuItemID);
 
-    // Derive the header element.
     const header = document.querySelector('header');
 
-    // Scroll to the top of the header when toggling a menu item.
     if (header) {
       header.scrollIntoView();
     }
@@ -57,7 +46,6 @@ export const MenuItemLevel1 = ({
             {item?.title}
           </span>
         )}
-
       {/* Title link */}
       {!item?.menuSections &&
         item?.href && (
@@ -68,7 +56,6 @@ export const MenuItemLevel1 = ({
             {item?.title}
           </a>
         )}
-
       {item?.menuSections && (
         <>
           {/* Expand title */}
@@ -92,7 +79,6 @@ export const MenuItemLevel1 = ({
               />
             )}
           </button>
-
           {/* Level 2 menu items */}
           {isExpanded && (
             <ul

--- a/src/platform/site-wide/header/components/MenuItemLevel1/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/MenuItemLevel1/index.unit.spec.js
@@ -1,18 +1,14 @@
-// Node modules.
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-// Relative imports.
 import { MenuItemLevel1 } from '.';
 
 describe('Header <MenuItemLevel1>', () => {
   it('renders an item with no children', () => {
-    // Set up.
     const item = { href: 'https://example.com', title: 'example' };
     const wrapper = shallow(<MenuItemLevel1 item={item} />);
 
-    // Assertions.
     expect(
       wrapper.find('li.vads-u-background-color--primary-darker'),
     ).to.have.length(1);
@@ -21,12 +17,10 @@ describe('Header <MenuItemLevel1>', () => {
     expect(wrapper.find('.header-menu-item-button')).to.have.length(0);
     expect(wrapper.find('i.fa.fa-plus')).to.have.length(0);
 
-    // Clean up.
     wrapper.unmount();
   });
 
   it('renders an expanded item with children and collapses it on click', () => {
-    // Set up.
     const updateExpandedMenuID = sinon.spy();
     const item = {
       menuSections: [{ title: 'random title', href: 'https://example.com' }],
@@ -40,7 +34,6 @@ describe('Header <MenuItemLevel1>', () => {
       />,
     );
 
-    // Assertions.
     expect(
       wrapper.find('li.vads-u-background-color--primary-darker'),
     ).to.have.length(1);
@@ -51,18 +44,14 @@ describe('Header <MenuItemLevel1>', () => {
     expect(wrapper.find('i.fa.fa-minus')).to.have.length(1);
     expect(wrapper.find('ul')).to.have.length(1);
 
-    // Set up.
     wrapper.find('.header-menu-item-button').simulate('click');
 
-    // Assertions.
     expect(updateExpandedMenuID.firstCall.args[0]).to.equal(undefined);
 
-    // Clean up.
     wrapper.unmount();
   });
 
   it('renders a collapsed item with children and expands it on click', () => {
-    // Set up.
     const updateExpandedMenuID = sinon.spy();
     const item = {
       menuSections: [{ title: 'random title', href: 'https://example.com' }],
@@ -76,7 +65,6 @@ describe('Header <MenuItemLevel1>', () => {
       />,
     );
 
-    // Assertions.
     expect(
       wrapper.find('li.vads-u-background-color--primary-darker'),
     ).to.have.length(1);
@@ -87,13 +75,10 @@ describe('Header <MenuItemLevel1>', () => {
     expect(wrapper.find('i.fa.fa-minus')).to.have.length(0);
     expect(wrapper.find('ul')).to.have.length(0);
 
-    // Set up.
     wrapper.find('.header-menu-item-button').simulate('click');
 
-    // Assertions.
     expect(updateExpandedMenuID.firstCall.args[0]).to.equal('example--1');
 
-    // Clean up.
     wrapper.unmount();
   });
 });

--- a/src/platform/site-wide/header/components/MenuItemLevel2/index.js
+++ b/src/platform/site-wide/header/components/MenuItemLevel2/index.js
@@ -1,20 +1,14 @@
-// Node modules.
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-// Relative imports.
-import recordEvent from 'platform/monitoring/record-event';
+import recordEvent from '~/platform/monitoring/record-event';
 import { deriveMenuItemID, formatMenuItems } from '../../helpers';
 import { updateSubMenuAction } from '../../containers/Menu/actions';
 
 export const MenuItemLevel2 = ({ item, lastClickedMenuID, updateSubMenu }) => {
-  // Derive the menu item's ID.
   const menuItemID = deriveMenuItemID(item, '2');
-
-  // Derive if we the menu item is expanded.
   const shouldFocus = menuItemID === lastClickedMenuID;
 
-  // Focus item if last clicked when coming back from SubMenu.
   useEffect(
     () => {
       if (shouldFocus) {
@@ -24,19 +18,16 @@ export const MenuItemLevel2 = ({ item, lastClickedMenuID, updateSubMenu }) => {
     [shouldFocus, menuItemID],
   );
 
-  // Do not render if we are missing necessary menu item data.
   if (!item?.links && !item?.href && !item?.title) {
     return null;
   }
 
   const toggleShowItems = title => () => {
-    // Record event.
     recordEvent({
       event: 'nav-header-second-level',
       'nav-header-action': `Navigation - Header - Open Second Level - ${title}`,
     });
 
-    // Update the sub menu.
     updateSubMenu({
       id: menuItemID,
       menuSections: formatMenuItems(item?.links),
@@ -52,7 +43,6 @@ export const MenuItemLevel2 = ({ item, lastClickedMenuID, updateSubMenu }) => {
             {item?.title}
           </span>
         )}
-
       {/* Title link */}
       {!item?.links &&
         item?.href && (
@@ -63,7 +53,6 @@ export const MenuItemLevel2 = ({ item, lastClickedMenuID, updateSubMenu }) => {
             {item?.title}
           </a>
         )}
-
       {/* Expand title */}
       {item?.links && (
         <button
@@ -165,9 +154,7 @@ MenuItemLevel2.propTypes = {
       }),
     }),
   ]),
-  // From mapStateToProps.
   lastClickedMenuID: PropTypes.string,
-  // From mapDispatchToProps.
   updateSubMenu: PropTypes.func.isRequired,
 };
 

--- a/src/platform/site-wide/header/components/MenuItemLevel2/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/MenuItemLevel2/index.unit.spec.js
@@ -1,18 +1,14 @@
-// Node modules.
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-// Relative imports.
 import { MenuItemLevel2 } from '.';
 
 describe('Header <MenuItemLevel2>', () => {
   it('renders an item with no children', () => {
-    // Set up.
     const item = { href: 'https://example.com', title: 'example' };
     const wrapper = shallow(<MenuItemLevel2 item={item} />);
 
-    // Assertions.
     expect(
       wrapper.find('li.vads-u-background-color--gray-lightest'),
     ).to.have.length(1);
@@ -21,12 +17,10 @@ describe('Header <MenuItemLevel2>', () => {
     expect(wrapper.find('.header-menu-item-button')).to.have.length(0);
     expect(wrapper.find('i.fa.fa-chevron-right')).to.have.length(0);
 
-    // Clean up.
     wrapper.unmount();
   });
 
   it('renders an item and updates the sub menu on click', () => {
-    // Set up.
     const updateSubMenu = sinon.spy();
     const item = {
       links: [{ text: 'random title', href: 'https://example.com' }],
@@ -36,7 +30,6 @@ describe('Header <MenuItemLevel2>', () => {
       <MenuItemLevel2 item={item} updateSubMenu={updateSubMenu} />,
     );
 
-    // Assertions.
     expect(
       wrapper.find('li.vads-u-background-color--gray-lightest'),
     ).to.have.length(1);
@@ -45,16 +38,13 @@ describe('Header <MenuItemLevel2>', () => {
     expect(wrapper.find('.header-menu-item-button').text()).to.equal('example');
     expect(wrapper.find('i.fa.fa-chevron-right')).to.have.length(1);
 
-    // Set up.
     wrapper.find('.header-menu-item-button').simulate('click');
 
-    // Assertions.
     expect(updateSubMenu.firstCall.args[0]).to.deep.equal({
       id: 'example--2',
       menuSections: [{ text: 'random title', href: 'https://example.com' }],
     });
 
-    // Clean up.
     wrapper.unmount();
   });
 });

--- a/src/platform/site-wide/header/components/OfficialGovtWebsite/index.js
+++ b/src/platform/site-wide/header/components/OfficialGovtWebsite/index.js
@@ -1,20 +1,17 @@
-// Node modules.
+/* eslint-disable react/button-has-type */
 import React, { useState } from 'react';
-// Relative imports.
-import recordEvent from 'platform/monitoring/record-event';
+import recordEvent from '~/platform/monitoring/record-event';
 
 export const OfficialGovtWebsite = () => {
   const [expanded, setExpanded] = useState(false);
 
   const onToggle = () => {
-    // Log the event.
     if (expanded) {
       recordEvent({ event: 'int-accordion-collapse' });
     } else {
       recordEvent({ event: 'int-accordion-expand' });
     }
 
-    // Toggle the state.
     setExpanded(!expanded);
   };
 
@@ -40,7 +37,6 @@ export const OfficialGovtWebsite = () => {
           />
         </button>
       </div>
-
       {/* Expanded section */}
       {expanded && (
         <div

--- a/src/platform/site-wide/header/components/OfficialGovtWebsite/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/OfficialGovtWebsite/index.unit.spec.js
@@ -1,16 +1,12 @@
-// Node modules.
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-// Relative imports.
 import { OfficialGovtWebsite } from '.';
 
 describe('Header <OfficialGovtWebsite>', () => {
   it('renders content', () => {
-    // Set up.
     const wrapper = shallow(<OfficialGovtWebsite />);
 
-    // Assertions.
     expect(wrapper.text()).includes(
       'An official website of the United States government.',
     );
@@ -22,15 +18,12 @@ describe('Header <OfficialGovtWebsite>', () => {
     expect(wrapper.text()).not.includes('The .gov means it’s official.');
     expect(wrapper.text()).not.includes('The site is secure.');
 
-    // Set up.
     wrapper.find('.expand-official-govt-explanation').simulate('click');
 
-    // Assertions.
     expect(wrapper.find('#official-govt-site-explanation')).to.have.length(1);
     expect(wrapper.text()).includes('The .gov means it’s official.');
     expect(wrapper.text()).includes('The site is secure.');
 
-    // Clean up.
     wrapper.unmount();
   });
 });

--- a/src/platform/site-wide/header/components/Search/index.js
+++ b/src/platform/site-wide/header/components/Search/index.js
@@ -1,15 +1,12 @@
-// Node modules.
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import * as Sentry from '@sentry/browser';
-
-// Relative imports.
-import { apiRequest } from 'platform/utilities/api';
-import recordEvent from 'platform/monitoring/record-event';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-import SearchDropdownComponent from 'applications/search/components/SearchDropdown/SearchDropdownComponent';
+import { apiRequest } from '~/platform/utilities/api';
+import recordEvent from '~/platform/monitoring/record-event';
+import { toggleValues } from '~/platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from '~/platform/utilities/feature-toggles/featureFlagNames';
+import SearchDropdownComponent from '~/applications/search/components/SearchDropdown/SearchDropdownComponent';
 import { replaceWithStagingDomain } from '../../../../utilities/environment/stagingDomains';
 
 export const Search = ({ searchDropdownComponentEnabled }) => {
@@ -18,10 +15,8 @@ export const Search = ({ searchDropdownComponentEnabled }) => {
   const onFormSubmit = event => {
     event.preventDefault();
 
-    // Derive the search results page.
     const searchResultsPage = `https://www.va.gov/search/?query=${term}&t=false`;
 
-    // Record the analytic event.
     recordEvent({
       event: 'view_search_results',
       'search-page-path': searchResultsPage,
@@ -38,7 +33,6 @@ export const Search = ({ searchDropdownComponentEnabled }) => {
       'type-ahead-options-count': null,
     });
 
-    // Redirect to the search results page.
     window.location.href = searchResultsPage;
   };
 
@@ -99,7 +93,6 @@ export const Search = ({ searchDropdownComponentEnabled }) => {
       'type-ahead-options-count': validSuggestions.length,
     });
 
-    // create a search url
     const searchUrl = replaceWithStagingDomain(
       `https://www.va.gov/search/?query=${encodeURIComponent(
         inputValue,
@@ -135,7 +128,6 @@ export const Search = ({ searchDropdownComponentEnabled }) => {
       'type-ahead-options-count': validSuggestions.length,
     });
 
-    // create a search url
     const searchUrl = replaceWithStagingDomain(
       `https://www.va.gov/search/?query=${encodeURIComponent(
         validSuggestions[index],

--- a/src/platform/site-wide/header/components/Search/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/Search/index.unit.spec.js
@@ -1,22 +1,17 @@
-// Node modules.
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-// Relative imports.
 import { Search } from '.';
 
 describe('Header <Search>', () => {
   it('renders correct content with no props', () => {
-    // Set up.
     const wrapper = shallow(<Search />);
 
-    // Assertions.
     expect(wrapper.find('form')).to.have.length(1);
     expect(wrapper.find('label')).to.have.length(1);
     expect(wrapper.find('input[type="text"]')).to.have.length(1);
     expect(wrapper.find('button[type="submit"]')).to.have.length(1);
 
-    // Clean up.
     wrapper.unmount();
   });
 });

--- a/src/platform/site-wide/header/components/SubMenu/index.js
+++ b/src/platform/site-wide/header/components/SubMenu/index.js
@@ -1,28 +1,21 @@
-// Node modules.
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-// Relative imports.
-import recordEvent from 'platform/monitoring/record-event';
+import recordEvent from '~/platform/monitoring/record-event';
 import { deriveMenuItemID, formatSubMenuSections } from '../../helpers';
 import { updateSubMenuAction } from '../../containers/Menu/actions';
 
 export const SubMenu = ({ subMenu, updateSubMenu }) => {
   useEffect(() => {
-    // Scroll to the top when the sub menu is opened.
     window.scrollTo(0, 0);
-
-    // Focus back to menu button.
     document.getElementById('header-back-to-menu')?.focus?.();
   }, []);
 
   const onBack = () => {
-    // Record analytic event.
     recordEvent({ event: 'nav-header-back-to-menu' });
     updateSubMenu();
   };
 
-  // Format the menu sections.
   const formattedMenuSections = formatSubMenuSections(subMenu?.menuSections);
 
   return (
@@ -42,9 +35,7 @@ export const SubMenu = ({ subMenu, updateSubMenu }) => {
             Back to menu
           </button>
         </li>
-
         {formattedMenuSections?.map(item => {
-          // Derive the menu item ID.
           const menuItemID = deriveMenuItemID(item, '3');
 
           return (
@@ -79,13 +70,11 @@ export const SubMenu = ({ subMenu, updateSubMenu }) => {
 };
 
 SubMenu.propTypes = {
-  // From mapStateToProps.
+  updateSubMenu: PropTypes.func.isRequired,
   subMenu: PropTypes.shape({
     id: PropTypes.string.isRequired,
     menuSections: PropTypes.arrayOf(PropTypes.object),
   }),
-  // From mapDispatchToProps.
-  updateSubMenu: PropTypes.func.isRequired,
 };
 
 const mapStateToProps = state => ({

--- a/src/platform/site-wide/header/components/SubMenu/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/SubMenu/index.unit.spec.js
@@ -1,9 +1,7 @@
-// Node modules.
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-// Relative imports.
 import { SubMenu } from '.';
 
 const menuSections = [
@@ -24,7 +22,6 @@ const menuSections = [
 
 describe('Header <SubMenu>', () => {
   it('renders correctly with a sub menu and fires off updateSubMenu when toggled', () => {
-    // Set up.
     const subMenu = {
       id: 'sub-menu-id',
       menuSections,
@@ -34,7 +31,6 @@ describe('Header <SubMenu>', () => {
       <SubMenu subMenu={subMenu} updateSubMenu={updateSubMenu} />,
     );
 
-    // Assertions.
     expect(wrapper.find('.header-menu-item-button')).to.have.length(1);
     expect(wrapper.find('.header-menu-item-button').text()).includes(
       'Back to menu',
@@ -46,13 +42,10 @@ describe('Header <SubMenu>', () => {
       wrapper.find('li.vads-u-background-color--primary-darker'),
     ).to.have.length(7);
 
-    // Set up.
     wrapper.find('.header-menu-item-button').simulate('click');
 
-    // Assertions.
     expect(updateSubMenu.calledOnce).to.be.true;
 
-    // Clean up.
     wrapper.unmount();
   });
 });

--- a/src/platform/site-wide/header/components/VeteranCrisisLine/index.js
+++ b/src/platform/site-wide/header/components/VeteranCrisisLine/index.js
@@ -1,7 +1,6 @@
-// Node modules.
+/* eslint-disable react/button-has-type */
 import React from 'react';
-// Relative imports.
-import recordEvent from 'platform/monitoring/record-event';
+import recordEvent from '~/platform/monitoring/record-event';
 
 export const VeteranCrisisLine = props => (
   <div className="vads-u-background-color--secondary-darkest vads-u-display--flex vads-u-flex-direction--row vads-u-align-items--center vads-u-justify-content--center vads-u-text-align--center vads-u-padding--0p5">

--- a/src/platform/site-wide/header/components/VeteranCrisisLine/index.unit.spec.js
+++ b/src/platform/site-wide/header/components/VeteranCrisisLine/index.unit.spec.js
@@ -1,20 +1,15 @@
-// Node modules.
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-// Relative imports.
 import { VeteranCrisisLine } from '.';
 
 describe('Header <VeteranCrisisLine>', () => {
   it('renders content', () => {
-    // Set up.
     const wrapper = shallow(<VeteranCrisisLine />);
 
-    // Assertions.
     expect(wrapper.find('.va-button-link')).to.have.length(1);
     expect(wrapper.text()).includes('Talk to the Veterans Crisis Line now');
 
-    // Clean up.
     wrapper.unmount();
   });
 });

--- a/src/platform/site-wide/header/containers/Menu/actions.js
+++ b/src/platform/site-wide/header/containers/Menu/actions.js
@@ -1,4 +1,3 @@
-// Relative imports.
 import { UPDATE_EXPANDED_MENU_ID, UPDATE_SUB_MENU } from './constants';
 
 export const updateExpandedMenuIDAction = expandedMenuID => ({

--- a/src/platform/site-wide/header/containers/Menu/actions.unit.spec.js
+++ b/src/platform/site-wide/header/containers/Menu/actions.unit.spec.js
@@ -1,16 +1,12 @@
-// Node modules.
 import { expect } from 'chai';
-// Relative imports.
 import { updateExpandedMenuIDAction, updateSubMenuAction } from './actions';
 import { UPDATE_EXPANDED_MENU_ID, UPDATE_SUB_MENU } from './constants';
 
 describe('Menu actions', () => {
   it('updateExpandedMenuIDAction', () => {
-    // Set up.
     const expandedMenuID = '123';
     const action = updateExpandedMenuIDAction(expandedMenuID);
 
-    // Assertions.
     expect(action).to.deep.equal({
       expandedMenuID,
       type: UPDATE_EXPANDED_MENU_ID,
@@ -18,11 +14,9 @@ describe('Menu actions', () => {
   });
 
   it('updateExpandedMenuIDAction', () => {
-    // Set up.
     const subMenu = { id: '123' };
     const action = updateSubMenuAction(subMenu);
 
-    // Assertions.
     expect(action).to.deep.equal({
       subMenu,
       type: UPDATE_SUB_MENU,

--- a/src/platform/site-wide/header/containers/Menu/index.js
+++ b/src/platform/site-wide/header/containers/Menu/index.js
@@ -1,20 +1,16 @@
-// Node modules.
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-// Relative imports.
 import MenuItemLevel1 from '../../components/MenuItemLevel1';
 import Search from '../../components/Search';
 import SubMenu from '../../components/SubMenu';
 import { deriveMenuItemID } from '../../helpers';
 
 export const Menu = ({ isMenuOpen, megaMenuData, showMegaMenu, subMenu }) => {
-  // Do not render if the menu is closed.
   if (!isMenuOpen) {
     return null;
   }
 
-  // Render the sub menu if it is in state.
   if (subMenu) {
     return <SubMenu />;
   }
@@ -26,10 +22,7 @@ export const Menu = ({ isMenuOpen, megaMenuData, showMegaMenu, subMenu }) => {
 
   return (
     <div className="vads-u-background-color--gray-lightest vads-u-display--flex vads-u-flex-direction--column vads-u-margin--0 vads-u-padding--0 vads-u-width--full">
-      {/* Search */}
       <Search />
-
-      {/* Menu items */}
       {showMegaMenu && (
         <ul
           id="header-nav-items"
@@ -50,7 +43,6 @@ Menu.propTypes = {
   isMenuOpen: PropTypes.bool.isRequired,
   showMegaMenu: PropTypes.bool.isRequired,
   megaMenuData: PropTypes.arrayOf(PropTypes.object),
-  // From mapStateToProps.
   subMenu: PropTypes.shape({
     id: PropTypes.string.isRequired,
     menuSections: PropTypes.arrayOf(PropTypes.object),

--- a/src/platform/site-wide/header/containers/Menu/index.unit.spec.js
+++ b/src/platform/site-wide/header/containers/Menu/index.unit.spec.js
@@ -1,38 +1,28 @@
-// Node modules.
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-// Relative imports.
 import { Menu } from '.';
 
 describe('Header <Menu>', () => {
   it('does not render when isMenuOpen is falsey', () => {
-    // Set up.
     const wrapper = shallow(<Menu />);
 
-    // Assertions.
     expect(wrapper.isEmptyRender()).to.equal(true);
 
-    // Clean up.
     wrapper.unmount();
   });
 
   it('renders SubMenu when subMenu is truthy', () => {
-    // Set up.
     const wrapper = shallow(<Menu isMenuOpen subMenu />);
 
-    // Assertions.
     expect(wrapper.find('Connect(SubMenu)')).to.have.length(1);
 
-    // Clean up.
     wrapper.unmount();
   });
 
   it('renders nav without megamenu data when isMenuOpen is truthy', () => {
-    // Set up.
     const wrapper = shallow(<Menu isMenuOpen />);
 
-    // Assertions.
     expect(wrapper.find('Connect(SubMenu)')).to.have.length(0);
     expect(
       wrapper.find('div.vads-u-background-color--gray-lightest'),
@@ -40,16 +30,12 @@ describe('Header <Menu>', () => {
     expect(wrapper.find('Search')).to.exist;
     expect(wrapper.find('ul')).to.have.length(0);
 
-    // Clean up.
     wrapper.unmount();
   });
 
   it('renders nav with megamenu data when subMenu and showMegaMenu is truthy', () => {
-    // Set up.
     const wrapper = shallow(<Menu isMenuOpen showMegaMenu />);
 
-    // Assertions.
-    expect(wrapper.find('Connect(SubMenu)')).to.have.length(0);
     expect(
       wrapper.find('div.vads-u-background-color--gray-lightest'),
     ).to.have.length(1);
@@ -57,12 +43,10 @@ describe('Header <Menu>', () => {
     expect(wrapper.find('ul')).to.have.length(1);
     expect(wrapper.find('Connect(MenuItemLevel1)')).to.have.length(1);
 
-    // Clean up.
     wrapper.unmount();
   });
 
   it('renders nav with megamenu data when subMenu and showMegaMenu is truthy and megaMenuData is populated', () => {
-    // Set up.
     const megaMenuData = [
       {
         href: 'https://staging.va.gov/find-locations',
@@ -73,7 +57,6 @@ describe('Header <Menu>', () => {
       <Menu isMenuOpen showMegaMenu megaMenuData={megaMenuData} />,
     );
 
-    // Assertions.
     expect(wrapper.find('Connect(SubMenu)')).to.have.length(0);
     expect(
       wrapper.find('div.vads-u-background-color--gray-lightest'),
@@ -82,7 +65,6 @@ describe('Header <Menu>', () => {
     expect(wrapper.find('ul')).to.have.length(1);
     expect(wrapper.find('Connect(MenuItemLevel1)')).to.have.length(2);
 
-    // Clean up.
     wrapper.unmount();
   });
 });

--- a/src/platform/site-wide/header/containers/Menu/reducer.js
+++ b/src/platform/site-wide/header/containers/Menu/reducer.js
@@ -1,4 +1,3 @@
-// Relative imports.
 import { UPDATE_EXPANDED_MENU_ID, UPDATE_SUB_MENU } from './constants';
 
 export const initialState = {

--- a/src/platform/site-wide/header/containers/Menu/reducer.unit.spec.js
+++ b/src/platform/site-wide/header/containers/Menu/reducer.unit.spec.js
@@ -1,12 +1,9 @@
-// Node modules.
 import { expect } from 'chai';
-// Relative imports.
 import headerMenuReducer, { initialState } from './reducer';
 import { UPDATE_EXPANDED_MENU_ID, UPDATE_SUB_MENU } from './constants';
 
 describe('Menu reducer', () => {
   it('initialState is what we expect', () => {
-    // Assertions.
     expect(initialState).to.deep.equal({
       expandedMenuID: undefined,
       lastClickedMenuID: undefined,
@@ -15,15 +12,12 @@ describe('Menu reducer', () => {
   });
 
   it('headerMenuReducer default case', () => {
-    // Assertions.
     expect(headerMenuReducer()).to.deep.equal(initialState);
   });
 
   it('headerMenuReducer handles UPDATE_EXPANDED_MENU_ID case', () => {
-    // Set up.
     const action = { expandedMenuID: 'test', type: UPDATE_EXPANDED_MENU_ID };
 
-    // Assertions.
     expect(headerMenuReducer(initialState, action)).to.deep.equal({
       expandedMenuID: 'test',
       lastClickedMenuID: undefined,
@@ -32,10 +26,8 @@ describe('Menu reducer', () => {
   });
 
   it('headerMenuReducer handles UPDATE_SUB_MENU case', () => {
-    // Set up.
     const action = { subMenu: { id: 'test' }, type: UPDATE_SUB_MENU };
 
-    // Assertions.
     expect(headerMenuReducer(initialState, action)).to.deep.equal({
       expandedMenuID: undefined,
       lastClickedMenuID: 'test',

--- a/src/platform/site-wide/header/helpers/index.js
+++ b/src/platform/site-wide/header/helpers/index.js
@@ -1,36 +1,28 @@
-// Node modules.
 import * as Sentry from '@sentry/browser';
 import { isArray } from 'lodash';
-// Relative imports.
-import recordEvent from 'platform/monitoring/record-event';
-import { apiRequest } from 'platform/utilities/api';
-import { replaceWithStagingDomain } from 'platform/utilities/environment/stagingDomains';
+import recordEvent from '~/platform/monitoring/record-event';
+import { apiRequest } from '~/platform/utilities/api';
+import { replaceWithStagingDomain } from '~/platform/utilities/environment/stagingDomains';
 
 export const hideLegacyHeader = () => {
-  // Derive the legacy header.
   const legacyHeader = document.getElementById('legacy-header');
 
-  // Escape early if the legacy header doesn't exist.
   if (!legacyHeader) {
     return;
   }
 
-  // Add `vads-u-display--none` to the legacy header if it doesn't already have it.
   if (!legacyHeader.classList.contains('vads-u-display--none')) {
     legacyHeader.classList.add('vads-u-display--none');
   }
 };
 
 export const showLegacyHeader = () => {
-  // Derive the legacy header.
   const legacyHeader = document.getElementById('legacy-header');
 
-  // Escape early if the legacy header doesn't exist.
   if (!legacyHeader) {
     return;
   }
 
-  // Add `vads-u-display--none` to the legacy header if it doesn't already have it.
   if (legacyHeader.classList.contains('vads-u-display--none')) {
     legacyHeader.classList.remove('vads-u-display--none');
   }
@@ -90,7 +82,6 @@ export const onSearch = componentState => {
     'type-ahead-options-count': validSuggestions?.length,
   });
 
-  // create a search url
   const searchUrl = replaceWithStagingDomain(
     `https://www.va.gov/search/?query=${encodeURIComponent(
       searchTerm,
@@ -126,7 +117,6 @@ export const onSuggestionSubmit = (index, componentState) => {
     'type-ahead-options-count': validSuggestions?.length,
   });
 
-  // create a search url
   const searchUrl = replaceWithStagingDomain(
     `https://www.va.gov/search/?query=${encodeURIComponent(
       validSuggestions?.[index],
@@ -140,12 +130,10 @@ export const onSuggestionSubmit = (index, componentState) => {
 export const formatMenuItems = menuItems => {
   const formattedMenuItems = [];
 
-  // Escape early if menu sections is already an array.
   if (menuItems && isArray(menuItems)) {
     return menuItems;
   }
 
-  // Add seeAllLink first.
   if (menuItems?.seeAllLink) {
     formattedMenuItems.push({
       title: menuItems?.seeAllLink?.text,
@@ -153,7 +141,6 @@ export const formatMenuItems = menuItems => {
     });
   }
 
-  // Add columns as items.
   if (menuItems?.mainColumn) {
     formattedMenuItems.push({
       title: menuItems?.mainColumn?.title,

--- a/src/platform/site-wide/header/index.js
+++ b/src/platform/site-wide/header/index.js
@@ -1,8 +1,6 @@
-// Node modules.
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-// Relative imports.
 import './components/LogoRow/styles.scss';
 import './components/OfficialGovtWebsite/styles.scss';
 import './components/Search/styles.scss';
@@ -10,11 +8,9 @@ import './containers/Menu/styles.scss';
 import App from './components/App';
 
 export default (store, megaMenuData) => {
-  // Derive the widget and its data properties for props.
   const root = document.querySelector(`[data-widget-type="header"]`);
   const props = root?.dataset;
 
-  // Render the widget.
   if (root) {
     ReactDOM.render(
       <Provider store={store}>

--- a/src/platform/site-wide/header/tests/components/App.unit.spec.js
+++ b/src/platform/site-wide/header/tests/components/App.unit.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { App } from '.';
+import { App } from '../../components/App';
 
 describe('Header <App>', () => {
   it('renders legacy header when our width is more than 768px', () => {

--- a/src/platform/site-wide/mega-menu/actions/index.js
+++ b/src/platform/site-wide/mega-menu/actions/index.js
@@ -5,12 +5,12 @@ export const TOGGLE_DISPLAY_HIDDEN = 'TOGGLE_DISPLAY_HIDDEN';
 const tabletMediaQuery = window.matchMedia('(min-width: 768px)');
 
 export const togglePanel = megaMenu => ({
-  type: 'TOGGLE_PANEL_OPEN',
+  type: TOGGLE_PANEL_OPEN,
   megaMenu,
 });
 
 export const toggleDisplayHidden = display => ({
-  type: 'TOGGLE_DISPLAY_HIDDEN',
+  type: TOGGLE_DISPLAY_HIDDEN,
   display,
 });
 

--- a/src/platform/site-wide/mega-menu/containers/Main.jsx
+++ b/src/platform/site-wide/mega-menu/containers/Main.jsx
@@ -1,10 +1,7 @@
-// Node modules.
 import React, { Component } from 'react';
 import { createPortal } from 'react-dom';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-
-// Relative imports.
 import { isLandingPageEnabled } from 'applications/mhv/landing-page/selectors';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import { toggleValues } from '@department-of-veterans-affairs/platform-site-wide/selectors';
@@ -60,7 +57,6 @@ export class Main extends Component {
     toggleMobileDisplayHidden: PropTypes.func.isRequired,
     togglePanelOpen: PropTypes.func.isRequired,
     updateCurrentSection: PropTypes.func.isRequired,
-    // From mapStateToProps.
     currentDropdown: PropTypes.string,
     currentSection: PropTypes.string,
     data: PropTypes.arrayOf(

--- a/src/platform/site-wide/mega-menu/tests/cypress/megaMenu.cypress.spec.js
+++ b/src/platform/site-wide/mega-menu/tests/cypress/megaMenu.cypress.spec.js
@@ -5,7 +5,6 @@
  * @testrailinfo groupId 2975
  * @testrailinfo runName SH-e2e-MegaMenu
  */
-// Relative imports.
 import { mockUser } from 'applications/personalization/profile/tests/fixtures/users/user.js';
 import featureFlagNames from '~/platform/utilities/feature-toggles/featureFlagNames';
 


### PR DESCRIPTION
## Summary
Cleaning up unnecessary comments in the header/footer code. Also refactored `/platform` imports to `~/platform` to satisfy the local linter (this is the same and has been used many times across the repository).

No functionality changes expected. This is cleanup I'm doing as part of the header/footer unit/Cypress test audit and expansion.

## Related issue(s)
- [FE: Add Cypress tests for mobile header and footer; audit existing unit tests for both](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15699)