### PR TITLE
updates configs for mhv usip + unit test

### DIFF
--- a/src/platform/user/authentication/config/dev.config.js
+++ b/src/platform/user/authentication/config/dev.config.js
@@ -31,7 +31,7 @@ export default {
       allowRedirect: true,
     },
     OAuthEnabled: false,
-    requiresVerification: false,
+    requiresVerification: true,
     externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.MHV],
   },
   [EXTERNAL_APPS.MY_VA_HEALTH]: {

--- a/src/platform/user/authentication/config/prod.config.js
+++ b/src/platform/user/authentication/config/prod.config.js
@@ -31,7 +31,7 @@ export default {
       allowRedirect: true,
     },
     OAuthEnabled: false,
-    requiresVerification: false,
+    requiresVerification: true,
     externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.MHV],
   },
   [EXTERNAL_APPS.MY_VA_HEALTH]: {

--- a/src/platform/user/authentication/config/prod.config.js
+++ b/src/platform/user/authentication/config/prod.config.js
@@ -31,7 +31,7 @@ export default {
       allowRedirect: true,
     },
     OAuthEnabled: false,
-    requiresVerification: true,
+    requiresVerification: false,
     externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.MHV],
   },
   [EXTERNAL_APPS.MY_VA_HEALTH]: {

--- a/src/platform/user/authentication/config/staging.config.js
+++ b/src/platform/user/authentication/config/staging.config.js
@@ -31,7 +31,7 @@ export default {
       allowRedirect: true,
     },
     OAuthEnabled: false,
-    requiresVerification: false,
+    requiresVerification: true,
     externalRedirectUrl: EXTERNAL_REDIRECTS[EXTERNAL_APPS.MHV],
   },
   [EXTERNAL_APPS.MY_VA_HEALTH]: {

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -32,6 +32,7 @@ const usipPath = '/sign-in';
 const nonUsipPath = '/about';
 const trickyNonUsipPath = '/sign-in-app';
 const mhvUsipParams = '?application=mhv&to=home';
+const ebenefitsUsipParams = '?application=ebnefits';
 const cernerUsipParams = '?application=myvahealth';
 const cernerComplicatedParams = `&to=%2Fsession-api%2Frealm%2Ff0fded0d-d00b-4b28-9190-853247fd9f9d%3Fto%3Dhttps%253A%252F%252Fstaging-patientportal.myhealth.va.gov%252F&oauth=false`;
 const occUsipParams = '?application=vaoccmobile';
@@ -269,7 +270,7 @@ describe('Authentication Utilities', () => {
     });
 
     it('should NOT return session url with _verified appended for external applications other than OCC/Flagship', () => {
-      setup({ path: usipPathWithParams(mhvUsipParams) });
+      setup({ path: usipPathWithParams(ebenefitsUsipParams) });
       expect(authUtilities.sessionTypeUrl({ type })).to.not.include(
         '_verified',
       );


### PR DESCRIPTION
## Summary
This PR updates the configuration files for MHV on the Unified Sign in Page (USiP). It essentially updates the configs to force LOA3 or verified users to be redirected to MHV by VA.gov.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#72044

## Testing done
Updated unit tests + manual testing

## Screenshots
n/a

## What areas of the site does it impact?
This will impact the Unified Sign in Page (`/sign-in/?application=mhv`) for MHV only in staging and below environments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
How to test
1. Pull down this branch and run `yarn` then `yarn watch`
2. Navigate to the Unified Sign in Page for MHV => https://localhost:3001/sign-in/?application=mhv
3. Confirm the URL for each CSP (without having `vets-api`)
    - [ ] Click each CSP sign in button and confirm it has the `_verified` after the CSP (should look like `v1/sessions/<csp>_verified/`)
    - [ ] Hover over Create an account links and confirm the URLs have the `signup_verified` (should look like `v1/sessions/<logingov|idme>_signup_verified/`
