### PR TITLE
Update cypress.config.js to remove deprecated param

### DIFF
--- a/config/cypress.config.js
+++ b/config/cypress.config.js
@@ -192,7 +192,6 @@ const cypressConfig = {
     baseUrl: 'http://localhost:3001',
     specPattern: 'src/**/tests/**/*.cypress.spec.js?(x)',
     supportFile: 'src/platform/testing/e2e/cypress/support/index.js',
-    experimentalSessionAndOrigin: true,
     includeShadowDom: true,
   },
 };


### PR DESCRIPTION
## Summary

The `experimentalSessionAndOrigin` parameter was [removed and made default behavior](https://docs.cypress.io/guides/references/experiments#History) as of version 12.0.0 - vets-website is [now on version 12.17.3](https://github.com/department-of-veterans-affairs/vets-website/blob/d2c10f8eb3ff3891b71cbc3520092aec5b0f4dc0/yarn.lock#L7522).

The following text is currently output when running cypress tests, removing the parameter from config suppresses it:

```
The experimentalSessionAndOrigin configuration option was removed in Cypress version 12.0.0.

You can safely remove this option from your config.
```
