### PR TITLE
My VA - a11y fixes for dot indicator

### DIFF
--- a/src/applications/personalization/dashboard/components/IconCTALink.jsx
+++ b/src/applications/personalization/dashboard/components/IconCTALink.jsx
@@ -65,7 +65,7 @@ const IconCTALink = ({
                 className="fa-stack fa-sm vads-u-height--full vads-u-margin-left--1"
               >
                 <i
-                  aria-label={`${ariaLabel} ${text}.`}
+                  aria-hidden="true"
                   className="fas fa-xs fa-stack-1x vads-u-height--full fa-circle vads-u-color--secondary-dark"
                 />
               </span>

--- a/src/applications/personalization/dashboard/components/health-care/HealthCareCTA.jsx
+++ b/src/applications/personalization/dashboard/components/health-care/HealthCareCTA.jsx
@@ -47,7 +47,10 @@ const HealthCareCTA = ({
               text="Go to your inbox"
               icon="comments"
               dotIndicator={unreadMessagesCount > 0}
-              ariaLabel={unreadMessagesCount > 0 && 'Unread messages.'}
+              ariaLabel={
+                unreadMessagesCount > 0 &&
+                'You have unread messages. Go to your inbox.'
+              }
               href={mhvUrl(authenticatedWithSSOe, 'secure-messaging')}
               testId="view-your-messages-link-from-cta"
               onClick={() =>

--- a/src/applications/personalization/dashboard/tests/components/health-care/HealthCareCTA.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/health-care/HealthCareCTA.unit.spec.jsx
@@ -72,8 +72,8 @@ describe('<HealthCareCTA />', () => {
         );
 
         expect(
-          tree.getByLabelText('Unread messages. Go to your inbox.', {
-            selector: 'i',
+          tree.getByLabelText('You have unread messages. Go to your inbox.', {
+            selector: 'a',
           }),
         ).to.exist;
       });


### PR DESCRIPTION
## Summary

This PR:
- removes unnecessary `aria-label` from icon markup (this doesn't get read by screenreaders anyway)
- updates `aria-label` for CTA link to be more descriptive
- updates relevant unit test

## Related issue(s)
Main tickets
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/68309
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/63788

from Platform staging review
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/68258
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/68259

## Testing done
- locally, in browser dev tools
- macOS voiceover
- all unit and e2e tests still pass

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
 | ------ | ----- |
 |      ![Screenshot 2023-11-03 at 3 35 07 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8542413/60fee032-8a88-490b-928b-282f95c336c4)  |     ![Screenshot 2023-11-03 at 3 34 38 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8542413/e2436feb-3484-46fc-acf8-fb419ed6f9b2)  |

## What areas of the site does it impact?
My VA - Health care - Go to inbox CTA link

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity-personalization/onsite-notifications/dot-indicator/create-dot-indicator/documentation/my-va-health-care-inbox-dot-indicator-FE-documentation.md) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
