### PR TITLE
Add unique key to CustomPage(Review) on review & submit

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -308,7 +308,7 @@ class ReviewCollapsibleChapter extends React.Component {
       const noop = function noop() {};
       return (
         <page.CustomPage
-          key={page.pageKey}
+          key={`${page.pageKey}${page.index ?? ''}`}
           name={page.pageKey}
           title={page.title}
           trackingPrefix={props.form.trackingPrefix}
@@ -329,7 +329,7 @@ class ReviewCollapsibleChapter extends React.Component {
     }
     return (
       <page.CustomPageReview
-        key={`${page.pageKey}Review`}
+        key={`${page.pageKey}Review${page.index ?? ''}`}
         editPage={() => this.handleEdit(page.pageKey, !editing, page.index)}
         name={page.pageKey}
         title={page.title}

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -1059,6 +1059,86 @@ describe('<ReviewCollapsibleChapter>', () => {
       expect(queryByTestId('custom-page-review')).not.to.exist;
     });
 
+    it('should render array of CustomPage in edit mode', () => {
+      const onEdit = sinon.spy();
+      const { chapterKey, chapter } = getProps();
+      // Can't check array `key` so we're checking the index instead
+      const CustomPage = ({ pagePerItemIndex }) => (
+        <div data-testid={`custom-page${pagePerItemIndex}`} />
+      );
+      const CustomPageReview = ({ pagePerItemIndex }) => (
+        <div data-testid={`custom-page-review${pagePerItemIndex}`} />
+      );
+      const pages = [
+        {
+          title: '',
+          pageKey: 'test',
+          showPagePerItem: true,
+          arrayPath: 'testing',
+          path: 'path/0',
+          index: 0,
+          CustomPage,
+          CustomPageReview,
+        },
+        {
+          title: '',
+          pageKey: 'test',
+          showPagePerItem: true,
+          arrayPath: 'testing',
+          path: 'path/1',
+          index: 1,
+          CustomPage,
+          CustomPageReview,
+        },
+      ];
+      const itemSchema = {
+        type: 'object',
+        properties: { foo: { type: 'string' } },
+      };
+      const form = {
+        pages: {
+          test: {
+            showPagePerItem: true,
+            arrayPath: 'testing',
+            title: '',
+            CustomPage,
+            CustomPageReview,
+            schema: {
+              type: 'object',
+              properties: {
+                testing: {
+                  items: [itemSchema, itemSchema],
+                },
+              },
+            },
+            uiSchema: {
+              testing: {
+                items: {},
+              },
+            },
+            editMode: [true, true],
+          },
+        },
+        data: {
+          testing: [{}, {}],
+        },
+      };
+      const { queryByTestId } = render(
+        <ReviewCollapsibleChapter
+          viewedPages={new Set()}
+          onEdit={onEdit}
+          expandedPages={pages}
+          chapterKey={chapterKey}
+          chapterFormConfig={chapter}
+          form={form}
+        />,
+      );
+
+      expect(queryByTestId('custom-page0')).to.exist;
+      expect(queryByTestId('custom-page1')).to.exist;
+      expect(queryByTestId('custom-page-review0')).not.to.exist;
+    });
+
     it('should include schema & uiSchema to CustomPage in edit mode', () => {
       const spy = sinon.spy();
       const { pages, chapterKey, chapter, form } = getProps();


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > On the review & submit page, our app can render multiple `CustomPage` components if the user opens more than one page in edit mode. This error message appears in the console:
  > > Warning: Encountered two children with the same key, `areaOfDisagreementFollowUp`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
  > This PR adds the page index to the key when rendering a `CustomPage` or `CustomPageReview` on the review & submit page
- _(If bug, how to reproduce)_
  > - Start [Notice of Disagreement](https://staging.va.gov/decision-reviews/board-appeal/request-board-appeal-form-10182/) form
  > - Add 2 issues and disagreements
  > - Hit review and submit page
  > - Click edit on the first disagreement (this is buggy, another ticket opened for it)
  > - Remove selection (get error)
  > - Click edit on the second disagreement
  > - Type something in the 'something else' field
  > - First disagreement starts to duplicate with every keystroke
- _(What is the solution, why is this the solution)_
  > Add page index to `key`
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#72542](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72542)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Editing values within the CustomPage component would cause the page to render a duplicate within the accordion
- _Describe the steps required to verify your changes are working as expected_
  > Manual & unit tests
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

![duplicates](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/01e1113a-b41a-4b33-a382-635414b995fe)

## What areas of the site does it impact?

All apps that render an array of `CustomPageReview` or `CustomPage` on the review & submit page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
