### PR TITLE
Add unit test for DetailsCC

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsCC.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsCC.jsx
@@ -12,11 +12,7 @@ import ProviderName from './ProviderName';
 import CCInstructions from './CCInstructions';
 import { getTypeOfCareById } from '../../../utils/appointment';
 
-export default function DetailsCC({
-  appointment,
-  useV2 = false,
-  featureVaosV2Next = false,
-}) {
+export default function DetailsCC({ appointment, useV2, featureVaosV2Next }) {
   const header = 'Community care provider';
   const facility = appointment.communityCareProvider;
   const typeOfCare = getTypeOfCareById(appointment.vaos.apiData.serviceType);
@@ -68,7 +64,6 @@ export default function DetailsCC({
         showDirectionsLink={!!appointment.communityCareProvider?.address}
         level={2}
       />
-
       <CCInstructions appointment={appointment} />
       <CalendarLink appointment={appointment} facility={facility} />
       <PrintLink appointment={appointment} />
@@ -78,7 +73,72 @@ export default function DetailsCC({
 }
 
 DetailsCC.propTypes = {
-  appointment: PropTypes.object.isRequired,
+  appointment: PropTypes.shape({
+    id: PropTypes.string,
+    start: PropTypes.string.isRequired,
+    comment: PropTypes.string,
+    status: PropTypes.string.isRequired,
+    vaos: PropTypes.shape({
+      isPastAppointment: PropTypes.bool.isRequired,
+      isUpcomingAppointment: PropTypes.bool.isRequired,
+      isPendingAppointment: PropTypes.bool.isRequired,
+      isCompAndPenAppointment: PropTypes.bool,
+      isPhoneAppointment: PropTypes.bool,
+      apiData: PropTypes.shape({
+        serviceType: PropTypes.string,
+      }),
+    }),
+    location: PropTypes.shape({
+      vistaId: PropTypes.string.isRequired,
+      stationId: PropTypes.string,
+    }),
+    communityCareProvider: PropTypes.shape({
+      treatmentSpecialty: PropTypes.string,
+      providerName: PropTypes.array,
+      telecom: PropTypes.array,
+      address: PropTypes.shape({
+        postalCode: PropTypes.string.isRequired,
+        city: PropTypes.string.isRequired,
+        state: PropTypes.string.isRequired,
+        line: PropTypes.array.isRequired,
+      }),
+    }),
+  }),
   featureVaosV2Next: PropTypes.bool,
   useV2: PropTypes.bool,
+};
+DetailsCC.defaultProps = {
+  appointment: {
+    id: '',
+    start: '',
+    comment: '',
+    status: '',
+    vaos: {
+      isPastAppointment: false,
+      isUpcomingAppointment: true,
+      isPendingAppointment: false,
+    },
+    location: {
+      vistaId: '',
+      stationId: '',
+    },
+    communityCareProvider: {
+      treatmentSpecialty: '',
+      providerName: [''],
+      telecom: [
+        {
+          system: '',
+          value: '',
+        },
+      ],
+      address: {
+        postalCode: '',
+        city: '',
+        state: '',
+        line: [''],
+      },
+    },
+  },
+  featureVaosV2Next: false,
+  useV2: false,
 };

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsCC.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsCC.jsx
@@ -73,72 +73,11 @@ export default function DetailsCC({ appointment, useV2, featureVaosV2Next }) {
 }
 
 DetailsCC.propTypes = {
-  appointment: PropTypes.shape({
-    id: PropTypes.string,
-    start: PropTypes.string.isRequired,
-    comment: PropTypes.string,
-    status: PropTypes.string.isRequired,
-    vaos: PropTypes.shape({
-      isPastAppointment: PropTypes.bool.isRequired,
-      isUpcomingAppointment: PropTypes.bool.isRequired,
-      isPendingAppointment: PropTypes.bool.isRequired,
-      isCompAndPenAppointment: PropTypes.bool,
-      isPhoneAppointment: PropTypes.bool,
-      apiData: PropTypes.shape({
-        serviceType: PropTypes.string,
-      }),
-    }),
-    location: PropTypes.shape({
-      vistaId: PropTypes.string.isRequired,
-      stationId: PropTypes.string,
-    }),
-    communityCareProvider: PropTypes.shape({
-      treatmentSpecialty: PropTypes.string,
-      providerName: PropTypes.array,
-      telecom: PropTypes.array,
-      address: PropTypes.shape({
-        postalCode: PropTypes.string.isRequired,
-        city: PropTypes.string.isRequired,
-        state: PropTypes.string.isRequired,
-        line: PropTypes.array.isRequired,
-      }),
-    }),
-  }),
+  appointment: PropTypes.object.isRequired,
   featureVaosV2Next: PropTypes.bool,
   useV2: PropTypes.bool,
 };
 DetailsCC.defaultProps = {
-  appointment: {
-    id: '',
-    start: '',
-    comment: '',
-    status: '',
-    vaos: {
-      isPastAppointment: false,
-      isUpcomingAppointment: true,
-      isPendingAppointment: false,
-    },
-    location: {
-      vistaId: '',
-      stationId: '',
-    },
-    communityCareProvider: {
-      treatmentSpecialty: '',
-      providerName: [''],
-      telecom: [
-        {
-          system: '',
-          value: '',
-        },
-      ],
-      address: {
-        postalCode: '',
-        city: '',
-        state: '',
-        line: [''],
-      },
-    },
-  },
   featureVaosV2Next: false,
   useV2: false,
 };

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/tests/DetailsCC.unit.spec.js
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/tests/DetailsCC.unit.spec.js
@@ -1,0 +1,128 @@
+import React from 'react';
+import { expect } from 'chai';
+import { renderWithStoreAndRouter } from '~/platform/testing/unit/react-testing-library-helpers';
+import DetailsCC from '../DetailsCC';
+
+const appointmentData = {
+  start: '2024-07-19T08:00:00-07:00',
+  version: 2,
+  status: 'booked',
+  videoData: {
+    isVideo: false,
+  },
+  location: {
+    vistaId: '983',
+    clinicId: '848',
+    stationId: '983',
+  },
+  vaos: {
+    isCanceled: false,
+    isUpcomingAppointment: true,
+    isPastAppointment: false,
+    isCommunityCare: true,
+    apiData: {},
+  },
+  communityCareProvider: {
+    treatmentSpecialty: 'Optometrist',
+    providerName: ['John Smith'],
+    telecom: [
+      {
+        system: 'phone',
+        value: '703-691-2020',
+      },
+    ],
+    address: {
+      postalCode: '22030',
+      city: 'FAIRFAX',
+      state: 'VA',
+      line: ['10640 MAIN ST ; STE 100'],
+    },
+  },
+};
+
+describe('DetailsCC component', () => {
+  const initialState = {
+    featureToggles: {},
+  };
+
+  it('should render the specialty type', async () => {
+    // Given the appointment has treatmentSpecialty
+    const appointment = {
+      ...appointmentData,
+    };
+    // when featureVaosV2Next flag is on
+    const screen = renderWithStoreAndRouter(
+      <DetailsCC appointment={appointment} useV2 featureVaosV2Next />,
+      {
+        initialState,
+        path: `/${appointment.id}`,
+      },
+    );
+    // it will display the div that contains the data-testid
+    expect(screen.getByTestId('appointment-treatment-specialty')).to.exist;
+  });
+  it('should not render the specialty type', async () => {
+    // Given the appointment has treatmentSpecialty
+    const appointment = {
+      ...appointmentData,
+    };
+    // when featureVaosV2Next flag is off
+    const screen = renderWithStoreAndRouter(
+      <DetailsCC appointment={appointment} useV2 featureVaosV2Next={false} />,
+      {
+        initialState,
+        path: `/${appointment.id}`,
+      },
+    );
+    // it will not display the div that contains the data-testid
+    expect(screen.queryByTestId('appointment-treatment-specialty')).to.be.null;
+  });
+  it('should render the type of care', async () => {
+    // Given the appointment has serviceType
+    const appointment = {
+      ...appointmentData,
+      vaos: {
+        ...appointmentData.vaos,
+        apiData: { serviceType: 'audiology' },
+      },
+      communityCareProvider: {
+        ...appointmentData.communityCareProvider,
+        treatmentSpecialty: null,
+      },
+    };
+    // when useV2 flag is on
+    const screen = renderWithStoreAndRouter(
+      <DetailsCC appointment={appointment} useV2 featureVaosV2Next />,
+      {
+        initialState,
+        path: `/${appointment.id}`,
+      },
+    );
+    // it will display type of care
+    expect(screen.getByText('Type of care')).to.exist;
+  });
+  it('should not render the type of care', async () => {
+    // Given the appointment has serviceType
+    const appointment = {
+      ...appointmentData,
+      vaos: {
+        ...appointmentData.vaos,
+        apiData: { serviceType: 'audiology' },
+      },
+      communityCareProvider: {
+        ...appointmentData.communityCareProvider,
+        treatmentSpecialty: null,
+      },
+    };
+    // when useV2 flag is off
+    const screen = renderWithStoreAndRouter(
+      <DetailsCC appointment={appointment} useV2={false} featureVaosV2Next />,
+      {
+        initialState,
+        path: `/${appointment.id}`,
+      },
+    );
+    // it will not display type of care
+    expect(screen.queryByText('Type of care')).to.be.null;
+  });
+});


### PR DESCRIPTION

## Summary

This PR adds unit test coverage for DetailsCC and defines the default Props

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#67666


## Testing done

unit test

## Screenshots
![Screenshot 2024-01-03 at 2 50 22 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/e47fecfb-2773-4c8b-a91e-1a672a37451b)


## What areas of the site does it impact?

unit test coverage

## Acceptance criteria

- [ ]  file coverage for Branches, functions, lines and statements is 100%

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

