### PR TITLE
Pension mvp 71727 Add care expenses

### DIFF
--- a/src/applications/pensions/config/chapters/05-financial-information/careExpenses.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/careExpenses.js
@@ -1,39 +1,141 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import fullSchemaPensions from 'vets-json-schema/dist/21P-527EZ-schema.json';
+import get from '@department-of-veterans-affairs/platform-forms-system/get';
 import {
-  yesNoSchema,
-  yesNoUI,
+  radioUI,
+  radioSchema,
 } from '@department-of-veterans-affairs/platform-forms-system/web-component-patterns';
+import currencyUI from '@department-of-veterans-affairs/platform-forms-system/currency';
+import dateRangeUI from '@department-of-veterans-affairs/platform-forms-system/dateRange';
 
-export const description = (
-  <section>
-    <p>We want to know about your unreimbursed care expenses.</p>
-    <p>
-      Examples of unreimbursed care expenses include payments to in-home care
-      providers, nursing homes, or other care facilities that insurance won’t
-      cover.
-    </p>
-  </section>
+const { dateRange } = fullSchemaPensions.definitions;
+
+const recipientOptions = {
+  VETERAN: 'Veteran',
+  SPOUSE: 'Veteran’s spouse',
+  CHILD: 'Veteran’s child',
+};
+
+const careOptions = {
+  CARE_FACILITY: 'Care facility',
+  IN_HOME_CARE_PROVIDER: 'In-home care provider',
+};
+
+const frequencyOptions = {
+  ONCE_MONTH: 'Once a month',
+  ONCE_YEAR: 'Once a year',
+  ONE_TIME: 'One-time',
+};
+
+const CareExpenseView = ({ formData }) => (
+  <h3 className="vads-u-font-size--h5 vads-u-margin-y--1">
+    {formData.provider}
+  </h3>
 );
+
+CareExpenseView.propTypes = {
+  formData: PropTypes.shape({
+    provider: PropTypes.string,
+  }),
+};
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'ui:title': 'Care expenses',
-    'ui:description': description,
-    careExpenses: yesNoUI({
-      title:
-        "Do you, your spouse, or your dependents pay recurring care expenses that aren't reimbursed?",
-      uswds: true,
-    }),
+    'ui:title': 'Add an unreimbursed care expense',
+    careExpenses: {
+      'ui:options': {
+        itemName: 'Care Expense',
+        viewField: CareExpenseView,
+        reviewTitle: 'Care Expenses',
+      },
+      items: {
+        recipients: radioUI({
+          title: 'Who receives care?',
+          labels: recipientOptions,
+          classNames: 'vads-u-margin-bottom--2',
+        }),
+        childName: {
+          'ui:title': 'Enter the child’s name',
+          'ui:options': {
+            expandUnder: 'recipients',
+            expandUnderCondition: 'Veteran’s child',
+          },
+          'ui:required': form =>
+            get(['recipients'], form) === 'Veteran’s child',
+        },
+        provider: {
+          'ui:title': 'What’s the name of the care provider?',
+        },
+        careType: radioUI({
+          title: 'Choose the type of care:',
+          labels: careOptions,
+        }),
+        ratePerHour: currencyUI(
+          'If this is an in-home provider, what is the rate per hour?',
+        ),
+        hoursPerWeek: {
+          'ui:title': 'How many hours per week does the care provider work?',
+          'ui:validations': [
+            (errors, fieldData) => {
+              if (fieldData > 168) {
+                errors.addError('Enter a number less than 169');
+              }
+            },
+          ],
+        },
+        careDateRange: {
+          ...dateRangeUI(
+            'Care start date',
+            'Care end date',
+            'End of care must be after start of care',
+          ),
+          'ui:description': 'Add an unreimbursed care expense',
+        },
+        noCareEndDate: {
+          'ui:title': 'No end date',
+        },
+        paymentFrequency: radioUI({
+          title: 'How often are the payments?',
+          labels: frequencyOptions,
+        }),
+        paymentAmount: currencyUI('How much is each payment?'),
+      },
+    },
   },
   schema: {
     type: 'object',
-    required: ['careExpenses'],
     properties: {
-      careExpenses: yesNoSchema,
-      'view:warningAlert': {
-        type: 'object',
-        properties: {},
+      careExpenses: {
+        type: 'array',
+        minItems: 1,
+        items: {
+          type: 'object',
+          required: [
+            'recipients',
+            'childName',
+            'provider',
+            'careType',
+            'paymentFrequency',
+            'paymentAmount',
+          ],
+          properties: {
+            recipients: radioSchema(Object.values(recipientOptions)),
+            childName: { type: 'string' },
+            provider: { type: 'string' },
+            careType: radioSchema(Object.values(careOptions)),
+            ratePerHour: { type: 'number' },
+            hoursPerWeek: { type: 'number' },
+            careDateRange: {
+              ...dateRange,
+              required: ['from'],
+            },
+            noCareEndDate: { type: 'boolean' },
+            paymentFrequency: radioSchema(Object.values(frequencyOptions)),
+            paymentAmount: { type: 'number' },
+          },
+        },
       },
     },
   },

--- a/src/applications/pensions/config/chapters/05-financial-information/careExpenses.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/careExpenses.js
@@ -85,14 +85,11 @@ export default {
             },
           ],
         },
