### PR TITLE
[DBEX-70682] validate Reserves/Guard dates using DateUI Schema 

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/reservesNationalGuardService.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/reservesNationalGuardService.jsx
@@ -1,9 +1,6 @@
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
-import {
-  validateDate,
-  validateDateRange,
-} from '@department-of-veterans-affairs/platform-forms-system/validation';
-import VaMemorableDateField from 'platform/forms-system/src/js/web-component-fields/VaMemorableDateField';
+import dateUI from '@department-of-veterans-affairs/platform-forms-system/date';
+import { validateDateRange } from '@department-of-veterans-affairs/platform-forms-system/validation';
 import { ReservesGuardDescription } from '../utils';
 
 const {
@@ -22,30 +19,10 @@ export const uiSchema = {
           pattern: 'End date must be after start date',
           required: 'Please enter a date',
         },
-        from: {
-          'ui:title': 'Obligation start date',
-          'ui:widget': 'date',
-          'ui:webComponentField': VaMemorableDateField,
-          'ui:validations': [validateDate],
-          'ui:errorMessages': {
-            pattern: 'Please enter a valid date',
-            required: 'Please enter a date',
-          },
-        },
-        to: {
-          'ui:title': 'Obligation end date',
-          'ui:widget': 'date',
-          'ui:webComponentField': VaMemorableDateField,
-          'ui:validations': [validateDate],
-          'ui:errorMessages': {
-            pattern: 'Please enter a valid date',
-            required: 'Please enter a date',
-          },
-        },
+        from: dateUI('Obligation start date'),
+        to: dateUI('Obligation end date'),
       },
-      unitName: {
-        'ui:title': 'Unit name',
-      },
+      unitName: { 'ui:title': 'Unit name' },
     },
   },
 };

--- a/src/applications/disability-benefits/all-claims/tests/pages/reservesNationalGuardService.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/reservesNationalGuardService.unit.spec.jsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import moment from 'moment';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import {
+  DefinitionTester,
+  fillData,
+  fillDate,
+} from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
+import { mount } from 'enzyme';
+import formConfig from '../../config/form';
+
+describe('Reserve and National Guard Information', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.veteranDetails.pages.reservesNationalGuardService;
+
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+      />,
+    );
+
+    expect(form.find('input').length).to.equal(3);
+    form.unmount();
+  });
+
+  it('should fail to submit when no data is filled out', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(3);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+
+  it('should submit when data filled in', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        appStateData={{
+          servicePeriods: [
+            { serviceBranch: 'Reserves', dateRange: { from: '2008-03-12' } },
+          ],
+        }}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fillDate(
+      form,
+      'root_serviceInformation_reservesNationalGuardService_obligationTermOfServiceDateRange_from',
+      '2010-05-05',
+    );
+    fillDate(
+      form,
+      'root_serviceInformation_reservesNationalGuardService_obligationTermOfServiceDateRange_to',
+      '2020-05-05',
+    );
+    fillData(
+      form,
+      'input#root_serviceInformation_reservesNationalGuardService_unitName',
+      'Lorem epsum',
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+
+  it('should fail to submit when obligation end date is before start date', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        appStateData={{
+          servicePeriods: [
+            { serviceBranch: 'Reserves', dateRange: { from: '2008-03-12' } },
+          ],
+        }}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    fillDate(
+      form,
+      'root_serviceInformation_reservesNationalGuardService_obligationTermOfServiceDateRange_from',
+      moment()
+        .add(100, 'days')
+        .format('YYYY-MM-DD'),
+    );
+    fillDate(
+      form,
+      'root_serviceInformation_reservesNationalGuardService_obligationTermOfServiceDateRange_to',
+      moment()
+        .add(90, 'days')
+        .format('YYYY-MM-DD'),
+    );
+    fillData(
+      form,
+      'input#root_serviceInformation_reservesNationalGuardService_unitName',
+      'Lorem epsum',
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+});

--- a/src/platform/forms-system/src/js/utilities/validations/index.js
+++ b/src/platform/forms-system/src/js/utilities/validations/index.js
@@ -98,8 +98,13 @@ export function isValidDateRange(fromDate, toDate, allowSameMonth = false) {
   if (isBlankDateField(toDate) || isBlankDateField(fromDate)) {
     return true;
   }
+
   const momentStart = dateToMoment(fromDate);
   const momentEnd = dateToMoment(toDate);
+
+  if (!momentStart.isValid() || !momentEnd.isValid()) {
+    return false;
+  }
 
   return allowSameMonth
     ? momentStart.isSameOrBefore(momentEnd)


### PR DESCRIPTION
## Summary

It is currently possible to create an "XX" value for the Day field of some dates in the 526 form causing primary and backup path failures after submission due to data invalidation errors. Issues with all date fields determined to have this issue are slotted to be resolved, beginning with this initially identified instance. Where required, date field days in which a user could previously input a value are being updated to dropdown select options based on the selected Month, ensuring reliable data inputs. The DateUI schema was imported directly into and accessed within the impacted page, instead of attempting to assign all UI attributes within the page itself. 

## Related issue

- [ticket](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/70682)

## Testing done

- Currently possible to input a non-numeric value in Day field resulting in a value of XX
- Changed Day input field to dropdown select utilizing DateUI Schema and validations
- Created previously non-existent unit test to validate render, the presence of error messages, and submission failure without completing required fields

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |![mobile before](https://github.com/department-of-veterans-affairs/vets-website/assets/50811220/90efc0f3-4124-475e-9dbf-5d8a89dcd95f)|![mobile after](https://github.com/department-of-veterans-affairs/vets-website/assets/50811220/cb22432c-9b9b-4993-8a20-dc6653ce787a)|
| Desktop |![desktop before](https://github.com/department-of-veterans-affairs/vets-website/assets/50811220/9572227b-c32e-4bd6-987c-a7eb053eb7f7)|![desktop after](https://github.com/department-of-veterans-affairs/vets-website/assets/50811220/2fa63303-1450-46d2-b61e-3d0f8aba78c6)|

## What areas of the site does it impact?

Form 526 > Veteran Details > Reserve and National Guard Information > Obligation start and end dates

## Acceptance criteria

- [x] Update date field to use the select element
- [x] Ensure change does not introduce impossible dates such as Feb 31st

### Quality Assurance & Testing

- [x] I added a unit test
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
