### PR TITLE
27448 add initial applicant information section to ivc champva form 1010d

### DIFF
--- a/src/applications/ivc-champva/10-10D/components/Applicant/ApplicantField.jsx
+++ b/src/applications/ivc-champva/10-10D/components/Applicant/ApplicantField.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function ApplicantField({ formData }) {
+  const { first, middle, last, suffix } = formData.applicantName;
+
+  return (
+    <div>
+      <strong>
+        {first} {middle && `${middle} `}
+        {last}
+        {suffix && `, ${suffix}`}
+      </strong>
+    </div>
+  );
+}

--- a/src/applications/ivc-champva/10-10D/components/SectionCompleteAlert.jsx
+++ b/src/applications/ivc-champva/10-10D/components/SectionCompleteAlert.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
-export default function ApplicantField() {
+export default function SectionCompleteAlert() {
   return (
     <VaAlert status="success" visible uswds>
       <h2>Section Complete</h2>

--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -3,16 +3,22 @@ import {
   fullNameUI,
   ssnOrVaFileNumberSchema,
   ssnOrVaFileNumberUI,
+  ssnSchema,
+  ssnUI,
   addressSchema,
   addressUI,
   phoneSchema,
   phoneUI,
+  emailSchema,
+  emailUI,
   dateOfBirthSchema,
   dateOfBirthUI,
   dateOfDeathSchema,
   dateOfDeathUI,
   yesNoSchema,
   yesNoUI,
+  radioSchema,
+  radioUI,
   titleSchema,
   inlineTitleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
@@ -20,6 +26,7 @@ import get from 'platform/utilities/data/get';
 
 import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
+import ApplicantField from '../components/Applicant/ApplicantField';
 import SectionCompleteAlert from '../components/SectionCompleteAlert.jsx';
 import ConfirmationPage from '../containers/ConfirmationPage';
 
@@ -203,6 +210,186 @@ const formConfig = {
               'view:alert': {
                 type: 'object',
                 properties: {},
+              },
+            },
+          },
+        },
+      },
+    },
+    applicantInformation: {
+      title: 'Applicant information',
+      pages: {
+        page8: {
+          path: 'applicant-information',
+          arrayPath: 'applicants',
+          title: 'Applicants',
+          uiSchema: {
+            applicants: {
+              'ui:options': {
+                viewField: ApplicantField,
+                keepInPageOnReview: true,
+                useDlWrap: false,
+              },
+              'ui:errorMessages': {
+                minItems: 'Must have at least one applicant listed.',
+              },
+              items: {
+                'ui:title': ApplicantField,
+                applicantName: fullNameUI(),
+              },
+            },
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              applicants: {
+                type: 'array',
+                minItems: 1,
+                items: {
+                  type: 'object',
+                  properties: {
+                    applicantName: fullNameSchema,
+                  },
+                },
+              },
+            },
+          },
+        },
+        page9: {
+          path: 'applicant-information/:index/ssn-dob',
+          arrayPath: 'applicants',
+          title: item =>
+            `${item?.applicantName?.first ||
+              'Applicant'} - SSN and date of birth`,
+          showPagePerItem: true,
+          uiSchema: {
+            applicants: {
+              'ui:options': {
+                viewField: ApplicantField,
+                keepInPageOnReview: true,
+              },
+              'ui:errorMessages': {
+                minItems: 'Must have at least one applicant listed.',
+              },
+              items: {
+                'ui:title': ApplicantField,
+                applicantSSN: ssnUI(),
+                applicantDOB: dateOfBirthUI(),
+              },
+            },
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              applicants: {
+                type: 'array',
+                minItems: 1,
+                items: {
+                  type: 'object',
+                  properties: {
+                    applicantSSN: ssnSchema,
+                    applicantDOB: dateOfBirthSchema,
+                  },
+                },
+              },
+            },
+          },
+        },
+        page10: {
+          path: 'applicant-information/:index/address',
+          arrayPath: 'applicants',
+          showPagePerItem: true,
+          title: item =>
+            `${item?.applicantName?.first || 'Applicant'} - address`,
+          uiSchema: {
+            'ui:title': 'Applicant Address',
+            applicants: {
+              items: {
+                'ui:title': ApplicantField,
+                applicantAddress: addressUI(),
+              },
+            },
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              applicants: {
+                type: 'array',
+                minItems: 1,
+                items: {
+                  type: 'object',
+                  properties: {
+                    applicantAddress: addressSchema(),
+                  },
+                },
+              },
+            },
+          },
+        },
+        page11: {
+          path: 'applicant-information/:index/email-phone',
+          arrayPath: 'applicants',
+          showPagePerItem: true,
+          title: item =>
+            `${item?.applicantName?.first || 'Applicant'} - email and phone`,
+          uiSchema: {
+            'ui:title': 'Applicant Email and Phone',
+            applicants: {
+              items: {
+                'ui:title': ApplicantField,
+                applicantEmailAddress: emailUI(),
+                applicantPhone: phoneUI(),
+              },
+            },
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              applicants: {
+                type: 'array',
+                minItems: 1,
+                items: {
+                  type: 'object',
+                  properties: {
+                    applicantEmailAddress: emailSchema,
+                    applicantPhone: phoneSchema,
+                  },
+                },
+              },
+            },
+          },
+        },
+        page12: {
+          path: 'applicant-information/:index/gender',
+          arrayPath: 'applicants',
+          showPagePerItem: true,
+          title: item =>
+            `${item?.applicantName?.first || 'Applicant'} - gender`,
+          uiSchema: {
+            'ui:title': 'Applicant Gender',
+            applicants: {
+              items: {
+                'ui:title': ApplicantField,
+                applicantGender: radioUI({
+                  title: 'Gender',
+                  required: true,
+                  labels: { male: 'Male', female: 'Female' },
+                }),
+              },
+            },
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              applicants: {
+                type: 'array',
+                minItems: 1,
+                items: {
+                  type: 'object',
+                  properties: {
+                    applicantGender: radioSchema(['male', 'female']),
+                  },
+                },
               },
             },
           },


### PR DESCRIPTION
## Summary

This PR introduces the first pass at the Applicant Information section of IVC/CHAMPVA form 10-10D. In the interest of keeping this PR around 200 lines, additional unit tests for the form have not been included here. A followup PR will include more test coverage.

The changes introduced do not impact anywhere other than the specific 10-10D form app.

- Added first few applicant information form pages to the 10-10D config file 
- Added a small react component used for displaying list-loop element names throughout the form
- **Team**: IVC-CHAMPVA (responsible for adding form 10-10D)
- **Flipper**: not in use, form is not set to go to prod

## Related issue(s)

- NA

## Testing done

- Manual testing to verify fields behave as expected
- Ran `yarn test:coverage-app ivc-champva/10-10D` to verify existing tests run and pass

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        | ![mobile](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/acd5f9e9-259a-475c-bf03-6d9aa8c2409b)|
| Desktop |        | ![desktop](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/ac99ce24-5a6a-4076-93c9-172059ac2753)|

## What areas of the site does it impact?

This form only.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

