### PR TITLE
Remove debt selection on reviewNavigation

### DIFF
--- a/src/applications/financial-status-report/config/chapters/veteranInformationChapter.js
+++ b/src/applications/financial-status-report/config/chapters/veteranInformationChapter.js
@@ -57,6 +57,7 @@ export default {
         title: 'Available Debts',
         uiSchema: combinedDebts.uiSchema,
         schema: combinedDebts.schema,
+        depends: formData => !formData.reviewNavigation,
       },
       contactInfo: {
         initialData: {


### PR DESCRIPTION

Adding/removing selected debts while using review navigation can lead to a great number of issues for navigation, and streamlined calculations, so it's safer to remove it from the flow when in review navigation mode.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#67588


### Behavior

- Given: A veteran completes a form
- When: A veteran uses review navigation to edit the form
- Then: Debt selection page should be hidden from flow when in review nav

### Tasks

 Update depends for debt selection page to include consideration for `reviewNavigation`
 
### Acceptance criteria

-  debt selection page is hidden from flow when in review navigation mode
-  current functionality is unaffected.

## Testing done

-  Verified debt selection is hidden when in review navigation mode
-  Current functionality is unaffected
- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
