### PR TITLE
Apply Datadog privacy attributes to 10-10EZ components

### DIFF
--- a/src/applications/hca/components/ConfirmationPage/ConfirmationPrintView.jsx
+++ b/src/applications/hca/components/ConfirmationPage/ConfirmationPrintView.jsx
@@ -31,20 +31,25 @@ const ConfirmationPrintView = ({ name, timestamp }) => {
       </h2>
       <dl className="vads-u-margin-bottom--0">
         <div className="vads-u-margin-bottom--2">
-          <dt
-            className="vads-u-font-family--serif vads-u-font-weight--bold"
-            data-dd-action-name="Veteran name"
-          >
+          <dt className="vads-u-font-family--serif vads-u-font-weight--bold">
             Veteran’s name
           </dt>
-          <dd className="hca-veteran-fullname dd-privacy-mask">{name}</dd>
+          <dd
+            className="hca-veteran-fullname dd-privacy-mask"
+            data-dd-action-name="Veteran name"
+          >
+            {name}
+          </dd>
         </div>
         {!!timestamp && (
           <div className="hca-application-date">
             <dt className="vads-u-font-family--serif vads-u-font-weight--bold">
               Date you applied
             </dt>
-            <dd className="dd-privacy-mask" data-dd-action-name="Applied date">
+            <dd
+              className="dd-privacy-mask"
+              data-dd-action-name="application date"
+            >
               {moment(timestamp).format('MMM D, YYYY')}
             </dd>
           </div>

--- a/src/applications/hca/components/ConfirmationPage/ConfirmationScreenView.jsx
+++ b/src/applications/hca/components/ConfirmationPage/ConfirmationScreenView.jsx
@@ -48,7 +48,7 @@ const ConfirmationScreenView = ({ name, timestamp }) => {
               </dt>
               <dd
                 className="dd-privacy-mask"
-                data-dd-action-name="Applied date"
+                data-dd-action-name="application date"
               >
                 {moment(timestamp).format('MMM D, YYYY')}
               </dd>

--- a/src/applications/hca/components/FormFields/DemographicViewField.jsx
+++ b/src/applications/hca/components/FormFields/DemographicViewField.jsx
@@ -14,14 +14,16 @@ const DemographicViewField = props => {
       <>
         <div className="review-row">
           <dt>{uiSchema['ui:title']}</dt>
-          <dd>
+          <dd className="dd-privacy-hidden" data-dd-action-name="data value">
             {categories.length > 0 && uiSchema[categories[0]]['ui:title']}
           </dd>
         </div>
         {categories.slice(1).map(prop => (
           <div key={prop} className="review-row">
             <dt />
-            <dd>{uiSchema[prop]['ui:title']}</dd>
+            <dd className="dd-privacy-hidden" data-dd-action-name="data value">
+              {uiSchema[prop]['ui:title']}
+            </dd>
           </div>
         ))}
       </>

--- a/src/applications/hca/components/FormFields/DependentList.jsx
+++ b/src/applications/hca/components/FormFields/DependentList.jsx
@@ -94,14 +94,16 @@ const DependentList = ({ labelledBy, list, mode, onDelete }) => {
         className="hca-dependent-list--card vads-u-border--1px vads-u-border-color--gray-medium"
       >
         <span
-          className="vads-u-display--block vads-u-line-height--2 vads-u-font-weight--bold"
+          className="vads-u-display--block vads-u-line-height--2 vads-u-font-weight--bold dd-privacy-mask"
           data-testid="hca-dependent-tile-name"
+          data-dd-action-name="Dependent name"
         >
           {dependentName}
         </span>
         <span
-          className="vads-u-display--block vads-u-line-height--2"
+          className="vads-u-display--block vads-u-line-height--2 dd-privacy-mask"
           data-testid="hca-dependent-tile-relationship"
+          data-dd-action-name="Dependent relationship to veteran"
         >
           {dependentRelation}
         </span>
@@ -113,7 +115,8 @@ const DependentList = ({ labelledBy, list, mode, onDelete }) => {
               search: `?index=${index}&action=${mode}`,
             }}
           >
-            Edit <span className="sr-only">{dependentName}</span>{' '}
+            Edit{' '}
+            <span className="sr-only dd-privacy-mask">{dependentName}</span>{' '}
             <i
               role="presentation"
               className="fas fa-chevron-right vads-u-margin-left--0p5"
@@ -128,7 +131,8 @@ const DependentList = ({ labelledBy, list, mode, onDelete }) => {
               role="presentation"
               className="fas fa-times vads-u-margin-right--0p5"
             />{' '}
-            Remove <span className="sr-only">{dependentName}</span>
+            Remove{' '}
+            <span className="sr-only dd-privacy-mask">{dependentName}</span>
           </button>
         </span>
       </li>
@@ -153,8 +157,9 @@ const DependentList = ({ labelledBy, list, mode, onDelete }) => {
         clickToClose
       >
         <p className="vads-u-margin--0">
-          This will remove <strong>{modal.item.name}</strong> and all their
-          information from your list of dependents.
+          This will remove{' '}
+          <strong className="dd-privacy-mask">{modal.item.name}</strong> and all
+          their information from your list of dependents.
         </p>
       </VaModal>
     </>

--- a/src/applications/hca/components/FormFields/DependentListLoopForm.jsx
+++ b/src/applications/hca/components/FormFields/DependentListLoopForm.jsx
@@ -20,7 +20,11 @@ const DependentListLoopForm = props => {
     page.id !== 'basic' ? `${fullName.first} ${fullName.last}` : 'Dependent';
   const currentUISchema = {
     ...uiSchema[page.id],
-    'ui:title': page.title.replace(/%s/g, nameToDisplay),
+    'ui:title': (
+      <span className="dd-privacy-mask" data-dd-action-name="Page title">
+        {page.title.replace(/%s/g, nameToDisplay)}
+      </span>
+    ),
   };
 
   return (

--- a/src/applications/hca/components/FormFields/DependentViewField.jsx
+++ b/src/applications/hca/components/FormFields/DependentViewField.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 const DependentViewField = ({ formData }) => {
   const { fullName, dependentRelation } = formData;
   return (
-    <div>
+    <div className="dd-privacy-hidden" data-dd-action-name="dependent">
       <strong>
         {fullName.first} {fullName.last}
       </strong>

--- a/src/applications/hca/components/FormFields/InsuranceProviderViewField.jsx
+++ b/src/applications/hca/components/FormFields/InsuranceProviderViewField.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const InsuranceProviderViewField = ({ formData }) => (
-  <div>
+  <div className="dd-privacy-hidden" data-dd-action-name="insurance provider">
     <strong>{formData.insuranceName}</strong>
   </div>
 );

--- a/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
+++ b/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
@@ -87,7 +87,13 @@ const VaMedicalCenter = props => {
   // render the static facility name on review page
   if (reviewMode) {
     return (
-      <span data-testid="hca-facility-name">{getFacilityName(value)}</span>
+      <span
+        className="dd-privacy-hidden"
+        data-testid="hca-facility-name"
+        data-dd-action-name="facility name"
+      >
+        {getFacilityName(value)}
+      </span>
     );
   }
 

--- a/src/applications/hca/components/FormReview/CompensationTypeReviewPage.jsx
+++ b/src/applications/hca/components/FormReview/CompensationTypeReviewPage.jsx
@@ -22,7 +22,12 @@ const CompensationTypeReviewPage = ({ data }) => {
         <dl className="review">
           <div className="review-row">
             <dt>Do you receive VA disability compensation?</dt>
-            <dd>{compensationType}</dd>
+            <dd
+              className="dd-privacy-hidden"
+              data-dd-action-name="VA disability compensation"
+            >
+              {compensationType}
+            </dd>
           </div>
         </dl>
         <p className="vads-u-margin-top--1p5">

--- a/src/applications/hca/components/FormReview/CustomDateReviewField.jsx
+++ b/src/applications/hca/components/FormReview/CustomDateReviewField.jsx
@@ -9,7 +9,9 @@ const CustomDateReviewField = ({
 }) => (
   <div className="review-row">
     <dt>{uiSchema['ui:title']}</dt>
-    <dd>{moment(formData).format('MM/DD/YYYY')}</dd>
+    <dd className="dd-privacy-hidden" data-dd-action-name="data value">
+      {moment(formData).format('MM/DD/YYYY')}
+    </dd>
   </div>
 );
 

--- a/src/applications/hca/components/FormReview/CustomReviewField.jsx
+++ b/src/applications/hca/components/FormReview/CustomReviewField.jsx
@@ -8,7 +8,9 @@ const CustomReviewField = ({
 }) => (
   <div className="review-row">
     <dt>{uiSchema['ui:title']}</dt>
-    <dd>{formData}</dd>
+    <dd className="dd-privacy-hidden" data-dd-action-name="data value">
+      {formData}
+    </dd>
   </div>
 );
 

--- a/src/applications/hca/components/FormReview/CustomYesNoReviewField.jsx
+++ b/src/applications/hca/components/FormReview/CustomYesNoReviewField.jsx
@@ -8,7 +8,9 @@ const CustomYesNoReviewField = ({
 }) => (
   <div className="review-row">
     <dt>{uiSchema['ui:title']}</dt>
-    <dd>{formData ? 'Yes' : 'No'}</dd>
+    <dd className="dd-privacy-hidden" data-dd-action-name="data value">
+      {formData ? 'Yes' : 'No'}
+    </dd>
   </div>
 );
 

--- a/src/applications/hca/components/FormReview/DependentsReviewPage.jsx
+++ b/src/applications/hca/components/FormReview/DependentsReviewPage.jsx
@@ -9,7 +9,7 @@ const DependentsReviewPage = ({ data, editPage }) => {
     const dependentName = normalizeFullName(fullName);
     return (
       <div key={index} className="review-row">
-        <dt>
+        <dt className="dd-privacy-hidden" data-dd-action-name="dependent">
           <strong>{dependentName}</strong>, {dependentRelation}
         </dt>
         <dd>&nbsp;</dd>
@@ -47,7 +47,12 @@ const DependentsReviewPage = ({ data, editPage }) => {
             <dl className="review">
               <div className="review-row">
                 <dt>Do you have any dependents to report?</dt>
-                <dd>No</dd>
+                <dd
+                  className="dd-privacy-hidden"
+                  data-dd-action-name="data value"
+                >
+                  No
+                </dd>
               </div>
             </dl>
           </>


### PR DESCRIPTION
## Summary
This PR applies the necessary Datadog privacy attributes to various components (including page titles and custom review components) in the Health Care Application to eliminate exposing potential PII when utilizing Datadogs RUM (Real User Monitoring) session recordings.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#72280

## Acceptance criteria

- No PP will be exposed from any component or widget in the application

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution