### PR TITLE
Check in/71440/add 45min reminder to ga

### DIFF
--- a/src/applications/check-in/api/versions/v2.js
+++ b/src/applications/check-in/api/versions/v2.js
@@ -6,7 +6,11 @@ import environment from '@department-of-veterans-affairs/platform-utilities/envi
 import { makeApiCallWithSentry } from '../utils';
 
 const v2 = {
-  getSession: async ({ token, checkInType }) => {
+  getSession: async ({
+    token,
+    checkInType = 'day-of',
+    setECheckinStartedCalled = false,
+  }) => {
     const url = '/check_in/v2/sessions/';
     let requestUrl = `${environment.API_URL}${url}${token}`;
     if (checkInType) {
@@ -14,7 +18,9 @@ const v2 = {
         checkInType,
       });
     }
-    const eventLabel = `${checkInType || 'day-of'}-get-current-session-dob`;
+    const eventLabel = `${checkInType || 'day-of'}-get-current-session-dob${
+      setECheckinStartedCalled ? '45min' : ''
+    }`;
 
     const json = await makeApiCallWithSentry(
       apiRequest(requestUrl),
@@ -96,7 +102,7 @@ const v2 = {
 
     const json = await makeApiCallWithSentry(
       apiRequest(`${environment.API_URL}${url}`, settings),
-      'check-in-user',
+      `check-in-user${setECheckinStartedCalled ? '-15MR' : ''}`,
       uuid,
     );
     return {

--- a/src/applications/check-in/api/versions/v2.js
+++ b/src/applications/check-in/api/versions/v2.js
@@ -6,11 +6,7 @@ import environment from '@department-of-veterans-affairs/platform-utilities/envi
 import { makeApiCallWithSentry } from '../utils';
 
 const v2 = {
-  getSession: async ({
-    token,
-    checkInType = 'day-of',
-    setECheckinStartedCalled = false,
-  }) => {
+  getSession: async ({ token, checkInType = 'day-of' }) => {
     const url = '/check_in/v2/sessions/';
     let requestUrl = `${environment.API_URL}${url}${token}`;
     if (checkInType) {
@@ -18,9 +14,7 @@ const v2 = {
         checkInType,
       });
     }
-    const eventLabel = `${checkInType || 'day-of'}-get-current-session-dob${
-      setECheckinStartedCalled ? '45min' : ''
-    }`;
+    const eventLabel = `${checkInType || 'day-of'}-get-current-session-dob`;
 
     const json = await makeApiCallWithSentry(
       apiRequest(requestUrl),

--- a/src/applications/check-in/api/versions/v2.js
+++ b/src/applications/check-in/api/versions/v2.js
@@ -6,7 +6,7 @@ import environment from '@department-of-veterans-affairs/platform-utilities/envi
 import { makeApiCallWithSentry } from '../utils';
 
 const v2 = {
-  getSession: async ({ token, checkInType = 'day-of' }) => {
+  getSession: async ({ token, checkInType }) => {
     const url = '/check_in/v2/sessions/';
     let requestUrl = `${environment.API_URL}${url}${token}`;
     if (checkInType) {
@@ -96,7 +96,7 @@ const v2 = {
 
     const json = await makeApiCallWithSentry(
       apiRequest(`${environment.API_URL}${url}`, settings),
-      `check-in-user${setECheckinStartedCalled ? '-15MR' : ''}`,
+      `check-in-user${setECheckinStartedCalled ? '-45MR' : ''}`,
       uuid,
     );
     return {

--- a/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
+++ b/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
@@ -8,7 +8,7 @@ import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring
 import { createAnalyticsSlug } from '../../../utils/analytics';
 import { useStorage } from '../../../hooks/useStorage';
 import { useFormRouting } from '../../../hooks/useFormRouting';
-import { makeSelectApp } from '../../../selectors';
+import { makeSelectApp, makeSelectCurrentContext } from '../../../selectors';
 
 import DemographicItem from '../../DemographicItem';
 import Wrapper from '../../layout/Wrapper';
@@ -34,6 +34,8 @@ const ConfirmablePage = ({
 
   const selectApp = useMemo(makeSelectApp, []);
   const { app } = useSelector(selectApp);
+  const selectCurrentContext = useMemo(makeSelectCurrentContext, []);
+  const { setECheckinStartedCalled } = useSelector(selectCurrentContext);
   const { jumpToPage } = useFormRouting(router);
   const { getCheckinComplete } = useStorage(app === APP_NAMES.PRE_CHECK_IN);
   useLayoutEffect(() => {
@@ -44,14 +46,22 @@ const ConfirmablePage = ({
 
   const onYesClick = () => {
     recordEvent({
-      event: createAnalyticsSlug(`yes-to-${pageType}-clicked`, 'nav'),
+      event: createAnalyticsSlug(
+        `yes-to-${pageType}${setECheckinStartedCalled ? '-15MR' : ''}-clicked`,
+        'nav',
+      ),
     });
     yesAction();
   };
 
   const onNoClick = () => {
     recordEvent({
-      event: createAnalyticsSlug(`no-to-${pageType}-clicked`, 'nav'),
+      event: createAnalyticsSlug(
+        `no-to-${pageType}${pageType}${
+          setECheckinStartedCalled ? '-15MR' : ''
+        }-clicked`,
+        'nav',
+      ),
     });
     noAction();
   };

--- a/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
+++ b/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
@@ -47,7 +47,7 @@ const ConfirmablePage = ({
   const onYesClick = () => {
     recordEvent({
       event: createAnalyticsSlug(
-        `yes-to-${pageType}${setECheckinStartedCalled ? '-15MR' : ''}-clicked`,
+        `yes-to-${pageType}${setECheckinStartedCalled ? '-45MR' : ''}-clicked`,
         'nav',
       ),
     });
@@ -58,7 +58,7 @@ const ConfirmablePage = ({
     recordEvent({
       event: createAnalyticsSlug(
         `no-to-${pageType}${pageType}${
-          setECheckinStartedCalled ? '-15MR' : ''
+          setECheckinStartedCalled ? '-45MR' : ''
         }-clicked`,
         'nav',
       ),

--- a/src/applications/check-in/components/pages/TravelPage/index.jsx
+++ b/src/applications/check-in/components/pages/TravelPage/index.jsx
@@ -1,6 +1,6 @@
-import React, { useLayoutEffect } from 'react';
+import React, { useLayoutEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 // eslint-disable-next-line import/no-unresolved
 import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
@@ -9,6 +9,7 @@ import { recordAnswer } from '../../../actions/universal';
 import { useFormRouting } from '../../../hooks/useFormRouting';
 import { useStorage } from '../../../hooks/useStorage';
 import { createAnalyticsSlug } from '../../../utils/analytics';
+import { makeSelectCurrentContext } from '../../../selectors';
 import { URLS } from '../../../utils/navigation';
 
 import BackButton from '../../BackButton';
@@ -35,10 +36,19 @@ const TravelPage = ({
     jumpToPage,
     getPreviousPageFromRouter,
   } = useFormRouting(router);
+
+  const selectCurrentContext = useMemo(makeSelectCurrentContext, []);
+  const { setECheckinStartedCalled } = useSelector(selectCurrentContext);
+
   const onClick = event => {
     const answer = event.target.value;
     recordEvent({
-      event: createAnalyticsSlug(`${answer}-to-${pageType}-clicked`, 'nav'),
+      event: createAnalyticsSlug(
+        `${answer}-to-${pageType}${
+          setECheckinStartedCalled ? '-15MR' : ''
+        }-clicked`,
+        'nav',
+      ),
     });
     dispatch(recordAnswer({ [pageType]: answer }));
     if (answer === 'no' && noFunction) {

--- a/src/applications/check-in/components/pages/TravelPage/index.jsx
+++ b/src/applications/check-in/components/pages/TravelPage/index.jsx
@@ -45,7 +45,7 @@ const TravelPage = ({
     recordEvent({
       event: createAnalyticsSlug(
         `${answer}-to-${pageType}${
-          setECheckinStartedCalled ? '-15MR' : ''
+          setECheckinStartedCalled ? '-45MR' : ''
         }-clicked`,
         'nav',
       ),


### PR DESCRIPTION
## Summary

- Adds 45MR context to GA events

There was a request in the ticket to add to validations calls to the /session endpoint but we don't have a way of knowing if it is a 45 minute reminder session until we get the check in data.

## Related issue(s)

- [department-of-veterans-affairs/va.gov-team#71440](https://github.com/department-of-veterans-affairs/va.gov-team/issues/71440)

## Testing done

- Tested events with adswerve

## What areas of the site does it impact?

GA events for:
- Demographics
- Travel
- Check-in Success
- Check-in Failure

## Acceptance criteria

- [ ] Adds the string 45MR to events when `setECheckinStartedCalled` is true

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
