### PR TITLE
Adjust positioning of HCA SIP dependent warning

### DIFF
--- a/src/applications/hca/components/FormAlerts/index.jsx
+++ b/src/applications/hca/components/FormAlerts/index.jsx
@@ -129,7 +129,7 @@ export const DependentSIPWarning = () => (
   <va-alert
     status="warning"
     data-testid="hca-sip-warning"
-    class="vads-u-margin-bottom--4"
+    class="vads-u-margin-bottom--2"
     background-only
   >
     <p className="vads-u-margin-y--0">

--- a/src/applications/hca/components/FormFields/DependentListLoopForm.jsx
+++ b/src/applications/hca/components/FormFields/DependentListLoopForm.jsx
@@ -18,11 +18,11 @@ const DependentListLoopForm = props => {
   const currentUISchema = {
     ...uiSchema[page.id],
     'ui:title': page.title.replace(/%s/g, nameToDisplay),
-    'ui:description': isLoggedIn ? DependentSIPWarning : undefined,
   };
 
   return (
     <>
+      {isLoggedIn ? <DependentSIPWarning /> : null}
       <SchemaForm
         name="Dependent"
         title="Dependent"


### PR DESCRIPTION
## Summary
This PR adjusts the positioning of the save-in-progress warning for dependents on the Health Care Application to move it above the page title.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#69132

## Acceptance criteria
- Alert is properly placed according to the desired UX positioning.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution