### PR TITLE
Creates IdentityPhone Component

### DIFF
--- a/src/applications/terms-of-use/containers/TermsOfUse.jsx
+++ b/src/applications/terms-of-use/containers/TermsOfUse.jsx
@@ -6,7 +6,7 @@ import {
   isAuthenticatedWithOAuth,
   AUTHN_SETTINGS,
 } from '@department-of-veterans-affairs/platform-user/exports';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import IdentityPhone from 'platform/user/authentication/components/IdentityPhone';
 import TermsAcceptance from '../components/TermsAcceptanceAction';
 import {
   parseRedirectUrl,
@@ -127,10 +127,7 @@ export default function TermsOfUse() {
               Your decision to decline these terms won’t affect your eligibility
               for VA health care and benefits in any way. You can still get VA
               health care and benefits without using online services. If you
-              need help or have questions, call us at{' '}
-              <va-telephone contact={CONTACTS.VA_411} />, select 0 (
-              <va-telephone contact={CONTACTS[711]} tty />
-              ). We’re here 24/7.
+              need help or have questions, <IdentityPhone /> We’re here 24/7.
             </p>
             <va-alert status="warning" visible>
               <h3 slot="headline" id="what-happens-if-you-decline">

--- a/src/platform/user/authentication/components/IdentityPhone.jsx
+++ b/src/platform/user/authentication/components/IdentityPhone.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+
+export default function IdentityPhone({ startSentance }) {
+  return (
+    <span>
+      {startSentance ? 'Call' : 'call'} us at{' '}
+      <va-telephone contact={CONTACTS.VA_411} /> and select 0(
+      <va-telephone contact={CONTACTS[711]} tty />
+      ).
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- Creates new ```IdentityPhone``` component
- Adds new component to ```TermsOfUse.jsx``` file
- Updates any tests if applicable
- remove unused imports from ```TermsOfUse.jsk```

## Related issue(s)

[ZenHub Ticket #71868](https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/gh/department-of-veterans-affairs/va.gov-team/71868)

## Screenshots

| Desktop | Mobile | Code |
| ------- | ------ | ------- |
| <img width="712" alt="Screenshot 2023-12-13 at 11 29 54 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/78328496/9325dae3-26c5-4565-a9cc-ce09dd065ce8"> | <img width="287" alt="Screenshot 2023-12-13 at 11 29 37 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/78328496/c3abc132-12a7-4f6e-8957-ba4f71d420c4"> | <img width="712" alt="Screenshot 2023-12-13 at 11 30 44 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/78328496/1f9cdb39-8dfe-443f-b581-4cfbc3096280"> |


## What areas of the site does it impact?

Terms Of Use

## Acceptance criteria

- [x] Update ```<SubmitSignUpForm />``` component to use <va-telephone />``` component
- [x] Add ```contact``` prop to ```<va-telephone />``` component
- [x] Update copy to match this [figma design]()
- [x] Update and tests as required

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
