### PR TITLE
MHV-52956-Added-Allergies-Subheader

### DIFF
--- a/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
@@ -130,6 +130,20 @@ const PrescriptionDetails = () => {
           },
           {
             header: 'Allergies',
+            ...(allergiesPdfList &&
+              allergiesPdfList.length > 0 && {
+                preface: [
+                  {
+                    value:
+                      'This list includes all allergies, reactions, and side effects in your VA medical records. This includes medication side effects (also called adverse drug reactions). If you have allergies or reactions that are missing from this list, tell your care team at your next appointment.',
+                  },
+                  {
+                    value: `Showing ${
+                      allergiesPdfList.length
+                    } records from newest to oldest`,
+                  },
+                ],
+              }),
             list: allergiesPdfList || [],
             ...(allergiesPdfList &&
               !allergiesPdfList.length && {


### PR DESCRIPTION
## Summary
Added subheader text and list count to medications details PDF.

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-52956
> As a Medications developer, I want to update the PDF's to match UCD mocks so that I have an accurate PDF.

## Testing done

- Tested locally 
- Ran unit tests locally

## Screenshots
Added the text beneath the 'Allergies' header:
<img width="1331" alt="Screenshot 2024-01-05 at 4 24 40 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/146013972/d0e64fb8-b337-4065-962b-3000e0df77bc">

## What areas of the site does it impact?

MHV Medications app medication details PDF

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
