### PR TITLE
Added txt download feature for Radiology

### DIFF
--- a/src/applications/mhv/medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -11,9 +11,11 @@ import DownloadingRecordsInfo from '../shared/DownloadingRecordsInfo';
 import GenerateRadiologyPdf from './GenerateRadiologyPdf';
 import { updatePageTitle } from '../../../shared/util/helpers';
 import { EMPTY_FIELD, pageTitles } from '../../util/constants';
+import { generateTextFile, getNameDateAndTime } from '../../util/helpers';
 
 const RadiologyDetails = props => {
   const { record, fullState, runningUnitTest } = props;
+  const user = useSelector(state => state.user.profile);
   const allowTxtDownloads = useSelector(
     state =>
       state.featureToggles[
@@ -36,6 +38,27 @@ const RadiologyDetails = props => {
 
   const download = () => {
     GenerateRadiologyPdf(record, runningUnitTest);
+  };
+
+  const generateRadioloyTxt = async () => {
+    const content = `\n
+${record.name}\n
+Date entered: ${record.date}\n
+_____________________________________________________\n\n
+    Reason for test: ${record.reason} \n
+    Clinical history: ${record.clinicalHistory} \n
+    Ordered by: ${record.orderedBy} \n
+    Order location: ${record.orderingLocation} \n
+    Imaging location: ${record.imagingLocation} \n
+    Imaging provider: ${record.imagingProvider} \n;
+_____________________________________________________\n\n
+Results\n
+${record.results}`;
+
+    generateTextFile(
+      content,
+      `VA-labs-and-tests-details-${getNameDateAndTime(user)}`,
+    );
   };
 
   return (
@@ -61,6 +84,7 @@ const RadiologyDetails = props => {
       <div className="no-print">
         <PrintDownload
           download={download}
+          downloadTxt={generateRadioloyTxt}
           allowTxtDownloads={allowTxtDownloads}
         />
         <DownloadingRecordsInfo allowTxtDownloads={allowTxtDownloads} />

--- a/src/applications/mhv/medical-records/tests/components/RadiologyDetails.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/RadiologyDetails.unit.spec.jsx
@@ -17,6 +17,10 @@ describe('Radiology details component', () => {
         labsAndTestsDetails: radiologyRecord,
       },
     },
+    featureToggles: {
+      // eslint-disable-next-line camelcase
+      mhv_medical_records_allow_txt_downloads: true,
+    },
   };
 
   let screen;
@@ -68,6 +72,11 @@ describe('Radiology details component', () => {
 
   it('should download a pdf', () => {
     fireEvent.click(screen.getByTestId('printButton-1'));
+    expect(screen).to.exist;
+  });
+
+  it('should download a text file', () => {
+    fireEvent.click(screen.getByTestId('printButton-2'));
     expect(screen).to.exist;
   });
 });


### PR DESCRIPTION

## Summary

- Added printDownloadTxt function for Radiology.
- Is not a bug.
- Wrote a couple of functions.
- MHV Medical Records.

## Related issue(s)
### [MHV-43514](https://jira.devops.va.gov/browse/MHV-43514) - Add TXT Download functionality for Radiology Results ###

<img width="943" alt="Screenshot 2023-11-16 at 5 40 31 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/9909777/13a09856-67bf-4f7f-af8b-144447ecffbf">
<img width="939" alt="Screenshot 2023-11-16 at 5 41 56 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/9909777/763500d8-2054-4435-8a2b-4311072dc1b4">

## Testing done

- Added test that checks for download button functioning. 

## What areas of the site does it impact?
MHV Medical Records