### PR TITLE
[AVS] Add health reminders section

### DIFF
--- a/src/applications/avs/components/YourTreatmentPlan.jsx
+++ b/src/applications/avs/components/YourTreatmentPlan.jsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 
+import ItemsBlock from './ItemsBlock';
 import MedicationTerms from './MedicationTerms';
 import OrdersBlock from './OrdersBlock';
 import ParagraphBlock from './ParagraphBlock';
@@ -20,6 +21,18 @@ const YourTreatmentPlan = props => {
       <MedicationTerms avs={avs} />
     </>
   );
+
+  const renderReminder = reminder => {
+    return (
+      <p>
+        {reminder.name}
+        <br />
+        When due: {reminder.whenDue}
+        <br />
+        Frequency: {reminder.frequency}
+      </p>
+    );
+  };
 
   return (
     <div>
@@ -60,7 +73,14 @@ const YourTreatmentPlan = props => {
         orders={orders}
         type={ORDER_TYPES.OTHER}
       />
-      {/* TODO: add health reminders. */}
+      <ItemsBlock
+        heading="Your reminders"
+        intro="The list below is your health reminders. These are health checks for prevention care (for example cancer screening) and checks on chronic conditions like diabetes. Your primary care provider and team will see this list in the computer and should discuss them with you."
+        itemType="your-reminders"
+        items={avs.clinicalReminders}
+        renderItem={renderReminder}
+        showSeparators
+      />
       <ParagraphBlock
         heading="Other instructions"
         headingLevel={4}

--- a/src/applications/avs/components/YourTreatmentPlan.jsx
+++ b/src/applications/avs/components/YourTreatmentPlan.jsx
@@ -74,9 +74,9 @@ const YourTreatmentPlan = props => {
         type={ORDER_TYPES.OTHER}
       />
       <ItemsBlock
-        heading="Your reminders"
+        heading="Health reminders"
         intro="The list below is your health reminders. These are health checks for prevention care (for example cancer screening) and checks on chronic conditions like diabetes. Your primary care provider and team will see this list in the computer and should discuss them with you."
-        itemType="your-reminders"
+        itemType="health-reminders"
         items={avs.clinicalReminders}
         renderItem={renderReminder}
         showSeparators

--- a/src/applications/avs/tests/components/YourTreatmentPlan.unit.spec.jsx
+++ b/src/applications/avs/tests/components/YourTreatmentPlan.unit.spec.jsx
@@ -29,6 +29,11 @@ describe('Avs: Your Treatment Plan', () => {
     expect(screen.getByTestId('other-orders').children[1]).to.contain.text(
       'PACT ALERT BRAVO\nConcern:',
     );
+    expect(
+      screen.getByTestId('your-reminders').children[2].firstChild,
+    ).to.contain.text(
+      'Hepatitis C risk Factor ScreeningWhen due: DUE NOWFrequency:  Due every 3 years for all ages.',
+    );
     expect(screen.getByTestId('other-instructions')).to.contain.text(
       'Recommend acetaminophen 500 mg',
     );
@@ -38,6 +43,7 @@ describe('Avs: Your Treatment Plan', () => {
     const avs = replacementFunctions.cloneDeep(avsData);
     delete avs.orders;
     delete avs.patientInstructions;
+    delete avs.clinicalReminders;
     const props = { avs };
     const screen = render(<YourTreatmentPlan {...props} />);
     expect(screen.queryByTestId('consultations')).to.not.exist;
@@ -45,6 +51,7 @@ describe('Avs: Your Treatment Plan', () => {
     expect(screen.queryByTestId('lab-tests')).to.not.exist;
     expect(screen.queryByTestId('medications')).to.not.exist;
     expect(screen.queryByTestId('other-orders')).to.not.exist;
+    expect(screen.queryByTestId('your-reminders')).to.not.exist;
     expect(screen.queryByTestId('other-instructions')).to.not.exist;
   });
 });

--- a/src/applications/avs/tests/components/YourTreatmentPlan.unit.spec.jsx
+++ b/src/applications/avs/tests/components/YourTreatmentPlan.unit.spec.jsx
@@ -30,7 +30,7 @@ describe('Avs: Your Treatment Plan', () => {
       'PACT ALERT BRAVO\nConcern:',
     );
     expect(
-      screen.getByTestId('your-reminders').children[2].firstChild,
+      screen.getByTestId('health-reminders').children[2].firstChild,
     ).to.contain.text(
       'Hepatitis C risk Factor ScreeningWhen due: DUE NOWFrequency:  Due every 3 years for all ages.',
     );
@@ -51,7 +51,7 @@ describe('Avs: Your Treatment Plan', () => {
     expect(screen.queryByTestId('lab-tests')).to.not.exist;
     expect(screen.queryByTestId('medications')).to.not.exist;
     expect(screen.queryByTestId('other-orders')).to.not.exist;
-    expect(screen.queryByTestId('your-reminders')).to.not.exist;
+    expect(screen.queryByTestId('health-reminders')).to.not.exist;
     expect(screen.queryByTestId('other-instructions')).to.not.exist;
   });
 });

--- a/src/applications/avs/tests/fixtures/9A7AF40B2BC2471EA116891839113252.json
+++ b/src/applications/avs/tests/fixtures/9A7AF40B2BC2471EA116891839113252.json
@@ -1404,6 +1404,29 @@
           }
         ]
       },
+      "clinicalReminders": [
+        {
+          "ien": "500047",
+          "whenDue": "DUE NOW",
+          "lastOccurrence": "",
+          "name": "Hepatitis C risk Factor Screening",
+          "frequency": " Due every 3 years for all ages."
+        },
+        {
+          "ien": "500062",
+          "whenDue": "DUE NOW",
+          "lastOccurrence": "",
+          "name": "Primary Care Depression Screening",
+          "frequency": " Due every 1 year for all ages."
+        },
+        {
+          "ien": "55",
+          "whenDue": "DUE NOW",
+          "lastOccurrence": "",
+          "name": "Suicide Hotline",
+          "frequency": " Due every 1 year for all ages."
+        }
+      ],
       "pharmacyTerms": [
         {
           "type": "status",


### PR DESCRIPTION
## Summary

- Adds "Your reminders" section to AVS
- Updates tests

## Related issue(s)

- issue: department-of-veterans-affairs/va.gov-team#70855
- hi-fi: https://www.sketch.com/s/05d5a740-4fc7-4380-8d83-e7acfbab201b/p/EEBE9459-2B99-46C6-8001-A1AED1811CC8/canvas

## Testing done

- Manual testing
- updated unit tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |  (nothing)  | ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/101649/73bc9171-7107-4339-bcb9-b26b14250084) |

## What areas of the site does it impact?

- AVS application

## Acceptance criteria

- [ ] "Your reminders" block is displayed under "Your treatment plan from this appointment" accordion if data is present in json
- [ ] block is not displayed if data is not available

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
