### PR TITLE
[#mhv-50828] fixed issue on details page

### DIFF
--- a/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
@@ -192,7 +192,11 @@ const PrescriptionDetails = () => {
         {prescription.dispensedDate ? (
           <span>
             Last filled on{' '}
-            {dateFormat(prescription.dispensedDate, 'MMMM D, YYYY')}
+            {dateFormat(
+              prescription.rxRfRecords?.[0]?.[1][0]?.dispensedDate ||
+                prescription.dispensedDate,
+              'MMMM D, YYYY',
+            )}
           </span>
         ) : (
           <span>Not filled yet</span>


### PR DESCRIPTION
## Summary
List page was showing "Last filled..." but showing the date of the first fill.
Now, it should look to the most recent refill in the rx history instead of the dispensed date.

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-50828

> Last filled on is currently showing the First fill date instead of the latest fill.
> 
>     Ex. Medication has two refills. First one was filled on Sep 29th second one was filled on October 3rd, last filled on field shows Sep 29th. Should show October 3rd. 
> 

## Testing done
All unit tests passing locally. Date is appearing as expected in local environment.

## Screenshots
![Screen Shot 2023-11-02 at 5 12 46 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/108146636/c56216df-1fa0-495b-bc35-86cf0028d048)

## What areas of the site does it impact?
mhv/medications

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
