### PR TITLE
[CST] Updating document upload parameter name

### DIFF
--- a/src/applications/claims-status/actions/index.js
+++ b/src/applications/claims-status/actions/index.js
@@ -824,7 +824,7 @@ export function submitFilesLighthouse(claimId, trackedItem, files) {
         /* eslint-disable camelcase */
         files.forEach(({ file, docType, password }) => {
           uploader.addFiles(file, {
-            tracked_item_id: trackedItemId,
+            tracked_item_ids: [trackedItemId],
             document_type: docType.value,
             password: password.value,
           });

--- a/src/applications/claims-status/actions/index.js
+++ b/src/applications/claims-status/actions/index.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import * as Sentry from '@sentry/browser';
 
-import recordEvent from 'platform/monitoring/record-event';
-import { apiRequest } from 'platform/utilities/api';
-import get from 'platform/utilities/data/get';
-import environment from 'platform/utilities/environment';
-import localStorage from 'platform/utilities/storage/localStorage';
+import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
+import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/exports';
+import get from '@department-of-veterans-affairs/platform-forms-system/get';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import localStorage from '@department-of-veterans-affairs/platform-utilities/storage/localStorage';
 
 import { getErrorStatus, UNKNOWN_STATUS } from '../utils/appeals-v2-helpers';
 import {

--- a/src/applications/claims-status/actions/index.js
+++ b/src/applications/claims-status/actions/index.js
@@ -5,7 +5,7 @@ import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/exports';
 import get from '@department-of-veterans-affairs/platform-forms-system/get';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
-import localStorage from '@department-of-veterans-affairs/platform-utilities/storage/localStorage';
+import localStorage from 'platform/utilities/storage/localStorage';
 
 import { getErrorStatus, UNKNOWN_STATUS } from '../utils/appeals-v2-helpers';
 import {


### PR DESCRIPTION
## Summary
The benefits documents vets-api service was updated to change the name of one of the parameters from `tracked_item_id` to `tracked_item_ids`. This parameter was also updated to accept an array instead of a single number

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#72886

## Screenshots
There are no visual changes associated with this PR

## What areas of the site does it impact?
Claim Status Tool
