### PR TITLE
MHV-51158: Staging review fixes for radiology complete

### DIFF
--- a/src/applications/mhv/medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -3,16 +3,21 @@ import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
+import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
 import PrintHeader from '../shared/PrintHeader';
 import PrintDownload from '../shared/PrintDownload';
 import DownloadingRecordsInfo from '../shared/DownloadingRecordsInfo';
 import InfoAlert from '../shared/InfoAlert';
 import GenerateRadiologyPdf from './GenerateRadiologyPdf';
-import { updatePageTitle } from '../../../shared/util/helpers';
-import { EMPTY_FIELD, pageTitles } from '../../util/constants';
+import { formatName, updatePageTitle } from '../../../shared/util/helpers';
+import { pageTitles } from '../../util/constants';
 import { generateTextFile, getNameDateAndTime } from '../../util/helpers';
 import DateSubheading from '../shared/DateSubheading';
-import { txtLine } from '../../../shared/util/constants';
+import {
+  crisisLineHeader,
+  reportGeneratedBy,
+  txtLine,
+} from '../../../shared/util/constants';
 
 const RadiologyDetails = props => {
   const { record, fullState, runningUnitTest } = props;
@@ -27,11 +32,8 @@ const RadiologyDetails = props => {
   useEffect(
     () => {
       focusElement(document.querySelector('h1'));
-      const titleDate = record.date !== EMPTY_FIELD ? `${record.date} - ` : '';
       updatePageTitle(
-        `${titleDate}${record.name} - ${
-          pageTitles.LAB_AND_TEST_RESULTS_PAGE_TITLE
-        }`,
+        `${record.name} - ${pageTitles.LAB_AND_TEST_RESULTS_PAGE_TITLE}`,
       );
     },
     [record],
@@ -43,15 +45,19 @@ const RadiologyDetails = props => {
 
   const generateRadioloyTxt = async () => {
     const content = `\n
+${crisisLineHeader}\n\n
 ${record.name}\n
+${formatName(user.userFullName)}\n
+Date of birth: ${formatDateLong(user.dob)}\n
+${reportGeneratedBy}\n
 Date entered: ${record.date}\n
 ${txtLine}\n\n
-    Reason for test: ${record.reason} \n
-    Clinical history: ${record.clinicalHistory} \n
-    Ordered by: ${record.orderedBy} \n
-    Order location: ${record.orderingLocation} \n
-    Imaging location: ${record.imagingLocation} \n
-    Imaging provider: ${record.imagingProvider} \n;
+Reason for test: ${record.reason} \n
+Clinical history: ${record.clinicalHistory} \n
+Ordered by: ${record.orderedBy} \n
+Order location: ${record.orderingLocation} \n
+Imaging location: ${record.imagingLocation} \n
+Imaging provider: ${record.imagingProvider} \n
 ${txtLine}\n\n
 Results\n
 ${record.results}`;
@@ -104,10 +110,6 @@ ${record.results}`;
           Ordered by
         </h3>
         <p>{record.orderedBy}</p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Ordering location
-        </h3>
-        <p>{record.orderingLocation}</p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Imaging location
         </h3>


### PR DESCRIPTION
## Summary

Labs and tests - radiology staging review fixes based review of allergies:

1. Remove aria label from allergy date on allergies list page - **N/A - dates for labs and tests are relevant and should be left intact in the aria label**
Issue details:
On /medical-records/allergies, each allergy link has an aria-label that includes the date entered: [allergen] on [date]. Associating a date with the visible link text using an aria-label is a really good technique when you have multiple instances of the same item, like multiple doses of an immunization that took place on different dates. But it seems unlikely that someone is going to have multiple instances of the same allergy, and the date is reflective of something administrative (when it was logged) rather than something relevant to the user (when something occurred). I think most screen reader users are going to be able to still navigate through the screens effectively, but the dates in the aria-label may cause some confusion.

2. Change date below 'h1' on details page from an 'h2' to a ‘p’ tag - **N/A - fixed as part of: https://github.com/department-of-veterans-affairs/vets-website/pull/26836**
Issue details:
On /medical-records/allergies/:allergyId, the date the allergy was entered is coded as an H2 (styled visually as paragraph text). Headings should describe the section of content that follows them, but this H2 doesn't really describe anything --- it's just stand-alone information about this allergy.

3. Change notification for a user with no records from an alert to a message - **FIXED**
Issue details:
If a user has no records of allergies they get an empty state that is styled with a slim info alert.

4. Fix floating print/download menu options - **N/A - fixed as part of: https://github.com/department-of-veterans-affairs/vets-website/pull/26836**
Issue details:
When a user selects Print or Download a list drops down below it with options. There is a space between the Print or download box and the box with the options in it which makes it looks like it is floating.

5. Change all caps data fields to sentence case - **NOT FIXED - Lexi had questions about this and is creating a separate ticket for fixing it**
Issue details:
my-health/medical-records/allergies/:allergyId > Allergies > ATORVASTATIN/EZETIMIBE >
Allergy results are in all caps. “Reaction” inputs are also capitalized.

6. Duplicate element id’s due to “print-only” content - **N/A - no duplicate id's found for radiology**
Issue details:
Both /medical-records/allergies and /medical-records/allergies/:allergyId contain HTML elements with duplicate IDs. Looks like this is happening with the hidden print-only content, eg. there's an #allergy-date that's visible on the page and another #allergy-date that's not visible and is contained in the .print-only div. The .print-only div is hidden with display: none which should hide it from just about all assistive technologies, so the impact is minimal. But there may be some users running very old screen readers that get tripped up by having duplicate IDs on the page.

7. Remove date from page title - **FIXED**
Issue details:
Page title tag for Allergy details pages has extra information and does not match the page title.

8. Get unit test coverage above 80% for all metrics - **N/A - unit test coverage is already above 80% for lines, functions, statements, and branches**
<img width="772" alt="Screenshot 2024-01-07 at 4 18 26 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/187ee44a-457f-4cfc-ad56-bb8f196d670f">

9. Update pdf/txt content/formatting for list and details view where applicable - **Fixed**
Issue details:
Ensure pdf content matches latest content from UCD team mockups
Ensure txt content is formatted properly so that all content is left aligned, 2 spaces before any headers, the following content should be present in the order below:
- Crisis line
- Vaccines (title)
- Name
- DOB
- Report generated by * on date
- This list includes... (subtitles)
- Showing 5 records from newest to oldest (count, list view only)
- Record(s)

Other fixes:
- Time removed from date as part of https://github.com/department-of-veterans-affairs/vets-website/pull/27531

## Related issue(s)
### [MHV-51158](https://jira.devops.va.gov/browse/MHV-51158) - Staging Review Validation for Radiology ###

<img width="896" alt="Screenshot 2024-01-17 at 10 12 09 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/60856679-0f60-433e-bce5-3751e41b099b">
<img width="902" alt="Screenshot 2024-01-17 at 10 12 30 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/082e2e87-f4c7-4154-930d-2e6667b34507">
<img width="921" alt="Screenshot 2024-01-17 at 10 12 43 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/239fc6fe-404e-433d-9924-92976a04c472">

## Testing done

- No new unit tests or unit test fixes needed

## Screenshots

details:
<img width="769" alt="Screenshot 2024-01-17 at 10 13 32 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/8d5f8faf-8657-4328-9d78-ebb26a304ee9">
<img width="752" alt="Screenshot 2024-01-17 at 10 13 42 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/0553f79c-f49e-4db0-8d38-720c96aa6ea1">

print:
<img width="551" alt="Screenshot 2024-01-17 at 10 14 28 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/b6c0fb1e-d714-4f8f-b8e5-91bc8121b20a">

pdf:
<img width="825" alt="Screenshot 2024-01-17 at 10 14 51 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/a1db764f-8e7c-4f9b-ab6e-8078e693522a">

txt:
<img width="685" alt="Screenshot 2024-01-17 at 10 15 40 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/ad95f833-f710-4d47-9654-4341c01d708b">


## What areas of the site does it impact?
MHV Medical Records - radiology

## Acceptance criteria
AC1 All staging review issues documented for Allergies have been reviewed for this domain.
AC2 Findings have been documented in this ticket and resolved, or new JIRA ticket have been created

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
