### PR TITLE
[CST] - Update claim detail subheading

### DIFF
--- a/src/applications/claims-status/components/ClaimDetailLayout.jsx
+++ b/src/applications/claims-status/components/ClaimDetailLayout.jsx
@@ -65,6 +65,7 @@ export default function ClaimDetailLayout(props) {
 
     const formatDate = buildDateFormatter(DATE_FORMATS.LONG_DATE);
     const formattedClaimDate = formatDate(claim.attributes.claimDate);
+    const claimSubheader = `Submitted on ${formattedClaimDate}`;
 
     headingContent = (
       <>
@@ -78,8 +79,8 @@ export default function ClaimDetailLayout(props) {
         )}
         <h1 className="claim-title">
           {claimTitle}
-          <span className="claim-subtitle vads-u-margin-top--1">
-            Submitted on {formattedClaimDate}
+          <span className="vads-u-font-family--sans vads-u-margin-top--1">
+            {claimSubheader}
           </span>
         </h1>
         {!synced && <ClaimSyncWarning olderVersion={!synced} />}

--- a/src/applications/claims-status/components/evss/ClaimDetailLayout.jsx
+++ b/src/applications/claims-status/components/evss/ClaimDetailLayout.jsx
@@ -59,6 +59,7 @@ export default function ClaimDetailLayout(props) {
   } else if (claim !== null) {
     const claimTitle = `Your ${claimType} claim`;
     const formattedClaimDate = formatDate(claim.attributes.dateFiled);
+    const claimSubheader = `Submitted on ${formattedClaimDate}`;
 
     headingContent = (
       <>
@@ -72,8 +73,8 @@ export default function ClaimDetailLayout(props) {
         )}
         <h1 className="claim-title">
           {claimTitle}
-          <span className="claim-subtitle vads-u-margin-top--1">
-            Submitted on {formattedClaimDate}
+          <span className="vads-u-font-family--sans vads-u-margin-top--1">
+            {claimSubheader}
           </span>
         </h1>
         {!synced && <ClaimSyncWarning olderVersion={!synced} />}


### PR DESCRIPTION
## Summary

- Updated the font of the subheading to be sans-serif
- Added a variable called claimSubheader that includes 'Submitted on {formattedClaimDate}' so that  we generate the heading text outside of the JSX , allowing voiceOver to read it correctly

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#72134
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#27049

## Testing done

- In [this](https://github.com/department-of-veterans-affairs/vets-website/pull/27049) pr we added the subheader but missed the font type and some accessibility stuff so added this ticket to resolve those two issues

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |  ![Screenshot 2023-12-18 at 12 08 49 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/0a8e837c-8782-4a46-90b0-16c0a0e6779d) | ![Screenshot 2023-12-18 at 12 06 58 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/5b36a576-f5a9-43e2-b2a1-c6572ccf99f8)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
