### PR TITLE
added custom submit transformer and unit tests

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -24,6 +24,7 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import get from 'platform/utilities/data/get';
 
+import transformForSubmit from './submitTransformer';
 import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
 import ApplicantField from '../components/Applicant/ApplicantField';
@@ -33,6 +34,7 @@ import ConfirmationPage from '../containers/ConfirmationPage';
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
+  transformForSubmit,
   // submitUrl: '/v0/api',
   submit: () =>
     Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),

--- a/src/applications/ivc-champva/10-10D/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-10D/config/submitTransformer.js
@@ -1,0 +1,115 @@
+/* eslint-disable camelcase */
+import { transformForSubmit as formsSystemTransformForSubmit } from 'platform/forms-system/src/js/helpers';
+
+// Simplify relationship to a single key/value.
+function transformRelationship(relationship) {
+  let ret;
+  if (typeof relationship === 'string') {
+    ret = relationship; // Nothing to do here
+  } else if (relationship?.relationshipToVeteran) {
+    // If they chose "other" and typed a freeform answer, grab the text
+    ret = relationship.otherRelationshipToVeteran
+      ? relationship.otherRelationshipToVeteran
+      : relationship.relationshipToVeteran;
+  }
+  return ret || '';
+}
+
+function transformApplicants(applicants) {
+  const applicantsPostTransform = [];
+
+  applicants.forEach(app => {
+    // Snake_case names are present because the existing backend controller
+    // for this form uses them. May adjust with future refactor.
+    const transformedApp = {
+      full_name: app.applicantName ?? '',
+      ssh_or_tin: app.applicantSSN ?? '',
+      date_of_birth: app.applicantDOB ?? '',
+      phone_number: app.applicantPhone ?? '',
+      vet_relationship: transformRelationship(
+        app.applicantRelationshipToSponsor?.relationshipToVeteran || 'NA',
+      ),
+      applicant_supporting_documents: [
+        app?.applicantMedicareCardFront,
+        app?.applicantMedicareCardBack,
+        app?.applicantOHICardFront,
+        app?.applicantOHICardBack,
+      ],
+      address: app.applicantAddress ?? '',
+      gender: app.applicantGender ?? '',
+    };
+
+    // eslint-disable-next-line dot-notation
+    transformedApp.address['postal_code'] = transformedApp.address.postalCode;
+    delete transformedApp.address.postalCode;
+
+    applicantsPostTransform.push(transformedApp);
+  });
+
+  return applicantsPostTransform;
+}
+
+export default function transformForSubmit(formConfig, form) {
+  const transformedData = JSON.parse(
+    formsSystemTransformForSubmit(formConfig, form),
+  );
+
+  const dataPostTransform = {
+    veteran: {
+      full_name: transformedData?.veteransFullName || {},
+      ssn_or_tin: transformedData?.ssn?.ssn || '',
+      va_claim_number: transformedData?.vaFileNumber || '',
+      date_of_birth: transformedData?.sponsorDOB || '',
+      phone_number: transformedData?.sponsorPhone || '',
+      address: transformedData?.sponsorAddress || {
+        street: 'NA',
+        city: 'NA',
+        state: 'NA',
+        postalCode: 'NA',
+        country: 'NA',
+      },
+      date_of_death: transformedData?.sponsorDOD || '',
+      date_of_marriage: transformedData?.sponsorDOM || '',
+    },
+    applicants: transformApplicants(transformedData.applicants ?? []),
+    certification: {
+      date: transformedData?.dateOfCertification || '',
+      lastName: transformedData?.certifierName?.last || '',
+      middleInitial: transformedData?.certifierName?.middle || '',
+      firstName: transformedData?.certifierName?.first || '',
+      phone_number: transformedData?.certifierPhone || '',
+      relationship: transformRelationship(
+        transformedData?.certifierRelationship,
+      ),
+      streetAddress: transformedData?.certifierAddress?.street || '',
+      city: transformedData?.certifierAddress?.city || '',
+      state: transformedData?.certifierAddress?.state || '',
+      postal_code: transformedData?.certifierAddress?.postalCode || '',
+    },
+    supporting_docs: [],
+  };
+
+  // Flatten supporting docs for all applicants to a single array
+  const supDocs = [];
+  dataPostTransform.applicants.forEach(app => {
+    if (app.applicant_supporting_documents.length > 0) {
+      app.applicant_supporting_documents.forEach(doc => {
+        if (doc !== undefined) {
+          supDocs.push(...doc);
+        }
+      });
+    }
+  });
+
+  dataPostTransform.supporting_docs = supDocs;
+
+  // eslint-disable-next-line dot-notation
+  dataPostTransform.veteran.address['postal_code'] =
+    dataPostTransform.veteran.address.postalCode || '';
+  delete dataPostTransform.veteran.address.postalCode;
+
+  return JSON.stringify({
+    ...dataPostTransform,
+    formNumber: formConfig.formId,
+  });
+}

--- a/src/applications/ivc-champva/10-10D/tests/config/submitTransformer.unit.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/config/submitTransformer.unit.spec.js
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+import formConfig from '../../config/form';
+import transformForSubmit from '../../config/submitTransformer';
+
+describe('transform for submit', () => {
+  it('should adjust zip code keyname', () => {
+    const transformed = JSON.parse(
+      transformForSubmit(formConfig, {
+        data: {
+          sponsorAddress: { postalCode: '12345' },
+        },
+      }),
+    );
+    expect(transformed.veteran.address.postal_code).to.not.equal(undefined);
+  });
+  it('should adjust zip code keyname for applicants', () => {
+    const zip = '12345';
+    const transformed = JSON.parse(
+      transformForSubmit(formConfig, {
+        data: {
+          applicants: [
+            {
+              applicantAddress: {
+                postalCode: zip,
+              },
+            },
+          ],
+        },
+      }),
+    );
+    expect(transformed.applicants[0].address.postal_code).to.equal(zip);
+  });
+  it('should return passed in relationship if already flat', () => {
+    const transformed = JSON.parse(
+      transformForSubmit(formConfig, {
+        data: {
+          certifierRelationship: 'Spouse',
+        },
+      }),
+    );
+    expect(transformed.certification.relationship).to.equal('Spouse');
+  });
+  it('should flatten relationship details', () => {
+    const transformed = JSON.parse(
+      transformForSubmit(formConfig, {
+        data: {
+          certifierRelationship: {
+            relationshipToVeteran: 'other',
+            otherRelationshipToVeteran: 'Sibling',
+          },
+        },
+      }),
+    );
+    expect(transformed.certification.relationship).to.equal('Sibling');
+  });
+  it('should insert blank values as needed', () => {
+    const transformed = JSON.parse(
+      transformForSubmit(formConfig, { data: {} }),
+    );
+    expect(transformed.veteran.ssn_or_tin).to.equal('');
+  });
+});


### PR DESCRIPTION
## Summary

This PR introduces a custom submission transformer for IVC/CHAMPVA form 10-10D. The key goal of this addition is to convert user-entered data into the appropriate configuration required by the [backend mapping](https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/simple_forms_api/app/form_mappings/vha_10_10d.json.erb). A forthcoming PR to vets-api will update the associated controller to complete certain functionality referenced in the transformer (namely the ability to upload files as supporting evidence).

The changes introduced do not impact anywhere other than the specific 10-10D form app.

- Added a new submit transformer file
- Added unit tests for the submit transformer
- **Team**: IVC-CHAMPVA (responsible for adding form 10-10D)
- **Flipper**: Not in use, form is not set to go to prod

## Related issue(s)

NA

## Testing done

- Manual testing to verify data is transformed properly
- Automated testing via new unit tests to verify data is transformed properly
- Ran `yarn test:coverage-app ivc-champva/10-10D` to verify existing and new tests run and pass

## Screenshots

NA

## What areas of the site does it impact?

This form only.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
