### PR TITLE
Add unit test to NoOnlineCancelAlert

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
@@ -25,9 +25,9 @@ export default function DetailsVA({ appointment, facilityData }) {
     isPastAppointment,
     isCompAndPenAppointment,
     isPhoneAppointment,
+    isCancellable: isAppointmentCancellable,
   } = appointment.vaos;
   const canceled = appointment.status === APPOINTMENT_STATUS.cancelled;
-  const isAppointmentCancellable = appointment.vaos.isCancellable;
 
   const typeOfCareName = selectTypeOfCareName(appointment);
   // we don't want to display the appointment type header for upcoming C&P appointments.
@@ -87,11 +87,7 @@ export default function DetailsVA({ appointment, facilityData }) {
       <PrintLink appointment={appointment} />
       {isAppointmentCancellable && <CancelLink appointment={appointment} />}
       {!isAppointmentCancellable && (
-        <NoOnlineCancelAlert
-          appointment={appointment}
-          facility={facility}
-          isCompAndPenAppointment={isCompAndPenAppointment}
-        />
+        <NoOnlineCancelAlert appointment={appointment} facility={facility} />
       )}
     </>
   );

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/NoOnlineCancelAlert.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/NoOnlineCancelAlert.jsx
@@ -1,16 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import FacilityPhone from '../../../components/FacilityPhone';
 import InfoAlert from '../../../components/InfoAlert';
 import { getFacilityPhone } from '../../../services/location';
 import { APPOINTMENT_STATUS } from '../../../utils/constants';
 
-export default function NoOnlineCancelAlert({
-  appointment,
-  facility,
-  isCompAndPenAppointment,
-}) {
+export default function NoOnlineCancelAlert({ appointment, facility }) {
   const canceled = appointment.status === APPOINTMENT_STATUS.cancelled;
-  const { isPastAppointment } = appointment.vaos;
+  const { isPastAppointment, isCompAndPenAppointment } = appointment.vaos;
 
   if (canceled || isPastAppointment) {
     return null;
@@ -58,3 +55,30 @@ export default function NoOnlineCancelAlert({
     </InfoAlert>
   );
 }
+
+NoOnlineCancelAlert.propTypes = {
+  appointment: PropTypes.shape({
+    status: PropTypes.string.isRequired,
+    vaos: PropTypes.shape({
+      isPastAppointment: PropTypes.bool,
+      isCompAndPenAppointment: PropTypes.bool,
+    }),
+  }),
+
+  facility: PropTypes.shape({
+    name: PropTypes.string,
+    telecom: PropTypes.array,
+  }),
+};
+
+NoOnlineCancelAlert.defaultProps = {
+  appointment: {
+    status: 'booked',
+    vaos: {
+      isPastAppointment: false,
+      isCompAndPenAppointment: false,
+    },
+  },
+
+  facility: null,
+};

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/tests/NoOnlineCancelAlert.unit.spec.js
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/tests/NoOnlineCancelAlert.unit.spec.js
@@ -1,0 +1,122 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { APPOINTMENT_STATUS } from '../../../../utils/constants';
+import NoOnlineCancelAlert from '../NoOnlineCancelAlert';
+import { Facility } from '../../../../tests/mocks/unit-test-helpers';
+
+describe('No Online Cancel Modal', () => {
+  const appointmentData = {
+    vaos: {
+      isPastAppointment: false,
+    },
+    status: APPOINTMENT_STATUS.booked,
+  };
+
+  const facilityData = new Facility();
+  it('should not render alert when the appointment has past', async () => {
+    // Given it is a past appointment
+    const appointment = {
+      ...appointmentData,
+      vaos: {
+        isPastAppointment: true,
+      },
+    };
+    // When the page is rendered
+    const screen = render(<NoOnlineCancelAlert appointment={appointment} />);
+    // It will not show alert message
+    expect(screen.baseElement).to.not.contain('.usa-alert-text');
+  });
+  it('should not render alert when status is cancelled', async () => {
+    // Given it is a cancelled appointment
+    const appointment = {
+      ...appointmentData,
+      status: APPOINTMENT_STATUS.cancelled,
+    };
+    // When the page is rendered
+    const screen = render(<NoOnlineCancelAlert appointment={appointment} />);
+    // It will not display alert message
+    expect(screen.baseElement).to.not.contain('.usa-alert-text');
+  });
+  it('should render alert message to contact comp and pension office', async () => {
+    // Given the appointment status is booked and is a comp and pension
+    const appointment = {
+      ...appointmentData,
+      vaos: {
+        isCompAndPenAppointment: true,
+      },
+    };
+    // When the page is rendered
+    const screen = render(
+      <NoOnlineCancelAlert appointment={appointment} facility={facilityData} />,
+    );
+    expect(screen.baseElement).to.contain('.usa-alert-text');
+    // Then it will display the alert box
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: /Need to make changes?/,
+      }),
+    );
+    // And the message to contact comp and pension office to cancel appointment
+    expect(screen.baseElement).to.contain.text(
+      'Contact the Cheyenne VA Medical Center compensation and pension',
+    );
+    // with associated phone number
+    expect(screen.findAllByTestId('facility-telephone')).to.exist;
+  });
+  it('should render alert message to contact facility to cancel', async () => {
+    // Given the appointment status is booked but is not a comp and pension
+    const appointment = {
+      ...appointmentData,
+      vaos: {
+        isCompAndPenAppointment: false,
+      },
+    };
+    // When the page is rendered
+    const screen = render(
+      <NoOnlineCancelAlert appointment={appointment} facility={facilityData} />,
+    );
+    // Then it will display the alert box
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: /Need to make changes?/,
+      }),
+    );
+    // And the message to contact facility to cancel appointment
+    expect(screen.baseElement).to.contain.text(
+      'Contact this facility if you need to reschedule or cancel',
+    );
+    // With the associated phone number
+    expect(screen.baseElement).to.contain('va-telephone');
+    expect(screen.findAllByTestId('facility-telephone')).to.exist;
+  });
+  it('should render alert message to contact the facility where patient scheduled it ', async () => {
+    // Given the appointment status is booked but is not a comp and pension
+    const appointment = {
+      ...appointmentData,
+      vaos: {
+        isCompAndPenAppointment: false,
+      },
+    };
+    // When the page is rendered with missing facility data
+    const screen = render(
+      <NoOnlineCancelAlert appointment={appointment} facility={null} />,
+    );
+
+    // Then it will display the alert box
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: /Need to make changes?/,
+      }),
+    );
+    // And the message to contact facility to cancel appointment
+    expect(screen.baseElement).to.contain.text(
+      'contact the VA facility where you scheduled it.',
+    );
+    // With no associated phone number
+    expect(screen.queryByTestId('facility-telephone')).to.be.null;
+  });
+});

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -71,6 +71,7 @@
         "slot": null,
         "start": "2023-12-21T18:19:34",
         "status": "cancelled",
+        "cancellable": false,
         "localStartTime": "2023-12-21T09:00:00.000-06:00",
         "telehealth": null
       }
@@ -913,6 +914,8 @@
         "minutesDuration": 30,
         "requestedPeriods": null,
         "cancellable": false,
+        "clinic": "some string",
+        "friendlyName": "clinic friendly name",
         "patientInstruction": "Preparations:\n- If you have any new non-VA medical records since your last visit, please bring them.\r\nIf you need to cancel or reschedule your appointment, please call our Contact Center at 614-257-5200 or visit the patient portal.",
         "extension": {
           "ccLocation": {
@@ -2080,10 +2083,11 @@
         ],
         "patientIcn": "1013120826V646496",
         "locationId": "983GC",
+        "localStartTime": "2024-06-22T09:00:00.000-06:00",
         "clinic": "945",
-        "start": "2023-06-22T13:00:00Z",
-        "end": "2023-06-22T14:00:00Z",
-        "created": "2023-03-17T00:00:00Z",
+        "start": "2024-06-22T13:00:00Z",
+        "end": "2024-06-22T14:00:00Z",
+        "created": "2024-03-17T00:00:00Z",
         "cancellable": false,
         "extension": {
           "ccLocation": {


### PR DESCRIPTION

## Summary

This PR refactors the code for `NoOnlineCancelAlert.jsx` and adds unit test coverage 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#67671

## Testing done

unit test

## Screenshots

![Screenshot 2023-12-19 at 4 55 56 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/87fca812-31b1-42e2-afbb-ed4007364403)


## What areas of the site does it impact?
unit test coverage

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

- [ ]  file coverage for Branches, functions, lines and statements is 100%

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions


