### PR TITLE
MHV-51982: Non VA prescriptions naming logic update

### DIFF
--- a/src/applications/mhv/medications/components/MedicationsList/MedicationsListCard.jsx
+++ b/src/applications/mhv/medications/components/MedicationsList/MedicationsListCard.jsx
@@ -33,9 +33,8 @@ const MedicationsListCard = props => {
             className="vads-u-margin-y--0p5 vads-u-font-size--h4 no-print"
             to={`/prescription/${rx.prescriptionId}`}
           >
-            {rx.dispStatus === 'Active: Non-VA'
-              ? rx.orderableItem
-              : rx.prescriptionName}
+            {rx.prescriptionName ||
+              (rx.dispStatus === 'Active: Non-VA' ? rx.orderableItem : '')}
           </Link>
           <p
             className="vads-u-margin-y--0p5 vads-u-font-size--h4 print-only"

--- a/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
@@ -40,9 +40,10 @@ const PrescriptionDetails = () => {
   const dispatch = useDispatch();
 
   const prescriptionHeader =
-    prescription?.dispStatus === 'Active: Non-VA'
+    prescription?.prescriptionName ||
+    (prescription?.dispStatus === 'Active: Non-VA'
       ? prescription?.orderableItem
-      : prescription?.prescriptionName;
+      : '');
 
   useEffect(() => {
     if (prescription) {

--- a/src/applications/mhv/medications/tests/containers/PrescriptionDetails.unit.spec.jsx
+++ b/src/applications/mhv/medications/tests/containers/PrescriptionDetails.unit.spec.jsx
@@ -80,7 +80,7 @@ describe('Prescription details container', () => {
     );
   });
 
-  it('prescription name for non va prescription', () => {
+  it('name should use orderableItem for non va prescription if no prescriptionName is available', () => {
     const mockData = [nonVaRxResponse];
     mockApiRequest(mockData);
     const screen = renderWithStoreAndRouter(<PrescriptionDetails />, {
@@ -96,6 +96,29 @@ describe('Prescription details container', () => {
     });
     const rxName = screen.findByText(
       nonVaRxResponse.data.attributes.orderableItem,
+    );
+
+    expect(rxName).to.exist;
+  });
+
+  it('name should use prescriptionName for non va prescription if available', () => {
+    const mockData = [nonVaRxResponse];
+    const testPrescriptionName = 'Test Name for Non-VA prescription';
+    mockData.prescriptionName = testPrescriptionName;
+    mockApiRequest(mockData);
+    const screen = renderWithStoreAndRouter(<PrescriptionDetails />, {
+      initialState: {
+        rx: {
+          prescriptions: {
+            prescriptionDetails: nonVaRxResponse.data.attributes,
+          },
+        },
+      },
+      reducers: reducer,
+      path: '/21142496',
+    });
+    const rxName = screen.findByText(
+      nonVaRxResponse.data.attributes.prescriptionName,
     );
 
     expect(rxName).to.exist;

--- a/src/applications/mhv/medications/util/pdfConfigs.js
+++ b/src/applications/mhv/medications/util/pdfConfigs.js
@@ -80,7 +80,9 @@ export const buildPrescriptionsPDFList = prescriptions => {
     if (rx?.prescriptionSource === 'NV') {
       return {
         ...buildNonVAPrescriptionPDFList(rx)[0],
-        header: rx.orderableItem,
+        header:
+          rx.prescriptionName ||
+          (rx.dispStatus === 'Active: Non-VA' ? rx.orderableItem : ''),
       };
     }
 


### PR DESCRIPTION
## Summary

This is a follow up of #26776 and #26425

- Medications List and Medication Details pages: changed header to use `orderableItem` for Non VA medications for both FE and PDF **_if_** `prescriptionName` is not available

## Acceptance criteria

- Logic for medication list is changed to only use ORDERABLE_ITEM when DRUG_NAME is empty
- Non-VA meds on PDF all have a name and use the same logic as above AC to get that name.

## Related issue(s)

[Jira ticket](https://jira.devops.va.gov/browse/MHV-51982)

<img width="1031" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/922dad3c-c92c-4499-ab92-e1f5dbf72763">

## What areas of the site does it impact?

my-health/Medications 

### Testing

Unit tests + manual testing for Medications List, Medication Details and PDFs.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
