### PR TITLE
Update 10-10EZR prefill transformer to account for view fields

### DIFF
--- a/src/applications/ezr/tests/unit/utils/helpers/prefill-transformer.unit.spec.js
+++ b/src/applications/ezr/tests/unit/utils/helpers/prefill-transformer.unit.spec.js
@@ -85,6 +85,9 @@ describe('ezr prefill transformer', () => {
       veteranSocialSecurityNumber: '796121200',
       homePhone: '4445551212',
       email: 'test2@test1.net',
+      isMedicaidEligible: false,
+      isEnrolledMedicarePartA: false,
+      maritalStatus: 'never married',
     };
 
     context('when profile data omits all addresses', () => {
@@ -103,7 +106,7 @@ describe('ezr prefill transformer', () => {
           null,
           state,
         );
-        expect(Object.keys(prefillData)).to.have.lengthOf(7);
+        expect(Object.keys(prefillData)).to.have.lengthOf(9);
         expect(Object.keys(prefillData).veteranAddress).to.not.exist;
         expect(Object.keys(prefillData).veteranHomeAddress).to.not.exist;
         expect(prefillData['view:doesMailingMatchHomeAddress']).to.equal(
@@ -154,7 +157,7 @@ describe('ezr prefill transformer', () => {
           null,
           state,
         );
-        expect(Object.keys(prefillData)).to.have.lengthOf(8);
+        expect(Object.keys(prefillData)).to.have.lengthOf(10);
         expect(prefillData.veteranAddress).to.equal(undefined);
         expect(Object.keys(prefillData.veteranHomeAddress)).to.have.lengthOf(8);
         expect(prefillData['view:doesMailingMatchHomeAddress']).to.equal(
@@ -230,7 +233,7 @@ describe('ezr prefill transformer', () => {
             null,
             state,
           );
-          expect(Object.keys(prefillData)).to.have.lengthOf(9);
+          expect(Object.keys(prefillData)).to.have.lengthOf(11);
           expect(Object.keys(prefillData.veteranAddress)).to.have.lengthOf(8);
           expect(Object.keys(prefillData.veteranHomeAddress)).to.have.lengthOf(
             8,
@@ -307,7 +310,7 @@ describe('ezr prefill transformer', () => {
             null,
             state,
           );
-          expect(Object.keys(prefillData)).to.have.lengthOf(8);
+          expect(Object.keys(prefillData)).to.have.lengthOf(10);
           expect(Object.keys(prefillData).veteranHomeAddress).to.not.exist;
           expect(Object.keys(prefillData.veteranAddress)).to.have.lengthOf(8);
           expect(prefillData['view:doesMailingMatchHomeAddress']).to.be.true;

--- a/src/applications/ezr/tests/unit/utils/helpers/submit-transformer.unit.spec.js
+++ b/src/applications/ezr/tests/unit/utils/helpers/submit-transformer.unit.spec.js
@@ -25,11 +25,13 @@ describe('ezr submit transformer', () => {
           veteranSocialSecurityNumber: '234243444',
           veteranDateOfBirth: '1990-01-01',
           gender: 'F',
+          medicareClaimNumber: '7AD5WC9MW60',
+          medicarePartAEffectiveDate: '2009-01-02',
           'view:isMedicaidEligible': {
             isMedicaidEligible: true,
           },
           'view:isEnrolledMedicarePartA': {
-            isEnrolledMedicarePartA: false,
+            isEnrolledMedicarePartA: true,
           },
           'view:deductibleMedicalExpenses': {
             deductibleMedicalExpenses: 234,
@@ -76,8 +78,10 @@ describe('ezr submit transformer', () => {
             last: 'Doe',
           },
           veteranSocialSecurityNumber: '234243444',
+          medicareClaimNumber: '7AD5WC9MW60',
+          medicarePartAEffectiveDate: '2009-01-02',
           isMedicaidEligible: true,
-          isEnrolledMedicarePartA: false,
+          isEnrolledMedicarePartA: true,
           deductibleMedicalExpenses: 234,
           deductibleFuneralExpenses: 11,
           deductibleEducationExpenses: 0,

--- a/src/applications/ezr/utils/helpers/prefill-transformer.js
+++ b/src/applications/ezr/utils/helpers/prefill-transformer.js
@@ -1,3 +1,4 @@
+import omit from 'platform/utilities/data/omit';
 import { MILITARY_CITIES } from '../constants';
 
 /**
@@ -52,8 +53,32 @@ export function prefillTransformer(pages, formData, metadata, state) {
   const parsedAddressMatch =
     veteranAddress && veteranHomeAddress ? doesAddressMatch : undefined;
 
+  // omit data values that belong in a viewfield
+  const withoutViewFields = omit(
+    [
+      'email',
+      'homePhone',
+      'maritalStatus',
+      'isMedicaidEligible',
+      'isEnrolledMedicarePartA',
+    ],
+    formData,
+  );
+
+  const {
+    email = '',
+    homePhone = '',
+    maritalStatus = '',
+    isMedicaidEligible = undefined,
+    isEnrolledMedicarePartA = undefined,
+  } = formData;
+
   let newData = {
-    ...formData,
+    ...withoutViewFields,
+    'view:contactInformation': { email, homePhone },
+    'view:maritalStatus': { maritalStatus },
+    'view:isMedicaidEligible': { isMedicaidEligible },
+    'view:isEnrolledMedicarePartA': { isEnrolledMedicarePartA },
     'view:doesMailingMatchHomeAddress': parsedAddressMatch,
   };
 


### PR DESCRIPTION
## Summary
This PR updates the prefill transformer to correctly format data that needs to be in view fields to be successfully rendered and updatable with in the 10-10EZR form

## Related issue(s)
department-of-veterans-affairs/va.gov-team#71804

## Testing done

- Prior to the change, the data was not getting updated on submit due to keys that were in view fields not overwriting duplicate keys in the root object.
- After the change, the submit transformer successfully reduces the values down for updating.

## Acceptance criteria

- Data is correctly formatted for use in the form

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution