### PR TITLE
863 full name validation

### DIFF
--- a/src/applications/simple-forms/21-0845/pages/authorizerPersonalInfo.js
+++ b/src/applications/simple-forms/21-0845/pages/authorizerPersonalInfo.js
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash';
 
-import fullNameDeprecatedUI from '../../shared/definitions/rjsfPatterns';
+import { fullNameDeprecatedUI } from '../../shared/definitions/rjsfPatterns';
 import { pdfFullNameNoSuffixSchema } from '../../shared/definitions/pdfFullNameNoSuffix';
 
 const authorizerFullNameUI = cloneDeep(fullNameDeprecatedUI);

--- a/src/applications/simple-forms/21-0845/pages/authorizerPersonalInfo.js
+++ b/src/applications/simple-forms/21-0845/pages/authorizerPersonalInfo.js
@@ -1,9 +1,9 @@
 import { cloneDeep } from 'lodash';
 
-import fullNameUI from 'platform/forms-system/src/js/definitions/fullName';
+import fullNameDeprecatedUI from '../../shared/definitions/rjsfPatterns';
 import { pdfFullNameNoSuffixSchema } from '../../shared/definitions/pdfFullNameNoSuffix';
 
-const authorizerFullNameUI = cloneDeep(fullNameUI);
+const authorizerFullNameUI = cloneDeep(fullNameDeprecatedUI);
 
 authorizerFullNameUI.middle['ui:title'] = 'Middle initial';
 

--- a/src/applications/simple-forms/21-10210/pages/claimantPersInfo.js
+++ b/src/applications/simple-forms/21-10210/pages/claimantPersInfo.js
@@ -1,6 +1,6 @@
 import definitions from 'vets-json-schema/dist/definitions.json';
 import { validateDateOfBirth } from 'platform/forms/validations';
-import fullNameDeprecatedUI from '../../shared/definitions/rjsfPatterns';
+import { fullNameDeprecatedUI } from '../../shared/definitions/rjsfPatterns';
 import { pdfFullNameNoSuffixSchema } from '../../shared/definitions/pdfFullNameNoSuffix';
 import ClaimantPersInfoUiTitle from '../components/ClaimantPersInfoUiTitle';
 

--- a/src/applications/simple-forms/21-10210/pages/claimantPersInfo.js
+++ b/src/applications/simple-forms/21-10210/pages/claimantPersInfo.js
@@ -1,6 +1,6 @@
 import definitions from 'vets-json-schema/dist/definitions.json';
-import fullNameUI from 'platform/forms-system/src/js/definitions/fullName';
 import { validateDateOfBirth } from 'platform/forms/validations';
+import fullNameDeprecatedUI from '../../shared/definitions/rjsfPatterns';
 import { pdfFullNameNoSuffixSchema } from '../../shared/definitions/pdfFullNameNoSuffix';
 import ClaimantPersInfoUiTitle from '../components/ClaimantPersInfoUiTitle';
 
