### PR TITLE
VACMS-16392 Spanish toggle for Community Care page

### DIFF
--- a/src/applications/static-pages/i18Select/tests/getNonActiveLinkUrls.unit.spec.js
+++ b/src/applications/static-pages/i18Select/tests/getNonActiveLinkUrls.unit.spec.js
@@ -9,7 +9,7 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(esp|tag)/i.test(url)).to.equal(true);
     });
 
-    expect(result.length).to.equal(18);
+    expect(result.length).to.equal(19);
   });
 
   it('should not return any "-esp" suffixed links when "es" is the active language code', () => {
@@ -19,7 +19,7 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(esp)/i.test(url)).to.equal(false);
     });
 
-    expect(result.length).to.equal(18);
+    expect(result.length).to.equal(19);
   });
 
   it('should not return any "-tag" suffixed links when "tl" is the active language code', () => {
@@ -29,6 +29,6 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(tag)/i.test(url)).to.equal(false);
     });
 
-    expect(result.length).to.equal(24);
+    expect(result.length).to.equal(26);
   });
 });

--- a/src/applications/static-pages/i18Select/utilities/urls.js
+++ b/src/applications/static-pages/i18Select/utilities/urls.js
@@ -58,4 +58,10 @@ export default {
     en: '/health-care/after-you-apply/',
     es: '/health-care/after-you-apply-esp/',
   },
+  compAssistanceForFamily: {
+    en:
+      '/family-member-benefits/comprehensive-assistance-for-family-caregivers/',
+    es:
+      '/family-member-benefits/comprehensive-assistance-for-family-caregivers-esp/',
+  },
 };


### PR DESCRIPTION
## Summary
The [Community Care pages](https://www.va.gov/family-member-benefits/comprehensive-assistance-for-family-caregivers/) have been live for a while but were waiting on QA to review. Now they need the English | Spanish toggle at the top. `vets-website` has a file that lists all of the pages that have translations so it can add the toggle without looping through hundreds of thousands of va.gov-wide pages. We simply needed to add the pages to that list.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16392

## Testing done
Tested locally. Ensure that each of these links loads the page with the correctly translated `<title>` & breadcrumb, and the toggle appears with the correct language selected.

- `/family-member-benefits/comprehensive-assistance-for-family-caregivers/`
- `/family-member-benefits/comprehensive-assistance-for-family-caregivers-esp/`

## Screenshots
<img width="1214" alt="Screenshot 2023-12-13 at 12 44 47 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/356570d0-faa8-4c52-a652-0f3c70cfaf46">
<img width="1217" alt="Screenshot 2023-12-13 at 12 44 42 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/ae7b11c7-14b6-4ceb-92d1-7eecfbe1b348">

## Acceptance criteria
- [x] Translation toggles appear on https://www.va.gov/family-member-benefits/comprehensive-assistance-for-family-caregivers-esp/ with Spanish highlighted
- [x] Translation toggles appear on https://www.va.gov/family-member-benefits/comprehensive-assistance-for-family-caregivers/ with English highlighted
- [x] The breadcrumb current page segment is translated
- [x] The title tags are translated
- [x] Pages are linked to/referenced in the language resource page (spanish)