### PR TITLE
Use getter for page title

### DIFF
--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -744,9 +744,7 @@ const formConfig = {
         },
         dependentChildInHousehold: {
           path: 'household/dependents/children/inhousehold/:index',
-          title: item =>
-            `${item.fullName.first || ''} ${item.fullName.last ||
-              ''} household`,
+          title: item => getDependentChildTitle(item, 'household'),
           showPagePerItem: true,
           arrayPath: 'dependents',
           schema: {


### PR DESCRIPTION
## Summary
Fix page title bug for 'Review application' page in the Pension Benefits application(21P-527EZ)

## How to run in local environment
1. Check out this branch locally
2. In your local environment, set the `pension_form_enabled` flipper to 'enabled' at http://localhost:3000/flipper/features/pension_form_enabled
3. Run `vets-website` and `vets-api`

## How to verify
1. Go to `http://localhost:3001/pension/application/527EZ` in your browser
2. Sign in via mocked authentication at `http://localhost:3001/sign-in/mocked-auth`
3. Go to the 'Review applicaiton' page
4. Verify that it renders without breaking
8. Verify that all chapters and pages are validated before submitting the form

## Related issue(s)
[Ticket in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73203)
[Ticket in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73297)
[Epic in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/63349)

## Testing done
- [x] Existing unit tests updated
- [ ] New unit tests added

## Screenshots
n/a

## What areas of the site does it impact?
Pension Benefits Application

## Acceptance criteria
[Ticket in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73297)

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

