### PR TITLE
MBMS-53309 Erroneous Text On Applicant Information Bug

### DIFF
--- a/src/applications/pre-need/config/pages/nonVeteranApplicantDetails.jsx
+++ b/src/applications/pre-need/config/pages/nonVeteranApplicantDetails.jsx
@@ -18,7 +18,7 @@ const { claimant } = fullSchemaPreNeed.properties.application.properties;
 
 export const uiSchema = !environment.isProduction()
   ? {
-      'ui:description': applicantDescription,
+      'ui:description': environment.isProduction() ? applicantDescription : '', // Connor Fewin - MBMS-53309 (delete entire line when removing prod flag)
       application: {
         'ui:title': applicantDetailsSubHeader,
         claimant: {
@@ -35,7 +35,11 @@ export const uiSchema = !environment.isProduction()
       },
     }
   : {
-      'ui:description': applicantDescription,
+      /* 
+       * Connor Fewin - MBMS-53309 (delete entire line when removing prod flag) 
+       * This is fine to be deleted when the parent prod flag is deleted.
+       */
+      'ui:description': environment.isProduction() ? applicantDescription : '',
       application: {
         'ui:title': applicantDetailsSubHeader,
         claimant: {


### PR DESCRIPTION


## Steps to reproduce:

1. Go to pre-need application
2. On the Applicant Information screen 1, select Non-Veteran (e.g., spouse or surviving spouse)
3. Click “Continue”
4. You will be navigated to Applicant Information screen 2

Expected Results: The text “You aren’t required to fill all fields, but we can review your application faster if you provide more information.” should not appear on Applicant Information Screen 2; Non-Veteran flow.

Actual Results: The text “You aren’t required to fill all fields, but we can review your application faster if you provide more information.” appears on the Applicant Information Screen 2; Non-Veteran flow.

## Related issue(s)

- Jira Link: [MBMS-53309](https://jira.devops.va.gov/browse/MBMS-53309)

## Testing done

- [ ] Unit Tests Passing
- [ ] 100% Code Coverage on affected components/pages

## Screenshots

### Before
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/122034971/5e547d5d-b935-486f-b976-205c982d0eb2)

### After
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/122034971/eb988fde-7b03-4c53-af4f-44059c19a8e7)
