### PR TITLE
Retrigger e2e tests for 0966 and 0247

### DIFF
--- a/src/applications/simple-forms/21-0966/manifest.json
+++ b/src/applications/simple-forms/21-0966/manifest.json
@@ -2,6 +2,6 @@
   "appName": "21-0966 Intent to file a claim",
   "entryFile": "./app-entry.jsx",
   "entryName": "21-0966-intent-to-file-a-claim",
-  "rootUrl": "/supporting-forms-for-claims/intent-to-file-a-claim-form-21-0966",
+  "rootUrl": "/supporting-forms-for-claims/intent-to-file-form-21-0966",
   "productId": "8233bd78-20c6-4498-b36f-55ec0028b1e5"
 }

--- a/src/applications/simple-forms/21-0966/tests/e2e/21-0966-intent-to-file-a-claim.cypress.spec.js
+++ b/src/applications/simple-forms/21-0966/tests/e2e/21-0966-intent-to-file-a-claim.cypress.spec.js
@@ -75,7 +75,6 @@ const testConfig = createTestConfig(
         });
       },
     },
-
     setupPerTest: () => {
       cy.intercept('POST', formConfig.submitUrl, mockSubmit);
     },

--- a/src/applications/simple-forms/40-0247/tests/e2e/0247-pmc.cypress.spec.js
+++ b/src/applications/simple-forms/40-0247/tests/e2e/0247-pmc.cypress.spec.js
@@ -142,7 +142,6 @@ const testConfig = createTestConfig(
         });
       },
     },
-
     setupPerTest: () => {
       cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
       cy.intercept(formConfig.submitUrl, mockSubmit);


### PR DESCRIPTION
## Summary

- Retrigger e2e tests for 0966 and 0247

## Testing done

- e2e tests should pass

## What areas of the site does it impact?

Being blocked by 0966 and 0247 not allowed list

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
