### PR TITLE
[CST] - Evidence request alert changes on status tab

### DIFF
--- a/src/applications/claims-status/components/DueDate.jsx
+++ b/src/applications/claims-status/components/DueDate.jsx
@@ -15,15 +15,8 @@ export default function DueDate({ date }) {
   const dueDateHeader = `Needed from you by ${formattedClaimDate}`;
 
   return (
-    <div className="tracked-item-due">
-      <strong className={className}>
-        <i className="fa fa-exclamation-triangle past-due-icon" /> Needed from
-        you
-      </strong>
-      <span className={className}> - due {dueDate.fromNow()}</span>
-      <div className="due-date-header">
-        <strong className={className}>{dueDateHeader}</strong>
-      </div>
+    <div className="due-date-header">
+      <strong className={className}>{dueDateHeader}</strong>
     </div>
   );
 }

--- a/src/applications/claims-status/components/DueDateOld.jsx
+++ b/src/applications/claims-status/components/DueDateOld.jsx
@@ -2,18 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
 
-import { DATE_FORMATS } from '../constants';
-import { buildDateFormatter } from '../utils/helpers';
-
-export default function DueDate({ date }) {
+export default function DueDateOld({ date }) {
   const now = moment();
   const dueDate = moment(date);
   const className = dueDate.isBefore(now) ? 'past-due' : 'due-file';
-
-  const formatDate = buildDateFormatter(DATE_FORMATS.LONG_DATE);
-  const formattedClaimDate = formatDate(date);
-  const dueDateHeader = `Needed from you by ${formattedClaimDate}`;
-
   return (
     <div className="tracked-item-due">
       <strong className={className}>
@@ -21,13 +13,10 @@ export default function DueDate({ date }) {
         you
       </strong>
       <span className={className}> - due {dueDate.fromNow()}</span>
-      <div className="due-date-header">
-        <strong className={className}>{dueDateHeader}</strong>
-      </div>
     </div>
   );
 }
 
-DueDate.propTypes = {
+DueDateOld.propTypes = {
   date: PropTypes.string.isRequired,
 };

--- a/src/applications/claims-status/components/FilesNeeded.jsx
+++ b/src/applications/claims-status/components/FilesNeeded.jsx
@@ -2,17 +2,16 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import { getTrackedItemId, truncateDescription } from '../utils/helpers';
-import DueDateOld from './DueDateOld';
+import DueDate from './DueDate';
 
 function FilesNeeded({ id, item }) {
   return (
     <va-alert status="warning" slim uswds>
       <div className="item-container">
         <h3 className="file-request-title">{item.displayName}</h3>
-        <DueDateOld date={item.suspenseDate} />
-
+        <DueDate date={item.suspenseDate} />
         <p className="submission-description">
-          {truncateDescription(item.description)}
+          {truncateDescription(item.description, 200)}
         </p>
       </div>
       <div className="link-action-container">

--- a/src/applications/claims-status/components/FilesNeeded.jsx
+++ b/src/applications/claims-status/components/FilesNeeded.jsx
@@ -6,7 +6,7 @@ import DueDate from './DueDate';
 
 function FilesNeeded({ id, item }) {
   return (
-    <va-alert status="warning" slim uswds>
+    <va-alert id={id} status="warning" slim uswds>
       <div className="item-container">
         <h3 className="file-request-title">{item.displayName}</h3>
         <DueDate date={item.suspenseDate} />

--- a/src/applications/claims-status/components/FilesNeeded.jsx
+++ b/src/applications/claims-status/components/FilesNeeded.jsx
@@ -6,7 +6,7 @@ import DueDate from './DueDate';
 
 function FilesNeeded({ id, item }) {
   return (
-    <va-alert id={id} status="warning" slim uswds>
+    <va-alert status="warning" slim uswds>
       <div className="item-container">
         <h3 className="file-request-title">{item.displayName}</h3>
         <DueDate date={item.suspenseDate} />

--- a/src/applications/claims-status/components/FilesNeeded.jsx
+++ b/src/applications/claims-status/components/FilesNeeded.jsx
@@ -6,11 +6,15 @@ import DueDate from './DueDate';
 
 function FilesNeeded({ id, item }) {
   return (
-    <va-alert status="warning" uswds>
+    <va-alert
+      class="primary-alert vads-u-margin-bottom--2"
+      status="warning"
+      uswds
+    >
       <div className="item-container">
-        <h3 className="file-request-title">{item.displayName}</h3>
+        <h3 className="alert-title">{item.displayName}</h3>
         <DueDate date={item.suspenseDate} />
-        <p className="submission-description">
+        <p className="alert-description">
           {truncateDescription(item.description, 200)}
         </p>
       </div>

--- a/src/applications/claims-status/components/FilesNeeded.jsx
+++ b/src/applications/claims-status/components/FilesNeeded.jsx
@@ -1,0 +1,37 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Link } from 'react-router';
+import { getTrackedItemId, truncateDescription } from '../utils/helpers';
+import DueDateOld from './DueDateOld';
+
+function FilesNeeded({ id, item }) {
+  return (
+    <va-alert status="warning" slim uswds>
+      <div className="item-container">
+        <h3 className="file-request-title">{item.displayName}</h3>
+        <DueDateOld date={item.suspenseDate} />
+
+        <p className="submission-description">
+          {truncateDescription(item.description)}
+        </p>
+      </div>
+      <div className="link-action-container">
+        <Link
+          aria-label={`View details for ${item.displayName}`}
+          title={`View details for ${item.displayName}`}
+          className="vads-c-action-link--blue"
+          to={`your-claims/${id}/document-request/${getTrackedItemId(item)}`}
+        >
+          View details
+        </Link>
+      </div>
+    </va-alert>
+  );
+}
+
+FilesNeeded.propTypes = {
+  id: PropTypes.string.isRequired,
+  item: PropTypes.object.isRequired,
+};
+
+export default FilesNeeded;

--- a/src/applications/claims-status/components/FilesNeeded.jsx
+++ b/src/applications/claims-status/components/FilesNeeded.jsx
@@ -6,7 +6,7 @@ import DueDate from './DueDate';
 
 function FilesNeeded({ id, item }) {
   return (
-    <va-alert status="warning" slim uswds>
+    <va-alert status="warning" uswds>
       <div className="item-container">
         <h3 className="file-request-title">{item.displayName}</h3>
         <DueDate date={item.suspenseDate} />

--- a/src/applications/claims-status/components/FilesNeededOld.jsx
+++ b/src/applications/claims-status/components/FilesNeededOld.jsx
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Link } from 'react-router';
+import { getTrackedItemId, truncateDescription } from '../utils/helpers';
+import DueDateOld from './DueDateOld';
+
+function FilesNeededOld({ id, item }) {
+  return (
+    <div className="file-request-list-item usa-alert usa-alert-warning background-color-only alert-with-details">
+      <div className="item-container">
+        <h3 className="file-request-title">{item.displayName}</h3>
+        <p className="submission-description">
+          {truncateDescription(item.description)}
+        </p>
+        <DueDateOld date={item.suspenseDate} />
+      </div>
+      <div className="button-container">
+        <Link
+          aria-label={`View Details for ${item.displayName}`}
+          title={`View Details for ${item.displayName}`}
+          className="usa-button usa-button-secondary view-details-button"
+          to={`your-claims/${id}/document-request/${getTrackedItemId(item)}`}
+        >
+          View Details
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+FilesNeededOld.propTypes = {
+  id: PropTypes.string.isRequired,
+  item: PropTypes.object.isRequired,
+};
+
+export default FilesNeededOld;

--- a/src/applications/claims-status/components/RequestedFilesInfo.jsx
+++ b/src/applications/claims-status/components/RequestedFilesInfo.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router';
 
 import AdditionalEvidencePage from '../containers/AdditionalEvidencePage';
 import { getTrackedItemId, truncateDescription } from '../utils/helpers';
-import DueDate from './DueDate';
+import DueDateOld from './DueDateOld';
 
 export default function RequestedFilesInfo({ id, filesNeeded, optionalFiles }) {
   return (
@@ -28,7 +28,7 @@ export default function RequestedFilesInfo({ id, filesNeeded, optionalFiles }) {
               <p className="submission-description">
                 {truncateDescription(item.description)}
               </p>
-              <DueDate date={item.suspenseDate} />
+              <DueDateOld date={item.suspenseDate} />
             </div>
             <div className="button-container">
               <Link

--- a/src/applications/claims-status/components/RequestedFilesInfo.jsx
+++ b/src/applications/claims-status/components/RequestedFilesInfo.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router';
 
 import AdditionalEvidencePage from '../containers/AdditionalEvidencePage';
 import { getTrackedItemId, truncateDescription } from '../utils/helpers';
-import DueDateOld from './DueDateOld';
+import FilesNeededOld from './FilesNeededOld';
 
 export default function RequestedFilesInfo({ id, filesNeeded, optionalFiles }) {
   return (
@@ -19,30 +19,7 @@ export default function RequestedFilesInfo({ id, filesNeeded, optionalFiles }) {
         ) : null}
 
         {filesNeeded.map(item => (
-          <div
-            className="file-request-list-item usa-alert usa-alert-warning background-color-only alert-with-details"
-            key={getTrackedItemId(item)}
-          >
-            <div className="item-container">
-              <h3 className="file-request-title">{item.displayName}</h3>
-              <p className="submission-description">
-                {truncateDescription(item.description)}
-              </p>
-              <DueDateOld date={item.suspenseDate} />
-            </div>
-            <div className="button-container">
-              <Link
-                aria-label={`View Details for ${item.displayName}`}
-                title={`View Details for ${item.displayName}`}
-                className="usa-button usa-button-secondary view-details-button"
-                to={`your-claims/${id}/document-request/${getTrackedItemId(
-                  item,
-                )}`}
-              >
-                View Details
-              </Link>
-            </div>
-          </div>
+          <FilesNeededOld key={getTrackedItemId(item)} id={id} item={item} />
         ))}
 
         {optionalFiles.map(item => (

--- a/src/applications/claims-status/components/WhatYouNeedToDo.jsx
+++ b/src/applications/claims-status/components/WhatYouNeedToDo.jsx
@@ -1,24 +1,21 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { getTrackedItemId } from '../utils/helpers';
+import {
+  getTrackedItemId,
+  getTrackedItems,
+  getFilesNeeded,
+} from '../utils/helpers';
 
 import FilesNeeded from './FilesNeeded';
 
-function WhatYouNeedToDo({ claim }) {
-  const { trackedItems } = claim.attributes;
-
-  const filesNeeded = trackedItems.filter(
-    item => item.status === 'NEEDED_FROM_YOU',
-  );
-
-  const optionalFiles = trackedItems.filter(
-    item => item.status === 'NEEDED_FROM_OTHERS',
-  );
+function WhatYouNeedToDo({ claim, useLighthouse }) {
+  const trackedItems = getTrackedItems(claim, useLighthouse);
+  const filesNeeded = getFilesNeeded(trackedItems, useLighthouse);
 
   return (
     <div className="what-you-need-to-do-container">
       <h3 className="claim-status-subheader">What you need to do</h3>
-      {filesNeeded.length + optionalFiles.length === 0 ? (
+      {filesNeeded.length === 0 ? (
         <div className="no-documents">
           <p>
             There's nothing we need from you right now. We'll let you know when
@@ -35,6 +32,7 @@ function WhatYouNeedToDo({ claim }) {
 
 WhatYouNeedToDo.propTypes = {
   claim: PropTypes.object,
+  useLighthouse: PropTypes.bool,
 };
 
 export default WhatYouNeedToDo;

--- a/src/applications/claims-status/components/WhatYouNeedToDo.jsx
+++ b/src/applications/claims-status/components/WhatYouNeedToDo.jsx
@@ -1,0 +1,40 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { getTrackedItemId } from '../utils/helpers';
+
+import FilesNeeded from './FilesNeeded';
+
+function WhatYouNeedToDo({ claim }) {
+  const { trackedItems } = claim.attributes;
+
+  const filesNeeded = trackedItems.filter(
+    item => item.status === 'NEEDED_FROM_YOU',
+  );
+
+  const optionalFiles = trackedItems.filter(
+    item => item.status === 'NEEDED_FROM_OTHERS',
+  );
+
+  return (
+    <div className="what-you-need-to-do-container">
+      <h3 className="claim-status-subheader">What you need to do</h3>
+      {filesNeeded.length + optionalFiles.length === 0 ? (
+        <div className="no-documents">
+          <p>
+            There's nothing we need from you right now. We'll let you know when
+            there's an update.
+          </p>
+        </div>
+      ) : null}
+      {filesNeeded.map(item => (
+        <FilesNeeded key={getTrackedItemId(item)} id={claim.id} item={item} />
+      ))}
+    </div>
+  );
+}
+
+WhatYouNeedToDo.propTypes = {
+  claim: PropTypes.object,
+};
+
+export default WhatYouNeedToDo;

--- a/src/applications/claims-status/components/evss/ClaimStatusPageContent.jsx
+++ b/src/applications/claims-status/components/evss/ClaimStatusPageContent.jsx
@@ -7,6 +7,7 @@ import ClaimComplete from '../ClaimComplete';
 import ClaimsDecision from '../ClaimsDecision';
 import ClaimsTimeline from '../ClaimsTimeline';
 import NeedFilesFromYou from '../NeedFilesFromYou';
+import WhatYouNeedToDo from '../WhatYouNeedToDo';
 
 const itemsNeedingAttentionFromVet = events => {
   return events?.filter(
@@ -33,7 +34,14 @@ export default function ClaimStatusPageContent({
   return (
     <div>
       {showDocsNeeded ? (
-        <NeedFilesFromYou claimId={claim.id} files={filesNeeded} />
+        <Toggler toggleName={Toggler.TOGGLE_NAMES.cstUseClaimDetailsV2}>
+          <Toggler.Enabled>
+            <WhatYouNeedToDo claim={claim} useLighthouse={false} />
+          </Toggler.Enabled>
+          <Toggler.Disabled>
+            <NeedFilesFromYou claimId={claim.id} files={filesNeeded} />
+          </Toggler.Disabled>
+        </Toggler>
       ) : null}
       {decisionLetterSent && !open ? (
         <ClaimsDecision

--- a/src/applications/claims-status/components/evss/ClaimStatusPageContent.jsx
+++ b/src/applications/claims-status/components/evss/ClaimStatusPageContent.jsx
@@ -33,16 +33,17 @@ export default function ClaimStatusPageContent({
 
   return (
     <div>
-      {showDocsNeeded ? (
-        <Toggler toggleName={Toggler.TOGGLE_NAMES.cstUseClaimDetailsV2}>
-          <Toggler.Enabled>
-            <WhatYouNeedToDo claim={claim} useLighthouse={false} />
-          </Toggler.Enabled>
+      <Toggler toggleName={Toggler.TOGGLE_NAMES.cstUseClaimDetailsV2}>
+        <Toggler.Enabled>
+          <WhatYouNeedToDo claim={claim} useLighthouse={false} />
+        </Toggler.Enabled>
+        {showDocsNeeded && (
           <Toggler.Disabled>
             <NeedFilesFromYou claimId={claim.id} files={filesNeeded} />
           </Toggler.Disabled>
-        </Toggler>
-      ) : null}
+        )}
+      </Toggler>
+
       {decisionLetterSent && !open ? (
         <ClaimsDecision
           completedDate={getCompletedDate(claim)}

--- a/src/applications/claims-status/components/evss/DocumentRequestPageContent.jsx
+++ b/src/applications/claims-status/components/evss/DocumentRequestPageContent.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import DueDate from '../DueDate';
+import DueDateOld from '../DueDateOld';
 
 export default function DocumentRequestPageContent({ trackedItem }) {
   return (
     <>
       <h1 className="claims-header">{trackedItem.displayName}</h1>
       {trackedItem.type.endsWith('you_list') ? (
-        <DueDate date={trackedItem.suspenseDate} />
+        <DueDateOld date={trackedItem.suspenseDate} />
       ) : null}
       {trackedItem.type.endsWith('others_list') ? (
         <div className="optional-upload">

--- a/src/applications/claims-status/containers/ClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/ClaimStatusPage.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import scrollToTop from '@department-of-veterans-affairs/platform-utilities/scrollToTop';
 
-import { Toggler } from '~/platform/utilities/feature-toggles';
+import { Toggler } from 'platform/utilities/feature-toggles';
 import { clearNotification } from '../actions';
 import ClaimComplete from '../components/ClaimComplete';
 // START lighthouse_migration
@@ -248,7 +248,7 @@ class ClaimStatusPage extends React.Component {
         {showDocsNeeded ? (
           <Toggler toggleName={Toggler.TOGGLE_NAMES.cstUseClaimDetailsV2}>
             <Toggler.Enabled>
-              <WhatYouNeedToDo claim={claim} />
+              <WhatYouNeedToDo claim={claim} useLighthouse={useLighthouse} />
             </Toggler.Enabled>
             <Toggler.Disabled>
               <NeedFilesFromYou claimId={claim.id} files={filesNeeded} />

--- a/src/applications/claims-status/containers/ClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/ClaimStatusPage.jsx
@@ -245,16 +245,17 @@ class ClaimStatusPage extends React.Component {
 
     return (
       <div>
-        {showDocsNeeded ? (
-          <Toggler toggleName={Toggler.TOGGLE_NAMES.cstUseClaimDetailsV2}>
-            <Toggler.Enabled>
-              <WhatYouNeedToDo claim={claim} useLighthouse={useLighthouse} />
-            </Toggler.Enabled>
+        <Toggler toggleName={Toggler.TOGGLE_NAMES.cstUseClaimDetailsV2}>
+          <Toggler.Enabled>
+            <WhatYouNeedToDo claim={claim} useLighthouse={useLighthouse} />
+          </Toggler.Enabled>
+          {showDocsNeeded && (
             <Toggler.Disabled>
               <NeedFilesFromYou claimId={claim.id} files={filesNeeded} />
             </Toggler.Disabled>
-          </Toggler>
-        ) : null}
+          )}
+        </Toggler>
+
         {decisionLetterSent && !isOpen ? (
           <ClaimsDecision
             completedDate={closeDate}

--- a/src/applications/claims-status/containers/ClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/ClaimStatusPage.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import scrollToTop from '@department-of-veterans-affairs/platform-utilities/scrollToTop';
 
-import { Toggler } from 'platform/utilities/feature-toggles';
+import { Toggler } from '~/platform/utilities/feature-toggles';
 import { clearNotification } from '../actions';
 import ClaimComplete from '../components/ClaimComplete';
 // START lighthouse_migration
@@ -15,6 +15,8 @@ import ClaimStatusPageContent from '../components/evss/ClaimStatusPageContent';
 import ClaimsDecision from '../components/ClaimsDecision';
 import ClaimTimeline from '../components/ClaimTimeline';
 import NeedFilesFromYou from '../components/NeedFilesFromYou';
+import WhatYouNeedToDo from '../components/WhatYouNeedToDo';
+
 import { DATE_FORMATS } from '../constants';
 import { cstUseLighthouse, showClaimLettersFeature } from '../selectors';
 import {
@@ -244,7 +246,14 @@ class ClaimStatusPage extends React.Component {
     return (
       <div>
         {showDocsNeeded ? (
-          <NeedFilesFromYou claimId={claim.id} files={filesNeeded} />
+          <Toggler toggleName={Toggler.TOGGLE_NAMES.cstUseClaimDetailsV2}>
+            <Toggler.Enabled>
+              <WhatYouNeedToDo claim={claim} />
+            </Toggler.Enabled>
+            <Toggler.Disabled>
+              <NeedFilesFromYou claimId={claim.id} files={filesNeeded} />
+            </Toggler.Disabled>
+          </Toggler>
         ) : null}
         {decisionLetterSent && !isOpen ? (
           <ClaimsDecision

--- a/src/applications/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/applications/claims-status/containers/DocumentRequestPage.jsx
@@ -5,14 +5,14 @@ import { withRouter, Link } from 'react-router';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import scrollTo from 'platform/utilities/ui/scrollTo';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import scrollTo from '@department-of-veterans-affairs/platform-utilities/scrollTo';
+import scrollToTop from '@department-of-veterans-affairs/platform-utilities/scrollToTop';
 
 import DocumentRequestPageContent from '../components/evss/DocumentRequestPageContent';
 import AddFilesForm from '../components/AddFilesForm';
 import AskVAQuestions from '../components/AskVAQuestions';
 import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
-import DueDate from '../components/DueDate';
+import DueDateOld from '../components/DueDateOld';
 import Notification from '../components/Notification';
 import {
   addFile,
@@ -94,7 +94,7 @@ class DocumentRequestPage extends React.Component {
       <>
         <h1 className="claims-header">{trackedItem.displayName}</h1>
         {trackedItem.status === 'NEEDED_FROM_YOU' ? (
-          <DueDate date={trackedItem.suspenseDate} />
+          <DueDateOld date={trackedItem.suspenseDate} />
         ) : null}
         {trackedItem.status === 'NEEDED_FROM_OTHERS' ? (
           <div className="optional-upload">

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -962,10 +962,8 @@ button .claim-timeline-icon.fa {
   margin-bottom: 1.5em;
 }
 
-.primary-alert .item-container {
-  >.due-date-header {
-    padding-bottom: 24px;
-  }
+.primary-alert .item-container .due-date-header {
+  padding-bottom: 24px;
 }
 
 .link-action-container {

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -962,6 +962,30 @@ button .claim-timeline-icon.fa {
   margin-bottom: 1.5em;
 }
 
+.primary-alert .item-container {
+  >.due-date-header {
+    padding-bottom: 24px;
+  }
+}
+
+.link-action-container {
+  padding-top: 32px;
+}
+
+.alert-title {
+  font-size: 20px;
+  line-height: 26px;
+  padding-bottom: 0;
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+.alert-description {
+  font-size: 16px;
+  padding-bottom: 0;
+  margin: 0;
+}
+
 .file-request-list-item {
   margin-top: 1.5em;
   &:last-child {

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -77,6 +77,16 @@
   }
 }
 
+.due-date-header {
+  > .due-file {
+    color: $color-base;
+  }
+
+  > .past-due {
+    color: $color-secondary-darkest;
+  }
+}
+
 .claim-list-item-container {
   background-color: $color-gray-lightest;
   padding: 2em 1em 1em;

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -963,11 +963,12 @@ button .claim-timeline-icon.fa {
 }
 
 .primary-alert .item-container .due-date-header {
-  padding-bottom: 24px;
+  padding-bottom: 16px;
 }
 
 .link-action-container {
-  padding-top: 32px;
+  padding-top: 16px;
+  margin-left: -2px;
 }
 
 .alert-title {

--- a/src/applications/claims-status/tests/components/ClaimStatusPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimStatusPage.unit.spec.jsx
@@ -73,22 +73,32 @@ describe('<ClaimStatusPage>', () => {
         },
       }));
 
-    it('should render status page without a timeline or WhatYouNeedToDo section when no trackedItems', () => {
+    it('should render status page without a timeline and with a WhatYouNeedToDo section without alerts when using lighthouse', () => {
       const claim = {
         id: '1',
         attributes: {
-          phase: 2,
-          open: true,
+          supportingDocuments: [],
+          claimDate: '2023-01-01',
           closeDate: null,
-          documentsNeeded: true,
+          documentsNeeded: false,
           decisionLetterSent: false,
-          waiverSubmitted: true,
-          trackedItems: [{}],
+          status: 'INITIAL_REVIEW',
+          claimPhaseDates: {
+            currentPhaseBack: false,
+            phaseChangeDate: '2015-01-01',
+            latestPhaseType: 'INITIAL_REVIEW',
+            previousPhases: {
+              phase1CompleteDate: '2023-02-08',
+              phase2CompleteDate: '2023-02-08',
+            },
+          },
+          trackedItems: [],
         },
       };
       const { container } = render(
         <Provider store={getStore()}>
           <ClaimStatusPage
+            useLighthouse
             claim={claim}
             params={params}
             clearNotification={() => {}}
@@ -97,15 +107,15 @@ describe('<ClaimStatusPage>', () => {
         </Provider>,
       );
       const statusPage = $('#tabPanelStatus', container);
+
       expect(statusPage).to.exist;
       expect(within(statusPage).queryByRole('list')).to.not.exist;
-      // const expectedText =
-      //   "There's nothing we need from you right now. We'll let you know when there's an update.";
-      // expect(getByText(expectedText)).not.to.exist;
-      expect($('.what-you-need-to-do-container', container)).not.to.exist;
+      expect($('.what-you-need-to-do-container', container)).to.exist;
+      expect($('va-alert', container)).not.to.exist;
+      expect($('.need-files-alert', container)).not.to.exist;
     });
 
-    it('should render status page without a timeline, with a WhatYouNeedToDoPage when using lighthouse', () => {
+    it('should render status page without a timeline and with a WhatYouNeedToDo section with alerts when using lighthouse', () => {
       const claim = {
         id: '1',
         attributes: {
@@ -126,6 +136,7 @@ describe('<ClaimStatusPage>', () => {
           },
           trackedItems: [
             {
+              id: 1,
               status: 'NEEDED_FROM_YOU',
               displayName: 'Test',
               description: 'Test',
@@ -147,16 +158,45 @@ describe('<ClaimStatusPage>', () => {
         </Provider>,
       );
       const statusPage = $('#tabPanelStatus', container);
+
       expect(statusPage).to.exist;
       expect(within(statusPage).queryByRole('list')).to.not.exist;
-      // const expectedText =
-      //   "There's nothing we need from you right now. We'll let you know when there's an update.";
-      // expect(queryByText(expectedText)).not.to.exist;
       expect($('.what-you-need-to-do-container', container)).to.exist;
       expect($('va-alert', container)).to.exist;
     });
 
-    it('should not render status page without a timeline when using evss', () => {
+    it('should render status page without a timeline and with a WhatYouNeedToDo section without alerts when using evss', () => {
+      const claim = {
+        id: '1',
+        attributes: {
+          open: true,
+          phase: 3,
+          dateFiled: '2023-01-01',
+          documentsNeeded: true,
+          decisionLetterSent: false,
+          eventsTimeline: [],
+        },
+      };
+      const { container } = render(
+        <Provider store={getStore()}>
+          <ClaimStatusPage
+            claim={claim}
+            params={params}
+            clearNotification={() => {}}
+          />
+          ,
+        </Provider>,
+      );
+      const statusPage = $('#tabPanelStatus', container);
+
+      expect(statusPage).to.exist;
+      expect(within(statusPage).queryByRole('list')).to.not.exist;
+      expect($('.what-you-need-to-do-container', container)).to.exist;
+      expect($('va-alert', container)).not.to.exist;
+      expect($('.need-files-alert', container)).not.to.exist;
+    });
+
+    it('should not render status page without a timeline and with a WhatYouNeedToDo section with alerts when using evss', () => {
       const claim = {
         id: '1',
         attributes: {
@@ -167,6 +207,7 @@ describe('<ClaimStatusPage>', () => {
           decisionLetterSent: false,
           eventsTimeline: [
             {
+              trackedItemId: 1,
               type: 'still_need_from_you_list',
               status: 'NEEDED',
               displayName: 'Test',
@@ -190,10 +231,12 @@ describe('<ClaimStatusPage>', () => {
         </Provider>,
       );
       const statusPage = $('#tabPanelStatus', container);
+
       expect(statusPage).to.exist;
       expect(within(statusPage).queryByRole('list')).to.not.exist;
       expect($('.what-you-need-to-do-container', container)).to.exist;
       expect($('va-alert', container)).to.exist;
+      expect($('.need-files-alert', container)).not.to.exist;
     });
   });
 

--- a/src/applications/claims-status/tests/components/ClaimStatusPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimStatusPage.unit.spec.jsx
@@ -65,22 +65,6 @@ describe('<ClaimStatusPage>', () => {
   });
 
   context('cstUseClaimDetailsV2 feature flag enabled', () => {
-    const claim = {
-      attributes: {
-        phase: 2,
-        open: true,
-        documentsNeeded: false,
-        decisionLetterSent: false,
-        waiverSubmitted: true,
-        eventsTimeline: [
-          {
-            type: 'still_need_from_you_list',
-            status: 'NEEDED',
-          },
-        ],
-      },
-    };
-
     const getStore = (cstUseClaimDetailsV2Enabled = true) =>
       createStore(() => ({
         featureToggles: {
@@ -89,8 +73,70 @@ describe('<ClaimStatusPage>', () => {
         },
       }));
 
-    it('should not render status page with a timeline when using lighthouse', () => {
-      const { container } = render(
+    it('should render status page without a timeline or alerts, with WhatYouNeedToDo section when no trackedItems', () => {
+      const claim = {
+        attributes: {
+          phase: 2,
+          open: true,
+          documentsNeeded: false,
+          decisionLetterSent: false,
+          waiverSubmitted: true,
+          trackedItems: [{}],
+        },
+      };
+      const { container, findByText } = render(
+        <Provider store={getStore()}>
+          <ClaimStatusPage
+            claim={claim}
+            params={params}
+            clearNotification={() => {}}
+          />
+          ,
+        </Provider>,
+      );
+      const statusPage = $('#tabPanelStatus', container);
+      expect(statusPage).to.exist;
+      expect(within(statusPage).queryByRole('list')).to.not.exist;
+      const expectedText =
+        "There's nothing we need from you right now. We'll let you know when there's an update.";
+      expect(findByText(expectedText)).to.exist;
+      expect($('va-alert', container)).not.to.exist;
+    });
+
+    it('should render status page without a timeline, with alerts when using lighthouse', () => {
+      const claim = {
+        id: '1',
+        type: 'claim',
+        attributes: {
+          supportingDocuments: [],
+          claimDate: '2023-01-01',
+          closeDate: null,
+          status: 'INITIAL_REVIEW',
+          claimPhaseDates: {
+            currentPhaseBack: false,
+            phaseChangeDate: '2015-01-01',
+            latestPhaseType: 'INITIAL_REVIEW',
+            previousPhases: {
+              phase1CompleteDate: '2023-02-08',
+              phase2CompleteDate: '2023-02-08',
+            },
+          },
+
+          documentsNeeded: false,
+          decisionLetterSent: false,
+          waiverSubmitted: true,
+          trackedItems: [
+            {
+              status: 'NEEDED_FROM_YOU',
+              displayName: 'Test',
+              description: 'Test',
+              suspenseDate: '2024-02-01',
+              date: '2023-01-01',
+            },
+          ],
+        },
+      };
+      const { container, findByText, queryByText } = render(
         <Provider store={getStore()}>
           <ClaimStatusPage
             useLighthouse
@@ -104,9 +150,37 @@ describe('<ClaimStatusPage>', () => {
       const statusPage = $('#tabPanelStatus', container);
       expect(statusPage).to.exist;
       expect(within(statusPage).queryByRole('list')).to.not.exist;
+      const expectedText =
+        "There's nothing we need from you right now. We'll let you know when there's an update.";
+      expect(queryByText(expectedText)).not.to.exist;
+      // console.log('peri', findByText(expectedText));
+      expect($('va-alert', container)).to.exist;
+
+      // console.log('statusPage', statusPage);
+
+      // const whatYouNeedToDo = $('.what-you-need-to-do-container', container);
+      // console.log('whatYouNeedToDo', whatYouNeedToDo);
+      // expect(whatYouNeedToDo).to.exist;
+
+      // expect($('.what-you-need-to-do-container', container)).to.exist;
     });
 
-    it('should not render status page with a timeline when using evss', () => {
+    it('should not render status page without a timeline when using evss', () => {
+      const claim = {
+        attributes: {
+          phase: 2,
+          open: true,
+          documentsNeeded: false,
+          decisionLetterSent: false,
+          waiverSubmitted: true,
+          eventsTimeline: [
+            {
+              type: 'still_need_from_you_list',
+              status: 'NEEDED',
+            },
+          ],
+        },
+      };
       const test = getStore();
 
       const { container } = render(

--- a/src/applications/claims-status/tests/components/ClaimStatusPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimStatusPage.unit.spec.jsx
@@ -73,18 +73,20 @@ describe('<ClaimStatusPage>', () => {
         },
       }));
 
-    it('should render status page without a timeline or alerts, with WhatYouNeedToDo section when no trackedItems', () => {
+    it('should render status page without a timeline or WhatYouNeedToDo section when no trackedItems', () => {
       const claim = {
+        id: '1',
         attributes: {
           phase: 2,
           open: true,
-          documentsNeeded: false,
+          closeDate: null,
+          documentsNeeded: true,
           decisionLetterSent: false,
           waiverSubmitted: true,
           trackedItems: [{}],
         },
       };
-      const { container, findByText } = render(
+      const { container } = render(
         <Provider store={getStore()}>
           <ClaimStatusPage
             claim={claim}
@@ -97,20 +99,21 @@ describe('<ClaimStatusPage>', () => {
       const statusPage = $('#tabPanelStatus', container);
       expect(statusPage).to.exist;
       expect(within(statusPage).queryByRole('list')).to.not.exist;
-      const expectedText =
-        "There's nothing we need from you right now. We'll let you know when there's an update.";
-      expect(findByText(expectedText)).to.exist;
-      expect($('va-alert', container)).not.to.exist;
+      // const expectedText =
+      //   "There's nothing we need from you right now. We'll let you know when there's an update.";
+      // expect(getByText(expectedText)).not.to.exist;
+      expect($('.what-you-need-to-do-container', container)).not.to.exist;
     });
 
-    it('should render status page without a timeline, with alerts when using lighthouse', () => {
+    it('should render status page without a timeline, with a WhatYouNeedToDoPage when using lighthouse', () => {
       const claim = {
         id: '1',
-        type: 'claim',
         attributes: {
           supportingDocuments: [],
           claimDate: '2023-01-01',
           closeDate: null,
+          documentsNeeded: true,
+          decisionLetterSent: false,
           status: 'INITIAL_REVIEW',
           claimPhaseDates: {
             currentPhaseBack: false,
@@ -121,10 +124,6 @@ describe('<ClaimStatusPage>', () => {
               phase2CompleteDate: '2023-02-08',
             },
           },
-
-          documentsNeeded: false,
-          decisionLetterSent: false,
-          waiverSubmitted: true,
           trackedItems: [
             {
               status: 'NEEDED_FROM_YOU',
@@ -136,7 +135,7 @@ describe('<ClaimStatusPage>', () => {
           ],
         },
       };
-      const { container, findByText, queryByText } = render(
+      const { container } = render(
         <Provider store={getStore()}>
           <ClaimStatusPage
             useLighthouse
@@ -150,33 +149,30 @@ describe('<ClaimStatusPage>', () => {
       const statusPage = $('#tabPanelStatus', container);
       expect(statusPage).to.exist;
       expect(within(statusPage).queryByRole('list')).to.not.exist;
-      const expectedText =
-        "There's nothing we need from you right now. We'll let you know when there's an update.";
-      expect(queryByText(expectedText)).not.to.exist;
-      // console.log('peri', findByText(expectedText));
+      // const expectedText =
+      //   "There's nothing we need from you right now. We'll let you know when there's an update.";
+      // expect(queryByText(expectedText)).not.to.exist;
+      expect($('.what-you-need-to-do-container', container)).to.exist;
       expect($('va-alert', container)).to.exist;
-
-      // console.log('statusPage', statusPage);
-
-      // const whatYouNeedToDo = $('.what-you-need-to-do-container', container);
-      // console.log('whatYouNeedToDo', whatYouNeedToDo);
-      // expect(whatYouNeedToDo).to.exist;
-
-      // expect($('.what-you-need-to-do-container', container)).to.exist;
     });
 
     it('should not render status page without a timeline when using evss', () => {
       const claim = {
+        id: '1',
         attributes: {
-          phase: 2,
           open: true,
-          documentsNeeded: false,
+          phase: 3,
+          dateFiled: '2023-01-01',
+          documentsNeeded: true,
           decisionLetterSent: false,
-          waiverSubmitted: true,
           eventsTimeline: [
             {
               type: 'still_need_from_you_list',
               status: 'NEEDED',
+              displayName: 'Test',
+              description: 'Test',
+              suspenseDate: '2024-02-01',
+              date: '2023-01-01',
             },
           ],
         },
@@ -196,6 +192,8 @@ describe('<ClaimStatusPage>', () => {
       const statusPage = $('#tabPanelStatus', container);
       expect(statusPage).to.exist;
       expect(within(statusPage).queryByRole('list')).to.not.exist;
+      expect($('.what-you-need-to-do-container', container)).to.exist;
+      expect($('va-alert', container)).to.exist;
     });
   });
 

--- a/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
@@ -120,8 +120,8 @@ describe('<DocumentRequestPage>', () => {
       />,
     );
     const content = tree.dive(['DocumentRequestPageContent']);
-    expect(content.subTree('DueDate')).not.to.be.false;
-    expect(content.subTree('DueDate').props.date).to.eql(
+    expect(content.subTree('DueDateOld')).not.to.be.false;
+    expect(content.subTree('DueDateOld').props.date).to.eql(
       trackedItem.suspenseDate,
     );
   });

--- a/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
@@ -3,31 +3,52 @@ import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 import moment from 'moment';
 
+import { DATE_FORMATS } from '../../constants';
+import { buildDateFormatter } from '../../utils/helpers';
 import DueDate from '../../components/DueDate';
 
 describe('<DueDate>', () => {
+  const formatDate = buildDateFormatter(DATE_FORMATS.LONG_DATE);
+
   it('should render past due class', () => {
     const date = moment()
       .subtract(1, 'day')
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
+    const formattedClaimDate = formatDate(date);
+    const dueDateHeader = `Needed from you by ${formattedClaimDate}`;
 
     expect(tree.everySubTree('.past-due')).not.to.be.empty;
+    expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
+      dueDateHeader,
+    );
   });
+
   it('should render past due class when less than day difference', () => {
     const date = moment()
       .subtract(1, 'hour')
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
+    const formattedClaimDate = formatDate(date);
+    const dueDateHeader = `Needed from you by ${formattedClaimDate}`;
 
     expect(tree.everySubTree('.past-due')).not.to.be.empty;
+    expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
+      dueDateHeader,
+    );
   });
+
   it('should render file due class', () => {
     const date = moment()
       .add(1, 'day')
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
+    const formattedClaimDate = formatDate(date);
+    const dueDateHeader = `Needed from you by ${formattedClaimDate}`;
 
     expect(tree.everySubTree('.due-file')).not.to.be.empty;
+    expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
+      dueDateHeader,
+    );
   });
 });

--- a/src/applications/claims-status/tests/components/DueDateOld.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DueDateOld.unit.spec.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+import moment from 'moment';
+
+import DueDateOld from '../../components/DueDateOld';
+
+describe('<DueDateOld>', () => {
+  it('should render past due class', () => {
+    const date = moment()
+      .subtract(1, 'day')
+      .format('YYYY-MM-DD');
+    const tree = SkinDeep.shallowRender(<DueDateOld date={date} />);
+
+    expect(tree.everySubTree('.past-due')).not.to.be.empty;
+  });
+  it('should render past due class when less than day difference', () => {
+    const date = moment()
+      .subtract(1, 'hour')
+      .format('YYYY-MM-DD');
+    const tree = SkinDeep.shallowRender(<DueDateOld date={date} />);
+
+    expect(tree.everySubTree('.past-due')).not.to.be.empty;
+  });
+  it('should render file due class', () => {
+    const date = moment()
+      .add(1, 'day')
+      .format('YYYY-MM-DD');
+    const tree = SkinDeep.shallowRender(<DueDateOld date={date} />);
+
+    expect(tree.everySubTree('.due-file')).not.to.be.empty;
+  });
+});

--- a/src/applications/claims-status/tests/components/FilesNeeded.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/FilesNeeded.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import SkinDeep from 'skin-deep';
-import { expect } from 'chai';
+
+import { render } from '@testing-library/react';
 import FilesNeeded from '../../components/FilesNeeded';
 
 describe('<FilesNeededOld>', () => {
@@ -11,13 +11,8 @@ describe('<FilesNeededOld>', () => {
       description: 'This is a alert',
       suspenseDate: '2024-12-01',
     };
-    const tree = SkinDeep.shallowRender(<FilesNeeded id={id} item={item} />);
-
-    expect(tree.everySubTree('.file-request-title')[0].text()).to.equal(
-      item.displayName,
-    );
-    expect(tree.everySubTree('.submission-description')[0].text()).to.equal(
-      item.description,
-    );
+    const screen = render(<FilesNeeded id={id} item={item} />);
+    screen.getByText(item.displayName);
+    screen.getByText(item.description);
   });
 });

--- a/src/applications/claims-status/tests/components/FilesNeeded.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/FilesNeeded.unit.spec.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+import FilesNeeded from '../../components/FilesNeeded';
+
+describe('<FilesNeededOld>', () => {
+  it('should render va-alert with item data', () => {
+    const id = 1;
+    const item = {
+      displayName: 'Request 1',
+      description: 'This is a alert',
+      suspenseDate: '2024-12-01',
+    };
+    const tree = SkinDeep.shallowRender(<FilesNeeded id={id} item={item} />);
+
+    expect(tree.everySubTree('.file-request-title')[0].text()).to.equal(
+      item.displayName,
+    );
+    expect(tree.everySubTree('.submission-description')[0].text()).to.equal(
+      item.description,
+    );
+  });
+});

--- a/src/applications/claims-status/tests/components/FilesNeededOld.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/FilesNeededOld.unit.spec.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import SkinDeep from 'skin-deep';
+import { expect } from 'chai';
+import FilesNeededOld from '../../components/FilesNeededOld';
+
+describe('<FilesNeededOld>', () => {
+  it('should render alert with item data', () => {
+    const id = 1;
+    const item = {
+      displayName: 'Request 1',
+      description: 'This is a alert',
+      suspenseDate: '2024-12-01',
+    };
+    const tree = SkinDeep.shallowRender(<FilesNeededOld id={id} item={item} />);
+
+    expect(tree.everySubTree('.file-request-title')[0].text()).to.equal(
+      item.displayName,
+    );
+    expect(tree.everySubTree('.submission-description')[0].text()).to.equal(
+      item.description,
+    );
+  });
+});

--- a/src/applications/claims-status/tests/components/FilesNeededOld.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/FilesNeededOld.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import SkinDeep from 'skin-deep';
-import { expect } from 'chai';
+
+import { render } from '@testing-library/react';
 import FilesNeededOld from '../../components/FilesNeededOld';
 
 describe('<FilesNeededOld>', () => {
@@ -11,13 +11,8 @@ describe('<FilesNeededOld>', () => {
       description: 'This is a alert',
       suspenseDate: '2024-12-01',
     };
-    const tree = SkinDeep.shallowRender(<FilesNeededOld id={id} item={item} />);
-
-    expect(tree.everySubTree('.file-request-title')[0].text()).to.equal(
-      item.displayName,
-    );
-    expect(tree.everySubTree('.submission-description')[0].text()).to.equal(
-      item.description,
-    );
+    const screen = render(<FilesNeededOld id={id} item={item} />);
+    screen.getByText(item.displayName);
+    screen.getByText(item.description);
   });
 });

--- a/src/applications/claims-status/tests/components/RequestedFilesInfo.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/RequestedFilesInfo.unit.spec.jsx
@@ -37,15 +37,15 @@ describe('<RequestedFilesInfo>', () => {
         optionalFiles={optionalFiles}
       />,
     );
-
-    expect(tree.everySubTree('.file-request-list-item')).not.to.be.empty;
-    expect(tree.everySubTree('.file-request-list-item')[0].text()).to.contain(
+    const content = tree.dive(['FilesNeededOld']);
+    expect(content).not.to.be.empty;
+    expect(content.subTree('.file-request-list-item').text()).to.contain(
       filesNeeded[0].displayName,
     );
-    expect(tree.everySubTree('.file-request-list-item')[0].text()).to.contain(
+    expect(content.subTree('.file-request-list-item').text()).to.contain(
       filesNeeded[0].description,
     );
-    expect(tree.everySubTree('.file-request-list-item')[0].text()).to.contain(
+    expect(content.subTree('.file-request-list-item').text()).to.contain(
       '<Link />',
     );
   });

--- a/src/applications/claims-status/tests/components/WhatYouNeedToDo.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/WhatYouNeedToDo.unit.spec.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
+
+import WhatYouNeedToDo from '../../components/WhatYouNeedToDo';
+
+describe('<WhatYouNeedToDo>', () => {
+  context('when useLighthouse true', () => {
+    const useLighthouse = true;
+    it('should render no-documents description when there are no flies needed', () => {
+      const claim = {
+        attributes: {
+          open: false,
+          trackedItems: [],
+        },
+      };
+      const { container, getByText } = render(
+        <WhatYouNeedToDo claim={claim} useLighthouse={useLighthouse} />,
+      );
+      const expectedText =
+        "There's nothing we need from you right now. We'll let you know when there's an update.";
+      getByText(expectedText);
+      expect($('va-alert', container)).not.to.exist;
+    });
+
+    it('should FilesNeeded', () => {
+      const claim = {
+        attributes: {
+          open: true,
+          trackedItems: [
+            {
+              status: 'NEEDED_FROM_YOU',
+            },
+          ],
+        },
+      };
+      const { container, queryByText } = render(
+        <WhatYouNeedToDo claim={claim} useLighthouse={useLighthouse} />,
+      );
+      const expectedText =
+        "There's nothing we need from you right now. We'll let you know when there's an update.";
+      expect(queryByText(expectedText)).not.to.exist;
+      expect($('va-alert', container)).to.exist;
+    });
+  });
+
+  context('when useLighthouse false', () => {
+    const useLighthouse = false;
+    it('should render no-documents description when there are no flies needed', () => {
+      const claim = {
+        attributes: {
+          open: false,
+          eventsTimeline: [],
+        },
+      };
+      const { container, getByText } = render(
+        <WhatYouNeedToDo claim={claim} useLighthouse={useLighthouse} />,
+      );
+      const expectedText =
+        "There's nothing we need from you right now. We'll let you know when there's an update.";
+      expect(getByText(expectedText)).to.exist;
+      expect($('va-alert', container)).not.to.exist;
+    });
+
+    it('should FilesNeeded', () => {
+      const claim = {
+        attributes: {
+          open: true,
+          eventsTimeline: [
+            {
+              type: 'still_need_from_you_list',
+              status: 'NEEDED',
+            },
+          ],
+        },
+      };
+      const { container, queryByText } = render(
+        <WhatYouNeedToDo claim={claim} useLighthouse={useLighthouse} />,
+      );
+      const expectedText =
+        "There's nothing we need from you right now. We'll let you know when there's an update.";
+      expect(queryByText(expectedText)).not.to.exist;
+      expect($('va-alert', container)).to.exist;
+    });
+  });
+});

--- a/src/applications/claims-status/tests/components/evss/ClaimStatusPageContent.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/evss/ClaimStatusPageContent.unit.spec.jsx
@@ -7,24 +7,26 @@ import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import ClaimStatusPageContent from '../../../components/evss/ClaimStatusPageContent';
 
 describe('<ClaimStatusPageContent>', () => {
-  context('when cstUseClaimDetailsV2 feature flag enabled', () => {
-    const claim = {
-      attributes: {
-        phase: 2,
-        decisionLetterSent: true,
-        open: true,
+  const getStore = (cstUseClaimDetailsV2Enabled = true) =>
+    createStore(() => ({
+      featureToggles: {
+        // eslint-disable-next-line camelcase
+        cst_use_claim_details_v2: cstUseClaimDetailsV2Enabled,
       },
-    };
-    const params = { id: 1 };
+    }));
 
-    const getStore = (cstUseClaimDetailsV2Enabled = true) =>
-      createStore(() => ({
-        featureToggles: {
-          // eslint-disable-next-line camelcase
-          cst_use_claim_details_v2: cstUseClaimDetailsV2Enabled,
+  context('when cstUseClaimDetailsV2 feature flag enabled', () => {
+    const params = { id: 1 };
+    it('should render ClaimStatusPageContent without a timeline and with a WhatYouNeedToDo section without alerts', () => {
+      const claim = {
+        id: '1',
+        attributes: {
+          phase: 2,
+          decisionLetterSent: true,
+          open: true,
+          eventsTimeline: [],
         },
-      }));
-    it('should not render ClaimStatusPageContent with a timeline', () => {
+      };
       const { container } = render(
         <Provider store={getStore()}>
           <ClaimStatusPageContent
@@ -37,6 +39,48 @@ describe('<ClaimStatusPageContent>', () => {
       );
 
       expect($('.claim-timeline', container)).not.to.exist;
+      expect($('.what-you-need-to-do-container', container)).to.exist;
+      expect($('va-alert', container)).not.to.exist;
+      expect($('.need-files-alert', container)).not.to.exist;
+    });
+
+    it('should render ClaimStatusPageContent without a timeline and with a WhatYouNeedToDo section', () => {
+      const claim = {
+        id: '1',
+        attributes: {
+          open: true,
+          phase: 3,
+          dateFiled: '2023-01-01',
+          documentsNeeded: true,
+          decisionLetterSent: false,
+          eventsTimeline: [
+            {
+              trackedItemId: 1,
+              type: 'still_need_from_you_list',
+              status: 'NEEDED',
+              displayName: 'Test',
+              description: 'Test',
+              suspenseDate: '2024-02-01',
+              date: '2023-01-01',
+            },
+          ],
+        },
+      };
+      const { container } = render(
+        <Provider store={getStore()}>
+          <ClaimStatusPageContent
+            params={params}
+            claim={claim}
+            showClaimLettersLink
+          />
+          ,
+        </Provider>,
+      );
+
+      expect($('.claim-timeline', container)).not.to.exist;
+      expect($('.what-you-need-to-do-container', container)).to.exist;
+      expect($('va-alert', container)).to.exist;
+      expect($('.need-files-alert', container)).not.to.exist;
     });
   });
 
@@ -49,7 +93,9 @@ describe('<ClaimStatusPageContent>', () => {
     };
     it('renders a link to the claim letters page', () => {
       const screen = render(
-        <ClaimStatusPageContent claim={claim} showClaimLettersLink />,
+        <Provider store={getStore(false)}>
+          <ClaimStatusPageContent claim={claim} showClaimLettersLink />,
+        </Provider>,
       );
 
       screen.getByText('Get your claim letters');
@@ -64,7 +110,11 @@ describe('<ClaimStatusPageContent>', () => {
       },
     };
     it('does not render a link to the claim letters page', () => {
-      const screen = render(<ClaimStatusPageContent claim={claim} />);
+      const screen = render(
+        <Provider store={getStore(false)}>
+          <ClaimStatusPageContent claim={claim} />
+        </Provider>,
+      );
 
       expect(screen.queryByText('Get your claim letters')).not.to.exist;
     });

--- a/src/applications/claims-status/tests/utils/helpers.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/helpers.unit.spec.js
@@ -11,6 +11,8 @@ import {
   getDocTypeDescription,
   displayFileSize,
   getTrackedItemId,
+  getTrackedItems,
+  getFilesNeeded,
   getUserPhase,
   getUserPhaseDescription,
   getPhaseDescription,
@@ -307,14 +309,27 @@ describe('Disability benefits helpers: ', () => {
   });
 
   describe('truncateDescription', () => {
-    it('should truncate text longer than 120 characters', () => {
-      const userText =
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris';
-      const userTextEllipsed =
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliq…';
+    context(' when default - maxlength is 120', () => {
+      it('should truncate text longer than 120 characters', () => {
+        const userText =
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris';
+        const userTextEllipsed =
+          'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliq…';
 
-      const text = truncateDescription(userText);
-      expect(text).to.equal(userTextEllipsed);
+        const text = truncateDescription(userText);
+        expect(text).to.equal(userTextEllipsed);
+      });
+    });
+    context('when maxlength is 200', () => {
+      it('should truncate text longer than 200 characters', () => {
+        const userText =
+          'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec qu quis nostrud exercitation ullamco laboris';
+        const userTextEllipsed =
+          'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec qu…';
+
+        const text = truncateDescription(userText, 200);
+        expect(text).to.equal(userTextEllipsed);
+      });
     });
   });
 
@@ -408,6 +423,101 @@ describe('Disability benefits helpers: ', () => {
     });
   });
   // END lighthouse_migration
+
+  describe('getTrackedItems', () => {
+    context('when useLighthouse is true', () => {
+      const useLighthouse = true;
+      it('when trackedItems is empty, should return empty array', () => {
+        const claim = {
+          attributes: {
+            open: false,
+            trackedItems: [],
+          },
+        };
+        const trackedItems = getTrackedItems(claim, useLighthouse);
+        expect(trackedItems.length).to.equal(0);
+      });
+
+      it('when trackedItems exists, should return data', () => {
+        const claim = {
+          attributes: {
+            open: false,
+            trackedItems: [
+              {
+                status: 'NEEDED_FROM_YOU',
+              },
+            ],
+          },
+        };
+        const trackedItems = getTrackedItems(claim, useLighthouse);
+        expect(trackedItems.length).to.equal(1);
+      });
+    });
+
+    context('when useLighthouse is false', () => {
+      const useLighthouse = false;
+      it('when eventsTimeline is empty, should return empty array', () => {
+        const claim = {
+          attributes: {
+            open: false,
+            eventsTimeline: [],
+          },
+        };
+        const trackedItems = getTrackedItems(claim, useLighthouse);
+        expect(trackedItems.length).to.equal(0);
+      });
+
+      it('when eventsTimeline exists, should return data', () => {
+        const claim = {
+          attributes: {
+            open: false,
+            eventsTimeline: [
+              {
+                type: 'still_need_from_you_list',
+                status: 'NEEDED',
+              },
+            ],
+          },
+        };
+        const trackedItems = getTrackedItems(claim, useLighthouse);
+        expect(trackedItems.length).to.equal(1);
+      });
+    });
+  });
+
+  describe('getFilesNeeded', () => {
+    context('when useLighthouse is true', () => {
+      const useLighthouse = true;
+      it('when trackedItems is empty, should return empty array', () => {
+        const trackedItems = [];
+        const filesNeeded = getFilesNeeded(trackedItems, useLighthouse);
+        expect(filesNeeded.length).to.equal(0);
+      });
+
+      it('when trackedItems exists, should return data', () => {
+        const trackedItems = [{ status: 'NEEDED_FROM_YOU' }];
+        const filesNeeded = getFilesNeeded(trackedItems, useLighthouse);
+        expect(filesNeeded.length).to.equal(1);
+      });
+    });
+
+    context('when useLighthouse is false', () => {
+      const useLighthouse = false;
+      it('when eventsTimeline is empty, should return empty array', () => {
+        const eventsTimeline = [];
+        const filesNeeded = getFilesNeeded(eventsTimeline, useLighthouse);
+        expect(filesNeeded.length).to.equal(0);
+      });
+
+      it('when eventsTimeline exists, should return data', () => {
+        const eventsTimeline = [
+          { type: 'still_need_from_you_list', status: 'NEEDED' },
+        ];
+        const filesNeeded = getFilesNeeded(eventsTimeline, useLighthouse);
+        expect(filesNeeded.length).to.equal(1);
+      });
+    });
+  });
 
   describe('getUserPhase', () => {
     it('should get phase 3 desc for 4-6', () => {

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -82,7 +82,6 @@ export const getTrackedItemDate = item => {
 export function getTrackedItems(claim, useLighthouse = true) {
   // claimAttributes are different between lighthouse and evss
   // Therefore we have to filter them differntly
-  // const { trackedItems } = claim.attributes;
   if (useLighthouse) {
     return claim.attributes.trackedItems;
   }

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -4,7 +4,7 @@ import { format, isValid, parseISO } from 'date-fns';
 
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 // import localStorage from 'platform/utilities/storage/localStorage';
-import { apiRequest } from 'platform/utilities/api';
+import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 // import { fetchAndUpdateSessionExpiration as fetch } from 'platform/utilities/api';
 import { SET_UNAUTHORIZED } from '../actions/types';
 
@@ -78,6 +78,32 @@ export const getTrackedItemDate = item => {
   return item.closedDate || item.receivedDate || item.requestedDate;
 };
 // END lighthouse_migration
+
+export function getTrackedItems(claim, useLighthouse = true) {
+  // claimAttributes are different between lighthouse and evss
+  // Therefore we have to filter them differntly
+  // const { trackedItems } = claim.attributes;
+  if (useLighthouse) {
+    return claim.attributes.trackedItems;
+  }
+
+  return claim.attributes.eventsTimeline.filter(event =>
+    event.type.endsWith('_list'),
+  );
+}
+
+export function getFilesNeeded(trackedItems, useLighthouse = true) {
+  // trackedItems are different between lighthouse and evss
+  // Therefore we have to filter them differntly
+  if (useLighthouse) {
+    return trackedItems.filter(item => item.status === 'NEEDED_FROM_YOU');
+  }
+
+  return trackedItems.filter(
+    event =>
+      event.status === 'NEEDED' && event.type === 'still_need_from_you_list',
+  );
+}
 
 export function getItemDate(item) {
   // Tracked item that has been marked received.
@@ -287,8 +313,7 @@ export function scrubDescription(text) {
   return stripEscapedChars(stripHtml(text));
 }
 
-export function truncateDescription(text) {
-  const maxLength = 120;
+export function truncateDescription(text, maxLength = 120) {
   if (text && text.length > maxLength) {
     return `${text.substr(0, maxLength)}…`;
   }


### PR DESCRIPTION
## Summary

**Code Changes:**
- Renamed DueDate.jsx to DueDateOld.jsx and then updated DueDate.jsx so that it had the new design
- Updated DocumentRequestPageContent.jsx (evss) to use DueDateOld.jsx instead of DueDate.jsx
- Updated DocumentRequestPage.jsx to use DueDateOld.jsx instead of DueDate.jsx
- Added changes to claims-status.scss for the new DueDate.jsx component

- Created FilesNeededOld.jsx so that there was a component that we could toggle on 
- Updated RequestedFilesInfo.jsx so that it used the component FilesNeededOld.jsx instead of harding the html
- Created FilesNeeded.jsx with the new design for the primary alert and so that we could toggle on it

- Created WhatWeNeedToDo.jsx to display on the Status Tab and so that we could toggle on it
- Updated helpers.js to have the new functions getTrackedItems() and getFilesNeeded() that are used on WhatWeNeedToDo.jsx
- Modified helpers.js function truncateDescription() so that the maxLength was a prop, defaulted to 120
- Updated ClaimStatusPageContent.jsx (evss) so that there was logic that used the toggle `cstUseClaimDetailsV2` to toggle between WhatWeNeedToDo.jsx and NeedFilesFromYou.jsx
- Updated ClaimStatusPage.jsxso that there was logic that used the toggle `cstUseClaimDetailsV2` to toggle between WhatWeNeedToDo.jsx and NeedFilesFromYou.jsx

**Added/Modified the following Tests**
- src/applications/claims-status/tests/components/ClaimStatusPage.unit.spec.jsx
- src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
- src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
- src/applications/claims-status/tests/components/DueDateOld.unit.spec.jsx
- src/applications/claims-status/tests/components/FilesNeeded.unit.spec.jsx
- src/applications/claims-status/tests/components/FilesNeededOld.unit.spec.jsx
- src/applications/claims-status/tests/components/RequestedFilesInfo.unit.spec.jsx
- src/applications/claims-status/tests/components/WhatYouNeedToDo.unit.spec.jsx
- src/applications/claims-status/tests/components/evss/ClaimStatusPageContent.unit.spec.jsx
- src/applications/claims-status/tests/utils/helpers.unit.spec.js

## Figma Designs

[Mocks in Figma](https://www.figma.com/file/F8U4wddaFouUPVd4mGBMDI/CST---Evidence-Submission---Spec?type=design&node-id=0-809&mode=design&t=vr7AAdcV08s2Uxmp-0)
[Figma new second alert design](https://www.figma.com/file/F8U4wddaFouUPVd4mGBMDI/CST---Evidence-Submission---Spec?type=design&node-id=0-1509&mode=design&t=KEAoDGS1gld7AhAm-0)

## Acceptance Criteria

- [x] There are clear alerts on the status page identifying evidence requests for the veteran
- [x] The header for the "what you need to do" section has to clearly differentiate this section for the user from other parts of the page.
- [x] Different evidence requests can be distinguished from one another and contain enough detail to provide a clear action item for the veteran
- [x] Contains a header that says 'What you need to do'
- [x] First Party Alerts show up under the Status tab
- [x] When a user selects 'view details' on a First Party Alert and they provided the requested information, the alerts for those requests go away (speak with @jerekshoe on if this currently happens, looks like it doesnt in Dev env)
- [x] Body text descriptions cannot be insanely long (apply existing logic from old cards if it's the best way to accomplish this)
- [x] Content elements/fields (such as dates) will conform to the previous alert designs and provide the same information to veterans
- [x] When there are no First Party Alerts, an empty state message appears under the header that says 'There's nothing that we need from you right now. We'll let you know when there's an update.'
- [x] New functionality is behind the feature flag `cst_use_claim_details_v2`

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#69450

## Testing done

Please view https://github.com/department-of-veterans-affairs/va.gov-team/issues/69450

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| EVSS  | ![Screenshot 2024-01-19 at 10 19 56 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/f54b40e0-2531-4a08-a514-d55071075373) | ![Screenshot 2024-01-18 at 3 18 03 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/44f88b50-49b7-42eb-b1d4-a11d39181fc4) |
| LIGHTHOUSE | ![Screenshot 2024-01-19 at 10 19 41 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/d3d5e1ef-f120-4cc4-8e2e-345ff9789b26) | ![Screenshot 2024-01-22 at 1 00 19 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/22bdef40-6133-45bf-b136-d3a937bf81bd) |
| EVSS  | ![Screenshot 2024-01-22 at 12 32 53 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/14eaf3e9-1fdf-437b-9f15-f88fa438bbc9)|
| LIGHTHOUSE |![Screenshot 2024-01-19 at 3 03 45 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/c67bd425-4e25-42fb-815f-2ff258bc5f31)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
