### PR TITLE
Fix pluralization of survivor in test data for 21-0966

### DIFF
--- a/src/applications/simple-forms/21-0966/tests/e2e/fixtures/data/surviving-maximal-test.json
+++ b/src/applications/simple-forms/21-0966/tests/e2e/fixtures/data/surviving-maximal-test.json
@@ -1,7 +1,7 @@
 {
   "preparerIdentification": "SURVIVING_DEPENDENT",
   "benefitSelection": {
-    "survivors": true
+    "survivor": true
   },
   "survivingDependentFullName": {
     "first": "Surviving",

--- a/src/applications/simple-forms/21-0966/tests/e2e/fixtures/data/surviving-minimal-test.json
+++ b/src/applications/simple-forms/21-0966/tests/e2e/fixtures/data/surviving-minimal-test.json
@@ -1,7 +1,7 @@
 {
   "preparerIdentification": "SURVIVING_DEPENDENT",
   "benefitSelection": {
-    "survivors": true
+    "survivor": true
   },
   "survivingDependentFullName": {
     "first": "Surviving",

--- a/src/applications/simple-forms/21-0966/tests/e2e/fixtures/data/third-party-surviving-maximal-test.json
+++ b/src/applications/simple-forms/21-0966/tests/e2e/fixtures/data/third-party-surviving-maximal-test.json
@@ -8,7 +8,7 @@
   "thirdPartyPreparerRole": "other",
   "otherThirdPartyPreparerRole": "Secret agent",
   "benefitSelection": {
-    "survivors": true
+    "survivor": true
   },
   "survivingDependentFullName": {
     "first": "Surviving",

--- a/src/applications/simple-forms/21-0966/tests/e2e/fixtures/data/third-party-surviving-minimal-test.json
+++ b/src/applications/simple-forms/21-0966/tests/e2e/fixtures/data/third-party-surviving-minimal-test.json
@@ -6,7 +6,7 @@
   },
   "thirdPartyPreparerRole": "fiduciary",
   "benefitSelection": {
-    "survivors": true
+    "survivor": true
   },
   "survivingDependentFullName": {
     "first": "Surviving",


### PR DESCRIPTION
## Summary

Along with [this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/14402), this is fixing some inaccurate plurals in test data for 21-0966.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/743