### PR TITLE
set branch back to main for init data repo

### DIFF
--- a/.github/workflows/init-data-repo/action.yml
+++ b/.github/workflows/init-data-repo/action.yml
@@ -10,7 +10,6 @@ runs:
         repository: department-of-veterans-affairs/qa-standards-dashboard-data
         token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
         path: qa-standards-dashboard-data
-        ref: unit-test-reporting-error
 
     - name: Get Node version
       id: get-node-version

--- a/script/github-actions/annotate-disallowed-tests.js
+++ b/script/github-actions/annotate-disallowed-tests.js
@@ -53,12 +53,12 @@ if (TESTS_BLOCKING_MERGE.length > 0) {
       path: spec,
       start_line: 1,
       end_line: 1,
-      title: `${mergeCheckType} Allow List Merge Block Warning`,
-      message: `*MERGE BLOCK WARNING* This PR contains changes related to this test spec which has been disabled for flakiness.
-                \n Beginning on Nov 6th, 2023, merging will be blocked for PRs in products that have flaky Unit/E2E tests associated with them.
-                \n Please resolve these tests BY 11/5/23 in order to avoid merge blocking.
+      title: `${mergeCheckType} Allow List Merge Blocked`,
+      message: `*MERGE BLOCK NOTICE* This PR contains changes related to this test spec which has been disabled for flakiness.
+                \n As of Nov 6th, 2023, merging is blocked for PRs in products that have flaky Unit/E2E tests associated with them.
+                \n Please resolve these tests to remove this blocker.
                 \n More information is available at: https://depo-platform-documentation.scrollhelp.site/developer-docs/test-stability-review.`,
-      annotation_level: 'warning',
+      annotation_level: 'failure',
     };
   });
   core.exportVariable(

--- a/script/github-actions/verify-merge-eligibility.js
+++ b/script/github-actions/verify-merge-eligibility.js
@@ -14,9 +14,8 @@ const errorMessages = [];
 
 if (testsBlockingMerge.length > 0) {
   errorMessages.push(
-    `*MERGE BLOCK WARNING* \n
-    This PR has test specs that have been disabled to to flakiness. \n 
-    Beginning on Nov 6th, 2023, merging will be blocked for PRs in products that have flaky Unit/E2E tests associated with them. Please resolve these tests BY 11/5/23 in order to avoid merge blocking.\n
+    `This PR has test specs that have been disabled due to flakiness. \n 
+    As of Nov 6th, 2023, merging is blocked for PRs in products that have flaky Unit/E2E tests associated with them. Please resolve these test errors to remove this blocker.\n
     More information is available at: https://depo-platform-documentation.scrollhelp.site/developer-docs/test-stability-review.\n
     
     The file paths causing this status are: \n ${testsBlockingMerge.join(


### PR DESCRIPTION
## Summary

- Alter annotation text to convey blocking instead of warning
- Alter CI text to convey blocking instead of warning


## Related issue(s)

https://app.zenhub.com/workspaces/reliability-team-633b069d2920b776613c93d8/issues/gh/department-of-veterans-affairs/va.gov-team/64179
