### PR TITLE
Add 20-10206 max test-data

### DIFF
--- a/src/applications/simple-forms/20-10206/tests/e2e/fixtures/data/test-data-maximal.json
+++ b/src/applications/simple-forms/20-10206/tests/e2e/fixtures/data/test-data-maximal.json
@@ -1,0 +1,53 @@
+{
+  "data": {
+    "preparerType": "non-citizen",
+    "fullName": {
+      "first": "John",
+      "middle": "A",
+      "last": "Preparer"
+    },
+    "dateOfBirth": "1985-01-01",
+    "placeOfBirth": "Washington, DC",
+    "address": {
+      "street": "123 Any St",
+      "street2": "Apt 2",
+      "city": "Washington",
+      "state": "DC",
+      "postalCode": "54321",
+      "country": "USA"
+    },
+    "homePhone": "1234567890",
+    "emailAddress": "jv@example.com",
+    "citizenId": {
+      "ssn": "333221111",
+      "vaFileNumber": "123456789"
+    },
+    "nonCitizenId": {
+      "arn": "123456789",
+      "vaFileNumber": "123456789"
+    },
+    "recordSelections": {
+      "dd214": true,
+      "disability-exams": true,
+      "financial": true,
+      "life-ins": true,
+      "other-comp-pen": true,
+      "other": true
+    },
+    "disabilityExams": [
+      {
+        "disabilityExamDate": "2019-01-01"
+      },
+      {
+        "disabilityExamDate": "2019-01-01"
+      }
+    ],
+    "otherCompAndPenDetails": "Other Comp&Pen details",
+    "financialRecordDetails": "Financial record details",
+    "lifeInsuranceBenefitDetails": "Life insurance details",
+    "otherBenefitDetails": "Other benefit details",
+    "additionalRecordsInformation": "Additional records information",
+    "vaRegionalOfficeName": "VA regional office name"
+  }
+}
+

--- a/src/applications/simple-forms/20-10206/tests/e2e/fixtures/data/test-data-maximal.json
+++ b/src/applications/simple-forms/20-10206/tests/e2e/fixtures/data/test-data-maximal.json
@@ -27,12 +27,20 @@
       "vaFileNumber": "123456789"
     },
     "recordSelections": {
+      "c-file": true,
       "dd214": true,
       "disability-exams": true,
+      "education": true,
       "financial": true,
+      "fiduciary": true,
+      "home-loan": true,
       "life-ins": true,
+      "ompf": true,
       "other-comp-pen": true,
-      "other": true
+      "other": true,
+      "pension": true,
+      "treatment": true,
+      "vre": true
     },
     "disabilityExams": [
       {
@@ -50,4 +58,3 @@
     "vaRegionalOfficeName": "VA regional office name"
   }
 }
-


### PR DESCRIPTION
## Summary

- Add maximal test-data file to facilitate back-end data-mapping
- Team: Veteran Facing Forms
- Flipper not implemented yet

## Context for backend data-mapping

PDF blocks to ignore:
- FOIA &mdash; we're only supporting the PA portion of the PDF
- Third-party preparer-type &mdash; we're only supporting first-party submissions

## Related issue(s)

- n/a

## Testing done

- n/a

## What areas of the site does it impact?

Nothing, just data to support local development.