### PR TITLE
GA event bug for 45 minute check-in message

### DIFF
--- a/src/applications/check-in/api/versions/v2.js
+++ b/src/applications/check-in/api/versions/v2.js
@@ -96,7 +96,7 @@ const v2 = {
 
     const json = await makeApiCallWithSentry(
       apiRequest(`${environment.API_URL}${url}`, settings),
-      `check-in-user${setECheckinStartedCalled ? '-45MR' : ''}`,
+      `check-in-user${setECheckinStartedCalled ? '' : '-45MR'}`,
       uuid,
     );
     return {

--- a/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
+++ b/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
@@ -47,7 +47,7 @@ const ConfirmablePage = ({
   const onYesClick = () => {
     recordEvent({
       event: createAnalyticsSlug(
-        `yes-to-${pageType}${setECheckinStartedCalled ? '-45MR' : ''}-clicked`,
+        `yes-to-${pageType}${setECheckinStartedCalled ? '' : '-45MR'}-clicked`,
         'nav',
       ),
     });
@@ -58,7 +58,7 @@ const ConfirmablePage = ({
     recordEvent({
       event: createAnalyticsSlug(
         `no-to-${pageType}${pageType}${
-          setECheckinStartedCalled ? '-45MR' : ''
+          setECheckinStartedCalled ? '' : '-45MR'
         }-clicked`,
         'nav',
       ),

--- a/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
+++ b/src/applications/check-in/components/pages/ConfirmablePage/index.jsx
@@ -57,9 +57,7 @@ const ConfirmablePage = ({
   const onNoClick = () => {
     recordEvent({
       event: createAnalyticsSlug(
-        `no-to-${pageType}${pageType}${
-          setECheckinStartedCalled ? '' : '-45MR'
-        }-clicked`,
+        `no-to-${pageType}${setECheckinStartedCalled ? '' : '-45MR'}-clicked`,
         'nav',
       ),
     });

--- a/src/applications/check-in/components/pages/TravelPage/index.jsx
+++ b/src/applications/check-in/components/pages/TravelPage/index.jsx
@@ -45,7 +45,7 @@ const TravelPage = ({
     recordEvent({
       event: createAnalyticsSlug(
         `${answer}-to-${pageType}${
-          setECheckinStartedCalled ? '-45MR' : ''
+          setECheckinStartedCalled ? '' : '-45MR'
         }-clicked`,
         'nav',
       ),


### PR DESCRIPTION
## Summary

This PR fixes a bug where we had reversed the 45 minute check-in event labels

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#72671

## Testing done

-  Manually tested

## What areas of the site does it impact?

Day-of check-in GA events

## Acceptance criteria

45 minute event labels fire when setECheckInStarted is false

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

