### PR TITLE
NOD | Clear redirect on continue

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -137,6 +137,7 @@ const formConfig = {
           depends: showPart3,
           uiSchema: extensionRequest.uiSchema,
           schema: extensionRequest.schema,
+          onContinue: extensionRequest.onContinue,
         },
         extensionReason: {
           title: 'Reason for extension',

--- a/src/applications/appeals/10182/pages/extensionRequest.js
+++ b/src/applications/appeals/10182/pages/extensionRequest.js
@@ -1,4 +1,5 @@
 import { content } from '../content/extensionRequest';
+import { SHOW_PART3, SHOW_PART3_REDIRECT } from '../constants';
 
 const requestExtension = {
   uiSchema: {
@@ -30,6 +31,17 @@ const requestExtension = {
         type: 'boolean',
       },
     },
+  },
+
+  // Set redirect flag to prevent multiple redirects
+  onContinue: (formData, setFormData) => {
+    // Clear form redirect flag after this page is viewed
+    if (formData[SHOW_PART3] && formData[SHOW_PART3_REDIRECT] !== 'done') {
+      setFormData({
+        ...formData,
+        [SHOW_PART3_REDIRECT]: 'done',
+      });
+    }
   },
 };
 

--- a/src/applications/appeals/10182/tests/pages/extensionRequest.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/extensionRequest.unit.spec.jsx
@@ -9,11 +9,12 @@ import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import formConfig from '../../config/form';
 import { content } from '../../content/extensionRequest';
-import { SHOW_PART3_REDIRECT } from '../../constants';
+import { SHOW_PART3, SHOW_PART3_REDIRECT } from '../../constants';
 
 const {
   schema,
   uiSchema,
+  onContinue,
 } = formConfig.chapters.conditions.pages.extensionRequest;
 
 describe('extension request page', () => {
@@ -127,6 +128,25 @@ describe('extension request page', () => {
       'radio-button-label': content.label,
       'radio-button-optionLabel': 'Yes',
       'radio-button-required': false,
+    });
+  });
+
+  it('should not change redirect form data', () => {
+    const setDataSpy = sinon.spy();
+    const formData = { [SHOW_PART3]: true, [SHOW_PART3_REDIRECT]: 'done' };
+    onContinue(formData, setDataSpy);
+
+    expect(setDataSpy.called).to.be.false;
+  });
+  it('should set redirect form data to "done"', () => {
+    const setDataSpy = sinon.spy();
+    const formData = { [SHOW_PART3]: true };
+    onContinue(formData, setDataSpy);
+
+    expect(setDataSpy.called).to.be.true;
+    expect(setDataSpy.args[0][0]).to.deep.equal({
+      ...formData,
+      [SHOW_PART3_REDIRECT]: 'done',
     });
   });
 });


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > When the Notice of Disagreement v2 form is released, Veteran past the new pages will be automatically redirected to the new page, and a informational alert will be shown. Currently, there is no way to clear the page redirect state while the form is in progress. To fix this, an [update to the `onContinue` callback](https://github.com/department-of-veterans-affairs/vets-website/pull/27348) was made to allow updating the form data prior to saving. Using this method, we can clear the redirect; so now it only shows one time.
  > To test:
  > - Toggle off `nod_part3_update` feature
  > - Start a new NOD in staging
  > - Get to, or past, the contestable issues page
  > - Use "Finish this application later"
  > - Toggle on `nod_part3_update` feature
  > - Continue NOD in progress
  > - You should be redirected to the extension request page
  > - Every time you save and continue the form, you'll be redirected to the extension request page
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Easiest solution
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#72540](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72540)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Everytime you reload the form, you get redirected to the page seen in the screenshot
- _Describe the steps required to verify your changes are working as expected_
  > See summary
- _Describe the tests completed and the results_
  > Added unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

<img width="569" alt="NOD extension request page with redirect informational alert" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/9cc650fb-67ce-4314-b193-5c29eb79ad95">

## What areas of the site does it impact?

Notice of Disagreement

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
