### PR TITLE
Adds Sponsors to redux state on successfull claimaint info API call

### DIFF
--- a/src/applications/toe/reducers.js
+++ b/src/applications/toe/reducers.js
@@ -58,7 +58,21 @@ export default {
           isPersonalInfoFetchFailed: false, // Set to false since the fetch was successful
           personalInfoFetchComplete: true,
           personalInfoFetchInProgress: false,
+          fetchedSponsorsComplete: true,
           formData: action?.response || {},
+          sponsors: {
+            sponsors: action?.response?.data?.attributes?.toeSponsors?.transferOfEntitlements?.map(
+              sponsor => {
+                return {
+                  ...sponsor,
+                  id: `${sponsor?.sponsorVaId}`,
+                  name: [sponsor.firstName, sponsor.lastName].join(' '),
+                  relationship: sponsor.sponsorRelationship,
+                };
+              },
+            ),
+            someoneNotListed: false,
+          },
         };
       case FETCH_PERSONAL_INFORMATION_FAILED:
         return {


### PR DESCRIPTION
## Summary
The differentiation of the success and failure states related to the claimant information call. Before the change, we used the default failure state, which included updating the Sponsor object in the application's state. We have traced the root cause of this [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/27327/files). The reducers file was modified to include a differentiated success state but did not include updating the sponsor data.
 
## Related issue(s)


## Testing done
Prior to the change the user wasn't able to select a sponsor because the page was not being displayed.

## Screenshots
### Submission Payload with Sponsor with VAID
<img width="893" alt="Screenshot 2024-01-11 at 1 44 38 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/8945799/cf8cbd5f-27e0-4be0-b211-73716a16d1fd">
###. Sponsor Selection Page
<img width="607" alt="Screenshot 2024-01-11 at 1 45 27 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/8945799/61b552e9-443b-463a-bb1d-58396b672593">

## What areas of the site does it impact?
TOE Application

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
