### PR TITLE
[CST] - 72065 Change 'Submitted on' to 'Received on'

### DIFF
--- a/src/applications/claims-status/components/ClaimDetailLayout.jsx
+++ b/src/applications/claims-status/components/ClaimDetailLayout.jsx
@@ -65,7 +65,7 @@ export default function ClaimDetailLayout(props) {
 
     const formatDate = buildDateFormatter(DATE_FORMATS.LONG_DATE);
     const formattedClaimDate = formatDate(claim.attributes.claimDate);
-    const claimSubheader = `Submitted on ${formattedClaimDate}`;
+    const claimSubheader = `Received on ${formattedClaimDate}`;
 
     headingContent = (
       <>

--- a/src/applications/claims-status/components/ClaimsListItem.jsx
+++ b/src/applications/claims-status/components/ClaimsListItem.jsx
@@ -93,7 +93,7 @@ export default function ClaimsListItem({ claim }) {
       </ul>
       <div className="card-status">
         <p>
-          <strong>Submitted on:</strong> {formattedReceiptDate}
+          <strong>Received on:</strong> {formattedReceiptDate}
         </p>
       </div>
       <Link

--- a/src/applications/claims-status/components/ClaimsListItemV3.jsx
+++ b/src/applications/claims-status/components/ClaimsListItemV3.jsx
@@ -72,7 +72,7 @@ export default function ClaimsListItemV3({ claim }) {
     <ClaimCard
       title={getTitle(claim)}
       label={inProgress ? 'In Progress' : null}
-      subtitle={`Submitted on ${formattedReceiptDate}`}
+      subtitle={`Received on ${formattedReceiptDate}`}
     >
       <ul className="communications">
         {showPrecomms && developmentLetterSent ? (

--- a/src/applications/claims-status/components/StemClaimListItem.jsx
+++ b/src/applications/claims-status/components/StemClaimListItem.jsx
@@ -44,7 +44,7 @@ export default function StemClaimListItem({ claim }) {
       </div>
       <div className="card-status">
         <p>
-          <strong>Submitted on:</strong> {formattedReceiptDate}
+          <strong>Received on:</strong> {formattedReceiptDate}
         </p>
       </div>
       <Link

--- a/src/applications/claims-status/components/StemClaimListItemV3.jsx
+++ b/src/applications/claims-status/components/StemClaimListItemV3.jsx
@@ -37,7 +37,7 @@ export default function StemClaimListItemV3({ claim }) {
   return (
     <ClaimCard
       title="Edith Nourse Rogers STEM Scholarship application"
-      subtitle={`Submitted on ${formattedReceiptDate}`}
+      subtitle={`Received on ${formattedReceiptDate}`}
     >
       <div className="card-status">
         <p>Status: Denied</p>

--- a/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
@@ -106,7 +106,7 @@ export default function AppealListItem({ appeal, name, external = false }) {
       {requestEvent && (
         <div className="card-status">
           <p>
-            <strong>Submitted on:</strong>{' '}
+            <strong>Received on:</strong>{' '}
             {moment(requestEvent.date).format('MMMM D, YYYY')}
           </p>
         </div>

--- a/src/applications/claims-status/components/appeals-v2/AppealListItemV3.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItemV3.jsx
@@ -83,7 +83,7 @@ export default function AppealListItemV3({ appeal, name }) {
       title={appealTitle}
       subtitle={
         requestEvent &&
-        `Submitted on ${moment(requestEvent.date).format('MMMM D, YYYY')}`
+        `Received on ${moment(requestEvent.date).format('MMMM D, YYYY')}`
       }
     >
       <div className="card-status">

--- a/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
@@ -63,7 +63,7 @@ export default function ClaimsListItem({ claim }) {
       </ul>
       <div className="card-status">
         <p>
-          <strong>Submitted on:</strong> {formattedReceiptDate}
+          <strong>Received on:</strong> {formattedReceiptDate}
         </p>
       </div>
       <Link

--- a/src/applications/claims-status/components/evss/ClaimDetailLayout.jsx
+++ b/src/applications/claims-status/components/evss/ClaimDetailLayout.jsx
@@ -59,7 +59,7 @@ export default function ClaimDetailLayout(props) {
   } else if (claim !== null) {
     const claimTitle = `Your ${claimType} claim`;
     const formattedClaimDate = formatDate(claim.attributes.dateFiled);
-    const claimSubheader = `Submitted on ${formattedClaimDate}`;
+    const claimSubheader = `Received on ${formattedClaimDate}`;
 
     headingContent = (
       <>

--- a/src/applications/claims-status/tests/components/ClaimDetailLayout.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimDetailLayout.unit.spec.jsx
@@ -62,7 +62,7 @@ describe('<ClaimDetailLayout>', () => {
     );
 
     expect(screen.getByRole('heading', { level: 1 })).to.contain.text(
-      'Submitted on November 23, 2023',
+      'Received on November 23, 2023',
     );
   });
 

--- a/src/applications/claims-status/tests/components/ClaimListItem.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimListItem.unit.spec.jsx
@@ -167,6 +167,7 @@ describe('<ClaimsListItem>', () => {
 
     const screen = render(<ClaimsListItem claim={claim} />);
     expect(screen.getByText(/updated on August 20, 2019/i)).to.exist;
-    expect(screen.getByText(/Received on February 10, 2019/i)).to.exist;
+    expect(screen.getByText(/Received on/i)).to.exist;
+    expect(screen.getByText(/February 10, 2019/i)).to.exist;
   });
 });

--- a/src/applications/claims-status/tests/components/ClaimListItem.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimListItem.unit.spec.jsx
@@ -167,6 +167,6 @@ describe('<ClaimsListItem>', () => {
 
     const screen = render(<ClaimsListItem claim={claim} />);
     expect(screen.getByText(/updated on August 20, 2019/i)).to.exist;
-    expect(screen.getByText(/February 10, 2019/i)).to.exist;
+    expect(screen.getByText(/Received on February 10, 2019/i)).to.exist;
   });
 });

--- a/src/applications/claims-status/tests/components/ClaimListItemV3.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimListItemV3.unit.spec.jsx
@@ -140,6 +140,6 @@ describe('<ClaimsListItemV3>', () => {
 
     const screen = render(<ClaimsListItemV3 claim={claim} />);
     expect(screen.getByText(/Last updated: August 20, 2019/i)).to.exist;
-    expect(screen.getByText(/Submitted on February 10, 2019/i)).to.exist;
+    expect(screen.getByText(/Received on February 10, 2019/i)).to.exist;
   });
 });

--- a/src/applications/claims-status/tests/components/StemClaimListItem.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/StemClaimListItem.unit.spec.jsx
@@ -41,7 +41,7 @@ describe('<StemClaimListItem>', () => {
         .find('p')
         .last()
         .text(),
-    ).to.equal('Submitted on: March 1, 2021');
+    ).to.equal('Received on: March 1, 2021');
     tree.unmount();
   });
 

--- a/src/applications/claims-status/tests/components/StemClaimListItemV3.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/StemClaimListItemV3.unit.spec.jsx
@@ -41,7 +41,7 @@ describe('<StemClaimListItemV3>', () => {
         .shallow()
         .find('.submitted-on')
         .text(),
-    ).to.equal('Submitted on March 1, 2021');
+    ).to.equal('Received on March 1, 2021');
     wrapper.unmount();
   });
 

--- a/src/applications/claims-status/tests/components/appeals-v2/AppealListItemV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/AppealListItemV2.unit.spec.jsx
@@ -93,7 +93,7 @@ describe('<AppealListItemV2/>', () => {
         .find('p')
         .last()
         .text(),
-    ).to.equal('Submitted on: May 1, 2016');
+    ).to.equal('Received on: May 1, 2016');
     wrapper.unmount();
   });
 

--- a/src/applications/claims-status/tests/components/appeals-v2/AppealListItemV3.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/AppealListItemV3.unit.spec.jsx
@@ -69,7 +69,7 @@ describe('<AppealListItemV3/>', () => {
         .shallow()
         .find('.submitted-on')
         .text(),
-    ).to.equal('Submitted on May 1, 2016');
+    ).to.equal('Received on May 1, 2016');
     wrapper.unmount();
   });
 

--- a/src/applications/claims-status/tests/components/appeals-v2/ClaimListItemV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/ClaimListItemV2.unit.spec.jsx
@@ -185,7 +185,7 @@ describe('<ClaimsListItemV2>', () => {
         .find('p')
         .last()
         .text(),
-    ).to.equal('Submitted on: February 10, 2019');
+    ).to.equal('Received on: February 10, 2019');
     tree.unmount();
   });
 });

