### PR TITLE
MHV-51102: Micriobio staging review fixes complete

### DIFF
--- a/src/applications/mhv/medical-records/components/LabsAndTests/MicroDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/MicroDetails.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
+import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
 import PrintHeader from '../shared/PrintHeader';
 import PrintDownload from '../shared/PrintDownload';
 import DownloadingRecordsInfo from '../shared/DownloadingRecordsInfo';
@@ -14,12 +15,17 @@ import {
   makePdf,
 } from '../../util/helpers';
 import {
+  formatName,
   generatePdfScaffold,
   updatePageTitle,
 } from '../../../shared/util/helpers';
-import { EMPTY_FIELD, pageTitles } from '../../util/constants';
+import { pageTitles } from '../../util/constants';
 import DateSubheading from '../shared/DateSubheading';
-import { txtLine } from '../../../shared/util/constants';
+import {
+  crisisLineHeader,
+  reportGeneratedBy,
+  txtLine,
+} from '../../../shared/util/constants';
 import {
   generateLabsIntro,
   generateMicrobioContent,
@@ -38,11 +44,8 @@ const MicroDetails = props => {
   useEffect(
     () => {
       focusElement(document.querySelector('h1'));
-      const titleDate = record.date !== EMPTY_FIELD ? `${record.date} - ` : '';
       updatePageTitle(
-        `${titleDate}${record.name} - ${
-          pageTitles.LAB_AND_TEST_RESULTS_PAGE_TITLE
-        }`,
+        `${record.name} - ${pageTitles.LAB_AND_TEST_RESULTS_PAGE_TITLE}`,
       );
     },
     [record],
@@ -58,7 +61,11 @@ const MicroDetails = props => {
 
   const generateMicroTxt = async () => {
     const content = `\n
+${crisisLineHeader}\n\n
 ${record.name}\n
+${formatName(user.userFullName)}\n
+Date of birth: ${formatDateLong(user.dob)}\n
+${reportGeneratedBy}\n
 Date: ${record.date}\n
 ${txtLine}\n\n
 Details about this test\n

--- a/src/applications/mhv/medical-records/reducers/labsAndTests.js
+++ b/src/applications/mhv/medical-records/reducers/labsAndTests.js
@@ -1,8 +1,8 @@
+import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
 import { Actions } from '../util/actionTypes';
 import {
   concatCategoryCodeText,
   concatObservationInterpretations,
-  dateFormat,
   getObservationValueWithUnits,
   isArrayAndHasItems,
 } from '../util/helpers';
@@ -59,7 +59,7 @@ const convertChemHemRecord = record => {
     orderedBy: record.physician || EMPTY_FIELD,
     requestedBy: record.physician || EMPTY_FIELD,
     date: record.effectiveDateTime
-      ? dateFormat(record.effectiveDateTime)
+      ? formatDateLong(record.effectiveDateTime)
       : EMPTY_FIELD,
     orderingLocation: record.location || EMPTY_FIELD,
     collectingLocation: record.location || EMPTY_FIELD,
@@ -82,7 +82,7 @@ const convertMicrobiologyRecord = record => {
     orderedBy: 'Beth M. Smith',
     requestedBy: 'John J. Lydon',
     date: record.effectiveDateTime
-      ? dateFormat(record.effectiveDateTime)
+      ? formatDateLong(record.effectiveDateTime)
       : EMPTY_FIELD,
     sampleFrom: record.type?.text || EMPTY_FIELD,
     sampleTested: record.specimen?.text || EMPTY_FIELD,
@@ -107,7 +107,7 @@ const convertPathologyRecord = record => {
     orderedBy: record.physician || EMPTY_FIELD,
     requestedBy: record.physician || EMPTY_FIELD,
     date: record.effectiveDateTime
-      ? dateFormat(record.effectiveDateTime)
+      ? formatDateLong(record.effectiveDateTime)
       : EMPTY_FIELD,
     sampleTested: record.specimen?.text || EMPTY_FIELD,
     labLocation: record.labLocation || EMPTY_FIELD,
@@ -157,9 +157,8 @@ const convertRadiologyRecord = record => {
       (isArrayAndHasItems(record.author) && record.author[0].display) ||
       EMPTY_FIELD,
     clinicalHistory: record.clinicalHistory || EMPTY_FIELD,
-    orderingLocation: record.location || EMPTY_FIELD,
     imagingLocation: authorDisplay,
-    date: record.date ? dateFormat(record.date) : EMPTY_FIELD,
+    date: record.date ? formatDateLong(record.date) : EMPTY_FIELD,
     imagingProvider: record.physician || EMPTY_FIELD,
     results: Buffer.from(record.content[0].attachment.data, 'base64').toString(
       'utf-8',


### PR DESCRIPTION
## Summary

Labs and tests - microbiology staging review fixes based review of allergies:

1. Remove aria label from allergy date on allergies list page - **N/A - dates for labs and tests are relevant and should be left intact in the aria label**
Issue details:
On /medical-records/allergies, each allergy link has an aria-label that includes the date entered: [allergen] on [date]. Associating a date with the visible link text using an aria-label is a really good technique when you have multiple instances of the same item, like multiple doses of an immunization that took place on different dates. But it seems unlikely that someone is going to have multiple instances of the same allergy, and the date is reflective of something administrative (when it was logged) rather than something relevant to the user (when something occurred). I think most screen reader users are going to be able to still navigate through the screens effectively, but the dates in the aria-label may cause some confusion.

2. Change date below 'h1' on details page from an 'h2' to a ‘p’ tag - **N/A - fixed as part of: https://github.com/department-of-veterans-affairs/vets-website/pull/26836**
Issue details:
On /medical-records/allergies/:allergyId, the date the allergy was entered is coded as an H2 (styled visually as paragraph text). Headings should describe the section of content that follows them, but this H2 doesn't really describe anything --- it's just stand-alone information about this allergy.

3. Change notification for a user with no records from an alert to a message - **FIXED**
Issue details:
If a user has no records of allergies they get an empty state that is styled with a slim info alert.

4. Fix floating print/download menu options - **N/A - fixed as part of: https://github.com/department-of-veterans-affairs/vets-website/pull/26836**
Issue details:
When a user selects Print or Download a list drops down below it with options. There is a space between the Print or download box and the box with the options in it which makes it looks like it is floating.

5. Change all caps data fields to sentence case - **NOT FIXED - Lexi had questions about this and is creating a separate ticket for fixing it**
Issue details:
my-health/medical-records/allergies/:allergyId > Allergies > ATORVASTATIN/EZETIMIBE >
Allergy results are in all caps. “Reaction” inputs are also capitalized.

6. Duplicate element id’s due to “print-only” content - **N/A - no duplicate id's found for microbiology**
Issue details:
Both /medical-records/allergies and /medical-records/allergies/:allergyId contain HTML elements with duplicate IDs. Looks like this is happening with the hidden print-only content, eg. there's an #allergy-date that's visible on the page and another #allergy-date that's not visible and is contained in the .print-only div. The .print-only div is hidden with display: none which should hide it from just about all assistive technologies, so the impact is minimal. But there may be some users running very old screen readers that get tripped up by having duplicate IDs on the page.

7. Remove date from page title - **FIXED**
Issue details:
Page title tag for Allergy details pages has extra information and does not match the page title.

8. Get unit test coverage above 80% for all metrics - **N/A - unit test coverage is already above 80% for lines, functions, statements, and branches**
<img width="772" alt="Screenshot 2024-01-07 at 4 18 26 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/187ee44a-457f-4cfc-ad56-bb8f196d670f">

9. Update pdf/txt content/formatting for list and details view where applicable - **Fixed**
Issue details:
Ensure pdf content matches latest content from UCD team mockups
Ensure txt content is formatted properly so that all content is left aligned, 2 spaces before any headers, the following content should be present in the order below:
- Crisis line
- Vaccines (title)
- Name
- DOB
- Report generated by * on date
- This list includes... (subtitles)
- Showing 5 records from newest to oldest (count, list view only)
- Record(s)

Other changes:
- Removed time from dates for labs and tests

## Related issue(s)
### [MHV-51102](https://jira.devops.va.gov/browse/MHV-51102) - Staging Review Validation for Microbiology ###

<img width="925" alt="Screenshot 2024-01-17 at 10 00 53 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/a5a1b4d6-9ef1-4579-818e-2c6e15bd393a">
<img width="919" alt="Screenshot 2024-01-17 at 10 01 07 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/5b2389db-3ba5-4c4b-8bb3-a5afa5db2ec9">
<img width="878" alt="Screenshot 2024-01-17 at 10 01 24 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/7226ebe7-38f7-48db-a02a-095fa83c202a">

## Testing done

- No new unit tests or unit test fixes needed

## Screenshots

details:
<img width="883" alt="Screenshot 2024-01-17 at 10 04 23 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/0786e80d-3936-4b7d-856c-a22fcb8a2e96">
<img width="775" alt="Screenshot 2024-01-17 at 10 04 31 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/8513d52d-bedf-45af-8f87-a60448423253">

print:
<img width="531" alt="Screenshot 2024-01-17 at 10 05 17 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/ab11cf2f-a90e-45a3-97a4-f24e29670b7c">

pdf:
<img width="531" alt="Screenshot 2024-01-17 at 10 05 17 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/6f2ccab5-01f7-4698-b6ac-29e243c7d1a3">

txt:
<img width="677" alt="Screenshot 2024-01-17 at 10 06 21 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/6b024ec3-be16-4876-a8bb-fd50c254d084">


## What areas of the site does it impact?
MHV Medical Records - microbiology

## Acceptance criteria
AC1 All staging review issues documented for Allergies have been reviewed for this domain.
AC2 Findings have been documented in this ticket and resolved, or new JIRA ticket have been created

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
