### PR TITLE
Update copy and address component in 21p-527ez household information

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -436,7 +436,6 @@ module.exports = async (env = {}) => {
           },
         },
       },
-      runtimeChunk: 'single',
     },
     plugins: [
       new webpack.DefinePlugin({

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -436,6 +436,7 @@ module.exports = async (env = {}) => {
           },
         },
       },
+      runtimeChunk: 'single',
     },
     plugins: [
       new webpack.DefinePlugin({

--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -20,6 +20,10 @@ import ssnUI from '@department-of-veterans-affairs/platform-forms-system/ssn';
 import fileUploadUI from '@department-of-veterans-affairs/platform-forms-system/definitions/file';
 import createNonRequiredFullName from '@department-of-veterans-affairs/platform-forms/nonRequiredFullName';
 import currencyUI from '@department-of-veterans-affairs/platform-forms-system/currency';
+import {
+  addressSchema,
+  addressUI,
+} from '@department-of-veterans-affairs/platform-forms-system/web-component-patterns';
 
 import {
   getSpouseMarriageTitle,
@@ -1027,7 +1031,7 @@ const formConfig = {
                   'ui:widget': 'yesNo',
                 },
                 married: {
-                  'ui:title': 'Are they currently married?',
+                  'ui:title': 'Is your child currently married?',
                   'ui:widget': 'yesNo',
                   'ui:required': (formData, index) =>
                     !!get(['dependents', index, 'previouslyMarried'], formData),
@@ -1056,7 +1060,9 @@ const formConfig = {
                   properties: {
                     childInHousehold:
                       dependents.items.properties.childInHousehold,
-                    childAddress: dependents.items.properties.childAddress,
+                    childAddress: addressSchema({
+                      omit: ['street3'],
+                    }),
                     personWhoLivesWithChild:
                       dependents.items.properties.personWhoLivesWithChild,
                     monthlyPayment: dependents.items.properties.monthlyPayment,
@@ -1075,12 +1081,11 @@ const formConfig = {
                 },
                 childAddress: merge(
                   {},
-                  address.uiSchema(
-                    'Address',
-                    false,
-                    (form, index) =>
+                  addressUI({
+                    omit: ['street3'],
+                    required: (form, index) =>
                       !get(['dependents', index, 'childInHousehold'], form),
-                  ),
+                  }),
                   {
                     'ui:options': {
                       expandUnder: 'childInHousehold',
@@ -1106,7 +1111,7 @@ const formConfig = {
                 monthlyPayment: merge(
                   {},
                   currencyUI(
-                    'How much do you contribute per month to their support?',
+                    "How much do you contribute per month to your child's support?",
                   ),
                   {
                     'ui:required': (form, index) =>

--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -1060,12 +1060,9 @@ const formConfig = {
                   properties: {
                     childInHousehold:
                       dependents.items.properties.childInHousehold,
-                    childAddress: merge(
-                      {},
-                      addressSchema({
-                        omit: ['street3', 'isMilitary'],
-                      }),
-                    ),
+                    childAddress: addressSchema({
+                      omit: ['street3', 'isMilitary'],
+                    }),
                     personWhoLivesWithChild:
                       dependents.items.properties.personWhoLivesWithChild,
                     monthlyPayment: dependents.items.properties.monthlyPayment,
@@ -1097,7 +1094,6 @@ const formConfig = {
                     },
                   }),
                   'ui:options': {
-                    test: 'bar',
                     expandUnder: 'childInHousehold',
                     expandUnderCondition: false,
                   },

--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -1061,7 +1061,7 @@ const formConfig = {
                     childInHousehold:
                       dependents.items.properties.childInHousehold,
                     childAddress: addressSchema({
-                      omit: ['street3'],
+                      omit: ['street3', 'isMilitary'],
                     }),
                     personWhoLivesWithChild:
                       dependents.items.properties.personWhoLivesWithChild,
@@ -1082,7 +1082,7 @@ const formConfig = {
                 childAddress: merge(
                   {},
                   addressUI({
-                    omit: ['street3'],
+                    omit: ['street3', 'isMilitary'],
                     required: (form, index) =>
                       !get(['dependents', index, 'childInHousehold'], form),
                   }),

--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -1060,9 +1060,12 @@ const formConfig = {
                   properties: {
                     childInHousehold:
                       dependents.items.properties.childInHousehold,
-                    childAddress: addressSchema({
-                      omit: ['street3', 'isMilitary'],
-                    }),
+                    childAddress: merge(
+                      {},
+                      addressSchema({
+                        omit: ['street3', 'isMilitary'],
+                      }),
+                    ),
                     personWhoLivesWithChild:
                       dependents.items.properties.personWhoLivesWithChild,
                     monthlyPayment: dependents.items.properties.monthlyPayment,
@@ -1079,20 +1082,26 @@ const formConfig = {
                   'ui:title': 'Does your child live with you?',
                   'ui:widget': 'yesNo',
                 },
-                childAddress: merge(
-                  {},
-                  addressUI({
+                childAddress: {
+                  ...addressUI({
                     omit: ['street3', 'isMilitary'],
-                    required: (form, index) =>
-                      !get(['dependents', index, 'childInHousehold'], form),
-                  }),
-                  {
-                    'ui:options': {
-                      expandUnder: 'childInHousehold',
-                      expandUnderCondition: false,
+                    required: {
+                      country: (form, index) =>
+                        !get(['dependents', index, 'childInHousehold'], form),
+                      street: (form, index) =>
+                        !get(['dependents', index, 'childInHousehold'], form),
+                      city: (form, index) =>
+                        !get(['dependents', index, 'childInHousehold'], form),
+                      postalCode: (form, index) =>
+                        !get(['dependents', index, 'childInHousehold'], form),
                     },
+                  }),
+                  'ui:options': {
+                    test: 'bar',
+                    expandUnder: 'childInHousehold',
+                    expandUnderCondition: false,
                   },
-                ),
+                },
                 personWhoLivesWithChild: merge({}, fullNameUI, {
                   'ui:title': 'Who do they live with?',
                   'ui:options': {

--- a/src/applications/pensions/tests/config/childrenAddress.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/childrenAddress.unit.spec.jsx
@@ -61,9 +61,8 @@ describe('Child address page', () => {
     const formDOM = getFormDOM(form);
     formDOM.setYesNo('input#root_childInHouseholdNo', 'N');
 
-    expect(formDOM.querySelectorAll('input, select, textarea').length).to.equal(
-      13,
-    );
+    expect(formDOM.querySelectorAll('va-select').length).to.equal(1);
+    expect(formDOM.querySelectorAll('va-text-input').length).to.equal(5);
   });
 
   it('should show errors when required fields are empty', () => {

--- a/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/addressPattern.jsx
@@ -223,6 +223,16 @@ export function addressUI(options) {
   /** @type {UISchemaOptions} */
   const uiSchema = {};
 
+  function requiredFunc(key, def) {
+    return (formData, index) => {
+      if (customRequired(key)) {
+        return customRequired(key)(formData, index);
+      }
+
+      return def;
+    };
+  }
+
   if (!omit('isMilitary')) {
     uiSchema.isMilitary = {
       'ui:title':
@@ -232,7 +242,7 @@ export function addressUI(options) {
       'ui:options': {
         hideEmptyValueInReview: true,
       },
-      'ui:required': customRequired('isMilitary') || (() => false),
+      'ui:required': requiredFunc('isMilitary', false),
     };
   }
 
@@ -244,9 +254,9 @@ export function addressUI(options) {
 
   if (!omit('country')) {
     uiSchema.country = {
-      'ui:required': formData => {
+      'ui:required': (formData, index) => {
         if (customRequired('country')) {
-          return customRequired('country')(formData);
+          return customRequired('country')(formData, index);
         }
         if (cachedPath) {
           const { isMilitary } = get(cachedPath, formData) ?? {};
@@ -295,7 +305,7 @@ export function addressUI(options) {
 
   if (!omit('street')) {
     uiSchema.street = {
-      'ui:required': customRequired('street') || (() => true),
+      'ui:required': requiredFunc('street', true),
       'ui:title': options?.labels?.street || 'Street address',
       'ui:autocomplete': 'address-line1',
       'ui:errorMessages': {
@@ -310,7 +320,7 @@ export function addressUI(options) {
     uiSchema.street2 = {
       'ui:title': options?.labels?.street2 || 'Street address line 2',
       'ui:autocomplete': 'address-line2',
-      'ui:required': customRequired('street2') || (() => false),
+      'ui:required': requiredFunc('street2', false),
       'ui:options': {
         hideEmptyValueInReview: true,
       },
@@ -322,7 +332,7 @@ export function addressUI(options) {
     uiSchema.street3 = {
       'ui:title': options?.labels?.street3 || 'Street address line 3',
       'ui:autocomplete': 'address-line3',
-      'ui:required': customRequired('street3') || (() => false),
+      'ui:required': requiredFunc('street3', false),
       'ui:options': {
         hideEmptyValueInReview: true,
       },
@@ -332,7 +342,7 @@ export function addressUI(options) {
 
   if (!omit('city')) {
     uiSchema.city = {
-      'ui:required': customRequired('city') || (() => true),
+      'ui:required': requiredFunc('city', true),
       'ui:autocomplete': 'address-level2',
       'ui:errorMessages': {
         required: 'City is required',
@@ -379,9 +389,9 @@ export function addressUI(options) {
   if (!omit('state')) {
     uiSchema.state = {
       'ui:autocomplete': 'address-level1',
-      'ui:required': formData => {
+      'ui:required': (formData, index) => {
         if (customRequired('state')) {
-          return customRequired('state')(formData);
+          return customRequired('state')(formData, index);
         }
         if (cachedPath) {
           const { country } = get(cachedPath, formData) ?? {};
@@ -444,7 +454,7 @@ export function addressUI(options) {
 
   if (!omit('postalCode')) {
     uiSchema.postalCode = {
-      'ui:required': customRequired('postalCode') || (() => true),
+      'ui:required': requiredFunc('postalCode', true),
       'ui:title': 'Postal code',
       'ui:autocomplete': 'postal-code',
       'ui:webComponentField': VaTextInputField,


### PR DESCRIPTION
## Summary

### 21P-527EZ App
- Copy fixes for the child dependent information
- Updating the child dependent address schema to use the modern web component schema and schemaui instead of the old one from vets-json-schema
- This also changes the state and postal code inputs

### Forms System Web Component Address Schema
- Introduces arguments for form data and index for all address fields' "required" functions.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/69972

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |<img width="430" alt="69972-married-before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/c6ea497b-aaba-4441-b584-f2d4bf9d270f">|<img width="540" alt="69972-married-after" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/04ef7e24-817b-4d81-9ecf-d46bb11f52eb">|
Desktop|<img width="639" alt="69972-support-before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/b3b68d78-441a-4efc-8899-5d6c82b5c0a5">|<img width="636" alt="69972-support-after" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/99781e9e-831c-4f8d-9022-eac2b562fce5">|
Desktop|![69972-address-before](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/b1252532-efd4-413c-843c-0d8fe3636766)|![69972-address-after](https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/228ca2c3-aad1-4309-9d3a-dc4fadbe6887)|

## What areas of the site does it impact?

- Form 21P-527EZ Household Information chapter

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
