### PR TITLE
20-10206 - Customize Review-page arrayfield-item header-level

### DIFF
--- a/src/applications/simple-forms/20-10206/pages/disabilityExamDetails.js
+++ b/src/applications/simple-forms/20-10206/pages/disabilityExamDetails.js
@@ -57,7 +57,7 @@ export default {
           },
           'ui:reviewField': ({ children }) => (
             <div className="review-row">
-              <dt>{dateUiTitle}!</dt>
+              <dt>{dateUiTitle}</dt>
               <dd>
                 {children.props.formData && (
                   <>

--- a/src/applications/simple-forms/20-10206/pages/disabilityExamDetails.js
+++ b/src/applications/simple-forms/20-10206/pages/disabilityExamDetails.js
@@ -20,7 +20,7 @@ export default {
     ),
     disabilityExams: {
       'ui:options': {
-        itemName: 'exam date',
+        itemName: 'Exam date',
         itemAriaLabel: formData => {
           const friendlyDateString = moment(
             formData.disabilityExamDate,
@@ -37,6 +37,7 @@ export default {
         useDlWrap: true,
         showSave: true,
         reviewMode: true,
+        reviewItemHeaderLevel: '4',
       },
       items: {
         'ui:options': {
@@ -56,7 +57,7 @@ export default {
           },
           'ui:reviewField': ({ children }) => (
             <div className="review-row">
-              <dt>{dateUiTitle}</dt>
+              <dt>{dateUiTitle}!</dt>
               <dd>
                 {children.props.formData && (
                   <>

--- a/src/platform/forms-system/src/js/review/ReadOnlyArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ReadOnlyArrayField.jsx
@@ -38,6 +38,9 @@ class ReadOnlyArrayField extends React.Component {
             itemIdPrefix,
             definitions,
           );
+          const H = uiOptions.reviewItemHeaderLevel
+            ? `h${uiOptions.reviewItemHeaderLevel}`
+            : 'h5';
 
           return (
             <div
@@ -46,9 +49,9 @@ class ReadOnlyArrayField extends React.Component {
             >
               <div className="row small-collapse">
                 <div className="small-12 columns">
-                  <h5 className="schemaform-array-readonly-header">
+                  <H className="schemaform-array-readonly-header">
                     {uiOptions.itemName}
-                  </h5>
+                  </H>
                   {/* outer wrapper needs uiOptions.customTitle = ' ' to prevent
                     * rendering of a <dl> around the schemaform-field-container
                     */}

--- a/src/platform/forms-system/src/js/review/ReadOnlyArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ReadOnlyArrayField.jsx
@@ -23,10 +23,15 @@ class ReadOnlyArrayField extends React.Component {
     } = this.props;
     const { definitions } = registry;
     const { SchemaField } = registry.fields;
+    const { onReviewPage } = registry.formContext;
     const uiOptions = uiSchema['ui:options'] || {};
 
     const items = formData || [];
     const Wrapper = uiSchema?.['ui:options']?.useDlWrap ? 'dl' : 'div';
+    const H =
+      uiOptions.reviewItemHeaderLevel && onReviewPage
+        ? `h${uiOptions.reviewItemHeaderLevel}`
+        : 'h5';
 
     return (
       <div className="schemaform-field-container rjsf-array-field">
@@ -38,9 +43,6 @@ class ReadOnlyArrayField extends React.Component {
             itemIdPrefix,
             definitions,
           );
-          const H = uiOptions.reviewItemHeaderLevel
-            ? `h${uiOptions.reviewItemHeaderLevel}`
-            : 'h5';
 
           return (
             <div

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -248,6 +248,7 @@
  * @property {(formData: any, schema: SchemaOptions, uiSchema: UISchemaOptions, index, path: string[]) => SchemaOptions} [replaceSchema]
  * @property {(formData: any, schema: SchemaOptions, uiSchema: UISchemaOptions, index, path: string[]) => SchemaOptions} [updateSchema]
  * @property {boolean} [reflectInputError] Whether or not to add usa-input--error as class if error message is outside of component.
+ * @property {string} [reviewItemHeaderLevel] Optional level for the item-header on Review page - for arrays. Defaults to '5' for a <h5> header-tag.
  * @property {boolean} [useDlWrap] On the review page, moves \<dl\> tag to immediately surrounding the \<dt\> field instead of using a \<div\>. \<dt\> fields should be wrapped in \<dl\> fields, so this fixes that a11y issue. Formats fields horizontally.
  * @property {boolean} [useHeaderStyling] Enables developer to implement and use alternate style classes for auto generated html elements such as in ObjectField or ArrayField
  * @property {boolean} [uswds] For web components. `true` will use the v3 web components and is the default option for `'ui:webComponentField'` if omitted. `false` will use the v1 web components.

--- a/src/platform/forms-system/test/js/review/ReadOnlyArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReadOnlyArrayField.unit.spec.jsx
@@ -30,6 +30,9 @@ describe('Schemaform review: ReadOnlyArrayField', () => {
           return null;
         },
       },
+      formContext: {
+        onReviewPage: false,
+      },
     };
     const formData = [{}];
 
@@ -76,6 +79,9 @@ describe('Schemaform review: ReadOnlyArrayField', () => {
           return null;
         },
       },
+      formContext: {
+        onReviewPage: false,
+      },
     };
     const formData = [{}];
 
@@ -95,5 +101,98 @@ describe('Schemaform review: ReadOnlyArrayField', () => {
     expect(tree.getByText('Item')).to.exist;
     expect(document.querySelector('div.review')).to.not.exist;
     expect(document.querySelector('dl.review')).to.exist;
+  });
+  it('should render default H5 item-header on Review page', () => {
+    const schema = {
+      items: [
+        {
+          type: 'object',
+          properties: {
+            test: {
+              type: 'string',
+            },
+          },
+        },
+      ],
+    };
+    const uiSchema = {
+      'ui:options': {
+        itemName: 'Item',
+        useDlWrap: true,
+      },
+    };
+    const registry = {
+      definitions: {},
+      fields: {
+        SchemaField: function SchemaField() {
+          return null;
+        },
+      },
+      formContext: {
+        onReviewPage: true,
+      },
+    };
+    const formData = [{}];
+
+    render(
+      <ReadOnlyArrayField
+        schema={schema}
+        formData={formData}
+        uiSchema={uiSchema}
+        idSchema={{}}
+        registry={registry}
+        requiredSchema={{}}
+      />,
+    );
+
+    expect(document.querySelector('h5.schemaform-array-readonly-header')).to
+      .exist;
+  });
+  it('should render H4 item-header on Review page with reviewItemHeaderLevel = 4', () => {
+    const schema = {
+      items: [
+        {
+          type: 'object',
+          properties: {
+            test: {
+              type: 'string',
+            },
+          },
+        },
+      ],
+    };
+    const uiSchema = {
+      'ui:options': {
+        itemName: 'Item',
+        reviewItemHeaderLevel: '4',
+        useDlWrap: true,
+      },
+    };
+    const registry = {
+      definitions: {},
+      fields: {
+        SchemaField: function SchemaField() {
+          return null;
+        },
+      },
+      formContext: {
+        onReviewPage: true,
+      },
+    };
+    const formData = [{}];
+
+    render(
+      <ReadOnlyArrayField
+        schema={schema}
+        formData={formData}
+        uiSchema={uiSchema}
+        idSchema={{}}
+        registry={registry}
+        requiredSchema={{}}
+      />,
+    );
+
+    expect(document.querySelector('h4.schemaform-array-readonly-header')).to
+      .exist;
   });
 });


### PR DESCRIPTION
## Summary

- Set Review-page arrayfield-item header-level for Personal Records Request (20-10206) disabilityExamDate
  - Customize ReadOnlyArrayField component to support an optional header-level setting `reviewItemHeaderLevel`, so that it can be set in page-uiSchema
- Team: Veteran Facing Forms
- Flipper ON in Staging, OFF in Prod.  End-date TBD.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#71876

## Testing done

- Local browser- & unit-testing were all successful
## What areas of the site does it impact?

This form ONLY for now.  New optional prop in ReadOnlyArrayField can be used by all other forms going forward.