### PR TITLE
Changing expiration date to 1 year for newly submitted ITFs

### DIFF
--- a/src/applications/simple-forms/21-0966/config/helpers.js
+++ b/src/applications/simple-forms/21-0966/config/helpers.js
@@ -174,11 +174,7 @@ export const getSuccessAlertTitle = (data, alreadySubmittedIntents) => {
   return 'You’ve submitted your intent to file';
 };
 
-export const getSuccessAlertText = (
-  data,
-  alreadySubmittedIntents,
-  expirationDate,
-) => {
+export const getSuccessAlertText = (data, alreadySubmittedIntents) => {
   let benefitSelection = benefitSelections(data)[0];
   const benefitSet = new Set(benefitSelections(data));
   if (
@@ -191,10 +187,10 @@ export const getSuccessAlertText = (
 
   const benefitPhrase = benefitPhrases[benefitSelection];
   if (Object.keys(alreadySubmittedIntents).length > 0) {
-    return `Your intent to file will expire on ${expirationDate}.`;
+    return `Your intent to file will expire in 1 year.`;
   }
 
-  return `Your intent to file for ${benefitPhrase} will expire on ${expirationDate}.`;
+  return `Your intent to file for ${benefitPhrase} will expire in 1 year.`;
 };
 
 export const getInfoAlertTitle = () =>
@@ -286,7 +282,6 @@ export const getAlreadySubmittedText = (data, alreadySubmittedIntents) => {
 export const getNextStepsTextSecondParagraph = (
   data,
   alreadySubmittedIntents,
-  newExpirationDate,
 ) => {
   const dateOptions = {
     weekday: 'long',
@@ -311,18 +306,9 @@ export const getNextStepsTextSecondParagraph = (
     return 'You’ll need to file your claims within 1 year to get retroactive payments (payments for the time between when you submit your intent to file and when we approve your claim).';
   }
 
-  let expirationDate = newExpirationDate;
-  const oldExpirationDate =
-    alreadySubmittedIntents[benefitSelection]?.expirationDate;
-  if (oldExpirationDate) {
-    expirationDate = new Date(
-      alreadySubmittedIntents[benefitSelection].expirationDate,
-    ).toLocaleDateString('en-US', dateOptions);
-  }
-
   return `Your intent to file for ${
     benefitPhrases[benefitSelection]
-  } expires on ${expirationDate}. You’ll need to file your claim by this date to get retroactive payments (payments for the time between when you submit your intent to file and when we approve your claim).`;
+  } expires in 1 year. You’ll need to file your claim within 1 year to get retroactive payments (payments for the time between when you submit your intent to file and when we approve your claim).`;
 };
 
 export const getNextStepsLinks = data => {

--- a/src/applications/simple-forms/21-0966/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-0966/containers/ConfirmationPage.jsx
@@ -99,13 +99,7 @@ export class ConfirmationPage extends React.Component {
             <h2 slot="headline">
               {getSuccessAlertTitle(data, alreadySubmittedIntents)}
             </h2>
-            <p>
-              {getSuccessAlertText(
-                data,
-                alreadySubmittedIntents,
-                expirationDate,
-              )}
-            </p>
+            <p>{getSuccessAlertText(data, alreadySubmittedIntents)}</p>
           </va-alert>
         )}
         <div className="inset">

--- a/src/applications/simple-forms/21-0966/tests/config/helpers.unit.spec.js
+++ b/src/applications/simple-forms/21-0966/tests/config/helpers.unit.spec.js
@@ -254,7 +254,6 @@ describe('confirmation page helper functions', () => {
             [selectedIntent]: true,
           },
         };
-        const expirationDate = 'expiration-date';
 
         it('shows a success alert', () => {
           expect(getAlertType(data, {})).to.equal('success');
@@ -267,10 +266,10 @@ describe('confirmation page helper functions', () => {
         });
 
         it('successfully gets the success alert text', () => {
-          expect(getSuccessAlertText(data, {}, expirationDate)).to.equal(
+          expect(getSuccessAlertText(data, {})).to.equal(
             `Your intent to file for ${
               benefitPhrases[selectedIntent]
-            } will expire on ${expirationDate}.`,
+            } will expire in 1 year.`,
           );
         });
       });
@@ -283,7 +282,6 @@ describe('confirmation page helper functions', () => {
           [veteranBenefits.PENSION]: true,
         },
       };
-      const expirationDate = 'expiration-date';
 
       it('shows a success alert', () => {
         expect(getAlertType(data, {})).to.equal('success');
@@ -296,8 +294,8 @@ describe('confirmation page helper functions', () => {
       });
 
       it('successfully gets the success alert text', () => {
-        expect(getSuccessAlertText(data, {}, expirationDate)).to.equal(
-          `Your intent to file for disability compensation and pension claims will expire on ${expirationDate}.`,
+        expect(getSuccessAlertText(data, {})).to.equal(
+          `Your intent to file for disability compensation and pension claims will expire in 1 year.`,
         );
       });
     });
@@ -309,7 +307,6 @@ describe('confirmation page helper functions', () => {
           [veteranBenefits.PENSION]: true,
         },
       };
-      const expirationDate = 'expiration-date';
 
       [veteranBenefits.COMPENSATION, veteranBenefits.PENSION].forEach(
         alreadySubmittedIntentType => {
@@ -343,13 +340,9 @@ describe('confirmation page helper functions', () => {
           });
 
           it('successfully gets the success alert text', () => {
-            expect(
-              getSuccessAlertText(
-                data,
-                alreadySubmittedIntents,
-                expirationDate,
-              ),
-            ).to.equal(`Your intent to file will expire on ${expirationDate}.`);
+            expect(getSuccessAlertText(data, alreadySubmittedIntents)).to.equal(
+              `Your intent to file will expire in 1 year.`,
+            );
           });
         },
       );
@@ -453,7 +446,6 @@ describe('confirmation page helper functions', () => {
             [selectedIntent]: true,
           },
         };
-        const expirationDate = 'expiration-date';
 
         it('successfully gets the already submitted title', () => {
           expect(getAlreadySubmittedTitle(data, {})).to.equal(null);
@@ -464,12 +456,10 @@ describe('confirmation page helper functions', () => {
         });
 
         it('successfully gets the second paragraph of the next steps text', () => {
-          expect(
-            getNextStepsTextSecondParagraph(data, {}, expirationDate),
-          ).to.equal(
+          expect(getNextStepsTextSecondParagraph(data, {})).to.equal(
             `Your intent to file for ${
               benefitPhrases[selectedIntent]
-            } expires on ${expirationDate}. You’ll need to file your claim by this date to get retroactive payments (payments for the time between when you submit your intent to file and when we approve your claim).`,
+            } expires in 1 year. You’ll need to file your claim within 1 year to get retroactive payments (payments for the time between when you submit your intent to file and when we approve your claim).`,
           );
         });
 
@@ -594,20 +584,10 @@ describe('confirmation page helper functions', () => {
             [selectedIntent]: true,
           },
         };
-        const dateOptions = {
-          weekday: 'long',
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-        };
-        const expirationDate = '2024-09-22T19:15:20.000-05:00';
-        const formattedExpirationDate = new Date(
-          expirationDate,
-        ).toLocaleDateString('en-us', dateOptions);
         const alreadySubmittedIntents = {
           [selectedIntent]: {
             creationDate: '2021-03-16T19:15:21.000-05:00',
-            expirationDate,
+            expirationDate: '2024-09-22T19:15:20.000-05:00',
             type: selectedIntent,
             status: 'active',
           },
@@ -627,7 +607,7 @@ describe('confirmation page helper functions', () => {
           ).to.equal(
             `Your intent to file for ${
               benefitPhrases[selectedIntent]
-            } expires on ${formattedExpirationDate}. You’ll need to file your claim by this date to get retroactive payments (payments for the time between when you submit your intent to file and when we approve your claim).`,
+            } expires in 1 year. You’ll need to file your claim within 1 year to get retroactive payments (payments for the time between when you submit your intent to file and when we approve your claim).`,
           );
         });
 


### PR DESCRIPTION

## Summary

We needed to make newly submitted ITFs expiration date less specific, so we changed it to `1 year` instead of printing the exact date.


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
https://github.com/department-of-veterans-affairs/VA.gov-team-forms/issues/817


## Testing done

- _Describe what the old behavior was prior to the change_
- Text on the confirmation page said the exact date 1 year from date of submission. We need to not print the exact date, and just say 1 year.

- _Describe the steps required to verify your changes are working as expected_
- Reviewed /confirmation page of the form in local environment

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*
just 0966 ITF form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
