### PR TITLE
add onNavBack and onNavForward to pageConfig options

### DIFF
--- a/src/platform/forms-system/src/js/containers/FormPage.jsx
+++ b/src/platform/forms-system/src/js/containers/FormPage.jsx
@@ -90,6 +90,15 @@ class FormPage extends React.Component {
 
     const path = getNextPagePath(route.pageList, form.data, location.pathname);
 
+    if (typeof route.pageConfig.onNavForward === 'function') {
+      route.pageConfig.onNavForward({
+        formData,
+        goPath: customPath => this.props.router.push(customPath),
+        goNextPath: () => this.props.router.push(path),
+      });
+      return;
+    }
+
     this.props.router.push(path);
   };
 
@@ -109,13 +118,22 @@ class FormPage extends React.Component {
   };
 
   goBack = () => {
-    const {
-      form,
-      route: { pageList },
-      location,
-    } = this.props;
+    const { form, route, location } = this.props;
 
-    const path = getPreviousPagePath(pageList, form.data, location.pathname);
+    const path = getPreviousPagePath(
+      route.pageList,
+      form.data,
+      location.pathname,
+    );
+
+    if (typeof route.pageConfig.onNavBack === 'function') {
+      route.pageConfig.onNavBack({
+        formData: form.data,
+        goPath: customPath => this.props.router.push(customPath),
+        goPreviousPath: () => this.props.router.push(path),
+      });
+      return;
+    }
 
     this.props.router.push(path);
   };
@@ -281,6 +299,8 @@ FormPage.propTypes = {
         PropTypes.func,
       ]),
       onContinue: PropTypes.func,
+      onNavBack: PropTypes.func,
+      onNavForward: PropTypes.func,
       pageClass: PropTypes.string,
       pageKey: PropTypes.string.isRequired,
       schema: PropTypes.object.isRequired,

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -142,7 +142,9 @@
  * @property {(props: any) => JSX.Element} [CustomPageReview]
  * @property {((formData: Object) => boolean) | {}} [depends] optional condition when page should be shown or not
  * @property {Object} [initialData]
- * @property {(formData: any) => void} [onContinue]
+ * @property {(formData: any) => void} [onContinue] Called when user clicks continue button. For simple callbacks/events. If you instead want to navigate to a different page, use onNavForward.
+ * @property {({ formData, goPath, goPreviousPath }: { formData, goPath: (path: string) => void, goPreviousPath: () => void }) => void} [onNavBack] Called instead of default navigation when user clicks back button. Use goPath or goPreviousPath to navigate.
+ * @property {({ formData, goPath, goNextPath }: { formData, goPath: (path: string) => void, goNextPath: () => void }) => void} [onNavForward] Called instead of default navigation when user clicks continue button. Use goPath or goNextPath to navigate.
  * @property {(data: any) => boolean} [itemFilter]
  * @property {string} [path] url path for page e.g. `'name-of-path'`, or `'name-of-path/:index'` for an array item page. Results in `http://localhost:3001/my-form/name-of-path`
  * @property {string} [returnUrl]

--- a/src/platform/forms-system/test/js/containers/FormPage.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/containers/FormPage.unit.spec.jsx
@@ -152,6 +152,96 @@ describe('Schemaform <FormPage>', () => {
       expect(router.push.calledWith('/last-page')).to.be.true;
     });
   });
+
+  describe('should allow a dynamic customized forward and back navigation paths', () => {
+    let tree;
+    let setData;
+    let router;
+    let onSubmit;
+    const baseForm = makeForm();
+    const testPageConfig = {
+      schema: {
+        type: 'object',
+        properties: {
+          test: { type: 'string' },
+        },
+      },
+      uiSchema: {},
+      onNavForward: ({ formData, goPath, goNextPath }) => {
+        if (formData.test) {
+          goPath('last-page');
+        } else {
+          goNextPath();
+        }
+      },
+      onNavBack: ({ formData, goPath, goPreviousPath }) => {
+        if (formData.test) {
+          goPath('last-page');
+        } else {
+          goPreviousPath();
+        }
+      },
+    };
+
+    function renderForm(data) {
+      tree = SkinDeep.shallowRender(
+        <FormPage
+          router={router}
+          setData={setData}
+          form={{
+            pages: {
+              firstPage: baseForm.pages.firstPage,
+              testPage: testPageConfig,
+              nextPage: baseForm.pages.nextPage,
+              lastPage: baseForm.pages.lastPage,
+            },
+            data,
+          }}
+          onSubmit={onSubmit}
+          location={{ pathname: '/testing' }}
+          route={makeRoute({
+            pageConfig: {
+              pageKey: 'testPage',
+              ...testPageConfig,
+            },
+          })}
+        />,
+      );
+    }
+
+    beforeEach(() => {
+      setData = sinon.spy();
+      onSubmit = sinon.spy();
+      router = {
+        push: sinon.spy(),
+      };
+    });
+
+    it('onNavForward goNextPath works correctly', () => {
+      renderForm({ test: '' });
+      tree.getMountedInstance().onSubmit({ formData: { test: '' } });
+      expect(router.push.calledWith('/next-page')).to.be.true;
+    });
+
+    it('onNavForward goPath works correctly', () => {
+      renderForm({ test: 'test' });
+      tree.getMountedInstance().onSubmit({ formData: { test: 'test' } });
+      expect(router.push.calledWith('last-page')).to.be.true;
+    });
+
+    it('onNavBack goPreviousPath works correctly', () => {
+      renderForm({ test: '' });
+      tree.getMountedInstance().goBack({ formData: { test: '' } });
+      expect(router.push.calledWith('/first-page')).to.be.true;
+    });
+
+    it('onNavBack goPath works correctly', () => {
+      renderForm({ test: 'test' });
+      tree.getMountedInstance().goBack({ formData: { test: 'test' } });
+      expect(router.push.calledWith('last-page')).to.be.true;
+    });
+  });
+
   it("should go back to the beginning if current page isn't found", () => {
     const router = {
       push: sinon.spy(),


### PR DESCRIPTION
## Summary

Add `onNavForward` and `onNavBack` to pageConfig options
Used like this:
```
onNavForward: ({ formData, goPath, goNextPath }) => {
  if (formData.something) {
    goPath('custom-path');
  } else {
    goNextPath();
  }
},
onNavBack: ({ formData, goPath, goPreviousPath }) => {
  if (formData.something) {
    goPath('custom-path');
  } else {
    goPreviousPath();
  }
}
```
- This is to enable upcoming list-and-loop work

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#747

## Testing done

- Tested that the methods work as expected and that no regressions happen in the existing code

## What areas of the site does it impact?

Nothing existing. This is a new feature.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
