### PR TITLE
[CST] Adding Downtime Notifications component

### DIFF
--- a/src/applications/claims-status/containers/ClaimsStatusApp.jsx
+++ b/src/applications/claims-status/containers/ClaimsStatusApp.jsx
@@ -3,6 +3,9 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import PropTypes from 'prop-types';
 
+import DowntimeNotification, {
+  externalServices,
+} from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
 import backendServices from 'platform/user/profile/constants/backendServices';
 import { RequiredLoginView } from 'platform/user/authorization/components/RequiredLoginView';
 import environment from 'platform/utilities/environment';
@@ -139,9 +142,21 @@ function ClaimsStatusApp({
       ]}
       user={user}
     >
-      <AppContent featureFlagsLoading={featureFlagsLoading}>
-        {children}
-      </AppContent>
+      <DowntimeNotification
+        appTitle="Claim Status"
+        dependencies={[
+          externalServices.evss,
+          externalServices.global,
+          externalServices.mvi,
+          externalServices.vaProfile,
+          externalServices.vbms,
+        ]}
+        downClassName="row vads-u-margin-y--5"
+      >
+        <AppContent featureFlagsLoading={featureFlagsLoading}>
+          {children}
+        </AppContent>
+      </DowntimeNotification>
     </RequiredLoginView>
   );
 }

--- a/src/platform/monitoring/DowntimeNotification/containers/DowntimeNotification.jsx
+++ b/src/platform/monitoring/DowntimeNotification/containers/DowntimeNotification.jsx
@@ -114,7 +114,11 @@ class DowntimeNotification extends React.Component {
     }
 
     if (this.props.status === externalServiceStatus.down) {
-      return <Down {...this.props} />;
+      return (
+        <div className={this.props.downClassName}>
+          <Down {...this.props} />
+        </div>
+      );
     }
 
     return children;


### PR DESCRIPTION
## Summary
Adding the DowntimeNotification component as a wrapper around the application code. Added a prop to allow us to set a wrapper className on the DowntimeNotification component that makes it possible to adjust the layout of the component

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#70007

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

### w/o `downClassName` prop
|         | Without `downClassName` prop | With `downClassName` prop |
| ------- | ------ | ----- |
| Desktop | <img width="1593" alt="Screenshot 2023-11-17 at 11 15 14 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/9b2c0edd-88ac-4ea9-be29-16c6d927b8e0"> | <img width="1253" alt="Screenshot 2023-11-17 at 11 14 54 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/9203a25f-8a2d-4abd-a401-2ff2346e2375"> |

## What areas of the site does it impact?
Claim Status Tool
*(Describe what parts of the site are impacted **if** code touched other areas)*

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
