### PR TITLE
VACMS-16218 Results screens update for SurveyMonkey

### DIFF
--- a/src/applications/pact-act/containers/results/1/Page1.jsx
+++ b/src/applications/pact-act/containers/results/1/Page1.jsx
@@ -28,7 +28,7 @@ const ResultsSet1Page1 = () => {
       </p>
       <p>
         Based on where you told us you served, we think you may have had
-        exposure to a toxic substance. We call this a "presumption of exposure."
+        exposure to a toxic substance. We call this a “presumption of exposure.”
       </p>
       <h2>Presumptive exposure locations we think may apply to you</h2>
       <p>
@@ -39,7 +39,7 @@ const ResultsSet1Page1 = () => {
         <li>Arabian Sea</li>
         <li>Gulf of Aden</li>
         <li>Gulf of Oman</li>
-        <li>Neutral zone between Iraq/Saudi Arabia</li>
+        <li>The neutral zone on the border between Iraq and Saudi Arabia</li>
         <li>Persian Gulf</li>
         <li>Red Sea</li>
       </ul>
@@ -61,7 +61,7 @@ const ResultsSet1Page1 = () => {
         className="vads-c-action-link--green"
         to={ROUTES.RESULTS_SET_1_PAGE_2}
       >
-        Learn what to do next
+        Learn more about presumptive conditions and what to do next
       </Link>
     </>
   );

--- a/src/applications/pact-act/containers/results/1/Page2.jsx
+++ b/src/applications/pact-act/containers/results/1/Page2.jsx
@@ -52,23 +52,42 @@ const ResultsSet1Page2 = () => {
         online now.
       </p>
       <article>
-        <va-on-this-page />
         <h2 id="file-a-disability-compensation-claim">
           File a claim for disability compensation
         </h2>
         <p>
           If you think you’re eligible, we encourage you to file a claim for
-          disability compensation now. If you have an illness that we don’t
-          consider presumptive, you can still file a claim. But you’ll need to
-          provide evidence that your service caused your condition.
+          disability compensation now.
+        </p>
+        <h3>Check presumptive conditions</h3>
+        <p>
+          Here are the presumptive conditions we think may apply to you based on
+          your answers.
         </p>
         {renderAccordions()}
-        <h3>If you haven’t yet filed a claim for your condition</h3>
         <p>
-          You can file a claim now. If you already get disability compensation
-          for a different condition, we still encourage you to file a claim for
-          any condition you believe your service caused. You may be able to get
-          additional or other benefits.
+          <strong>Note:</strong> If your condition isn’t listed here, you can
+          learn more about other presumptive conditions and disability benefit
+          eligibility. And if you have an illness that we don’t consider
+          presumptive, you can still file a claim. But you’ll need to provide
+          evidence that your service caused your condition.{' '}
+          <a
+            href="/disability/eligibility"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Learn more about eligibility for disability benefits (opens in a new
+            tab)
+          </a>
+        </p>
+        <h3>
+          How to file a claim for a condition you haven’t filed a claim for yet
+        </h3>
+        <p>You can file a claim now.</p>
+        <p>
+          Already get disability compensation for a different condition? We
+          still encourage you to file a claim for any condition you believe your
+          service caused. You may be able to get additional or other benefits.
         </p>
         <a
           className="vads-c-action-link--blue"
@@ -76,7 +95,7 @@ const ResultsSet1Page2 = () => {
         >
           File a disability compensation claim
         </a>
-        <h3>If we denied your claim for this condition in the past</h3>
+        <h3>How to file a claim for a condition we’ve denied in the past</h3>
         <p>
           If we now consider your condition presumptive under the PACT Act, you
           can file a Supplemental Claim. We’ll reconsider your claim.


### PR DESCRIPTION
## Summary
Updating text content for PACT Act results pages for SurveyMonkey. The dynamic content on these pages follows the chosen path of the existing results screens for SurveyMonkey ("Yes" to any Burn Pit flow question).

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16218

## Testing done
Locally.

## Screenshots

### Page 1
<img width="1200" alt="Screenshot 2023-11-29 at 10 21 09 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/25ead70c-d0e4-41ff-aa82-a08d2c037300">

### Page 2
<img width="1200" alt="Screenshot 2023-11-29 at 10 21 16 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/7e5d91ff-5f76-40e9-8c14-96452e4a4489">
<img width="1200" alt="Screenshot 2023-11-29 at 10 21 28 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/ad22c7bb-c3bd-4452-9c94-8c143cd1984f">

### Page 2 accordions
<img width="1200" alt="Screenshot 2023-11-29 at 10 25 56 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/1705aef8-ea98-4964-a7d7-a1ca38f27d18">
<img width="1200" alt="Screenshot 2023-11-29 at 10 26 11 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/0f973aa9-a0e1-4133-8d14-61d34d8a47eb">

## Acceptance criteria
- [x] The SM results screens are updated with Danielle's latest content