### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -176,7 +176,7 @@ src/applications/mhv/medical-records @department-of-veterans-affairs/vfs-mhv-med
 src/applications/mhv/medications @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/mhv/secure-messaging @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/mhv/landing-page @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/va-platform-cop-frontend
-src/applications/avs @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/avs @department-of-veterans-affairs/after-visit-summary @department-of-veterans-affairs/va-platform-cop-frontend
 
 # Profile
 


### PR DESCRIPTION
Updates AVS to use its own [team](https://github.com/orgs/department-of-veterans-affairs/teams/after-visit-summary).