### PR TITLE
Fix H1 capitalization

### DIFF
--- a/src/applications/avs/containers/Avs.jsx
+++ b/src/applications/avs/containers/Avs.jsx
@@ -86,7 +86,7 @@ const Avs = props => {
         serviceRequired={[backendServices.USER_PROFILE]}
       >
         <BreadCrumb />
-        <h1>After-visit Summary</h1>
+        <h1>After-visit summary</h1>
 
         <va-accordion>
           <va-accordion-item

--- a/src/applications/avs/containers/Avs.jsx
+++ b/src/applications/avs/containers/Avs.jsx
@@ -74,7 +74,7 @@ const Avs = props => {
     return (
       <va-loading-indicator
         data-testid="avs-loading-indicator"
-        message="Loading your After-visit Summary"
+        message="Loading your After-visit summary"
       />
     );
   }

--- a/src/applications/avs/tests/containers/Avs.unit.spec.jsx
+++ b/src/applications/avs/tests/containers/Avs.unit.spec.jsx
@@ -97,7 +97,7 @@ describe('Avs container', () => {
       },
     });
     await waitFor(() => {
-      expect(screen.getByText('After-visit Summary'));
+      expect(screen.getByText('After-visit summary'));
     });
   });
 


### PR DESCRIPTION
## Summary

- Fixes capitalization in title

hi-fi:  ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/101649/6a060c43-d690-48db-a481-30fd8c574fb9)


## Related issue(s)

- https://dsva.slack.com/archives/C04UBETRY8N/p1701880048105009?thread_ts=1701450766.823419&cid=C04UBETRY8N

## Screenshots

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/101649/b2443bbb-2c46-466f-b0b8-d8d03954417f)


## What areas of the site does it impact?

- AVS app

## Acceptance criteria

- [ ] "summary" is not capitalized in H1
