### PR TITLE
Create static page content widget for 10-10EZR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -139,6 +139,7 @@ src/applications/caregivers @department-of-veterans-affairs/1010-health-apps-fro
 src/applications/hca @department-of-veterans-affairs/1010-health-apps-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/ezr @department-of-veterans-affairs/1010-health-apps-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/static-pages/hca-performance-warning @department-of-veterans-affairs/1010-health-apps-frontend @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/static-pages/ezr-submission-options @department-of-veterans-affairs/1010-health-apps-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 
 # Healthcare Experience
 

--- a/src/applications/static-pages/ezr-submission-options/components/App/index.jsx
+++ b/src/applications/static-pages/ezr-submission-options/components/App/index.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import {
+  InPersonDescription,
+  MailDescription,
+  PhoneDescription,
+} from '../Descriptions';
+
+export const App = ({ isEzrEnabled }) => {
+  return isEzrEnabled ? (
+    <>
+      <p>
+        You can update your health benefits information online, by phone, by
+        mail, or in person.
+      </p>
+
+      <h3>Option 1: Online</h3>
+      <p>
+        You’ll need to sign in to VA.gov to update your health benefits
+        information online.
+      </p>
+      <a
+        className="vads-c-action-link--green"
+        href="/my-health/update-benefits-information-form-10-10ezr/"
+      >
+        Update your health benefits information online
+      </a>
+
+      <h3>Option 2: By phone</h3>
+      <PhoneDescription />
+
+      <h3>Option 3: By mail</h3>
+      <MailDescription />
+
+      <h3>Option 4: In person</h3>
+      <InPersonDescription />
+    </>
+  ) : (
+    <>
+      <p>
+        You can update your health benefits information by phone, by mail, or in
+        person.
+      </p>
+
+      <h3>Option 1: By phone</h3>
+      <PhoneDescription />
+
+      <h3>Option 2: By mail</h3>
+      <MailDescription />
+
+      <h3>Option 3: In person</h3>
+      <InPersonDescription />
+    </>
+  );
+};
+
+App.propTypes = {
+  isEzrEnabled: PropTypes.bool,
+};
+
+const mapStateToProps = state => ({
+  isEzrEnabled: state.featureToggles.ezrProdEnabled,
+});
+
+export default connect(mapStateToProps)(App);

--- a/src/applications/static-pages/ezr-submission-options/components/App/index.unit.spec.jsx
+++ b/src/applications/static-pages/ezr-submission-options/components/App/index.unit.spec.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import { App } from '.';
+
+describe('ezr submission options', () => {
+  it('should not render link to the online form when feature toggle is false', () => {
+    const wrapper = shallow(<App isEzrEnabled={false} />);
+    const selectors = {
+      headings: wrapper.find('h3'),
+      link: wrapper.find('.vads-c-action-link--green'),
+    };
+    expect(selectors.headings).to.have.lengthOf(3);
+    expect(selectors.link).to.have.lengthOf(0);
+    wrapper.unmount();
+  });
+
+  it('renders link to the online form when feature toggle is true', () => {
+    const wrapper = shallow(<App isEzrEnabled />);
+    const selectors = {
+      headings: wrapper.find('h3'),
+      link: wrapper.find('.vads-c-action-link--green'),
+    };
+    expect(selectors.headings).to.have.lengthOf(4);
+    expect(selectors.link).to.have.lengthOf(1);
+    wrapper.unmount();
+  });
+});

--- a/src/applications/static-pages/ezr-submission-options/components/Descriptions/index.jsx
+++ b/src/applications/static-pages/ezr-submission-options/components/Descriptions/index.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+
+export const PhoneDescription = () => {
+  return (
+    <p>
+      Call our Health Eligibility Center at{' '}
+      <va-telephone contact={CONTACTS['222_VETS']} /> and select 1 (
+      <va-telephone contact={CONTACTS['711']} tty />
+      ). We’re available Monday through Friday, 8:00 a.m. to 8:00 p.m.{' '}
+      <dfn>
+        <abbr title="Eastern Time">ET</abbr>
+      </dfn>
+      .
+    </p>
+  );
+};
+
+export const MailDescription = () => {
+  return (
+    <>
+      <p>Fill out a Health Benefits Update Form (VA Form 10-10EZR).</p>
+      <p>
+        <va-link
+          href="/find-forms/about-form-10-10ezr/"
+          text="Get VA Form 10-10EZR to download"
+        />
+      </p>
+      <p>
+        Mail the completed form and any supporting documents to this address:
+      </p>
+      <p className="va-address-block">
+        VA Health Eligibility Center
+        <br role="presentation" />
+        2957 Clairmont Road, Suite 200
+        <br role="presentation" />
+        Atlanta, GA 30329
+      </p>
+    </>
+  );
+};
+
+export const InPersonDescription = () => {
+  return (
+    <>
+      <p>You can update your information in person at a VA health facility.</p>
+      <p>
+        <va-link
+          href="/find-locations/"
+          text="Find your nearest VA health facility"
+        />
+      </p>
+    </>
+  );
+};

