### PR TITLE
#67684: Add unit test coverage for VideoLink.jsx

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoLink.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VideoLink.jsx
@@ -49,5 +49,18 @@ export default function VideoLink({ appointment }) {
   );
 }
 VideoLink.propTypes = {
-  appointment: PropTypes.object.isRequired,
+  appointment: PropTypes.shape({
+    start: PropTypes.string.isRequired,
+    videoData: PropTypes.shape({
+      url: PropTypes.string.isRequired,
+    }),
+  }),
+};
+VideoLink.defaultProps = {
+  appointment: {
+    start: '',
+    videoData: {
+      url: '',
+    },
+  },
 };

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/tests/VideoLink.unit.spec.js
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/tests/VideoLink.unit.spec.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import moment from 'moment';
+import VideoLink from '../VideoLink';
+
+describe('VideoVisitInstructions', () => {
+  it('renders join appoinment link', () => {
+    const appointment = {
+      start: moment(),
+      videoData: {
+        url: 'test.com',
+      },
+    };
+    const props = { appointment };
+    const wrapper = render(<VideoLink {...props} />);
+    expect(wrapper.queryByText('Join appointment')).to.exist;
+    expect(wrapper.container.querySelector('.usa-button')).to.exist;
+    expect(wrapper.container.querySelector('.usa-button-disabled')).to.not
+      .exist;
+  });
+  it('renders disabled join appoinment link 35 minutes prior to start time', () => {
+    const appointment = {
+      start: moment().add(35, 'm'),
+      videoData: {
+        url: 'test.com',
+      },
+    };
+    const props = { appointment };
+    const wrapper = render(<VideoLink {...props} />);
+    expect(wrapper.queryByText('Join appointment')).to.exist;
+    expect(wrapper.container.querySelector('.usa-button')).to.exist;
+    expect(wrapper.container.querySelector('.usa-button-disabled')).to.exist;
+  });
+  it('renders disabled join appoinment link 4 hours after start time', () => {
+    const appointment = {
+      start: moment().subtract(241, 'm'),
+      videoData: {
+        url: 'test.com',
+      },
+    };
+    const props = { appointment };
+    const wrapper = render(<VideoLink {...props} />);
+    expect(wrapper.queryByText('Join appointment')).to.exist;
+    expect(wrapper.container.querySelector('.usa-button')).to.exist;
+    expect(wrapper.container.querySelector('.usa-button-disabled')).to.exist;
+  });
+});

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/tests/VideoLink.unit.spec.js
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/tests/VideoLink.unit.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import moment from 'moment';
 import VideoLink from '../VideoLink';
 
@@ -18,6 +18,11 @@ describe('VideoVisitInstructions', () => {
     expect(wrapper.container.querySelector('.usa-button')).to.exist;
     expect(wrapper.container.querySelector('.usa-button-disabled')).to.not
       .exist;
+    // fireEvent.click returns false if event is cancelable, and at least one of the event
+    // handlers which received event called Event.preventDefault(). Otherwise true.
+    // We do not expect preventDefault() to be called if the link is active.
+    expect(fireEvent.click(wrapper.container.querySelector('.usa-button'))).to
+      .be.true;
   });
   it('renders disabled join appoinment link 35 minutes prior to start time', () => {
     const appointment = {
@@ -44,5 +49,24 @@ describe('VideoVisitInstructions', () => {
     expect(wrapper.queryByText('Join appointment')).to.exist;
     expect(wrapper.container.querySelector('.usa-button')).to.exist;
     expect(wrapper.container.querySelector('.usa-button-disabled')).to.exist;
+  });
+  it('call preventDefault function', () => {
+    const appointment = {
+      start: moment().add(35, 'm'),
+      videoData: {
+        url: 'test.com',
+      },
+    };
+    const props = { appointment };
+    const wrapper = render(<VideoLink {...props} />);
+    expect(wrapper.queryByText('Join appointment')).to.exist;
+    expect(wrapper.container.querySelector('.usa-button')).to.exist;
+    expect(wrapper.container.querySelector('.usa-button-disabled')).to.exist;
+
+    // fireEvent.click returns false if event is cancelable, and at least one of the event
+    // handlers which received event called Event.preventDefault(). Otherwise true.
+    // We expect preventDefault() to be called if the link is disabled.
+    expect(fireEvent.click(wrapper.container.querySelector('.usa-button'))).to
+      .be.false;
   });
 });


### PR DESCRIPTION
## Summary
Added unit test coverage for `VideoLink.jsx`.



## Related issue(s)

- https://app.zenhub.com/workspaces/appointments-team-603fdef281af6500110a1691/issues/gh/department-of-veterans-affairs/va.gov-team/67684

## Testing done
Checked file coverage and confirmed it was 100% covered.

<img width="1331" alt="Screenshot 2023-11-03 at 3 52 43 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/47654119/b8ddc05d-7a14-4f74-b3e9-a2ed6ab9eb0d">






## Acceptance criteria
- [x] file coverage for Branches, functions, lines and statements is 100%
