### PR TITLE
Added setECheckinStartedCalled to context and pass through on check-in.

### DIFF
--- a/src/applications/check-in/actions/day-of/day-of.actions.unit.spec.js
+++ b/src/applications/check-in/actions/day-of/day-of.actions.unit.spec.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-
 import {
   receivedMultipleAppointmentDetails,
   RECEIVED_APPOINTMENT_DETAILS,
@@ -9,6 +8,8 @@ import {
   TRIGGER_REFRESH,
   SEE_STAFF_MESSAGE_UPDATED,
   seeStaffMessageUpdated,
+  additionalContext,
+  ADDITIONAL_CONTEXT,
 } from './index';
 
 describe('check in actions', () => {
@@ -56,6 +57,16 @@ describe('check in actions', () => {
       it('should return correct structure', () => {
         const action = seeStaffMessageUpdated('test');
         expect(action.payload.seeStaffMessage).to.equal('test');
+      });
+    });
+    describe('additionalContext', () => {
+      it('should return correct action', () => {
+        const action = additionalContext();
+        expect(action.type).to.equal(ADDITIONAL_CONTEXT);
+      });
+      it('should return correct structure', () => {
+        const action = additionalContext({ newContext: true });
+        expect(action.payload.context.newContext).to.equal(true);
       });
     });
   });

--- a/src/applications/check-in/actions/day-of/index.js
+++ b/src/applications/check-in/actions/day-of/index.js
@@ -68,11 +68,11 @@ export const updateFormAction = ({
 
 export const ADDITIONAL_CONTEXT = 'ADDITIONAL_CONTEXT';
 
-export const additionalContext = ({ setECheckinStartedCalled }) => {
+export const additionalContext = newContext => {
   return {
     type: ADDITIONAL_CONTEXT,
     payload: {
-      context: { setECheckinStartedCalled },
+      context: newContext,
     },
   };
 };

--- a/src/applications/check-in/actions/day-of/index.js
+++ b/src/applications/check-in/actions/day-of/index.js
@@ -65,3 +65,14 @@ export const updateFormAction = ({
     },
   };
 };
+
+export const ADDITIONAL_CONTEXT = 'ADDITIONAL_CONTEXT';
+
+export const additionalContext = ({ setECheckinStartedCalled }) => {
+  return {
+    type: ADDITIONAL_CONTEXT,
+    payload: {
+      context: { setECheckinStartedCalled },
+    },
+  };
+};

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/check-in-data/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/check-in-data/get.js
@@ -39,6 +39,7 @@ const createMockSuccessResponse = (
         emergencyContactNeedsUpdate,
         emergencyContactConfirmedAt,
       },
+      setECheckinStartedCalled: true,
     },
   };
   if (hasBeenValidated) {

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/shared/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/shared/get.js
@@ -253,6 +253,7 @@ const createAppointments = (
         emergencyContactNeedsUpdate,
         emergencyContactConfirmedAt,
       },
+      setECheckinStartedCalled: true,
     },
   };
 };

--- a/src/applications/check-in/api/versions/v2.js
+++ b/src/applications/check-in/api/versions/v2.js
@@ -68,7 +68,12 @@ const v2 = {
       ...json,
     };
   },
