### PR TITLE
Check in/70311/upcoming details link

### DIFF
--- a/src/applications/check-in/components/layout/ReloadWrapper.jsx
+++ b/src/applications/check-in/components/layout/ReloadWrapper.jsx
@@ -8,6 +8,7 @@ import { setForm } from '../../actions/universal';
 import { createSetSession } from '../../actions/authentication';
 import { useStorage } from '../../hooks/useStorage';
 import { useGetCheckInData } from '../../hooks/useGetCheckInData';
+import { useGetUpcomingAppointmentsData } from '../../hooks/useGetUpcomingAppointmentsData';
 import { useUpdateError } from '../../hooks/useUpdateError';
 
 const ReloadWrapper = props => {
@@ -35,6 +36,13 @@ const ReloadWrapper = props => {
       isPreCheckIn,
     },
   );
+  const {
+    upcomingAppointmentsDataError,
+    refreshUpcomingData,
+    isLoading: isUpcomingLoading,
+  } = useGetUpcomingAppointmentsData({
+    refreshNeeded: false,
+  });
   const [refreshData, setRefreshData] = useState(true);
 
   const sessionToken = getCurrentToken(window);
@@ -42,11 +50,11 @@ const ReloadWrapper = props => {
 
   useEffect(
     () => {
-      if (checkInDataError) {
+      if (checkInDataError || upcomingAppointmentsDataError) {
         updateError('reload-data-error');
       }
     },
-    [checkInDataError, updateError],
+    [checkInDataError, upcomingAppointmentsDataError, updateError],
   );
 
   useEffect(
@@ -63,6 +71,7 @@ const ReloadWrapper = props => {
             }),
           );
           refreshCheckInData();
+          refreshUpcomingData();
         } else {
           setRefreshData(false);
         }
@@ -75,6 +84,7 @@ const ReloadWrapper = props => {
       sessionToken,
       location,
       refreshCheckInData,
+      refreshUpcomingData,
       dispatch,
       getPermissions,
       progressState,
@@ -88,7 +98,7 @@ const ReloadWrapper = props => {
     [currentForm, setProgressState],
   );
 
-  if (refreshData || isLoading) {
+  if (refreshData || isLoading || isUpcomingLoading) {
     window.scrollTo(0, 0);
     return (
       <div>

--- a/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
@@ -12,6 +12,23 @@ import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 
 describe('check-in experience', () => {
   describe('shared components', () => {
+    const upcomingAppointments = [...multipleAppointments];
+    upcomingAppointments[0] = {
+      ...upcomingAppointments[0],
+      kind: 'clinic',
+      appointmentIen: 2222,
+      doctorName: 'test doc',
+      stationNo: '0001',
+      clinicIen: '0001',
+    };
+    upcomingAppointments[1] = {
+      ...upcomingAppointments[1],
+      kind: 'clinic',
+      appointmentIen: 9999,
+      doctorName: 'test doc',
+      stationNo: '9999',
+      clinicIen: '9999',
+    };
     const initAppointments = [...multipleAppointments, ...singleAppointment];
     const now = format(new Date(), "yyyy-LL-dd'T'HH:mm:ss");
     initAppointments[0] = {
@@ -68,6 +85,7 @@ describe('check-in experience', () => {
     const dayOfCheckInStore = {
       app: 'dayOf',
       appointments: initAppointments,
+      upcomingAppointments,
     };
     const appointmentOneRoute = {
       currentPage: '/appointment',
@@ -91,6 +109,18 @@ describe('check-in experience', () => {
       currentPage: '/appointment',
       params: {
         appointmentId: '4444-0001',
+      },
+    };
+    const upcomingAppointmentOneRoute = {
+      currentPage: '/appointment',
+      params: {
+        appointmentId: '2222-0001',
+      },
+    };
+    const upcomingAppointmentTwoRoute = {
+      currentPage: '/appointment',
+      params: {
+        appointmentId: '9999-9999',
       },
     };
     describe('AppointmentDetails', () => {
@@ -288,6 +318,32 @@ describe('check-in experience', () => {
             </CheckInProvider>,
           );
           expect(getByTestId('appointment-action-message')).to.exist;
+          expect(queryByTestId('check-in-button')).to.not.exist;
+        });
+      });
+      describe('Upcoming appointment', () => {
+        it('Renders the check-in button and message for appointment in both arrays', () => {
+          const { getByTestId } = render(
+            <CheckInProvider
+              store={dayOfCheckInStore}
+              router={upcomingAppointmentOneRoute}
+            >
+              <AppointmentDetails />
+            </CheckInProvider>,
+          );
+          expect(getByTestId('appointment-action-message')).to.exist;
+          expect(getByTestId('check-in-button')).to.exist;
+        });
+        it('Does not show the check-in button and message for appointment only in upcoming', () => {
+          const { queryByTestId } = render(
+            <CheckInProvider
+              store={dayOfCheckInStore}
+              router={upcomingAppointmentTwoRoute}
+            >
+              <AppointmentDetails />
+            </CheckInProvider>,
+          );
+          expect(queryByTestId('appointment-action-message')).to.not.exist;
           expect(queryByTestId('check-in-button')).to.not.exist;
         });
       });

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -135,9 +135,7 @@ const AppointmentDetails = props => {
                     : t('in-person-appointment')
                 }`}
               </h1>
-              {isUpcoming ? (
-                ''
-              ) : (
+              {!isUpcoming && (
                 <>
                   {app === APP_NAMES.PRE_CHECK_IN ? (
                     preCheckInSubTitle

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -31,10 +31,11 @@ const AppointmentDetails = props => {
   const { t } = useTranslation();
   const { goToPreviousPage, jumpToPage } = useFormRouting(router);
   const selectVeteranData = useMemo(makeSelectVeteranData, []);
-  const { appointments } = useSelector(selectVeteranData);
+  const { appointments, upcomingAppointments } = useSelector(selectVeteranData);
   const selectApp = useMemo(makeSelectApp, []);
   const { app } = useSelector(selectApp);
   const [appointment, setAppointment] = useState({});
+  const [isUpcoming, setIsUpcoming] = useState(false);
 
   const appointmentDay = new Date(appointment?.startTime);
   const isPhoneAppointment = appointment?.kind === 'phone';
@@ -55,11 +56,20 @@ const AppointmentDetails = props => {
           setAppointment(activeAppointmentDetails);
           return;
         }
+        const activeUpcomingAppointmentDetails = findAppointment(
+          appointmentId,
+          upcomingAppointments,
+        );
+        if (activeUpcomingAppointmentDetails) {
+          setIsUpcoming(true);
+          setAppointment(activeUpcomingAppointmentDetails);
+          return;
+        }
       }
-      // Go back to complete page if no activeAppointment or not in list.
-      jumpToPage('complete');
+      // Go back to appointments page if no activeAppointment or not in list.
+      jumpToPage('appointments');
     },
-    [appointmentId, appointments, jumpToPage],
+    [appointmentId, appointments, upcomingAppointments, jumpToPage],
   );
 
   const handlePhoneNumberClick = () => {
@@ -125,12 +135,18 @@ const AppointmentDetails = props => {
                     : t('in-person-appointment')
                 }`}
               </h1>
-              {app === APP_NAMES.PRE_CHECK_IN ? (
-                preCheckInSubTitle
+              {isUpcoming ? (
+                ''
               ) : (
-                <div className="vads-u-margin-x--neg2 vads-u-margin-top--2">
-                  <AppointmentMessage appointment={appointment} />
-                </div>
+                <>
+                  {app === APP_NAMES.PRE_CHECK_IN ? (
+                    preCheckInSubTitle
+                  ) : (
+                    <div className="vads-u-margin-x--neg2 vads-u-margin-top--2">
+                      <AppointmentMessage appointment={appointment} />
+                    </div>
+                  )}
+                </>
               )}
               <div data-testid="appointment-details--when">
                 <h2 className="vads-u-font-size--sm">{t('when')}</h2>
@@ -199,15 +215,16 @@ const AppointmentDetails = props => {
                   </div>
                 </div>
               )}
-              {app === APP_NAMES.CHECK_IN && (
-                <div className="vads-u-margin-top--2">
-                  <AppointmentAction
-                    appointment={appointment}
-                    router={router}
-                    event="check-in-clicked-VAOS-design"
-                  />
-                </div>
-              )}
+              {app === APP_NAMES.CHECK_IN &&
+                !isUpcoming && (
+                  <div className="vads-u-margin-top--2">
+                    <AppointmentAction
+                      appointment={appointment}
+                      router={router}
+                      event="check-in-clicked-VAOS-design"
+                    />
+                  </div>
+                )}
             </div>
           </Wrapper>
         </>


### PR DESCRIPTION
## Summary

Adds the ability to use the details page component on upcoming appointments. Anything in the normal appointments array supersedes rules on upcoming appointments. Appointments that are only in the upcoming array do not have a message or action.

Also the reload wrapper will now fetch upcoming appointments to allow upcoming details to be reloadable. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#70311

## Testing done

- Updates unit test

## What areas of the site does it impact?

Unified check-in

## Acceptance criteria

[ ] - Details links for for upcoming appointments
[ ] - You can reload the details page

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

