### PR TITLE
Migrate ArrayField remove-modal to v3-web-components

### DIFF
--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -470,6 +470,7 @@ export default class ArrayField extends React.Component {
                         this.closeRemoveModal(index)
                       }
                       visible={isRemoving}
+                      uswds
                     >
                       {uiOptions.confirmRemoveDescription && (
                         <p>{uiOptions.confirmRemoveDescription}</p>


### PR DESCRIPTION
## Summary

- Migrate ArrayField components VaModal component to v3-web-components (USWDS)
- Team: Veteran Facing Forms
- Flipper On in Staging, OFF in Prod. End-date TBD.

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms#856

## Testing done

- Local browser- & unit-tests were all successful

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/587583/ecb89022-68ca-4e54-ae8e-6d32d79f744a) | ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/587583/21f4c281-6d18-41dc-b778-d81a8a15fb8a) |

## What areas of the site does it impact?

All forms that have array-fields
