### PR TITLE
Remove ppiu legacy direct deposit code

### DIFF
--- a/src/applications/personalization/profile/actions/paymentInformation.js
+++ b/src/applications/personalization/profile/actions/paymentInformation.js
@@ -52,7 +52,6 @@ export function fetchCNPPaymentInformation({
 }) {
   return async dispatch => {
     const client = new DirectDepositClient({
-      useLighthouseDirectDepositEndpoint: true,
       recordEvent,
     });
 
@@ -106,13 +105,11 @@ export function fetchCNPPaymentInformation({
 export function saveCNPPaymentInformation({
   fields,
   isEnrollingInDirectDeposit = false,
-  useLighthouseDirectDepositEndpoint = true,
   recordEvent = recordAnalyticsEvent,
   captureCNPError = captureError,
 }) {
   return async dispatch => {
     const client = new DirectDepositClient({
-      useLighthouseDirectDepositEndpoint: true,
       recordEvent,
     });
 
@@ -133,7 +130,6 @@ export function saveCNPPaymentInformation({
       const analyticsData = createCNPDirectDepositAnalyticsDataObject({
         errors,
         isEnrolling: isEnrollingInDirectDeposit,
-        useLighthouseDirectDepositEndpoint,
       });
 
       client.recordCNPEvent({

--- a/src/applications/personalization/profile/msw-mocks.js
+++ b/src/applications/personalization/profile/msw-mocks.js
@@ -843,10 +843,6 @@ export const getServiceHistory401 = [
   rest.get(`${prefix}/v0/profile/service_history`, errorResponseHandler401),
 ];
 
-export const getDD4CNPFailure = [
-  rest.get(`${prefix}/v0/ppiu/payment_information`, errorResponseHandler401),
-];
-
 export const getDD4EDUFailure = [
   rest.get(`${prefix}/v0/profile/ch33_bank_accounts`, errorResponseHandler401),
 ];

--- a/src/applications/personalization/profile/tests/actions/paymentInformation.unit.spec.js
+++ b/src/applications/personalization/profile/tests/actions/paymentInformation.unit.spec.js
@@ -490,13 +490,13 @@ describe('actions/paymentInformation', () => {
                 meta: {
                   messages: [
                     {
-                      key: 'cnp.payment.routing.number.fraud.message',
+                      key: 'test.edu.error.message',
                       severity: 'ERROR',
                       text: 'Routing number related to potential fraud',
                     },
                   ],
                 },
-                source: 'EVSS::PPIU::Service',
+                source: 'EVSS::EDU::Service',
                 status: '422',
                 title: 'Potential Fraud',
               },

--- a/src/applications/personalization/profile/tests/components/direct-deposit/PaymentInformationEditError.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/PaymentInformationEditError.unit.spec.jsx
@@ -2,211 +2,20 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
 
+import mockDisabilityCompensations from '@@profile/mocks/endpoints/disability-compensations';
+
 import PaymentInformationEditError from '@@profile/components/direct-deposit/PaymentInformationEditError';
 
+const { errors } = mockDisabilityCompensations.updates;
+
 describe('<PaymentInformationEditError />', () => {
-  const checksumError = {
-    errors: [
-      {
-        title: 'Internal server error',
-        detail: 'Internal server error',
-        code: '500',
-        source: 'EVSS::PPIU::Service',
-        status: '500',
-        meta: {
-          messages: [
-            {
-              key: 'payment.accountRoutingNumber.invalidCheckSum',
-              severity: 'ERROR',
-              text: 'Account Routing Number contains invalid checksum',
-            },
-          ],
-        },
-      },
-    ],
-  };
-  const restrictionIndicatorsPresentError = {
-    errors: [
-      {
-        code: '126',
-        detail: 'One or more unprocessable user payment properties',
-        meta: {
-          messages: [
-            {
-              key: 'payment.restriction.indicators.present',
-              severity: 'ERROR',
-              text: 'Cannot perform an update due to restriction indicators',
-            },
-          ],
-        },
-        source: 'EVSS::PPIU::Service',
-        status: '422',
-        title: 'Unprocessable Entity',
-      },
-    ],
-  };
-  const invalidRoutingNumberError = {
-    errors: [
-      {
-        code: '126',
-        detail: 'One or more unprocessable user payment properties',
-        meta: {
-          messages: [
-            {
-              key: 'cnp.payment.generic.error.message',
-              severity: 'ERROR',
-              text:
-                'Generic CnP payment update error. Update response: Update Failed: Invalid Routing Number',
-            },
-          ],
-        },
-        source: 'EVSS::PPIU::Service',
-        status: '422',
-        title: 'Unprocessable Entity',
-      },
-    ],
-  };
-  const accountFlaggedError = {
-    errors: [
-      {
-        title: 'Account Flagged',
-        detail: 'The account has been flagged',
-        code: '136',
-        source: 'EVSS::PPIU::Service',
-        status: '422',
-        meta: {
-          messages: [
-            {
-              key: 'cnp.payment.flashes.on.record.message',
-              severity: 'ERROR',
-              text: 'Flashes on record',
-            },
-          ],
-        },
-      },
-    ],
-  };
-  const routingNumberFlaggedError = {
-    errors: [
-      {
-        title: 'Potential Fraud',
-        detail: 'Routing number related to potential fraud',
-        code: '135',
-        source: 'EVSS::PPIU::Service',
-        status: '422',
-        meta: {
-          messages: [
-            {
-              key: 'cnp.payment.routing.number.fraud.message',
-              severity: 'ERROR',
-              text: 'Routing number related to potential fraud',
-            },
-          ],
-        },
-      },
-    ],
-  };
-  const badWorkPhoneNumberError = {
-    errors: [
-      {
-        title: 'Unprocessable Entity',
-        detail: 'One or more unprocessable user payment properties',
-        code: '126',
-        source: 'EVSS::PPIU::Service',
-        status: '422',
-        meta: {
-          messages: [
-            {
-              key: 'cnp.payment.generic.error.message',
-              severity: 'ERROR',
-              text:
-                'Generic CnP payment update error. Update response: Update Failed: Day phone number is invalid, must be 7 digits',
-            },
-          ],
-        },
-      },
-    ],
-  };
-  const badHomeAreaCodeError = {
-    errors: [
-      {
-        title: 'Unprocessable Entity',
-        detail: 'One or more unprocessable user payment properties',
-        code: '126',
-        source: 'EVSS::PPIU::Service',
-        status: '422',
-        meta: {
-          messages: [
-            {
-              key: 'cnp.payment.generic.error.message',
-              severity: 'ERROR',
-              text:
-                'Generic CnP payment update error. Update response: Update Failed: Night area number is invalid, must be 3 digits',
-            },
-          ],
-        },
-      },
-    ],
-  };
-  const badAddressError = {
-    errors: [
-      {
-        title: 'Unprocessable Entity',
-        detail: 'One or more unprocessable user payment properties',
-        code: '126',
-        source: 'EVSS::PPIU::Service',
-        status: '422',
-        meta: {
-          messages: [
-            {
-              key: 'cnp.payment.generic.error.message',
-              severity: 'ERROR',
-              text:
-                'Generic CnP payment update error. Update response: Update Failed: Required field not entered for mailing address update',
-            },
-          ],
-        },
-      },
-    ],
-  };
-  const genericError = {
-    errors: [
-      {
-        title: 'Unprocessable Entity',
-        detail: 'One or more unprocessable user payment properties',
-        code: '126',
-        source: 'EVSS::PPIU::Service',
-        status: '422',
-        meta: {
-          messages: [
-            {
-              key: 'cnp.payment.generic.error.message',
-              severity: 'ERROR',
-              text: 'This is a generic error that we do not recognize.',
-            },
-          ],
-        },
-      },
-    ],
-  };
-
-  // When VA Profile was not working in the staging env, we saw this error when
-  // saving direct deposit info (hitting PUT ppiu/payment_information)
-  const upstreamError = {
-    errors: [
-      {
-        title: 'Bad Gateway',
-        detail: 'Received an an invalid response from the upstream server',
-        code: 'VET360_502',
-        source: 'Vet360::ContactInformation::Service',
-        status: '502',
-      },
-    ],
-  };
-
   it('renders', () => {
     const wrapper = shallow(
-      <PaymentInformationEditError responseError={{ error: genericError }} />,
+      <PaymentInformationEditError
+        responseError={{
+          error: errors.generic,
+        }}
+      />,
     );
     expect(wrapper.html()).to.not.be.empty;
     wrapper.unmount();
@@ -214,7 +23,11 @@ describe('<PaymentInformationEditError />', () => {
 
   it('renders the default error when it gets an unrecognized error message', () => {
     const wrapper = shallow(
-      <PaymentInformationEditError responseError={{ error: genericError }} />,
+      <PaymentInformationEditError
+        responseError={{
+          error: errors.generic,
+        }}
+      />,
     );
     expect(wrapper.html()).to.contain(
       'We’re sorry. We couldn’t update your payment information. Please try again later.',
@@ -224,7 +37,9 @@ describe('<PaymentInformationEditError />', () => {
 
   it('renders the invalid routing number error', () => {
     let wrapper = shallow(
-      <PaymentInformationEditError responseError={{ error: checksumError }} />,
+      <PaymentInformationEditError
+        responseError={{ error: errors.invalidChecksumRoutingNumber }}
+      />,
     );
     expect(wrapper.html()).to.contain(
       'We can’t find a bank linked to the routing number you entered.',
@@ -233,7 +48,7 @@ describe('<PaymentInformationEditError />', () => {
 
     wrapper = shallow(
       <PaymentInformationEditError
-        responseError={{ error: invalidRoutingNumberError }}
+        responseError={{ error: errors.invalidRoutingNumber }}
       />,
     );
     expect(wrapper.html()).to.contain(
@@ -243,19 +58,9 @@ describe('<PaymentInformationEditError />', () => {
   });
 
   it('renders the flagged/locked account error', () => {
-    let wrapper = shallow(
+    const wrapper = shallow(
       <PaymentInformationEditError
-        responseError={{ error: accountFlaggedError }}
-      />,
-    );
-    expect(wrapper.html()).to.contain(
-      'We’re sorry. You can’t change your direct deposit information right now because we’ve locked the ability to edit this information. We do this to protect your bank account information and prevent fraud when we think there may be a security issue.',
-    );
-    wrapper.unmount();
-
-    wrapper = shallow(
-      <PaymentInformationEditError
-        responseError={{ error: restrictionIndicatorsPresentError }}
+        responseError={{ error: errors.paymentRestrictionsPresent }}
       />,
     );
     expect(wrapper.html()).to.contain(
@@ -267,7 +72,7 @@ describe('<PaymentInformationEditError />', () => {
   it('renders the flagged routing number error', () => {
     const wrapper = shallow(
       <PaymentInformationEditError
-        responseError={{ error: routingNumberFlaggedError }}
+        responseError={{ error: errors.routingNumberFlagged }}
       />,
     );
     expect(wrapper.html()).to.contain(
@@ -279,7 +84,7 @@ describe('<PaymentInformationEditError />', () => {
   it('renders an error message prompting the user to update their address', () => {
     const wrapper = shallow(
       <PaymentInformationEditError
-        responseError={{ error: badAddressError }}
+        responseError={{ error: errors.invalidMailingAddress }}
       />,
     );
     expect(wrapper.html()).to.contain(
@@ -291,7 +96,7 @@ describe('<PaymentInformationEditError />', () => {
   it('renders the bad phone number error messages', () => {
     let wrapper = shallow(
       <PaymentInformationEditError
-        responseError={{ error: badWorkPhoneNumberError }}
+        responseError={{ error: errors.invalidDayPhone }}
       />,
     );
     expect(wrapper.html()).to.contain(
@@ -301,7 +106,7 @@ describe('<PaymentInformationEditError />', () => {
 
     wrapper = shallow(
       <PaymentInformationEditError
-        responseError={{ error: badHomeAreaCodeError }}
+        responseError={{ error: errors.invalidNightPhone }}
       />,
     );
     expect(wrapper.html()).to.contain(
@@ -312,7 +117,9 @@ describe('<PaymentInformationEditError />', () => {
 
   it('renders the default error when an upstream error occurs', () => {
     const wrapper = shallow(
-      <PaymentInformationEditError responseError={upstreamError} />,
+      <PaymentInformationEditError
+        responseError={{ error: errors.unspecified }}
+      />,
     );
     expect(wrapper.html()).to.contain(
       'We’re sorry. We couldn’t update your payment information. Please try again later.',

--- a/src/applications/personalization/profile/tests/util/index.hasErrorCombos.unit.spec.js
+++ b/src/applications/personalization/profile/tests/util/index.hasErrorCombos.unit.spec.js
@@ -1,90 +1,23 @@
 import { expect } from 'chai';
 
 import mockDisabilityCompensations from '@@profile/mocks/endpoints/disability-compensations';
-import {
-  LIGHTHOUSE_ERROR_KEYS,
-  PPIU_ERROR_MAP,
-  hasErrorCombos,
-} from '../../util';
-
-const dayPhoneErrorNumberInvalidPPIU = [
-  {
-    title: 'Unprocessable Entity',
-    detail: 'One or more unprocessable user payment properties',
-    code: '126',
-    source: 'EVSS::PPIU::Service',
-    status: '422',
-    meta: {
-      messages: [
-        {
-          key: 'cnp.payment.generic.error.message',
-          severity: 'ERROR',
-          text:
-            'Generic CnP payment update error. Update response: Update Failed: Day phone number is invalid, must be 7 digits',
-        },
-      ],
-    },
-  },
-];
-
-const dayPhoneErrorAreaInvalidPPIU = [
-  {
-    title: 'Unprocessable Entity',
-    detail: 'One or more unprocessable user payment properties',
-    code: '126',
-    source: 'EVSS::PPIU::Service',
-    status: '422',
-    meta: {
-      messages: [
-        {
-          key: 'cnp.payment.generic.error.message',
-          severity: 'ERROR',
-          text:
-            'Generic CnP payment update error. Update response: Update Failed: Day area number is invalid, must be 3 digits',
-        },
-      ],
-    },
-  },
-];
+import { LIGHTHOUSE_ERROR_KEYS, hasErrorCombos } from '../../util';
 
 describe('hasErrorCombos', () => {
   context('cases for invalid routing number', () => {
-    it('return true for PPIU routing number error', () => {
+    it('return true for routing number error', () => {
       expect(
         hasErrorCombos({
           errors:
             mockDisabilityCompensations.updates.errors.invalidRoutingNumber
               .errors,
-          errorKeys: [
-            PPIU_ERROR_MAP.INVALID_ROUTING_NUMBER.RESPONSE_KEY,
-            LIGHTHOUSE_ERROR_KEYS.ROUTING_NUMBER_INVALID,
-          ],
+          errorKeys: [LIGHTHOUSE_ERROR_KEYS.ROUTING_NUMBER_INVALID],
         }),
       ).to.be.true;
     });
   });
 
   context('cases for phone number errors', () => {
-    it('return true for PPIU day phone number error', () => {
-      expect(
-        hasErrorCombos({
-          errors: dayPhoneErrorNumberInvalidPPIU,
-          errorKeys: [PPIU_ERROR_MAP.GENERIC_ERROR.RESPONSE_KEY],
-          errorTexts: ['day phone'],
-        }),
-      ).to.be.true;
-    });
-
-    context('return true for PPIU day phone area error', () => {
-      expect(
-        hasErrorCombos({
-          errors: dayPhoneErrorAreaInvalidPPIU,
-          errorKeys: [PPIU_ERROR_MAP.GENERIC_ERROR.RESPONSE_KEY],
-          errorTexts: ['day area'],
-        }),
-      ).to.be.true;
-    });
-
     it('return true for Lighthouse day phone error', () => {
       expect(
         hasErrorCombos({

--- a/src/applications/personalization/profile/tests/util/index.unit.spec.js
+++ b/src/applications/personalization/profile/tests/util/index.unit.spec.js
@@ -129,54 +129,20 @@ describe('profile utils', () => {
     });
 
     it('hasInvalidHomePhoneNumberError returns false if text does not contain night phone', () => {
-      const errors = [
-        {
-          title: 'Unprocessable Entity',
-          detail: 'One or more unprocessable user payment properties',
-          code: '126',
-          source: 'EVSS::PPIU::Service',
-          status: '422',
-          meta: {
-            messages: [
-              {
-                key: 'cnp.payment.generic.error.message',
-                severity: 'ERROR',
-                text:
-                  'Generic CnP payment update error. Update response: Update Failed: Some other random error',
-              },
-            ],
-          },
-        },
-      ];
+      const { errors } = mockDisabilityCompensations.updates.errors.generic;
       expect(hasInvalidHomePhoneNumberError(errors)).to.not.be.ok;
     });
 
     it('should return false with multiple errors with text not matching desired error conditions', () => {
-      const errors = [
-        {
-          title: 'Unprocessable Entity',
-          detail: 'One or more unprocessable user payment properties',
-          code: '126',
-          source: 'EVSS::PPIU::Service',
-          status: '422',
-          meta: {
-            messages: [
-              {
-                key: 'cnp.payment.generic.error.message',
-                severity: 'ERROR',
-                text: "some error we don't know about",
-              },
-              {
-                key: 'unknown.key',
-                severity: 'ERROR',
-                text:
-                  'Generic CnP payment update error. Update response: Update Failed: Night area number is invalid, must be 3 digits',
-              },
-            ],
-          },
-        },
-      ];
-      expect(!!hasInvalidHomePhoneNumberError(errors)).to.be.not.ok;
+      const { errors } = mockDisabilityCompensations.updates.errors.generic;
+
+      expect(
+        !!hasInvalidHomePhoneNumberError([
+          ...errors,
+          ...mockDisabilityCompensations.updates.errors.invalidAccountNumber
+            .errors,
+        ]),
+      ).to.be.not.ok;
     });
   });
 });

--- a/src/applications/personalization/profile/util/direct-deposit.js
+++ b/src/applications/personalization/profile/util/direct-deposit.js
@@ -2,23 +2,22 @@ import cloneDeep from 'lodash/cloneDeep';
 import set from 'lodash/set';
 import capitalize from 'lodash/capitalize';
 import recordAnalyticsEvent from '~/platform/monitoring/record-event';
-import { API_STATUS } from '../constants';
 
 export class DirectDepositClient {
-  #PPIU_ENDPOINT = '/ppiu/payment_information';
-
   #LH_ENDPOINT = '/profile/direct_deposits/disability_compensations';
 
-  constructor({
-    useLighthouseDirectDepositEndpoint = true,
-    recordEvent = recordAnalyticsEvent,
-  } = {}) {
-    this.useLighthouseEndpoint = useLighthouseDirectDepositEndpoint;
+  #DEFAULT_FIELDS = {
+    accountType: '',
+    accountNumber: '',
+    routingNumber: '',
+  };
+
+  constructor({ recordEvent = recordAnalyticsEvent } = {}) {
     this.recordAnalyticsEvent = recordEvent;
   }
 
   get endpoint() {
-    return this.useLighthouseEndpoint ? this.#LH_ENDPOINT : this.#PPIU_ENDPOINT;
+    return this.#LH_ENDPOINT;
   }
 
   formatDirectDepositResponseFromLighthouse = response => {
@@ -37,29 +36,19 @@ export class DirectDepositClient {
   };
 
   generateApiRequestOptions(fields) {
-    // The PPIU endpoint REQUIRES a financialInstitutionName field, but the
-    // Lighthouse endpoint does not. We set a dummy value here
-    // to avoid 500 errors from vets-api
-    set(fields, 'financialInstitutionName', 'Hidden form field');
-
-    const options = {
+    const formattedFields = {
+      accountType: fields.accountType,
+      accountNumber: fields.accountNumber,
+      routingNumber: fields.financialInstitutionRoutingNumber,
+    };
+    return {
       headers: {
         'Content-Type': 'application/json',
       },
       method: 'PUT',
-      body: JSON.stringify(fields),
+      body: JSON.stringify({ ...this.#DEFAULT_FIELDS, ...formattedFields }),
       mode: 'cors',
     };
-
-    if (this.useLighthouseEndpoint) {
-      options.body = JSON.stringify({
-        accountType: fields.accountType,
-        accountNumber: fields.accountNumber,
-        routingNumber: fields.financialInstitutionRoutingNumber,
-      });
-    }
-
-    return options;
   }
 
   recordLighthouseEvent({ method, status, errorKey = '' }) {
@@ -76,29 +65,11 @@ export class DirectDepositClient {
     this.recordAnalyticsEvent(payload);
   }
 
-  recordPPIUEvent({ status, method, extraProperties }) {
-    const result =
-      status === API_STATUS.SUCCESSFUL && method === 'GET'
-        ? 'retrieved'
-        : status.toLowerCase();
-
-    const payload = {
-      event: `profile-${method.toLowerCase()}-cnp-direct-deposit-${result}`,
-      ...extraProperties,
-    };
-
-    this.recordAnalyticsEvent(payload);
-  }
-
   recordCNPEvent({ status, method = 'GET', extraProperties = {} }) {
-    if (this.useLighthouseEndpoint) {
-      this.recordLighthouseEvent({
-        method,
-        status,
-        errorKey: extraProperties?.['error-key'],
-      });
-      return;
-    }
-    this.recordPPIUEvent({ status, method, extraProperties });
+    this.recordLighthouseEvent({
+      method,
+      status,
+      errorKey: extraProperties?.['error-key'],
+    });
   }
 }

--- a/src/applications/personalization/profile/util/index.js
+++ b/src/applications/personalization/profile/util/index.js
@@ -24,41 +24,6 @@ export const LIGHTHOUSE_ERROR_KEYS = {
 
 const OTHER_ERROR_GA_KEY = 'other-error';
 
-// possible values for the `key` property on error messages we get from the server
-// these are for the ppiu/payment_information endpoint
-// along with the GA event key for the corresponding error
-export const PPIU_ERROR_MAP = {
-  ACCOUNT_FLAGGED_FOR_FRAUD: {
-    RESPONSE_KEY: 'cnp.payment.flashes.on.record.message',
-    GA_KEY: 'account-flagged-for-fraud-error',
-  },
-  GENERIC_ERROR: {
-    RESPONSE_KEY: 'cnp.payment.generic.error.message',
-    GA_KEY: OTHER_ERROR_GA_KEY,
-  },
-  INVALID_ROUTING_NUMBER: {
-    RESPONSE_KEY: 'payment.accountRoutingNumber.invalidCheckSum',
-    GA_KEY: 'invalid-routing-number-error',
-  },
-  PAYMENT_RESTRICTIONS_PRESENT: {
-    RESPONSE_KEY: 'payment.restriction.indicators.present',
-    GA_KEY: 'payment-restriction-indicators-error',
-  },
-  ROUTING_NUMBER_FLAGGED_FOR_FRAUD: {
-    RESPONSE_KEY: 'cnp.payment.routing.number.fraud.message',
-    GA_KEY: 'routing-number-flagged-for-fraud-error',
-  },
-  BAD_ADDRESS: {
-    GA_KEY: 'mailing-address-error',
-  },
-  BAD_HOME_PHONE: {
-    GA_KEY: 'home-phone-error',
-  },
-  BAD_WORK_PHONE: {
-    GA_KEY: 'work-phone-error',
-  },
-};
-
 export async function getData(apiRoute, options) {
   try {
     const response = await apiRequest(apiRoute, options);
@@ -67,24 +32,6 @@ export async function getData(apiRoute, options) {
     return { error };
   }
 }
-
-// used for legacy, remove once moved to lighthouse endpoint
-const hasPPIUErrorText = (errors, errorKey, errorText) => {
-  return errors.some(err =>
-    err.meta?.messages?.some(
-      message =>
-        message.key === errorKey &&
-        message.text?.toLowerCase().includes(errorText.toLowerCase()),
-    ),
-  );
-};
-
-// used for legacy, remove once moved to lighthouse endpoint
-const hasPPIUErrorKey = (errors, errorKey) => {
-  return errors.some(err =>
-    err.meta?.messages?.some(message => message.key === errorKey),
-  );
-};
 
 const hasLighthouseErrorText = (errors, errorKey, errorText) => {
   return errors.some(
@@ -100,14 +47,9 @@ const hasLighthouseErrorKey = (errors, errorKey) => {
 
 const hasErrorMessage = (errors, errorKey, errorText) => {
   if (errorText) {
-    return (
-      hasPPIUErrorText(errors, errorKey, errorText) ||
-      hasLighthouseErrorText(errors, errorKey, errorText)
-    );
+    return hasLighthouseErrorText(errors, errorKey, errorText);
   }
-  return (
-    hasPPIUErrorKey(errors, errorKey) || hasLighthouseErrorKey(errors, errorKey)
-  );
+  return hasLighthouseErrorKey(errors, errorKey);
 };
 
 export const hasErrorCombos = ({
@@ -128,26 +70,19 @@ export const hasErrorCombos = ({
 export const hasAccountFlaggedError = errors =>
   hasErrorCombos({
     errors,
-    errorKeys: [
-      PPIU_ERROR_MAP.ACCOUNT_FLAGGED_FOR_FRAUD.RESPONSE_KEY,
-      LIGHTHOUSE_ERROR_KEYS.ACCOUNT_FLAGGED_FOR_FRAUD,
-    ],
+    errorKeys: [LIGHTHOUSE_ERROR_KEYS.ACCOUNT_FLAGGED_FOR_FRAUD],
   });
 
 export const hasRoutingNumberFlaggedError = errors =>
   hasErrorCombos({
     errors,
-    errorKeys: [
-      PPIU_ERROR_MAP.ROUTING_NUMBER_FLAGGED_FOR_FRAUD.RESPONSE_KEY,
-      LIGHTHOUSE_ERROR_KEYS.ROUTING_NUMBER_FLAGGED_FOR_FRAUD,
-    ],
+    errorKeys: [LIGHTHOUSE_ERROR_KEYS.ROUTING_NUMBER_FLAGGED_FOR_FRAUD],
   });
 
 export const hasInvalidRoutingNumberError = errors =>
   hasErrorCombos({
     errors,
     errorKeys: [
-      PPIU_ERROR_MAP.INVALID_ROUTING_NUMBER.RESPONSE_KEY,
       LIGHTHOUSE_ERROR_KEYS.ROUTING_NUMBER_INVALID_CHECKSUM,
       LIGHTHOUSE_ERROR_KEYS.ROUTING_NUMBER_INVALID,
     ],
@@ -155,7 +90,6 @@ export const hasInvalidRoutingNumberError = errors =>
   hasErrorCombos({
     errors,
     errorKeys: [
-      PPIU_ERROR_MAP.GENERIC_ERROR.RESPONSE_KEY,
       LIGHTHOUSE_ERROR_KEYS.UNSPECIFIED_ERROR,
       LIGHTHOUSE_ERROR_KEYS.GENERIC_ERROR,
     ],
@@ -166,7 +100,6 @@ export const hasInvalidAddressError = errors =>
   hasErrorCombos({
     errors,
     errorKeys: [
-      PPIU_ERROR_MAP.GENERIC_ERROR.RESPONSE_KEY,
       LIGHTHOUSE_ERROR_KEYS.UNSPECIFIED_ERROR,
       LIGHTHOUSE_ERROR_KEYS.GENERIC_ERROR,
     ],
@@ -177,7 +110,6 @@ export const hasInvalidHomePhoneNumberError = errors =>
   hasErrorCombos({
     errors,
     errorKeys: [
-      PPIU_ERROR_MAP.GENERIC_ERROR.RESPONSE_KEY,
       LIGHTHOUSE_ERROR_KEYS.UNSPECIFIED_ERROR,
       LIGHTHOUSE_ERROR_KEYS.GENERIC_ERROR,
     ],
@@ -195,7 +127,6 @@ export const hasInvalidWorkPhoneNumberError = errors =>
   hasErrorCombos({
     errors,
     errorKeys: [
-      PPIU_ERROR_MAP.GENERIC_ERROR.RESPONSE_KEY,
       LIGHTHOUSE_ERROR_KEYS.UNSPECIFIED_ERROR,
       LIGHTHOUSE_ERROR_KEYS.GENERIC_ERROR,
     ],
@@ -212,10 +143,7 @@ export const hasInvalidWorkPhoneNumberError = errors =>
 export const hasPaymentRestrictionIndicatorsError = errors =>
   hasErrorCombos({
     errors,
-    errorKeys: [
-      PPIU_ERROR_MAP.PAYMENT_RESTRICTIONS_PRESENT.RESPONSE_KEY,
-      LIGHTHOUSE_ERROR_KEYS.PAYMENT_RESTRICTIONS_PRESENT,
-    ],
+    errorKeys: [LIGHTHOUSE_ERROR_KEYS.PAYMENT_RESTRICTIONS_PRESENT],
   });
 
 export const cnpDirectDepositBankInfo = apiData => {
@@ -251,38 +179,6 @@ const getLighthouseErrorCode = (errors = []) => {
   return `${error?.code || OTHER_ERROR_GA_KEY} | ${error?.detail || ''}`;
 };
 
-const getPPIUErrorCode = (errors = []) => {
-  if (hasAccountFlaggedError(errors)) {
-    return PPIU_ERROR_MAP.ACCOUNT_FLAGGED_FOR_FRAUD.GA_KEY;
-  }
-
-  if (hasRoutingNumberFlaggedError(errors)) {
-    return PPIU_ERROR_MAP.ROUTING_NUMBER_FLAGGED_FOR_FRAUD.GA_KEY;
-  }
-
-  if (hasInvalidRoutingNumberError(errors)) {
-    return PPIU_ERROR_MAP.INVALID_ROUTING_NUMBER.GA_KEY;
-  }
-
-  if (hasInvalidAddressError(errors)) {
-    return PPIU_ERROR_MAP.BAD_ADDRESS.GA_KEY;
-  }
-
-  if (hasInvalidHomePhoneNumberError(errors)) {
-    return PPIU_ERROR_MAP.BAD_HOME_PHONE.GA_KEY;
-  }
-
-  if (hasInvalidWorkPhoneNumberError(errors)) {
-    return PPIU_ERROR_MAP.BAD_WORK_PHONE.GA_KEY;
-  }
-
-  if (hasPaymentRestrictionIndicatorsError(errors)) {
-    return PPIU_ERROR_MAP.PAYMENT_RESTRICTIONS_PRESENT.GA_KEY;
-  }
-
-  return PPIU_ERROR_MAP.GENERIC_ERROR.GA_KEY;
-};
-
 // Helper that creates and returns an object to pass to the recordEvent()
 // function when an error occurs while trying to save/update a user's direct
 // deposit for compensation and pension payment information. The value of the
@@ -290,11 +186,8 @@ const getPPIUErrorCode = (errors = []) => {
 export const createCNPDirectDepositAnalyticsDataObject = ({
   errors = [],
   isEnrolling = false,
-  useLighthouseDirectDepositEndpoint = true,
 } = {}) => {
-  const errorCode = useLighthouseDirectDepositEndpoint
-    ? getLighthouseErrorCode(errors)
-    : getPPIUErrorCode(errors);
+  const errorCode = getLighthouseErrorCode(errors);
 
   return cloneDeep({
     event: 'profile-edit-failure',

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -136,7 +136,6 @@ export default Object.freeze({
   profileContacts: 'profile_contacts',
   profileDoNotRequireInternationalZipCode: 'profile_do_not_require_international_zip_code',
   profileHideDirectDepositCompAndPen: 'profile_hide_direct_deposit_comp_and_pen',
-  profileLighthouseDirectDeposit: 'profile_lighthouse_direct_deposit',
   profileShowEmailNotificationSettings: 'profile_show_email_notification_settings',
   profileShowMhvNotificationSettings: 'profile_show_mhv_notification_settings',
   profileShowPronounsAndSexualOrientation: 'profile_show_pronouns_and_sexual_orientation',


### PR DESCRIPTION
## Summary

- Removes logic, and all other mention of the PPIU direct deposit endpoint, and removes all tests around that endpoint being used.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/71150

## Testing done

- Updated all unit and e2e tests to not check using ppiu endpoint

## Screenshots

No UI changes

## What areas of the site does it impact?

Profile -> Direct Deposit, although since we are already rolled out to 100% using lighthouse, this PR should have no direct impact on site functionality.

## Acceptance criteria

- Code and tests are PPIU endpoint removed
- Feature toggle removed from platform code

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)