### PR TITLE
PDF: Only the first header and the last footer are readable by screen readers 

### DIFF
--- a/src/platform/pdf/templates/medical_records.js
+++ b/src/platform/pdf/templates/medical_records.js
@@ -203,7 +203,7 @@ const generate = async data => {
     await generateResultsContent(doc, wrapper, data);
   }
 
-  await generateFinalHeaderContent(doc, wrapper, data, config);
+  await generateFinalHeaderContent(doc, data, config);
   await generateFooterContent(doc, wrapper, data, config);
 
   wrapper.end();

--- a/src/platform/pdf/templates/medications.js
+++ b/src/platform/pdf/templates/medications.js
@@ -234,7 +234,7 @@ const generate = async data => {
     await generateResultsContent(doc, wrapper, data);
   }
 
-  await generateFinalHeaderContent(doc, wrapper, data, config);
+  await generateFinalHeaderContent(doc, data, config);
   await generateFooterContent(doc, wrapper, data, config);
 
   wrapper.end();

--- a/src/platform/pdf/templates/utils.js
+++ b/src/platform/pdf/templates/utils.js
@@ -220,7 +220,7 @@ const generateInitialHeaderContent = async (doc, parent, data, config) => {
     right: 16,
   };
 
-  const header = doc.struct('Sect', {
+  const header = doc.struct('Div', {
     type: 'Pagination',
     title: 'Header',
     attached: 'Top',

--- a/src/platform/pdf/templates/utils.js
+++ b/src/platform/pdf/templates/utils.js
@@ -245,13 +245,12 @@ const generateInitialHeaderContent = async (doc, parent, data, config) => {
  * Generates Final Header Content
  *
  * @param {Object} doc
- * @param {Object} parent parent struct
  * @param {Object} data PDF data
  * @param {Object} config layout config
  *
  * @returns {void}
  */
-const generateFinalHeaderContent = async (doc, parent, data, config) => {
+const generateFinalHeaderContent = async (doc, data, config) => {
   const pages = doc.bufferedPageRange();
   for (let i = 1; i < pages.count; i += 1) {
     doc.switchToPage(i);
@@ -265,22 +264,15 @@ const generateFinalHeaderContent = async (doc, parent, data, config) => {
       right: 16,
     };
 
-    const header = doc.struct('Artifact', {
-      type: 'Pagination',
-      title: 'Header',
-      attached: 'Top',
-    });
-    parent.add(header);
-    const leftOptions = { continued: true, x: 16, y: 12 };
-    header.add(createArtifactText(doc, config, data.headerLeft, leftOptions));
-    const rightOptions = { align: 'right' };
-    header.add(createArtifactText(doc, config, data.headerRight, rightOptions));
-    header.end();
+    doc.markContent('Artifact');
+    doc.text(data.headerLeft, 16, 12);
+    doc.text(data.headerRight, 16, 12, { align: 'right' });
+    doc.endMarkedContent();
   }
 };
 
 /**
- * Generates Final Header Content
+ * Generates Footer Content
  *
  * @param {Object} doc
  * @param {Object} parent parent struct
@@ -303,36 +295,24 @@ const generateFooterContent = async (doc, parent, data, config) => {
       right: 16,
     };
 
-    const groupingStruct = i === pages.count - 1 ? 'Struct' : 'Artifact';
-    const footer = doc.struct(groupingStruct, {
-      type: 'Pagination',
-      title: 'Footer',
-      attached: 'Bottom',
-    });
-    parent.add(footer);
+    // Only allow the last footer element to be read by screen readers
+    const footer =
+      i === pages.count - 1
+        ? doc.markStructureContent('Div')
+        : doc.markContent('Artifact');
 
     let footerRightText = data.footerRight.replace('%PAGE_NUMBER%', i + 1);
     footerRightText = footerRightText.replace('%TOTAL_PAGES%', pages.count);
-    const footerLeftOptions = {
-      continued: true,
-      x: config.margins.left,
-      y: 766,
-    };
-    const footerRightOptions = { align: 'right' };
 
-    // Only allow the last footer element to be read by screen readers.
+    doc.text(data.footerLeft, config.margins.left, 766);
+    doc.text(footerRightText, config.margins.left, 766, { align: 'right' });
+
+    doc.endMarkedContent();
+
+    // only structural content needs to be added to parent
     if (i === pages.count - 1) {
-      footer.add(createSpan(doc, config, data.footerLeft, footerLeftOptions));
-      footer.add(createSpan(doc, config, footerRightText, footerRightOptions));
-    } else {
-      footer.add(
-        createArtifactText(doc, config, data.footerLeft, footerLeftOptions),
-      );
-      footer.add(
-        createArtifactText(doc, config, footerRightText, footerRightOptions),
-      );
+      parent.add(footer);
     }
-    footer.end();
   }
 };
 

--- a/src/platform/pdf/test/templates/medications/medications.unit.spec.js
+++ b/src/platform/pdf/test/templates/medications/medications.unit.spec.js
@@ -60,7 +60,7 @@ describe('Medications PDF template', () => {
       // There should be one and only one root element.
       expect(structure.children.length).to.equal(1);
       expect(rootElement.role).to.equal('Document');
-      expect(rootElement.children.length).to.equal(4);
+      expect(rootElement.children.length).to.equal(3);
       expect(rootElement.children[1].children[0].role).to.equal('H1');
     });
   });


### PR DESCRIPTION
## Summary

Medications + Medical Records PDFs: Fixed the common functionality to ensure only the first header and the last footer are readable by voice over

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-50605

<img width="1088" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/54b0a74b-dcee-4423-b818-c3e5e2f49b28">

## Testing done

- Updated unit tests + manual testing

## What areas of the site does it impact?

/my-health/medications/
/my-health/medical-records

## Acceptance criteria

“If this is content is important and should be read, only one instance of the header/footer should be accessed” - suggests the importance of ensuring that critical information in headers or footers is presented in a way that avoids redundancy or confusion.

## Example PDF

[VA-medications-list-null-12-7-2023_71551pm.pdf](https://github.com/department-of-veterans-affairs/vets-website/files/13607519/VA-medications-list-null-12-7-2023_71551pm.pdf)

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
