### PR TITLE
Remove SIP ability for Dependent list-loop records in the Health Care Application

### DIFF
--- a/src/applications/hca/components/FormAlerts/index.jsx
+++ b/src/applications/hca/components/FormAlerts/index.jsx
@@ -133,8 +133,8 @@ export const DependentSIPWarning = () => (
     background-only
   >
     <p className="vads-u-margin-y--0">
-      To save your progress, make sure to fill in all the required fields for
-      your dependent.
+      Be sure to enter all the required information for your dependent. We can
+      only save your progress when you enter the required information.
     </p>
   </va-alert>
 );

--- a/src/applications/hca/components/FormAlerts/index.jsx
+++ b/src/applications/hca/components/FormAlerts/index.jsx
@@ -124,3 +124,17 @@ export const FinancialDisclosureAlert = () => (
     qualifying eligibility factor, VA can’t enroll you.
   </va-alert>
 );
+
+export const DependentSIPWarning = () => (
+  <va-alert
+    status="warning"
+    data-testid="hca-sip-warning"
+    class="vads-u-margin-bottom--4"
+    background-only
+  >
+    <p className="vads-u-margin-y--0">
+      To save your progress, make sure to fill in all the required fields for
+      your dependent.
+    </p>
+  </va-alert>
+);

--- a/src/applications/hca/components/FormFields/DependentListLoopForm.jsx
+++ b/src/applications/hca/components/FormFields/DependentListLoopForm.jsx
@@ -6,10 +6,11 @@ import {
   dependentSchema as schema,
   dependentUISchema as uiSchema,
 } from '../../definitions/dependent';
