### PR TITLE
Remove "Please" from all copy in 28-1880

### DIFF
--- a/src/applications/lgy/coe/form/components/MissingEDIPI.jsx
+++ b/src/applications/lgy/coe/form/components/MissingEDIPI.jsx
@@ -21,8 +21,8 @@ const MissingEDIPI = () => {
       </h2>
       <p className="vads-u-font-size--base">
         We don’t have all of your ID information for your account. We need this
-        information before you can request a COE. To update your account, please
-        call Veterans Benefits Assistance at{' '}
+        information before you can request a COE. To update your account, call
+        Veterans Benefits Assistance at{' '}
         <va-telephone contact={CONTACTS.VA_BENEFITS} /> (
         <va-telephone contact={CONTACTS['711']} tty />
         ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.

--- a/src/applications/lgy/coe/form/components/statuses/Ineligible.jsx
+++ b/src/applications/lgy/coe/form/components/statuses/Ineligible.jsx
@@ -5,10 +5,9 @@ const Ineligible = () => (
     <h2 className="vads-u-margin--0">You didn’t automatically receive a COE</h2>
     <p>
       Since you didn’t automatically receive your Certificate of Eligibility,{' '}
-      <strong>please work with your lender</strong> to request your Certificate
-      of Eligibility. If you’d like to submit an online request for your COE
-      without your lender’s assistance, please continue to start the request
-      process.
+      <strong>work with your lender</strong> to request your Certificate of
+      Eligibility. If you’d like to submit an online request for your COE
+      without your lender’s assistance, continue to start the request process.
     </p>
   </>
 );

--- a/src/applications/lgy/coe/form/components/statuses/Pending.jsx
+++ b/src/applications/lgy/coe/form/components/statuses/Pending.jsx
@@ -19,8 +19,8 @@ const Pending = ({ referenceNumber, requestDate, status }) => (
       </p>
       <p>
         If more than 5 business days have passed since you submitted your
-        request and you haven’t heard back, please don’t request a COE again.
-        Call our toll-free number at <va-telephone contact="8778273702" />.
+        request and you haven’t heard back, don’t request a COE again. Call our
+        toll-free number at <va-telephone contact="8778273702" />.
       </p>
       <p>
         The only time you’d need to make a new request is if our VA home loan

--- a/src/applications/lgy/coe/form/config/chapters/applicant/applicantInformation.js
+++ b/src/applications/lgy/coe/form/config/chapters/applicant/applicantInformation.js
@@ -9,7 +9,7 @@ const description = () => (
   <>
     <p>
       This is the personal information we have on file for you. If you notice
-      any errors, please correct them now. Any updates you make will change the
+      any errors, correct them now. Any updates you make will change the
       information on this request only.
     </p>
     <p>

--- a/src/applications/lgy/coe/form/config/chapters/contact-information/mailing-address.js
+++ b/src/applications/lgy/coe/form/config/chapters/contact-information/mailing-address.js
@@ -9,10 +9,9 @@ const description = () => (
   <>
     <p>We’ll send any updates about your request to this address.</p>
     <p>
-      If you notice any errors, please correct them now. Any updates you make
-      will change the information on this request only. If you need to update
-      your address with VA, please go to your profile to make any changes.{' '}
-      <br />
+      If you notice any errors, correct them now. Any updates you make will
+      change the information on this request only. If you need to update your
+      address with VA, go to your profile to make any changes. <br />
       <a href="/profile/contact-information#addresses">
         Update your address in your profile
       </a>

--- a/src/applications/lgy/coe/form/config/chapters/documents/UploadRequirements.jsx
+++ b/src/applications/lgy/coe/form/config/chapters/documents/UploadRequirements.jsx
@@ -32,7 +32,7 @@ const UploadRequirements = ({ formData }) => {
         Upload your documents
       </h3>
       {identity && (
-        <p className="vads-u-font-weight--bold">Please upload the following</p>
+        <p className="vads-u-font-weight--bold">Upload the following</p>
       )}
       <ul>
         {identity &&

--- a/src/applications/lgy/coe/form/config/chapters/service/history.js
+++ b/src/applications/lgy/coe/form/config/chapters/service/history.js
@@ -9,7 +9,7 @@ export const uiSchema = {
   periodsOfService: {
     'ui:title': 'Military service history',
     'ui:description':
-      'Please add or update your military service history details below.',
+      'Add or update your military service history details below.',
     'ui:options': {
       itemName: 'Service Period',
       viewField: ServicePeriodView,

--- a/src/applications/lgy/coe/form/config/form.js
+++ b/src/applications/lgy/coe/form/config/form.js
@@ -50,15 +50,15 @@ const formConfig = {
   preSubmitInfo,
   getHelp: GetFormHelp,
   savedFormMessages: {
-    notFound: 'Please start over to request benefits.',
-    noAuth: 'Please sign in again to continue your request for benefits.',
+    notFound: 'Start over to request benefits.',
+    noAuth: 'Sign in again to continue your request for benefits.',
   },
   saveInProgress: {
     messages: {
       inProgress:
         'Your Certificate of Eligibility form (26-1880) is in progress.',
       expired:
-        'Your saved Certificate of Eligibility form (26-1880) has expired. If you want to request Chapter 31 benefits, please start a new request.',
+        'Your saved Certificate of Eligibility form (26-1880) has expired. If you want to request Chapter 31 benefits, start a new request.',
       saved: 'Your Certificate of Eligibility request has been saved.',
     },
   },

--- a/src/applications/lgy/coe/form/containers/ConfirmationPage.jsx
+++ b/src/applications/lgy/coe/form/containers/ConfirmationPage.jsx
@@ -83,8 +83,8 @@ const ConfirmationPage = ({ form }) => {
         </h3>
         <p>
           If more than 5 business days have passed since you submitted your
-          request and you haven’t heard back, please don’t request a COE again.
-          Call our toll-free number at <va-telephone contact="8778273702" />.
+          request and you haven’t heard back, don’t request a COE again. Call
+          our toll-free number at <va-telephone contact="8778273702" />.
         </p>
         <a href={statusUrl}>
           Check the status of your VA home loan Certificate of Eligibility

--- a/src/applications/lgy/coe/form/content/loanHistory.js
+++ b/src/applications/lgy/coe/form/content/loanHistory.js
@@ -17,7 +17,7 @@ export default {
   address1: {
     title: 'Street address',
     value: data => get('propertyAddress.propertyAddress1', data, ''),
-    error: 'Please enter a street address',
+    error: 'Enter a street address',
   },
   address2: {
     title: 'Street address line 2',
@@ -26,26 +26,26 @@ export default {
   city: {
     title: 'City',
     value: data => get('propertyAddress.propertyCity', data, ''),
-    error: 'Please enter a city',
+    error: 'Enter a city',
   },
   state: {
     title: 'State',
     value: data => get('propertyAddress.propertyState', data, ''),
-    error: 'Please enter a state',
+    error: 'Enter a state',
   },
   postal: {
     title: 'Postal code',
     value: data => get('propertyAddress.propertyZip', data, ''),
-    error: 'Please enter a postal code',
-    pattern: 'Please enter a valid 5- or 9-digit postal code (dashes allowed)',
+    error: 'Enter a postal code',
+    pattern: 'Enter a valid 5- or 9-digit postal code (dashes allowed)',
   },
   loanNumber: {
     title: 'VA loan number',
     description: 'This number has 12 digits.',
     value: data => get('vaLoanNumber', data, ''),
-    pattern: 'Please enter numbers only (dashes allowed)',
+    pattern: 'Enter numbers only (dashes allowed)',
     lengthError: 'Make sure you include 12 digits.',
-    unique: 'Please enter a unique loan number',
+    unique: 'Enter a unique loan number',
   },
   owned: {
     title: 'Do you still own this property?',

--- a/src/applications/lgy/coe/form/tests/validations.unit.spec.js
+++ b/src/applications/lgy/coe/form/tests/validations.unit.spec.js
@@ -29,7 +29,7 @@ describe('validateDocumentDescription', () => {
     const spy = sinon.spy();
     validateDocumentDescription(errors(spy), fileList('Other', ''));
     expect(spy.called).to.be.true;
-    expect(spy.calledWith('Please provide a description'));
+    expect(spy.calledWith('Provide a description'));
   });
 });
 

--- a/src/applications/lgy/coe/form/validations.js
+++ b/src/applications/lgy/coe/form/validations.js
@@ -6,7 +6,7 @@ export const validateDocumentDescription = (errors, fileList) => {
   fileList.forEach((file, index) => {
     const error =
       file.attachmentType === 'Other' && !file.attachmentDescription
-        ? 'Please provide a description'
+        ? 'Provide a description'
         : null;
     if (error && !errors[index]) {
       /* eslint-disable no-param-reassign */

--- a/src/applications/lgy/coe/shared/components/WIP.jsx
+++ b/src/applications/lgy/coe/shared/components/WIP.jsx
@@ -9,7 +9,7 @@ export const WIP = () => (
         </h1>
         <p>
           We’re rolling out the VA home loan Certificate of Eligibility form in
-          stages. It’s not quite ready yet. Please check back again soon.
+          stages. It’s not quite ready yet. Check back again soon.
         </p>
         <p>
           <a href="/housing-assistance/home-loans/">

--- a/src/applications/lgy/coe/status/components/DocumentList/DocumentList.jsx
+++ b/src/applications/lgy/coe/status/components/DocumentList/DocumentList.jsx
@@ -27,9 +27,9 @@ const DocumentList = ({ notOnUploadPage }) => {
           You have letters about your COE request
         </h2>
         <p className="vads-u-border-color--gray-lighter vads-u-border-bottom--1px vads-u-margin--0 vads-u-padding-y--3">
-          We’ve emailed you notification letters about your COE request. Please
-          read these and follow the steps they outline. You may need to take
-          action before we can make a final decision.
+          We’ve emailed you notification letters about your COE request. Read
+          these and follow the steps they outline. You may need to take action
+          before we can make a final decision.
         </p>
         <List documents={documents} />
       </>

--- a/src/applications/lgy/coe/status/components/DocumentUploader/DocumentUploader.jsx
+++ b/src/applications/lgy/coe/status/components/DocumentUploader/DocumentUploader.jsx
@@ -38,7 +38,7 @@ const DocumentUploader = () => {
     if (state.documentType === '') {
       setState({
         ...state,
-        errorMessage: 'Please choose a document type above.',
+        errorMessage: 'Choose a document type above.',
       });
       return;
     }
@@ -59,8 +59,8 @@ const DocumentUploader = () => {
       <h2>We need documents from you</h2>
       <p>
         We’ve emailed you a notification letter about documentation for your COE
-        request. Please send us all the documents listed so we can make a
-        decision about your request.
+        request. Send us all the documents listed so we can make a decision
+        about your request.
       </p>
       {state.successMessage ? (
         <va-alert

--- a/src/applications/lgy/coe/status/components/DocumentUploader/addFile.js
+++ b/src/applications/lgy/coe/status/components/DocumentUploader/addFile.js
@@ -6,7 +6,7 @@ export const addFile = (file, state, setState) => {
     setState({
       ...state,
       files: [],
-      errorMessage: 'Please choose a file from one of the accepted file types.',
+      errorMessage: 'Choose a file from one of the accepted file types.',
       submissionPending: false,
     });
     return;

--- a/src/applications/lgy/coe/status/components/DocumentUploader/submit.js
+++ b/src/applications/lgy/coe/status/components/DocumentUploader/submit.js
@@ -6,7 +6,7 @@ export const submitToAPI = (state, setState) => {
   if (state.files.length === 0) {
     setState({
       ...state,
-      errorMessage: 'Please choose a file to upload.',
+      errorMessage: 'Choose a file to upload.',
     });
     return;
   }
@@ -51,7 +51,7 @@ export const submitToAPI = (state, setState) => {
       setState({
         ...state,
         errorMessage:
-          'We’re sorry, we had a connection problem. Please try again later.',
+          'We’re sorry, we had a connection problem. Try again later.',
         submissionPending: false,
       });
     });

--- a/src/applications/lgy/coe/status/components/MoreQuestions.jsx
+++ b/src/applications/lgy/coe/status/components/MoreQuestions.jsx
@@ -4,9 +4,9 @@ export const MoreQuestions = () => (
   <>
     <h2>What if I have more questions?</h2>
     <p>
-      If you have any questions that your lender can’t answer, please call your
-      VA regional loan center at <va-telephone contact="8778273702" />. We’re
-      here Monday through Friday, 8:00 a.m. to 6:00 p.m. ET.
+      If you have any questions that your lender can’t answer, call your VA
+      regional loan center at <va-telephone contact="8778273702" />. We’re here
+      Monday through Friday, 8:00 a.m. to 6:00 p.m. ET.
       <br />
       <a
         target="_blank"

--- a/src/applications/lgy/coe/status/components/statuses/Ineligible.jsx
+++ b/src/applications/lgy/coe/status/components/statuses/Ineligible.jsx
@@ -42,8 +42,8 @@ const Ineligible = () => (
       <p>
         To request a COE by mail, fill out a Request for a Certificate of
         Eligibility (VA Form 26-1880) and mail it to the address listed on the
-        form. Please keep in mind that this may take longer than requesting a
-        COE online or through our WebLGY system.
+        form. Keep in mind that this may take longer than requesting a COE
+        online or through our WebLGY system.
       </p>
       <va-link
         download

--- a/src/applications/lgy/coe/status/components/statuses/Pending.jsx
+++ b/src/applications/lgy/coe/status/components/statuses/Pending.jsx
@@ -31,8 +31,8 @@ const Pending = ({
         </p>
         <p>
           If more than 5 business days have passed since you submitted your
-          request and you haven’t heard back, please don’t request a COE again.
-          Call our toll-free number at <va-telephone contact="8778273702" />.
+          request and you haven’t heard back, don’t request a COE again. Call
+          our toll-free number at <va-telephone contact="8778273702" />.
         </p>
         <MoreQuestions />
       </div>

--- a/src/applications/lgy/coe/status/tests/components/DocumentUploader/DocumentUploader.unit.spec.jsx
+++ b/src/applications/lgy/coe/status/tests/components/DocumentUploader/DocumentUploader.unit.spec.jsx
@@ -20,7 +20,7 @@ describe('DocumentUploader', () => {
 
     const fileInput = document.querySelector('va-file-input');
     expect(fileInput.getAttribute('error')).to.equal(
-      'Please choose a file to upload.',
+      'Choose a file to upload.',
     );
   });
 

--- a/src/applications/lgy/coe/status/tests/components/DocumentUploader/submit.unit.spec.js
+++ b/src/applications/lgy/coe/status/tests/components/DocumentUploader/submit.unit.spec.js
@@ -78,7 +78,7 @@ describe('submitToAPI', () => {
     setTimeout(() => {
       const response2 = setState.secondCall.args[0];
       expect(response2.files.length).to.eq(1);
-      expect(response2.errorMessage).to.contain('try again later');
+      expect(response2.errorMessage).to.contain('Try again later');
       expect(response2.successMessage).to.be.undefined;
       expect(response2.submissionPending).to.be.false;
       done();
@@ -90,6 +90,6 @@ describe('submitToAPI', () => {
     submitToAPI({ files: [] }, setState);
 
     expect(setState.called).to.be.true;
-    expect(setState.args[0][0].errorMessage).to.contain('choose a file');
+    expect(setState.args[0][0].errorMessage).to.contain('Choose a file');
   });
 });


### PR DESCRIPTION
## Summary

- Removing the word "please" from all copy in this form. The word may still appear in error messages that come from platform's shared error messages.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/65341

## What areas of the site does it impact?

- Just this one form

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
