### PR TITLE
fixed history issues with browser back button

### DIFF
--- a/src/applications/mhv/medications/components/MedicationsList/MedicationsList.jsx
+++ b/src/applications/mhv/medications/components/MedicationsList/MedicationsList.jsx
@@ -3,19 +3,21 @@ import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { VaPagination } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { waitForRenderThenFocus } from '@department-of-veterans-affairs/platform-utilities/ui';
+import { useHistory } from 'react-router-dom';
 import MedicationsListCard from './MedicationsListCard';
 import { rxListSortingOptions } from '../../util/constants';
 
 const MAX_PAGE_LIST_LENGTH = 6;
 const perPage = 20;
 const MedicationsList = props => {
-  const { rxList, pagination, setCurrentPage, selectedSortOption } = props;
+  const history = useHistory();
+  const { rxList, pagination, selectedSortOption } = props;
   const prescriptionId = useSelector(
     state => state.rx.prescriptions?.prescriptionDetails?.prescriptionId,
   );
   const scrollLocation = useRef();
   const goToPrevious = () => {
-    scrollLocation.current.scrollIntoView();
+    scrollLocation.current?.scrollIntoView();
   };
 
   useEffect(
@@ -30,7 +32,7 @@ const MedicationsList = props => {
     "[data-testid='page-total-info']";
 
   const onPageChange = page => {
-    setCurrentPage(page);
+    history.push(`/${page}`);
     waitForRenderThenFocus(displaynumberOfPrescriptionsSelector, document, 500);
   };
 

--- a/src/applications/mhv/medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv/medications/containers/Prescriptions.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import PropTypes from 'prop-types';
@@ -33,6 +33,8 @@ import { updatePageTitle } from '../../shared/util/helpers';
 
 const Prescriptions = props => {
   const { fullList = [] } = props;
+  const location = useLocation();
+  const history = useHistory();
   const { page } = useParams();
   const dispatch = useDispatch();
   const paginatedPrescriptionsList = useSelector(
@@ -53,7 +55,6 @@ const Prescriptions = props => {
   );
   const [isAlertVisible, setAlertVisible] = useState('false');
   const [isLoading, setLoading] = useState();
-  const [currentPage, setCurrentPage] = useState(page ?? 1);
   const [pdfGenerateStatus, setPdfGenerateStatus] = useState(
     PDF_GENERATE_STATUS.NotStarted,
   );
@@ -64,15 +65,6 @@ const Prescriptions = props => {
     sessionStorage.setItem(SESSION_SELECTED_SORT_OPTION, sortOption);
     focusElement(document.getElementById('showingRx'));
   };
-
-  useEffect(
-    () => {
-      updatePageTitle('Medications | Veterans Affairs');
-      const newUrl = `/my-health/medications/${currentPage}`;
-      window.history.pushState(null, '', newUrl);
-    },
-    [currentPage],
-  );
 
   useEffect(
     () => {
@@ -99,16 +91,18 @@ const Prescriptions = props => {
       if (!paginatedPrescriptionsList) {
         setLoading(true);
       }
+      if (!page) history.replace('/1');
       dispatch(
         getPrescriptionsPaginatedSortedList(
-          currentPage,
+          page ?? 1,
           rxListSortingOptions[selectedSortOption].API_ENDPOINT,
         ),
       ).then(() => setLoading(false));
+      updatePageTitle('Medications | Veterans Affairs');
     },
     // disabled warning: paginatedPrescriptionsList must be left of out dependency array to avoid infinite loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [dispatch, currentPage, selectedSortOption],
+    [dispatch, location.pathname, selectedSortOption],
   );
 
   useEffect(
@@ -288,7 +282,6 @@ const Prescriptions = props => {
               <MedicationsList
                 rxList={paginatedPrescriptionsList}
                 pagination={pagination}
-                setCurrentPage={setCurrentPage}
                 selectedSortOption={selectedSortOption}
               />
             </div>


### PR DESCRIPTION
## Summary

Removed useState hook used to keep track of current page and replaced with react-router to maintain consistent browser history and keep track of current page.

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-50645

> ISSUE: Right now when you are on a page other than page one of the list page, the user is taken back to the landing page when the user clicks the browser 'back' button rather than the page they were previously on.

> SOLUTION: After pressing the browser 'back' button, the user should land on the page they were previously on. If the user went straight to page 5 from page 1 then they should land back on page 1 when they click the back button. If they went to page 5 from page 4 then it should go back to page 4 when they click the back button. 

## Testing done

- Tested Locally
- Ran MHV unit tests

This change should not require new unit tests or affect any current unit tests.

## Screenshots

No changes to UI with this change.

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

Impacts MHV Medications application's landing page, medications list and medications detail pages. 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