--- a/src/applications/static-pages/ezr-submission-options/components/Descriptions/index.unit.spec.jsx
+++ b/src/applications/static-pages/ezr-submission-options/components/Descriptions/index.unit.spec.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { InPersonDescription, MailDescription, PhoneDescription } from '.';
+
+describe('ezr submission option descriptions', () => {
+  context('when PhoneDescription renders', () => {
+    it('should not be empty', () => {
+      const { container } = render(<PhoneDescription />);
+      expect(container).to.not.be.empty;
+    });
+  });
+
+  context('when MailDescription renders', () => {
+    it('should not be empty', () => {
+      const { container } = render(<MailDescription />);
+      expect(container).to.not.be.empty;
+    });
+  });
+
+  context('when InPersonDescription renders', () => {
+    it('should not be empty', () => {
+      const { container } = render(<InPersonDescription />);
+      expect(container).to.not.be.empty;
+    });
+  });
+});

--- a/src/applications/static-pages/ezr-submission-options/index.js
+++ b/src/applications/static-pages/ezr-submission-options/index.js
@@ -1,0 +1,23 @@
+// Node modules.
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+import { connectFeatureToggle } from 'platform/utilities/feature-toggles';
+
+export default (store, widgetType) => {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+  if (root) {
+    import(/* webpackChunkName: "ezr-submission-options" */
+    './components/App').then(module => {
+      const App = module.default;
+      connectFeatureToggle(store.dispatch);
+
+      ReactDOM.render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+        root,
+      );
+    });
+  }
+};

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -44,6 +44,7 @@ import createDisabilityRatingCalculator from '../disability-benefits/disability-
 import createEducationApplicationStatus from '../edu-benefits/components/createEducationApplicationStatus';
 import createEventsPage from './events';
 import createExpandableOperatingStatus from './facilities/vet-center/createExpandableOperatingStatus';
+import createEZRSubmissionOptions from './ezr-submission-options';
 import createFacilityPage from './facilities/createFacilityPage';
 import createFacilityMapSatelliteMainOffice from './facilities/createFacilityMapSatelliteMainOffice';
 import createFacilityPageSatelliteLocations from './facilities/createFacilityPageSatelliteLocations';
@@ -183,6 +184,7 @@ createViewDependentsCTA(store, widgetTypes.VIEW_DEPENDENTS_CTA);
 form686CTA(store, widgetTypes.FORM_686_CTA);
 createAskVAWidget(store, widgetTypes.ASK_VA);
 createEventsPage(store, widgetTypes.EVENTS);
+createEZRSubmissionOptions(store, widgetTypes.EZR_SUBMISSION_OPTIONS);
 createMedicalCopaysCTA(store, widgetTypes.MEDICAL_COPAYS_CTA);
 createGetMedicalRecordsPage(store, widgetTypes.GET_MEDICAL_RECORDS_PAGE);
 createRefillTrackPrescriptionsPage(

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -17,6 +17,7 @@ export default {
   DISABILITY_RATING_CALCULATOR: 'disability-rating-calculator',
   EDUCATION_APP_STATUS: 'education-app-status',
   EVENTS: 'events',
+  EZR_SUBMISSION_OPTIONS: 'ezr-submission-options',
   FACILITY_APPOINTMENT_WAIT_TIMES_WIDGET:
     'facility-appointment-wait-times-widget',
   FACILITY_DETAIL: 'facility-detail',


### PR DESCRIPTION
## Summary
This PR creates a static widget for use with CMS on the 10-10EZR information page. The widget is being used to control what submission options are available for users while the EZR is being slow-rolled to production. Users without prod access will be shown the standard options available today, while users with prod access are given a link to the online form.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#71934

## Testing done

- [x] Unit testing has been completed for all components

## Screenshots

**For unauthenticated users:**

![Screenshot 2023-12-18 at 1 07 01 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/84984237-ec88-426a-b54e-fa2075bd3d1c)


**For authenticated users:**

![Screenshot 2023-12-18 at 1 06 09 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/8bf94db5-96ac-4169-abd3-abca65c9df2e)

## Acceptance criteria

- Widget successfully renders based on authentication status

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution