### PR TITLE
dismissible alert

### DIFF
--- a/src/applications/check-in/components/PreCheckInSuccessAlert.jsx
+++ b/src/applications/check-in/components/PreCheckInSuccessAlert.jsx
@@ -35,13 +35,14 @@ const PreCheckInSuccessAlert = () => {
   }
 
   return (
-    <section data-testid="pre-check-in-success-alert">
+    <section>
       <VaAlert
         close-btn-aria-label="Close notification"
         closeable
         status="success"
         visible={showPreCheckInSuccess !== false}
         onCloseEvent={hideAlert}
+        data-testid="pre-check-in-success-alert"
       >
         <h2 slot="headline">{t('your-information-is-up-to-date')}</h2>
         <p data-testid="success-message" className="vads-u-margin-y--0">

--- a/src/applications/check-in/components/PreCheckInSuccessAlert.jsx
+++ b/src/applications/check-in/components/PreCheckInSuccessAlert.jsx
@@ -1,18 +1,24 @@
 import React, { useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { useSendPreCheckInData } from '../hooks/useSendPreCheckInData';
-
-import { makeSelectVeteranData } from '../selectors';
+import { additionalContext } from '../actions/day-of';
+import { makeSelectVeteranData, makeSelectCurrentContext } from '../selectors';
 import { hasPhoneAppointments } from '../utils/appointment';
 
 const PreCheckInSuccessAlert = () => {
   const selectVeteranData = useMemo(makeSelectVeteranData, []);
   const { appointments } = useSelector(selectVeteranData);
   const { t } = useTranslation();
+  const dispatch = useDispatch();
 
+  const hideAlert = () => {
+    dispatch(additionalContext({ showPreCheckInSuccess: false }));
+  };
   const { isLoading } = useSendPreCheckInData();
-
+  const selectCurrentContext = useMemo(makeSelectCurrentContext, []);
+  const { showPreCheckInSuccess } = useSelector(selectCurrentContext);
   const successMessage = hasPhoneAppointments(appointments)
     ? t('your-provider-will-call-you-at-your-appointment-time')
     : t('you-can-check-in-with-your-smartphone', {
@@ -30,17 +36,18 @@ const PreCheckInSuccessAlert = () => {
 
   return (
     <section data-testid="pre-check-in-success-alert">
-      <va-alert
+      <VaAlert
         close-btn-aria-label="Close notification"
         closeable
         status="success"
-        visible
+        visible={showPreCheckInSuccess !== false}
+        onCloseEvent={hideAlert}
       >
         <h2 slot="headline">{t('your-information-is-up-to-date')}</h2>
         <p data-testid="success-message" className="vads-u-margin-y--0">
           {successMessage}
         </p>
-      </va-alert>
+      </VaAlert>
     </section>
   );
 };

--- a/src/applications/check-in/components/tests/PreCheckInSuccessAlert.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/PreCheckInSuccessAlert.unit.spec.jsx
@@ -141,5 +141,46 @@ describe('unified check-in experience', () => {
       );
       sandbox.assert.calledOnce(updateError);
     });
+    it('alert is visable on load', () => {
+      const mockstore = {
+        appointments: singleAppointment,
+        app: 'preCheckIn',
+      };
+      const useSendPreCheckInDataStub = sinon
+        .stub(useSendPreCheckInDataModule, 'useSendPreCheckInData')
+        .returns({
+          isLoading: false,
+        });
+      const screen = render(
+        <CheckInProvider store={mockstore}>
+          <PreCheckInSuccessAlert />
+        </CheckInProvider>,
+      );
+      expect(
+        screen.getByTestId('pre-check-in-success-alert'),
+      ).to.have.attribute('visible', 'true');
+      useSendPreCheckInDataStub.restore();
+    });
+    it('alert is hidden when value in context is false', () => {
+      const mockstore = {
+        appointments: singleAppointment,
+        app: 'preCheckIn',
+        additionalContext: { showPreCheckInSuccess: false },
+      };
+      const useSendPreCheckInDataStub = sinon
+        .stub(useSendPreCheckInDataModule, 'useSendPreCheckInData')
+        .returns({
+          isLoading: false,
+        });
+      const screen = render(
+        <CheckInProvider store={mockstore}>
+          <PreCheckInSuccessAlert />
+        </CheckInProvider>,
+      );
+      expect(
+        screen.getByTestId('pre-check-in-success-alert'),
+      ).to.have.attribute('visible', 'false');
+      useSendPreCheckInDataStub.restore();
+    });
   });
 });

--- a/src/applications/check-in/tests/unit/utils/initState.js
+++ b/src/applications/check-in/tests/unit/utils/initState.js
@@ -43,6 +43,7 @@ const createStore = ({
   error = null,
   seeStaffMessage = null,
   token = 'some-token',
+  additionalContext = {},
 } = {}) => {
   const middleware = [];
   const mockStore = configureStore(middleware);
@@ -51,6 +52,7 @@ const createStore = ({
       app,
       context: {
         token,
+        ...additionalContext,
       },
       form: {
         pages: formPages,


### PR DESCRIPTION
## Summary
Adds the ability to dismiss pre-check-in success alert. Leverages additionalContext in redux to store the value. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#68866

## Testing done

Added unit tests.

## What areas of the site does it impact?

Pre-check-in

## Acceptance criteria

- [ ] Alert closes when "X" is clicked
- [ ] Alert stays closed when navigating away and back to page
- [ ] Alert shows back up on reload

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)