@@ -8,7 +8,7 @@ import ClaimantPersInfoUiTitle from '../components/ClaimantPersInfoUiTitle';
 export default {
   uiSchema: {
     'ui:title': ClaimantPersInfoUiTitle,
-    claimantFullName: fullNameUI,
+    claimantFullName: fullNameDeprecatedUI,
     claimantDateOfBirth: {
       'ui:title': 'Date of birth',
       'ui:widget': 'date',

--- a/src/applications/simple-forms/21-10210/pages/vetPersInfo.js
+++ b/src/applications/simple-forms/21-10210/pages/vetPersInfo.js
@@ -1,6 +1,6 @@
 import definitions from 'vets-json-schema/dist/definitions.json';
 import { validateDateOfBirth } from 'platform/forms/validations';
-import fullNameDeprecatedUI from '../../shared/definitions/rjsfPatterns';
+import { fullNameDeprecatedUI } from '../../shared/definitions/rjsfPatterns';
 import { pdfFullNameNoSuffixSchema } from '../../shared/definitions/pdfFullNameNoSuffix';
 import VetPersInfoUiTitle from '../components/VetPersInfoUiTitle';
 

--- a/src/applications/simple-forms/21-10210/pages/vetPersInfo.js
+++ b/src/applications/simple-forms/21-10210/pages/vetPersInfo.js
@@ -1,6 +1,6 @@
 import definitions from 'vets-json-schema/dist/definitions.json';
-import fullNameUI from 'platform/forms-system/src/js/definitions/fullName';
 import { validateDateOfBirth } from 'platform/forms/validations';
+import fullNameDeprecatedUI from '../../shared/definitions/rjsfPatterns';
 import { pdfFullNameNoSuffixSchema } from '../../shared/definitions/pdfFullNameNoSuffix';
 import VetPersInfoUiTitle from '../components/VetPersInfoUiTitle';
 
@@ -8,7 +8,7 @@ import VetPersInfoUiTitle from '../components/VetPersInfoUiTitle';
 export default {
   uiSchema: {
     'ui:title': VetPersInfoUiTitle,
-    veteranFullName: fullNameUI,
+    veteranFullName: fullNameDeprecatedUI,
     veteranDateOfBirth: {
       'ui:title': 'Date of birth',
       'ui:widget': 'date',

--- a/src/applications/simple-forms/21-10210/pages/witnessPersInfo.js
+++ b/src/applications/simple-forms/21-10210/pages/witnessPersInfo.js
@@ -1,4 +1,4 @@
-import fullNameUI from 'platform/forms-system/src/js/definitions/fullName';
+import fullNameDeprecatedUI from '../../shared/definitions/rjsfPatterns';
 import {
   RELATIONSHIP_TO_VETERAN_OPTIONS,
   RELATIONSHIP_TO_CLAIMANT_OPTIONS,
@@ -8,7 +8,7 @@ import GroupCheckboxWidget from '../../shared/components/GroupCheckboxWidget';
 
 /** @type {PageSchema} */
 const commonUiSchema = {
-  witnessFullName: fullNameUI,
+  witnessFullName: fullNameDeprecatedUI,
   witnessRelationshipToClaimant: {
     // different ui:title between uiSchemaA & uiSchemaB
     'ui:description': 'You can select more than one.',

--- a/src/applications/simple-forms/21-10210/pages/witnessPersInfo.js
+++ b/src/applications/simple-forms/21-10210/pages/witnessPersInfo.js
@@ -1,4 +1,4 @@
-import fullNameDeprecatedUI from '../../shared/definitions/rjsfPatterns';
+import { fullNameDeprecatedUI } from '../../shared/definitions/rjsfPatterns';
 import {
   RELATIONSHIP_TO_VETERAN_OPTIONS,
   RELATIONSHIP_TO_CLAIMANT_OPTIONS,

--- a/src/applications/simple-forms/21-4142/pages/patientIdentification2.js
+++ b/src/applications/simple-forms/21-4142/pages/patientIdentification2.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 import fullSchema from 'vets-json-schema/dist/21-4142-schema.json';
 import { intersection, pick } from 'lodash';
-import fullNameDeprecatedUI from '../../shared/definitions/rjsfPatterns';
+import { fullNameDeprecatedUI } from '../../shared/definitions/rjsfPatterns';
 import { patientIdentificationFields } from '../definitions/constants';
 
 const { required, properties } = fullSchema.properties[

--- a/src/applications/simple-forms/21-4142/pages/patientIdentification2.js
+++ b/src/applications/simple-forms/21-4142/pages/patientIdentification2.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
-import fullNameUI from 'platform/forms-system/src/js/definitions/fullName';
 import fullSchema from 'vets-json-schema/dist/21-4142-schema.json';
 import { intersection, pick } from 'lodash';
+import fullNameDeprecatedUI from '../../shared/definitions/rjsfPatterns';
 import { patientIdentificationFields } from '../definitions/constants';
 
 const { required, properties } = fullSchema.properties[
@@ -24,7 +24,7 @@ export default {
           of
         </h3>
       ),
-      [patientIdentificationFields.patientFullName]: fullNameUI,
+      [patientIdentificationFields.patientFullName]: fullNameDeprecatedUI,
       [patientIdentificationFields.patientSsn]: {
         ...ssnUI,
         'ui:required': () => true,

--- a/src/applications/simple-forms/21-4142/pages/personalInformation1.js
+++ b/src/applications/simple-forms/21-4142/pages/personalInformation1.js
@@ -2,7 +2,7 @@ import React from 'react';
 import fullSchema from 'vets-json-schema/dist/21-4142-schema.json';
 import dateUI from 'platform/forms-system/src/js/definitions/date';
 import { intersection, pick } from 'lodash';
-import fullNameDeprecatedUI from '../../shared/definitions/rjsfPatterns';
+import { fullNameDeprecatedUI } from '../../shared/definitions/rjsfPatterns';
 import { veteranFields } from '../definitions/constants';
 
 const { required, properties } = fullSchema.properties[

--- a/src/applications/simple-forms/21-4142/pages/personalInformation1.js
+++ b/src/applications/simple-forms/21-4142/pages/personalInformation1.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import fullSchema from 'vets-json-schema/dist/21-4142-schema.json';
-import fullNameUI from 'platform/forms-system/src/js/definitions/fullName';
 import dateUI from 'platform/forms-system/src/js/definitions/date';
 import { intersection, pick } from 'lodash';
+import fullNameDeprecatedUI from '../../shared/definitions/rjsfPatterns';
 import { veteranFields } from '../definitions/constants';
 
 const { required, properties } = fullSchema.properties[
@@ -19,7 +19,7 @@ export default {
           Tell us about the Veteran connected to this authorization
         </h3>
       ),
-      [veteranFields.fullName]: fullNameUI,
+      [veteranFields.fullName]: fullNameDeprecatedUI,
       [veteranFields.dateOfBirth]: dateUI('Date of birth'),
     },
   },

--- a/src/applications/simple-forms/21-4142/pages/preparerPersonalInformation.js
+++ b/src/applications/simple-forms/21-4142/pages/preparerPersonalInformation.js
@@ -1,6 +1,6 @@
-import fullNameUI from 'platform/forms-system/src/js/definitions/fullName';
 import fullSchema from 'vets-json-schema/dist/21-4142-schema.json';
 import { intersection, pick } from 'lodash';
+import fullNameDeprecatedUI from '../../shared/definitions/rjsfPatterns';
 import {
   preparerIdentificationFields,
   veteranDirectRelative,
@@ -28,7 +28,7 @@ const isThirdParty = formData => !isNotThirdParty(formData);
 export default {
   uiSchema: {
     [preparerIdentificationFields.parentObject]: {
-      [preparerIdentificationFields.preparerFullName]: fullNameUI,
+      [preparerIdentificationFields.preparerFullName]: fullNameDeprecatedUI,
       [preparerIdentificationFields.preparerTitle]: {
         'ui:title': 'Title',
         'ui:options': {

--- a/src/applications/simple-forms/21-4142/pages/preparerPersonalInformation.js
+++ b/src/applications/simple-forms/21-4142/pages/preparerPersonalInformation.js
@@ -1,6 +1,6 @@
 import fullSchema from 'vets-json-schema/dist/21-4142-schema.json';
 import { intersection, pick } from 'lodash';
-import fullNameDeprecatedUI from '../../shared/definitions/rjsfPatterns';
+import { fullNameDeprecatedUI } from '../../shared/definitions/rjsfPatterns';
 import {
   preparerIdentificationFields,
   veteranDirectRelative,

--- a/src/applications/simple-forms/26-4555/pages/personalInformation1.js
+++ b/src/applications/simple-forms/26-4555/pages/personalInformation1.js
@@ -3,8 +3,8 @@ import { intersection, pick } from 'lodash';
 
 import fullSchema from 'vets-json-schema/dist/26-4555-schema.json';
 import PrefillMessage from 'platform/forms/save-in-progress/PrefillMessage';
-import fullNameUI from 'platform/forms-system/src/js/definitions/fullName';
 import dateUI from 'platform/forms-system/src/js/definitions/date';
+import fullNameDeprecatedUI from '../../shared/definitions/rjsfPatterns';
 import { veteranFields } from '../definitions/constants';
 
 const { required, properties } = fullSchema.properties[
@@ -22,7 +22,7 @@ export default {
           Name and date of birth
         </h3>
       ),
-      [veteranFields.fullName]: fullNameUI,
+      [veteranFields.fullName]: fullNameDeprecatedUI,
       [veteranFields.dateOfBirth]: dateUI('Date of birth'),
     },
   },

--- a/src/applications/simple-forms/26-4555/pages/personalInformation1.js
+++ b/src/applications/simple-forms/26-4555/pages/personalInformation1.js
@@ -4,7 +4,7 @@ import { intersection, pick } from 'lodash';
 import fullSchema from 'vets-json-schema/dist/26-4555-schema.json';
 import PrefillMessage from 'platform/forms/save-in-progress/PrefillMessage';
 import dateUI from 'platform/forms-system/src/js/definitions/date';
-import fullNameDeprecatedUI from '../../shared/definitions/rjsfPatterns';
+import { fullNameDeprecatedUI } from '../../shared/definitions/rjsfPatterns';
 import { veteranFields } from '../definitions/constants';
 
 const { required, properties } = fullSchema.properties[

--- a/src/applications/simple-forms/shared/definitions/rjsfPatterns.js
+++ b/src/applications/simple-forms/shared/definitions/rjsfPatterns.js
@@ -1,11 +1,11 @@
 import {
   validateEmpty,
   validateNameSymbols,
-} from 'platform/forms-system/src/js/web-component-patterns';
+} from 'platform/forms-system/src/js/web-component-patterns/fullNamePattern';
 
 // RJSF version of web-component fullNameUI
 // Deprecated because web-components are preferred
-const fullNameDeprecatedUI = {
+export const fullNameDeprecatedUI = {
   'ui:validations': [validateEmpty],
   first: {
     'ui:title': 'First name',
@@ -36,5 +36,3 @@ const fullNameDeprecatedUI = {
     },
   },
 };
-
-export default fullNameDeprecatedUI;

--- a/src/applications/simple-forms/shared/definitions/rjsfPatterns.js
+++ b/src/applications/simple-forms/shared/definitions/rjsfPatterns.js
@@ -1,0 +1,40 @@
+import {
+  validateEmpty,
+  validateNameSymbols,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+// RJSF version of web-component fullNameUI
+// Deprecated because web-components are preferred
+const fullNameDeprecatedUI = {
+  'ui:validations': [validateEmpty],
+  first: {
+    'ui:title': 'First name',
+    'ui:autocomplete': 'given-name',
+    'ui:validations': [validateNameSymbols],
+    'ui:errorMessages': {
+      required: 'Please enter a first name',
+    },
+  },
+  last: {
+    'ui:title': 'Last name',
+    'ui:autocomplete': 'family-name',
+    'ui:validations': [validateNameSymbols],
+    'ui:errorMessages': {
+      required: 'Please enter a last name',
+    },
+  },
+  middle: {
+    'ui:title': 'Middle name',
+    'ui:autocomplete': 'additional-name',
+    'ui:validations': [validateNameSymbols],
+  },
+  suffix: {
+    'ui:title': 'Suffix',
+    'ui:autocomplete': 'honorific-suffix',
+    'ui:options': {
+      widgetClassNames: 'form-select-medium',
+    },
+  },
+};
+
+export default fullNameDeprecatedUI;

--- a/src/platform/forms-system/src/js/web-component-patterns/fullNamePattern.js
+++ b/src/platform/forms-system/src/js/web-component-patterns/fullNamePattern.js
@@ -20,8 +20,8 @@ export function validateNameSymbols(errors, value, uiSchema, schema, messages) {
   if (matches) {
     const uniqueInvalidChars = [...new Set(matches)].join(', ');
     const staticText =
-      messages.symbols ||
-      'You entered a character we can’t accept. Try removing any special characters such as:';
+      messages?.symbols ||
+      'You entered a character we can’t accept. Try removing';
     errors.addError(`${staticText} ${uniqueInvalidChars}`);
   }
 }

--- a/src/platform/forms-system/src/js/web-component-patterns/fullNamePattern.js
+++ b/src/platform/forms-system/src/js/web-component-patterns/fullNamePattern.js
@@ -9,6 +9,16 @@ function validateName(errors, pageData) {
   validateWhiteSpace(errors.last, last);
 }
 
+function validateSymbols(errors, value, _uiSchema, _schema, messages) {
+  const invalidChars = /[~!@#$%^&*+=[\]\\;:"`<>/_|]/;
+  if (invalidChars.test(value)) {
+    errors.addError(messages.symbols);
+  }
+}
+
+const SYMBOLS_ERROR_MESSAGE =
+  'You entered a character we can’t accept. Try removing any special characters.';
+
 /**
  * Web component uiSchema for `first`, `middle`, and `last name`
  *
@@ -27,8 +37,10 @@ const fullNameNoSuffixUI = (formatTitle, uiOptions = {}) => {
       'ui:title': formatTitle ? formatTitle('first name') : 'First name',
       'ui:autocomplete': 'given-name',
       'ui:webComponentField': VaTextInputField,
+      'ui:validations': [validateSymbols],
       'ui:errorMessages': {
         required: 'Please enter a first name',
+        symbols: SYMBOLS_ERROR_MESSAGE,
       },
       'ui:options': {
         uswds: true,
@@ -39,6 +51,10 @@ const fullNameNoSuffixUI = (formatTitle, uiOptions = {}) => {
       'ui:title': formatTitle ? formatTitle('middle name') : 'Middle name',
       'ui:webComponentField': VaTextInputField,
       'ui:autocomplete': 'additional-name',
+      'ui:validations': [validateSymbols],
+      'ui:errorMessages': {
+        symbols: SYMBOLS_ERROR_MESSAGE,
+      },
       'ui:options': {
         uswds: true,
         ...uiOptions,
@@ -48,8 +64,10 @@ const fullNameNoSuffixUI = (formatTitle, uiOptions = {}) => {
       'ui:title': formatTitle ? formatTitle('last name') : 'Last name',
       'ui:autocomplete': 'family-name',
       'ui:webComponentField': VaTextInputField,
+      'ui:validations': [validateSymbols],
       'ui:errorMessages': {
         required: 'Please enter a last name',
+        symbols: SYMBOLS_ERROR_MESSAGE,
       },
       'ui:options': {
         uswds: true,
@@ -101,6 +119,7 @@ const fullNameWithMaidenNameUI = (formatTitle, uiOptions) => {
     maiden: {
       'ui:title': "Mother's maiden name",
       'ui:webComponentField': VaTextInputField,
+      'ui:validations': [validateSymbols],
       'ui:options': {
         uswds: true,
         ...uiOptions,

--- a/src/platform/forms-system/src/js/web-component-tests/validations.unit.spec.js
+++ b/src/platform/forms-system/src/js/web-component-tests/validations.unit.spec.js
@@ -5,6 +5,7 @@ import {
   symbolsValidation,
   emailValidation,
 } from '../web-component-patterns/emailPattern';
+import { validateNameSymbols } from '../web-component-patterns/fullNamePattern';
 
 describe('minMaxValidation', () => {
   it('should add an error if the number is less than the minimum range', () => {
@@ -90,5 +91,34 @@ describe('email validation', () => {
     const value = 'User_name32+ok-name@email.va';
     emailValidation(errors, value, null, null, errorMessages);
     expect(errors.addError.called).to.be.false;
+  });
+});
+
+describe('name symbol validation', () => {
+  const errorMessages = {
+    symbols: `Error symbols message`,
+  };
+
+  it('should show an error message specific to name symbol validation', () => {
+    const errors = { addError: sinon.stub() };
+    // Accented characters like this are not allowed in some APIs, however
+    // we can choose pass this, and let our local backend handle this instead.
+    const value = 'José Ramírez';
+    validateNameSymbols(errors, value, null, null, errorMessages);
+    expect(errors.addError.calledWithMatch(errorMessages.symbols)).to.be.false;
+  });
+
+  it('should show an error message specific to name symbol validation', () => {
+    const errors = { addError: sinon.stub() };
+    const value = 'Oops;';
+    validateNameSymbols(errors, value, null, null, errorMessages);
+    expect(errors.addError.calledWithMatch(errorMessages.symbols)).to.be.true;
+  });
+
+  it('should show an error message specific to name symbol validation', () => {
+    const errors = { addError: sinon.stub() };
+    const value = 'The "name"';
+    validateNameSymbols(errors, value, null, null, errorMessages);
+    expect(errors.addError.calledWithMatch(errorMessages.symbols)).to.be.true;
   });
 });


### PR DESCRIPTION
## Summary

- Add basic symbols validation to name fields
- (We're still allowing names like José Ramírez to go through, and backend can decide what to do, but we'll just block basic symbols /[~!@#$%^&*+=[\]{}()<>;:"`\\/_|]/
- Affects all name fields for all simple-forms forms, both RJSF and web-components

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#863

## Testing done

- Browser and unit testing

## Screenshots

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/6c6313a5-69ff-4664-a12a-7f8a6f713b4d)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/a8538b20-1527-47ab-a8c9-1245f41ed5f3)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/3cff2a78-136c-4106-a9c3-9c8403a73d3b)

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
