### PR TITLE
[CST] Add lighthouse to list of required services

### DIFF
--- a/src/applications/claims-status/containers/ClaimsStatusApp.jsx
+++ b/src/applications/claims-status/containers/ClaimsStatusApp.jsx
@@ -139,6 +139,7 @@ function ClaimsStatusApp({
       serviceRequired={[
         backendServices.EVSS_CLAIMS,
         backendServices.APPEALS_STATUS,
+        backendServices.LIGHTHOUSE,
       ]}
       user={user}
     >

--- a/src/applications/claims-status/tests/components/ClaimsStatusApp.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimsStatusApp.unit.spec.jsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 
-import backendServices from 'platform/user/profile/constants/backendServices';
+import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
 
 import { ClaimsStatusApp, AppContent } from '../../containers/ClaimsStatusApp';
 
@@ -20,6 +20,7 @@ describe('<ClaimsStatusApp>', () => {
     expect(tree.subTree('RequiredLoginView').props.serviceRequired).to.eql([
       backendServices.EVSS_CLAIMS,
       backendServices.APPEALS_STATUS,
+      backendServices.LIGHTHOUSE,
     ]);
     expect(tree.subTree('RequiredLoginView').props.verify).to.be.true;
   });


### PR DESCRIPTION
## Summary

- Updated ClaimStatusApp.jsx so that lighthouse is a part of the serviceRequired array
- Updated ClaimStatusApp.unit.spec.jsx so that the tests now account for this new lighthouse service to be required

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#71326

## Testing done

- Updated tests
- We were unable to find a user that had a participant id but no edipi, therefore this is a test that we will manually test in production. @jerekshoe is going to be my test user for this. Currently when he logs into va.gov he gets a forbidden error from the evss endpoint that we use for claims data. When this new change is merged he should no longer receive and error when attempting to view the claim status tool and he will be returned an empty list.

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
