### PR TITLE
[FSR] Hiding review page edit buttons 

### DIFF
--- a/src/applications/financial-status-report/sass/financial-status-report.scss
+++ b/src/applications/financial-status-report/sass/financial-status-report.scss
@@ -354,6 +354,12 @@
   }
 }
 
+.form-review-panel-page-header-row {
+  va-button {
+    display: none;
+  }
+}
+
 @include hide-button("button.edit-page");
 @include hide-button(".edit-btn.primary-outline");
 

--- a/src/applications/financial-status-report/sass/financial-status-report.scss
+++ b/src/applications/financial-status-report/sass/financial-status-report.scss
@@ -354,8 +354,9 @@
   }
 }
 
+/* Hide default edit buttons on final review page */
 .form-review-panel-page-header-row {
-  va-button {
+  va-button, button {
     display: none;
   }
 }


### PR DESCRIPTION
## Summary
Recent platform changes reintroduced edit buttons FSR was hiding in favor of a custom solution. This PR hides the edit buttons again to ensure consistent functionality

## Related issue(s)
Issue that introduced bug:
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#64149

## Testing done
Local testing complete

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
| ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/25368370/844d5bf3-0e92-49d4-9c19-0825715e995a) | ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/25368370/e030b39c-d7ba-4c11-8f0e-a0c181185f73) |

## What areas of the site does it impact?
FSR
*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
