### PR TITLE
Add has dependents page

### DIFF
--- a/src/applications/pensions/config/chapters/04-household-information/dependentChildren.js
+++ b/src/applications/pensions/config/chapters/04-household-information/dependentChildren.js
@@ -1,10 +1,6 @@
 import currentOrPastDateUI from '@department-of-veterans-affairs/platform-forms-system/currentOrPastDate';
 import fullNameUI from '@department-of-veterans-affairs/platform-forms-system/fullName';
 import fullSchemaPensions from 'vets-json-schema/dist/21P-527EZ-schema.json';
-import {
-  yesNoSchema,
-  yesNoUI,
-} from '@department-of-veterans-affairs/platform-forms-system/web-component-patterns';
 
 import { dependentsMinItem } from '../../../helpers';
 import DependentField from '../../../components/DependentField';
@@ -15,14 +11,11 @@ const { dependents } = fullSchemaPensions.properties;
 export default {
   uiSchema: {
     'ui:title': 'Dependent children',
-    'view:hasDependents': yesNoUI({
-      title: 'Do you have any dependent children?',
-    }),
     dependents: {
       'ui:options': {
         itemName: 'Dependent',
-        expandUnder: 'view:hasDependents',
         viewField: DependentField,
+        reviewTitle: 'Dependent children',
       },
       'ui:errorMessages': {
         minItems: dependentsMinItem,
@@ -35,9 +28,7 @@ export default {
   },
   schema: {
     type: 'object',
-    required: ['view:hasDependents'],
     properties: {
-      'view:hasDependents': yesNoSchema,
       dependents: {
         type: 'array',
         minItems: 1,

--- a/src/applications/pensions/config/chapters/04-household-information/hasDependents.js
+++ b/src/applications/pensions/config/chapters/04-household-information/hasDependents.js
@@ -1,0 +1,21 @@
+import {
+  yesNoSchema,
+  yesNoUI,
+} from '@department-of-veterans-affairs/platform-forms-system/web-component-patterns';
+
+/** @type {PageSchema} */
+export default {
+  uiSchema: {
+    'ui:title': 'Dependent children',
+    'view:hasDependents': yesNoUI({
+      title: 'Do you have any dependent children?',
+    }),
+  },
+  schema: {
+    type: 'object',
+    required: ['view:hasDependents'],
+    properties: {
+      'view:hasDependents': yesNoSchema,
+    },
+  },
+};

--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -47,6 +47,7 @@ import currentSpouseFormerMarriages from './chapters/04-household-information/cu
 import currentSpouseMaritalHistory from './chapters/04-household-information/currentSpouseMaritalHistory';
 import currentSpouseMonthlySupport from './chapters/04-household-information/currentSpouseMonthlySupport';
 import dependentChildInformation from './chapters/04-household-information/dependentChildInformation';
+import hasDependents from './chapters/04-household-information/hasDependents';
 import dependentChildren from './chapters/04-household-information/dependentChildren';
 import documentUpload from './chapters/06-additional-information/documentUpload';
 import fasterClaimProcessing from './chapters/06-additional-information/fasterClaimProcessing';
@@ -664,9 +665,16 @@ const formConfig = {
           uiSchema: currentSpouseFormerMarriages.uiSchema,
           schema: currentSpouseFormerMarriages.schema,
         },
+        hasDependents: {
+          title: 'Dependents',
+          path: 'household/dependents',
+          uiSchema: hasDependents.uiSchema,
+          schema: hasDependents.schema,
+        },
         dependents: {
           title: 'Dependent children',
-          path: 'household/dependents',
+          path: 'household/dependents/add',
+          depends: form => get(['view:hasDependents'], form),
           uiSchema: dependentChildren.uiSchema,
           schema: dependentChildren.schema,
         },
@@ -675,6 +683,7 @@ const formConfig = {
           title: item =>
             `${item.fullName.first || ''} ${item.fullName.last ||
               ''} information`,
+          depends: form => get(['view:hasDependents'], form),
           showPagePerItem: true,
           arrayPath: 'dependents',
           schema: dependentChildInformation.schema,
@@ -684,6 +693,7 @@ const formConfig = {
           path: 'household/dependents/children/address/:index',
           title: item =>
             `${item.fullName.first || ''} ${item.fullName.last || ''} address`,
+          depends: form => get(['view:hasDependents'], form),
           showPagePerItem: true,
           arrayPath: 'dependents',
           schema: {

--- a/src/applications/pensions/tests/chapters/04-household-information/dependentChildren.unit.spec.jsx
+++ b/src/applications/pensions/tests/chapters/04-household-information/dependentChildren.unit.spec.jsx
@@ -1,33 +1,16 @@
-import React from 'react';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
-import { expect } from 'chai';
-import sinon from 'sinon';
-import { render, fireEvent, waitFor } from '@testing-library/react';
-
 import {
-  $,
-  $$,
-} from '@department-of-veterans-affairs/platform-forms-system/ui';
-
-import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
-import getData from '../../fixtures/mocks/mockStore';
-
-import {
-  testNumberOfErrorsOnSubmitForWebComponents,
-  testNumberOfWebComponentFields,
+  testNumberOfErrorsOnSubmit,
+  testNumberOfFields,
 } from '../pageTests.spec';
 import formConfig from '../../../config/form';
-import dependentChildren from '../../../config/chapters/04-household-information/dependentChildren';
+import careExpenses from '../../../config/chapters/04-household-information/dependentChildren';
 
-const definitions = formConfig.defaultDefinitions;
+const { schema, uiSchema } = careExpenses;
 
-const { schema, uiSchema } = dependentChildren;
-
-describe('web component tests', () => {
-  const pageTitle = 'dependent children';
-  const expectedNumberOfFields = 1;
-  testNumberOfWebComponentFields(
+describe('Add dependent children page', () => {
+  const pageTitle = 'Add dependent children';
+  const expectedNumberOfFields = 7;
+  testNumberOfFields(
     formConfig,
     schema,
     uiSchema,
@@ -35,75 +18,12 @@ describe('web component tests', () => {
     pageTitle,
   );
 
-  const expectedNumberOfErrors = 1;
-  testNumberOfErrorsOnSubmitForWebComponents(
+  const expectedNumberOfErrors = 3;
+  testNumberOfErrorsOnSubmit(
     formConfig,
     schema,
     uiSchema,
     expectedNumberOfErrors,
     pageTitle,
   );
-});
-
-describe('pension dependent children page', () => {
-  const middleware = [];
-  const mockStore = configureStore(middleware);
-
-  it('should submit with valid data', async () => {
-    const onSubmit = sinon.spy();
-    const { data } = getData({ loggedIn: false });
-    const { queryByText, container } = render(
-      <Provider store={mockStore(data)}>
-        <DefinitionTester
-          definitions={definitions}
-          schema={schema}
-          uiSchema={uiSchema}
-          data={{}}
-          formData={{}}
-          onSubmit={onSubmit}
-        />
-      </Provider>,
-    );
-    const submitBtn = queryByText('Submit');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: 'N' },
-    });
-    $('va-radio', container).__events.vaValueChange(changeEvent);
-
-    fireEvent.click(submitBtn);
-    await waitFor(() => {
-      expect(onSubmit.called).to.be.true;
-    });
-  });
-
-  it('should reveal additional fields', async () => {
-    const onSubmit = sinon.spy();
-    const { data } = getData({ loggedIn: false });
-    const { container } = render(
-      <Provider store={mockStore(data)}>
-        <DefinitionTester
-          definitions={definitions}
-          schema={schema}
-          uiSchema={uiSchema}
-          data={{}}
-          formData={{}}
-          onSubmit={onSubmit}
-        />
-      </Provider>,
-    );
-
-    // Verify fields not visible
-    expect($$('input,select', container).length).to.equal(0);
-
-    await waitFor(() => {
-      const changeEvent = new CustomEvent('selected', {
-        detail: { value: 'Y' },
-      });
-      $('va-radio', container).__events.vaValueChange(changeEvent);
-
-      // Verify fields are now visible
-      expect($$('select', container).length).to.equal(3);
-      expect($$('input', container).length).to.equal(4);
-    });
-  });
 });

--- a/src/applications/pensions/tests/chapters/04-household-information/hasDependents.unit.spec.jsx
+++ b/src/applications/pensions/tests/chapters/04-household-information/hasDependents.unit.spec.jsx
@@ -1,0 +1,29 @@
+import {
+  testNumberOfErrorsOnSubmitForWebComponents,
+  testNumberOfWebComponentFields,
+} from '../pageTests.spec';
+import formConfig from '../../../config/form';
+import hasCareExpenses from '../../../config/chapters/04-household-information/hasDependents';
+
+const { schema, uiSchema } = hasCareExpenses;
+
+describe('Has dependent children page', () => {
+  const pageTitle = 'Has dependents';
+  const expectedNumberOfFields = 1;
+  testNumberOfWebComponentFields(
+    formConfig,
+    schema,
+    uiSchema,
+    expectedNumberOfFields,
+    pageTitle,
+  );
+
+  const expectedNumberOfErrors = 1;
+  testNumberOfErrorsOnSubmitForWebComponents(
+    formConfig,
+    schema,
+    uiSchema,
+    expectedNumberOfErrors,
+    pageTitle,
+  );
+});


### PR DESCRIPTION
## Summary
Update the page order of the 'Household information' chapter in the Pension Benefits application(21P-527EZ)

## How to run in local environment
1. Check out this branch locally
2. In your local environment, set the `pension_form_enabled` flipper to 'enabled' at http://localhost:3000/flipper/features/pension_form_enabled
3. Run `vets-website` and `vets-api`

## How to verify
1. Go to `http://localhost:3001/pension/application/527EZ` in your browser
2. Sign in via mocked authentication at `http://localhost:3001/sign-in/mocked-auth`
3. Start or continue the application
4. Go to the 'Household information' chapter and the `/household/dependents` page
5. Select 'Yes' and verify that the next page is the `/household/dependents/add` page
6. Verify the content and layout of the page
7. Verify that you can add a dependent and Continue
8. Verify that you can add multiple dependents
9. Verify subsequent pages collect entered dependents information
10. Select 'No' on the `/household/dependents` page and verify that all dependent pages are skipped

## Related issue(s)
[Ticket in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72989)
[Epic in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/63349)

## Testing done
- [x] Existing unit tests updated
- [x] New unit tests added

## Screenshots
| Has Dependents | Required | Add dependent | Add multiple dependents |
| ------- | ------- | ------- | ------- |
|![localhost_3001_pension_application_527EZ_applicant_information](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/7d603c00-d72d-4ee0-850f-72d7edd3f5fb)|![localhost_3001_pension_application_527EZ_applicant_information (1)](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/77419458-536e-4b40-af1c-8d9749f723e3)|![localhost_3001_pension_application_527EZ_applicant_information (2)](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/429dc187-4cd9-4487-b015-5c97f3dce111)|![localhost_3001_pension_application_527EZ_applicant_information (3)](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/adb3255f-9d1c-4d10-bab8-dc758fdbd47d)|


## What areas of the site does it impact?
Pension Benefits Application

## Acceptance criteria
[Ticket in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72989)

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

