### PR TITLE
20-10206 Updates Round 1

### DIFF
--- a/src/applications/simple-forms/20-10206/pages/disabilityExamDetails.js
+++ b/src/applications/simple-forms/20-10206/pages/disabilityExamDetails.js
@@ -22,6 +22,9 @@ export default {
         viewField: DisabilityExamDate,
         keepInPageOnReview: true,
         customTitle: ' ',
+        confirmRemove: true,
+        confirmRemoveDescription:
+          'This will remove the date of your disability exam and may make it harder to find your record.',
         useDlWrap: true,
       },
       items: {

--- a/src/applications/simple-forms/20-10206/pages/disabilityExamDetails.js
+++ b/src/applications/simple-forms/20-10206/pages/disabilityExamDetails.js
@@ -18,7 +18,7 @@ export default {
     ),
     disabilityExams: {
       'ui:options': {
-        itemName: 'exam',
+        itemName: 'exam date',
         viewField: DisabilityExamDate,
         keepInPageOnReview: true,
         customTitle: ' ',
@@ -26,6 +26,8 @@ export default {
         confirmRemoveDescription:
           'This will remove the date of your disability exam and may make it harder to find your record.',
         useDlWrap: true,
+        showSave: true,
+        reviewMode: true,
       },
       items: {
         'ui:options': {

--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -367,8 +367,9 @@ export default class ArrayField extends React.Component {
               definitions,
             );
             const { showSave } = uiOptions;
-            const updateText = showSave && index === 0 ? 'Save' : 'Update';
             const isLast = items.length === index + 1;
+            // if showSave is true, all items show Update except the last item
+            const updateText = showSave && isLast ? 'Save' : 'Update';
             const isEditing = this.state.editing[index];
             const isRemoving = this.state.removing[index];
             const ariaLabel = uiOptions.itemAriaLabel;

--- a/src/platform/forms-system/src/js/utilities/validations/index.js
+++ b/src/platform/forms-system/src/js/utilities/validations/index.js
@@ -36,15 +36,6 @@ export function isValidSSN(value) {
   return /^\d{9}$/.test(value) || /^\d{3}-\d{2}-\d{4}$/.test(value);
 }
 
-// Conditions for valid ARN:
-// A value with 3 digits, an optional -, 2 digits, an optional -, and 4 digits is a valid ARN
-export function isValidARN(value) {
-  // Remove all non-digit characters
-  const strippedValue = value.replace(/\D/g, '');
-
-  return /^[1-9]\d{6,8}$/.test(strippedValue);
-}
-
 // A 9 digit VA File Number must be an SSN
 // The only other valid option is an 8-digit number
 export function isValidVAFileNumber(value) {

--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -7,7 +7,6 @@ import unset from '../../../utilities/data/unset';
 
 import { isActivePage, parseISODate, minYear, maxYear } from './helpers';
 import {
-  isValidARN,
   isValidSSN,
   isValidYear,
   isValidVAFileNumber,
@@ -340,14 +339,6 @@ export function isValidForm(form, pageList, isTesting = false) {
     },
     { isValid: true, errors: [] },
   );
-}
-
-export function validateARN(errors, arn) {
-  if (arn && !isValidARN(arn)) {
-    errors.addError(
-      'Please enter a valid 7-9 digit Alien registration number (dashes allowed)',
-    );
-  }
 }
 
 export function validateSSN(errors, ssn) {

--- a/src/platform/forms-system/src/js/web-component-patterns/arnPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/arnPattern.jsx
@@ -1,7 +1,6 @@
 import get from 'platform/utilities/data/get';
 import ArnField from '../web-component-fields/ArnField';
 import { vaFileNumberUI, vaFileNumberSchema } from './ssnPattern';
-import { validateARN } from '../validation';
 import ARNReviewWidget from '../review/ARNWidget';
 
 const ARN_DEFAULT_TITLE = 'Alien registration number';
@@ -24,11 +23,13 @@ const arnUI = title => {
     'ui:title': title ?? ARN_DEFAULT_TITLE,
     'ui:webComponentField': ArnField,
     'ui:reviewWidget': ARNReviewWidget,
-    'ui:validations': [validateARN],
     'ui:errorMessages': {
-      pattern:
-        'Please enter a valid 7-9 digit Alien registration number (dashes allowed)',
+      pattern: 'Enter a valid 8 or 9 digit A-number (only numbers are allowed)',
       required: 'Please enter an Alien registration number',
+    },
+    'ui:options': {
+      hint:
+        'Only numbers are allowed. If your A-number is “A12345678,” enter “12345678”',
     },
   };
 };
@@ -46,7 +47,7 @@ const arnUI = title => {
  */
 const arnSchema = {
   type: 'string',
-  pattern: '^[0-9]{7,9}$',
+  pattern: '^\\d{8,9}$',
 };
 
 /**
@@ -63,10 +64,14 @@ const arnSchema = {
  */
 const arnOrVaFileNumberUI = () => {
   return {
-    arn: arnUI(),
-    vaFileNumber: {
-      ...vaFileNumberUI(),
+    arn: {
+      ...arnUI(),
+      'ui:errorMessages': {
+        ...arnUI()['ui:errorMessages'],
+        required: 'Enter at least one identification number',
+      },
     },
+    vaFileNumber: vaFileNumberUI(),
     'ui:options': {
       updateSchema: (formData, _schema, _uiSchema, index, path) => {
         const { arn, vaFileNumber } = get(path, formData) ?? {};

--- a/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
@@ -186,7 +186,7 @@ describe('Schemaform <ArrayField>', () => {
     const button = tree.everySubTree('button');
     expect(button.length).to.equal(4);
     expect(button[0].text()).to.equal('Edit');
-    expect(button[1].text()).to.equal('Update');
+    expect(button[1].text()).to.equal('Save');
     expect(button[2].text()).to.equal('Remove');
     expect(button[3].text()).to.contain('Add another');
   });
@@ -262,8 +262,8 @@ describe('Schemaform <ArrayField>', () => {
     expect(button.length).to.equal(4);
     expect(button[0].text()).to.equal('Edit');
     expect(button[0].props['aria-label']).to.equal('Edit foo');
-    expect(button[1].text()).to.equal('Update');
-    expect(button[1].props['aria-label']).to.equal('Update bar');
+    expect(button[1].text()).to.equal('Save');
+    expect(button[1].props['aria-label']).to.equal('Save bar');
     expect(button[2].text()).to.equal('Remove');
     expect(button[2].props['aria-label']).to.equal('Remove bar');
     expect(button[3].text()).to.contain('Add another');


### PR DESCRIPTION
## Summary
This pull request contains a handful of fixes and updates to form 20-10206. Please consult the linked tickets for more information on these changes.

I was having some strange results with the conditionally required ARN and VA file number where the requirement wouldn't lift from ARN when entering a VA file number. I didn't change anything about this logic, so hopefully there's just some issue with how I was loading the data locally without being logged in and directly loading the form page instead of going through a flow. If there is an actual issue, then we'll need to revisit this page.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#71065
department-of-veterans-affairs/va.gov-team-forms#839
department-of-veterans-affairs/va.gov-team-forms#840

## Screenshots
I synced with Jeana on this one, but because we don't have a way of tracking which fields are "dirty" vs. "new", there's not a way to have the new items exclusively have the "Save" button and the edited items exclusively have the "Update" button. My simple solution was to just have the last item in the array be considered the "new" one, so it shows "Save" while all others show "Update".

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/53942725/1b5904ee-6d67-42fc-8047-be781cdfb683)

For this change, the header does not perfectly match the sketch. Instead of "remove this date" the header says "remove this exam date". This is because of how the logic determines the header name based on the item name. The confirmation button uses the same logic. Additional logic can be added if necessary, but hopefully this is acceptable.

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/53942725/65be9e9b-d7d1-4f0e-8313-a19dbb44ed2b)

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/53942725/ff293600-e263-4e0a-9415-e0ee2b5c0bce)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/53942725/d339f27d-67c0-437a-b5ff-10d2880301e6)
