### PR TITLE
Check in/68802/demographics uptodate utility

### DIFF
--- a/src/applications/check-in/utils/appConstants/index.js
+++ b/src/applications/check-in/utils/appConstants/index.js
@@ -242,7 +242,10 @@ const phoneNumbers = {
   emergency: '911',
 };
 
+const DEMOGRAPHICS_UPDATE_FREQUENCY = 7; // days
+
 export {
+  DEMOGRAPHICS_UPDATE_FREQUENCY,
   APP_NAMES,
   VISTA_CHECK_IN_STATUS_IENS,
   getLabelForEditField,

--- a/src/applications/check-in/utils/demographics/demographics.unit.spec.js
+++ b/src/applications/check-in/utils/demographics/demographics.unit.spec.js
@@ -37,6 +37,16 @@ describe('Utils', () => {
           emergencyContactUpToDate: false,
         });
       });
+      it('returns an object with the correct key value pairs with empty object', () => {
+        const patientDemographicsStatus = {};
+        expect(
+          getDemographicsStatuses(patientDemographicsStatus),
+        ).to.deep.equal({
+          demographicsUpToDate: false,
+          nextOfKinUpToDate: false,
+          emergencyContactUpToDate: false,
+        });
+      });
     });
   });
 });

--- a/src/applications/check-in/utils/demographics/demographics.unit.spec.js
+++ b/src/applications/check-in/utils/demographics/demographics.unit.spec.js
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+
+import { getDemographicsStatuses } from './index';
+
+describe('Utils', () => {
+  describe('demographics utils', () => {
+    describe('getDemographicsStatuses', () => {
+      it('returns an object with the correct key value pairs with valid values', () => {
+        const patientDemographicsStatus = {
+          demographicsNeedsUpdate: true,
+          demographicsConfirmedAt: '2022-01-04T00:00:00.000-05:00',
+          nextOfKinNeedsUpdate: false,
+          nextOfKinConfirmedAt: '2022-01-04T00:00:00.000-05:00',
+          emergencyContactNeedsUpdate: false,
+          emergencyContactConfirmedAt: new Date().toISOString(),
+        };
+        expect(
+          getDemographicsStatuses(patientDemographicsStatus),
+        ).to.deep.equal({
+          demographicsUpToDate: false,
+          nextOfKinUpToDate: false,
+          emergencyContactUpToDate: true,
+        });
+      });
+      it('returns an object with the correct key value pairs with unsupplied or invalid values', () => {
+        const patientDemographicsStatus = {
+          demographicsConfirmedAt: '',
+          nextOfKinNeedsUpdate: null,
+          nextOfKinConfirmedAt: null,
+          emergencyContactConfirmedAt: new Date().toISOString(),
+        };
+        expect(
+          getDemographicsStatuses(patientDemographicsStatus),
+        ).to.deep.equal({
+          demographicsUpToDate: false,
+          nextOfKinUpToDate: false,
+          emergencyContactUpToDate: false,
+        });
+      });
+    });
+  });
+});

--- a/src/applications/check-in/utils/demographics/index.js
+++ b/src/applications/check-in/utils/demographics/index.js
@@ -1,0 +1,44 @@
+import { differenceInCalendarDays, sub } from 'date-fns';
+
+// How often demgraphics have to be reviewed in days
+const UPDATE_FREQUENCY = 7;
+
+const isWithInDays = (days, date) => {
+  const daysAgo = differenceInCalendarDays(Date.now(), date);
+  return daysAgo <= days;
+};
+
+const upToDate = (needsUpdate, confirmedAt) => {
+  const demoLastUpdated = confirmedAt
+    ? new Date(confirmedAt)
+    : sub(new Date(), { years: 99 }); // if none supplied make this always be not within the update frequency
+
+  return (
+    isWithInDays(UPDATE_FREQUENCY, demoLastUpdated) && needsUpdate === false
+  );
+};
+
+const getDemographicsStatuses = patientDemographicsStatus => {
+  const {
+    demographicsNeedsUpdate,
+    demographicsConfirmedAt,
+    nextOfKinNeedsUpdate,
+    nextOfKinConfirmedAt,
+    emergencyContactNeedsUpdate,
+    emergencyContactConfirmedAt,
+  } = patientDemographicsStatus;
+
+  return {
+    demographicsUpToDate: upToDate(
+      demographicsNeedsUpdate,
+      demographicsConfirmedAt,
+    ),
+    nextOfKinUpToDate: upToDate(nextOfKinNeedsUpdate, nextOfKinConfirmedAt),
+    emergencyContactUpToDate: upToDate(
+      emergencyContactNeedsUpdate,
+      emergencyContactConfirmedAt,
+    ),
+  };
+};
+
+export { UPDATE_FREQUENCY, getDemographicsStatuses };

--- a/src/applications/check-in/utils/demographics/index.js
+++ b/src/applications/check-in/utils/demographics/index.js
@@ -1,7 +1,5 @@
 import { differenceInCalendarDays, sub } from 'date-fns';
