### PR TITLE
Add formConfig & pageConfig onFormExit callback

### DIFF
--- a/src/platform/forms-system/src/js/components/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/components/ContactInfo.jsx
@@ -123,6 +123,7 @@ const ContactInfo = ({
       if (missingInfo.length || validationErrors.length) {
         scrollAndFocus(wrapRef.current);
       } else {
+        clearReturnState();
         goForward(data);
       }
     },

--- a/src/platform/forms-system/src/js/definitions/profileContactInfo.js
+++ b/src/platform/forms-system/src/js/definitions/profileContactInfo.js
@@ -14,6 +14,7 @@ import {
   standardEmailSchema,
   profileAddressSchema,
   blankSchema,
+  clearReturnState,
 } from '../utilities/data/profile';
 
 /**
@@ -181,6 +182,10 @@ const profileContactInfo = ({
         },
       },
       depends,
+      onFormExit: formData => {
+        clearReturnState();
+        return formData;
+      },
     },
     // edit pages; only accessible via ContactInfo component links
     ...config,

--- a/src/platform/forms-system/test/js/components/ContactInfo.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/ContactInfo.unit.spec.jsx
@@ -12,6 +12,7 @@ import {
   getContent,
   setReturnState,
   clearReturnState,
+  getReturnState,
 } from '../../../src/js/utilities/data/profile';
 
 const getData = ({
@@ -444,5 +445,36 @@ describe('<ContactInfo>', () => {
     expect($$('h3', container).length).to.equal(0);
     expect($$('h4', container).length).to.equal(1);
     expect($$('h5', container).length).to.equal(4);
+  });
+
+  it('should call go forward callback', async () => {
+    setReturnState('testing123');
+    const forwardSpy = sinon.spy();
+    const data = getData({ forwardSpy });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <ContactInfo {...data} />
+      </Provider>,
+    );
+
+    fireEvent.click($('.usa-button-primary', container));
+    expect(forwardSpy.called).to.be.true;
+    // return state gets cleared on continuing past the page
+    await expect(getReturnState()).to.equal('');
+  });
+  it('should call updatePage callback', async () => {
+    const updateSpy = sinon.spy();
+    const data = getData({ updateSpy, onReviewPage: true });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <ContactInfo {...data} />
+      </Provider>,
+    );
+
+    fireEvent.click($('va-button', container));
+    expect(updateSpy.called).to.be.true;
+    // return state is set to 'true,' on update so the form returns back to the
+    // review & submit page
+    await expect(getReturnState()).to.contain('true');
   });
 });

--- a/src/platform/forms/save-in-progress/SaveFormLink.jsx
+++ b/src/platform/forms/save-in-progress/SaveFormLink.jsx
@@ -22,7 +22,17 @@ class SaveFormLink extends React.Component {
   handleSave = event => {
     event.preventDefault();
     const { route = {}, form, locationPathname } = this.props;
-    const { formId, version, data, submission } = form;
+    const { formId, version, submission } = form;
+    let { data } = form;
+
+    // Save form on a specific page form exit callback
+    if (typeof route.pageConfig.onFormExit === 'function') {
+      data = route.pageConfig.onFormExit(data);
+    }
+    // Save form global form exit callback
+    if (typeof this.props.formConfig.onFormExit === 'function') {
+      data = this.props.formConfig.onFormExit(data);
+    }
 
     const returnUrl = route.pageConfig?.returnUrl || locationPathname;
     this.props.saveAndRedirectToReturnUrl(
@@ -111,6 +121,7 @@ SaveFormLink.propTypes = {
     customText: PropTypes.shape({
       appType: PropTypes.string,
     }),
+    onFormExit: PropTypes.func,
   }),
   route: PropTypes.shape({
     pageConfig: PropTypes.shape({

--- a/src/platform/forms/save-in-progress/SaveFormLink.jsx
+++ b/src/platform/forms/save-in-progress/SaveFormLink.jsx
@@ -26,11 +26,11 @@ class SaveFormLink extends React.Component {
     let { data } = form;
 
     // Save form on a specific page form exit callback
-    if (typeof route.pageConfig.onFormExit === 'function') {
+    if (typeof route.pageConfig?.onFormExit === 'function') {
       data = route.pageConfig.onFormExit(data);
     }
     // Save form global form exit callback
-    if (typeof this.props.formConfig.onFormExit === 'function') {
+    if (typeof this.props.formConfig?.onFormExit === 'function') {
       data = this.props.formConfig.onFormExit(data);
     }
 


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > In our app we use session storage to save states between pages, if the Veteran decides to "Finish this application later" the session storage is not automatically cleared. So this PR adds a new `onFormExit` callback which can be added to either the `formConfig` or the `pageConfig`
  > - A `formConfig` would be useful for clearing session storage used by the overall form
  > - A `pageConfig` would be useful for clearing session storage (contact info update alert visibility) for a specific page
  > Both would be useful for modifying form data immediately before saving for the form, e.g. clearing the visibility of some components (e.g. alerts)
  >
  > Use it as follows:
  > ```js
  > onFormExit: formData => {
  >   window.sessionStorage.removeItem('foo');
  >   return formData;
  > },
  > ```
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > The "Finish this application later" is disconnected from the form and therefore there is no way to modify form data or storage state prior to leaving the form
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#72540](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72540)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Returning to a form immediately after restarting may show alerts, or content, that isn't meant to be visible.
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Added unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

All form apps that use a form or page config to render the app

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72990))
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
