### PR TITLE
[VA-16195] Fix Facility Locator urgent and emergency care links

### DIFF
--- a/src/applications/facility-locator/components/search-results-items/EmergencyCareResult.jsx
+++ b/src/applications/facility-locator/components/search-results-items/EmergencyCareResult.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import recordEvent from 'platform/monitoring/record-event';
 import LocationAddress from './common/LocationAddress';
 import LocationDirectionsLink from './common/LocationDirectionsLink';
 import LocationPhoneLink from './common/LocationPhoneLink';
 
-import recordEvent from 'platform/monitoring/record-event';
 import LocationDistance from './common/LocationDistance';
 
 const EmergencyCareResult = ({ provider, query }) => {
@@ -27,28 +27,24 @@ const EmergencyCareResult = ({ provider, query }) => {
         <LocationAddress location={provider} />
         <LocationDirectionsLink
           location={provider}
-          from={'SearchResult'}
+          from="SearchResult"
           query={query}
         />
         <LocationPhoneLink
           location={provider}
-          from={'SearchResult'}
+          from="SearchResult"
           query={query}
         />
         <p>Call to confirm services and hours</p>
-        <div
-          className={`usa-alert usa-alert-info background-color-only vads-u-padding--1  vads-u-font-weight--bold`}
-        >
+        <div className="usa-alert usa-alert-info background-color-only vads-u-padding--1  vads-u-font-weight--bold">
           <i
             aria-hidden="true"
-            className={`fa fa-info-circle vads-u-margin-top--1 icon-base`}
+            className="fa fa-info-circle vads-u-margin-top--1 icon-base"
           />
           <div className="usa-alert-body">
             <a
-              href={
-                'https://www.va.gov/COMMUNITYCARE/programs/veterans/Emergency_Care.asp'
-              }
-              target={'_/blank'}
+              href="https://www.va.gov/COMMUNITYCARE/programs/veterans/Emergency-Care.asp"
+              target="_/blank"
               onClick={() => {
                 // Record event
                 recordEvent({ event: 'cta-emergency-benefit-button-click' });

--- a/src/applications/facility-locator/components/search-results-items/UrgentCareResult.jsx
+++ b/src/applications/facility-locator/components/search-results-items/UrgentCareResult.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import recordEvent from 'platform/monitoring/record-event';
 import LocationAddress from './common/LocationAddress';
 import LocationDirectionsLink from './common/LocationDirectionsLink';
 import LocationPhoneLink from './common/LocationPhoneLink';
 
-import recordEvent from 'platform/monitoring/record-event';
 import LocationDistance from './common/LocationDistance';
 
 const UrgentCareResult = ({ provider, query }) => {
@@ -27,28 +27,24 @@ const UrgentCareResult = ({ provider, query }) => {
         <LocationAddress location={provider} />
         <LocationDirectionsLink
           location={provider}
-          from={'SearchResult'}
+          from="SearchResult"
           query={query}
         />
         <LocationPhoneLink
           location={provider}
-          from={'SearchResult'}
+          from="SearchResult"
           query={query}
         />
         <p>Call to confirm services and hours</p>
-        <div
-          className={`usa-alert usa-alert-info background-color-only vads-u-padding--1  vads-u-font-weight--bold`}
-        >
+        <div className="usa-alert usa-alert-info background-color-only vads-u-padding--1  vads-u-font-weight--bold">
           <i
             aria-hidden="true"
-            className={`fa fa-info-circle vads-u-margin-top--1 icon-base`}
+            className="fa fa-info-circle vads-u-margin-top--1 icon-base"
           />
           <div className="usa-alert-body">
             <a
-              href={
-                'https://www.va.gov/COMMUNITYCARE/programs/veterans/Urgent_Care.asp'
-              }
-              target={'_/blank'}
+              href="https://www.va.gov/COMMUNITYCARE/programs/veterans/Urgent-Care.asp"
+              target="_/blank"
               onClick={() => {
                 // Record event
                 recordEvent({ event: 'cta-primary-button-click' });

--- a/src/applications/facility-locator/containers/UrgentCareAlert.jsx
+++ b/src/applications/facility-locator/containers/UrgentCareAlert.jsx
@@ -18,10 +18,8 @@ export default function UrgentCareAlert() {
           </dd>
           <a
             className="usa-button-primary vads-u-margin-y--0"
-            href={
-              'https://www.va.gov/COMMUNITYCARE/programs/veterans/Urgent_Care.asp'
-            }
-            target={'_/blank'}
+            href="https://www.va.gov/COMMUNITYCARE/programs/veterans/Urgent-Care.asp"
+            target="_/blank"
             onClick={() => {
               // Record event
               recordEvent({ event: 'cta-primary-button-click' });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

The Facility Locator has broken links in results that include more information about urgent and emergency care. The link structure in this repo is slightly outdated with the formatting. This pull request fixes the formatting for the affected links.

## Related issue(s)

Related to [#16195 (which includes steps to reproduce the bug).](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16195)

## Testing done

I went to [the Find Locations page locally](http://localhost:3001/find-locations/) and [searched for Urgent Care in the 55101 zip code.](http://localhost:3001/find-locations/?page=1&address=55101&facilityType=urgent_care&serviceType&latitude=44.949749&longitude=-93.093103&radius=10&bounds%5B%5D=-93.843103&bounds%5B%5D=44.199749&bounds%5B%5D=-92.343103&bounds%5B%5D=45.699749&context=Saint%20Paul%2C%20Minnesota%2055101%2C%20United%20States). The "in-network urgent care benefits" link now goes to the correct page and doesn't break. I also tested the Emergency Care link at this local URL and the "in-network emergency care benefits" link also works.

## Screenshots

<img width="706" alt="Screen Shot 2023-11-28 at 1 35 13 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/10790736/05689143-2cc0-4ba1-b810-ab77d630ae08">

<img width="1409" alt="Screen Shot 2023-11-28 at 3 24 01 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/10790736/88f47b3e-52bd-4392-a01d-84aa40d25e30">

## What areas of the site does it impact?

Facility Locator

## Acceptance criteria

### Quality Assurance & Testing

Confirmed the bug is fixed through the reproduction steps described in the ticket.
