### PR TITLE
[CST] Migrating Breadcrumbs React component to va-breadcrumb web component

### DIFF
--- a/src/applications/claims-status/components/ClaimsBreadcrumbs.jsx
+++ b/src/applications/claims-status/components/ClaimsBreadcrumbs.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
-import Breadcrumbs from '@department-of-veterans-affairs/component-library/Breadcrumbs';
+import PropTypes from 'prop-types';
 
 class ClaimsBreadcrumbs extends React.Component {
   renderBreadcrumbs = childNodes => {
@@ -27,9 +27,16 @@ class ClaimsBreadcrumbs extends React.Component {
 
   render() {
     return (
-      <Breadcrumbs>{this.renderBreadcrumbs(this.props.children)}</Breadcrumbs>
+      // Note: not using uswds option here because react-router Links are not compatible currently
+      <va-breadcrumbs>
+        {this.renderBreadcrumbs(this.props.children)}
+      </va-breadcrumbs>
     );
   }
 }
+
+ClaimsBreadcrumbs.propTypes = {
+  children: PropTypes.node,
+};
 
 export default ClaimsBreadcrumbs;

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
@@ -27,6 +27,7 @@ class TrackClaimsPage {
       'eq',
       'Check your claim, decision review, or appeal status | Veterans Affairs',
     );
+
     if (claimsList.data.length) {
       cy.get('.claim-list-item-container', { timeout: Timeouts.slow }).should(
         'be.visible',
@@ -37,8 +38,9 @@ class TrackClaimsPage {
         'You do not have any submitted claims',
       );
     }
-    cy.get('.va-nav-breadcrumbs').should('be.visible');
-    cy.get('.va-nav-breadcrumbs-list').should('be.visible');
+
+    cy.get('va-breadcrumbs').should('be.visible');
+    cy.get('.va-breadcrumbs-li').should('be.visible');
     cy.get('a[aria-current="page"').should('be.visible');
     cy.injectAxeThenAxeCheck();
   }


### PR DESCRIPTION
## Summary
Migrating the existing usage of the `Breadcrumbs` React component to the `va-breadcrumbs` web component

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#67096

## Testing done
Updated tests to look for the proper component

## What areas of the site does it impact?
Claim Status Tool

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