--- a/src/applications/claims-status/tests/components/evss/ClaimDetailLayout.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/evss/ClaimDetailLayout.unit.spec.jsx
@@ -54,7 +54,7 @@ describe('<ClaimDetailLayoutEVSS>', () => {
     );
 
     expect(screen.getByRole('heading', { level: 1 })).to.contain.text(
-      'Submitted on November 23, 2023',
+      'Received on November 23, 2023',
     );
   });
 


### PR DESCRIPTION
## Summary

**Updated multiple files so that the language was 'Received on' instead of 'Submitted on':**
- src/applications/claims-status/components/ClaimDetailLayout.jsx
- src/applications/claims-status/components/ClaimsListItem.jsx
- src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
- src/applications/claims-status/components/ClaimsListItemV3.jsx
- src/applications/claims-status/components/StemClaimListItem.jsx
- src/applications/claims-status/components/StemClaimListItemV3.jsx
- src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
- src/applications/claims-status/components/appeals-v2/AppealListItemV3.jsx

**Updated the following evss files so that the language was 'Received on' instead of 'Submitted on':**
-src/applications/claims-status/components/evss/ClaimDetailLayout.jsx

**Updated multiple test files so that the language was 'Received on' instead of 'Submitted on':**
- src/applications/claims-status/tests/components/ClaimDetailLayout.unit.spec.jsx
- src/applications/claims-status/tests/components/ClaimListItem.unit.spec.jsx
- src/applications/claims-status/tests/components/appeals-v2/ClaimListItemV2.unit.spec.jsx
- src/applications/claims-status/tests/components/ClaimListItemV3.unit.spec.jsx
- src/applications/claims-status/tests/components/StemClaimListItem.unit.spec.jsx
- src/applications/claims-status/tests/components/StemClaimListItemV3.unit.spec.jsx
- src/applications/claims-status/tests/components/appeals-v2/AppealListItemV2.unit.spec.jsx
- src/applications/claims-status/tests/components/appeals-v2/AppealListItemV3.unit.spec.jsx

