### PR TITLE
MHV-52038 Added some quick content fixes

### DIFF
--- a/src/applications/mhv/medical-records/components/Navigation.jsx
+++ b/src/applications/mhv/medical-records/components/Navigation.jsx
@@ -58,14 +58,14 @@ const Navigation = () => {
   ];
 
   paths[0].subpaths.push({
-    path: '/allergies',
-    label: 'Allergies',
-    datatestid: 'allergies-sidebar',
-  });
-  paths[0].subpaths.push({
     path: '/vaccines',
     label: 'Vaccines',
     datatestid: 'vaccines-sidebar',
+  });
+  paths[0].subpaths.push({
+    path: '/allergies',
+    label: 'Allergies and reactions',
+    datatestid: 'allergies-sidebar',
   });
 
   function openNavigation() {

--- a/src/applications/mhv/medical-records/containers/LandingPage.jsx
+++ b/src/applications/mhv/medical-records/containers/LandingPage.jsx
@@ -109,7 +109,7 @@ const LandingPage = () => {
               )}
               rel="noreferrer"
             >
-              Go back to medical records on the My HealtheVet website
+              Go to medical records on the My HealtheVet website
             </a>
           </p>
         </section>


### PR DESCRIPTION
## Summary

This is a follow-on to a previous PR. I missed a few small things per [this Slack message](https://dsva.slack.com/archives/C04ER7MHX5E/p1701714580020849?thread_ts=1701443126.878209&cid=C04ER7MHX5E).

Prev PR: https://github.com/department-of-veterans-affairs/vets-website/pull/26876

## Related issue(s)

### [MHV-52038](https://jira.devops.va.gov/browse/MHV-52038) - Implement feature flags and content for Vaccines Phase 0 ###

> We will need a feature flag for the Vaccines Domain and also one for the SideNav.
> 
> Re-implement the Sidenav.
> 
> Add any vaccines-specific content for Phase 0.
> 
> Audit done by Lexi -see below or slack https://dsva.slack.com/archives/C03Q2UQL1AS/p1700697692642599?thread_ts=1700697683.614639&cid=C03Q2UQL1AS
> 
> Landing page (all accordions expanded)
> Adjust all content to fill full width of page
> Add left nav menu back to desktop; “In this section” menu back to mobile
> Add Vaccines section back to page. Change the Primary Action Link (with the green icon) to the secondary Action Link (with the blue icon) for the domain sections.
> Update content of ‘How too find your other medical records’ section.
> Update content of “What if I can’t find all my…” accordion title and section
> List page
> Update content of Intro paragraph
> Cards: Added “Date received: ” in front of the date
> Cards: Removed location field
> Update pagination component to V3
> Details page
> Added “Vaccines: ” before the vaccine name to all vaccine details page H1’s
> Update content under H1 to “Date received: [date]”
> Removed the Manufacturer field (may return in Phase 1)
> Removed the Reaction field (may return in Phase 1)
> PDF (List)
> Update content of Intro paragraph (This content intentionally does not match the web view)
> Removed the Reaction field (may return in Phase 1)
> PDF (Details page)
> Added “Vaccines: ” to H1 before the vaccine name
> Removed the Reaction field (may return in Phase 1)
> There are also a few issues I noticed in Staging that will be surfaced in the upcoming UCD audit but y'all could probably get a head start:
> The breadcrumbs on all are wonky. Refer to the mocks for the correct format.
> The field label+data in the cards on the list page should be side-by-side, not stacked vertically
> The text style of the field labels on the details page should be body-bold (not lead/intro text)
> The fields in the printed reports and the downloaded reports are kind of wonky

## Testing done

Minor content changes. No tests needed.

## Screenshots

<img width="260" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/ac76d88c-b7b0-4fd1-b95c-c8d102b20cc1">

## What areas of the site does it impact?

MHV MR

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
