### PR TITLE
MHV-47854 Content changes to TXT download

### DIFF
--- a/src/applications/mhv/medical-records/components/shared/DownloadingRecordsInfo.jsx
+++ b/src/applications/mhv/medical-records/components/shared/DownloadingRecordsInfo.jsx
@@ -8,10 +8,10 @@ const DownloadingRecordsInfo = props => {
     return (
       <>
         <span className="vads-u-font-weight--bold">
-          If you’re on a public or shared computer,
+          If you’re using a public or shared computer,
         </span>{' '}
-        remember that downloading will save a copy of your records to the
-        computer.
+        remember that downloading saves a copy of your records to the computer
+        you’re using.
       </>
     );
   };
@@ -28,10 +28,9 @@ const DownloadingRecordsInfo = props => {
           <li>{publicSharedContent()}</li>
           <li>
             <span className="vads-u-font-weight--bold">
-              If you use assistive technology,
+              If you’re using assistive technology like a screen reader,
             </span>{' '}
-            a Text file (.txt) may work better for technology such as screen
-            reader, screen enlargers, or Braille displays.
+            a text file may work better for you.
           </li>
         </ul>
       ) : (

--- a/src/applications/mhv/medical-records/components/shared/PrintDownload.jsx
+++ b/src/applications/mhv/medical-records/components/shared/PrintDownload.jsx
@@ -53,6 +53,7 @@ const PrintDownload = props => {
       ref={menu}
     >
       <button
+        className="vads-u-padding-x--2"
         type="button"
         className={toggleMenuButtonClasses}
         onClick={() => setMenuOpen(!menuOpen)}
@@ -65,6 +66,7 @@ const PrintDownload = props => {
       <ul className={menuOptionsClasses}>
         <li>
           <button
+            className="vads-u-padding-x--2"
             type="button"
             onClick={window.print}
             id="printButton-0"
@@ -75,6 +77,7 @@ const PrintDownload = props => {
         </li>
         <li>
           <button
+            className="vads-u-padding-x--2"
             type="button"
             onClick={download}
             id="printButton-1"
@@ -86,6 +89,7 @@ const PrintDownload = props => {
         {allowTxtDownloads && (
           <li>
             <button
+              className="vads-u-padding-x--2"
               type="button"
               id="printButton-2"
               data-testid="printButton-2"

--- a/src/applications/mhv/medical-records/components/shared/PrintDownload.jsx
+++ b/src/applications/mhv/medical-records/components/shared/PrintDownload.jsx
@@ -91,7 +91,7 @@ const PrintDownload = props => {
               data-testid="printButton-2"
               onClick={downloadTxt}
             >
-              Download {list ? 'list' : 'page'} as a text file
+              Download a text file (.txt) of this {list ? 'list' : 'page'}
             </button>
           </li>
         )}

--- a/src/applications/mhv/medical-records/components/shared/PrintDownload.jsx
+++ b/src/applications/mhv/medical-records/components/shared/PrintDownload.jsx
@@ -53,9 +53,8 @@ const PrintDownload = props => {
       ref={menu}
     >
       <button
-        className="vads-u-padding-x--2"
+        className={`vads-u-padding-x--2 ${toggleMenuButtonClasses}`}
         type="button"
-        className={toggleMenuButtonClasses}
         onClick={() => setMenuOpen(!menuOpen)}
         data-testid="print-records-button"
         aria-expanded={menuOpen}

--- a/src/applications/mhv/medical-records/sass/print-download.scss
+++ b/src/applications/mhv/medical-records/sass/print-download.scss
@@ -1,5 +1,5 @@
 .print-download {
-  width: 275px;
+  width: 293px;
   button {
     background-color: var(--color-white);
     color: var(--color-primary);
@@ -78,7 +78,7 @@
   }
 
   .menu-options-open {
-    width: 275px;
+    width: 293px;
     position: absolute;
     z-index: 99;
     list-style: none;

--- a/src/applications/mhv/medical-records/tests/components/PrintDownload.unit.spec.jsx
+++ b/src/applications/mhv/medical-records/tests/components/PrintDownload.unit.spec.jsx
@@ -63,7 +63,7 @@ describe('Print download menu component', () => {
     const screen = render(<PrintDownload list allowTxtDownloads />);
 
     const downloadTextButton = screen.getByText(
-      'Download list as a text file',
+      'Download a text file (.txt) of this list',
       {
         exact: true,
         selector: 'button',

--- a/src/applications/mhv/medical-records/tests/e2e/medical-records-Download-functionality-for-Radiology.cypress.spec.js
+++ b/src/applications/mhv/medical-records/tests/e2e/medical-records-Download-functionality-for-Radiology.cypress.spec.js
@@ -18,7 +18,7 @@ describe('Medical Records Download Functionality For Radiology', () => {
     // should display a download pdf file button "Download PDF of this page"
     LabsAndTestsListPage.verifyDownloadPDF();
 
-    // should display a download text file button "Download list as a text file"
+    // should display a download text file button "Download a text file (.txt) of this list"
     LabsAndTestsListPage.verifyDownloadTextFile();
     LabsAndTestsListPage.clickDownloadPDFFile();
     cy.readFile(`${Cypress.config('downloadsFolder')}/radiology_report.pdf`);

--- a/src/applications/mhv/medical-records/tests/e2e/medical-records-download-txt-allergies.cypress.spec.js
+++ b/src/applications/mhv/medical-records/tests/e2e/medical-records-download-txt-allergies.cypress.spec.js
@@ -31,7 +31,7 @@ describe('Medical Records View Allergies', () => {
     // should display a download pdf file button "Download PDF of this page"
     AllergyDetailsPage.verifyDownloadPDF();
 
-    // should display a download text file button "Download list as a text file"
+    // should display a download text file button "Download a text file (.txt) of this list"
     AllergyDetailsPage.verifyDownloadTextFile();
 
     cy.reload({ force: true });

--- a/src/applications/mhv/medical-records/tests/e2e/medical-records-download-txt-functionality-health-conditions.cypress.spec.js
+++ b/src/applications/mhv/medical-records/tests/e2e/medical-records-download-txt-functionality-health-conditions.cypress.spec.js
@@ -25,7 +25,7 @@ describe('Medical Records Health Conditions', () => {
     // should display a download pdf file button "Download PDF of this page"
     ConditionDetailsPage.verifyDownloadPDF();
 
-    // should display a download text file button "Download list as a text file"
+    // should display a download text file button "Download a text file (.txt) of this list"
     ConditionDetailsPage.verifyDownloadTextFile();
 
     ConditionDetailsPage.clickDownloadPDFFile();

--- a/src/applications/mhv/medical-records/tests/e2e/medical-records-download-txt-functionality-vitals.cypress.spec.js
+++ b/src/applications/mhv/medical-records/tests/e2e/medical-records-download-txt-functionality-vitals.cypress.spec.js
@@ -24,7 +24,7 @@ describe('Medical Records Vitals', () => {
     // should display a download pdf file button "Download PDF of this page"
     VitalsListPage.verifyDownloadPDF();
 
-    // should display a download text file button "Download list as a text file"
+    // should display a download text file button "Download a text file (.txt) of this list"
     VitalsListPage.verifyDownloadTextFile();
 
     // PathologyListPage.clickDownloadPDFFile();


### PR DESCRIPTION
## Summary

- Updated verbiage in Print/Download button and info dropdown
- Updated width and padding of dropdown button to match Sketch file

## Related issue(s)

### [MHV-47854](https://jira.devops.va.gov/browse/MHV-47854) - Add Download as TXT file from dropdown once TXT functionality is ready ###

> -Add text download option back to all domains
> 
> -Add content back to the 'what to know about downloading'... to include references to text files
> 
> Mocks need to be added for the actual content
> Wait until content is ready??? [MHV-51585](https://jira.devops.va.gov/browse/MHV-51585) Sprint 117
> 
> User Story: As a Medical Record user, I want to see a download option for all domains for TXT files
> 
> GIVEN:
> WHEN:
> THEN:
> 
> Feature Flag Y/N ? Y
> Manual Testing Y/N ? Y
> Automated Testing Y/N ? Y
> Accessibility Testing Y/N ? Y
> UCD Validation Y/N Y
> 
> Acceptance Criteria:
> AC1 Users are able to see and click on TXT download option in all domains
> AC2 Content is displayed in the 'what to know about downloading'... to include references to text files
> AC3 UCD has validated dev work
> AC4
> 
> Links to UCD:
> Sketch Link: https://www.sketch.com/s/4c2728ff-649d-4212-98d2-04c9b3fff9d4/a/y9zArnA#Inspect (This content was approved by Laura W. as of 12/6/23)
> Other Design Notes
> 
> Architectural Notes:

## Testing done

- Updated unit and Cypress tests to match new content.

## Screenshots

<img width="698" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/46c64c11-0027-4648-8f8b-fc04b17f9740">

<img width="308" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/08fd26f8-fe69-472a-bcd9-4b4a6bef58d5">


## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
