### PR TITLE
Add pageConfig onContinue setData arg

### DIFF
--- a/src/platform/forms-system/src/js/containers/FormPage.jsx
+++ b/src/platform/forms-system/src/js/containers/FormPage.jsx
@@ -181,6 +181,15 @@ class FormPage extends React.Component {
     this.props.router.push(path);
   };
 
+  onContinue = () => {
+    const { route } = this.props;
+    if (typeof route.pageConfig.onContinue === 'function') {
+      // pass in data & set form data function to allow modifying data or
+      // flags upon leaving a page
+      route.pageConfig.onContinue(this.formData(), this.props.setData);
+    }
+  };
+
   render() {
     const {
       route,
@@ -216,12 +225,6 @@ class FormPage extends React.Component {
     const isFirstRoutePage =
       route.pageList[0].path === this.props.location.pathname;
 
-    function callOnContinue() {
-      if (typeof route.pageConfig.onContinue === 'function') {
-        route.pageConfig.onContinue(data);
-      }
-    }
-
     const showNavLinks =
       environment.isLocalhost() && route.formConfig?.dev?.showNavLinks;
     const hideNavButtons =
@@ -246,7 +249,7 @@ class FormPage extends React.Component {
             goBack={this.goBack}
             goForward={this.onSubmit}
             goToPath={this.goToPath}
-            callOnContinue={callOnContinue}
+            onContinue={this.onContinue}
             onChange={this.onChange}
             onSubmit={this.onSubmit}
             setFormData={this.props.setData}
@@ -281,7 +284,7 @@ class FormPage extends React.Component {
               {contentBeforeButtons}
               <FormNavButtons
                 goBack={!isFirstRoutePage && this.goBack}
-                goForward={callOnContinue}
+                goForward={this.onContinue}
                 submitToContinue
               />
               {contentAfterButtons}

--- a/src/platform/forms-system/test/js/containers/FormPage.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/containers/FormPage.unit.spec.jsx
@@ -10,7 +10,7 @@ import set from '../../../../utilities/data/set';
 import { FormPage } from '../../../src/js/containers/FormPage';
 
 // Build our mock objects
-function makeRoute(obj) {
+function makeRoute(obj, pageConfig = {}) {
   return {
     pageConfig: {
       pageKey: 'testPage',
@@ -18,6 +18,7 @@ function makeRoute(obj) {
       uiSchema: {},
       errorMessages: {},
       title: '',
+      ...pageConfig,
     },
     pageList: [
       {
@@ -179,6 +180,7 @@ describe('Schemaform <FormPage>', () => {
   describe('should handle', () => {
     let tree;
     let setData;
+    let route;
     let router;
     let onSubmit;
     beforeEach(() => {
@@ -187,15 +189,16 @@ describe('Schemaform <FormPage>', () => {
       router = {
         push: sinon.spy(),
       };
+      route = makeRoute({}, { onContinue: sinon.spy() });
 
       tree = SkinDeep.shallowRender(
         <FormPage
           router={router}
           setData={setData}
-          form={makeForm()}
+          form={makeForm({ data: { test: true } })}
           onSubmit={onSubmit}
           location={location}
-          route={makeRoute()}
+          route={route}
         />,
       );
     });
@@ -222,6 +225,15 @@ describe('Schemaform <FormPage>', () => {
       tree.getMountedInstance().goToPath('/last-page');
 
       expect(router.push.calledWith('/last-page')).to.be.true;
+    });
+    it('onContinue', () => {
+      tree.getMountedInstance().onContinue();
+
+      expect(route.pageConfig.onContinue.called).to.be.true;
+      expect(route.pageConfig.onContinue.args[0][0]).to.deep.equal({
+        test: true,
+      });
+      expect(route.pageConfig.onContinue.args[0][1]).to.deep.equal(setData);
     });
   });
 


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > In our app we have a feature flag set for a new form version. If a Veteran has a save-in-progress, we need to check where in the form they are and redirect them back to the start of the new questions. We're using the `onFormLoaded` callback to check and redirect the Veteran, but we need to show an alert as to why they were redirected. The visibility of the alert depends on a form data setting, but there is no easy way to clear this form data unless we do it on the next form page. Which makes the code messy.
  > This PR uses the page config `onContinue` callback to clear the form data flag, but needs a `setFormData` action to do this, so this action is added as a second argument of the `onContinue` callback function.
  > Currently, the `onContinue` callback is used for recording Google Analytic events; but has the potential for manipulating data and clearing session/local storage.
  > Use it as follows:
  > ```js
  > onContinue: (formData, setFormData) => {
  >   setFormData({ ...formData, 'view:foo': false });
  > },
  > ```
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Clean method to clear form data flags within the `onContinue` function
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits decision reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#72540](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72540)

## Testing done

- _Describe what the old behavior was prior to the change_
  > The `onContinue` callback only included the form data, with no ability to manipulate it
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Added unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

All form apps that use the page config `onContinue` callback function

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72990))
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
