### PR TITLE
Add error message for "pattern" mismatch to v3 web component email pattern

### DIFF
--- a/src/platform/forms-system/src/js/web-component-patterns/emailPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/emailPattern.jsx
@@ -24,6 +24,8 @@ const emailUI = (title, showAllowCorrespondence = false) => {
       required: 'Please enter an email address',
       format:
         'Enter a valid email address using the format email@domain.com. Your email address can only have letters, numbers, the @ symbol and a period, with no spaces.',
+      pattern:
+        'Enter a valid email address using the format email@domain.com. Your email address can only have letters, numbers, the @ symbol and a period, with no spaces.',
     },
     'ui:options': {
       inputType: 'email',


### PR DESCRIPTION
## Summary
This PR adds the email validation message for `pattern` mismatch into the v3 web component email pattern in the forms library. This addresses cases where teams may be using a regex pattern other than the standard `format` that would be the default schema setup

## Related issue(s)
department-of-veterans-affairs/va.gov-team#69778

## Testing done
- As shown in the screenshots below, the previous behavior exposed the regex pattern as part of an error message that isnt helpful to the user. The pattern message duplicates the same message used for invalid format to give users a better sense of what to do.

## Screenshots

**Before:** 
![Screenshot 2023-11-13 at 12 02 18 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/a2e96368-3e32-4a1b-bbb3-e000e29bf117)

**After:**
![Screenshot 2023-11-13 at 12 01 38 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/bc882615-c3d9-4e1b-b3a9-a236c85c7f39)

## Acceptance criteria
- Invalid patterns are accounted for when showing error messages to users for email address patterns

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution