### PR TITLE
27427 add initial sponsor information section to ivc champva form 1010d

### DIFF
--- a/src/applications/ivc-champva/10-10D/components/SectionCompleteAlert.jsx
+++ b/src/applications/ivc-champva/10-10D/components/SectionCompleteAlert.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+export default function ApplicantField() {
+  return (
+    <VaAlert status="success" visible uswds>
+      <h2>Section Complete</h2>
+    </VaAlert>
+  );
+}

--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -1,11 +1,27 @@
+import {
+  fullNameSchema,
+  fullNameUI,
+  ssnOrVaFileNumberSchema,
+  ssnOrVaFileNumberUI,
+  addressSchema,
+  addressUI,
+  phoneSchema,
+  phoneUI,
+  dateOfBirthSchema,
+  dateOfBirthUI,
+  dateOfDeathSchema,
+  dateOfDeathUI,
+  yesNoSchema,
+  yesNoUI,
+  titleSchema,
+  inlineTitleUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import get from 'platform/utilities/data/get';
+
 import manifest from '../manifest.json';
-
 import IntroductionPage from '../containers/IntroductionPage';
+import SectionCompleteAlert from '../components/SectionCompleteAlert.jsx';
 import ConfirmationPage from '../containers/ConfirmationPage';
-
-// const { } = fullSchema.properties;
-
-// const { } = fullSchema.definitions;
 
 const formConfig = {
   rootUrl: manifest.rootUrl,
@@ -34,16 +50,161 @@ const formConfig = {
   title: '10-10d Application for CHAMPVA benefits',
   defaultDefinitions: {},
   chapters: {
-    chapter1: {
-      title: 'Chapter 1',
+    sponsorInformation: {
+      title: 'Sponsor information',
       pages: {
         page1: {
-          path: 'first-page',
-          title: 'First Page',
-          uiSchema: {},
+          path: 'sponsor-information/name-dob',
+          title: 'Sponsor name and date of birth',
+          uiSchema: {
+            sponsorInfoTitle: inlineTitleUI('Sponsor name and date of birth'),
+            veteransFullName: fullNameUI(),
+            sponsorDOB: dateOfBirthUI(),
+          },
           schema: {
             type: 'object',
-            properties: {},
+            required: ['sponsorDOB'],
+            properties: {
+              sponsorInfoTitle: titleSchema,
+              veteransFullName: fullNameSchema,
+              sponsorDOB: dateOfBirthSchema,
+            },
+          },
+        },
+        page2: {
+          path: 'sponsor-information/ssn',
+          title: 'Sponsor SSN and VA file number',
+          uiSchema: {
+            sponsorInfoTitle: inlineTitleUI('Sponsor SSN or VA file number'),
+            ssn: ssnOrVaFileNumberUI(),
+          },
+          schema: {
+            type: 'object',
+            required: ['ssn'],
+            properties: {
+              sponsorInfoTitle: titleSchema,
+              ssn: ssnOrVaFileNumberSchema,
+            },
+          },
+        },
+        page3: {
+          path: 'sponsor-information/status',
+          title: 'Sponsor status',
+          uiSchema: {
+            sponsorInfoTitle: inlineTitleUI('Sponsor status'),
+            sponsorIsDeceased: yesNoUI({
+              title: 'Is sponsor still living?',
+              labels: {
+                Y: 'Yes, sponsor is alive',
+                N: 'No, sponsor is deceased',
+              },
+              yesNoReverse: true,
+            }),
+          },
+          schema: {
+            type: 'object',
+            required: ['sponsorIsDeceased'],
+            properties: {
+              sponsorInfoTitle: titleSchema,
+              sponsorIsDeceased: yesNoSchema,
+            },
+          },
+        },
+        page4: {
+          path: 'sponsor-information/status-date',
+          title: 'Sponsor status',
+          depends: formData => get('sponsorIsDeceased', formData),
+          uiSchema: {
+            sponsorInfoTitle: inlineTitleUI('Sponsor status'),
+            sponsorDOD: dateOfDeathUI(),
+            sponsorDeathConditions: yesNoUI({
+              title: 'Did sponsor pass away on active military service?',
+              labels: {
+                Y: 'Yes, sponsor passed away during active military service',
+                N:
+                  'No, sponsor did not pass away during active military service',
+              },
+            }),
+          },
+          schema: {
+            type: 'object',
+            required: ['sponsorDOD'],
+            properties: {
+              sponsorInfoTitle: titleSchema,
+              sponsorDOD: dateOfDeathSchema,
+              sponsorDeathConditions: yesNoSchema,
+            },
+          },
+        },
+        page6: {
+          path: 'sponsor-information/address',
+          title: "Sponsor's address",
+          depends: formData => !get('sponsorIsDeceased', formData),
+          uiSchema: {
+            sponsorInfoTitle: inlineTitleUI("Sponsor's address"),
+            sponsorAddress: {
+              ...addressUI({
+                labels: {
+                  militaryCheckbox:
+                    'My sponsor lives on a United States military base outside the country.',
+                },
+              }),
+            },
+          },
+          schema: {
+            type: 'object',
+            required: ['sponsorAddress'],
+            properties: {
+              sponsorInfoTitle: titleSchema,
+              sponsorAddress: addressSchema(),
+            },
+          },
+        },
+        page7: {
+          path: 'sponsor-information/phone',
+          title: "Sponsor's phone number",
+          depends: formData => !get('sponsorIsDeceased', formData),
+          uiSchema: {
+            sponsorInfoTitle: inlineTitleUI("Sponsor's phone number"),
+            sponsorPhone: {
+              ...phoneUI({
+                title: 'Home phone number',
+              }),
+              'ui:required': () => true,
+            },
+            sponsorPhoneAlt: {
+              ...phoneUI({ title: 'Mobile phone number' }),
+            },
+          },
+          schema: {
+            type: 'object',
+            required: ['sponsorPhone'],
+            properties: {
+              sponsorInfoTitle: titleSchema,
+              sponsorPhone: phoneSchema,
+              sponsorPhoneAlt: phoneSchema,
+            },
+          },
+        },
+        page7a: {
+          path: 'sponsor-information/complete',
+          title: 'Sponsor information complete',
+          uiSchema: {
+            'view:alert': {
+              'ui:title': SectionCompleteAlert,
+            },
+            'ui:options': {
+              keepInPageOnReview: false,
+            },
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              'view:alert': {
+                type: 'object',
+                properties: {},
+              },
+            },
           },
         },
       },

--- a/src/applications/ivc-champva/10-10D/tests/config/form.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10D/tests/config/form.unit.spec.jsx
@@ -1,0 +1,22 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { testNumberOfWebComponentFields } from '../../../../simple-forms/shared/tests/pages/pageTests.spec';
+import formConfig from '../../config/form';
+
+testNumberOfWebComponentFields(
+  formConfig,
+  formConfig.chapters.sponsorInformation.pages.page7.schema,
+  formConfig.chapters.sponsorInformation.pages.page7.uiSchema,
+  2,
+  "Sponsor's phone number continued",
+  { sponsorIsDeceased: false },
+);
+
+describe('submit property of formConfig', () => {
+  it('should be a promise', () => {
+    const goToPathSpy = sinon.spy(formConfig.submit);
+    formConfig.submit().then(() => {
+      expect(goToPathSpy.called).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR introduces the first pass at the Sponsor Information section of IVC/CHAMPVA form 10-10D. In the interest of keeping this PR under 200 lines, unit tests for the form have been kept to a minimum with the intention of filing a followup PR including more test coverage. 

The changes introduced do not impact anywhere other than the specific 10-10D form app.

- Added sponsor information form pages to the 10-10D config file 
- Added a small Section Complete react component to be displayed in the form
- **Team**: IVC-CHAMPVA (responsible for adding form 10-10D)
- **Flipper**: not in use, form is not set to go to prod

## Related issue(s)

- NA

## Testing done

- Initial unit test file created with two starter tests included, more to come
- Ran `yarn test:coverage-app ivc-champva/10-10D` to verify tests run and pass
- Manual testing to verify fields behave as expected

## Screenshots

**Desktop**
| Screen 1 | Screen 2|
| --------- | --------- | 
![desktop1](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/9cb4d339-8277-4c5a-87a1-47933ce9aa11) | ![desktop2](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/870da23b-1af3-4c25-9a92-fc8fcb6caab3)

**Mobile**
| Screen 1 | Screen 2|
| --------- | --------- | 
![mobile1](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/805d1820-90ed-4668-9b2d-359e7dcc704d)| ![mobile2](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/c19c17a0-92c0-46f6-b79f-04d714de33ba)


## What areas of the site does it impact?

This form only.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
