### PR TITLE
[20-10206] Remove third-party preparer type and add additional information

### DIFF
--- a/src/applications/simple-forms/20-10206/config/constants.js
+++ b/src/applications/simple-forms/20-10206/config/constants.js
@@ -1,15 +1,14 @@
+import React from 'react';
+
 export const PREPARER_TYPES = Object.freeze({
   CITIZEN: 'citizen',
   NON_CITIZEN: 'non-citizen',
-  THIRD_PARTY: 'third-party',
 });
 export const PREPARER_TYPE_LABELS = Object.freeze({
   [PREPARER_TYPES.CITIZEN]:
     'I’m a U.S. citizen requesting my own personal VA records',
   [PREPARER_TYPES.NON_CITIZEN]:
     'I’m a non-U.S. citizen requesting my own personal VA records',
-  [PREPARER_TYPES.THIRD_PARTY]:
-    'I’m a third-party or power of attorney requesting personal VA records for someone else',
 });
 
 export const RECORD_TYPES = Object.freeze({
@@ -45,3 +44,63 @@ export const RECORD_TYPE_LABELS = Object.freeze({
   [RECORD_TYPES.VRE]: 'Vocational rehabilitation and employment',
   [RECORD_TYPES.OTHER]: 'Other benefit records',
 });
+
+export const ADDITIONAL_INFO_THIRD_PARTY = Object.freeze(
+  <va-additional-info trigger="How do I request personal records for someone else?">
+    <div>
+      <p>
+        If you’re asking for someone else’s records,{' '}
+        <a
+          href="https://www.va.gov/FOIA/index.asp"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          submit a FOIA request (opens in new tab)
+        </a>
+        . You’ll need to have proper authorization on record for your request to
+        be processed.
+      </p>
+      <ul>
+        <li>
+          <strong>If you’re a third-party representative</strong> (a family
+          member or other assigned person who is not a power of attorney, agent,
+          or fiduciary) requesting VA records for someone else, we must have an
+          authorization form on record (VA Form 21-0845) for us to release their
+          information.
+          <a
+            href="https://www.va.gov/find-forms/about-form-21-0845/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="vads-u-display--block vads-u-margin-top--2"
+          >
+            Go to VA Form 21-0845 Authorization to Disclose Personal Information
+            to a Third-Party (opens in new tab)
+          </a>
+        </li>
+        <li className="vads-u-margin-top--2">
+          <strong>If you’re a power of attorney</strong> requesting VA records
+          for someone else, we must have an official record that you were
+          appointed as their representative (VA Form 21-22 or VA Form 21-22a).
+          <a
+            href="https://www.va.gov/find-forms/about-form-21-22/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="vads-u-display--block vads-u-margin-top--2"
+          >
+            Go to VA Form 21-22 Appointment of Veterans Service Organization as
+            Claimant’s Representative (opens in new tab)
+          </a>
+          <a
+            href="https://www.va.gov/find-forms/about-form-21-22a/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="vads-u-display--block vads-u-margin-top--2"
+          >
+            Go to VA Form 21-22a Appointment of Individual as Claimant’s
+            Representative (opens in new tab)
+          </a>
+        </li>
+      </ul>
+    </div>
+  </va-additional-info>,
+);

--- a/src/applications/simple-forms/20-10206/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/20-10206/containers/IntroductionPage.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { isLOA3, isLoggedIn } from 'platform/user/selectors';
 import { connect } from 'react-redux';
 import { IntroductionPageView } from '../../shared/components/IntroductionPageView';
+import { ADDITIONAL_INFO_THIRD_PARTY } from '../config/constants';
 
 const ombInfo = {
   resBurden: '5',
@@ -103,66 +104,7 @@ export const IntroductionPage = ({ route, userIdVerified, userLoggedIn }) => {
           </div>
         </va-alert>
       </div>
-      <div className="vads-u-margin-y--4">
-        <va-additional-info trigger="How do I request personal records for someone else?">
-          <div>
-            <p>
-              If you’re asking for someone else’s records,{' '}
-              <a
-                href="https://www.va.gov/FOIA/index.asp"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                submit a FOIA request (opens in new tab)
-              </a>
-              . You’ll need to have proper authorization on record for your
-              request to be processed.
-            </p>
-            <ul>
-              <li>
-                <strong>If you’re a third-party representative</strong> (a
-                family member or other assigned person who is not a power of
-                attorney, agent, or fiduciary) requesting VA records for someone
-                else, we must have an authorization form on record (VA Form
-                21-0845) for us to release their information.
-                <a
-                  href="https://www.va.gov/find-forms/about-form-21-0845/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="vads-u-display--block vads-u-margin-top--2"
-                >
-                  Go to VA Form 21-0845 Authorization to Disclose Personal
-                  Information to a Third-Party (opens in new tab)
-                </a>
-              </li>
-              <li className="vads-u-margin-top--2">
-                <strong>If you’re a power of attorney</strong> requesting VA
-                records for someone else, we must have an official record that
-                you were appointed as their representative (VA Form 21-22 or VA
-                Form 21-22a).
-                <a
-                  href="https://www.va.gov/find-forms/about-form-21-22/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="vads-u-display--block vads-u-margin-top--2"
-                >
-                  Go to VA Form 21-22 Appointment of Veterans Service
-                  Organization as Claimant’s Representative (opens in new tab)
-                </a>
-                <a
-                  href="https://www.va.gov/find-forms/about-form-21-22a/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="vads-u-display--block vads-u-margin-top--2"
-                >
-                  Go to VA Form 21-22a Appointment of Individual as Claimant’s
-                  Representative (opens in new tab)
-                </a>
-              </li>
-            </ul>
-          </div>
-        </va-additional-info>
-      </div>
+      <div className="vads-u-margin-y--4">{ADDITIONAL_INFO_THIRD_PARTY}</div>
       <h2 id="start-your-request">Start your request</h2>
       {userLoggedIn &&
       !userIdVerified /* If User's signed-in but not identity-verified [not LOA3] */ && (

--- a/src/applications/simple-forms/20-10206/pages/preparerType.js
+++ b/src/applications/simple-forms/20-10206/pages/preparerType.js
@@ -3,7 +3,11 @@ import {
   radioSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
-import { PREPARER_TYPES, PREPARER_TYPE_LABELS } from '../config/constants';
+import {
+  PREPARER_TYPES,
+  PREPARER_TYPE_LABELS,
+  ADDITIONAL_INFO_THIRD_PARTY,
+} from '../config/constants';
 
 /** @type {PageSchema} */
 export default {
@@ -16,11 +20,18 @@ export default {
       },
       labelHeaderLevel: '3',
     }),
+    'view:additionalInfoPreparerType': {
+      'ui:description': ADDITIONAL_INFO_THIRD_PARTY,
+    },
   },
   schema: {
     type: 'object',
     properties: {
       preparerType: radioSchema(Object.values(PREPARER_TYPES)),
+      'view:additionalInfoPreparerType': {
+        type: 'object',
+        properties: {},
+      },
     },
     required: ['preparerType'],
   },

--- a/src/applications/simple-forms/20-10206/tests/e2e/fixtures/mocks/submitTransformerForm.json
+++ b/src/applications/simple-forms/20-10206/tests/e2e/fixtures/mocks/submitTransformerForm.json
@@ -72,8 +72,7 @@
                   "ui:options": {
                       "labels": {
                           "citizen": "I’m a U.S. citizen requesting my own personal VA records",
-                          "non-citizen": "I’m a non-U.S. citizen requesting my own personal VA records",
-                          "third-party": "I’m a third-party or power of attorney requesting personal VA records for someone else"
+                          "non-citizen": "I’m a non-U.S. citizen requesting my own personal VA records"
                       },
                       "labelHeaderLevel": "3"
                   },
@@ -89,8 +88,7 @@
                       "type": "string",
                       "enum": [
                           "citizen",
-                          "non-citizen",
-                          "third-party"
+                          "non-citizen"
                       ]
                   }
               },


### PR DESCRIPTION
## Summary
This updates the preparer type page in 20-10206 to remove the third party option and provide additional information on what steps to take if you are a third party.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#71699

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/53942725/c812dcd6-ef48-4558-b319-7c8b6d27fa8f)
