### PR TITLE
[Rated Disabilities] Fix issue with margins

### DIFF
--- a/src/applications/rated-disabilities/components/AppContent.jsx
+++ b/src/applications/rated-disabilities/components/AppContent.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const loadingIndicator = (
-  <va-loading-indicator
-    data-testid="feature-flags-loading"
-    message="Loading your information..."
-  />
+  <div className="vads-u-margin-y--5">
+    <va-loading-indicator
+      data-testid="feature-flags-loading"
+      message="Loading your information..."
+    />
+  </div>
 );
 
 export default function AppContent({ children, featureFlagsLoading }) {

--- a/src/applications/rated-disabilities/containers/RatedDisabilitiesApp.jsx
+++ b/src/applications/rated-disabilities/containers/RatedDisabilitiesApp.jsx
@@ -21,37 +21,35 @@ const RatedDisabilitiesApp = props => {
   const { featureFlagsLoading, ratedDisabilities } = props.ratedDisabilities;
 
   return (
-    <div className="vads-u-margin-y--5">
-      <RequiredLoginView
-        serviceRequired={backendServices.USER_PROFILE}
-        user={props.user}
+    <RequiredLoginView
+      serviceRequired={backendServices.USER_PROFILE}
+      user={props.user}
+    >
+      <DowntimeNotification
+        appTitle="Rated Disabilities"
+        dependencies={[
+          externalServices.evss,
+          externalServices.global,
+          externalServices.mvi,
+          externalServices.vaProfile,
+          externalServices.vbms,
+        ]}
       >
-        <DowntimeNotification
-          appTitle="Rated Disabilities"
-          dependencies={[
-            externalServices.evss,
-            externalServices.global,
-            externalServices.mvi,
-            externalServices.vaProfile,
-            externalServices.vbms,
-          ]}
-        >
-          <AppContent featureFlagsLoading={featureFlagsLoading}>
-            <RatedDisabilityView
-              detectDiscrepancies={props.detectDiscrepancies}
-              error={props.error}
-              fetchRatedDisabilities={props.fetchRatedDisabilities}
-              fetchTotalDisabilityRating={props.fetchTotalDisabilityRating}
-              loading={props.loading}
-              ratedDisabilities={ratedDisabilities}
-              sortToggle={props.sortToggle}
-              totalDisabilityRating={props.totalDisabilityRating}
-              user={props.user}
-            />
-          </AppContent>
-        </DowntimeNotification>
-      </RequiredLoginView>
-    </div>
+        <AppContent featureFlagsLoading={featureFlagsLoading}>
+          <RatedDisabilityView
+            detectDiscrepancies={props.detectDiscrepancies}
+            error={props.error}
+            fetchRatedDisabilities={props.fetchRatedDisabilities}
+            fetchTotalDisabilityRating={props.fetchTotalDisabilityRating}
+            loading={props.loading}
+            ratedDisabilities={ratedDisabilities}
+            sortToggle={props.sortToggle}
+            totalDisabilityRating={props.totalDisabilityRating}
+            user={props.user}
+          />
+        </AppContent>
+      </DowntimeNotification>
+    </RequiredLoginView>
   );
 };
 


### PR DESCRIPTION
## Summary
I added a div with a class of `vads-u-margin-y--5` to the app to help deal with cases where the loading indicator is rendered by the app. I applied this to the whole app container, but realized that that affected the margin-top of the whole app, so I'm moving the div to the appropriate location

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#66310

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | ![Screenshot 2023-11-07 at 3 13 34 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/7be39e26-d094-46dc-b677-158741858801) | ![Screenshot 2023-11-07 at 3 13 13 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/8422bab3-af78-4e56-83f8-a70d80a80dc9) |

## What areas of the site does it impact?
Rated Disabilities Application

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
