### PR TITLE
Update dependentChildAddress depends value

### DIFF
--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -777,7 +777,8 @@ const formConfig = {
         dependentChildAddress: {
           path: 'household/dependents/children/address/:index',
           title: item => getDependentChildTitle(item, 'address'),
-          depends: form => get(['view:hasDependents'], form),
+          depends: (form, index) =>
+            !get(['dependents', index, 'childInHousehold'], form),
           showPagePerItem: true,
           arrayPath: 'dependents',
           schema: {


### PR DESCRIPTION
## Summary
Only show dependent child address when Veteran does not live with dependent Pension Benefits application(21P-527EZ)

## How to run in local environment
1. Check out this branch locally
2. In your local environment, set the `pension_form_enabled` flipper to 'enabled' at http://localhost:3000/flipper/features/pension_form_enabled
3. Run `vets-website` and `vets-api`

## How to verify
1. Go to `http://localhost:3001/pension/application/527EZ` in your browser
2. Sign in via mocked authentication at `http://localhost:3001/sign-in/mocked-auth`
3. Go to the 'Dependents' pages
4. Verify that for each entered dependent the child address page does not display when 'Does your child live with you?' is false for each dependent

## Related issue(s)
[Epic in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/63349)

## Testing done
- [ ] Existing unit tests updated
- [ ] New unit tests added

## Screenshots
n/a

## What areas of the site does it impact?
Pension Benefits Application

## Acceptance criteria
When you answer “yes” to “does your child live with you?“, the follow up page we created with the fields asking for where they live, who they live with, and how much $ the veterans contributes to their support, is showing up. This follow up page should show up only if they answer “no” to “does your child live with you?”

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

