### PR TITLE
20-10206 - Unhide unauthenticated start-link temporarily

### DIFF
--- a/src/applications/simple-forms/20-10206/config/form.js
+++ b/src/applications/simple-forms/20-10206/config/form.js
@@ -6,7 +6,7 @@ import manifest from '../manifest.json';
 // we're NOT using JSON Schema for this form, so we don't need to import it
 
 import IntroductionPage from '../containers/IntroductionPage';
-import IdVerificationPage from '../containers/IdVerificationPage';
+// import IdVerificationPage from '../containers/IdVerificationPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import preparerTypePg from '../pages/preparerType';
 import persInfoPg from '../pages/personalInfo';
@@ -52,7 +52,7 @@ const formConfig = {
     },
   },
   formId: '20-10206',
-  hideUnauthedStartLink: true,
+  // hideUnauthedStartLink: true,
   transformForSubmit,
   saveInProgress: {
     messages: {
@@ -77,16 +77,16 @@ const formConfig = {
     },
   },
   v3SegmentedProgressBar: true,
-  additionalRoutes: [
-    {
-      // for User not identity-verified
-      path: 'identity-verification',
-      pageKey: 'identity-verification',
-      component: IdVerificationPage,
-      // user-state view-field below was added by App.jsx
-      depends: formData => !formData['view:userIdVerified'],
-    },
-  ],
+  // additionalRoutes: [
+  //   {
+  //     // for User not identity-verified
+  //     path: 'identity-verification',
+  //     pageKey: 'identity-verification',
+  //     component: IdVerificationPage,
+  //     // user-state view-field below was added by App.jsx
+  //     depends: formData => !formData['view:userIdVerified'],
+  //   },
+  // ],
   chapters: {
     preparerTypeChapter: {
       title: 'Your identity',
@@ -94,9 +94,9 @@ const formConfig = {
         preparerTypePage: {
           path: 'preparer-type',
           title: 'Preparer type',
-          depends: {
-            'view:userIdVerified': true,
-          },
+          // depends: {
+          //   'view:userIdVerified': true,
+          // },
           // we want req'd fields prefilled for LOCAL testing/previewing
           // one single initialData prop here will suffice for entire form
           initialData:
@@ -115,16 +115,16 @@ const formConfig = {
         personalInfoPage: {
           path: 'personal-information',
           title: 'Name and date of birth',
-          depends: {
-            'view:userIdVerified': true,
-          },
+          // depends: {
+          //   'view:userIdVerified': true,
+          // },
           uiSchema: persInfoPg.uiSchema,
           schema: persInfoPg.schema,
           pageClass: 'personal-information',
         },
         citizenIdentificationInfoPage: {
           depends: {
-            'view:userIdVerified': true,
+            // 'view:userIdVerified': true,
             preparerType: PREPARER_TYPES.CITIZEN,
           },
           path: 'citizen-identification-information',
@@ -135,7 +135,7 @@ const formConfig = {
         },
         nonCitizenIdentificationInfoPage: {
           depends: {
-            'view:userIdVerified': true,
+            // 'view:userIdVerified': true,
             preparerType: PREPARER_TYPES.NON_CITIZEN,
           },
           path: 'non-citizen-identification-information',
@@ -152,9 +152,9 @@ const formConfig = {
         addressPage: {
           path: 'contact-information',
           title: 'Mailing address',
-          depends: {
-            'view:userIdVerified': true,
-          },
+          // depends: {
+          //   'view:userIdVerified': true,
+          // },
           uiSchema: addressPg.uiSchema,
           schema: addressPg.schema,
           pageClass: 'address',
@@ -162,6 +162,9 @@ const formConfig = {
         phoneEmailPage: {
           path: 'phone-email',
           title: 'Phone and email address',
+          // depends: {
+          //   'view:userIdVerified': true,
+          // },
           uiSchema: phoneEmailPg.uiSchema,
           schema: phoneEmailPg.schema,
           pageClass: 'phone-email',
@@ -174,9 +177,9 @@ const formConfig = {
         recordSelectionsPage: {
           path: 'record-selections',
           title: 'Select at least one record',
-          depends: {
-            'view:userIdVerified': true,
-          },
+          // depends: {
+          //   'view:userIdVerified': true,
+          // },
           uiSchema: recordSelectionsPg.uiSchema,
           schema: recordSelectionsPg.schema,
           pageClass: 'record-selections',
@@ -188,7 +191,7 @@ const formConfig = {
       pages: {
         disabilityExamDetailsPage: {
           depends: {
-            'view:userIdVerified': true,
+            // 'view:userIdVerified': true,
             recordSelections: {
               [RECORD_TYPES.DISABILITY_EXAMS]: true,
             },
@@ -208,7 +211,7 @@ const formConfig = {
           path: 'financial-record-details',
           title: 'Financial record details',
           depends: {
-            'view:userIdVerified': true,
+            // 'view:userIdVerified': true,
             recordSelections: {
               [RECORD_TYPES.FINANCIAL]: true,
             },
@@ -224,7 +227,7 @@ const formConfig = {
       pages: {
         lifeInsuranceBenefitDetailsPage: {
           depends: {
-            'view:userIdVerified': true,
+            // 'view:userIdVerified': true,
             recordSelections: {
               [RECORD_TYPES.LIFE_INS]: true,
             },
@@ -242,7 +245,7 @@ const formConfig = {
       pages: {
         otherCompensationAndPensionDetailsPage: {
           depends: {
-            'view:userIdVerified': true,
+            // 'view:userIdVerified': true,
             recordSelections: {
               [RECORD_TYPES.OTHER_COMP_PEN]: true,
             },
@@ -260,7 +263,7 @@ const formConfig = {
       pages: {
         otherBenefitDetailsPage: {
           depends: {
-            'view:userIdVerified': true,
+            // 'view:userIdVerified': true,
             recordSelections: {
               [RECORD_TYPES.OTHER]: true,
             },


### PR DESCRIPTION
## Summary

- Unhide unauthenticated start-link for Personal Records Request (20-10206)
  - This should enable testing/validation of form-content/-functionalities other than the broken auth'd-exp-LOA3
  - Will be reverted once auth'd-exp-LOA3's fixed
- Team: Veteran Facing Forms
- Flipper not implemented yet

## Related issue(s)

- N/A; this is a quick, temporary change.

## Testing done

- Local browser-testing was successful.

## What areas of the site does it impact?

This form ONLY
