### PR TITLE
[Rated Disabilities] Moving the learn and need help sections into their own components

### DIFF
--- a/src/applications/rated-disabilities/components/Learn.jsx
+++ b/src/applications/rated-disabilities/components/Learn.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+export const heading = 'Learn about VA disability ratings';
+
 export default function Learn() {
   return (
     <div className="vads-u-margin-top--4">
@@ -7,7 +9,7 @@ export default function Learn() {
         id="learn"
         className="vads-u-padding-bottom--1p5 vads-u-border-bottom--3px vads-u-border-color--primary vads-u-font-size--h3"
       >
-        Learn about VA disability ratings
+        {heading}
       </h2>
       <p>
         To learn how we determined your VA combined disability rating, use our

--- a/src/applications/rated-disabilities/components/Learn.jsx
+++ b/src/applications/rated-disabilities/components/Learn.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function Learn() {
+  return (
+    <div className="vads-u-margin-top--4">
+      <h2
+        id="learn"
+        className="vads-u-padding-bottom--1p5 vads-u-border-bottom--3px vads-u-border-color--primary vads-u-font-size--h3"
+      >
+        Learn about VA disability ratings
+      </h2>
+      <p>
+        To learn how we determined your VA combined disability rating, use our
+        disability rating calculator and ratings table.
+      </p>
+      <va-link
+        href="/disability/about-disability-ratings"
+        text="About VA disability ratings"
+      />
+    </div>
+  );
+}

--- a/src/applications/rated-disabilities/components/NeedHelp.jsx
+++ b/src/applications/rated-disabilities/components/NeedHelp.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+
+export default function NeedHelp() {
+  return (
+    <va-need-help class="vads-u-margin-y--3">
+      <div slot="content">
+        <p>
+          You can call us at <va-telephone contact={CONTACTS.VA_BENEFITS} />.
+          We’re here Monday through Friday, 8:00 a.m to 9:00 p.m. ET. If you
+          have hearing loss, call <va-telephone contact={CONTACTS['711']} tty />
+        </p>
+      </div>
+    </va-need-help>
+  );
+}

--- a/src/applications/rated-disabilities/components/RatedDisabilityView.jsx
+++ b/src/applications/rated-disabilities/components/RatedDisabilityView.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import { checkForDiscrepancies } from '../actions';
-import TotalRatedDisabilities from './TotalRatedDisabilities';
+import NeedHelp from './NeedHelp';
+import Learn from './Learn';
 import OnThisPage from './OnThisPage';
+import TotalRatedDisabilities from './TotalRatedDisabilities';
 import RatedDisabilityList from './RatedDisabilityList';
 
 const RatedDisabilityView = ({
@@ -54,26 +55,8 @@ const RatedDisabilityView = ({
             ratedDisabilities={ratedDisabilities}
             sortToggle={sortToggle}
           />
-          <h2
-            id="learn"
-            className="vads-u-padding-bottom--1p5 vads-u-border-bottom--3px vads-u-border-color--primary vads-u-font-size--h3 vads-u-margin-top--2"
-          >
-            Learn about VA disability ratings
-          </h2>
-          <p>
-            To learn how we determined your VA combined disability rating, use
-            our disability rating calculator and ratings table.
-          </p>
-          <a href="/disability/about-disability-ratings/">
-            About VA disability ratings
-          </a>
-          <h3 className="vads-u-margin-top--3 vads-u-padding-bottom--1p5 vads-u-border-bottom--3px vads-u-border-color--primary">
-            Need help?
-          </h3>
-          <p className="vads-u-padding-bottom--3">
-            You can call us at <va-telephone contact={CONTACTS.VA_BENEFITS} />.
-            We’re here Monday through Friday, 8:00 a.m to 9:00 p.m. ET.
-          </p>
+          <Learn />
+          <NeedHelp />
         </div>
       </div>
     </div>

--- a/src/applications/rated-disabilities/components/RatedDisabilityView.jsx
+++ b/src/applications/rated-disabilities/components/RatedDisabilityView.jsx
@@ -2,11 +2,11 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { checkForDiscrepancies } from '../actions';
-import NeedHelp from './NeedHelp';
 import Learn from './Learn';
+import NeedHelp from './NeedHelp';
 import OnThisPage from './OnThisPage';
-import TotalRatedDisabilities from './TotalRatedDisabilities';
 import RatedDisabilityList from './RatedDisabilityList';
+import TotalRatedDisabilities from './TotalRatedDisabilities';
 
 const RatedDisabilityView = ({
   detectDiscrepancies,

--- a/src/applications/rated-disabilities/tests/components/RatedDisabilityListItem.unit.spec.jsx
+++ b/src/applications/rated-disabilities/tests/components/RatedDisabilityListItem.unit.spec.jsx
@@ -11,7 +11,7 @@ describe('<RatedDisabilityListItem />', () => {
     ratedDisability = {
       decisionText: 'Service Connected',
       diagnosticCode: 5238,
-      effectiveDate: moment('05/06/1999'),
+      effectiveDate: moment('1999-05-06'),
       relatedTo: 'Personal Trauma PTSD',
       name: 'Diabetes mellitus0',
       ratingPercentage: 100,
@@ -22,6 +22,7 @@ describe('<RatedDisabilityListItem />', () => {
     const formattedEffectiveDate = ratedDisability.effectiveDate.format(
       'MMMM DD, YYYY',
     );
+
     const wrapper = shallow(
       <RatedDisabilityListItem ratedDisability={ratedDisability} />,
     );

--- a/src/applications/rated-disabilities/tests/components/RatedDisabilityView.unit.spec.jsx
+++ b/src/applications/rated-disabilities/tests/components/RatedDisabilityView.unit.spec.jsx
@@ -2,7 +2,11 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
+import { render } from '@testing-library/react';
 
+import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
+
+import { heading as learnHeading } from '../../components/Learn';
 import RatedDisabilityView from '../../components/RatedDisabilityView';
 
 describe('<RatedDisabilityView/>', () => {
@@ -26,5 +30,29 @@ describe('<RatedDisabilityView/>', () => {
         .exists(),
     ).to.be.true;
     wrapper.unmount();
+  });
+
+  it('should display the Learn component', () => {
+    const screen = render(
+      <RatedDisabilityView
+        fetchRatedDisabilities={fetchRatedDisabilities}
+        fetchTotalDisabilityRating={fetchTotalDisabilityRating}
+        ratedDisabilities={ratedDisabilities}
+      />,
+    );
+
+    expect(screen.getByText(learnHeading));
+  });
+
+  it('should display the NeedHelp component', () => {
+    const { container } = render(
+      <RatedDisabilityView
+        fetchRatedDisabilities={fetchRatedDisabilities}
+        fetchTotalDisabilityRating={fetchTotalDisabilityRating}
+        ratedDisabilities={ratedDisabilities}
+      />,
+    );
+
+    expect($('va-need-help', container)).to.exist;
   });
 });


### PR DESCRIPTION
## Summary
Moving the learn and need help sections of the `RatedDisabilityView` component into their own components because there is a plan to reuse them in the the components related to the EVSS -> Lighthouse migration

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#63310

## Screenshots
**Note:** The 'Feedback' button only shows up in staging, the before picture is from staging, the after one is from my local

|               | Before | After |
| -------- | ------ | ----- |
| Desktop | <img width="1079" alt="Screenshot 2023-12-19 at 4 11 04 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/9e6f230d-3cfe-48b8-839b-8fceb2db5994"> | <img width="1079" alt="Screenshot 2023-12-19 at 4 22 33 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/be7bc70d-3d0d-429f-b313-9a6bf6b827bf"> |


## What areas of the site does it impact?
Rated Disabilities app

### Authentication
- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
