### PR TITLE
Fix web component focus/scrolling issues including va-segmented-progress-bar

### DIFF
--- a/src/platform/utilities/tests/ui/webComponents.unit.spec.jsx
+++ b/src/platform/utilities/tests/ui/webComponents.unit.spec.jsx
@@ -1,16 +1,20 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render, waitFor } from '@testing-library/react';
-import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import {
+  VaCheckboxGroup,
+  VaTextInput,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { $ } from '../../../forms-system/src/js/utilities/ui';
 import {
-  awaitShadowRoot,
+  waitForShadowRoot,
   isWebComponent,
   isWebComponentReady,
+  querySelectorWithShadowRoot,
 } from '../../ui/webComponents';
 
-describe('web component UI tests', async () => {
-  it('web component UI tests', async () => {
+describe('web component basic checkers', async () => {
+  it('isWebComponent check', async () => {
     const { container } = await render(
       <div>
         <VaTextInput id="web-component" label="Text input" />
@@ -18,27 +22,141 @@ describe('web component UI tests', async () => {
       </div>,
     );
 
-    await waitFor(() => {
+    expect(isWebComponent('va-text-input')).to.eq(true);
+    expect(isWebComponent($('va-text-input', container))).to.eq(true);
+
+    expect(isWebComponent('input')).to.eq(false);
+    expect(isWebComponent($('input', container))).to.eq(false);
+
+    expect(isWebComponent(null)).to.eq(false);
+    expect(isWebComponent({})).to.eq(false);
+  });
+
+  it('isWebComponentReady check', async () => {
+    const { container } = await render(
+      <div>
+        <VaTextInput id="web-component" label="Text input" />
+        <input type="text" id="text" />
+      </div>,
+    );
+
+    const vaTextInput = $('#web-component', container);
+    const textInput = $('#text', container);
+
+    // Unfortunately we can't test this in react testing library
+    // because web-component shadowRoots don't get populated.
+    // We can instead rely on Cypress tests to make sure UI is done properly.
+    // We could choose to arbitrarily return true instead if we wanted to
+    expect(isWebComponentReady(vaTextInput)).to.eq(false);
+    expect(isWebComponentReady(textInput)).to.eq(false);
+
+    expect(isWebComponentReady(null)).to.eq(false);
+    expect(isWebComponentReady({})).to.eq(false);
+  });
+
+  it('waitForShadowRoot tests', async () => {
+    const { container } = await render(
+      <div>
+        <VaTextInput id="web-component" label="Text input" />
+        <input type="text" id="text" />
+      </div>,
+    );
+
+    await waitFor(async () => {
       const vaTextInput = $('#web-component', container);
       const textInput = $('#text', container);
-      expect(isWebComponent(vaTextInput)).to.eq(true);
-      expect(isWebComponent(textInput)).to.eq(false);
 
-      // web component will never be "ready" for unit tests because
-      // it does not have shadowRoot, and it won't go through the
-      // lifecycle in react testing library to get a shadowRoot
-      expect(isWebComponentReady(vaTextInput)).to.eq(false);
-      expect(isWebComponentReady(textInput)).to.eq(false);
+      // shadowRoot won't be populated in React testing library.
+      // Just showing that it will pass tests, despite this.
+      let el = await waitForShadowRoot(vaTextInput);
+      expect(el.id).to.eq('web-component');
+      expect(el.shadowRoot).to.eq(null);
 
-      let awaitedShadowRoot = false;
-      awaitShadowRoot(vaTextInput, () => {
-        // This isn't actually waiting for a shadowRoot, because
-        // the shadowRoot won't be populated in React testing library.
-        // Just showing that it will pass tests, despite this.
-        awaitedShadowRoot = true;
-      });
+      await waitForShadowRoot(textInput);
+      expect(textInput.id).to.eq('text');
 
-      expect(awaitedShadowRoot).to.eq(true);
+      el = await waitForShadowRoot(null);
+      expect(el).to.eq(null);
+
+      el = await waitForShadowRoot({});
+      expect(el).to.deep.eq({});
+    });
+  });
+});
+
+describe('web component query selector tests', async () => {
+  let container;
+
+  beforeEach(async () => {
+    const rendered = await render(
+      <div>
+        <input id="text" type="text" />
+        <div id="nested-container">
+          <input id="nested-text" type="text" />
+          <va-checkbox
+            id="nested-checkbox"
+            name="group1"
+            uswds
+            label="Checkbox"
+          />
+        </div>
+        <VaCheckboxGroup id="checkbox-group" label="CheckboxGroup" uswds>
+          <span>Description of checkbox group</span>
+          <va-checkbox
+            id="checkbox-group-checkbox"
+            name="group2"
+            uswds
+            label="Checkbox"
+          />
+        </VaCheckboxGroup>
+      </div>,
+    );
+    container = rendered.container;
+  });
+
+  it('querySelectorWithShadowRoot can select a web component or regular element', async () => {
+    await waitFor(async () => {
+      let el = await querySelectorWithShadowRoot('#nested-checkbox');
+      expect(el.id).to.eq('nested-checkbox');
+
+      el = await querySelectorWithShadowRoot('#text');
+      expect(el.id).to.eq('text');
+    });
+  });
+
+  it('querySelectorWithShadowRoot can specify a root element', async () => {
+    await waitFor(async () => {
+      let el = await querySelectorWithShadowRoot('#nested-checkbox', container);
+      expect(el.id).to.eq('nested-checkbox');
+
+      el = await querySelectorWithShadowRoot(
+        '#checkbox-group-checkbox',
+        container.querySelector('#checkbox-group'),
+      );
+      expect(el.id).to.eq('checkbox-group-checkbox');
+    });
+  });
+
+  it('querySelectorWithShadowRoot can use strings for selector and root', async () => {
+    await waitFor(async () => {
+      const el = await querySelectorWithShadowRoot(
+        '#checkbox-group-checkbox',
+        '#checkbox-group',
+      );
+      expect(el.id).to.eq('checkbox-group-checkbox');
+    });
+  });
+
+  it('querySelectorWithShadowRoot negative tests', async () => {
+    await waitFor(async () => {
+      let el = await querySelectorWithShadowRoot(null);
+      expect(el).to.eq(null);
+
+      el = await querySelectorWithShadowRoot('#checkbox-group', null);
+      expect(el.id).to.eq('checkbox-group');
+
+      el = await querySelectorWithShadowRoot('#not-found', null);
+      expect(el).to.eq(null);
     });
   });
 });

--- a/src/platform/utilities/tests/ui/webComponents.unit.spec.jsx
+++ b/src/platform/utilities/tests/ui/webComponents.unit.spec.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, waitFor } from '@testing-library/react';
+import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { $ } from '../../../forms-system/src/js/utilities/ui';
+import {
+  awaitShadowRoot,
+  isWebComponent,
+  isWebComponentReady,
+} from '../../ui/webComponents';
+
+describe('web component UI tests', async () => {
+  it('web component UI tests', async () => {
+    const { container } = await render(
+      <div>
+        <VaTextInput id="web-component" label="Text input" />
+        <input type="text" id="text" />
+      </div>,
+    );
+
+    await waitFor(() => {
+      const vaTextInput = $('#web-component', container);
+      const textInput = $('#text', container);
+      expect(isWebComponent(vaTextInput)).to.eq(true);
+      expect(isWebComponent(textInput)).to.eq(false);
+
+      // web component will never be "ready" for unit tests because
+      // it does not have shadowRoot, and it won't go through the
+      // lifecycle in react testing library to get a shadowRoot
+      expect(isWebComponentReady(vaTextInput)).to.eq(false);
+      expect(isWebComponentReady(textInput)).to.eq(false);
+
+      let awaitedShadowRoot = false;
+      awaitShadowRoot(vaTextInput, () => {
+        // This isn't actually waiting for a shadowRoot, because
+        // the shadowRoot won't be populated in React testing library.
+        // Just showing that it will pass tests, despite this.
+        awaitedShadowRoot = true;
+      });
+
+      expect(awaitedShadowRoot).to.eq(true);
+    });
+  });
+});

--- a/src/platform/utilities/ui/focus.js
+++ b/src/platform/utilities/ui/focus.js
@@ -66,9 +66,23 @@ export function focusElement(selectorOrElement, options, root) {
  *  shadowRoot
  * @example waitForRenderThenFocus('h3', document.querySelector('va-radio').shadowRoot);
  */
-export function waitForRenderThenFocus(selector, root = document) {
-  const el = (root || document).querySelector(selector);
-  focusElement(el);
+export function waitForRenderThenFocus(
+  selector,
+  root = document,
+  timeInterval = 250,
+) {
+  const maxIterations = 6; // 1.5 seconds
+  let count = 0;
+  const interval = setInterval(() => {
+    if ((root || document).querySelector(selector)) {
+      clearInterval(interval);
+      focusElement(selector, {}, root);
+    } else if (count >= maxIterations) {
+      clearInterval(interval);
+      focusElement(defaultFocusSelector); // fallback to breadcrumbs
+    }
+    count += 1;
+  }, timeInterval);
 }
 
 /**

--- a/src/platform/utilities/ui/focus.js
+++ b/src/platform/utilities/ui/focus.js
@@ -1,5 +1,9 @@
 /* eslint-disable no-console */
-import { awaitShadowRoot } from './webComponents';
+import {
+  awaitShadowRoot,
+  isWebComponent,
+  isWebComponentReady,
+} from './webComponents';
 
 // .nav-header > h2 contains "Step {index} of {total}: {page title}"
 export const defaultFocusSelector =
@@ -45,10 +49,7 @@ export function focusElement(selectorOrElement, options, root) {
   }
 
   if (el) {
-    if (
-      el.tagName.includes('VA-') &&
-      (!el.shadowRoot || !el.classList.contains('hydrated'))
-    ) {
+    if (isWebComponent(el) && !isWebComponentReady(el)) {
       awaitShadowRoot(el, focus);
     } else {
       focus();

--- a/src/platform/utilities/ui/webComponents.js
+++ b/src/platform/utilities/ui/webComponents.js
@@ -149,7 +149,7 @@ export async function querySelectorWithShadowRoot(selector, root) {
     }
 
     const selectorElement =
-      typeof selector === 'string'
+      typeof selector === 'string' && rootElement
         ? rootElement.querySelector(selector)
         : selector;
 

--- a/src/platform/utilities/ui/webComponents.js
+++ b/src/platform/utilities/ui/webComponents.js
@@ -1,0 +1,58 @@
+/* eslint-disable no-console */
+
+/**
+ * Web components initially render as 0 width / 0 height with no
+ * shadow dom content, so this waits until it contains a shadowRoot
+ * and a class "hydrated" and is visually rendered
+ *
+ * @param {HTMLElement} hostEl e.g. `document.querySelect('va-segmented-progress-bar')`
+ * @param {() => void} callback called once shadow dom is ready
+ * @param {boolean} [waitForAnimationFrame] Defaults to true. Whether to callback immediately, or wait until the next paint.
+ */
+export function awaitShadowRoot(
+  hostEl,
+  callback,
+  waitForAnimationFrame = true,
+) {
+  if (!hostEl || !(hostEl instanceof HTMLElement)) {
+    console.error('Invalid hostEl provided to awaitShadowRoot.');
+    return;
+  }
+  if (hostEl.hasAttribute('data-observing-shadow')) {
+    return;
+  }
+  hostEl.setAttribute('data-observing-shadow', 'true');
+
+  const hostObserver = new MutationObserver(() => {
+    try {
+      // web component is ready when these are true
+      if (hostEl.shadowRoot && hostEl.classList.contains('hydrated')) {
+        if (waitForAnimationFrame) {
+          // shadowRoot will exist, but its contents may not be
+          // visible at this point because it hasn't rerendered
+          requestAnimationFrame(() => {
+            callback();
+          });
+        } else {
+          callback();
+        }
+        hostEl.removeAttribute('data-observing-shadow');
+        if (hostObserver) {
+          hostObserver.disconnect();
+        }
+      }
+    } catch (error) {
+      console.error('An error occurred in awaitShadowRoot: ', error);
+      hostEl.removeAttribute('data-observing-shadow');
+      if (hostObserver) {
+        hostObserver.disconnect();
+      }
+    }
+  });
+
+  hostObserver.observe(hostEl, {
+    childList: true,
+    attributes: true,
+    subtree: true,
+  });
+}

--- a/src/platform/utilities/ui/webComponents.js
+++ b/src/platform/utilities/ui/webComponents.js
@@ -141,12 +141,12 @@ export async function querySelectorWithShadowRoot(selector, root) {
         ? document.querySelector(root)
         : root || document;
 
-    if (isWebComponent(root) && !isWebComponentReady(root)) {
+    if (isWebComponent(currentRoot) && !isWebComponentReady(currentRoot)) {
       const waitForPaint = false;
-      await waitForShadowRoot(root, waitForPaint);
+      await waitForShadowRoot(currentRoot, waitForPaint);
       // Fallback to root if shadowRoot is not available,
       // for example in unit tests where shadowRoot is null
-      currentRoot = root.shadowRoot || currentRoot;
+      currentRoot = currentRoot.shadowRoot || currentRoot;
     }
 
     if (!element) {

--- a/src/platform/utilities/ui/webComponents.js
+++ b/src/platform/utilities/ui/webComponents.js
@@ -42,8 +42,7 @@ export function awaitShadowRoot(
 
   const hostObserver = new MutationObserver(() => {
     try {
-      // web component is ready when these are true
-      if (hostEl.shadowRoot && hostEl.classList.contains('hydrated')) {
+      if (isWebComponentReady(hostEl)) {
         if (waitForAnimationFrame) {
           // shadowRoot will exist, but its contents may not be
           // visible at this point because it hasn't rerendered

--- a/src/platform/utilities/ui/webComponents.js
+++ b/src/platform/utilities/ui/webComponents.js
@@ -1,5 +1,13 @@
 /* eslint-disable no-console */
 
+export function isWebComponent(el) {
+  return !!el?.tagName?.includes('VA-');
+}
+
+export function isWebComponentReady(el) {
+  return !!(el?.shadowRoot && el?.classList.contains('hydrated'));
+}
+
 /**
  * Web components initially render as 0 width / 0 height with no
  * shadow dom content, so this waits until it contains a shadowRoot
@@ -18,6 +26,15 @@ export function awaitShadowRoot(
     console.error('Invalid hostEl provided to awaitShadowRoot.');
     return;
   }
+
+  if (process.env.NODE_ENV === 'test') {
+    // Skip for unit tests
+    // shadowRoot is not properly populated in
+    // React testing library, so just callback
+    callback();
+    return;
+  }
+
   if (hostEl.hasAttribute('data-observing-shadow')) {
     return;
   }

--- a/src/platform/utilities/ui/webComponents.js
+++ b/src/platform/utilities/ui/webComponents.js
@@ -130,35 +130,39 @@ export function waitForShadowRoot(el, waitForPaint = true) {
  * ```
  *
  * @param {string | HTMLElement} selector
- * @param {HTMLElement} [root]
+ * @param {string | HTMLElement} [root]
  * @returns {Promise<HTMLElement | null>}
  */
 export async function querySelectorWithShadowRoot(selector, root) {
   try {
-    let element = typeof selector === 'string' ? null : selector;
-    let currentRoot =
+    let rootElement =
       typeof root === 'string'
         ? document.querySelector(root)
         : root || document;
 
-    if (isWebComponent(currentRoot) && !isWebComponentReady(currentRoot)) {
+    if (isWebComponent(rootElement) && !isWebComponentReady(rootElement)) {
       const waitForPaint = false;
-      await waitForShadowRoot(currentRoot, waitForPaint);
+      await waitForShadowRoot(rootElement, waitForPaint);
       // Fallback to root if shadowRoot is not available,
       // for example in unit tests where shadowRoot is null
-      currentRoot = currentRoot.shadowRoot || currentRoot;
+      rootElement = rootElement?.shadowRoot || rootElement;
     }
 
-    if (!element) {
-      element = currentRoot.querySelector(selector);
-    }
+    const selectorElement =
+      typeof selector === 'string'
+        ? rootElement.querySelector(selector)
+        : selector;
 
-    if (element && isWebComponent(element) && !isWebComponentReady(element)) {
+    if (
+      selectorElement &&
+      isWebComponent(selectorElement) &&
+      !isWebComponentReady(selectorElement)
+    ) {
       const waitForPaint = true;
-      await waitForShadowRoot(element, waitForPaint);
+      await waitForShadowRoot(selectorElement, waitForPaint);
     }
 
-    return element; // Returns a promise, since this is an async function
+    return selectorElement; // Returns a promise, since this is an async function
   } catch (error) {
     console.error('Error in querySelectorWithShadowRoot:', error);
     return null;


### PR DESCRIPTION
## Summary

- Fix web component focus generally
- Affects any form using `v3SegmentedProgressBar: true` that is not using `customScrollAndFocus`
    - `ask-va-too` 
    - `pensions` 
    - `20-10206` 
    - `21-0966` 
    - `mock-alternate-header` 
    - `mock-simple-forms-patterns`
    - `mock-simple-forms-patterns-v3`
- Fix issue where it would often scroll down on the page when it shouldn't, due to not properly focusing on  `va-segmented-progress-bar`. This happened because although `va-segmented-progress-bar` existed, it initially starts with no shadowRoot,  and has height/width = 0, and attempting to focus this does not work, so waiting until it is properly hydrated/shadowRoot exists fixes this issue. 

Old behavior:
Wherever you scroll down on the intro page, will be the scroll position on the first page

New behavior:
If your scroll position on the intro page contains the va-segmented-progress-bar h2, it will keep the scroll position, otherwise it seems to try center it in the screen (?), which would scroll to the top.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#661

## Testing done

- Existing unit and e2e tests
- Browser tests

## Screenshots

0966 Before:
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/75e9c381-bb17-4116-8889-1b899a942eed)

0966 After:
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/760bda47-00cb-42fe-ba47-faacc190d461)

pensions before:
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/0bd0e4df-ab22-4d77-ab8d-6d2a97c90ca3)

pensions after:
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/57445519-5426-45b9-9404-7e13c06c5a3c)


ask-va-too before (scrolling down a little at intro page):
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/18f99979-29d0-4a7d-926b-a0a253537f32)

ask-va-too after (if you scroll down too far, it will show like this, otherwise it will keep your scroll position as long as the h2 is visible):
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/51580672-93d3-4c68-bf57-03b50baa6e61)

mock-simple-forms-patterns before:
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/169945a0-157c-43e3-ba02-8cba3cd78396)

mock-simple-forms-patterns after:
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/cceef02a-2391-4160-ab62-fa95c94fb065)

## What areas of the site does it impact?

Any form using the va-segmented-progress-bar with a h2. Web components in general. 

## Acceptance criteria

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
