### PR TITLE
[Rated Disabilities] Ensure app waits for feature flags to load before rendering

### DIFF
--- a/src/applications/rated-disabilities/components/AppContent.jsx
+++ b/src/applications/rated-disabilities/components/AppContent.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const loadingIndicator = (
+  <va-loading-indicator
+    data-testid="feature-flags-loading"
+    message="Loading your information..."
+  />
+);
+
+export default function AppContent({ children, featureFlagsLoading }) {
+  return !featureFlagsLoading ? children : loadingIndicator;
+}
+
+AppContent.propTypes = {
+  children: PropTypes.node,
+  featureFlagsLoading: PropTypes.bool,
+};

--- a/src/applications/rated-disabilities/containers/RatedDisabilitiesApp.jsx
+++ b/src/applications/rated-disabilities/containers/RatedDisabilitiesApp.jsx
@@ -5,17 +5,19 @@ import { connect } from 'react-redux';
 import DowntimeNotification, {
   externalServices,
 } from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
-import { toggleValues } from '@department-of-veterans-affairs/platform-site-wide/selectors';
 import { RequiredLoginView } from '@department-of-veterans-affairs/platform-user/RequiredLoginView';
 import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
-import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 
 import { fetchRatedDisabilities, fetchTotalDisabilityRating } from '../actions';
 import RatedDisabilityView from '../components/RatedDisabilityView';
-import { rdDetectDiscrepancies } from '../selectors';
+import {
+  isLoadingFeatures,
+  rdDetectDiscrepancies,
+  rdSortAbTest,
+} from '../selectors';
 
 const RatedDisabilitiesApp = props => {
-  const { ratedDisabilities } = props.ratedDisabilities;
+  const { featureFlagsLoading, ratedDisabilities } = props.ratedDisabilities;
 
   return (
     <RequiredLoginView
@@ -32,17 +34,26 @@ const RatedDisabilitiesApp = props => {
           externalServices.vbms,
         ]}
       >
-        <RatedDisabilityView
-          detectDiscrepancies={props.detectDiscrepancies}
-          error={props.error}
-          fetchRatedDisabilities={props.fetchRatedDisabilities}
-          fetchTotalDisabilityRating={props.fetchTotalDisabilityRating}
-          loading={props.loading}
-          ratedDisabilities={ratedDisabilities}
-          sortToggle={props.sortToggle}
-          totalDisabilityRating={props.totalDisabilityRating}
-          user={props.user}
-        />
+        {!featureFlagsLoading ? (
+          <RatedDisabilityView
+            detectDiscrepancies={props.detectDiscrepancies}
+            error={props.error}
+            fetchRatedDisabilities={props.fetchRatedDisabilities}
+            fetchTotalDisabilityRating={props.fetchTotalDisabilityRating}
+            loading={props.loading}
+            ratedDisabilities={ratedDisabilities}
+            sortToggle={props.sortToggle}
+            totalDisabilityRating={props.totalDisabilityRating}
+            user={props.user}
+          />
+        ) : (
+          <div className="vads-u-margin-y--5">
+            <va-loading-indicator
+              data-testid="feature-flags-loading"
+              message="Loading your information..."
+            />
+          </div>
+        )}
       </DowntimeNotification>
     </RequiredLoginView>
   );
