### PR TITLE
My VA - fix off-by-one date on Claims and appeals

### DIFF
--- a/src/applications/personalization/dashboard/components/claims-and-appeals/Appeal.jsx
+++ b/src/applications/personalization/dashboard/components/claims-and-appeals/Appeal.jsx
@@ -9,6 +9,7 @@ import {
   getTypeName,
   programAreaMap,
 } from '../../utils/appeals-v2-helpers';
+import { replaceDashesWithSlashes as replace } from '../../utils/date-formatting/helpers';
 
 import { getStatusContents } from '../../utils/getStatusContents';
 
@@ -70,7 +71,7 @@ const Appeal = ({ appeal, name }) => {
   }
 
   appealTitle += ` updated on ${format(
-    new Date(updatedEventDateString.replace(/-/g, '/')),
+    new Date(replace(updatedEventDateString)),
     'MMMM d, yyyy',
   )}`;
   appealTitle = capitalizeFirstLetter(appealTitle);

--- a/src/applications/personalization/dashboard/components/claims-and-appeals/Claim.jsx
+++ b/src/applications/personalization/dashboard/components/claims-and-appeals/Claim.jsx
@@ -11,6 +11,7 @@ import {
   isLighthouseClaimComplete,
   getClaimType,
 } from '../../utils/claims-helpers';
+import { replaceDashesWithSlashes as replace } from '../../utils/date-formatting/helpers';
 
 import CTALink from '../CTALink';
 
@@ -56,7 +57,7 @@ const Claim = ({ claim, useLighthouseClaims = false }) => {
     claim,
     useLighthouseClaims,
   );
-  const dateRecd = format(new Date(claimDate), 'MMMM d, yyyy');
+  const dateRecd = format(new Date(replace(claimDate)), 'MMMM d, yyyy');
 
   const content = (
     <>

--- a/src/applications/personalization/dashboard/mocks/server.js
+++ b/src/applications/personalization/dashboard/mocks/server.js
@@ -22,7 +22,7 @@ const hasDebts = false;
 /* eslint-disable camelcase */
 const responses = {
   'GET /v0/feature_toggles': generateFeatureToggles({
-    authExpVbaDowntimeMessage: true,
+    authExpVbaDowntimeMessage: false,
     myVaEnableNotificationComponent: true,
     myVaUseExperimental: false,
     myVaUseExperimentalFrontend: true,

--- a/src/applications/personalization/dashboard/tests/components/claims-and-appeals/Appeal.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/claims-and-appeals/Appeal.unit.spec.jsx
@@ -7,6 +7,7 @@ import { renderWithStoreAndRouter } from '~/platform/testing/unit/react-testing-
 
 import Appeal from '../../../components/claims-and-appeals/Appeal';
 import { APPEAL_TYPES } from '../../../utils/appeals-v2-helpers';
+import { replaceDashesWithSlashes } from '../../../utils/date-formatting/helpers';
 
 function makeAppealObject({
   updateDate,
@@ -71,7 +72,7 @@ describe('<Appeal />', () => {
   it('should render', () => {
     const appeal = makeAppealObject({ updateDate: daysAgo(1) });
     const updatedDate = format(
-      new Date(daysAgo(1).replace(/-/g, '/')),
+      new Date(replaceDashesWithSlashes(daysAgo(1))),
       'MMMM d, yyyy',
     );
     const appealTitle = `Disability compensation appeal updated on ${updatedDate}`;

--- a/src/applications/personalization/dashboard/tests/components/claims-and-appeals/Claim.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/claims-and-appeals/Claim.unit.spec.jsx
@@ -53,7 +53,11 @@ describe('<Claim />', () => {
       initialState,
     });
 
-    expect(tree.getByText(/Compensation claim received/)).to.exist;
+    expect(
+      tree.getByRole('heading', {
+        name: /Compensation claim received January 21, 2021/,
+      }),
+    ).to.exist;
     expect(tree.getByText(/Review details/)).to.exist;
   });
 

--- a/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
+++ b/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
@@ -4,6 +4,7 @@ import {
   formDescriptions,
   sipEnabledForms,
 } from 'applications/personalization/dashboard/helpers';
+import { replaceDashesWithSlashes } from '../utils/date-formatting/helpers';
 
 describe('profile helpers:', () => {
   describe('formDescriptions', () => {
@@ -12,5 +13,11 @@ describe('profile helpers:', () => {
         expect(formDescriptions[form]).to.exist;
       });
     });
+  });
+});
+
+describe('replaceDashesWithSlashes function', () => {
+  it('should replace the dashes in a string with slashes', () => {
+    expect(replaceDashesWithSlashes('2023-10-23')).to.equal('2023/10/23');
   });
 });

--- a/src/applications/personalization/dashboard/utils/date-formatting/helpers.js
+++ b/src/applications/personalization/dashboard/utils/date-formatting/helpers.js
@@ -1,0 +1,9 @@
+/**
+ *
+ * @param {string} date in the format of 'year-month-day' e.g. 2023-12-07
+ * @returns {string} in the format of 'year/month/day' e.g. 2023/12/07
+ */
+
+export const replaceDashesWithSlashes = date => {
+  return date.replace(/-/g, '/');
+};


### PR DESCRIPTION
## Summary

This PR 
- creates a folder and file for date formatting helper functions
- adds a `replaceDashWithSlashes` function due to weird [Javascript behavior around the Date object](https://stackoverflow.com/questions/7556591/is-the-javascript-date-object-always-one-day-off) 
- applies the function to dates within Appeal and Claim cards

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/71289

## Testing done
- locally, visually
- added one new unit test, updated two existing ones
- all existing unit and e2e still pass

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?
- My VA - Claims and appeals section

## Acceptance criteria
- [ ] date on Claims or appeals card matches that on the Claims timeline/details page

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

