### PR TITLE
[Letters] Convert `AddressSection` component into a functional component

### DIFF
--- a/src/applications/letters/components/NoAddressBanner.jsx
+++ b/src/applications/letters/components/NoAddressBanner.jsx
@@ -1,17 +1,17 @@
 import React from 'react';
 
-const noAddressBanner = (
-  <>
-    <va-alert status="warning" className="vads-u-margin-bottom--4">
-      <h3 slot="headline">We don’t have a valid address on file for you</h3>
-      <div>
-        You’ll need to{' '}
-        <a href="/profile/contact-information">update your address</a> before
-        you can view and download your VA letters or documents.
-      </div>
-    </va-alert>
-    <p />
-  </>
-);
-
-export default noAddressBanner;
+export default function NoAddressBanner() {
+  return (
+    <>
+      <va-alert status="warning" className="vads-u-margin-bottom--4">
+        <h3 slot="headline">We don’t have a valid address on file for you</h3>
+        <div>
+          You’ll need to{' '}
+          <a href="/profile/contact-information">update your address</a> before
+          you can view and download your VA letters or documents.
+        </div>
+      </va-alert>
+      <p />
+    </>
+  );
+}

--- a/src/applications/letters/containers/AddressSection.jsx
+++ b/src/applications/letters/containers/AddressSection.jsx
@@ -10,11 +10,11 @@ import {
 import InitializeVAPServiceID from '@@vap-svc/containers/InitializeVAPServiceID';
 import VAPServicePendingTransactionCategory from '@@vap-svc/containers/VAPServicePendingTransactionCategory';
 import AddressField from '@@vap-svc/components/AddressField/AddressField';
-import { focusElement } from '~/platform/utilities/ui';
-import { selectVAPContactInfo } from '~/platform/user/selectors';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
+import { selectVAPContactInfo } from '@department-of-veterans-affairs/platform-user/selectors';
 
+import NoAddressBanner from '../components/NoAddressBanner';
 import { isAddressEmpty } from '../utils/helpers';
-import noAddressBanner from '../components/NoAddressBanner';
 
 const navigateToLetterList = router => {
   router.push('/letter-list');
@@ -71,7 +71,7 @@ export function AddressSection({ address, location, router }) {
     <div>
       <div>
         <div aria-live="polite" aria-relevant="additions">
-          {emptyAddress ? noAddressBanner : addressContent}
+          {emptyAddress ? NoAddressBanner : addressContent}
         </div>
       </div>
       {viewLettersButton}

--- a/src/applications/letters/containers/AddressSection.jsx
+++ b/src/applications/letters/containers/AddressSection.jsx
@@ -71,7 +71,7 @@ export function AddressSection({ address, location, router }) {
     <div>
       <div>
         <div aria-live="polite" aria-relevant="additions">
-          {emptyAddress ? NoAddressBanner : addressContent}
+          {emptyAddress ? <NoAddressBanner /> : addressContent}
         </div>
       </div>
       {viewLettersButton}

--- a/src/applications/letters/containers/AddressSection.jsx
+++ b/src/applications/letters/containers/AddressSection.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import {
@@ -15,76 +16,77 @@ import { selectVAPContactInfo } from '~/platform/user/selectors';
 import { isAddressEmpty } from '../utils/helpers';
 import noAddressBanner from '../components/NoAddressBanner';
 
-export class AddressSection extends React.Component {
-  componentDidMount() {
+const navigateToLetterList = router => {
+  router.push('/letter-list');
+};
+
+export function AddressSection({ address, location, router }) {
+  useEffect(() => {
     focusElement('#content');
-  }
+  });
 
-  navigateToLetterList = () => {
-    this.props.router.push('/letter-list');
-  };
+  const emptyAddress = isAddressEmpty(address);
 
-  render() {
-    const address = this.props.savedAddress;
-    const emptyAddress = isAddressEmpty(address);
-    const { location } = this.props;
+  const addressContent = (
+    <div className="step-content">
+      <p>Downloaded documents will list your address as:</p>
 
-    const addressContent = (
-      <div className="step-content">
-        <p>Downloaded documents will list your address as:</p>
-
-        <div className="va-profile-wrapper">
-          <InitializeVAPServiceID>
-            <VAPServicePendingTransactionCategory
-              categoryType={TRANSACTION_CATEGORY_TYPES.VAP_ADDRESS}
-            >
-              <AddressField
-                fieldName={FIELD_NAMES.MAILING_ADDRESS}
-                title={FIELD_TITLES[FIELD_NAMES.MAILING_ADDRESS]}
-              />
-            </VAPServicePendingTransactionCategory>
-          </InitializeVAPServiceID>
-        </div>
-        <p>
-          When you download a letter, it will show this address. If this address
-          is incorrect you may want to update it, but your letter will still be
-          valid even with the incorrect address.
-        </p>
-      </div>
-    );
-
-    let viewLettersButton;
-    if (location.pathname === '/confirm-address') {
-      viewLettersButton = (
-        <div className="step-content">
-          <button
-            onClick={this.navigateToLetterList}
-            className="usa-button-primary view-letters-button"
-            disabled={emptyAddress}
+      <div className="va-profile-wrapper">
+        <InitializeVAPServiceID>
+          <VAPServicePendingTransactionCategory
+            categoryType={TRANSACTION_CATEGORY_TYPES.VAP_ADDRESS}
           >
-            View Letters
-          </button>
-        </div>
-      );
-    }
+            <AddressField
+              fieldName={FIELD_NAMES.MAILING_ADDRESS}
+              title={FIELD_TITLES[FIELD_NAMES.MAILING_ADDRESS]}
+            />
+          </VAPServicePendingTransactionCategory>
+        </InitializeVAPServiceID>
+      </div>
+      <p>
+        When you download a letter, it will show this address. If this address
+        is incorrect you may want to update it, but your letter will still be
+        valid even with the incorrect address.
+      </p>
+    </div>
+  );
 
-    return (
-      <div>
-        <div>
-          <div aria-live="polite" aria-relevant="additions">
-            {emptyAddress ? noAddressBanner : addressContent}
-          </div>
-        </div>
-        {viewLettersButton}
+  let viewLettersButton;
+  if (location.pathname === '/confirm-address') {
+    viewLettersButton = (
+      <div className="step-content">
+        <button
+          onClick={() => navigateToLetterList(router)}
+          className="usa-button-primary view-letters-button"
+          disabled={emptyAddress}
+          type="button"
+        >
+          View Letters
+        </button>
       </div>
     );
   }
+
+  return (
+    <div>
+      <div>
+        <div aria-live="polite" aria-relevant="additions">
+          {emptyAddress ? noAddressBanner : addressContent}
+        </div>
+      </div>
+      {viewLettersButton}
+    </div>
+  );
 }
 
-function mapStateToProps(state) {
-  return {
-    savedAddress: selectVAPContactInfo(state)?.mailingAddress,
-  };
-}
+const mapStateToProps = state => ({
+  address: selectVAPContactInfo(state)?.mailingAddress,
+});
+
+AddressSection.propTypes = {
+  address: PropTypes.object,
+  location: PropTypes.object,
+  router: PropTypes.object,
+};
 
 export default connect(mapStateToProps)(AddressSection);

--- a/src/applications/letters/tests/containers/AddressSection.unit.spec.jsx
+++ b/src/applications/letters/tests/containers/AddressSection.unit.spec.jsx
@@ -7,7 +7,7 @@ import { ADDRESS_TYPES_ALTERNATE } from '@@vap-svc/constants';
 import { AddressSection } from '../../containers/AddressSection';
 
 const defaultProps = {
-  savedAddress: {
+  address: {
     type: ADDRESS_TYPES_ALTERNATE.domestic,
     addressOne: '2476 Main Street',
     addressTwo: '',
@@ -44,14 +44,10 @@ describe('<AddressSection>', () => {
 
   it('should render an empty address warning on the view screen and disable the View Letters button', () => {
     const tree = shallow(
-      <AddressSection {...defaultProps} savedAddress={emptyAddress} />,
+      <AddressSection {...defaultProps} address={emptyAddress} />,
     );
-    expect(
-      tree
-        .find('va-alert')
-        .first()
-        .text(),
-    ).to.contain('We don’t have a valid address on file for you');
+
+    expect(tree.find('NoAddressBanner'));
     expect(tree.find('button').prop('disabled')).to.be.true;
     tree.unmount();
   });


### PR DESCRIPTION
## Summary
**Note:** The changes below are being made in preparation for the upgrade from `react-router` v3 -> v6

Converting the `AddressSection` component from a class-based component to a functional one. This will allow us to use the hooks that `react-router` v6 provides as we won't be able to rely on the `location` and `router` props being passed in anymore once we upgrade

Other changes:
* Converted the `noAddressBanner` pseudo-component to an actual component
* Added `propTypes` to the `AddressSection` component
* Converted the `mapStateToProps` function in `AddressSection.jsx` to an arrow function

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#71074

## What areas of the site does it impact?
Letters Application

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