+import { DependentSIPWarning } from '../FormAlerts';
 
 const DependentListLoopForm = props => {
   const { children, data, page, onChange, onSubmit } = props;
-  const { fullName = {} } = data || {};
+  const { fullName = {}, 'view:isLoggedIn': isLoggedIn } = data || {};
 
   // build the uiSchema title attribute based on form data & page
   const nameToDisplay =
@@ -17,6 +18,7 @@ const DependentListLoopForm = props => {
   const currentUISchema = {
     ...uiSchema[page.id],
     'ui:title': page.title.replace(/%s/g, nameToDisplay),
+    'ui:description': isLoggedIn ? DependentSIPWarning : undefined,
   };
 
   return (

--- a/src/applications/hca/components/FormPages/DependentInformation.jsx
+++ b/src/applications/hca/components/FormPages/DependentInformation.jsx
@@ -2,14 +2,19 @@ import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-// eslint-disable-next-line deprecate/import
 import { focusElement } from 'platform/utilities/ui';
-// eslint-disable-next-line deprecate/import
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import DependentListLoopForm from '../FormFields/DependentListLoopForm';
 
 import useAfterRenderEffect from '../../hooks/useAfterRenderEffect';
-import { isOfCollegeAge, getDependentPageList } from '../../utils/helpers';
+import {
+  isOfCollegeAge,
+  getDependentPageList,
+  getDataToSet,
+  getSearchAction,
+  getSearchIndex,
+  getDefaultState,
+} from '../../utils/helpers';
 import {
   DEPENDENT_VIEW_FIELDS,
   SESSION_ITEM_NAME,
@@ -51,49 +56,21 @@ const SUB_PAGES = [
 
 // declare default component
 const DependentInformation = props => {
-  const {
-    data,
-    goToPath,
-    setFormData,
-    contentBeforeButtons,
-    contentAfterButtons,
-  } = props;
+  const { data, goToPath, setFormData } = props;
 
   const { dependents = [] } = data;
   const search = new URLSearchParams(window.location.search);
-  const mode = search.get('action') || 'add';
-  const action = {
-    label: `${mode === 'add' ? 'add' : 'edit'}ing`,
-    pathToGo:
-      mode === 'update' ? '/review-and-submit' : `/${DEPENDENT_PATHS.summary}`,
-  };
+  const searchIndex = getSearchIndex(search, dependents);
+  const searchAction = getSearchAction(search, DEPENDENT_PATHS.summary);
+  const defaultState = getDefaultState({
+    defaultData: { data: {}, page: SUB_PAGES[0] },
+    dataToSearch: dependents,
+    name: SESSION_ITEM_NAME,
+    searchAction,
+    searchIndex,
+  });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const listRef = useMemo(() => dependents, []);
-
-  // determine where this dependent data will live in the array
-  const searchIndex = () => {
-    let indexToReturn = parseInt(search.get('index'), 10);
-    if (Number.isNaN(indexToReturn) || indexToReturn > dependents.length) {
-      indexToReturn = dependents.length;
-    }
-    return indexToReturn;
-  };
-
-  // determine which `page` & dataset to start with based on the index
-  const defaultStates = () => {
-    const resultToReturn = { data: {}, page: SUB_PAGES[0] };
-
-    // check if data exists at the array index and set return result accordingly
-    if (typeof dependents[searchIndex()] !== 'undefined') {
-      resultToReturn.data = dependents[searchIndex()];
-
-      if (mode !== 'add') {
-        window.sessionStorage.setItem(SESSION_ITEM_NAME, searchIndex());
-      }
-    }
-
-    return resultToReturn;
-  };
 
   /**
    * declare default state/ref variables
@@ -105,8 +82,8 @@ const DependentInformation = props => {
   const [activePages, setActivePages] = useState(
     SUB_PAGES.filter(item => !('depends' in item)),
   );
-  const [currentPage, setCurrentPage] = useState(defaultStates().page);
-  const [localData, setLocalData] = useState(defaultStates().data);
+  const [currentPage, setCurrentPage] = useState(defaultState.page);
+  const [localData, setLocalData] = useState(defaultState.data);
   const [modal, showModal] = useState(false);
 
   /**
@@ -130,7 +107,7 @@ const DependentInformation = props => {
     },
     onConfirm: () => {
       setLocalData(null);
-      goToPath(action.pathToGo);
+      goToPath(searchAction.pathToGo);
     },
     onGoBack: () => {
       const index = activePages.findIndex(item => item.id === currentPage.id);
@@ -143,12 +120,18 @@ const DependentInformation = props => {
     onSubmit: () => {
       const index = activePages.findIndex(item => item.id === currentPage.id);
       if (index === activePages.length - 1) {
-        setFormData({
-          ...data,
-          [DEPENDENT_VIEW_FIELDS.report]: null,
-          [DEPENDENT_VIEW_FIELDS.skip]: true,
+        const dataToSet = getDataToSet({
+          slices: {
+            beforeIndex: dependents.slice(0, searchIndex),
+            afterIndex: dependents.slice(searchIndex + 1),
+          },
+          viewFields: DEPENDENT_VIEW_FIELDS,
+          dataKey: 'dependents',
+          localData,
+          listRef,
         });
-        goToPath(action.pathToGo);
+        setFormData({ ...data, ...dataToSet });
+        goToPath(searchAction.pathToGo);
       } else {
         setCurrentPage(activePages[index + 1]);
       }
@@ -168,31 +151,27 @@ const DependentInformation = props => {
   );
 
   // set form data on each change to the localData object state
+  /**
+   * TODO: bring this back when we have proper validation for partial
+   * dependent records
   useEffect(
     () => {
-      const slices = {
-        beforeIndex: dependents.slice(0, searchIndex()),
-        afterIndex: dependents.slice(searchIndex() + 1),
-      };
-      const dataToSet =
-        localData === null
-          ? {
-              dependents: listRef,
-              [DEPENDENT_VIEW_FIELDS.report]: null,
-              [DEPENDENT_VIEW_FIELDS.skip]: true,
-            }
-          : {
-              dependents: [
-                ...slices.beforeIndex,
-                localData,
-                ...slices.afterIndex,
-              ],
-            };
+      const dataToSet = getDataToSet({
+        slices: {
+          beforeIndex: dependents.slice(0, searchIndex),
+          afterIndex: dependents.slice(searchIndex + 1),
+        },
+        viewFields: DEPENDENT_VIEW_FIELDS,
+        dataKey: 'dependents',
+        localData,
+        listRef,
+      });
       setFormData({ ...data, ...dataToSet });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [localData],
   );
+  */
 
   // set active pages array based on form data conditionals
   useEffect(
@@ -211,10 +190,11 @@ const DependentInformation = props => {
    * NOTE: This is a bit of a hack, as we cannot reset the submitted state of the
    * SchemaForm component
    */
-  const FormList = SUB_PAGES.map(({ id, title }) => {
+  const FormList = SUB_PAGES.map(({ id, title }, index) => {
     return currentPage.id === id ? (
       <>
         <DependentListLoopForm
+          key={index}
           data={localData}
           page={{ id, title }}
           onChange={handlers.onChange}
@@ -223,7 +203,7 @@ const DependentInformation = props => {
           {/** Cancel confirmation modal trigger */}
           <div className="vads-u-margin-y--2">
             <va-button
-              text={`Cancel ${action.label} this dependent`}
+              text={`Cancel ${searchAction.label} this dependent`}
               onClick={handlers.showConfirm}
               secondary
               id="hca-modal-cancel"
@@ -231,9 +211,7 @@ const DependentInformation = props => {
           </div>
 
           {/** Form progress buttons */}
-          {contentBeforeButtons}
           <FormNavButtons goBack={handlers.onGoBack} submitToContinue />
-          {contentAfterButtons}
         </DependentListLoopForm>
       </>
     ) : null;
@@ -244,9 +222,9 @@ const DependentInformation = props => {
       {FormList}
 
       <VaModal
-        modalTitle={`Cancel ${action.label} this dependent?`}
-        primaryButtonText={`Yes, cancel ${action.label}`}
-        secondaryButtonText={`No, continue ${action.label}`}
+        modalTitle={`Cancel ${searchAction.label} this dependent?`}
+        primaryButtonText={`Yes, cancel ${searchAction.label}`}
+        secondaryButtonText={`No, continue ${searchAction.label}`}
         onPrimaryButtonClick={handlers.onConfirm}
         onSecondaryButtonClick={handlers.onCancel}
         onCloseEvent={handlers.onCancel}
@@ -255,7 +233,7 @@ const DependentInformation = props => {
         clickToClose
       >
         <p className="vads-u-margin--0">
-          If you cancel {action.label} this dependent, we won’t save their
+          If you cancel {searchAction.label} this dependent, we won’t save their
           information. You’ll return to a screen where you can add or remove
           dependents.
         </p>

--- a/src/applications/hca/tests/components/FormAlerts/FormAlerts.unit.spec.js
+++ b/src/applications/hca/tests/components/FormAlerts/FormAlerts.unit.spec.js
@@ -7,6 +7,7 @@ import {
   ServerErrorAlert,
   ShortFormAlert,
   IdentityVerificationAlert,
+  DependentSIPWarning,
 } from '../../../components/FormAlerts';
 
 describe('hca <DowntimeWarning>', () => {
@@ -51,5 +52,14 @@ describe('hca <IdentityVerificationAlert>', () => {
     expect(selector).to.contain.text(
       'Please verify your identity before applying for VA health care',
     );
+  });
+});
+
+describe('hca <DependentSIPWarning>', () => {
+  it('should render', () => {
+    const { container } = render(<DependentSIPWarning />);
+    const selector = container.querySelector('va-alert');
+    expect(selector).to.exist;
+    expect(selector).to.contain.attr('status', 'warning');
   });
 });

--- a/src/applications/hca/tests/components/FormFields/DependentListLoopForm.unit.spec.js
+++ b/src/applications/hca/tests/components/FormFields/DependentListLoopForm.unit.spec.js
@@ -36,4 +36,28 @@ describe('hca <DependentListLoopForm>', () => {
       expect(title).to.contain.text('Mary Smith\u2019s additional information');
     });
   });
+
+  describe('when the user is logged out', () => {
+    it('should not render the save-in-progress warning', () => {
+      const props = {
+        ...defaultProps,
+        data: { 'view:isLoggedIn': false },
+      };
+      const { container } = render(<DependentListLoopForm {...props} />);
+      const alert = container.querySelector('[data-testid="hca-sip-warning"]');
+      expect(alert).to.not.exist;
+    });
+  });
+
+  describe('when the user is logged in', () => {
+    it('should render the save-in-progress warning', () => {
+      const props = {
+        ...defaultProps,
+        data: { 'view:isLoggedIn': true },
+      };
+      const { container } = render(<DependentListLoopForm {...props} />);
+      const alert = container.querySelector('[data-testid="hca-sip-warning"]');
+      expect(alert).to.exist;
+    });
+  });
 });

--- a/src/applications/hca/tests/utils/helpers.unit.spec.js
+++ b/src/applications/hca/tests/utils/helpers.unit.spec.js
@@ -11,6 +11,10 @@ import {
   isOfCollegeAge,
   getDependentPageList,
   normalizeFullName,
+  getDataToSet,
+  getSearchAction,
+  getSearchIndex,
+  getDefaultState,
 } from '../../utils/helpers';
 import { HIGH_DISABILITY_MINIMUM } from '../../utils/constants';
 
@@ -636,6 +640,220 @@ describe('hca helpers', () => {
             );
           });
         });
+      });
+    });
+  });
+
+  context('when `getDataToSet` executes', () => {
+    const listRef = [{ name: 'John' }, { name: 'Jane' }, { name: 'Mary' }];
+    const searchIndex = 1;
+    const defaultProps = {
+      slices: {
+        beforeIndex: listRef.slice(0, searchIndex),
+        afterIndex: listRef.slice(searchIndex + 1),
+      },
+      dataKey: 'dependents',
+      localData: { name: 'Liz' },
+      listRef,
+      viewFields: {
+        report: 'view:reportDependents',
+        skip: 'view:skipDependents',
+      },
+    };
+    const expectedResults = {
+      blank: {
+        dependents: listRef,
+        [defaultProps.viewFields.report]: null,
+        [defaultProps.viewFields.skip]: true,
+      },
+      populated: {
+        dependents: [{ name: 'John' }, { name: 'Liz' }, { name: 'Mary' }],
+        [defaultProps.viewFields.report]: null,
+        [defaultProps.viewFields.skip]: true,
+      },
+    };
+
+    context('when localData is populated', () => {
+      it('should return the modified dataset without modifying the viewfield values', () => {
+        expect(JSON.stringify(getDataToSet(defaultProps))).to.equal(
+          JSON.stringify(expectedResults.populated),
+        );
+      });
+    });
+
+    context('when localData is set to `null`', () => {
+      it('should return the original dataset with the modified viewfield values', () => {
+        const props = { ...defaultProps, localData: null };
+        expect(JSON.stringify(getDataToSet(props))).to.equal(
+          JSON.stringify(expectedResults.blank),
+        );
+      });
+    });
+  });
+
+  context('when `getSearchAction` executes', () => {
+    context('when the action is omitted', () => {
+      it('should default to adding a new record', () => {
+        const params = new URLSearchParams('');
+        const returnPath = 'summary';
+        const expectedResult = {
+          mode: 'add',
+          label: 'adding',
+          pathToGo: `/${returnPath}`,
+        };
+        expect(JSON.stringify(getSearchAction(params, returnPath))).to.equal(
+          JSON.stringify(expectedResult),
+        );
+      });
+    });
+
+    context('when the action is set to `add`', () => {
+      it('should default to adding a new record', () => {
+        const params = new URLSearchParams('action=add');
+        const returnPath = 'summary';
+        const expectedResult = {
+          mode: 'add',
+          label: 'adding',
+          pathToGo: `/${returnPath}`,
+        };
+        expect(JSON.stringify(getSearchAction(params, returnPath))).to.equal(
+          JSON.stringify(expectedResult),
+        );
+      });
+    });
+
+    context('when the action is set to `edit`', () => {
+      it('should set the correct props in the response', () => {
+        const params = new URLSearchParams('action=edit');
+        const returnPath = 'summary';
+        const expectedResult = {
+          mode: 'edit',
+          label: 'editing',
+          pathToGo: `/${returnPath}`,
+        };
+        expect(JSON.stringify(getSearchAction(params, returnPath))).to.equal(
+          JSON.stringify(expectedResult),
+        );
+      });
+    });
+
+    context('when the action is set to `update`', () => {
+      it('should set the correct props in the response', () => {
+        const params = new URLSearchParams('action=update');
+        const returnPath = 'summary';
+        const expectedResult = {
+          mode: 'update',
+          label: 'editing',
+          pathToGo: `/review-and-submit`,
+        };
+        expect(JSON.stringify(getSearchAction(params, returnPath))).to.equal(
+          JSON.stringify(expectedResult),
+        );
+      });
+    });
+  });
+
+  context('when `getSearchIndex` executes', () => {
+    context('when the index is omitted', () => {
+      it('should default to the end of the array', () => {
+        const params = new URLSearchParams('');
+        const arrayToParse = [1, 2];
+        expect(getSearchIndex(params, arrayToParse)).to.equal(
+          arrayToParse.length,
+        );
+      });
+    });
+
+    context('when the index is not a number', () => {
+      it('should default to the end of the array', () => {
+        const params = new URLSearchParams('index=ddd');
+        const arrayToParse = [1, 2];
+        expect(getSearchIndex(params, arrayToParse)).to.equal(
+          arrayToParse.length,
+        );
+      });
+    });
+
+    context('when the index is greater than the array length', () => {
+      it('should default to the end of the array', () => {
+        const params = new URLSearchParams('index=40');
+        const arrayToParse = [1, 2];
+        expect(getSearchIndex(params, arrayToParse)).to.equal(
+          arrayToParse.length,
+        );
+      });
+    });
+
+    context('when the index is within the the array length', () => {
+      it('should return the correct index', () => {
+        const params = new URLSearchParams('index=1');
+        const arrayToParse = [1, 2];
+        expect(getSearchIndex(params, arrayToParse)).to.equal(1);
+      });
+    });
+  });
+
+  context('when `getDefaultState` executes', () => {
+    const defaultProps = {
+      defaultData: { data: {}, page: 'basic-info' },
+      dataToSearch: [],
+      name: 'ITEM',
+    };
+    const expectedResults = {
+      blank: defaultProps.defaultData,
+      populated: { data: { name: 'Mary' }, page: 'basic-info' },
+    };
+
+    context('when the `searchAction` & `searchIndex` props are omitted', () => {
+      it('should return the default data', () => {
+        expect(JSON.stringify(getDefaultState(defaultProps))).to.equal(
+          JSON.stringify(expectedResults.blank),
+        );
+      });
+    });
+
+    context('when there is no data record for the search index', () => {
+      it('should return the default data', () => {
+        const props = {
+          ...defaultProps,
+          searchIndex: 0,
+          searchAction: { mode: 'add' },
+        };
+        expect(JSON.stringify(getDefaultState(props))).to.equal(
+          JSON.stringify(expectedResults.blank),
+        );
+      });
+    });
+
+    context('when there is a data record for the search index', () => {
+      it('should return the found data record', () => {
+        const props = {
+          ...defaultProps,
+          dataToSearch: [{ name: 'Mary' }],
+          searchIndex: 0,
+          searchAction: { mode: 'add' },
+        };
+        expect(JSON.stringify(getDefaultState(props))).to.equal(
+          JSON.stringify(expectedResults.populated),
+        );
+        expect(window.sessionStorage.getItem(props.name)).to.be.null;
+      });
+    });
+
+    context('when the search action is set to `edit`', () => {
+      it('should return the found data record', () => {
+        const props = {
+          ...defaultProps,
+          dataToSearch: [{ name: 'Mary' }],
+          searchIndex: 0,
+          searchAction: { mode: 'edit' },
+        };
+        expect(JSON.stringify(getDefaultState(props))).to.equal(
+          JSON.stringify(expectedResults.populated),
+        );
+        expect(window.sessionStorage.getItem(props.name)).to.equal(
+          props.searchIndex.toString(),
+        );
       });
     });
   });

--- a/src/applications/hca/utils/helpers.js
+++ b/src/applications/hca/utils/helpers.js
@@ -440,3 +440,79 @@ export function normalizeFullName(name = {}, outputMiddle = false) {
     : `${first} ${last} ${suffix}`;
   return nameToReturn.replace(/ +(?= )/g, '').trim();
 }
+
+/**
+ * Helper that takes query params and sets labels and return paths for
+ * the multiresponse (list/loop) information pages
+ * @param {Object} props - the original dataset, key name, localData object,
+ * search index, view field object and ref item for the src array
+ * @returns {Object} - the dataset to return
+ */
+export function getDataToSet(props) {
+  const { slices, dataKey, localData, listRef, viewFields } = props;
+  return localData === null
+    ? { [dataKey]: listRef, [viewFields.report]: null, [viewFields.skip]: true }
+    : {
+        [dataKey]: [...slices.beforeIndex, localData, ...slices.afterIndex],
+        [viewFields.report]: null,
+        [viewFields.skip]: true,
+      };
+}
+
+/**
+ * Helper that takes query params and sets labels and return paths for
+ * the multiresponse (list/loop) information pages
+ * @param {Object} params - the URL Search Params object to query
+ * @param {String} returnPath - the path to return upon completing an update action
+ * @returns {Object} - the labels, returnPath and action mode
+ */
+export function getSearchAction(params, returnPath) {
+  const mode = params.get('action') || 'add';
+  return {
+    mode,
+    label: `${mode === 'add' ? 'add' : 'edit'}ing`,
+    pathToGo: mode === 'update' ? '/review-and-submit' : `/${returnPath}`,
+  };
+}
+
+/**
+ * Helper that takes query params and looks for an associated index in the
+ * provided array
+ * @param {Object} params - the URL Search Params object to query
+ * @param {Array} array - the array from which to find the index value
+ * @returns {Number} - the desired index of the array
+ */
+export function getSearchIndex(params, array = []) {
+  let indexToReturn = parseInt(params.get('index'), 10);
+  if (Number.isNaN(indexToReturn) || indexToReturn > array.length) {
+    indexToReturn = array.length;
+  }
+  return indexToReturn;
+}
+
+/**
+ * Helper that determines the default dataset to use based on search params
+ * @param {Object} props - the params to use to parse the default state
+ * @returns {Object} - the parsed state data
+ */
+export function getDefaultState(props) {
+  const {
+    searchIndex,
+    searchAction,
+    defaultData = {},
+    dataToSearch = [],
+    name,
+  } = props;
+  const resultToReturn = { ...defaultData };
+
+  // check if data exists at the array index and set return result accordingly
+  if (typeof dataToSearch[searchIndex] !== 'undefined') {
+    resultToReturn.data = dataToSearch[searchIndex];
+
+    if (searchAction.mode !== 'add') {
+      window.sessionStorage.setItem(name, searchIndex);
+    }
+  }
+
+  return resultToReturn;
+}


### PR DESCRIPTION
## Summary
This PR addresses an issue with partial dependent records being saved in progress for authenticated users without a validation mechanism in place to force them to update the records when coming back to the application. The PR temporarily removes the ability for dependent records to be saved in progress while a long-term validation mechanism can be developed.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#69132

## Testing done
- [x] Unit tested all helper functions to ensure correct output
- [x] Ran through multiple scenarios with live data and checked Redux records to ensure no partial records were being saved 
## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
