### PR TITLE
Adds drop-in maintenance alert for Enrollment Verification

### DIFF
--- a/src/applications/enrollment-verification/containers/EnrollmentVerificationIntroPage.jsx
+++ b/src/applications/enrollment-verification/containers/EnrollmentVerificationIntroPage.jsx
@@ -3,6 +3,8 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 
+import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
+
 import { fetchPost911GiBillEligibility } from '../actions';
 
 import EnrollmentVerificationLoadingIndicator from '../components/EnrollmentVerificationLoadingIndicator';
@@ -22,6 +24,7 @@ export function EnrollmentVerificationIntroPage({
   hasCheckedKeepAlive,
   getPost911GiBillEligibility,
   post911GiBillEligibility,
+  showMebEnrollmentVerificationMaintenanceAlert,
 }) {
   const history = useHistory();
   const [
@@ -83,6 +86,23 @@ export function EnrollmentVerificationIntroPage({
 
   return (
     <EnrollmentVerificationPageWrapper>
+      {showMebEnrollmentVerificationMaintenanceAlert && (
+        <va-alert
+          close-btn-aria-label="Close notification"
+          status="error"
+          visible
+        >
+          <h2 slot="headline">System Maintenance</h2>
+          <div>
+            <p className="vads-u-margin-top--0">
+              We’re currently making updates to the My Education Benefits
+              platform. We apologize for the inconvenience. Please check back
+              soon.
+            </p>
+          </div>
+        </va-alert>
+      )}
+
       <h1>Verify your school enrollments</h1>
       <p className="va-introtext">
         If you have education benefits, verify your enrollments each month to
@@ -200,7 +220,13 @@ export function EnrollmentVerificationIntroPage({
   );
 }
 
-const mapStateToProps = state => getEVData(state);
+const mapStateToProps = state => ({
+  ...getEVData(state),
+  showMebEnrollmentVerificationMaintenanceAlert:
+    state.featureToggles[
+      featureFlagNames.showMebEnrollmentVerificationMaintenanceAlert
+    ],
+});
 
 const mapDispatchToProps = {
   getPost911GiBillEligibility: fetchPost911GiBillEligibility,


### PR DESCRIPTION
## Summary
Adds an alert on the Enrollment Verification application introduction page when the flag is manually turned on for maintenance purposes.

## Related issue(s)


## Testing done


## Screenshots
Need to add


## What areas of the site does it impact?
Enrollment Verification Application managed by My Education Benefits Team.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
