### PR TITLE
MBMS-50039: Self-Service Preneed Supporting Files page typo

### DIFF
--- a/src/platform/forms-system/src/js/utilities/file/ShowPdfPassword.jsx
+++ b/src/platform/forms-system/src/js/utilities/file/ShowPdfPassword.jsx
@@ -2,6 +2,8 @@ import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
+import environment from 'platform/utilities/environment';
+
 import { focusElement } from '../ui';
 
 const ShowPdfPassword = ({
@@ -78,12 +80,22 @@ ShowPdfPassword.propTypes = {
   onSubmitPassword: PropTypes.func,
 };
 
-const PasswordLabel = () => (
-  <p>
-    This is en encrypted PDF document. In order for us to be able to view the
-    document, we will need the password to decrypt it.
-  </p>
-);
+const PasswordLabel = () => {
+  if (!environment.isProduction()) {
+    return (
+      <p>
+        This is an encrypted PDF document. In order for us to be able to view
+        the document, we will need the password to decrypt it.
+      </p>
+    );
+  }
+  return (
+    <p>
+      This is en encrypted PDF document. In order for us to be able to view the
+      document, we will need the password to decrypt it.
+    </p>
+  );
+};
 
 const PasswordSuccess = () => (
   <>


### PR DESCRIPTION
# Jira Link: [MBMS-50039](https://jira.devops.va.gov/browse/MBMS-50039)

## Summary

Issue:

"an" is spelled "en" in the message that displays after uploading an encrypted PDF

## Related issue(s)

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/132934480/4a6bf068-8ec6-46e7-aabd-64f7c334135b)

### Platform approval ticket: https://dsva.slack.com/archives/CBU0KDSB1/p1699043014561479

## Testing done

- Local testing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

### Before:
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/132934480/1edce5f7-16f4-4bd4-b89e-129bc4efc182)

### After:
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/132934480/a61a0cbc-49f0-448c-bf42-f51beee041c8)

## What areas of the site does it impact?

All forms which use the common Platform code for uploading PDF's.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
