### PR TITLE
Removed encodeURIComponent

### DIFF
--- a/src/applications/vaos/tests/new-appointment/components/ScheduleCernerPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ScheduleCernerPage.unit.spec.jsx
@@ -62,7 +62,7 @@ describe('VAOS <ScheduleCernerPage>', () => {
 
     expect(
       screen.getByRole('link', { name: 'My VA Health' }).getAttribute('href'),
-    ).to.contain('pages%2Fscheduling%2Fupcoming');
+    ).to.contain('pages/scheduling/upcoming');
 
     expect(screen.getByTestId('facility-telephone')).to.exist;
     expect(screen.getByRole('button', { name: /Continue/ })).to.have.attribute(
@@ -169,7 +169,7 @@ describe('VAOS <ScheduleCernerPage>', () => {
         screen
           .getByRole('link', { name: /My VA Health/i })
           .getAttribute('href'),
-      ).to.contain('pages%2Fscheduling%2Fupcoming');
+      ).to.contain('pages/scheduling/upcoming');
     });
   });
 });

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.jsx
@@ -1373,7 +1373,7 @@ describe('VAOS <VAFacilityPage>', () => {
         within(cernerSiteLabel)
           .getByRole('link', { name: /My VA Health/ })
           .getAttribute('href'),
-      ).to.contain('pages%2Fscheduling%2Fupcoming');
+      ).to.contain('pages/scheduling/upcoming');
 
       // Make sure Cerner facilities show up only once
       expect(screen.getAllByText(/Second Cerner facility/i)).to.have.length(1);

--- a/src/platform/utilities/cerner/index.js
+++ b/src/platform/utilities/cerner/index.js
@@ -10,7 +10,7 @@ export const getCernerURL = (path, useSingleLogoutPaths = false) => {
     return `${host}${path}?authenticated=true`;
   }
 
-  return encodeURIComponent(`${host}${path}?authenticated=true`);
+  return `${host}${path}?authenticated=true`;
 };
 
 export const appointmentsToolLink = '/my-health/appointments';


### PR DESCRIPTION
## Summary
Remove the `encodeURIComponent` from the Cerner deep linking URL.
Note: I opted to leave in the `useSingleLogoutPaths` path, despite being redundant. This function is called in several places and I figured it would be best to maintain the function's interface (in case it changes again in the future).

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/71273

## What areas of the site does it impact?
This primarily impacts the following components which all call `getCernerURL`:
- `CernerWidgets`
- `CernerAlert`
- `ScheduleCernerPage`
- `FacilitiesRadioWidget`

## Acceptance criteria
- [x] Remove the `encodeURIComponent` from the Cerner utilities file in `vets-website`
- [x] Update unit tests if required