### PR TITLE
MHV-52496 adds allergies to print view

### DIFF
--- a/src/applications/mhv/medications/components/shared/AllergiesPrintOnly.jsx
+++ b/src/applications/mhv/medications/components/shared/AllergiesPrintOnly.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { validateField } from '../../util/helpers';
+import FeedbackEmail from './FeedbackEmail';
+
+const AllergiesPrintOnly = props => {
+  const { allergies, allergiesError } = props;
+
+  const content = () => {
+    if (allergiesError === true) {
+      return (
+        <div data-testid="allergy-error-message">
+          We couldn’t access your allergy records when you downloaded this list.
+          We’re sorry. There was a problem with our system. Try again later. If
+          it still doesn’t work, email us at <FeedbackEmail forPrint />.
+        </div>
+      );
+    }
+    return (
+      <>
+        {allergies?.length > 0 ? (
+          <>
+            <div>
+              <div>
+                This list includes all allergies, reactions, and side effects in
+                your VA medical records. This includes medication side effects
+                (also called adverse drug reactions). If you have allergies or
+                reactions that are missing from this list, tell your care team
+                at your next appointment.
+              </div>
+              <br />
+              Showing {allergies.length} records from newest to oldest
+            </div>
+            <div>
+              {allergies?.map(allergy => (
+                <div key={allergy.id} className="vads-u-border-bottom--1px">
+                  <div className="print-only-rx-details-container">
+                    <h3>{allergy.name}</h3>
+                    <div className="print-only-rx-details-container">
+                      <p>
+                        <strong>Date entered:</strong>{' '}
+                        {validateField(allergy.date)}
+                        <br />
+                        <strong>Signs and symptoms:</strong>{' '}
+                        {allergy?.reaction?.length > 0 ? (
+                          allergy?.reaction?.map(
+                            (reaction, idx) =>
+                              idx === 0 ? (
+                                <span key={idx}>{reaction}</span>
+                              ) : (
+                                <span key={idx}>, {reaction}</span>
+                              ),
+                          )
+                        ) : (
+                          <span>None noted</span>
+                        )}
+                        <br />
+                        <strong>Type of allergy:</strong>{' '}
+                        {validateField(allergy.type)}
+                        <br />
+                        <strong>Location:</strong>{' '}
+                        {validateField(allergy.location)}
+                        <br />
+                        <strong>Observed or historical:</strong>{' '}
+                        {validateField(allergy.observedOrReported)}
+                        <br />
+                        <strong>Provider notes:</strong>{' '}
+                        {validateField(allergy.notes)}
+                        <br />
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        ) : (
+          <div data-testid="no-allergies-message">
+            There are no allergies or reactions in your VA medical records. If
+            you have allergies or reactions that are missing from your records,
+            tell your care team at your next appointment.
+          </div>
+        )}
+      </>
+    );
+  };
+
+  return (
+    <div className="print-only-rx-container">
+      <h2>Allergies</h2>
+      {content()}
+    </div>
+  );
+};
+
+export default AllergiesPrintOnly;
+
+AllergiesPrintOnly.propTypes = {
+  allergies: PropTypes.array,
+  allergiesError: PropTypes.bool,
+};

--- a/src/applications/mhv/medications/components/shared/FeedbackEmail.jsx
+++ b/src/applications/mhv/medications/components/shared/FeedbackEmail.jsx
@@ -1,7 +1,23 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const FeedbackEmail = () => {
-  return <a href="mailto: vamhvfeedback@va.gov">vamhvfeedback@va.gov</a>;
+const FeedbackEmail = ({ forPrint = false }) => {
+  if (forPrint)
+    return (
+      <span className="print-only vads-u-display--inline-block">
+        vamhvfeedback@va.gov
+      </span>
+    );
+
+  return (
+    <a className="no-print" href="mailto: vamhvfeedback@va.gov">
+      vamhvfeedback@va.gov
+    </a>
+  );
 };
 
 export default FeedbackEmail;
+
+FeedbackEmail.propTypes = {
+  forPrint: PropTypes.bool,
+};

--- a/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
@@ -25,6 +25,7 @@ import { PDF_GENERATE_STATUS } from '../util/constants';
 import { getPrescriptionImage } from '../api/rxApi';
 import PrescriptionPrintOnly from '../components/PrescriptionDetails/PrescriptionPrintOnly';
 import { reportGeneratedBy } from '../../shared/util/constants';
+import AllergiesPrintOnly from '../components/shared/AllergiesPrintOnly';
 
 const PrescriptionDetails = () => {
   const prescription = useSelector(
@@ -176,6 +177,13 @@ const PrescriptionDetails = () => {
 
   useEffect(
     () => {
+      dispatch(getAllergiesList());
+    },
+    [dispatch],
+  );
+
+  useEffect(
+    () => {
       if (allergies && pdfGenerateStatus === PDF_GENERATE_STATUS.InProgress) {
         generatePDF(buildAllergiesPDFList(allergies));
       }
@@ -300,6 +308,10 @@ const PrescriptionDetails = () => {
               rx={prescription}
               refillHistory={!nonVaPrescription ? refillHistory : []}
               isDetailsRx
+            />
+            <AllergiesPrintOnly
+              allergies={allergies}
+              allergiesError={allergiesError}
             />
           </PrintOnlyPage>
         </>

--- a/src/applications/mhv/medications/containers/PrescriptionsPrintOnly.jsx
+++ b/src/applications/mhv/medications/containers/PrescriptionsPrintOnly.jsx
@@ -1,15 +1,19 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import MedicationsList from '../components/MedicationsList/MedicationsList';
 import { rxListSortingOptions } from '../util/constants';
 import { getPrescriptionSortedList } from '../api/rxApi';
+import { getAllergiesList } from '../actions/prescriptions';
 import PrintOnlyPage from './PrintOnlyPage';
+import AllergiesPrintOnly from '../components/shared/AllergiesPrintOnly';
 
 const PrescriptionsPrintOnly = () => {
   const location = useLocation();
   const [fullPrescriptionsList, setFullPrescriptionsList] = React.useState([]);
-  // const allergies = useSelector(state => state.rx.allergies); TODO:// Use later
+  const dispatch = useDispatch();
+  const allergies = useSelector(state => state.rx.allergies.allergiesList);
+  const allergiesError = useSelector(state => state.rx.allergies.error);
   const selectedSortOption = useSelector(
     state => state.rx.prescriptions.selectedSortOption,
   );
@@ -28,7 +32,7 @@ const PrescriptionsPrintOnly = () => {
             response.data.map(rx => ({ ...rx.attributes })),
           ),
         );
-        // if (!allergies) dispatch(getAllergiesList()); TODO:// Use later
+        dispatch(getAllergiesList());
       };
       if (
         LIST_PAGE_PATTERN.test(location.pathname) &&
@@ -45,6 +49,8 @@ const PrescriptionsPrintOnly = () => {
       fullPrescriptionsList.length,
       LIST_PAGE_PATTERN,
       currentSortOption,
+      allergies,
+      dispatch,
     ],
   );
   const content = () => {
@@ -64,6 +70,10 @@ const PrescriptionsPrintOnly = () => {
                   totalEntries: fullPrescriptionsList.length,
                 }}
                 selectedSortOption={selectedSortOption}
+              />
+              <AllergiesPrintOnly
+                allergies={allergies}
+                allergiesError={allergiesError}
               />
             </PrintOnlyPage>
           </div>

--- a/src/applications/mhv/medications/tests/components/shared/AllergiesPrintOnly.unit.spec.jsx
+++ b/src/applications/mhv/medications/tests/components/shared/AllergiesPrintOnly.unit.spec.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import AllergiesPrintOnly from '../../../components/shared/AllergiesPrintOnly';
+
+describe('Medications Print Allergies', () => {
+  const allergies = [
+    {
+      id: 1234,
+      type: 'Medication',
+      name: 'Penicillin',
+      date: 'January 1, 2024',
+      reaction: ['Abdominal pain', 'headaches'],
+      location: 'SLC10 TEST LAB',
+      observedOrReported:
+        'Historical (you experienced this allergy or reaction in the past, before you started getting care at this VA location)',
+      notes: 'Unit test',
+    },
+    {
+      id: 1234,
+      type: 'Medication',
+      name: 'Penicillin',
+      date: 'January 1, 2024',
+      reaction: [],
+      location: 'SLC10 TEST LAB',
+      observedOrReported:
+        'Historical (you experienced this allergy or reaction in the past, before you started getting care at this VA location)',
+      notes: 'Unit test',
+    },
+  ];
+
+  const setup = (emptyAllergies = false, allergiesError = false) => {
+    if (emptyAllergies === true) {
+      return render(
+        <AllergiesPrintOnly allergies={[]} allergiesError={allergiesError} />,
+      );
+    }
+    return render(
+      <AllergiesPrintOnly
+        allergies={allergies}
+        allergiesError={allergiesError}
+      />,
+    );
+  };
+
+  it('renders without errors', () => {
+    const screen = setup();
+    expect(screen);
+  });
+
+  it('renders allergies', () => {
+    const screen = setup();
+    const allergyName = screen.findByText(allergies.name);
+    expect(allergyName).to.exist;
+  });
+
+  it('renders empty list', () => {
+    const screen = setup(true);
+    const noAllergiesMessage = screen.getByTestId('no-allergies-message');
+    expect(noAllergiesMessage).to.exist;
+  });
+
+  it('renders error message', () => {
+    const screen = setup(false, true);
+    const errorMessage = screen.getByTestId('allergy-error-message');
+    expect(errorMessage).to.exist;
+  });
+});


### PR DESCRIPTION
## Summary
Adds the user's list of allergies to the end of both the list and details pages' print view.

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-52946

> * Phase 1
> [List page Sketch link](https://www.sketch.com/s/6ef3de45-2534-4584-a8a6-b9dce212ad90/a/uuid/FACFC084-C3DD-4019-91D5-2A0A3102F42A)
> [VA med details page Sketch link](https://www.sketch.com/s/6ef3de45-2534-4584-a8a6-b9dce212ad90/a/uuid/79F5F4E7-C692-4906-A388-C610CCA9BB1D)
> [Non-VA med details page Sketch link](https://www.sketch.com/s/6ef3de45-2534-4584-a8a6-b9dce212ad90/a/uuid/FA622DEF-A8C4-4A4A-A617-ADE4EEDE6CC5)
> Notes for phase 1 prints:
- > We will add the description field in when we get it.
- > In Phase 1 we will match the PDF view, therefore we will
- > Include allergies
> 
> User Story: As a Medications developer, I want to update the Print view to follow the UCD mocks so that it is accurate to what is wanted for that option.
> 

## Testing done
All unit tests passing locally, new unit tests created for allergies Print view. New component test coverage = 100%
![Screen Shot 2024-01-08 at 10 32 45 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/108146636/d0886bcd-1d32-457d-9582-1660e09c2453)

## Screenshots
![Screen Shot 2024-01-08 at 10 01 54 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/108146636/f9ef765d-a941-4669-aa39-a9236e8b507f)
![Screen Shot 2024-01-08 at 10 05 44 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/108146636/94746f29-0965-45d2-b58b-e55043dbdbb1)
![Screen Shot 2024-01-08 at 10 06 01 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/108146636/6238cada-be9a-4f34-8601-4f5cdb4c994b)

## What areas of the site does it impact?
my-health/medications

## Acceptance criteria
- [x] AC1: Print view matches the mocks UCD provided. 
- [x] AC2: UCD validates them and approves
- [ ] AC3: Accessibility team makes sure they are still fully accessible. 

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
