### PR TITLE
MHV-50215: Fill/Refill button loader/accessibility

### DIFF
--- a/src/applications/mhv/medications/components/shared/FillRefillButton.jsx
+++ b/src/applications/mhv/medications/components/shared/FillRefillButton.jsx
@@ -58,7 +58,11 @@ const FillRefillButton = rx => {
             </>
           )}
         {isLoading && (
-          <va-loading-indicator label="Submitting your request..." set-focus />
+          <va-loading-indicator
+            label="Submitting your request..."
+            set-focus
+            data-testid="refill-loader"
+          />
         )}
         <button
           type="button"

--- a/src/applications/mhv/medications/components/shared/FillRefillButton.jsx
+++ b/src/applications/mhv/medications/components/shared/FillRefillButton.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { fillPrescription } from '../../actions/prescriptions';
@@ -16,31 +16,49 @@ const FillRefillButton = rx => {
     isRefillable,
   } = rx;
 
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(
+    () => {
+      if (success || error) {
+        setIsLoading(false);
+      }
+    },
+    [success, error],
+  );
+
   if (isRefillable) {
     return (
-      <div>
+      <div className="rx-fill-refill-button">
         {success && (
           <va-alert status="success" setFocus aria-live="polite">
-            <p className="vads-u-margin-y--0">We got your request.</p>
+            <p className="vads-u-margin-y--0">
+              We got your request to {`${dispensedDate ? 'refill' : 'fill'}`}{' '}
+              this prescription.
+            </p>
           </va-alert>
         )}
-        {error && (
-          <>
-            <va-alert
-              status="error"
-              setFocus
-              id="fill-error-alert"
-              aria-live="polite"
-            >
-              <p className="vads-u-margin-y--0">
-                We didn’t get your request. Try again.
+        {error &&
+          !isLoading && (
+            <>
+              <va-alert
+                status="error"
+                setFocus
+                id="fill-error-alert"
+                aria-live="polite"
+              >
+                <p className="vads-u-margin-y--0">
+                  We didn’t get your request. Try again.
+                </p>
+              </va-alert>
+              <p className="vads-u-margin-bottom--1 vads-u-margin-top--2">
+                If it still doesn’t work, call your VA pharmacy
+                <CallPharmacyPhone cmopDivisionPhone={cmopDivisionPhone} />
               </p>
-            </va-alert>
-            <p className="vads-u-margin-bottom--1 vads-u-margin-top--2">
-              If it still doesn’t work, call your VA pharmacy
-              <CallPharmacyPhone cmopDivisionPhone={cmopDivisionPhone} />
-            </p>
-          </>
+            </>
+          )}
+        {isLoading && (
+          <va-loading-indicator label="Submitting your request..." set-focus />
         )}
         <button
           type="button"
@@ -48,8 +66,9 @@ const FillRefillButton = rx => {
           aria-describedby={`card-header-${prescriptionId}`}
           className="vads-u-width--responsive"
           data-testid="refill-request-button"
-          hidden={success}
+          hidden={success || isLoading}
           onClick={() => {
+            setIsLoading(true);
             dispatch(fillPrescription(prescriptionId));
           }}
         >

--- a/src/applications/mhv/medications/sass/medications.scss
+++ b/src/applications/mhv/medications/sass/medications.scss
@@ -214,3 +214,10 @@
   position: fixed;
   bottom: 20px;
 }
+
+.rx-fill-refill-button {
+  va-loading-indicator {
+    display: flex;
+    justify-content: left;
+  }
+}

--- a/src/applications/mhv/medications/tests/components/shared/FillRefillButton.unit.spec.jsx
+++ b/src/applications/mhv/medications/tests/components/shared/FillRefillButton.unit.spec.jsx
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
-import { fireEvent } from '@testing-library/dom';
+import { fireEvent, waitFor } from '@testing-library/dom';
 import reducer from '../../../reducers';
 import FillRefillButton from '../../../components/shared/FillRefillButton';
 
@@ -45,13 +45,13 @@ describe('Fill Refill Button component', () => {
     expect(errorMessage).to.exist;
   });
 
-  it('dispatches the fillPrescription action', () => {
+  it('dispatches the fillPrescription action', async () => {
     const screen = setup();
     const fillButton = screen.getByTestId('refill-request-button');
     expect(screen.getByTestId('refill-loader')).not.to.exist;
     fireEvent.click(fillButton);
     expect(fillButton).to.exist;
-    expect(screen.getByTestId('refill-loader')).to.exist;
+    await waitFor(() => expect(screen.getByTestId('refill-loader')).to.exist);
   });
 
   it('does not render the fill button when the prescription is NOT fillable', () => {

--- a/src/applications/mhv/medications/tests/components/shared/FillRefillButton.unit.spec.jsx
+++ b/src/applications/mhv/medications/tests/components/shared/FillRefillButton.unit.spec.jsx
@@ -48,10 +48,10 @@ describe('Fill Refill Button component', () => {
   it('dispatches the fillPrescription action', () => {
     const screen = setup();
     const fillButton = screen.getByTestId('refill-request-button');
-    expect(screen.find('va-loading-indicator').length).to.equal(0);
+    expect(screen.getByTestId('refill-loader')).not.to.exist;
     fireEvent.click(fillButton);
     expect(fillButton).to.exist;
-    expect(screen.find('va-loading-indicator').length).to.equal(1);
+    expect(screen.getByTestId('refill-loader')).to.exist;
   });
 
   it('does not render the fill button when the prescription is NOT fillable', () => {

--- a/src/applications/mhv/medications/tests/components/shared/FillRefillButton.unit.spec.jsx
+++ b/src/applications/mhv/medications/tests/components/shared/FillRefillButton.unit.spec.jsx
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { fireEvent } from '@testing-library/dom';
-import { $ } from 'platform/forms-system/src/js/utilities/ui';
 import reducer from '../../../reducers';
 import FillRefillButton from '../../../components/shared/FillRefillButton';
 
@@ -32,7 +31,9 @@ describe('Fill Refill Button component', () => {
 
   it('renders a success message', () => {
     const screen = setup();
-    const successMessage = screen.getByText('We got your request.');
+    const successMessage = screen.getByText(
+      'We got your request to refill this prescription.',
+    );
     expect(successMessage).to.exist;
   });
 
@@ -47,10 +48,10 @@ describe('Fill Refill Button component', () => {
   it('dispatches the fillPrescription action', () => {
     const screen = setup();
     const fillButton = screen.getByTestId('refill-request-button');
-    expect($('va-loading-indicator', screen)).to.not.exist;
+    expect(screen.find('va-loading-indicator').length).to.equal(0);
     fireEvent.click(fillButton);
     expect(fillButton).to.exist;
-    expect($('va-loading-indicator', screen)).to.exist;
+    expect(screen.find('va-loading-indicator').length).to.equal(1);
   });
 
   it('does not render the fill button when the prescription is NOT fillable', () => {

--- a/src/applications/mhv/medications/tests/components/shared/FillRefillButton.unit.spec.jsx
+++ b/src/applications/mhv/medications/tests/components/shared/FillRefillButton.unit.spec.jsx
@@ -48,7 +48,6 @@ describe('Fill Refill Button component', () => {
   it('dispatches the fillPrescription action', async () => {
     const screen = setup();
     const fillButton = screen.getByTestId('refill-request-button');
-    expect(screen.getByTestId('refill-loader')).not.to.exist;
     fireEvent.click(fillButton);
     expect(fillButton).to.exist;
     await waitFor(() => expect(screen.getByTestId('refill-loader')).to.exist);

--- a/src/applications/mhv/medications/tests/components/shared/FillRefillButton.unit.spec.jsx
+++ b/src/applications/mhv/medications/tests/components/shared/FillRefillButton.unit.spec.jsx
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { fireEvent } from '@testing-library/dom';
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
 import reducer from '../../../reducers';
 import FillRefillButton from '../../../components/shared/FillRefillButton';
 
@@ -46,8 +47,10 @@ describe('Fill Refill Button component', () => {
   it('dispatches the fillPrescription action', () => {
     const screen = setup();
     const fillButton = screen.getByTestId('refill-request-button');
+    expect($('va-loading-indicator', screen)).to.not.exist;
     fireEvent.click(fillButton);
     expect(fillButton).to.exist;
+    expect($('va-loading-indicator', screen)).to.exist;
   });
 
   it('does not render the fill button when the prescription is NOT fillable', () => {


### PR DESCRIPTION
## Summary

- Medications list & Medication Details pages: Fill/Refill button accessibility updates

## Acceptance criteria

-Loading indicator then message after clicking request a fill/refill button receives focus by screen readers for both the list page and details page.
-Loading indicator is added inline where success message goes while waiting for success message

## Related issue(s)

[Jira ticket](https://jira.devops.va.gov/browse/MHV-50215)

<img width="945" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/c65d143c-4edf-4ed9-9cc7-53ee0b4c72df">

## After

<img width="530" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/ac67f7f3-2b75-48dd-b46b-924765a80071">

## What areas of the site does it impact?

my-health/Medications 

### Testing

Unit tests updated to reflect the loader.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
