### PR TITLE
Exclusion Period Information Race Condition Resolution

### DIFF
--- a/src/applications/my-education-benefits/containers/App.jsx
+++ b/src/applications/my-education-benefits/containers/App.jsx
@@ -165,7 +165,9 @@ export const App = ({
       if (!isLoggedIn || !featureTogglesLoaded || isLOA3 !== true) {
         return;
       }
-      if (mebExclusionPeriodEnabled && !fetchedExclusionPeriods) {
+      // the firstName check ensures that exclusion periods only gets called after we have obtained claimant info
+      // we need this to avoid a race condition when a user is being loaded freshly from VADIR on DGIB
+      if (mebExclusionPeriodEnabled && firstName && !fetchedExclusionPeriods) {
         setFetchedExclusionPeriods(true);
         getExclusionPeriods();
       }
@@ -181,6 +183,7 @@ export const App = ({
     [
       mebExclusionPeriodEnabled,
       fetchedExclusionPeriods,
+      firstName,
       getExclusionPeriods,
       exclusionPeriods,
       formData,


### PR DESCRIPTION

## Summary
Exclusion Periods was failing on the initial page load due to a race condition where it would resolve before the claimant information call was complete and would get a 404 from the server cause it was requesting without having the claimant ID.

## Related issue(s)


## Testing done
Before the change, the exclusion Periods request was completed faster than the claimant information request. After we see the Exclusion Periods side-effect request after the the claimant-info request is completed.

## Screenshots
### Before (Look at the waterfall of the timing of request Eligibilliity vs Exclusion Periods)
![image-2024-01-09-14-53-27-364](https://github.com/department-of-veterans-affairs/vets-website/assets/8945799/8943915f-e77d-49e2-98d9-28c49ecfb10e)

### After (Look at waterfall of the timing of request Eligibilliity vs Exclusion Periods)
<img width="858" alt="Screenshot 2024-01-09 at 6 57 23 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/8945799/0de4b95c-549b-435c-816b-e94d8bfb2017">



## What areas of the site does it impact?
My-Education-Benefits Application

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
