### PR TITLE
Form config and maximal data updates

### DIFF
--- a/src/applications/pensions/config/chapters/02-military-history/generalHistory.js
+++ b/src/applications/pensions/config/chapters/02-military-history/generalHistory.js
@@ -14,7 +14,7 @@ const { placeOfSeparation, previousNames } = fullSchemaPensions.properties;
 export default {
   uiSchema: {
     'ui:title': 'Other service names',
-    'view:serveUnderOtherNames': yesNoUI({
+    serveUnderOtherNames: yesNoUI({
       title: 'Did you serve under another name?',
       uswds: true,
       classNames: 'vads-u-margin-bottom--2',
@@ -22,7 +22,7 @@ export default {
     previousNames: {
       'ui:options': {
         itemName: 'Name',
-        expandUnder: 'view:serveUnderOtherNames',
+        expandUnder: 'serveUnderOtherNames',
         viewField: FullNameField,
         reviewTitle: 'Previous names',
       },
@@ -36,9 +36,9 @@ export default {
   },
   schema: {
     type: 'object',
-    required: ['view:serveUnderOtherNames'],
+    required: ['serveUnderOtherNames'],
     properties: {
-      'view:serveUnderOtherNames': yesNoSchema,
+      serveUnderOtherNames: yesNoSchema,
       previousNames: {
         ...previousNames,
         minItems: 1,

--- a/src/applications/pensions/config/chapters/02-military-history/pow.js
+++ b/src/applications/pensions/config/chapters/02-military-history/pow.js
@@ -13,15 +13,14 @@ const { powDateRange } = fullSchemaPensions.properties;
 export default {
   uiSchema: {
     'ui:title': 'POW Status',
-    'ui:order': ['view:powStatus', 'powDateRange'],
-    'view:powStatus': yesNoUI({
+    powStatus: yesNoUI({
       title: 'Have you ever been a prisoner of war?',
       uswds: true,
       classNames: 'vads-u-margin-bottom--2',
     }),
     powDateRange: set(
       'ui:options.expandUnder',
-      'view:powStatus',
+      'powStatus',
       dateRangeUI(
         'Start of confinement',
         'End of confinement',
@@ -31,9 +30,9 @@ export default {
   },
   schema: {
     type: 'object',
-    required: ['view:powStatus'],
+    required: ['powStatus'],
     properties: {
-      'view:powStatus': yesNoSchema,
+      powStatus: yesNoSchema,
       powDateRange,
     },
   },

--- a/src/applications/pensions/config/chapters/04-household-information/reasonForCurrentSeparation.js
+++ b/src/applications/pensions/config/chapters/04-household-information/reasonForCurrentSeparation.js
@@ -26,7 +26,7 @@ export default {
         expandUnderCondition: 'Other',
       },
       'ui:required': form =>
-        get(['reasonForCurrentSeparation'], form) === 'Other',
+        get(['reasonForCurrentSeparation'], form) === 'OTHER',
     },
   },
   schema: {
@@ -34,7 +34,7 @@ export default {
     required: ['reasonForCurrentSeparation'],
     properties: {
       reasonForCurrentSeparation: radioSchema(
-        Object.values(reasonForCurrentSeparationOptions),
+        Object.keys(reasonForCurrentSeparationOptions),
       ),
       otherExplanation: { type: 'string' },
     },

--- a/src/applications/pensions/config/chapters/05-financial-information/transferredAssets.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/transferredAssets.js
@@ -15,7 +15,7 @@ export default {
     'view:informationAlert': {
       'ui:description': AssetTransferInformationAlert,
     },
-    assetTransfer: yesNoUI({
+    transferredAssets: yesNoUI({
       title:
         'Did you, your spouse or your dependents transfer any assets in the last 3 calendar years?',
       uswds: true,
@@ -24,19 +24,19 @@ export default {
     'view:warningAlert': {
       'ui:description': AssetTransferFormAlert,
       'ui:options': {
-        hideIf: formData => formData.assetTransfer !== true,
+        hideIf: formData => formData.transferredAssets !== true,
       },
     },
   },
   schema: {
     type: 'object',
-    required: ['assetTransfer'],
+    required: ['transferredAssets'],
     properties: {
       'view:informationAlert': {
         type: 'object',
         properties: {},
       },
-      assetTransfer: yesNoSchema,
+      transferredAssets: yesNoSchema,
       'view:warningAlert': {
         type: 'object',
         properties: {},

--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -158,7 +158,10 @@ export function isUnder65(formData, currentDate) {
 }
 
 function showSpouseAddress(form) {
-  return form.maritalStatus === 'Separated' || form.liveWithSpouse === false;
+  return (
+    form.maritalStatus === 'Separated' ||
+    get(['view:liveWithSpouse'], form) === false
+  );
 }
 
 function isCurrentMarriage(form, index) {
@@ -202,9 +205,15 @@ const formConfig = {
   version: 3,
   migrations,
   prefillEnabled: true,
+  // verifyRequiredPrefill: true,
+  // transformForSubmit: transform,
   downtime: {
     dependencies: [externalServices.icmhs],
   },
+  // beforeLoad: props => { console.log('form config before load', props); },
+  // onFormLoaded: ({ formData, savedForms, returnUrl, formConfig, router }) => {
+  //   console.log('form loaded', formData, savedForms, returnUrl, formConfig, router);
+  // },
   savedFormMessages: {
     notFound: 'Please start over to apply for pension benefits.',
     noAuth:
@@ -213,6 +222,10 @@ const formConfig = {
   title: 'Apply for pension benefits',
   subTitle: 'Form 21P-527EZ',
   preSubmitInfo,
+  // showReviewErrors: true,
+  // when true, initial focus on page to H3s by default, and enable page
+  // scrollAndFocusTarget (selector string or function to scroll & focus)
+  useCustomScrollAndFocus: true,
   footerContent: FormFooter,
   getHelp: GetFormHelp,
   errorText: ErrorText,
@@ -585,7 +598,7 @@ const formConfig = {
                 pattern: 'Your VA file number must be 8 or 9 digits',
               },
             },
-            liveWithSpouse: {
+            'view:liveWithSpouse': {
               'ui:widget': 'yesNo',
               'ui:options': {
                 updateSchema: createSpouseLabelSelector(
@@ -601,14 +614,14 @@ const formConfig = {
               'spouseDateOfBirth',
               'spouseSocialSecurityNumber',
               'spouseIsVeteran',
-              'liveWithSpouse',
+              'view:liveWithSpouse',
             ],
             properties: {
               spouseDateOfBirth,
               spouseSocialSecurityNumber,
               spouseIsVeteran,
               spouseVaFileNumber,
-              liveWithSpouse,
+              'view:liveWithSpouse': liveWithSpouse,
             },
           },
         },
@@ -770,9 +783,9 @@ const formConfig = {
         netWorthEstimation: {
           title: 'Net worth estimation',
           path: 'financial/net-worth-estimation',
+          depends: formData => !formData.totalNetWorth,
           uiSchema: netWorthEstimation.uiSchema,
           schema: netWorthEstimation.schema,
-          depends: formData => !formData.totalNetWorth,
         },
         transferredAssets: {
           title: 'Transferred assets',

--- a/src/applications/pensions/tests/config/spouseMarriageInfo.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/spouseMarriageInfo.unit.spec.jsx
@@ -111,7 +111,7 @@ describe('Pensions spouse info', () => {
     formDOM.fillData('#root_spouseDateOfBirthYear', '2000');
     formDOM.fillData('#root_spouseSocialSecurityNumber', '234432444');
     formDOM.fillData('#root_spouseIsVeteranNo', 'N');
-    formDOM.fillData('#root_liveWithSpouseYes', 'Y');
+    formDOM.fillData('#root_view\\:liveWithSpouseYes', 'Y');
 
     submitForm(form);
 

--- a/src/applications/pensions/tests/schema/maximal-test.json
+++ b/src/applications/pensions/tests/schema/maximal-test.json
@@ -6,17 +6,19 @@
       "last": "Doe",
       "suffix": "Sr."
     },
-    "veteranSocialSecurityNumber": "123123123",
+    "veteranSocialSecurityNumber": "987654321",
     "vaClaimsHistory": true,
     "vaFileNumber": "12345678",
     "veteranDateOfBirth": "1960-01-01",
-    "serviceBranch": "Army",
+    "serviceBranch": {
+      "ARMY": true
+    },
     "activeServiceDateRange": {
       "from": "2003-03-02",
       "to": "2007-03-20"
     },
     "serviceNumber": "123456",
-    "view:serveUnderOtherNames": true,
+    "serveUnderOtherNames": true,
     "previousNames": [
       {
         "first": "John",
@@ -28,7 +30,7 @@
       }
     ],
     "placeOfSeparation": "Northampton, MA",
-    "view:powStatus": true,
+    "powStatus": true,
     "powDateRange": {
       "from": "1971-02-26",
       "to": "1973-03-02"
@@ -99,7 +101,7 @@
     "spouseSocialSecurityNumber": "342342444",
     "spouseIsVeteran": true,
     "spouseVaFileNumber": "23423444",
-    "liveWithSpouse": false,
+    "view:liveWithSpouse": false,
     "spouseAddress": {
       "street": "123 7th st",
       "street2": "Apt 3",
@@ -108,7 +110,7 @@
       "state": "MA",
       "postalCode": "01050"
     },
-    "reasonForCurrentSeparation": "Other",
+    "reasonForCurrentSeparation": "OTHER",
     "otherExplanation": "Personal reason",
     "currentSpouseMonthlySupport": 2444,
     "currentSpouseMaritalHistory": "Yes",
@@ -236,6 +238,7 @@
         "amount": 278.0
       }
     ],
+    "view:noDirectDeposit": false,
     "bankAccount": {
       "accountType": "checking",
       "bankName": "Best Bank",


### PR DESCRIPTION
## Summary
On the Pension Benefits application(21P-527EZ)
- Add helpful commented out form config functions for future development
- Update some property names
- Update properties to use on not use the `view:xxx` read only syntax correctly
- Use object keys where beneficial
- Update maximal-test.json

## How to run in local environment
1. Check out this branch locally
2. In your local environment, set the `pension_form_enabled` flipper to 'enabled' at http://localhost:3000/flipper/features/pension_form_enabled
3. Run `vets-website` and `vets-api`

## How to verify
1. Go to `http://localhost:3001/pension/application/527EZ` in your browser
2. Start or continue the application
3. Verify the application is functional

## Related issue(s)
[Epic in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/63349)

## Testing done
- [ ] Existing unit tests updated
- [ ] New unit tests added


## What areas of the site does it impact?
Pension Benefits Application

## Acceptance criteria
[Ticket in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/71345)

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

