### PR TITLE
Pension: Marriage type copy location change

### DIFF
--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -478,14 +478,14 @@ const formConfig = {
                   },
                   marriageType: {
                     'ui:title': 'How did you get married?',
-                    'ui:description': generateHelpText(
-                      'You can enter common law, proxy (someone else represented you or your spouse at your marriage ceremony), tribal ceremony, or another way.',
-                    ),
                     'ui:widget': 'radio',
                     'ui:required': (...args) => isCurrentMarriage(...args),
                   },
                   otherExplanation: {
                     'ui:title': 'Please specify',
+                    'ui:description': generateHelpText(
+                      'You can enter common law, proxy (someone else represented you or your spouse at your marriage ceremony), tribal ceremony, or another way.',
+                    ),
                     'ui:required': (form, index) =>
                       get(['marriages', index, 'marriageType'], form) ===
                       'Other',

--- a/src/applications/pensions/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/pensions/tests/e2e/fixtures/data/maximal-test.json
@@ -113,7 +113,7 @@
         },
         "dateOfMarriage": "1989-03-02",
         "locationOfMarriage": "Dallas",
-        "marriageType": "Ceremonial",
+        "marriageType": "In a civil or religious ceremony with an officiant who signed my marriage license",
         "view:pastMarriage": {
           "reasonForSeparation": "Divorce",
           "dateOfSeparation": "1990-03-02",

--- a/src/applications/pensions/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/pensions/tests/e2e/fixtures/data/maximal-test.json
@@ -128,7 +128,7 @@
         "dateOfMarriage": "1994-03-02",
         "locationOfMarriage": "North Adams, MA",
         "view:currentMarriage": {
-          "marriageType": "Ceremonial"
+          "marriageType": "In a civil or religious ceremony with an officiant who signed my marriage license"
         }
       }
     ],


### PR DESCRIPTION
## Summary

- small changes related to marriage type

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/72867
- https://github.com/department-of-veterans-affairs/vets-website/pull/27384
## Testing done

- Manual
- Unit
- Axe

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |<img src=https://github.com/department-of-veterans-affairs/vets-website/assets/57480791/34d12a91-41df-4f66-9430-68daf008136b width='400'>|<img src=https://github.com/department-of-veterans-affairs/vets-website/assets/57480791/997b28b3-e399-4181-9fd6-df9662c2d29c width='350'>|


## What areas of the site does it impact?

- Pensions form `21p-527ez`

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

- [x] Update the copy to the question "type of marriage" to: How did you get married?
- [x] Update the single-answer options to what is [listed above]( https://github.com/department-of-veterans-affairs/va.gov-team/issues/72867).

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
