### PR TITLE
Return to review & submit after add issue

### DIFF
--- a/src/applications/appeals/shared/components/AddIssue.jsx
+++ b/src/applications/appeals/shared/components/AddIssue.jsx
@@ -11,7 +11,13 @@ import recordEvent from 'platform/monitoring/record-event';
 
 import { content } from '../content/addIssue';
 
-import { CONTESTABLE_ISSUES_PATH, MAX_LENGTH, SELECTED } from '../constants';
+import {
+  CONTESTABLE_ISSUES_PATH,
+  REVIEW_AND_SUBMIT,
+  REVIEW_ISSUES,
+  MAX_LENGTH,
+  SELECTED,
+} from '../constants';
 import { calculateIndexOffset, getSelected } from '../utils/issues';
 import { setStorage } from '../utils/addIssue';
 import { checkValidations } from '../validations';
@@ -39,7 +45,10 @@ const AddIssue = ({
   const currentData = allIssues[index] || {};
 
   const addOrEdit = currentData.issue ? 'edit' : 'add';
-  const returnPath = `/${CONTESTABLE_ISSUES_PATH}`;
+  const returnPath =
+    window.sessionStorage.getItem(REVIEW_ISSUES) === 'true'
+      ? REVIEW_AND_SUBMIT
+      : `/${CONTESTABLE_ISSUES_PATH}`;
 
   const nameValidations = [
     missingIssueName,

--- a/src/applications/appeals/shared/tests/components/AddIssue.unit.spec.js
+++ b/src/applications/appeals/shared/tests/components/AddIssue.unit.spec.js
@@ -11,7 +11,14 @@ import {
 import AddIssue from '../../components/AddIssue';
 import { getDate } from '../../utils/dates';
 
-import { LAST_ISSUE, MAX_LENGTH, MAX_YEARS_PAST } from '../../constants';
+import {
+  CONTESTABLE_ISSUES_PATH,
+  REVIEW_AND_SUBMIT,
+  REVIEW_ISSUES,
+  LAST_ISSUE,
+  MAX_LENGTH,
+  MAX_YEARS_PAST,
+} from '../../constants';
 import sharedErrorMessages from '../../content/errorMessages';
 
 import { errorMessages } from '../../../995/constants';
@@ -218,6 +225,26 @@ describe('<AddIssue>', () => {
 
     expect($('va-text-input', container).error).to.be.null;
     expect($('va-memorable-date', container).error).to.be.null;
-    expect(goToPathSpy.called).to.be.true;
+    expect(goToPathSpy.calledWith(`/${CONTESTABLE_ISSUES_PATH}`)).to.be.true;
+  });
+  it('should submit when everything is valid', () => {
+    window.sessionStorage.setItem(REVIEW_ISSUES, 'true');
+    const goToPathSpy = sinon.spy();
+    const additionalIssues = [
+      { issue: 'test', decisionDate: getDate({ offset: { months: -3 } }) },
+    ];
+    const { container } = render(
+      setup({
+        goToPath: goToPathSpy,
+        data: { contestedIssues, additionalIssues },
+        index: 1,
+      }),
+    );
+    fireEvent.click($('#submit', container));
+
+    expect($('va-text-input', container).error).to.be.null;
+    expect($('va-memorable-date', container).error).to.be.null;
+    expect(goToPathSpy.calledWith(REVIEW_AND_SUBMIT)).to.be.true;
+    window.sessionStorage.removeItem(REVIEW_ISSUES);
   });
 });


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > After moving our decision reviews add issue code into the shared folder, we may have removed the ability for the page to return to the review & submit page. This PR ensures that after updating or canceling changes on the add/edit issue page, the Veteran is returned to the correct page: contestable issues page within the form flow, or on the review & submit page. The review & submit page accordion does not expand currently; this is because of the change to use web components which do not currently allow programmatically opening the accordion with a property. 
- _(If bug, how to reproduce)_
  > In any decision review form, on the review & submit page, edit or add an issue; after canceling or updating the issue, you will be returned to the contestable issues page within the flow, not the review & submit page
- _(What is the solution, why is this the solution)_
  > The return path was not correctly checking the review page flag in session storage.
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#72285](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72285)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Incorrect return path was called
- _Describe the steps required to verify your changes are working as expected_
  > Follow steps described in summary
- _Describe the tests completed and the results_
  > Added test to check return path
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A - no UI changes

## What areas of the site does it impact?

Decision reviews: HLR, NOD & Supplemental Claim

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