-
-// How often demgraphics have to be reviewed in days
-const UPDATE_FREQUENCY = 7;
+import { DEMOGRAPHICS_UPDATE_FREQUENCY } from '../appConstants';
 
 const isWithInDays = (days, date) => {
   const daysAgo = differenceInCalendarDays(Date.now(), date);
@@ -11,10 +9,11 @@ const isWithInDays = (days, date) => {
 const upToDate = (needsUpdate, confirmedAt) => {
   const demoLastUpdated = confirmedAt
     ? new Date(confirmedAt)
-    : sub(new Date(), { years: 99 }); // if none supplied make this always be not within the update frequency
+    : sub(new Date(), { days: DEMOGRAPHICS_UPDATE_FREQUENCY + 1 }); // if none supplied make this always be not within the update frequency
 
   return (
-    isWithInDays(UPDATE_FREQUENCY, demoLastUpdated) && needsUpdate === false
+    isWithInDays(DEMOGRAPHICS_UPDATE_FREQUENCY, demoLastUpdated) &&
+    needsUpdate === false
   );
 };
 
@@ -41,4 +40,4 @@ const getDemographicsStatuses = patientDemographicsStatus => {
   };
 };
 
-export { UPDATE_FREQUENCY, getDemographicsStatuses };
+export { getDemographicsStatuses };

--- a/src/applications/check-in/utils/navigation/index.js
+++ b/src/applications/check-in/utils/navigation/index.js
@@ -19,13 +19,13 @@ const updateFormPages = (
     emergencyContactUpToDate,
   } = getDemographicsStatuses(patientDemographicsStatus);
 
-  if (!demographicsUpToDate) {
+  if (demographicsUpToDate) {
     skippedPages.push(URLS.DEMOGRAPHICS);
   }
-  if (!nextOfKinUpToDate) {
+  if (nextOfKinUpToDate) {
     skippedPages.push(URLS.NEXT_OF_KIN);
   }
-  if (!emergencyContactUpToDate) {
+  if (emergencyContactUpToDate) {
     skippedPages.push(URLS.EMERGENCY_CONTACT);
   }
 

--- a/src/applications/check-in/utils/navigation/index.js
+++ b/src/applications/check-in/utils/navigation/index.js
@@ -1,10 +1,6 @@
 import { differenceInCalendarDays, parseISO } from 'date-fns';
 import { isInPilot } from '../pilotFeatures';
-
-const isWithInDays = (days, pageLastUpdated) => {
-  const daysAgo = differenceInCalendarDays(Date.now(), pageLastUpdated);
-  return daysAgo <= days;
-};
+import { getDemographicsStatuses } from '../demographics';
 
 const updateFormPages = (
   patientDemographicsStatus,
@@ -16,44 +12,22 @@ const updateFormPages = (
   travelPaySent = {},
 ) => {
   const skippedPages = [];
-  const {
-    demographicsNeedsUpdate,
-    demographicsConfirmedAt,
-    nextOfKinNeedsUpdate,
-    nextOfKinConfirmedAt,
-    emergencyContactNeedsUpdate,
-    emergencyContactConfirmedAt,
-  } = patientDemographicsStatus;
 
-  const skippablePages = [
-    {
-      url: URLS.DEMOGRAPHICS,
-      confirmedAt: demographicsConfirmedAt,
-      needsUpdate: demographicsNeedsUpdate,
-    },
-    {
-      url: URLS.NEXT_OF_KIN,
-      confirmedAt: nextOfKinConfirmedAt,
-      needsUpdate: nextOfKinNeedsUpdate,
-    },
-    {
-      url: URLS.EMERGENCY_CONTACT,
-      confirmedAt: emergencyContactConfirmedAt,
-      needsUpdate: emergencyContactNeedsUpdate,
-    },
-  ];
-  skippablePages.forEach(page => {
-    const pageLastUpdated = page.confirmedAt
-      ? new Date(page.confirmedAt)
-      : null;
-    if (
-      pageLastUpdated &&
-      isWithInDays(7, pageLastUpdated) &&
-      page.needsUpdate === false
-    ) {
-      skippedPages.push(page.url);
-    }
-  });
+  const {
+    demographicsUpToDate,
+    nextOfKinUpToDate,
+    emergencyContactUpToDate,
+  } = getDemographicsStatuses(patientDemographicsStatus);
+
+  if (!demographicsUpToDate) {
+    skippedPages.push(URLS.DEMOGRAPHICS);
+  }
+  if (!nextOfKinUpToDate) {
+    skippedPages.push(URLS.NEXT_OF_KIN);
+  }
+  if (!emergencyContactUpToDate) {
+    skippedPages.push(URLS.EMERGENCY_CONTACT);
+  }
 
   const travelPayPages = [
     URLS.TRAVEL_QUESTION,


### PR DESCRIPTION
## Summary

- Adds a utility function for determining demographics statuses

## Related issue(s)

- [department-of-veterans-affairs/va.gov-team#68802](https://github.com/department-of-veterans-affairs/va.gov-team/issues/68802)

## Testing done

- Unit

## What areas of the site does it impact?

Check-in -> updateFormPages

## Acceptance criteria

- [ ] Code is easier to read and test
- [ ] Utility could potentially be used elsewhere if we persist the data in redux(larger refactor)

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
