### PR TITLE
Pensions Cypress E2E Test finalization

### DIFF
--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -1013,24 +1013,6 @@ const formConfig = {
         },
       },
     },
-    // This chapter is here so that the cypress test ends successfully since
-    // the form tester will only consider the test a success when it gets to a
-    // page which has a URL ending in '/confirmation';
-    //
-    // This chapter should be entirely removed/replaced once the form has an
-    // actual confirmation page.
-    confirmation: {
-      title: 'Confirmation',
-      pages: {
-        confirmation: {
-          path: 'confirmation',
-          title: 'Confirmation',
-          // Needs something as a schema. Doesn't matter what.
-          uiSchema: applicantInformation.uiSchema,
-          schema: applicantInformation.schema,
-        },
-      },
-    },
   },
 };
 

--- a/src/applications/pensions/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/pensions/tests/e2e/fixtures/data/maximal-test.json
@@ -10,7 +10,10 @@
     "vaClaimsHistory": true,
     "vaFileNumber": "12345678",
     "veteranDateOfBirth": "1960-01-01",
-    "serviceBranch": "ARMY",
+    "serviceBranch": {
+      "ARMY": true,
+      "NAVY": true
+    },
     "activeServiceDateRange": {
       "from": "2003-03-02",
       "to": "2007-03-20"

--- a/src/applications/pensions/tests/e2e/pensions.cypress.spec.js
+++ b/src/applications/pensions/tests/e2e/pensions.cypress.spec.js
@@ -12,17 +12,65 @@ import manifest from '../../manifest.json';
 
 import {
   fillAddressWebComponentPattern,
-  selectCheckboxWebComponent,
   selectRadioWebComponent,
 } from './helpers';
 
 import pagePaths from './pagePaths';
 
 const TEST_URL = '/pension/application/527EZ/introduction';
+const IN_PROGRESS_URL = '/v0/in_progress_forms/21P-527EZ';
+const PENSIONS_CLAIMS_URL = '/v0/pension_claims';
+const SUBMISSION_DATE = new Date().toISOString();
+
+const SUBMISSION_CONFIRMATION_NUMBER = '01e77e8d-79bf-4991-a899-4e2defff11e0';
 
 export const setup = ({ authenticated, isEnabled = true } = {}) => {
   const features = isEnabled ? featuresEnabled : featuresDisabled;
   cy.intercept('GET', '/v0/feature_toggles*', features);
+
+  cy.get('@testData').then(testData => {
+    cy.intercept('GET', IN_PROGRESS_URL, {
+      formData: {},
+      metadata: {
+        version: 0,
+        prefill: true,
+        returnUrl: '/applicant/information',
+      },
+    });
+    cy.intercept('PUT', IN_PROGRESS_URL, testData);
+  });
+
+  cy.intercept('POST', PENSIONS_CLAIMS_URL, {
+    data: {
+      id: '8',
+      type: 'saved_claim_pensions',
+      attributes: {
+        submittedAt: SUBMISSION_DATE,
+        regionalOffice: [
+          'Attention:  Philadelphia Pension Center',
+          'P.O. Box 5206',
+          'Janesville, WI 53547-5206',
+        ],
+        confirmationNumber: SUBMISSION_CONFIRMATION_NUMBER,
+        guid: '01e77e8d-79bf-4991-a899-4e2defff11e0',
+        form: '21P-527EZ',
+      },
+    },
+  }).as('submitApplication');
+
+  cy.intercept(
+    'GET',
+    `${PENSIONS_CLAIMS_URL}/${SUBMISSION_CONFIRMATION_NUMBER}`,
+    {
+      data: {
+        attributes: {
+          submittedAt: SUBMISSION_DATE,
+          state: 'success',
+        },
+      },
+    },
+  ).as('pollSubmission');
+
   if (!authenticated) {
     cy.visit(TEST_URL);
     return;
@@ -42,16 +90,6 @@ export const pageHooks = cy => ({
   [pagePaths.mailingAddress]: () => {
     cy.get('@testData').then(data => {
       fillAddressWebComponentPattern('veteranAddress', data.veteranAddress);
-    });
-  },
-  [pagePaths.servicePeriod]: () => {
-    // Providing a hook for this page prevents the default fill, so we need to call that
-    cy.fillPage();
-
-    // Once that's done, go back and fill in the web component that it missed
-    cy.get('@testData').then(data => {
-      const value = `serviceBranch_${data.serviceBranch}`;
-      selectCheckboxWebComponent(value, true);
     });
   },
   [pagePaths.maritalStatus]: () => {
@@ -75,6 +113,23 @@ export const pageHooks = cy => ({
   [pagePaths.currentSpouseAddress]: () => {
     cy.get('@testData').then(data => {
       fillAddressWebComponentPattern('spouseAddress', data.spouseAddress);
+    });
+  },
+  'review-and-submit': ({ afterHook }) => {
+    afterHook(() => {
+      cy.get('#veteran-signature')
+        .shadow()
+        .find('input')
+        .first()
+        .type('John Edmund Doe');
+      cy.get(`#veteran-certify`)
+        .first()
+        .shadow()
+        .find('input')
+        .check();
+      cy.findAllByText(/Submit application/i, {
+        selector: 'button',
+      }).click();
     });
   },
 });


### PR DESCRIPTION
## Summary

- Removes the fake 'confirmation' page that was letting the cypress form test pass without having a functioning submission page.
- Adds an intercept & mock response to the pension form in the form test so that the form can successfully 'submit' and get to the confirmation page.
- Big shout out to Scott Gorman for writing the intercept code. :)

## Testing done

- This is the test

## What areas of the site does it impact?

None, just the test.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed