### PR TITLE
[DR-70429] Remove timezone enums from schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -314,6 +314,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
+    // TODO: Update commit hash when schema changes are merged in
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2092ad296ec27a62023674ad2fc597ee25b9d720"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -314,8 +314,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    // TODO: Update commit hash when schema changes are merged in
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2092ad296ec27a62023674ad2fc597ee25b9d720"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#6b17e3975a42babafa14f4cfb9db7e376cd7fafe"
   },
   "resolutions": {
     "**/lodash": "4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19990,9 +19990,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#2092ad296ec27a62023674ad2fc597ee25b9d720":
-  version "20.32.4"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2092ad296ec27a62023674ad2fc597ee25b9d720"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#6b17e3975a42babafa14f4cfb9db7e376cd7fafe":
+  version "20.33.5"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#6b17e3975a42babafa14f4cfb9db7e376cd7fafe"
   dependencies:
     minimist "^1.2.3"
 


### PR DESCRIPTION
## Summary
This updates the vets-json-schema, where there were updates to the appeals (v1) schemas to remove the timezone enums — it was causing issues because it needed to be updated after Lighthouse updated their timezone schemas and we decided for better maintainability we would just rely on Lighthouse to validate the timezone value. 

> Which team do you work for
Benefits Decision Reviews

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/70429


## Testing done

- Manual tests locally — went through each form and confirmed I could submit them all. I even hard coded the original timezone (`America/Ciudad_Juarez`) into the frontend to make sure that it could submit and it did.

**NOTE**: I'm not sure that it'll be a huge issue once we switch to v2 NOD, but v1 NOD is still being used and _that_ version uses an older set of timezones that are actually [defined in vets-api](https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/decision_review/service.rb#L77) so in theory, if a veteran were to submit a v1 NOD request from a more newly defined timezone, they could run into the same issue as before. However, we could fix it easily (without having to go through vets-json-schema) if we really had to, _and_ the original veteran who had this problem seems to have found away to resubmit, so even if we do have that error before switching back to v2, we should be okay. I just wanted to flag it as something we might see. cc: @data-doge 

## What areas of the site does it impact?
*(Describe what parts of the site are impacted and*if*code touched other areas)*
Appeals

## Acceptance criteria
- vets-json-schema updated

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution

