### PR TITLE
[CST] Removing top border from list of claims

### DIFF
--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -231,52 +231,48 @@ class YourClaimsPageV2 extends React.Component {
       content = (
         <va-loading-indicator message="Loading your claims and appeals..." />
       );
-    } else {
-      if (!emptyList) {
-        const listLen = list.length;
-        const numPages = Math.ceil(listLen / ITEMS_PER_PAGE);
-        const shouldPaginate = numPages > 1;
+    } else if (!emptyList) {
+      const listLen = list.length;
+      const numPages = Math.ceil(listLen / ITEMS_PER_PAGE);
+      const shouldPaginate = numPages > 1;
 
-        const pageItems = getVisibleRows(list, this.state.page);
+      const pageItems = getVisibleRows(list, this.state.page);
 
-        if (shouldPaginate) {
-          const range = getPageRange(this.state.page, listLen);
-          const { end, start } = range;
+      if (shouldPaginate) {
+        const range = getPageRange(this.state.page, listLen);
+        const { end, start } = range;
 
-          const txt = `Showing ${start} \u2012 ${end} of ${listLen} events`;
+        const txt = `Showing ${start} \u2012 ${end} of ${listLen} events`;
 
-          pageInfo = <p id="pagination-info">{txt}</p>;
-        }
-
-        content = (
-          <>
-            {this.state.show30DayNotice && (
-              <ClosedClaimMessage
-                claims={pageItems}
-                onClose={this.hide30DayNotice}
-              />
-            )}
-            {pageInfo}
-            <div className="claim-list">
-              {atLeastOneRequestLoading && (
-                <va-loading-indicator message="Loading your claims and appeals..." />
-              )}
-              {pageItems.map(claim => this.renderListItem(claim))}
-              {shouldPaginate && (
-                <VaPagination
-                  page={this.state.page}
-                  pages={numPages}
-                  onPageSelect={this.changePage}
-                />
-              )}
-            </div>
-          </>
-        );
-      } else if (allRequestsLoaded) {
-        content = <NoClaims />;
+        pageInfo = <p id="pagination-info">{txt}</p>;
       }
 
-      content = <div className="tab-content">{content}</div>;
+      content = (
+        <>
+          {this.state.show30DayNotice && (
+            <ClosedClaimMessage
+              claims={pageItems}
+              onClose={this.hide30DayNotice}
+            />
+          )}
+          {pageInfo}
+          <div className="claim-list">
+            {atLeastOneRequestLoading && (
+              <va-loading-indicator message="Loading your claims and appeals..." />
+            )}
+            {pageItems.map(claim => this.renderListItem(claim))}
+            {shouldPaginate && (
+              <VaPagination
+                page={this.state.page}
+                pages={numPages}
+                onPageSelect={this.changePage}
+              />
+            )}
+          </div>
+        </>
+      );
+    } else if (allRequestsLoaded) {
+      content = <NoClaims />;
     }
 
     return (


### PR DESCRIPTION
## Summary
**Note:** I'm just putting this PR out on behalf of @pmclaren19 while she waits for access to the GH org

When a user had less than 10 claims, the Claims Page would show a random border under the `va-additional-info` on the `YourClaimsPageV2` component

### The fix
Update the `YourClaimsPageV2` component so that the `content` variable doesn't get wrapped in a `div` with `className="tab-content"`. We found that the `tab-content` class was adding the top border that we would like to remove. Ended up restructuring the nested-if statement inside of the else block as well to fix a linting error that popped up when removing the update to `content` that wraps it's existing value in a `div`

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#69123

## Screenshots
|         | Before | After |
| ------- | ------ | ----- |
| Desktop | ![Screenshot 2023-12-07 at 10 52 14 AM (2)](https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/947e2295-5a3f-4359-bc5e-620daeddb1a0) | ![Screenshot 2023-12-07 at 11 46 25 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/180cc523-1b2e-4668-9ebc-cd9a45a1f091) |

## What areas of the site does it impact?
Claim Status Tool

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
