### PR TITLE
VACMS-15703 Add unit and Cypress test coverage to Find Forms

### DIFF
--- a/src/applications/find-forms/actions/index.js
+++ b/src/applications/find-forms/actions/index.js
@@ -1,7 +1,5 @@
-// Dependencies.
 import URLSearchParams from 'url-search-params';
-// Relative imports.
-import recordEvent from 'platform/monitoring/record-event';
+import recordEvent from '~/platform/monitoring/record-event';
 import { fetchFormsApi } from '../api';
 import { MAX_PAGE_LIST_LENGTH } from '../containers/SearchResults';
 import {

--- a/src/applications/find-forms/api/index.js
+++ b/src/applications/find-forms/api/index.js
@@ -1,23 +1,18 @@
-// Dependencies.
 import appendQuery from 'append-query';
-import { apiRequest } from 'platform/utilities/api';
-// Relative imports.
+import { apiRequest } from '~/platform/utilities/api';
 import STUBBED_RESPONSE from '../constants/stub.json';
 
 export const fetchFormsApi = async (query, options = {}) => {
-  // Derive options properties.
   const mockRequest = options?.mockRequest || false;
 
   // Change to https://dev-api.va.gov/v0/forms for quick local config
   let FORMS_URL = '/forms';
   let response = STUBBED_RESPONSE;
 
-  // Add the `query` query param if provided.
   if (query) {
     FORMS_URL = appendQuery(FORMS_URL, { query });
   }
 
-  // Make the request for the forms.
   if (!mockRequest) {
     response = await apiRequest(FORMS_URL);
   }

--- a/src/applications/find-forms/components/FindVaForms.jsx
+++ b/src/applications/find-forms/components/FindVaForms.jsx
@@ -1,14 +1,10 @@
 /* eslint-disable jsx-a11y/no-redundant-roles */
-// Node modules.
 import React from 'react';
-
-// Relative imports.
 import { connect } from 'react-redux';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-
-import recordEvent from 'platform/monitoring/record-event';
 import PropTypes from 'prop-types';
+import { toggleValues } from '~/platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from '~/platform/utilities/feature-toggles/featureFlagNames';
+import recordEvent from '~/platform/monitoring/record-event';
 import SearchForm from '../containers/SearchForm';
 import SearchResults from '../containers/SearchResults';
 import PdfAlert from './PdfAlert';
@@ -32,7 +28,6 @@ export const FindVaForms = ({ showPdfWarningBanner = false }) => {
         claim and applying for the GI Bill or VA health care. We’ll walk you
         through the process step-by-step.
       </p>
-      {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
       <ul
         className="usa-grid usa-grid-full vads-u-margin-top--3 vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row"
         role="list"

--- a/src/applications/find-forms/components/FormTitle.jsx
+++ b/src/applications/find-forms/components/FormTitle.jsx
@@ -46,12 +46,13 @@ const FormTitle = ({ id, formUrl, title, lang, recordGAEvent, formName }) => (
 );
 
 FormTitle.propTypes = {
-  currentPosition: PropTypes.number,
   id: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  currentPosition: PropTypes.number,
+  formName: PropTypes.string,
   formUrl: PropTypes.string,
   lang: PropTypes.string,
   recordGAEvent: PropTypes.func,
-  title: PropTypes.string.isRequired,
   showPDFInfoVersionTwo: PropTypes.bool,
 };
 

--- a/src/applications/find-forms/components/PdfAlert.jsx
+++ b/src/applications/find-forms/components/PdfAlert.jsx
@@ -15,6 +15,7 @@ const PdfAlert = () => {
 
     const introTextNode = document.getElementsByClassName('va-introtext')[0];
     const introTextParentNode = introTextNode?.parentNode;
+
     if (introTextNode && introTextParentNode) {
       introTextParentNode.insertBefore(domNode, introTextNode);
       setPdfCertWarningElementCreated(true);

--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -1,10 +1,8 @@
-// Node modules.
 import React from 'react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-// Relative imports.
-import environment from 'platform/utilities/environment';
-import recordEvent from 'platform/monitoring/record-event';
+import environment from '~/platform/utilities/environment';
+import recordEvent from '~/platform/monitoring/record-event';
 import * as customPropTypes from '../prop-types';
 import {
   FORM_MOMENT_PRESENTATION_DATE_FORMAT,
@@ -12,7 +10,6 @@ import {
 } from '../constants';
 import FormTitle from './FormTitle';
 
-// Helper to derive the download link props.
 const deriveLinkPropsFromFormURL = url => {
   const linkProps = {};
   if (!url) return linkProps;
@@ -21,11 +18,10 @@ const deriveLinkPropsFromFormURL = url => {
   const isPDF = url.toLowerCase().includes('.pdf');
 
   if (!isSameOrigin || !isPDF) {
-    // Just open in a new tab if we'd otherwise hit a CORS issue or if the form URL isn't a PDF.
     linkProps.target = '_blank';
   } else {
-    // Use HTML5 `download` attribute.
     linkProps.download = true;
+
     if (isPDF) linkProps.type = 'application/pdf';
   }
 
@@ -36,12 +32,10 @@ const deriveLinkPropsFromFormURL = url => {
 const regulateURL = url => {
   if (!url) return '';
 
-  // On prod, give back the raw URL.
   if (environment.isProduction()) {
     return url;
   }
 
-  // Derive the current hostname.
   const currentHostname = url.substring(0, url.indexOf('/find-forms'));
 
   // On non-prod envs, we need to swap the hostname of the URL.
@@ -145,7 +139,6 @@ const SearchResult = ({
   toggleModalState,
   setPrevFocusedLink,
 }) => {
-  // Escape early if we don't have the necessary form attributes.
   if (!form?.attributes) {
     return null;
   }
@@ -167,10 +160,7 @@ const SearchResult = ({
     id,
   } = form;
 
-  // Derive the download link props.
   const linkProps = deriveLinkPropsFromFormURL(url);
-
-  // Derive labels.
   const pdfLabel = url.toLowerCase().includes('.pdf') ? '(PDF)' : '';
   const lastRevision = deriveLatestIssue(firstIssuedOn, lastRevisionOn);
 
@@ -185,12 +175,14 @@ const SearchResult = ({
 
   const pdfDownloadHandler = () => {
     setPrevFocusedLink(`pdf-link-${id}`);
+
     if (showPDFInfoVersionOne) {
       recordEvent({
         event: 'int-modal-click',
         'modal-status': 'opened',
         'modal-title': 'Download this PDF and open it in Acrobat Reader',
       });
+
       toggleModalState(formName, url, pdfLabel);
     } else {
       recordGAEvent(`Download VA form ${formName} ${pdfLabel}`, url, 'pdf');
@@ -270,6 +262,7 @@ const SearchResult = ({
 SearchResult.propTypes = {
   form: customPropTypes.Form.isRequired,
   formMetaInfo: customPropTypes.FormMetaInfo,
+  setPrevFocusedLink: PropTypes.func,
   showPDFInfoVersionOne: PropTypes.bool,
   toggleModalState: PropTypes.func,
 };

--- a/src/applications/find-forms/containers/SearchForm.jsx
+++ b/src/applications/find-forms/containers/SearchForm.jsx
@@ -1,18 +1,13 @@
-// Dependencies.
 import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import URLSearchParams from 'url-search-params';
 import { VaSearchInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-
-// Relative imports.
 import { getFindFormsAppState } from '../helpers/selectors';
 import { fetchFormsThunk } from '../actions';
 
 export const SearchForm = ({ fetchForms }) => {
-  // Derive the current query params.
   const queryParams = new URLSearchParams(window.location.search);
-  // Derive the query.
   const query = queryParams.get('q') || '';
   const [queryState, setQueryState] = useState(query);
   const [showQueryError, setShowQueryError] = useState(false);
@@ -20,24 +15,19 @@ export const SearchForm = ({ fetchForms }) => {
   const findFormInputFieldRef = useRef(null);
 
   useEffect(() => {
-    // Check if URL query is zero chars, disable error initially
-    if (queryState.length === 0) setShowQueryError(false);
-    // Check if URL query is one char, show error
-    else if (queryState.length === 1) setShowQueryError(true);
-    // If URL query is valid, fetch the forms.
-    else if (queryState) {
+    if (queryState.length === 0) {
+      setShowQueryError(false);
+    } else if (queryState.length === 1) {
+      setShowQueryError(true);
+    } else if (queryState) {
       fetchForms(queryState);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Checks if string is only spaces
   const onlySpaces = str => /^\s+$/.test(str);
-
-  // Checks if string is less than two chars
   const isLessThanTwoChars = str => str.length < 2;
 
-  // Sets focus on the input field
   const setInputFieldFocus = selector => {
     const element =
       typeof selector === 'string'
@@ -46,24 +36,20 @@ export const SearchForm = ({ fetchForms }) => {
     if (element) element.focus();
   };
 
-  // Handles the input textbox change
   const handleQueryChange = event => {
-    // Derive the new query value.
     const q = event.target.value;
 
-    // Set error if query is less than 2 chars
-    if (!isLessThanTwoChars(q)) setShowQueryError(false);
+    if (!isLessThanTwoChars(q)) {
+      setShowQueryError(false);
+    }
 
-    // Update our query in state
-    // Also prevent users from entering spaces because this will not trigger a change when they exit the field
+    // Prevent users from entering spaces because this will not trigger a change when they exit the field
     setQueryState(onlySpaces(q) ? q.trim() : q);
   };
 
-  // Handles clicking the Search button
   const onSubmitHandler = event => {
     event.preventDefault();
 
-    // Check if query is valid to search
     const checkQueryState = isLessThanTwoChars(queryState);
     setShowQueryError(checkQueryState);
 
@@ -77,6 +63,8 @@ export const SearchForm = ({ fetchForms }) => {
     fetchForms(queryState);
   };
 
+  const errorTestId = showQueryError ? 'find-form-error-body' : '';
+
   return (
     <div
       role="search"
@@ -87,7 +75,8 @@ export const SearchForm = ({ fetchForms }) => {
       data-e2e-id="find-form-search-form"
     >
       <p
-        data-e2e-id={showQueryError ? "'find-form-error-body'" : ''}
+        data-e2e-id={errorTestId}
+        data-testid={errorTestId}
         className="vads-u-margin--0"
       >
         Enter a keyword, form name, or number
@@ -119,7 +108,6 @@ export const SearchForm = ({ fetchForms }) => {
 };
 
 SearchForm.propTypes = {
-  // From mapDispatchToProps.
   fetchForms: PropTypes.func.isRequired,
 };
 

--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -1,4 +1,3 @@
-// Dependencies.
 import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -7,10 +6,8 @@ import {
   VaSelect,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { connect } from 'react-redux';
-
-// Relative imports.
-import recordEvent from 'platform/monitoring/record-event';
-import { focusElement } from 'platform/utilities/ui';
+import recordEvent from '~/platform/monitoring/record-event';
+import { focusElement } from '~/platform/utilities/ui';
 import * as customPropTypes from '../prop-types';
 import {
   updateSortByPropertyNameThunk,
@@ -87,7 +84,6 @@ export const SearchResults = ({
 
   const setSortByPropertyNameState = formMetaInfo => state => {
     if (state?.value) {
-      // console.log('AA: ', state.value, ' | ', results);
       updateSortByPropertyName(state.value, results);
 
       recordEvent({
@@ -129,14 +125,12 @@ export const SearchResults = ({
     }
   };
 
-  // Show loading indicator if we are fetching.
   if (fetching) {
     return (
       <va-loading-indicator set-focus message="Loading search results..." />
     );
   }
 
-  // Show the error alert box if there was an error.
   if (error) {
     return (
       <va-alert status="error">
@@ -146,7 +140,6 @@ export const SearchResults = ({
     );
   }
 
-  // Do not render if we have not fetched, yet.
   if (!results) {
     return null;
   }
@@ -164,7 +157,6 @@ export const SearchResults = ({
       </p>
     );
 
-  // Show no results found message.
   if (!results.length) {
     return (
       <p
@@ -187,14 +179,10 @@ export const SearchResults = ({
     );
   }
 
-  // Derive the last index.
   const lastIndex = startIndex + MAX_PAGE_LIST_LENGTH;
 
-  // Derive the display labels.
   const startLabel = startIndex + 1;
   const lastLabel = lastIndex + 1 > results.length ? results.length : lastIndex;
-
-  // Derive the total number of pages.
   const totalPages = Math.ceil(results.length / MAX_PAGE_LIST_LENGTH);
 
   const formMetaInfo = {
@@ -217,7 +205,6 @@ export const SearchResults = ({
       />
     ));
 
-  // modal state variables
   const { isOpen, pdfSelected, pdfUrl, pdfLabel } = modalState;
 
   return (
@@ -325,19 +312,17 @@ export const SearchResults = ({
 };
 
 SearchResults.propTypes = {
-  // From mapStateToProps.
   error: PropTypes.string.isRequired,
   fetching: PropTypes.bool.isRequired,
+  hasOnlyRetiredForms: PropTypes.bool.isRequired,
   page: PropTypes.number.isRequired,
   query: PropTypes.string.isRequired,
-  results: PropTypes.arrayOf(customPropTypes.Form.isRequired),
-  hasOnlyRetiredForms: PropTypes.bool.isRequired,
-  sortByPropertyName: PropTypes.string,
   startIndex: PropTypes.number.isRequired,
-  showPDFInfoVersionOne: PropTypes.bool,
-  // From mapDispatchToProps.
-  updateSortByPropertyName: PropTypes.func,
   updatePagination: PropTypes.func.isRequired,
+  results: PropTypes.arrayOf(customPropTypes.Form.isRequired),
+  showPDFInfoVersionOne: PropTypes.bool,
+  sortByPropertyName: PropTypes.string,
+  updateSortByPropertyName: PropTypes.func,
 };
 
 const mapStateToProps = state => ({

--- a/src/applications/find-forms/createFindVaForms.js
+++ b/src/applications/find-forms/createFindVaForms.js
@@ -1,17 +1,13 @@
-// Dependencies.
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-// Relative imports.
 import reducer from './reducers';
 
 export { reducer as findVaFormsWidgetReducer };
 
 export default (store, widgetType) => {
-  // Derive the element to render our widget.
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
 
-  // Escape early if no element was found.
   if (!root) {
     return;
   }

--- a/src/applications/find-forms/helpers/index.js
+++ b/src/applications/find-forms/helpers/index.js
@@ -1,7 +1,4 @@
-// dependencies
 import moment from 'moment';
-
-// relative imports
 import { deriveLatestIssue } from '../components/SearchResult';
 import {
   FAF_SORT_OPTIONS,

--- a/src/applications/find-forms/helpers/selectors.js
+++ b/src/applications/find-forms/helpers/selectors.js
@@ -1,6 +1,5 @@
-// import the toggleValues helper
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+import { toggleValues } from '~/platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from '~/platform/utilities/feature-toggles/featureFlagNames';
 
 export const getFindFormsAppState = state => state.findVAFormsReducer;
 export const showPDFModal = state =>

--- a/src/applications/find-forms/reducers/findVAFormsReducer.js
+++ b/src/applications/find-forms/reducers/findVAFormsReducer.js
@@ -1,7 +1,4 @@
-// Dependencies
 import cloneDeep from 'lodash/cloneDeep';
-
-// Relative imports.
 import { sortTheResults } from '../helpers';
 import {
   FETCH_FORMS,
@@ -14,7 +11,7 @@ import {
   UPDATE_RESULTS,
 } from '../constants';
 
-const initialState = {
+export const initialState = {
   error: '',
   fetching: false,
   page: 1,
@@ -36,6 +33,7 @@ export default (state = initialState, action) => {
     }
     case FETCH_FORMS_SUCCESS: {
       const clonedResults = cloneDeep(action.results);
+
       return {
         ...state,
         fetching: false,
@@ -54,6 +52,7 @@ export default (state = initialState, action) => {
     }
     case UPDATE_RESULTS: {
       const clonedResults = cloneDeep(action.results);
+
       return {
         ...state,
         results:

--- a/src/applications/find-forms/reducers/index.js
+++ b/src/applications/find-forms/reducers/index.js
@@ -1,4 +1,3 @@
-// Relative imports.
 import findVAFormsReducer from './findVAFormsReducer';
 
 export default {

--- a/src/applications/find-forms/tests/actions/index.unit.spec.js
+++ b/src/applications/find-forms/tests/actions/index.unit.spec.js
@@ -1,7 +1,5 @@
-// Dependencies.
 import { expect } from 'chai';
 import sinon from 'sinon';
-// Relative imports.
 import {
   fetchFormsAction,
   fetchFormsFailure,
@@ -156,11 +154,7 @@ describe('Find VA Forms actions', () => {
     it('calls dispatch', async () => {
       const dispatch = sinon.stub();
       const query = 'health';
-      const thunk = fetchFormsThunk(query, {
-        location: mockedLocation,
-        history: mockedHistory,
-        mockRequest: true,
-      });
+      const thunk = fetchFormsThunk(query);
 
       await thunk(dispatch);
 

--- a/src/applications/find-forms/tests/components/FindVaForms.unit.spec.jsx
+++ b/src/applications/find-forms/tests/components/FindVaForms.unit.spec.jsx
@@ -1,46 +1,24 @@
-// Dependencies.
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { Provider } from 'react-redux';
-// Relative imports.
-import FindVaForms from '../../components/FindVaForms';
-
-const getData = ({
-  showNod = true,
-  isLoading = false,
-  loggedIn = true,
-} = {}) => ({
-  props: {
-    isLoading,
-    loggedIn,
-  },
-  mockStore: {
-    getState: () => ({
-      featureToggles: {
-        form10182: showNod,
-      },
-      user: {
-        login: {
-          currentlyLoggedIn: loggedIn,
-        },
-      },
-    }),
-    subscribe: () => {},
-    dispatch: () => {},
-  },
-});
+import { FindVaForms } from '../../components/FindVaForms';
 
 describe('Find VA Forms <FindVaForms>', () => {
   it('should render', () => {
-    const { mockStore } = getData();
-    const tree = shallow(
-      <Provider store={mockStore}>
-        <FindVaForms />
-      </Provider>,
-    );
-
+    const tree = shallow(<FindVaForms showPdfWarningBanner />);
+    expect(tree.find('PdfAlert')).to.be.empty;
     expect(tree.find('SearchForm')).to.exist;
+    expect(tree.find('SearchResults')).to.exist;
+
+    tree.unmount();
+  });
+
+  it('should render correctly when showPdfWarningBanner is true', () => {
+    const tree = shallow(<FindVaForms showPdfWarningBanner />);
+    expect(tree.find('PdfAlert')).to.exist;
+    expect(tree.find('SearchForm')).to.exist;
+    expect(tree.find('SearchResults')).to.exist;
+
     tree.unmount();
   });
 });

--- a/src/applications/find-forms/tests/components/FormTitle.unit.spec.jsx
+++ b/src/applications/find-forms/tests/components/FormTitle.unit.spec.jsx
@@ -1,19 +1,19 @@
 import React from 'react';
-// Dependencies.
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
-// Relative imports.
 import FormTitle from '../../components/FormTitle';
 
 describe('Find VA Forms <FormTitle />', () => {
+  const recordSpy = sinon.spy();
+
   const props = {
     id: 'VA10192',
     formDetailsUrl:
       'https://www.va.gov/health-care/about-information-for-pre-complaint-processing/',
     title: 'Information for Pre-Complaint Processing',
     language: 'en',
-    recordGAEvent: sinon.stub(),
+    recordGAEvent: recordSpy,
     formName: 'VA10192',
   };
 
@@ -29,7 +29,6 @@ describe('Find VA Forms <FormTitle />', () => {
       />,
     );
 
-    // Props testing
     expect(tree.props().id).to.equal(props.id);
     expect(tree.props().formUrl).to.equal(props.formDetailsUrl);
     expect(tree.props().title).to.equal(props.title);
@@ -68,5 +67,23 @@ describe('Find VA Forms <FormTitle />', () => {
     // expect html title node to be the link
     expect(tree.html()).to.include(`href="${props.formDetailsUrl}"`);
     tree.unmount();
+  });
+
+  describe('when clicking on the form url', () => {
+    it('should record a GA event', () => {
+      const tree = mount(
+        <FormTitle
+          id={props.id}
+          formUrl={props.formDetailsUrl}
+          title={props.title}
+          recordGAEvent={recordSpy}
+        />,
+      );
+
+      tree.find('a').simulate('click');
+      expect(recordSpy.called).to.be.true;
+
+      tree.unmount();
+    });
   });
 });

--- a/src/applications/find-forms/tests/components/SearchResult.unit.spec.jsx
+++ b/src/applications/find-forms/tests/components/SearchResult.unit.spec.jsx
@@ -1,10 +1,7 @@
-// Dependencies.
 import React from 'react';
 import { expect } from 'chai';
 import { mount, shallow } from 'enzyme';
 import moment from 'moment';
-
-// Relative imports.
 import SearchResult, { deriveLatestIssue } from '../../components/SearchResult';
 import { FORM_MOMENT_PRESENTATION_DATE_FORMAT } from '../../constants';
 import FormTitle from '../../components/FormTitle';
@@ -17,6 +14,7 @@ describe('Find VA Forms <SearchResult />', () => {
     totalResultsPages: 1,
     currentPositionOnPage: 1,
   };
+
   const form = {
     id: '10-10CG',
     attributes: {
@@ -56,15 +54,18 @@ describe('Find VA Forms <SearchResult />', () => {
       validPdf: true,
     },
   };
+
   const formWithoutBenefitCats = {
     benefitCategories: [],
     vaFormAdministration: 'Veterans Health Administration',
   };
+
   const formWithFormTypeEmployment = {
     benefitCategories: [],
     vaFormAdministration: 'Veterans Health Administration',
     formType: 'employment',
   };
+
   const formWithFormTypeNonVa = {
     benefitCategories: [],
     vaFormAdministration: 'Veterans Health Administration',
@@ -75,7 +76,7 @@ describe('Find VA Forms <SearchResult />', () => {
     const tree = mount(
       <SearchResult form={form} formMetaInfo={formMetaInfo} />,
     );
-    // does parent contain child?
+
     expect(tree.contains(FormTitle));
     tree.unmount();
   });

--- a/src/applications/find-forms/tests/containers/SearchForm.unit.spec.jsx
+++ b/src/applications/find-forms/tests/containers/SearchForm.unit.spec.jsx
@@ -1,39 +1,63 @@
-// Dependencies.
 import React from 'react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
 import sinon from 'sinon';
-
-// Relative imports.
+import { render } from '@testing-library/react';
 import { SearchForm } from '../../containers/SearchForm';
 
-import stub from '../../constants/stub.json';
-
 describe('Find VA Forms <SearchForm>', () => {
-  it('should render', () => {
-    const tree = shallow(<SearchForm />);
-    const input = tree.find('[data-e2e-id="find-form-search-form"]');
-    expect(input.length).to.be.equal(1);
-    tree.unmount();
+  beforeEach(() => {
+    delete window.location;
   });
 
-  it.skip('fetches data on mount', () => {
-    // 5/19/2019 skipping due to Enzyme still not playing well with useEffect.
-    // There's an issue with the useEffect() not being invoked. Enzyme team is working on a solve.
-    const oldWindow = global.window;
-    global.window = {
-      location: {
+  describe('when a search query is added', () => {
+    beforeEach(() => {
+      window.location = {
         search: '?q=health',
-      },
-    };
-    const fetchForms = sinon.stub().resolves(stub);
-    const tree = shallow(<SearchForm fetchForms={fetchForms} />);
-    expect(fetchForms.called).to.be.true;
-    expect(fetchForms.calledWith('health')).to.be.true;
-    expect(tree.state().query).to.be.equal('health');
+      };
+    });
 
-    tree.unmount();
+    const spy1 = sinon.spy();
 
-    global.window = oldWindow;
+    it('should fetch data on mount', () => {
+      const { queryByTestId } = render(<SearchForm fetchForms={spy1} />);
+
+      expect(spy1.called).to.be.true;
+      expect(spy1.calledWith('health')).to.be.true;
+      expect(queryByTestId(/find-form-error-body/i)).to.be.null;
+    });
+  });
+
+  describe('when there is no search query added', () => {
+    beforeEach(() => {
+      window.location = {
+        search: '?q=',
+      };
+    });
+
+    const spy2 = sinon.spy();
+
+    it('should not fetch data', () => {
+      const { queryByTestId } = render(<SearchForm fetchForms={spy2} />);
+
+      expect(spy2.called).to.be.false;
+      expect(queryByTestId(/find-form-error-body/i)).to.be.null;
+    });
+  });
+
+  describe('when there is a one-character query added', () => {
+    beforeEach(() => {
+      window.location = {
+        search: '?q=a',
+      };
+    });
+
+    const spy3 = sinon.spy();
+
+    it('should not fetch data and show an error', async () => {
+      const { queryByTestId } = render(<SearchForm fetchForms={spy3} />);
+
+      expect(spy3.called).to.be.false;
+      expect(queryByTestId(/find-form-error-body/i)).not.to.be.null;
+    });
   });
 });

--- a/src/applications/find-forms/tests/containers/SearchResults.unit.spec.jsx
+++ b/src/applications/find-forms/tests/containers/SearchResults.unit.spec.jsx
@@ -1,10 +1,8 @@
-// Dependencies.
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { mount, shallow } from 'enzyme';
 import times from 'lodash/times';
-// Relative imports.
 import { INITIAL_SORT_STATE } from '../../constants';
 import {
   SearchResults,

--- a/src/applications/find-forms/tests/e2e/find-forms-required.cypress.spec.js
+++ b/src/applications/find-forms/tests/e2e/find-forms-required.cypress.spec.js
@@ -5,10 +5,7 @@
  * @testrailinfo groupId 3026
  * @testrailinfo runName FF-e2e-Required
  */
-// Dependencies.
 import chunk from 'lodash/chunk';
-
-// Relative Imports
 import { INITIAL_SORT_STATE, FAF_SORT_OPTIONS } from '../../constants';
 import { sortTheResults } from '../../helpers';
 import stub from '../../constants/stub.json';

--- a/src/applications/find-forms/tests/helpers/index.unit.spec.js
+++ b/src/applications/find-forms/tests/helpers/index.unit.spec.js
@@ -1,7 +1,4 @@
-// Dependencies.
 import { expect } from 'chai';
-
-// Relative imports
 import { sortTheResults } from '../../helpers';
 import { deriveLatestIssue } from '../../components/SearchResult';
 import { FAF_SORT_OPTIONS } from '../../constants';

--- a/src/applications/find-forms/tests/reducers/findVAFormsReducer.unit.spec.js
+++ b/src/applications/find-forms/tests/reducers/findVAFormsReducer.unit.spec.js
@@ -1,61 +1,250 @@
-// Dependencies.
 import { expect } from 'chai';
-// Relative imports.
 import {
+  FAF_OPTION_CLOSEST_MATCH,
   FETCH_FORMS,
+  FETCH_FORMS_FAILURE,
   FETCH_FORMS_SUCCESS,
-  INITIAL_SORT_STATE,
+  UPDATE_HOW_TO_SORT,
+  UPDATE_PAGINATION,
+  UPDATE_RESULTS,
 } from '../../constants';
-import findVAFormsReducer from '../../reducers/findVAFormsReducer';
+import findVAFormsReducer, {
+  initialState,
+} from '../../reducers/findVAFormsReducer';
 
 describe('Find VA Forms reducer: findVAFormsReducer', () => {
-  it('returns the default state', () => {
-    const emptyAction = {};
-    const result = findVAFormsReducer(undefined, emptyAction);
+  it('returns the default state when no action is given', () => {
+    expect(findVAFormsReducer(initialState, { type: 'TEST' })).to.be.deep.equal(
+      initialState,
+    );
+  });
 
-    expect(result).to.be.deep.equal({
-      error: '',
-      fetching: false,
-      page: 1,
-      query: '',
-      results: null,
-      sortByPropertyName: INITIAL_SORT_STATE,
-      hasOnlyRetiredForms: false,
-      closestMatchSearchResults: null,
-      startIndex: 0,
+  describe('FETCH_FORMS', () => {
+    it('returns the correct state', () => {
+      expect(
+        findVAFormsReducer(initialState, {
+          type: FETCH_FORMS,
+          query: 'testing',
+        }),
+      ).to.be.deep.equal({
+        ...initialState,
+        fetching: true,
+        query: 'testing',
+      });
     });
   });
 
-  it('fetches forms', () => {
-    const action = { type: FETCH_FORMS, query: 'testing' };
-    const state = findVAFormsReducer(undefined, action);
+  describe('FETCH_FORMS_FAILURE', () => {
+    it('returns the correct state', () => {
+      const error = 'service failed';
 
-    expect(state).to.be.deep.equal({
-      error: '',
-      fetching: true,
-      page: 1,
-      query: 'testing',
-      results: null,
-      sortByPropertyName: INITIAL_SORT_STATE,
-      hasOnlyRetiredForms: false,
-      closestMatchSearchResults: null,
-      startIndex: 0,
+      expect(
+        findVAFormsReducer(
+          {
+            ...initialState,
+            fetching: true,
+          },
+          {
+            type: FETCH_FORMS_FAILURE,
+            error,
+          },
+        ),
+      ).to.be.deep.equal({
+        ...initialState,
+        error,
+      });
     });
   });
 
-  it('receives forms', () => {
-    const initialState = {
-      fetching: true,
-      results: null,
-    };
-    const action = {
-      type: FETCH_FORMS_SUCCESS,
-      results: [],
-      hasOnlyRetiredForms: false,
-    };
-    const state = findVAFormsReducer(initialState, action);
+  describe('FETCH_FORMS_SUCCESS', () => {
+    it('returns the correct state when Closest Match is used', () => {
+      const results = [
+        {
+          attributes: {
+            formName: 'test1',
+          },
+        },
+        {
+          attributes: {
+            formName: 'test2',
+          },
+        },
+        {
+          attributes: {
+            formName: 'test2',
+          },
+        },
+      ];
 
-    expect(state.fetching).to.be.false;
-    expect(state.results).to.be.instanceOf(Array);
+      expect(
+        findVAFormsReducer(
+          {
+            ...initialState,
+            fetching: true,
+          },
+          {
+            type: FETCH_FORMS_SUCCESS,
+            results,
+            hasOnlyRetiredForms: false,
+            sortByPropertyName: FAF_OPTION_CLOSEST_MATCH,
+          },
+        ),
+      ).to.be.deep.equal({
+        ...initialState,
+        closestMatchSearchResults: results,
+        results,
+      });
+    });
+
+    it('returns the correct state when Closest Match is not used', () => {
+      const results = [
+        {
+          attributes: {
+            formName: 'cantaloupe',
+          },
+        },
+        {
+          attributes: {
+            formName: 'apple',
+          },
+        },
+        {
+          attributes: {
+            formName: 'banana',
+          },
+        },
+      ];
+
+      expect(
+        findVAFormsReducer(
+          {
+            ...initialState,
+            fetching: true,
+            sortByPropertyName: 'ALPHA_DESCENDING',
+          },
+          {
+            type: FETCH_FORMS_SUCCESS,
+            results,
+            closestMatchSearchResults: results,
+            hasOnlyRetiredForms: false,
+          },
+        ),
+      ).to.be.deep.equal({
+        ...initialState,
+        closestMatchSearchResults: results,
+        sortByPropertyName: 'ALPHA_DESCENDING',
+        results,
+      });
+    });
+  });
+
+  describe('UPDATE_HOW_TO_SORT', () => {
+    it('returns the correct state', () => {
+      const sort = 'test';
+
+      expect(
+        findVAFormsReducer(initialState, {
+          type: UPDATE_HOW_TO_SORT,
+          sortByPropertyName: sort,
+        }),
+      ).to.be.deep.equal({
+        ...initialState,
+        sortByPropertyName: sort,
+      });
+    });
+  });
+
+  describe('UPDATE_RESULTS', () => {
+    it('returns the correct state when Closest Match is used', () => {
+      const results = [
+        {
+          attributes: {
+            formName: 'test1',
+          },
+        },
+        {
+          attributes: {
+            formName: 'test2',
+          },
+        },
+        {
+          attributes: {
+            formName: 'test3',
+          },
+        },
+      ];
+
+      expect(
+        findVAFormsReducer(
+          {
+            ...initialState,
+            sortByPropertyName: FAF_OPTION_CLOSEST_MATCH,
+            closestMatchSearchResults: results,
+          },
+          {
+            type: UPDATE_RESULTS,
+            results,
+          },
+        ),
+      ).to.be.deep.equal({
+        ...initialState,
+        results,
+        closestMatchSearchResults: results,
+      });
+    });
+
+    it('returns the correct state when Closest Match is not used', () => {
+      const results = [
+        {
+          attributes: {
+            formName: 'cantaloupe',
+          },
+        },
+        {
+          attributes: {
+            formName: 'apple',
+          },
+        },
+        {
+          attributes: {
+            formName: 'banana',
+          },
+        },
+      ];
+
+      expect(
+        findVAFormsReducer(
+          {
+            ...initialState,
+            sortByPropertyName: 'ALPHA_DESCENDING',
+          },
+          {
+            type: UPDATE_RESULTS,
+            results,
+            closestMatchSearchResults: results,
+          },
+        ),
+      ).to.be.deep.equal({
+        ...initialState,
+        sortByPropertyName: 'ALPHA_DESCENDING',
+        results,
+      });
+    });
+  });
+
+  describe('UPDATE_PAGINATION', () => {
+    it('returns the correct state when UPDATE_PAGINATION is given', () => {
+      expect(
+        findVAFormsReducer(initialState, {
+          type: UPDATE_PAGINATION,
+          page: 2,
+          startIndex: 2,
+        }),
+      ).to.be.deep.equal({
+        ...initialState,
+        page: 2,
+        startIndex: 2,
+      });
+    });
   });
 });

--- a/src/applications/find-forms/tests/widgets/DownloadPDFGuidance.unit.spec.js
+++ b/src/applications/find-forms/tests/widgets/DownloadPDFGuidance.unit.spec.js
@@ -1,0 +1,164 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import DownloadPDFGuidance from '../../widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFGuidance';
+import featureFlagNames from '~/platform/utilities/feature-toggles/featureFlagNames';
+
+describe('DownloadPDFGuidance', () => {
+  const insertSpy = sinon.spy();
+  const removeSpy = sinon.spy();
+  const clickSpy = sinon.spy();
+  const removeChildSpy = sinon.spy();
+
+  describe('if the feature flag is on', () => {
+    let domStub;
+    let reduxStore;
+
+    before(() => {
+      domStub = sinon.stub(ReactDOM, 'render').returns(<div />);
+
+      reduxStore = {
+        getState: () => {
+          return {
+            featureToggles: {
+              [featureFlagNames.findFormsShowPdfModal]: true,
+            },
+          };
+        },
+      };
+    });
+
+    after(() => {
+      domStub.restore();
+    });
+
+    it('should render the download pdf modal when everything is valid and retrieved', () => {
+      DownloadPDFGuidance({
+        downloadUrl: 'https://test.com',
+        form: {},
+        formNumber: 10109,
+        formPdfIsValid: true,
+        formPdfUrlIsValid: true,
+        link: {
+          parentNode: {
+            insertBefore: insertSpy,
+          },
+          removeEventListener: removeSpy,
+          click: clickSpy,
+        },
+        listenerFunction: () => {},
+        netWorkRequestError: null,
+        reduxStore,
+      });
+
+      expect(domStub.called).to.be.true;
+    });
+  });
+
+  describe('if the feature flag is off', () => {
+    describe('if the PDF is valid', () => {
+      it('should not render the PDF', () => {
+        DownloadPDFGuidance({
+          downloadUrl: 'https://test.com',
+          form: {},
+          formNumber: 10109,
+          formPdfIsValid: true,
+          formPdfUrlIsValid: true,
+          link: {
+            parentNode: {
+              insertBefore: insertSpy,
+              removeChild: removeChildSpy,
+            },
+            removeEventListener: removeSpy,
+            click: clickSpy,
+          },
+          listenerFunction: () => {},
+          netWorkRequestError: null,
+          reduxStore: {},
+        });
+
+        expect(removeSpy.called).to.be.true;
+        expect(clickSpy.called).to.be.true;
+      });
+    });
+
+    describe('if the PDF is not valid', () => {
+      it('should not render the PDF', () => {
+        DownloadPDFGuidance({
+          downloadUrl: 'https://test.com',
+          form: {},
+          formNumber: 10109,
+          formPdfIsValid: false,
+          formPdfUrlIsValid: false,
+          link: {
+            parentNode: {
+              insertBefore: insertSpy,
+              removeChild: removeChildSpy,
+            },
+            removeEventListener: removeSpy,
+            click: clickSpy,
+          },
+          listenerFunction: () => {},
+          netWorkRequestError: null,
+          reduxStore: {},
+        });
+
+        expect(insertSpy.called).to.be.true;
+        expect(removeChildSpy.called).to.be.true;
+      });
+    });
+
+    describe('if the PDF is not valid', () => {
+      it('should not render the PDF', () => {
+        DownloadPDFGuidance({
+          downloadUrl: 'https://test.com',
+          form: {},
+          formNumber: 10109,
+          formPdfIsValid: true,
+          formPdfUrlIsValid: false,
+          link: {
+            parentNode: {
+              insertBefore: insertSpy,
+              removeChild: removeChildSpy,
+            },
+            removeEventListener: removeSpy,
+            click: clickSpy,
+          },
+          listenerFunction: () => {},
+          netWorkRequestError: null,
+          reduxStore: {},
+        });
+
+        expect(insertSpy.called).to.be.true;
+        expect(removeChildSpy.called).to.be.true;
+      });
+    });
+
+    describe('if there is a network error', () => {
+      it('should not render the PDF', () => {
+        DownloadPDFGuidance({
+          downloadUrl: 'https://test.com',
+          form: {},
+          formNumber: 10109,
+          formPdfIsValid: true,
+          formPdfUrlIsValid: true,
+          link: {
+            parentNode: {
+              insertBefore: insertSpy,
+              removeChild: removeChildSpy,
+            },
+            removeEventListener: removeSpy,
+            click: clickSpy,
+          },
+          listenerFunction: () => {},
+          netWorkRequestError: true,
+          reduxStore: {},
+        });
+
+        expect(insertSpy.called).to.be.true;
+        expect(removeChildSpy.called).to.be.true;
+      });
+    });
+  });
+});

--- a/src/applications/find-forms/tests/widgets/DownloadPDFModal.unit.spec.jsx
+++ b/src/applications/find-forms/tests/widgets/DownloadPDFModal.unit.spec.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import sinon from 'sinon';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import DownloadPDFModal from '../../widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFModal';
+
+const removeSpy = sinon.spy();
+const url = 'https://test.com/';
+
+describe('DownloadPDFModal', () => {
+  it('should render correctly', () => {
+    const { getByTestId } = render(
+      <DownloadPDFModal formNumber={10109} removeNode={removeSpy} url={url} />,
+    );
+
+    expect(getByTestId('faf-pdf-alert-modal')).to.exist;
+  });
+
+  describe('download button', () => {
+    it('should have the correct attributes', () => {
+      const { getByRole } = render(
+        <DownloadPDFModal
+          formNumber={10109}
+          removeNode={removeSpy}
+          url={url}
+        />,
+      );
+
+      const button = getByRole('button');
+      expect(button).to.have.property('href', url);
+      expect(button).to.have.text('Download VA Form 10109');
+    });
+  });
+});

--- a/src/applications/find-forms/tests/widgets/createInvalidPdfAlert.unit.spec.js
+++ b/src/applications/find-forms/tests/widgets/createInvalidPdfAlert.unit.spec.js
@@ -1,10 +1,9 @@
 import sinon from 'sinon';
 import { expect } from 'chai';
-
 import {
   mockFetch,
   setFetchJSONResponse as setFetchResponse,
-} from 'platform/testing/unit/helpers';
+} from '~/platform/testing/unit/helpers';
 
 import { onDownloadLinkClick } from '../../widgets/createFindVaFormsPDFDownloadHelper';
 

--- a/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFGuidance.js
+++ b/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFGuidance.js
@@ -1,10 +1,7 @@
-// Dependencies.
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-
-// relative imports
-import recordEvent from 'platform/monitoring/record-event';
+import recordEvent from '~/platform/monitoring/record-event';
 import DownloadPDFModal from './DownloadPDFModal';
 import InvalidFormDownload from './InvalidFormAlert';
 import { sentryLogger } from './index';
@@ -44,9 +41,10 @@ const DownloadPDFGuidance = ({
         </Provider>,
         div,
       );
+
       parentEl.insertBefore(div, link); // Insert modal on DOM
+
       recordEvent({
-        // Record GA event
         event: 'int-modal-click',
         'modal-status': 'opened',
         'modal-title': 'Download this PDF and open it in Acrobat Reader',

--- a/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFModal.jsx
+++ b/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFModal.jsx
@@ -1,10 +1,7 @@
-// Dependencies.
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-
-// Relative imports
-import recordEvent from 'platform/monitoring/record-event';
+import recordEvent from '~/platform/monitoring/record-event';
 
 // DownloadPDFModal is state wrapper + modal for PDF guidance upon PDf being valid
 const DownloadPDFModal = ({ formNumber, removeNode, url }) => {
@@ -26,11 +23,12 @@ const DownloadPDFModal = ({ formNumber, removeNode, url }) => {
   const toggleModalState = () =>
     setModalState({ ...modalState, isOpen: !modalState.isOpen });
 
-  // modal state variables
   const { isOpen, pdfSelected, pdfUrl } = modalState;
+
   return (
     <div
       className="faf-pdf-alert-modal"
+      data-testid="faf-pdf-alert-modal"
       style={{
         pointerEvents: 'all',
       }}

--- a/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/InvalidFormAlert.jsx
+++ b/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/InvalidFormAlert.jsx
@@ -1,4 +1,3 @@
-// Dependencies.
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/index.js
+++ b/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/index.js
@@ -1,7 +1,4 @@
-// Dependencies.
 import * as Sentry from '@sentry/browser';
-
-// Relative
 import { fetchFormsApi } from '../../api';
 import DownloadPDFGuidance from './DownloadPDFGuidance';
 
@@ -21,7 +18,7 @@ export async function onDownloadLinkClick(event, reduxStore, listenerFunction) {
   event.preventDefault();
   const link = event.target;
   const downloadUrl = link.href;
-  const formNumber = link.dataset.formNumber;
+  const { formNumber } = link.dataset;
 
   // Default to true in case we encounter an error
   // determining validity through the API.


### PR DESCRIPTION
## Summary
Improve Find Forms unit test coverage.

Since much of the interaction in the Find Forms application is via the shadow DOM, we are limited in how much unit test coverage we can add. There are also a few calls to `recordEvent`, our Platform implementation of Google Analytics tracking. Since they're calling Platform code directly, it's not that valuable to try to test that those were called. Both of these combined makes it difficult to achieve the 80% across the board that we'd like, but we have made some gains:

### Before 
<img width="1143" alt="Screenshot 2023-11-22 at 2 06 07 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/c4dc068e-f708-4611-bfb9-9fcc2c1608b9">

### After 
<img width="1147" alt="Screenshot 2023-11-22 at 2 05 37 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/59759145-4aad-4518-85c3-4a6879d0dae2">


Our Cypress test suites for this application are quite thorough, and test all of the functionality that the unit tests cannot (for lack of access to the shadow DOM).

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15703

## Testing done
Successfully ran unit tests for Find Forms and the whole repo.