### PR TITLE
Reenable deep linking PACT Act test after devops change

### DIFF
--- a/src/applications/pact-act/tests/cypress/service-period-during-both/deep-linking.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/deep-linking.cypress.spec.js
@@ -5,7 +5,7 @@ import { ROUTES } from '../../../constants';
 // target the shadow DOM
 // Skipping temporarily while we do a URL change in devops (this will fail until that change is implemented)
 // To be un-skipped on Wednesday, Nov 8
-xdescribe('PACT Act', () => {
+describe('PACT Act', () => {
   describe('During both of these time periods - deep linking', () => {
     it('redirects to home when the service period page is loaded without the right criteria', () => {
       cy.visit(`${h.ROOT}/${ROUTES.SERVICE_PERIOD}`);


### PR DESCRIPTION
## Summary
Last week I disabled the PACT Act test for deep-linking as we needed to wait until the `devops` change for enabling client-side routing had the new PACT Act URL (`/pact-act-eligibility`). This change has been merged and is working, so now we can enable this test again.

Related ticket: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15699
