### PR TITLE
Disable front-end classification

### DIFF
--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -107,7 +107,7 @@ export function transform(formConfig, form) {
   // new disabilities that match a name on our mapped list need their
   // respective classification code added
   const addClassificationCodeToNewDisabilities = formData => {
-    if (revisedFormWrapper.isRevisedForm(!environment.isProduction())) {
+    if (revisedFormWrapper.isRevisedForm(environment.isStaging())) {
       return formData;
     }
     const { newDisabilities } = formData;

--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -1,10 +1,11 @@
 import _ from 'platform/utilities/data';
-
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import {
   transformForSubmit,
   filterViewFields,
 } from 'platform/forms-system/src/js/helpers';
 import removeDeeplyEmptyObjects from 'platform/utilities/data/removeDeeplyEmptyObjects';
+import revisedFormWrapper from './content/revisedFormWrapper';
 
 import {
   causeTypes,
@@ -106,6 +107,9 @@ export function transform(formConfig, form) {
   // new disabilities that match a name on our mapped list need their
   // respective classification code added
   const addClassificationCodeToNewDisabilities = formData => {
+    if (revisedFormWrapper.isRevisedForm(!environment.isProduction())) {
+      return formData;
+    }
     const { newDisabilities } = formData;
     if (!newDisabilities) {
       return formData;

--- a/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
@@ -29,6 +29,7 @@ describe('transform', () => {
 
   // Read all the data files
   const dataDir = path.join(__dirname, './fixtures/data/');
+
   fs.readdirSync(dataDir)
     .filter(fileName => fileName.endsWith('.json'))
     .forEach(fileName => {
@@ -58,10 +59,14 @@ describe('transform', () => {
           rawData.data.serviceInformation.servicePeriods = servicePeriodsBDD;
           transformedData.form526.serviceInformation.servicePeriods = servicePeriodsBDD;
         }
-
+        sinon.spy();
+        const stub = sinon
+          .stub(revisedFormWrapper, 'isRevisedForm')
+          .callsFake(() => false);
         expect(JSON.parse(transform(formConfig, rawData))).to.deep.equal(
           transformedData,
         );
+        stub.restore();
       });
     });
 });

--- a/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
@@ -4,12 +4,15 @@ import moment from 'moment';
 
 import { expect } from 'chai';
 
+import sinon from 'sinon';
 import formConfig from '../config/form';
 import { CHAR_LIMITS } from '../constants';
 
 import { transform } from '../submit-transformer';
 
 import maximalData from './fixtures/data/maximal-test.json';
+
+import revisedFormWrapper from '../content/revisedFormWrapper';
 
 describe('transform', () => {
   const servicePeriodsBDD = [
@@ -65,6 +68,11 @@ describe('transform', () => {
 
 describe('Test internal transform functions', () => {
   it('will truncate long descriptions', () => {
+    sinon.spy();
+    const stub = sinon
+      .stub(revisedFormWrapper, 'isRevisedForm')
+      .callsFake(() => false);
+
     const getString = (key, diff = 0) =>
       new Array(42)
         .fill('1234567890')
@@ -149,5 +157,97 @@ describe('Test internal transform functions', () => {
         )}`,
       },
     ]);
+    stub.restore();
+  });
+});
+
+describe('Test transform functions in staging', () => {
+  it('will not assign classification codes', () => {
+    sinon.spy();
+    const stub = sinon
+      .stub(revisedFormWrapper, 'isRevisedForm')
+      .callsFake(() => true);
+
+    const getString = (key, diff = 0) =>
+      new Array(42)
+        .fill('1234567890')
+        .join('')
+        .substring(0, CHAR_LIMITS[key] + diff);
+    const longString = getString('primaryDescription', 20);
+    const phlebitisPrefix = 'Secondary to Diabetes Mellitus0\n';
+    const form = {
+      data: {
+        ...maximalData.data,
+        newDisabilities: [
+          {
+            cause: 'NEW',
+            primaryDescription: longString,
+            condition: 'asthma',
+            'view:descriptionInfo': {},
+          },
+          {
+            cause: 'SECONDARY',
+            'view:secondaryFollowUp': {
+              causedByDisability: 'Diabetes Mellitus0',
+              causedByDisabilityDescription: longString,
+            },
+            condition: 'phlebitis',
+            'view:descriptionInfo': {},
+          },
+          {
+            cause: 'WORSENED',
+            'view:worsenedFollowUp': {
+              worsenedDescription: longString,
+              worsenedEffects: longString,
+            },
+            condition: 'knee replacement',
+            'view:descriptionInfo': {},
+          },
+          {
+            cause: 'VA',
+            'view:vaFollowUp': {
+              vaMistreatmentDescription: longString,
+              vaMistreatmentLocation: longString,
+              vaMistreatmentDate: longString,
+            },
+            condition: 'myocardial infarction (MI)',
+            'view:descriptionInfo': {},
+          },
+        ],
+      },
+    };
+    expect(
+      JSON.parse(transform(formConfig, form)).form526.newPrimaryDisabilities,
+    ).to.deep.equal([
+      {
+        cause: 'NEW',
+        primaryDescription: getString('primaryDescription'),
+        condition: 'asthma',
+      },
+      {
+        cause: 'WORSENED',
+        worsenedDescription: getString('worsenedDescription'),
+        worsenedEffects: getString('worsenedEffects'),
+        condition: 'knee replacement',
+        specialIssues: ['POW'],
+      },
+      {
+        cause: 'VA',
+        vaMistreatmentDescription: getString('vaMistreatmentDescription'),
+        vaMistreatmentLocation: getString('vaMistreatmentLocation'),
+        vaMistreatmentDate: getString('vaMistreatmentDate'),
+        condition: 'myocardial infarction (MI)',
+        specialIssues: ['POW'],
+      },
+      {
+        condition: 'phlebitis',
+        cause: 'NEW',
+        primaryDescription: `${phlebitisPrefix}${getString(
+          'primaryDescription',
+          -phlebitisPrefix.length,
+        )}`,
+      },
+    ]);
+    stub.restore();
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -390,7 +390,7 @@ describe('526 All Claims validations', () => {
         .callsFake(() => true);
       validateDisabilityName(err, getDisabilityLabels()[528]);
       expect(err.addError.called).to.be.false;
-      stub.reset();
+      stub.restore();
     });
     it('should not add error when disability is in list but capitalization is different', () => {
       const err = { addError: sinon.spy() };


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
These changes disable adding a classification code to disabilities when the Veteran submits the 526EZ.  After editing the disabilityLabels.js, this classification is no longer valid and is preventing the contentions showing up in VBMS.  The classification codes will be assigned by the contention classification service in VRO for single contention CFI and new claims. 

## Related issue(s)

- [#245](https://app.zenhub.com/workspaces/contention-classification-640a24db5dcd08457cebbc79/issues/gh/department-of-veterans-affairs/vagov-claim-classification/245)
- [#297](https://app.zenhub.com/workspaces/contention-classification-640a24db5dcd08457cebbc79/issues/gh/department-of-veterans-affairs/vagov-claim-classification/297)
- [#325](https://app.zenhub.com/workspaces/contention-classification-640a24db5dcd08457cebbc79/issues/gh/department-of-veterans-affairs/vagov-claim-classification/325)

## Testing done
Before disabling the classification, when the Veteran submitted the 526EZ if the disabilities were in the disabilityLabels.js file, the key from the Javascript Object was assigned as the classification code for the disability. After disabling this for the staging environment, the code will still be assigned in Production allowing us to test in staging. 

Incorporated unit tests in [src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js](https://github.com/department-of-veterans-affairs/vets-website/blob/cc-245-disable-frontend-classification/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js) and tested in localhost. 

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
