### PR TITLE
Add unit test coverage for ProviderName

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/ProviderName.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/ProviderName.jsx
@@ -1,21 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function ProviderName({ appointment, useV2 = false }) {
-  const { name, practiceName, providerName } =
-    appointment.communityCareProvider || {};
+export default function ProviderName({ appointment, useV2 }) {
+  const { providerName } = appointment.communityCareProvider || {};
   let displayName = null;
 
-  if (!!providerName || !!practiceName || !!name) {
-    displayName = useV2
-      ? providerName[0] || practiceName || name
-      : providerName || practiceName || name;
+  if (providerName) {
+    displayName = useV2 ? providerName[0] : null;
   }
 
   return <div>{displayName}</div>;
 }
 
 ProviderName.propTypes = {
-  appointment: PropTypes.object.isRequired,
+  appointment: PropTypes.shape({
+    communityCareProvider: PropTypes.shape({
+      providerName: PropTypes.array,
+    }),
+  }),
   useV2: PropTypes.bool,
+};
+
+ProviderName.defaultProps = {
+  appointment: {
+    communityCareProvider: {
+      providerName: [''],
+    },
+  },
+  useV2: false,
 };

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/tests/ProviderName.unit.spec.js
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/tests/ProviderName.unit.spec.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import ProviderName from '../ProviderName';
+
+describe('Provider Name component', () => {
+  const appointmentData = {
+    communityCareProvider: {
+      providerName: ['First LastName'],
+    },
+  };
+
+  it('should render provider name', async () => {
+    const appointment = {
+      ...appointmentData,
+    };
+
+    const screen = render(<ProviderName appointment={appointment} useV2 />);
+
+    expect(screen.baseElement).to.contain.text('First LastName');
+  });
+  it('should not render provider name when communityCareProvider is missing', async () => {
+    const appointment = {};
+    const screen = render(<ProviderName appointment={appointment} useV2 />);
+
+    expect(screen.baseElement).to.not.contain.text('First LastName');
+  });
+  it('should not render provider name when useV2 is false', async () => {
+    const appointment = {
+      ...appointmentData,
+    };
+
+    const screen = render(
+      <ProviderName appointment={appointment} useV2={false} />,
+    );
+    expect(screen.baseElement).to.not.contain.text('First LastName');
+  });
+});

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -4,7 +4,6 @@
       "id": "00C891va",
       "type": "Appointment",
       "attributes": {
-        "cancelationReason": null,
         "clinic": "437",
         "comment": "Follow-up/Routine: I have a headache",
         "contact": {
@@ -16,7 +15,7 @@
           ]
         },
         "description": "Upcoming COVID-19 appointment",
-        "end": "2023-11-21T18:19:34",
+        "end": "2024-10-13T16:00:00Z",
         "id": "00C891va",
         "kind": "clinic",
         "locationId": "983",
@@ -30,9 +29,12 @@
         },
         "requestedPeriods": null,
         "serviceType": "covid",
-        "slot": null,
-        "start": "2023-11-21T18:19:34",
+        "start": "2024-10-13T15:00:00Z",
         "status": "booked",
+        "created": "2024-11-01T00:00:00Z",
+        "cancellable": true,
+        "localStartTime": "2024-10-13T09:00:00.000-06:00",
+        "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988663350853",
         "telehealth": null
       }
     },
@@ -69,6 +71,7 @@
         "slot": null,
         "start": "2023-12-21T18:19:34",
         "status": "cancelled",
+        "localStartTime": "2023-12-21T09:00:00.000-06:00",
         "telehealth": null
       }
     },
@@ -102,8 +105,10 @@
             }
           }
         ],
-        "start": "2022-08-22T12:00:00Z",
-        "created": "2022-08-22T20:33:54Z",
+        "start": "2024-08-22T12:00:00Z",
+        "created": "2024-08-22T20:33:54Z",
+        "localStartTime": "2024-08-21T09:00:00.000-06:00",
+        "avsPath": null,
         "cancellable": true,
         "extension": {
           "ccLocation": {
@@ -1006,16 +1011,12 @@
         "locationId": "984",
         "practitioners": [
           {
-            "name": {
-              "family": "RICHMOND",
-              "given": [
-                "TANISHA R"
-              ]
-            }
           }
         ],
-        "start": "2022-10-22T12:00:00Z",
-        "created": "2022-10-22T20:33:54Z",
+        "start": "2024-08-22T12:00:00Z",
+        "created": "2024-08-22T20:33:54Z",
+        "localStartTime": "2024-08-21T09:00:00.000-06:00",
+        "avsPath": null,
         "cancellable": false,
         "extension": {
           "ccLocation": {
@@ -1536,7 +1537,10 @@
         "requestedPeriods": null,
         "serviceType": "outpatientMentalHealth",
         "slot": null,
-        "start": "2023-09-23T20:00:00Z",
+        "start": "2024-09-22T12:00:00Z",
+        "created": "2024-09-22T20:33:54Z",
+        "localStartTime": "2024-09-21T09:00:00.000-06:00",
+        "avsPath": null,
         "status": "booked",
         "extension": {
           "patientHasMobileGfe": false
@@ -1593,7 +1597,9 @@
         "requestedPeriods": null,
         "serviceType": "amputation",
         "slot": null,
-        "start": "2024-01-23T20:00:00Z",
+        "start": "2023-01-23T20:00:00Z",
+        "localStartTime": "2023-01-13T09:00:00.000-06:00",
+        "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988663350853",
         "status": "booked",
         "telehealth": {
           "url": null,
@@ -1683,6 +1689,8 @@
         },
         "slot": null,
         "start": "2023-11-09T20:30:00Z",
+        "localStartTime": "2023-11-13T09:00:00.000-06:00",
+        "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988663350853",
         "status": "booked",
         "telehealth": {
           "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#",


### PR DESCRIPTION

## Summary

This PR modifies `ProviderName.jsx`that removes data structure that was decommissioned for Scheduling Manager services (pre VAOS services)  and add unit test coverage to  the component

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#67677


## Testing done

unit test

## Screenshots

![Screenshot 2023-12-12 at 1 41 37 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/fafa0ee3-f77c-4749-b0d7-6a604e13be06)


## What areas of the site does it impact?

unit test and providerName component

## Acceptance criteria

- [ ] file coverage for Branches, functions, lines and statements is 100%

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

