### PR TITLE
reduce number of runs of test stability review in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -327,29 +327,7 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        runs:
-          [
-            1,
-            2,
-            3,
-            4,
-            5,
-            6,
-            7,
-            8,
-            9,
-            10,
-            11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20,
-          ]
+        runs: [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
     steps:
       - name: Checkout
@@ -777,8 +755,7 @@ jobs:
       fail-fast: false
       max-parallel: 20
       matrix:
-        ci_node_index:
-          [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+        ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
     env:
       CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -325,9 +325,9 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 20
+      max-parallel: 10
       matrix:
-        runs: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        runs: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
     steps:
       - name: Checkout
@@ -753,7 +753,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      max-parallel: 20
+      max-parallel: 10
       matrix:
         ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 


### PR DESCRIPTION
## Summary

- Reduce number of CI runs of Test Stability Review processes to free up runners.

