### PR TITLE
Focus on alert after submit

### DIFF
--- a/src/applications/appeals/shared/components/ContestableIssues.jsx
+++ b/src/applications/appeals/shared/components/ContestableIssues.jsx
@@ -6,6 +6,7 @@ import { VaModal } from '@department-of-veterans-affairs/component-library/dist/
 
 import set from 'platform/utilities/data/set';
 import { setData } from 'platform/forms-system/src/js/actions';
+import { focusElement, scrollTo } from 'platform/utilities/ui';
 
 import { LAST_ISSUE, MAX_LENGTH, REVIEW_ISSUES, SELECTED } from '../constants';
 import { FETCH_CONTESTABLE_ISSUES_FAILED } from '../actions';
@@ -84,6 +85,22 @@ const ContestableIssues = props => {
     .concat(formData.additionalIssues || []);
 
   const hasSelected = someSelected(items);
+  const showNoIssues =
+    !submitted &&
+    !onReviewPage &&
+    apiLoadStatus === FETCH_CONTESTABLE_ISSUES_FAILED;
+  const showEditModeError =
+    !showNoIssues && !hasSelected && (onReviewPage || submitted);
+
+  useEffect(
+    () => {
+      if (showEditModeError) {
+        focusElement('va-alert[status="error"]');
+        scrollTo('va-alert[status="error"]');
+      }
+    },
+    [showEditModeError, submitted],
+  );
 
   if (onReviewPage && inReviewMode && items.length && !hasSelected) {
     return (
@@ -183,24 +200,17 @@ const ContestableIssues = props => {
     return hideCard ? null : <IssueCard {...cardProps} />;
   });
 
-  const showNoIssues =
-    !submitted &&
-    !onReviewPage &&
-    apiLoadStatus === FETCH_CONTESTABLE_ISSUES_FAILED;
-
   return (
     <>
       <div name="eligibleScrollElement" />
       {showNoIssues && <NoIssuesLoadedAlert />}
-      {!showNoIssues &&
-        !hasSelected &&
-        (onReviewPage || submitted) && (
-          <NoneSelectedAlert
-            count={formData.contestedIssues?.length || 0}
-            headerLevel={onReviewPage ? 4 : 3}
-            inReviewMode={inReviewMode}
-          />
-        )}
+      {showEditModeError && (
+        <NoneSelectedAlert
+          count={formData.contestedIssues?.length || 0}
+          headerLevel={onReviewPage ? 4 : 3}
+          inReviewMode={inReviewMode}
+        />
+      )}
       <fieldset className="review-fieldset">
         <ContestableIssuesLegend
           onReviewPage={onReviewPage}

--- a/src/applications/appeals/shared/tests/components/ContestableIssues.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/ContestableIssues.unit.spec.jsx
@@ -115,14 +115,58 @@ describe('<ContestableIssues>', () => {
     expect($$('.usa-input-error', container).length).to.equal(0);
   });
 
-  it('should show an error when submitted with no selections', () => {
+  it('should show an error when submitted with no selections', async () => {
     const props = getProps({ submitted: true });
     const { container } = render(<ContestableIssues {...props} />);
     expect($$('va-alert', container).length).to.equal(1);
-    expect($('va-alert', container).innerHTML).to.contain(
+    const alert = $('va-alert', container);
+    expect(alert.innerHTML).to.contain(
       'at least 1 issue before you can continue',
     );
+    await waitFor(() => {
+      expect(document.activeElement).to.equal(alert);
+    });
   });
+
+  it('should focus to error alert when submitted with no selections', async () => {
+    const props = getProps();
+    const { container, rerender } = render(
+      <>
+        <va-button type="button">foo</va-button>
+        <ContestableIssues
+          {...props}
+          formContext={{
+            onReviewPage: true,
+            reviewMode: false,
+            submitted: false,
+          }}
+        />
+      </>,
+    );
+
+    // focus on button to test that the focus is shifted to the alert after
+    // the page is submitted
+    $('va-button', container).focus();
+
+    rerender(
+      <>
+        <va-button type="button">foo</va-button>
+        <ContestableIssues
+          {...props}
+          formContext={{
+            onReviewPage: true,
+            reviewMode: false,
+            submitted: true, // submitting the page
+          }}
+        />
+      </>,
+    );
+
+    await waitFor(() => {
+      expect(document.activeElement).to.equal($('va-alert', container));
+    });
+  });
+
   it('should show a message when no issues selected on review page', () => {
     const props = getProps({ review: true });
     const { container } = render(<ContestableIssues {...props} />);


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > On the review & submit page, if all contestable issues are unchecked, an alert at the top of the page should be focused & scrolled to. Currently, after clicking on "Update page" focus is shifted to the first "Remove" issue button. This will be fixed in 2 steps, the first in [#27408](https://github.com/department-of-veterans-affairs/vets-website/pull/27408) & this PR. After these fixes, only the first time the "Update page" button is used, will the focus be shifted to the error alert and scrolled into view. Subsequent use of "Update page" will do nothing.
- _(If bug, how to reproduce)_
  > On the review & submit page, follow these steps to see the problem:
  > - Edit contestable issues
  > - Have at least one additional issue (with edit & remove buttons)
  > - Deselect all contestable issues
  > - Focus should move to the "You'll need to select an issue" alert at the top of the page
  > - Now use the "Update page" button
  > - Focus now shifts to the first "Remove" button; it should return focus to the alert
- _(What is the solution, why is this the solution)_
  > Without changing platform code, we checked that the page is submitted before moving focus & scrolling to the alert.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reivews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#72290](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72290)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Added unit test for focus
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

Before

![focus moved to remove button after update page](https://github.com/department-of-veterans-affairs/va.gov-team/assets/136959/fe0e9abd-08fa-41f7-84fe-266d7418bd81)

## What areas of the site does it impact?

All 3 Decision Review apps: HLR, NOD & Supplemental Claims

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