**Updated the following evss test files so that the language was 'Received on' instead of 'Submitted on':**
- src/applications/claims-status/tests/components/evss/ClaimDetailLayout.unit.spec.jsx

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#72065

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Evss  | ![Screenshot 2024-01-22 at 11 49 03 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/ea2a1bf8-5b60-4395-8699-7452439c026a) | ![Screenshot 2024-01-22 at 3 09 45 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/0563b092-663f-4c0b-a4c0-83a9ff5835dd) |
| Lighthouse | ![Screenshot 2024-01-22 at 11 49 21 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/6a04508a-b82a-47dc-b413-8edac2756a98) | ![Screenshot 2024-01-22 at 11 53 12 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/229a3312-c512-4852-b154-53735c290346)|
| Evss  | ![Screenshot 2024-01-22 at 2 56 29 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/7b76f7f2-4510-4226-bdb2-2adcc5c9237d) | ![Screenshot 2024-01-22 at 11 47 47 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/76486f55-0e19-45ae-b638-764e04960b2a) |
| Lighthouse  | ![Screenshot 2024-01-22 at 2 58 45 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/8ea80dfe-a8a2-4260-a0f3-f8c52ce6c81d) | ![Screenshot 2024-01-22 at 11 47 30 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/065c4028-a29b-493e-b03b-513c31ab873f) |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Tasks

- [x]  Update the V2 claim card
- [x]  Update the V3 claim card
- [x]  Update the subheading on the EVSS version of the claim details page
- [x]  Update the subheading on the Lighthouse version of the claim details page
- [x]  Update any tests that are associated with the components mentioned above

## Acceptance criteria

- [x] Claims cards are updated to use 'Received on' language
- [x]  Claim details subheading is updated to use 'Received on' language
- [ ]  Update https://github.com/department-of-veterans-affairs/va.gov-team/issues/72065 so sitewide team is aware of this change
- [ ]  Notify VA Mobile, VA Chatbot team, and other status tool teams about the language changes and why we made those changes.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
