### PR TITLE
Add prod redirect for 10-10EZR users without feature toggle enabled

### DIFF
--- a/src/applications/ezr/containers/App.jsx
+++ b/src/applications/ezr/containers/App.jsx
@@ -11,13 +11,29 @@ import formConfig from '../config/form';
 const App = props => {
   const { children, features, formData, location, setFormData, user } = props;
   const { veteranFullName } = formData;
-  const { loading: isLoadingFeatures, isSigiEnabled } = features;
+  const { loading: isLoadingFeatures, isProdEnabled, isSigiEnabled } = features;
   const {
     dob: veteranDateOfBirth,
     gender: veteranGender,
     loading: isLoadingProfile,
   } = user;
   const isAppLoading = isLoadingFeatures || isLoadingProfile;
+
+  /**
+   * Redirect users without the prod feature toggle enabled to the VA.gov home page
+   *
+   * NOTE: this is temporary functionality while the new application is being
+   * rolled out for user research and production testing
+   */
+  useEffect(
+    () => {
+      if (!isLoadingFeatures && !isProdEnabled) {
+        window.location.replace('https://www.va.gov');
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isLoadingFeatures],
+  );
 
   /**
    * Set default view fields in the form data
@@ -45,10 +61,10 @@ const App = props => {
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [isSigiEnabled, isAppLoading, veteranFullName, veteranDateOfBirth],
+    [isAppLoading, veteranFullName],
   );
 
-  return isAppLoading ? (
+  return isAppLoading || !isProdEnabled ? (
     <va-loading-indicator
       message={content['load-app']}
       class="vads-u-margin-y--4"
@@ -76,6 +92,7 @@ App.propTypes = {
 const mapStateToProps = state => ({
   features: {
     loading: state.featureToggles.loading,
+    isProdEnabled: state.featureToggles.ezrProdEnabled,
     isSigiEnabled: state.featureToggles.hcaSigiEnabled,
   },
   formData: state.form.data,

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -58,6 +58,7 @@ export default Object.freeze({
   disability526ToxicExposure: 'disability_526_toxic_exposure',
   dischargeWizardFeatures: 'discharge_wizard_features',
   enrollmentVerification: 'enrollment_verification',
+  ezrProdEnabled: 'ezr_prod_enabled',
   facilitiesPpmsSuppressAll: 'facilities_ppms_suppress_all',
   facilitiesPpmsSuppressCommunityCare:
     'facilities_ppms_suppress_community_care',


### PR DESCRIPTION
## Summary
In order to conduct user research, the 10-10EZR application needs to be enabled in prod for the users participating the research study. Since, we are still in the research stage and not ready for full production access, we need to limit access to the application using a feature toggle. This PR checks the feature toggle setting and allows access for users with the toggle enabled and simply redirects to the VA.gov homepage for users who do not have the toggle enabled.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#69557

## Testing done

- [x] Verified with local flipper toggling that the redirect only occurs when the feature is off, and the application is accessible with the feature on.

## Acceptance criteria
- Application redirects for users with the feature off
- Application can be accessed for users with the feature on

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution