### PR TITLE
Add ga events for travel review and travel success

### DIFF
--- a/src/applications/check-in/api/versions/v2.js
+++ b/src/applications/check-in/api/versions/v2.js
@@ -189,7 +189,7 @@ const v2 = {
     };
   },
 
-  postDayOfTravelPayClaim: async data => {
+  postDayOfTravelPayClaim: async (data, setECheckinStartedCalled) => {
     const url = '/check_in/v0/travel_claims/';
     const headers = { 'Content-Type': 'application/json' };
 
@@ -211,7 +211,7 @@ const v2 = {
 
     const json = await makeApiCallWithSentry(
       apiRequest(`${environment.API_URL}${url}`, settings),
-      'submit-travel-pay-claim',
+      `submit-travel-pay-claim${setECheckinStartedCalled ? '' : '-45MR'}`,
       data.uuid,
       true,
     );

--- a/src/applications/check-in/day-of/pages/TravelReview.jsx
+++ b/src/applications/check-in/day-of/pages/TravelReview.jsx
@@ -3,15 +3,10 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useTranslation, Trans } from 'react-i18next';
 import PropTypes from 'prop-types';
 import { VaCheckbox } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 
 import { recordAnswer } from '../../actions/universal';
 import { useFormRouting } from '../../hooks/useFormRouting';
-import {
-  makeSelectVeteranData,
-  makeSelectCurrentContext,
-} from '../../selectors';
-import { createAnalyticsSlug } from '../../utils/analytics';
+import { makeSelectVeteranData } from '../../selectors';
 import AddressBlock from '../../components/AddressBlock';
 import TravelPage from '../../components/pages/TravelPage';
 
@@ -21,8 +16,6 @@ const TravelQuestion = props => {
   const { jumpToPage, goToNextPage } = useFormRouting(router);
   const selectVeteranData = useMemo(makeSelectVeteranData, []);
   const { demographics } = useSelector(selectVeteranData);
-  const selectCurrentContext = useMemo(makeSelectCurrentContext, []);
-  const { setECheckinStartedCalled } = useSelector(selectCurrentContext);
   const [agree, setAgree] = useState(false);
   const [error, setError] = useState(false);
   const dispatch = useDispatch();
@@ -35,26 +28,12 @@ const TravelQuestion = props => {
   };
   const validation = () => {
     if (agree) {
-      recordEvent({
-        event: createAnalyticsSlug(
-          `yes-to-travel-review${
-            setECheckinStartedCalled ? '' : '-45MR'
-          }-clicked`,
-          'nav',
-        ),
-      });
       goToNextPage();
     } else {
       setError(true);
     }
   };
   const fileLater = () => {
-    recordEvent({
-      event: createAnalyticsSlug(
-        `no-to-travel-review${setECheckinStartedCalled ? '' : '-45MR'}-clicked`,
-        'nav',
-      ),
-    });
     dispatch(recordAnswer({ 'travel-question': 'no' }));
     goToNextPage();
   };

--- a/src/applications/check-in/hooks/useSendTravelPayClaim.jsx
+++ b/src/applications/check-in/hooks/useSendTravelPayClaim.jsx
@@ -1,12 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 import { api } from '../api';
 import { makeSelectFeatureToggles } from '../utils/selectors/feature-toggles';
 import { useStorage } from './useStorage';
 import { useTravelPayFlags } from './useTravelPayFlags';
 import { makeSelectCurrentContext } from '../selectors';
-import { createAnalyticsSlug } from '../utils/analytics';
 
 const useSendTravelPayClaim = appointment => {
   const [isLoading, setIsLoading] = useState(false);
@@ -46,19 +44,11 @@ const useSendTravelPayClaim = appointment => {
 
       setIsLoading(true);
       api.v2
-        .postDayOfTravelPayClaim(travelPayData)
+        .postDayOfTravelPayClaim(travelPayData, setECheckinStartedCalled)
         .catch(() => {
           setTravelPayClaimError(true);
         })
         .finally(() => {
-          recordEvent({
-            event: createAnalyticsSlug(
-              `submit-travel-pay-claim${
-                setECheckinStartedCalled ? '' : '-45MR'
-              }-success`,
-              'nav',
-            ),
-          });
           setTravelPayClaimSent(true);
           setIsLoading(false);
         });


### PR DESCRIPTION
## Summary

- Adds GA events for the review page and check in travel submit success
- if setECheckinStartedCalled is null or false then label should include the string 45MR
- use adswerve extension on chrome to inspect

## Related issue(s)

- [department-of-veterans-affairs/va.gov-team#72961](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72961)

## Testing done

- Visual

## Screenshots

<img width="465" alt="Screenshot 2024-01-05 at 4 55 59 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2982977/a092c3bf-2798-488b-b296-d19411cfed13">
<img width="521" alt="Screenshot 2024-01-05 at 4 56 46 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2982977/d7a7225d-5042-4966-874f-134ee9869284">
<img width="533" alt="Screenshot 2024-01-05 at 4 58 08 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2982977/41afa1eb-eac5-4fa4-a0aa-261eb07856e5">



## What areas of the site does it impact?

check-in -> day-of -> travel review and complete pages

## Acceptance criteria

- [ ] Events fire and are labeled properly based on setECheckinStartedCalled value
