### PR TITLE
Update CODEOWNERS for MHV landing page app

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -177,7 +177,7 @@ src/applications/mhv @department-of-veterans-affairs/vfs-mhv-medical-records @de
 src/applications/mhv/medical-records @department-of-veterans-affairs/vfs-mhv-medical-records @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/mhv/medications @department-of-veterans-affairs/vfs-mhv-medications @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/mhv/secure-messaging @department-of-veterans-affairs/vfs-mhv-secure-messaging @department-of-veterans-affairs/va-platform-cop-frontend
-src/applications/mhv/landing-page @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/va-cto-health-products @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/mhv/landing-page @department-of-veterans-affairs/vfs-mhv-integration @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/avs @department-of-veterans-affairs/after-visit-summary @department-of-veterans-affairs/va-platform-cop-frontend
 
 # Profile


### PR DESCRIPTION
Approval on PRs is no longer needed from the cto health products team for the MHV landing page app. 