### PR TITLE
Revert "Tune code splitting config (#27406)"

### DIFF
--- a/config/manifest-helpers.js
+++ b/config/manifest-helpers.js
@@ -11,14 +11,13 @@ function getAppManifests() {
       // eslint-disable-next-line import/no-dynamic-require
       const manifest = require(file);
 
-      return {
-        ...manifest,
+      return Object.assign({}, manifest, {
         filePath: file,
         entryFile: path.resolve(
           root,
           path.join(path.dirname(file), manifest.entryFile),
         ),
-      };
+      });
     });
 }
 
@@ -31,10 +30,7 @@ function getAppRoutes() {
 function getWebpackEntryPoints(manifests) {
   return manifests.reduce((apps, next) => {
     // eslint-disable-next-line no-param-reassign
-    apps[next.entryName] = {
-      import: next.entryFile,
-      dependOn: 'vendor',
-    };
+    apps[next.entryName] = next.entryFile;
     return apps;
   }, {});
 }

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -60,10 +60,7 @@ const globalEntryFiles = {
   vendor: sharedModules,
   // This is to solve the issue of the vendor file being cached
   'shared-modules': sharedModules,
-  'web-components': {
-    import: getAbsolutePath('src/platform/site-wide/wc-loader.js'),
-    dependOn: 'vendor',
-  },
+  'web-components': getAbsolutePath('src/platform/site-wide/wc-loader.js'),
 };
 
 function getEntryManifests(entry) {
@@ -428,7 +425,6 @@ module.exports = async (env = {}) => {
           parallel: true,
         }),
       ],
-      runtimeChunk: 'single',
       splitChunks: {
         cacheGroups: {
           // this needs to be "vendors" to overwrite a default group


### PR DESCRIPTION
This reverts commit d8d720d353b9bb95597a2e2ef12f7a28950d8dbf.


## Summary

This PR reverts an [effort to tune webpack](https://github.com/department-of-veterans-affairs/vets-website/pull/27406). The PR being reverted was merged to test in dev/staging; deploying to prod must wait until coordination from Teamsites but this coordination requires demonstrating that dev/staging work with the change in place.

## Related issue(s)
[27406](https://github.com/department-of-veterans-affairs/vets-website/pull/27406)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
