### PR TITLE
Travel review page back bug HOTFIX

### DIFF
--- a/src/applications/check-in/day-of/pages/TravelReview.jsx
+++ b/src/applications/check-in/day-of/pages/TravelReview.jsx
@@ -28,6 +28,7 @@ const TravelQuestion = props => {
   };
   const validation = () => {
     if (agree) {
+      dispatch(recordAnswer({ 'travel-question': 'yes' }));
       goToNextPage();
     } else {
       setError(true);


### PR DESCRIPTION
Set travelQuestion to yes on accept in case the use traveled back aft…er choosing to file later.

## Summary
Since we are setting the initial travel question to "no" on file later, we need to set it to yes on accept just in case the user hits the back button and decides to change this answer to file the claim. This was causing a bug where the complete page never returned due to mis-matched values in the travel hook.

## Testing done

Manual testing

## What areas of the site does it impact?

Day-of check-in.

## Acceptance criteria

 - [ ] - A user can choose file later, then go back to the review page and change their answer and be able to check-in and file travel.
 
### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
