### PR TITLE
Revert appointment events back to Universal Analytics

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/CancelLink.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/CancelLink.jsx
@@ -36,8 +36,7 @@ export default function CancelLink({ appointment }) {
       <button
         onClick={() => {
           recordEvent({
-            event: 'interaction',
-            action: `${GA_PREFIX}-cancel-booked-clicked`,
+            event: `${GA_PREFIX}-cancel-booked-clicked`,
           });
           dispatch(startAppointmentCancel(appointment));
         }}

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/tests/CancelLink.unit.spec.js
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/tests/CancelLink.unit.spec.js
@@ -90,8 +90,7 @@ describe('CancelLink', () => {
     fireEvent.click(await wrapper.getByTestId('cancelButton'));
     const event = global.window.dataLayer[0];
     expect(event).to.deep.equal({
-      action: 'vaos-cancel-booked-clicked',
-      event: 'interaction',
+      event: 'vaos-cancel-booked-clicked',
     });
   });
 });

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -197,8 +197,7 @@ export function updateFacilityType(facilityType) {
 
 export function startDirectScheduleFlow() {
   recordEvent({
-    event: 'interaction',
-    action: 'vaos-direct-path-started',
+    event: 'vaos-direct-path-started',
   });
 
   return {
@@ -743,17 +742,14 @@ export function submitAppointmentOrRequest(history) {
     });
 
     let additionalEventData = {
-      custom_string_1: `health-TypeOfCare: ${typeOfCare}`,
-      custom_string_2: `health-ReasonForAppointment: ${
-        data?.reasonForAppointment
-      }`,
+      'health-TypeOfCare': typeOfCare,
+      'health-ReasonForAppointment': data?.reasonForAppointment,
     };
 
     if (newAppointment.flowType === FLOW_TYPES.DIRECT) {
       const flow = GA_FLOWS.DIRECT;
       recordEvent({
-        event: 'interaction',
-        action: `${GA_PREFIX}-direct-submission`,
+        event: `${GA_PREFIX}-direct-submission`,
         flow,
         ...additionalEventData,
       });

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -565,18 +565,15 @@ const eventPrefix = `${GA_PREFIX}-cancel-appointment-submission`;
  */
 export async function cancelAppointment({ appointment, useAcheron = false }) {
   const additionalEventData = {
-    custom_string_1:
+    appointmentType:
       appointment.status === APPOINTMENT_STATUS.proposed
-        ? 'appointmentType: pending'
-        : 'appointmentType: confirmed',
-    custom_string_2: appointment.vaos?.isCommunityCare
-      ? 'facilityType: cc'
-      : 'facilityType: va',
+        ? 'pending'
+        : 'confirmed',
+    facilityType: appointment.vaos?.isCommunityCare ? 'cc' : 'va',
   };
 
   recordEvent({
-    event: 'interaction',
-    action: eventPrefix,
+    event: eventPrefix,
     ...additionalEventData,
   });
 

--- a/src/applications/vaos/services/patient/index.js
+++ b/src/applications/vaos/services/patient/index.js
@@ -378,7 +378,11 @@ export async function fetchFlowEligibilityAndClinics({
     if (!results.patientEligibility.direct.hasRequiredAppointmentHistory) {
       eligibility.direct = false;
       eligibility.directReasons.push(ELIGIBILITY_REASONS.noRecentVisit);
-      recordEligibilityFailure('direct-check-past-visits');
+      recordEligibilityFailure(
+        'direct-check-past-visits',
+        typeOfCare?.id,
+        location?.id,
+      );
     }
 
     if (!results.clinics.length) {

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -773,8 +773,7 @@ describe('VAOS <ConfirmedAppointmentDetailsPage> with VAOS service', () => {
     userEvent.click(screen.getByText(/cancel appointment/i));
     await screen.findByRole('alertdialog');
     expect(window.dataLayer[15]).to.deep.equal({
-      event: 'interaction',
-      action: 'vaos-cancel-booked-clicked',
+      event: 'vaos-cancel-booked-clicked',
     });
     //  And clicks on 'yes, cancel this appointment' to confirm
     userEvent.click(screen.getByText(/yes, cancel this appointment/i));

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.jsx
@@ -238,8 +238,8 @@ describe('VAOS <ReviewPage> CC request with VAOS service', () => {
     expect(global.window.dataLayer[1]).to.deep.include({
       event: 'vaos-community-care-submission-successful',
       flow: 'cc-request',
-      custom_string_1: 'health-TypeOfCare: Primary care',
-      custom_string_2: 'health-ReasonForAppointment: undefined',
+      'health-TypeOfCare': 'Primary care',
+      'health-ReasonForAppointment': undefined,
       'vaos-community-care-preferred-language': 'english',
       'vaos-number-of-preferred-providers': 1,
       'vaos-number-of-days-from-preference': '1-1-null',
@@ -297,8 +297,8 @@ describe('VAOS <ReviewPage> CC request with VAOS service', () => {
     expect(global.window.dataLayer[1]).to.deep.include({
       event: 'vaos-community-care-submission-failed',
       flow: 'cc-request',
-      custom_string_1: 'health-TypeOfCare: Primary care',
-      custom_string_2: 'health-ReasonForAppointment: undefined',
+      'health-TypeOfCare': 'Primary care',
+      'health-ReasonForAppointment': undefined,
       'vaos-community-care-preferred-language': 'english',
       'vaos-number-of-preferred-providers': 1,
       'vaos-number-of-days-from-preference': '1-1-null',

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.jsx
@@ -304,8 +304,8 @@ describe('VAOS <ReviewPage> VA request with VAOS service', () => {
     expect(window.dataLayer[1]).to.deep.equal({
       event: 'vaos-request-submission-successful',
       flow: 'va-request',
-      custom_string_1: 'health-TypeOfCare: Primary care',
-      custom_string_2: 'health-ReasonForAppointment: routine-follow-up',
+      'health-TypeOfCare': 'Primary care',
+      'health-ReasonForAppointment': 'routine-follow-up',
       'vaos-preferred-combination': 'afternoon-evening-morning',
       'vaos-number-of-days-from-preference': '1-1-null',
     });
@@ -357,8 +357,8 @@ describe('VAOS <ReviewPage> VA request with VAOS service', () => {
     expect(window.dataLayer[1]).to.deep.include({
       event: 'vaos-request-submission-failed',
       flow: 'va-request',
-      custom_string_1: 'health-TypeOfCare: Primary care',
-      custom_string_2: 'health-ReasonForAppointment: routine-follow-up',
+      'health-TypeOfCare': 'Primary care',
+      'health-ReasonForAppointment': 'routine-follow-up',
       'vaos-preferred-combination': 'afternoon-evening-morning',
     });
   });

--- a/src/applications/vaos/utils/events.js
+++ b/src/applications/vaos/utils/events.js
@@ -13,8 +13,7 @@ export function recordEligibilityFailure(
   facilityId = null,
 ) {
   recordEvent({
-    event: 'interaction',
-    action: `vaos-eligibility${errorKey ? `-${errorKey}` : ''}-failed`,
+    event: `vaos-eligibility${errorKey ? `-${errorKey}` : ''}-failed`,
     'health-TypeOfCare': typeOfCare,
     'health-FacilityID': facilityId,
   });


### PR DESCRIPTION

## Summary

All five of listed events need to be reverted back to UA (Google Universal Analytics). The `event` attribute should have the event_label_name as its value, Remove the `actions`, `custom_string_1`, `custom_string_2` attributes.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#71348


## How to test


1. Add `console.log(data);` above line 26 to the file 'src/platform/monitoring/record-event.js' so it will look like 

 ``` 
console.log(data);
return pushEvent();
 ```
2. open the inspect tool to view the `console` tab

## Screenshots

3. Start the direct schedule flow using primary care > VAMC > Cheyenne VAMC

 **vaos-direct-path-started**
![Screenshot 2023-12-07 at 2 33 05 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/a4e802ed-3f63-42d7-9e6d-1a3773b82371)

4. Complete the form to submit the primary care appointment
 **vaos-direct-submission** 
![Screenshot 2023-12-07 at 2 38 14 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/a5390f80-939b-4c6a-b269-9c4c87dadbb9)

5. Click on `cancel appointment` link from any upcoming booked appointment details page
 **vaos-cancel-booked-clicked**
![Screenshot 2023-12-07 at 2 42 28 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/653585b1-0753-4a78-a553-b0bcae48e9d0)

6. Complete the cancel appointment 
 **vaos-cancel-appointment-submission**
![Screenshot 2023-12-07 at 2 43 34 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/e6802905-3860-4ef2-8ef4-bd9629b07213)

7. Complete a cancel request on any pending appointment
![Screenshot 2023-12-07 at 6 05 41 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/cc76b274-e5bd-4b3a-b50a-28cdd03e2b14)

8. Start a new direct schedule flow using Eye care> Optometry > VAMC > Lima VA Clinic (this should display the modal "We couldn't find a recent appointment at this location" ) 

 **vaos-eligibility-direct-check-past-visits-failed**
![Screenshot 2023-12-07 at 5 42 29 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/b2a40cc6-1a2d-4807-9101-63fb3ddf0df6)

## What areas of the site does it impact?

Tracking events for Universal Analytics 

## Acceptance criteria

1) Update the `vaos-direct-path-started` event
- [ ] The `event` attribute will be 'vaos-direct-path-started'
- [ ] Remove the `action` attribute

2) Update the `vaos-direct-submission` event
- [ ] The `event` attribute will be 'vaos-direct-submission'
- [ ] Remove the `action` attribute

3) Update the `vaos-cancel-booked-clicked` event
- [ ] The `event` attribute will be 'vaos-cancel-booked-clicked'
- [ ]  Remove the `action` attribute

4) Update the `vaos-cancel-appointment-submission` event
- [ ] The `event` attribute will be 'vaos-cancel-appointment-submission'
- [ ] Remove the `action` attribute

5) Update the `vaos-eligibility-direct-check-past-visits-failed` event
- [ ] The `event` attribute will be 'vaos-eligibility-direct-check-past-visits-failed'
- [ ] Remove the `action` attribute

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
