### PR TITLE
VACMS-16255 SearchForm flaky test fix

### DIFF
--- a/src/applications/find-forms/tests/containers/SearchForm.cypress.spec.js
+++ b/src/applications/find-forms/tests/containers/SearchForm.cypress.spec.js
@@ -27,10 +27,10 @@ class FindFormComponent {
         .find(SELECTORS.FINDFORM_INPUT)
         .as('formInput');
       cy.get('@formInput').scrollIntoView();
-      cy.get('@formInput').clear();
       cy.get('@formInput').focus();
-      cy.get('@formInput').type(str, { force: true });
+      cy.get('@formInput').clear();
       cy.get('@formInput').should('not.be.disabled');
+      cy.get('@formInput').type(str, { force: true });
     }
   };
 
@@ -54,10 +54,7 @@ class FindFormComponent {
   };
 
   inputTextAndSearch = str => {
-    // Find input field, clear, and enter the string
     this.inputText(str);
-
-    // Click search button
     this.clickSearch();
   };
 
@@ -84,7 +81,7 @@ class FindFormComponent {
 }
 
 // Tests for find-forms application
-xdescribe('Find a VA form smoke test', () => {
+describe('Find a VA form smoke test', () => {
   const findFormComponent = new FindFormComponent();
 
   it('does not display an error on initial page load with no URL query', () => {


### PR DESCRIPTION
Ticket: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16255

Attempt to resolve flakiness in the `SearchForm.cypress.spec.js`. Slight tweak to make sure the input is focused before trying to make any changes to it. Removal of unnecessary comments. And also un-skipping the test suite.

Relevant Slack thread: https://dsva.slack.com/archives/CBU0KDSB1/p1701272317089959
Mocha report for failing Cypress test: https://testing-tools-testing-reports.s3-us-gov-west-1.amazonaws.com/vets-website-cypress-reports/7f2d0c7d-1a42-4b51-b28f-3a5b845da5b8.html