-  postCheckInData: async ({ uuid, appointmentIen, facilityId }) => {
+  postCheckInData: async ({
+    uuid,
+    appointmentIen,
+    facilityId,
+    setECheckinStartedCalled,
+  }) => {
     const url = '/check_in/v2/patient_check_ins/';
     const headers = { 'Content-Type': 'application/json' };
     const data = {
@@ -76,6 +81,7 @@ const v2 = {
         uuid,
         appointmentIen,
         facilityId,
+        setECheckinStartedCalled,
       },
     };
     const body = JSON.stringify(data);

--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentAction.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentAction.jsx
@@ -20,7 +20,7 @@ const AppointmentAction = props => {
   const { appointment, router, event } = props;
 
   const selectCurrentContext = useMemo(makeSelectCurrentContext, []);
-  const { token } = useSelector(selectCurrentContext);
+  const { token, setECheckinStartedCalled } = useSelector(selectCurrentContext);
 
   const { setCheckinComplete } = useStorage(false);
 
@@ -38,7 +38,8 @@ const AppointmentAction = props => {
         const json = await api.v2.postCheckInData({
           uuid: token,
           appointmentIen: appointment.appointmentIen,
-          facilityId: appointment.facilityId,
+          facilityId: 'appointment.facilityId',
+          setECheckinStartedCalled,
         });
         const { status } = json;
         if (status === 200) {

--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentAction.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentAction.jsx
@@ -52,7 +52,15 @@ const AppointmentAction = props => {
         updateError('error-completing-check-in');
       }
     },
-    [appointment, updateError, jumpToPage, token, event, setCheckinComplete],
+    [
+      appointment,
+      updateError,
+      jumpToPage,
+      token,
+      event,
+      setCheckinComplete,
+      setECheckinStartedCalled,
+    ],
   );
   if (
     appointment.eligibility &&

--- a/src/applications/check-in/hooks/useGetCheckInData.jsx
+++ b/src/applications/check-in/hooks/useGetCheckInData.jsx
@@ -90,7 +90,15 @@ const useGetCheckInData = ({
         }
       });
     },
-    [appointmentsOnly, dispatch, token, isTravelReimbursementEnabled, reload],
+    [
+      appointmentsOnly,
+      dispatch,
+      token,
+      isTravelReimbursementEnabled,
+      reload,
+      getTravelPaySent,
+      isTravelLogicEnabled,
+    ],
   );
 
   const setPreCheckInData = useCallback(

--- a/src/applications/check-in/hooks/useGetCheckInData.jsx
+++ b/src/applications/check-in/hooks/useGetCheckInData.jsx
@@ -13,6 +13,7 @@ import {
   receivedMultipleAppointmentDetails,
   triggerRefresh,
   updateFormAction as updateDayOfForm,
+  additionalContext,
 } from '../actions/day-of';
 
 import {
@@ -65,10 +66,11 @@ const useGetCheckInData = ({
           appointments,
           demographics,
           patientDemographicsStatus,
+          setECheckinStartedCalled,
         } = payload;
         dispatch(triggerRefresh(false));
         dispatch(receivedMultipleAppointmentDetails(appointments, token));
-
+        dispatch(additionalContext({ setECheckinStartedCalled }));
         if (!appointmentsOnly) {
           const travelPaySent = getTravelPaySent(window);
           dispatch(receivedDemographicsData(demographics));

--- a/src/applications/check-in/reducers/day-of/day-of.reducers.unit.spec.js
+++ b/src/applications/check-in/reducers/day-of/day-of.reducers.unit.spec.js
@@ -5,6 +5,7 @@ import {
   receivedAppointmentDetailsHandler,
   seeStaffMessageUpdatedHandler,
   triggerRefreshHandler,
+  additionalContextHandler,
 } from './index';
 
 import { updateFormHandler } from '../navigation';
@@ -15,6 +16,7 @@ import {
   seeStaffMessageUpdated,
   triggerRefresh,
   updateFormAction,
+  additionalContext,
 } from '../../actions/day-of';
 
 import appReducer from '../index';
@@ -246,6 +248,28 @@ describe('check in', () => {
             'details',
             'complete',
           ]);
+        });
+      });
+      describe('additionalContext', () => {
+        describe('additionalContextHandler', () => {
+          it('should create basic structure', () => {
+            const action = additionalContext({ newContextValue: true });
+            const state = additionalContextHandler({}, action);
+            expect(state).haveOwnProperty('context');
+            expect(state.context).haveOwnProperty('newContextValue');
+          });
+          it('should set the correct values', () => {
+            const action = additionalContext({ newContextValue: true });
+            const state = additionalContextHandler({}, action);
+            expect(state.context.newContextValue).to.equal(true);
+          });
+        });
+        describe('reducer is called; finds the correct handler', () => {
+          it('finds the correct handler', () => {
+            const action = additionalContext({ newContextValue: true });
+            const state = appReducer.checkInData(undefined, action);
+            expect(state.context.newContextValue).to.equal(true);
+          });
         });
       });
     });

--- a/src/applications/check-in/reducers/day-of/index.js
+++ b/src/applications/check-in/reducers/day-of/index.js
@@ -26,9 +26,17 @@ const seeStaffMessageUpdatedHandler = (state, action) => {
   return { ...state, ...action.payload };
 };
 
