### PR TITLE
Removes button from provisioning error

### DIFF
--- a/src/applications/auth/components/RenderErrorContainer.jsx
+++ b/src/applications/auth/components/RenderErrorContainer.jsx
@@ -406,9 +406,6 @@ export default function RenderErrorContainer({
         <>
           <h2>How can I fix this issue?</h2>
           <Helpdesk startScentence />
-          <button type="button" onClick={openLoginModal}>
-            Sign in
-          </button>
         </>
       );
       break;

--- a/src/applications/terms-of-use/containers/TermsOfUse.jsx
+++ b/src/applications/terms-of-use/containers/TermsOfUse.jsx
@@ -114,7 +114,7 @@ export default function TermsOfUse() {
             <div className="vads-u-margin-y--2p5">
               <a
                 className="vads-c-action-link--blue"
-                href="https://www.va.gov/terms-of-use/?next=loginModal"
+                href="/terms-of-use/?next=loginModal"
               >
                 Sign in to VA.gov
               </a>


### PR DESCRIPTION
[Zenhub Ticket](https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/gh/department-of-veterans-affairs/vets-website/27445)

## Summary

We removed the 'Sign In' button from the 110 error page. This was requested in this [Slack Thread](https://dsva.slack.com/archives/C04MM3WJN1E/p1704988511322349)