### PR TITLE
20-10206 - Add array-field custom item-aria-label

### DIFF
--- a/src/applications/simple-forms/20-10206/pages/disabilityExamDetails.js
+++ b/src/applications/simple-forms/20-10206/pages/disabilityExamDetails.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import moment from 'moment';
+
 import commonDefinitions from 'vets-json-schema/dist/definitions.json';
 import VaMemorableDateField from 'platform/forms-system/src/js/web-component-fields/VaMemorableDateField';
 import { validateCurrentOrPastMemorableDate } from 'platform/forms-system/src/js/validation.js';
@@ -19,6 +21,13 @@ export default {
     disabilityExams: {
       'ui:options': {
         itemName: 'exam date',
+        itemAriaLabel: formData => {
+          const friendlyDateString = moment(
+            formData.disabilityExamDate,
+            'YYYY-MM-DD',
+          ).format('LL');
+          return `Exam Date for ${friendlyDateString}`;
+        },
         viewField: DisabilityExamDate,
         keepInPageOnReview: true,
         customTitle: ' ',


### PR DESCRIPTION
## Summary

- Add `itemAriaLabel` ui-Options-prop to Personal Records Request (20-10206) disability-exam-details page:
  - The function for this prop injects the inputted date from formData, enabling screen readers to announce the actual date right after 'Edit exam date' or 'Remove exam date'.  Without this \[[currently in Staging](https://staging.va.gov/records/request-personal-records-form-20-10206)\], screen readers only announced 'Edit exam date' or 'Remove exam date'
- Team: Veteran Facing Forms
- Flipper not implemented yet

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#71635

## Testing done

- Local browser-testing w/ macOS VoiceOver was successful.

## What areas of the site does it impact?

This form ONLY