### PR TITLE
Pension: Re-launch static widget

### DIFF
--- a/src/applications/static-pages/pension-how-do-i-apply-widget/components/App/index.js
+++ b/src/applications/static-pages/pension-how-do-i-apply-widget/components/App/index.js
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { toggleLoginModal as toggleLoginModalAction } from '@department-of-veterans-affairs/platform-site-wide/actions';
-import { VA_FORM_IDS } from 'platform/forms/constants';
-import ApplicationStatus from 'platform/forms/save-in-progress/ApplicationStatus';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 
 export const App = ({ loggedIn, toggleLoginModal }) => {
@@ -11,26 +9,53 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
   const pensionFormEnabled = useToggleValue(TOGGLE_NAMES.pensionFormEnabled);
   return pensionFormEnabled ? (
     <>
-      <ApplicationStatus
-        formId={VA_FORM_IDS.FORM_21P_527EZ}
-        showApplyButton
-        showLearnMoreLink
-        additionalText="You can apply online right now."
-        applyHeading="How do I apply?"
-        applyLink="/pension/how-to-apply/"
-        applyText="Apply for Veterans Pension benefits"
-      />
-      <h3>You can also apply:</h3>
-      <h4>By mail</h4>
-      <p>Fill out an application for Pension (VA Form 21P-527EZ).</p>
+      <p>You can apply online, or using a PDF form.</p>
+      <h3 className="vads-u-margin-bottom--3">Apply online</h3>
+      <va-alert
+        close-btn-aria-label="Close notification"
+        status="info"
+        visible
+        aria-labelledby="alert-heading"
+        aria-describedby="alert-description"
+      >
+        <h4 id="alert-heading" slot="headline">
+          We updated our online pension form
+        </h4>
+        <p>
+          <strong>
+            If you started applying online before November 8, 2023,
+          </strong>{' '}
+          we have some new questions for you to answer. And we changed some
+          questions, so you may need to provide certain information again.
+        </p>
+      </va-alert>
+      <p>You can apply online right now.</p>
+      <a
+        className="vads-c-action-link--green"
+        href="/pension/application/527EZ/introduction"
+      >
+        Apply for Veteran Pension benefits
+      </a>
+      <h3 className="vads-u-margin-bottom--3">Apply using a PDF form</h3>
+      <p>First, fill out an Application for Pension (VA Form 21P-527EZ).</p>
       <va-link
         text="Get VA Form 21P-527EZ to download"
-        filetype="PDF"
-        href="https://www.vba.va.gov/pubs/forms/VBA-21P-527EZ-ARE.pdf"
-        pages={8}
+        href="/find-forms/about-form-21p-527ez/"
       />
-      <br />
-      <p>Mail the completed form to the pension management center (PMC):</p>
+      <p>Then submit your completed form in 1 of these ways:</p>
+      <h4>Upload your form online</h4>
+      <p>
+        Upload a copy of your completed form using the QuickSubmit tool through
+        AccessVA. If it’s your first time signing in to this tool, you’ll need
+        to register first. After you’ve registered, you can upload your
+        application and documents online.
+      </p>
+      <va-link
+        text="Upload your form through AccessVA"
+        href="https://eauth.va.gov/accessva/?cspSelectFor=quicksubmit"
+      />
+      <h4> Mail your form</h4>
+      <p>Mail your completed form to the pension management center (PMC):</p>
       <p className="va-address-block">
         Department of Veterans Affairs <br />
         Pension Intake Center
@@ -40,13 +65,13 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
         Janesville, WI 53547-5365
         <br />
       </p>
-      <h4>In person</h4>
-      <p>Bring your application to a VA regional office near you.</p>
+      <h4>Submit your form in person</h4>
+      <p>Bring your completed form to a VA regional office near you.</p>
       <va-link
         text="Find your nearest VA regional office"
         href="/find-locations/?facilityType=benefits"
       />
-      <h4>With the help of a trained professional</h4>
+      <h4>Apply with the help of a trained professional</h4>
       <p>
         You can work with a trained professional called an accredited
         representative to get help applying for VA pension benefits.
@@ -54,12 +79,6 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
       <va-link
         text="Get help filing your claim"
         href="/disability/get-help-filing-claim/"
-      />
-      <br />
-      <br />
-      <va-link
-        text="Find out how to apply for a Survivors Pension"
-        href="/pension/survivors-pension/"
       />
     </>
   ) : (
@@ -106,7 +125,7 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
               </p>
               <va-link
                 text="Find out how to submit an intent to file form"
-                href="https://www.va.gov/pension/how-to-apply/#should-i-submit-an-intent-to-f"
+                href="/pension/how-to-apply/#should-i-submit-an-intent-to-f"
               />
             </div>
           </va-alert>
@@ -115,12 +134,11 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
           <va-link
             text="Get
           VA Form 21P-527EZ to download"
-            href="https://www.vba.va.gov/pubs/forms/VBA-21P-527EZ-ARE.pdf"
+            href="/find-forms/about-form-21p-527ez/"
           />
           <p>
-            If you started applying online already, you can still sign in to
-            VA.gov to refer to your saved information when you fill out the PDF
-            form.
+            If you started applying online already, you can still refer to your
+            saved information when you fill out the PDF form.
           </p>
           <va-link
             href="/pension/application/527EZ/introduction"
@@ -218,7 +236,7 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
           <va-link
             text="Get
             VA Form 21P-527EZ to download"
-            href="https://www.vba.va.gov/pubs/forms/VBA-21P-527EZ-ARE.pdf"
+            href="/find-forms/about-form-21p-527ez/"
           />
           <p>
             If you started applying online already, you can still sign in to
@@ -260,7 +278,7 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
           <p>Bring your completed form to a VA regional office near you.</p>
           <va-link
             text="Find your nearest VA regional office"
-            href="href=/find-locations/?facilityType=benefits"
+            href="/find-locations/?facilityType=benefits"
           />
           <h4>Apply with the help of a trained professional</h4>
           <p>

--- a/src/applications/static-pages/pension-how-do-i-apply-widget/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/pension-how-do-i-apply-widget/components/App/index.unit.spec.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import { Provider } from 'react-redux';
 import { render, fireEvent } from '@testing-library/react';
 import { expect } from 'chai';
-import { $ } from 'platform/forms-system/src/js/utilities/ui';
+import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import { toggleLoginModal as toggleLoginModalAction } from '@department-of-veterans-affairs/platform-site-wide/actions';
 import { App, mapDispatchToProps, mapStateToProps } from '.';
 
@@ -41,14 +41,28 @@ describe('Pension Widget <App>', () => {
     );
   });
 
-  it('renders the application status component', () => {
+  it('renders the Pension re-launch widget when signed out', () => {
     const mockStore = store({ pensionFormEnabled: true });
     const { container } = render(
       <Provider store={mockStore}>
         <App />
       </Provider>,
     );
-    expect($('h2', container).textContent).to.equal(`How do I apply?`);
+    expect($('h4', container).textContent).to.equal(
+      `We updated our online pension form`,
+    );
+  });
+
+  it('renders the Pension re-launch widget when signed in', () => {
+    const mockStore = store({ pensionFormEnabled: true });
+    const { container } = render(
+      <Provider store={mockStore}>
+        <App loggedIn />
+      </Provider>,
+    );
+    expect($('h4', container).textContent).to.equal(
+      `We updated our online pension form`,
+    );
   });
 
   it('shows "Refer to your saved form" link when user is logged in', () => {


### PR DESCRIPTION
## Summary

- Widget built for the Pension How to apply page (`/pension/how-to-apply`)
- Uses flipper `pension_form_enabled`: shows activated widget state when set to `true` (screenshot)
- Widget reference for use with Drupal: `pension-app-status`

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/73478

## Testing done

- Manual / Unit / Axe

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |<img src=https://github.com/department-of-veterans-affairs/vets-website/assets/57480791/9e1e4eec-786c-4b5c-852e-593a9fadfa79 width=300 />|<img src=https://github.com/department-of-veterans-affairs/vets-website/assets/57480791/88bbd834-2748-47d3-9671-f4f6f697b3b0 width=300 />|

## Acceptance criteria

- [x] Once the Pension 527ez form is flipped to production on the week of January 22, the How to Apply page that leads to the form will have updated content for the % release of traffic on January 24.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
