### PR TITLE
remove period from the end of the documentation link for test stability errors

### DIFF
--- a/script/github-actions/annotate-disallowed-tests.js
+++ b/script/github-actions/annotate-disallowed-tests.js
@@ -57,7 +57,7 @@ if (TESTS_BLOCKING_MERGE.length > 0) {
       message: `*MERGE BLOCK NOTICE* This PR contains changes related to this test spec which has been disabled for flakiness.
                 \n As of Nov 6th, 2023, merging is blocked for PRs in products that have flaky Unit/E2E tests associated with them.
                 \n Please resolve these tests to remove this blocker.
-                \n More information is available at: https://depo-platform-documentation.scrollhelp.site/developer-docs/test-stability-review.`,
+                \n More information is available at: https://depo-platform-documentation.scrollhelp.site/developer-docs/test-stability-review`,
       annotation_level: 'failure',
     };
   });

--- a/script/github-actions/verify-merge-eligibility.js
+++ b/script/github-actions/verify-merge-eligibility.js
@@ -16,7 +16,7 @@ if (testsBlockingMerge.length > 0) {
   errorMessages.push(
     `This PR has test specs that have been disabled due to flakiness. \n 
     As of Nov 6th, 2023, merging is blocked for PRs in products that have flaky Unit/E2E tests associated with them. Please resolve these test errors to remove this blocker.\n
-    More information is available at: https://depo-platform-documentation.scrollhelp.site/developer-docs/test-stability-review.\n
+    More information is available at: https://depo-platform-documentation.scrollhelp.site/developer-docs/test-stability-review\n
     
     The file paths causing this status are: \n ${testsBlockingMerge.join(
       '\n',


### PR DESCRIPTION
## Summary

The period at the end of the urls was causing engineers to be sent to a 404 page instead of documentation about fixing test stability issues.


