### PR TITLE
Update 527ez URL to point to find a form

### DIFF
--- a/src/applications/simple-forms/21-0966/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-0966/containers/ConfirmationPage.jsx
@@ -161,7 +161,7 @@ export class ConfirmationPage extends React.Component {
               href =
                 '/disability/file-disability-claim-form-21-526ez/introduction';
             } else if (nextStep === veteranBenefits.PENSION) {
-              href = '/pension/application/527EZ/introduction';
+              href = '/find-forms/about-form-21p-527ez/';
             } else if (nextStep === veteranBenefits.SURVIVOR) {
               href = '/find-forms/about-form-21p-534ez/';
             }

--- a/src/applications/simple-forms/21-0966/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-0966/containers/IntroductionPage.jsx
@@ -65,7 +65,7 @@ class IntroductionPage extends React.Component {
             automatically of your intent to file.
           </li>
           <li>
-            <a href="https://www.va.gov/pension/application/527EZ/introduction">
+            <a href="https://www.va.gov/find-forms/about-form-21p-527ez/">
               Pension claim (VA Form 21P-527EZ)
             </a>
           </li>


### PR DESCRIPTION

## Summary

- _(Summarize the changes that have been made to the platform)_
VA Form 527ez's digital experience has temporarily been disabled. We need to update our URLs to point to the about page in find a form so users can still download the PDF if they so choose.

- _(Which team do you work for, does your team own the maintenance of this component?)_
Veteran Facing forms

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/780

- _Link to previous change of the code/bug (if applicable)_
https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/695#issuecomment-1787568123

- _Link to epic if not included in ticket_
https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/603

## Testing done

- _Describe what the old behavior was prior to the change_

527ez URL Pointed to https://www.va.gov/pension/application/527EZ/introduction

- _Describe the steps required to verify your changes are working as expected_

527ez URL now points to https://www.va.gov/find-forms/about-form-21p-527ez/



## What areas of the site does it impact?

Only 21-0966 intro and confirmation pages

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