@@ -63,11 +74,10 @@ RatedDisabilitiesApp.propTypes = {
 const mapStateToProps = state => ({
   detectDiscrepancies: rdDetectDiscrepancies(state),
   error: state.totalRating.error,
+  featureFlagsLoading: isLoadingFeatures(state),
   loading: state.totalRating.loading,
   ratedDisabilities: state.ratedDisabilities,
-  sortToggle: toggleValues(state)[
-    FEATURE_FLAG_NAMES.ratedDisabilitiesSortAbTest
-  ],
+  sortToggle: rdSortAbTest(state),
   totalDisabilityRating: state.totalRating.totalDisabilityRating,
   user: state.user,
 });

--- a/src/applications/rated-disabilities/containers/RatedDisabilitiesApp.jsx
+++ b/src/applications/rated-disabilities/containers/RatedDisabilitiesApp.jsx
@@ -9,6 +9,7 @@ import { RequiredLoginView } from '@department-of-veterans-affairs/platform-user
 import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
 
 import { fetchRatedDisabilities, fetchTotalDisabilityRating } from '../actions';
+import AppContent from '../components/AppContent';
 import RatedDisabilityView from '../components/RatedDisabilityView';
 import {
   isLoadingFeatures,
@@ -20,42 +21,37 @@ const RatedDisabilitiesApp = props => {
   const { featureFlagsLoading, ratedDisabilities } = props.ratedDisabilities;
 
   return (
-    <RequiredLoginView
-      serviceRequired={backendServices.USER_PROFILE}
-      user={props.user}
-    >
-      <DowntimeNotification
-        appTitle="Rated Disabilities"
-        dependencies={[
-          externalServices.evss,
-          externalServices.global,
-          externalServices.mvi,
-          externalServices.vaProfile,
-          externalServices.vbms,
-        ]}
+    <div className="vads-u-margin-y--5">
+      <RequiredLoginView
+        serviceRequired={backendServices.USER_PROFILE}
+        user={props.user}
       >
-        {!featureFlagsLoading ? (
-          <RatedDisabilityView
-            detectDiscrepancies={props.detectDiscrepancies}
-            error={props.error}
-            fetchRatedDisabilities={props.fetchRatedDisabilities}
-            fetchTotalDisabilityRating={props.fetchTotalDisabilityRating}
-            loading={props.loading}
-            ratedDisabilities={ratedDisabilities}
-            sortToggle={props.sortToggle}
-            totalDisabilityRating={props.totalDisabilityRating}
-            user={props.user}
-          />
-        ) : (
-          <div className="vads-u-margin-y--5">
-            <va-loading-indicator
-              data-testid="feature-flags-loading"
-              message="Loading your information..."
+        <DowntimeNotification
+          appTitle="Rated Disabilities"
+          dependencies={[
+            externalServices.evss,
+            externalServices.global,
+            externalServices.mvi,
+            externalServices.vaProfile,
+            externalServices.vbms,
+          ]}
+        >
+          <AppContent featureFlagsLoading={featureFlagsLoading}>
+            <RatedDisabilityView
+              detectDiscrepancies={props.detectDiscrepancies}
+              error={props.error}
+              fetchRatedDisabilities={props.fetchRatedDisabilities}
+              fetchTotalDisabilityRating={props.fetchTotalDisabilityRating}
+              loading={props.loading}
+              ratedDisabilities={ratedDisabilities}
+              sortToggle={props.sortToggle}
+              totalDisabilityRating={props.totalDisabilityRating}
+              user={props.user}
             />
-          </div>
-        )}
-      </DowntimeNotification>
-    </RequiredLoginView>
+          </AppContent>
+        </DowntimeNotification>
+      </RequiredLoginView>
+    </div>
   );
 };
 

--- a/src/applications/rated-disabilities/selectors.js
+++ b/src/applications/rated-disabilities/selectors.js
@@ -24,9 +24,16 @@ export const hasTotalDisabilityServerError = state => {
 };
 
 // Feature toggles
+export const isLoadingFeatures = state => toggleValues(state).loading;
+
+// 'rated_disabilities_detect_discrepancies'
+export const rdDetectDiscrepancies = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.ratedDisabilitiesDetectDiscrepancies];
+
 // 'rated_disabilities_use_lighthouse`
 export const rdUseLighthouse = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.ratedDisabilitiesUseLighthouse];
 
-export const rdDetectDiscrepancies = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.ratedDisabilitiesDetectDiscrepancies];
+// 'rated_disabilities_sort_ab_test'
+export const rdSortAbTest = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.ratedDisabilitiesSortAbTest];

--- a/src/applications/rated-disabilities/tests/components/AppContent.unit.spec.jsx
+++ b/src/applications/rated-disabilities/tests/components/AppContent.unit.spec.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+
+import AppContent from '../../components/AppContent';
+
+describe('<AppContent />', () => {
+  it('should render loading indicator if feature toggles are not available', () => {
+    const screen = render(
+      <AppContent featureFlagsLoading>
+        <div data-testid="children" />
+      </AppContent>,
+    );
+
+    expect(screen.getByTestId('feature-flags-loading')).to.exist;
+    expect(screen.queryByTestId('children')).to.not.exist;
+  });
+
+  it('should render children if feature toggles are available', () => {
+    const screen = render(
+      <AppContent featureFlagsLoading={false}>
+        <div data-testid="children" />
+      </AppContent>,
+    );
+
+    expect(screen.queryByTestId('feature-flags-loading')).to.not.exist;
+    expect(screen.queryByTestId('children')).to.exist;
+  });
+});

--- a/src/applications/rated-disabilities/tests/containers/RatedDisabilitiesApp.unit.spec.jsx
+++ b/src/applications/rated-disabilities/tests/containers/RatedDisabilitiesApp.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
+
 import { RatedDisabilitiesApp } from '../../containers/RatedDisabilitiesApp';
 
 describe('<RatedDisabilityApp/>', () => {
@@ -12,6 +13,7 @@ describe('<RatedDisabilityApp/>', () => {
     verifyUrl: '',
     fetchRatedDisabilities: sinon.stub(),
   };
+
   it('should render a RequiredLoginView', () => {
     const wrapper = shallow(
       <RatedDisabilitiesApp {...props}>


### PR DESCRIPTION
## Summary
We are going to be using a feature toggle inside of a `useEffect` hook to control whether we call a vets-api endpoint that uses EVSS, or a different one that uses Lighthouse to retrieve rated disabilities data. In order to avoid the edge case where the `useEffect` is called before the feature flags have finished loading, I added a component that checks the value of the featureFlags loading flag and only renders the application when it is false (which indicates that the call to get feature toggles has completed)

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#63310

## Testing done
Added unit tests to check that the expected content (either the children node or a loading-indicator) is rendered based on the value of the featureFlagsLoading value

## What areas of the site does it impact?
Rated Disabilities App
*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