+const additionalContextHandler = (state, action) => {
+  return {
+    ...state,
+    context: { ...state.context, ...action.payload.context },
+  };
+};
+
 export {
   triggerRefreshHandler,
   receivedAppointmentDetailsHandler,
   receivedDemographicsDataHandler,
   seeStaffMessageUpdatedHandler,
+  additionalContextHandler,
 };

--- a/src/applications/check-in/reducers/index.js
+++ b/src/applications/check-in/reducers/index.js
@@ -25,6 +25,7 @@ import {
   TRIGGER_REFRESH,
   SEE_STAFF_MESSAGE_UPDATED,
   UPDATE_DAY_OF_CHECK_IN_FORM,
+  ADDITIONAL_CONTEXT,
 } from '../actions/day-of';
 
 import {
@@ -32,6 +33,7 @@ import {
   receivedDemographicsDataHandler,
   triggerRefreshHandler,
   seeStaffMessageUpdatedHandler,
+  additionalContextHandler,
 } from './day-of';
 
 import { setAppHandler, setErrorHandler, setFormHandler } from './universal';
@@ -65,6 +67,7 @@ const handler = Object.freeze({
   [SET_APP]: setAppHandler,
   [SET_ERROR]: setErrorHandler,
   [SET_FORM]: setFormHandler,
+  [ADDITIONAL_CONTEXT]: additionalContextHandler,
 
   default: state => {
     return { ...state };

--- a/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
+++ b/src/applications/check-in/utils/appointment/appointment.utils.unit.spec.js
@@ -21,7 +21,6 @@ import {
 import { get } from '../../api/local-mock-api/mocks/v2/shared';
 import { ELIGIBILITY } from './eligibility';
 
-// Re-test stress tests.
 describe('check in', () => {
   afterEach(() => {
     MockDate.reset();
@@ -58,12 +57,12 @@ describe('check in', () => {
         ).to.equal(false);
       });
       it('returns false if the selected appointment is found and is the only eligible appointment', () => {
-        const selectedAppointment = createAppointment(
-          'ELIGIBLE',
-          'some-facility',
-          'some-ien',
-          'TEST CLINIC',
-        );
+        const selectedAppointment = createAppointment({
+          eligibility: 'ELIGIBLE',
+          facility: 'some-facility',
+          appointmentIen: 'some-ien',
+          clinicFriendlyName: 'TEST CLINIC',
+        });
         const appointments = [
           createAppointment({ eligibility: 'INELIGIBLE_TOO_EARLY' }),
           createAppointment({ eligibility: 'INELIGIBLE_TOO_EARLY' }),
@@ -76,12 +75,12 @@ describe('check in', () => {
         ).to.equal(false);
       });
       it('returns true if the selected appointment is found and there are more eligible appointments', () => {
-        const selectedAppointment = createAppointment(
-          'ELIGIBLE',
-          'some-facility',
-          'some-ien',
-          'TEST CLINIC',
-        );
+        const selectedAppointment = createAppointment({
+          eligibility: 'ELIGIBLE',
+          facilityId: 'some-facility',
+          appointmentIen: 'some-ien',
+          clinicFriendlyName: 'TEST CLINIC',
+        });
         const appointments = [
           createAppointment({ eligibility: 'INELIGIBLE_TOO_EARLY' }),
           createAppointment({ eligibility: 'INELIGIBLE_TOO_EARLY' }),


### PR DESCRIPTION
## Summary

This PR adds a generic action and handler for setting additional items in redux context. This use case is to pass back the 45 minute window state of eCheckInStarted back to vets-api for this ticket: https://app.zenhub.com/workspaces/check-in-experience-61fc23a2cb8a14001132e102/issues/gh/department-of-veterans-affairs/va.gov-team/66835

I would like us to also use this method of setting data to context for this upcoming frontend ticket: https://app.zenhub.com/workspaces/check-in-experience-61fc23a2cb8a14001132e102/issues/gh/department-of-veterans-affairs/va.gov-team/68165

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#66835

## Testing done

Adds unit tests.

## What areas of the site does it impact?

logging in vets-api

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

