### PR TITLE
Bugfix 10-10EZR data setting for list-loop items

### DIFF
--- a/src/applications/ezr/components/FormPages/DependentInformation.jsx
+++ b/src/applications/ezr/components/FormPages/DependentInformation.jsx
@@ -138,7 +138,7 @@ const DependentInformation = props => {
           beforeIndex: dependents.slice(0, searchIndex),
           afterIndex: dependents.slice(searchIndex + 1),
         },
-        viewsFields: DEPENDENT_VIEW_FIELDS,
+        viewFields: DEPENDENT_VIEW_FIELDS,
         dataKey: 'dependents',
         localData,
         listRef,

--- a/src/applications/ezr/components/FormPages/InsurancePolicyInformation.jsx
+++ b/src/applications/ezr/components/FormPages/InsurancePolicyInformation.jsx
@@ -111,7 +111,7 @@ const InsurancePolicyInformation = props => {
           beforeIndex: providers.slice(0, searchIndex),
           afterIndex: providers.slice(searchIndex + 1),
         },
-        viewsFields: INSURANCE_VIEW_FIELDS,
+        viewFields: INSURANCE_VIEW_FIELDS,
         dataKey: 'providers',
         localData,
         listRef,


### PR DESCRIPTION
## Summary
This PR corrects a small typo that is causing data to not be set for the list-loop response patterns.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#68620

## Acceptance criteria
- Data keys match the intended keys in the called function

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution