### PR TITLE
added sip and updated constants so form shows on user profile

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -41,11 +41,12 @@ const formConfig = {
   confirmation: ConfirmationPage,
   formId: '10-10D',
   saveInProgress: {
-    // messages: {
-    //   inProgress: 'Your CHAMPVA benefits application (10-10D) is in progress.',
-    //   expired: 'Your saved CHAMPVA benefits application (10-10D) has expired. If you want to apply for CHAMPVA benefits, please start a new application.',
-    //   saved: 'Your CHAMPVA benefits application has been saved.',
-    // },
+    messages: {
+      inProgress: 'Your CHAMPVA benefits application (10-10D) is in progress.',
+      expired:
+        'Your saved CHAMPVA benefits application (10-10D) has expired. If you want to apply for CHAMPVA benefits, please start a new application.',
+      saved: 'Your CHAMPVA benefits application has been saved.',
+    },
   },
   version: 0,
   prefillEnabled: true,

--- a/src/platform/forms/constants.js
+++ b/src/platform/forms/constants.js
@@ -70,6 +70,7 @@ export const VA_FORM_IDS_IN_PROGRESS_FORMS_API = Object.freeze({
 });
 
 export const FORM_BENEFITS = {
+  [VA_FORM_IDS.FORM_10_10D]: 'application for champva benefits',
   [VA_FORM_IDS.FORM_20_10206]: 'personal records request',
   [VA_FORM_IDS.FORM_21_0972]: 'alternate signer',
   [VA_FORM_IDS.FORM_21_10210]: 'lay/witness statement',
@@ -139,6 +140,7 @@ export const FORM_DESCRIPTIONS = Object.keys(FORM_BENEFITS).reduce(
 
 export const FORM_LINKS = {
   [VA_FORM_IDS.FEEDBACK_TOOL]: `${getAppUrl('feedback-tool')}/`,
+  [VA_FORM_IDS.FORM_10_10D]: `${getAppUrl('10-10D')}/`,
   [VA_FORM_IDS.FORM_10_10EZ]: `${getAppUrl('hca')}/`,
   [VA_FORM_IDS.FORM_10182]: `${getAppUrl('10182-board-appeal')}/`,
   [VA_FORM_IDS.FORM_20_0995]: `${getAppUrl('995-supplemental-claim')}/`,
@@ -170,6 +172,7 @@ export const FORM_LINKS = {
 };
 
 export const TRACKING_PREFIXES = {
+  [VA_FORM_IDS.FORM_10_10D]: '10-10D-',
   [VA_FORM_IDS.FORM_20_10206]: 'pa-10206-',
   [VA_FORM_IDS.FORM_21_0972]: '21-0972-alternate-signer-',
   [VA_FORM_IDS.FORM_21_10210]: 'lay-witness-10210-',
@@ -201,6 +204,7 @@ export const TRACKING_PREFIXES = {
 };
 
 export const SIP_ENABLED_FORMS = new Set([
+  VA_FORM_IDS.FORM_10_10D,
   VA_FORM_IDS.FORM_10_10EZ,
   VA_FORM_IDS.FORM_20_10206,
   VA_FORM_IDS.FORM_21_0972,


### PR DESCRIPTION
## Summary

This PR adds save in progress functionality to IVC/CHAMPVA form 10-10D. 

- Added SIP messages to form 10-10D
- Updated platform form constants file to allow SIP progress to display on user profile
- **Team**: IVC-CHAMPVA (responsible for adding form 10-10D)
- **Flipper**: Not in use, form is not set to go to prod

## Related issue(s)

- Ticket [73447](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73447)

## Testing done

- Manual testing to verify form progress saves as expected and displays on user profile
- Ran `yarn test:coverage-app ivc-champva/10-10D` to verify existing tests run and pass

## Screenshots

NA

## What areas of the site does it impact?

This form and the main forms constants file `platform/forms/constants.js`

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
