### PR TITLE
fix: update end time

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
@@ -148,7 +148,7 @@ const DirectDeposit = ({
               We’re updating our systems to add the 2024 cost-of-living increase
               for VA benefits. Direct deposit information isn’t available right
               now. Check back after <strong>Sunday, November 19, 2023</strong>,
-              at <strong>11:59 p.m. ET</strong>.
+              at <strong>7:00 p.m. ET</strong>.
             </p>
           </va-alert>
         </Toggler.Enabled>

--- a/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile/components/personal-information/PersonalInformation.jsx
@@ -169,7 +169,7 @@ const PersonalInformation = () => {
               We’re updating our systems to add the 2024 cost-of-living increase
               for VA benefits. If you have trouble using this tool, check back
               after <strong>Sunday, November 19, 2023</strong>, at{' '}
-              <strong>11:59 p.m. ET</strong>.
+              <strong>7:00 p.m. ET</strong>.
             </p>
           </VaAlert>
         )}


### PR DESCRIPTION
## Summary

- Changed from midnight to 7pm for the end of downtime alert

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/69386

## Testing done

- tests passing, no functionality changes made

## Screenshots

![Screenshot 2023-11-16 at 8 11 09 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/29f30695-df96-4b83-9349-788bb2e3a508)


## What areas of the site does it impact?

Profile

## Acceptance criteria

- time changed

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed