### PR TITLE
NOD - Fix area of disagreement updating on review page

### DIFF
--- a/src/applications/appeals/shared/components/AreaOfDisagreement.jsx
+++ b/src/applications/appeals/shared/components/AreaOfDisagreement.jsx
@@ -9,6 +9,7 @@ import {
 import cloneDeep from 'platform/utilities/data/cloneDeep';
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import { waitForRenderThenFocus } from 'platform/utilities/ui';
+import { scrollToFirstError } from 'platform/forms-system/src/js/utilities//ui';
 
 import { DISAGREEMENT_TYPES, MAX_LENGTH } from '../constants';
 import {
@@ -69,7 +70,7 @@ const AreaOfDisagreement = ({
       // event.target.name doesn't work on va-checkbox
       const name = event.target.getAttribute('name');
       const { checked } = event.detail;
-      if (name && pagePerItemIndex) {
+      if (name) {
         const areaOfDisagreement = cloneDeep(data.areaOfDisagreement || []);
         const disagreement = areaOfDisagreement[pagePerItemIndex] || {};
         disagreement.disagreementOptions = {
@@ -102,10 +103,15 @@ const AreaOfDisagreement = ({
       return false;
     },
     updatePage: () => {
-      waitForRenderThenFocus(
-        `[name="areaOfDisagreementFollowUp${pagePerItemIndex}ScrollElement"] + form va-button[text="Edit"]`,
-      );
-      updatePage();
+      const disagreement = data.areaOfDisagreement[pagePerItemIndex] || {};
+      if (!setMaxError(disagreement) && !setCheckboxError(disagreement)) {
+        waitForRenderThenFocus(
+          `[name="areaOfDisagreementFollowUp${pagePerItemIndex}ScrollElement"] + form va-button[text="Edit"]`,
+        );
+        updatePage();
+      } else {
+        scrollToFirstError();
+      }
     },
   };
 

--- a/src/applications/appeals/shared/tests/components/AreaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/AreaOfDisagreement.unit.spec.jsx
@@ -169,12 +169,39 @@ describe('<AreaOfDisagreement>', () => {
     });
     const { container } = render(
       <div>
-        <AreaOfDisagreement {...data} />
+        <AreaOfDisagreement {...data} pagePerItemIndex="0" />
       </div>,
     );
 
     fireEvent.click($('va-button', container));
     expect(updateSpy.called).to.be.true;
+  });
+
+  it('should not submit on review page with nothing is set', () => {
+    const updateSpy = sinon.spy();
+    const aod = {
+      ...aod2,
+      disagreementOptions: {
+        serviceConnection: false,
+        effectiveDate: false,
+        evaluation: false,
+      },
+      otherEntry: '',
+    };
+    const data = getData({
+      updatePage: updateSpy,
+      data: [aod],
+      onReviewPage: true,
+    });
+    const { container } = render(
+      <div>
+        <AreaOfDisagreement {...data} />
+      </div>,
+    );
+
+    fireEvent.click($('va-button', container));
+    expect(updateSpy.called).to.be.false;
+    expect($('va-checkbox-group[error]', container)).to.exist;
   });
 
   it('should not submit page when nothing is checked or input is empty', async () => {


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Fix updating the first area of disagreement entry on the review & submit page. Updates are now properly saved. In addition, removing all area of disagreement values will now properly show and focus on the error & prevent page updating. 
- _(If bug, how to reproduce)_
  > Edit first area of disagreement, if changing selections & then updating page, no changes are saved. If removing all values, in any area of disagreement, the update page will ignore validation and allow saving the page with no values set.
- _(What is the solution, why is this the solution)_
  > Removed array index check (the zero falsey value was preventing data update) - the index is a string within the form flow, and a number on the review & submit page
  > Added error checking to the update page callback, used on the review & submit page
  > Added unit tests
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#71284](https://github.com/department-of-veterans-affairs/va.gov-team/issues/71284)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

![area of disagreement edits now properly update the form data, and removing all values will now focus on the error & prevent page update on the review & submit page](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/5a3022af-b2b9-4675-9b3f-6a027a5fa92c)

## What areas of the site does it impact?

HLR & NOD

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
