### PR TITLE
MHV-51157 Staging-Review-Validation-For-Pathology

### DIFF
--- a/src/applications/mhv/medical-records/components/LabsAndTests/PathologyDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/PathologyDetails.jsx
@@ -94,7 +94,7 @@ ${record.results} \n`;
         <DownloadingRecordsInfo allowTxtDownloads={allowTxtDownloads} />
       </div>
       <div className="test-details-container max-80">
-        <h4>Details about this test</h4>
+        <h2>Details about this test</h2>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Sample tested
         </h3>

--- a/src/applications/mhv/medical-records/components/LabsAndTests/PathologyDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/PathologyDetails.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
+import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
 import PrintHeader from '../shared/PrintHeader';
 import PrintDownload from '../shared/PrintDownload';
 import DownloadingRecordsInfo from '../shared/DownloadingRecordsInfo';
@@ -15,10 +16,11 @@ import {
 import {
   updatePageTitle,
   generatePdfScaffold,
+  formatName,
 } from '../../../shared/util/helpers';
-import { EMPTY_FIELD, pageTitles } from '../../util/constants';
+import { pageTitles } from '../../util/constants';
 import DateSubheading from '../shared/DateSubheading';
-import { txtLine } from '../../../shared/util/constants';
+import { txtLine, crisisLineHeader } from '../../../shared/util/constants';
 import {
   generateLabsIntro,
   generatePathologyContent,
@@ -37,11 +39,8 @@ const PathologyDetails = props => {
   useEffect(
     () => {
       focusElement(document.querySelector('h1'));
-      const titleDate = record.date !== EMPTY_FIELD ? `${record.date} - ` : '';
       updatePageTitle(
-        `${titleDate}${record.name} - ${
-          pageTitles.LAB_AND_TEST_RESULTS_PAGE_TITLE
-        }`,
+        `${record.name} - ${pageTitles.LAB_AND_TEST_RESULTS_PAGE_TITLE}`,
       );
     },
     [record],
@@ -57,7 +56,10 @@ const PathologyDetails = props => {
 
   const generatePathologyTxt = async () => {
     const content = `
+${crisisLineHeader}\n\n    
 ${record.name} \n
+${formatName(user.userFullName)}\n
+Date of birth: ${formatDateLong(user.dob)}\n
 Details about this test: \n
 ${txtLine} \n
 Sample tested: ${record.sampleTested} \n

--- a/src/applications/mhv/medical-records/components/LabsAndTests/PathologyDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/PathologyDetails.jsx
@@ -109,7 +109,7 @@ ${record.results} \n`;
         <p data-testid="pathology-date-completed">{record.date}</p>
       </div>
       <div className="test-results-container">
-        <h4>Results</h4>
+        <h2>Results</h2>
         <InfoAlert fullState={fullState} />
         <p data-testid="pathology-results">{record.results}</p>
       </div>

--- a/src/applications/mhv/medical-records/containers/LabsAndTests.jsx
+++ b/src/applications/mhv/medical-records/containers/LabsAndTests.jsx
@@ -4,6 +4,7 @@ import { focusElement } from '@department-of-veterans-affairs/platform-utilities
 import RecordList from '../components/RecordList/RecordList';
 import { getLabsAndTestsList } from '../actions/labsAndTests';
 import { setBreadcrumbs } from '../actions/breadcrumbs';
+import NoRecordsMessage from '../components/shared/NoRecordsMessage';
 import {
   ALERT_TYPE_ERROR,
   accessAlertTypes,
@@ -13,7 +14,6 @@ import {
 import { updatePageTitle } from '../../shared/util/helpers';
 import AccessTroubleAlertBox from '../components/shared/AccessTroubleAlertBox';
 import useAlerts from '../hooks/use-alerts';
-import NoRecordsMessage from '../components/shared/NoRecordsMessage';
 
 const LabsAndTests = () => {
   const dispatch = useDispatch();
@@ -49,6 +49,9 @@ const LabsAndTests = () => {
       return (
         <AccessTroubleAlertBox alertType={accessAlertTypes.LABS_AND_TESTS} />
       );
+    }
+    if (labsAndTests?.length === 0) {
+      return <NoRecordsMessage type={recordType.LABS_AND_TESTS} />;
     }
     if (labsAndTests?.length > 0) {
       return (

--- a/src/applications/mhv/medical-records/tests/containers/LabsAndTests.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/containers/LabsAndTests.unit.spec.jsx
@@ -100,7 +100,7 @@ describe('Labs and tests list container with no data', () => {
       screen.getByText(
         'There are no lab and test results in your VA medical records.',
         {
-          exact: true,
+          exact: false,
         },
       ),
     ).to.exist;


### PR DESCRIPTION

## Summary
I have recently updated and reviewed both PathologyDetails.jsx and LabsAndTests.jsx to ensure they align with the acceptance criteria required for the staging review.

## Related issue(s)

[MHV-51157](https://jira.devops.va.gov/browse/MHV-51157) - Staging Review Validation for Pathology

User Story: As a Medical Records Team we want to ensure all staging review recommendations given during the Allergies staging review filters down to all other domains.

Feature Flag Y/N ? TBD
Manual Testing Y/N ? TBD
Automated Testing Y/N ? TBD
Accessibility Testing Y/N ? TBD

Acceptance Criteria:
AC1 Allergies staging review feedback has been reviewed for this domain and any issues found have been resolved or new JIRA tickets have been created.
AC2 Findings have been documented in this ticket.
AC3
AC4
AC5

Links to UCD:
Sketch Link:
Other Design Notes

Architectural Notes:

## Testing done

Conducted UI testing to ensure the expected behavior. I updated existing unit test for new components.

## Screenshots

![Screenshot 2023-12-26 at 12 21 31 PM (2)](https://github.com/department-of-veterans-affairs/vets-website/assets/8038703/7ba6ff00-a82a-4a22-bd1c-1653fe620274)

![Screenshot 2023-12-26 at 12 20 22 PM (2)](https://github.com/department-of-veterans-affairs/vets-website/assets/8038703/1a98e267-50c4-4c3f-b505-343e7614cac7)


## What areas of the site does it impact?

PathologyDetails & LabsAndTests pages.

## Acceptance criteria

1.  The date below 'h1' on the details page (/medical-records/allergies/:allergyId) should be changed from an 'h2' to a 'p' tag.

2. The notification for a user with no records of allergies should be changed from an alert to a message.

3. The floating print/download menu options should be fixed to eliminate the space between the Print or Download box and the options box.

4. Duplicate element IDs caused by "print-only" content in /medical-records/allergies and /medical-records/allergies/:allergyId should be discussed with Mike and resolved as needed.

5. The date should be removed from the page title for Allergy details pages to ensure it matches the correct page title format.

6. Unit test coverage for all metrics (lines, functions, statements, and branches) is already above 80%, so no further action is required.

7. The PDF and TXT content/formatting for list and details views must be updated where applicable to match the latest content from the UCD team mockups. The TXT content should be formatted properly with specific guidelines, including the presence of specific information in a particular order.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user