-        careDateRange: {
-          ...dateRangeUI(
-            'Care start date',
-            'Care end date',
-            'End of care must be after start of care',
-          ),
-          'ui:description': 'Add an unreimbursed care expense',
-        },
+        careDateRange: dateRangeUI(
+          'Care start date',
+          'Care end date',
+          'End of care must be after start of care',
+        ),
         noCareEndDate: {
           'ui:title': 'No end date',
         },

--- a/src/applications/pensions/config/chapters/05-financial-information/hasCareExpenses.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/hasCareExpenses.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import {
+  yesNoSchema,
+  yesNoUI,
+} from '@department-of-veterans-affairs/platform-forms-system/web-component-patterns';
+
+export const description = (
+  <section>
+    <p>We want to know about your unreimbursed care expenses.</p>
+    <p>
+      Examples of unreimbursed care expenses include payments to in-home care
+      providers, nursing homes, or other care facilities that insurance won’t
+      cover.
+    </p>
+  </section>
+);
+
+/** @type {PageSchema} */
+export default {
+  uiSchema: {
+    'ui:title': 'Care expenses',
+    'ui:description': description,
+    hasCareExpenses: yesNoUI({
+      title:
+        "Do you, your spouse, or your dependents pay recurring care expenses that aren't reimbursed?",
+      uswds: true,
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['hasCareExpenses'],
+    properties: {
+      hasCareExpenses: yesNoSchema,
+      'view:warningAlert': {
+        type: 'object',
+        properties: {},
+      },
+    },
+  },
+};

--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -86,6 +86,7 @@ import dateOfCurrentMarriage from './chapters/04-household-information/dateOfCur
 import reasonForCurrentSeparation from './chapters/04-household-information/reasonForCurrentSeparation';
 import totalNetWorth from './chapters/05-financial-information/totalNetWorth';
 import netWorthEstimation from './chapters/05-financial-information/netWorthEstimation';
+import hasCareExpenses from './chapters/05-financial-information/hasCareExpenses';
 import careExpenses from './chapters/05-financial-information/careExpenses';
 import transferredAssets from './chapters/05-financial-information/transferredAssets';
 import homeOwnership from './chapters/05-financial-information/homeOwnership';
@@ -1395,9 +1396,16 @@ const formConfig = {
           schema: netWorthEstimation.schema,
           depends: formData => !formData.totalNetWorth,
         },
-        careExpenses: {
+        hasCareExpenses: {
           path: 'financial/care-expenses',
           title: 'Care expenses',
+          uiSchema: hasCareExpenses.uiSchema,
+          schema: hasCareExpenses.schema,
+        },
+        careExpenses: {
+          path: 'financial/care-expenses/add',
+          title: 'Unreimbursed care expenses',
+          depends: formData => formData.hasCareExpenses,
           uiSchema: careExpenses.uiSchema,
           schema: careExpenses.schema,
         },

--- a/src/applications/pensions/tests/chapters/05-financial-information/careExpenses.unit.spec.jsx
+++ b/src/applications/pensions/tests/chapters/05-financial-information/careExpenses.unit.spec.jsx
@@ -1,6 +1,8 @@
 import {
-  testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
+  testNumberOfErrorsOnSubmitForWebComponents,
+  testNumberOfErrorsOnSubmit,
+  testNumberOfFields,
 } from '../pageTests.spec';
 import formConfig from '../../../config/form';
 import careExpenses from '../../../config/chapters/05-financial-information/careExpenses';
@@ -9,8 +11,8 @@ const { schema, uiSchema } = careExpenses;
 
 describe('Unreimbursed care expenses pension page', () => {
   const pageTitle = 'Care expenses';
-  const expectedNumberOfFields = 1;
-  testNumberOfWebComponentFields(
+  const expectedNumberOfFields = 11;
+  testNumberOfFields(
     formConfig,
     schema,
     uiSchema,
@@ -18,12 +20,30 @@ describe('Unreimbursed care expenses pension page', () => {
     pageTitle,
   );
 
-  const expectedNumberOfErrors = 1;
-  testNumberOfErrorsOnSubmitForWebComponents(
+  const expectedNumberOfErrors = 3;
+  testNumberOfErrorsOnSubmit(
     formConfig,
     schema,
     uiSchema,
     expectedNumberOfErrors,
+    pageTitle,
+  );
+
+  const expectedNumberOfWebComponentFields = 3;
+  testNumberOfWebComponentFields(
+    formConfig,
+    schema,
+    uiSchema,
+    expectedNumberOfWebComponentFields,
+    pageTitle,
+  );
+
+  const expectedNumberOfErrorsForWebComponents = 3;
+  testNumberOfErrorsOnSubmitForWebComponents(
+    formConfig,
+    schema,
+    uiSchema,
+    expectedNumberOfErrorsForWebComponents,
     pageTitle,
   );
 });

--- a/src/applications/pensions/tests/chapters/05-financial-information/hasCareExpenses.unit.spec.jsx
+++ b/src/applications/pensions/tests/chapters/05-financial-information/hasCareExpenses.unit.spec.jsx
@@ -1,0 +1,29 @@
+import {
+  testNumberOfErrorsOnSubmitForWebComponents,
+  testNumberOfWebComponentFields,
+} from '../pageTests.spec';
+import formConfig from '../../../config/form';
+import hasCareExpenses from '../../../config/chapters/05-financial-information/hasCareExpenses';
+
+const { schema, uiSchema } = hasCareExpenses;
+
+describe('Unreimbursed care expenses pension page', () => {
+  const pageTitle = 'Has care expenses';
+  const expectedNumberOfFields = 1;
+  testNumberOfWebComponentFields(
+    formConfig,
+    schema,
+    uiSchema,
+    expectedNumberOfFields,
+    pageTitle,
+  );
+
+  const expectedNumberOfErrors = 1;
+  testNumberOfErrorsOnSubmitForWebComponents(
+    formConfig,
+    schema,
+    uiSchema,
+    expectedNumberOfErrors,
+    pageTitle,
+  );
+});

--- a/src/applications/pensions/tests/schema/maximal-test.json
+++ b/src/applications/pensions/tests/schema/maximal-test.json
@@ -310,18 +310,49 @@
       }
     ],
     "totalNetWorth": true,
-    "careExpenses": true,
+    "hasCareExpenses": true,
+    "careExpenses": [
+      {
+        "recipients": "Veteran",
+        "provider": "NYC Care Provider",
+        "careType": "Care facility",
+        "ratePerHour": 100,
+        "hoursPerWeek": 20,
+        "careDateRange": {
+          "from": "2020-08-01",
+          "to": "2023-05-25"
+        },
+        "paymentFrequency": "Once a month",
+        "paymentAmount": 2500
+      },
+      {
+        "recipients": "Veteran’s child",
+        "childName": "Joe Doe",
+        "provider": "LA Care Provider",
+        "careType": "Care facility",
+        "ratePerHour": 200,
+        "hoursPerWeek": 10,
+        "careDateRange": {
+          "from": "2020-08-01"
+        },
+        "noCareEndDate": true,
+        "paymentFrequency": "Once a year",
+        "paymentAmount": 22500
+      }
+    ],
     "transferredAssets": true,
     "homeOwnership": true,
     "homeAcreageMoreThanTwo": "true",
     "homeAcreageValue": 75000,
     "receivesIncome": true,
-    "incomeSources": [{
-      "typeOfIncome": "Social Security",
-      "receiver": "Jane Doe",
-      "payer": "John Doe",
-      "amount": 2.0
-    }],
+    "incomeSources": [
+      {
+        "typeOfIncome": "Social Security",
+        "receiver": "Jane Doe",
+        "payer": "John Doe",
+        "amount": 2.0
+      }
+    ],
     "bankAccount": {
       "accountType": "checking",
       "bankName": "Best Bank",


### PR DESCRIPTION
## Summary
On the Pension Benefits application(21P-527EZ), update the 'Financial information' chapter to collect information about care expenses.

## How to run in local environment
1. Check out this branch locally
2. In your local environment, set the `pension_form_enabled` flipper to 'enabled' at http://localhost:3000/flipper/features/pension_form_enabled
3. Run `vets-website` and `vets-api`

## How to verify
1. Go to `http://localhost:3001/pension/application/527EZ` in your browser
2. Start or continue the application
3. Go to the 'Financial Information' chapter
4. Continue to the 'Care expenses' page
5. Verify that the 'Care expenses page' Add an unreimbursed care expense page is the next page when 'Yes' is selected
6. Verify that the 'Care expenses page' Add an unreimbursed care expense page is NOT the next page when 'No' is selected
7. Verify the layout and content on the Add an unreimbursed care expense page
8. Verify that appropriate fields are required to add a care expense
9. Verify that a valid entered care expanse collapses when [ Add another expense ] is pressed
10. Verify that you can edit and add multiple care expenses 
12. Verify that the form data is saved to the redux store and submitted to the api

## Related issue(s)
[Ticket in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/71727)
[Epic in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/63349)

## Testing done
- [x] Existing unit tests updated
- [x] New unit tests added

## Screenshots

### Desktop
| Add care expense | Valid | Invalid | Multiple care expenses |
| ------ | ------ | ------ | ------ |
|![localhost_3001_pension_application_527EZ_ (1)](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/5179a0e2-8392-4df6-8483-bf40f213aae5)|![localhost_3001_pension_application_527EZ_financial_care-expenses (1)](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/583e7b4f-3b47-40d8-8029-fa88b80ac772)|![localhost_3001_pension_application_527EZ_ (2)](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/5fd9d9c8-4d79-4d57-ae9d-b1233db79121)|![localhost_3001_pension_application_527EZ_financial_care-expenses](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/8a73c8c0-b1f9-48c9-a0bb-01560cb93171)

## What areas of the site does it impact?
Pension Benefits Application

## Acceptance criteria
[Ticket in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/71727)

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

