### PR TITLE
69670 Fix cg pdf download link

### DIFF
--- a/src/applications/caregivers/components/ApplicationDownloadLink.jsx
+++ b/src/applications/caregivers/components/ApplicationDownloadLink.jsx
@@ -6,6 +6,7 @@ import { apiRequest } from 'platform/utilities/api';
 import { focusElement } from 'platform/utilities/ui';
 import environment from 'platform/utilities/environment';
 import recordEvent from 'platform/monitoring/record-event';
+import localStorage from 'platform/utilities/storage/localStorage';
 import { downloadErrorsByCode } from '../definitions/content';
 import { submitTransform } from '../utils/helpers';
 import formConfig from '../config/form';
@@ -30,6 +31,7 @@ const ApplicationDownloadLink = ({ form }) => {
     return downloadErrorsByCode[code] || generic;
   };
 
+  const csrfTokenStored = localStorage.getItem('csrfToken');
   // define our method of retrieving the link to download
   const fetchDownloadUrl = body => {
     isLoading(true);
@@ -41,6 +43,7 @@ const ApplicationDownloadLink = ({ form }) => {
       headers: {
         'Content-Type': 'application/json',
         'Source-App-Name': window.appName,
+        'X-CSRF-Token': csrfTokenStored,
       },
     })
       .then(response => response.blob())


### PR DESCRIPTION
## Summary
- Add csrf token header to CG PDF download request

## Related issue(s)

- [https://app.zenhub.com/workspaces/10-10-health-apps-5fff0cfd1462b6000e320fc7/issues/gh/department-of-veterans-affairs/va.gov-team/69670](https://app.zenhub.com/workspaces/10-10-health-apps-5fff0cfd1462b6000e320fc7/issues/gh/department-of-veterans-affairs/va.gov-team/69670)

## Testing done

- Verified CG PDF was able to be downloaded without issue.

## What areas of the site does it impact?

- PDF Download functionality when a user completes the Caregiver application
