### PR TITLE
Move PageNotFound app specific styles from Formation to app

### DIFF
--- a/src/applications/dhp-connected-devices/sass/dhp-consent-flow.scss
+++ b/src/applications/dhp-connected-devices/sass/dhp-consent-flow.scss
@@ -48,6 +48,19 @@
 }
 
 .va-quicklinks {
+  ul {
+    margin-top: 0.8rem;
+  }
+  li {
+    padding: 0.56rem 0;
+  }
+  h3 {
+    line-height: 1.2em;
+    font-size: 1.65em;
+    color: $color-primary-darkest;
+    margin: 0 0 1rem 0;
+    padding: 0 0 0.2em 0;
+  }
   &--commpop {
     padding-bottom: 6.4rem;
   }

--- a/src/applications/dhp-connected-devices/sass/dhp-consent-flow.scss
+++ b/src/applications/dhp-connected-devices/sass/dhp-consent-flow.scss
@@ -41,3 +41,65 @@
   margin-bottom: -1em;
   max-width: 75%;
 }
+
+// PageNotFound
+.text-center {
+  text-align: center;
+}
+
+.va-quicklinks {
+  &--commpop {
+    padding-bottom: 6.4rem;
+  }
+}
+
+.maintenance-page {
+  padding-top: 3.2rem;
+
+  .text-center {
+    margin: auto;
+  }
+}
+
+#search_form {
+  position: relative;
+  width: 100%;
+
+  label {
+    left: -9999rem;
+    position: absolute;
+  }
+
+  [type="text"] {
+    height: 5.7rem;
+    margin: 0;
+    max-width: 100%;
+  }
+
+  [type="submit"] {
+    border-radius: 0 3px 3px 0;
+    height: 5.7rem;
+    margin: 0;
+  }
+}
+
+// Vertically aligns at top when flex-direction: row;
+// Aligns flush left when flex-direction: column
+.va-flex--top {
+  -webkit-align-items: flex-start;
+  align-items: flex-start;
+}
+
+// Vertically aligns in the middle when flex-direction: row;
+// Aligns center horizontally when flex-direction: column
+.va-flex--ctr {
+  -webkit-align-items: center;
+  align-items: center;
+}
+
+// Horizontally aligns in the center when flex-direction: row;
+// Aligns middle vertically when flex-direction: column
+.va-flex--jctr {
+  -webkit-justify-items: center;
+  justify-items: center;
+}

--- a/src/applications/dhp-connected-devices/tests/dhp-consent-flow.cypress.spec.js
+++ b/src/applications/dhp-connected-devices/tests/dhp-consent-flow.cypress.spec.js
@@ -37,11 +37,7 @@ describe(manifest.appName, () => {
     cy.get('#signin-signup-modal').should('be.visible');
     cy.axeCheck();
 
-    cy.get('.va-modal-close').click({
-      multiple: true,
-      force: true,
-      waitForAnimations: true,
-    });
+    cy.get('#signin-signup-modal .va-modal-close').click();
     cy.get('#signin-signup-modal').should('not.exist');
   });
 });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

I did an audit of the Formation stylesheet here [formation/sass/base/_va.scss](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages/formation/sass/base/_va.scss) and found several styles that only appear to be used in the `src/applications/dhp-connected-devices/components/PageNotFound.jsx` file.

This PR moves those styles into the app itself so that it's no longer being loaded globally.

![Screenshot 2023-12-11 at 12 55 18 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/872479/55b7f788-7538-4c68-8ebb-2146a5e561b2)

![Screenshot 2023-12-11 at 12 53 57 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/872479/3a34360f-10b9-4c35-a5ca-e01c2a812230)


## Related issue(s)
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2043

## Testing done

- Locally at: http://localhost:3001/health-care/connected-devices/
- Used the Verdaccio local registry to test Formation with it too.
 
## What areas of the site does it impact?

- The dhp-connected-devices app

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
