### PR TITLE
[MHV-50757] Increase Interstitial "Continue" link to Large size

### DIFF
--- a/src/applications/mhv/secure-messaging/containers/InterstitialPage.jsx
+++ b/src/applications/mhv/secure-messaging/containers/InterstitialPage.jsx
@@ -48,7 +48,7 @@ const InterstitialPage = props => {
           // eslint-disable-next-line jsx-a11y/anchor-is-valid
           <a
             data-testid="continue-button"
-            className="vads-c-action-link--green vads-u-margin-bottom--2 small-screen:vads-u-margin-bottom--1 link"
+            className="vads-c-action-link--green vads-u-margin-bottom--2 small-screen:vads-u-margin-bottom--1 vads-u-font-size--lg link"
             tabIndex={0}
             role="button"
             onKeyPress={handleKeyPress}

--- a/src/applications/mhv/secure-messaging/tests/containers/InterstitialPage.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/containers/InterstitialPage.unit.spec.jsx
@@ -76,4 +76,10 @@ describe('Interstitial page header', () => {
     userEvent.tab();
     expect(acknowledgeSpy.called).to.be.false;
   });
+
+  it('"Continue to start message" font size uses Large class', async () => {
+    const screen = render(<InterstitialPage />);
+    const continueButton = screen.getByTestId('continue-button');
+    expect(continueButton).to.have.class('vads-u-font-size--lg');
+  });
 });


### PR DESCRIPTION

- now 20px
- uses va-class
- unit test to check className


## Summary

User story: A a veteran user, I want the Continue to start new message to have equal visual weight to the Start a new message link so that I can find it quickly.

Solve: Increased the text size to 20px using the va-class components from the va.gov design system.

## Related issue(s)

### [MHV-50757](https://jira.devops.va.gov/browse/MHV-50757) - Increase Interstitial "Continue" link to Large size


## Testing done

- Unit test ✅

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |
<img width="194" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/59583325/8e1316b8-9f75-40e8-9021-6556c731466a">
|
<img width="224" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/59583325/69f5c971-641b-4330-af49-be8eb7bd3d66">
|
| Desktop |<img width="573" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/59583325/8101f758-4c03-433f-86f6-ce48349fd834">|
<img width="330" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/59583325/dbcc3338-0278-4559-a70e-f04cf75c7c51">
|

## What areas of the site does it impact?

*Va.gov - Secure Messaging - Interstitial Page*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
