### PR TITLE
VYE-197 updated startApp import in app-entry.jsx

### DIFF
--- a/src/applications/verify-your-enrollment/app-entry.jsx
+++ b/src/applications/verify-your-enrollment/app-entry.jsx
@@ -2,7 +2,8 @@ import '@department-of-veterans-affairs/platform-polyfills';
 import './sass/verify-your-enrollment.scss';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment/index';
 
-import { startAppFromIndex } from '@department-of-veterans-affairs/platform-startup/exports';
+// import { startAppFromIndex } from '@department-of-veterans-affairs/platform-startup/exports';
+import startApp from '@department-of-veterans-affairs/platform-startup/router';
 
 import routes from './routes';
 import reducer from './reducers';
@@ -10,7 +11,8 @@ import manifest from './manifest.json';
 
 // eslint-disable-next-line no-unused-expressions
 !environment.isProduction() &&
-  startAppFromIndex({
+  // startAppFromIndex({
+  startApp({
     url: manifest.rootUrl,
     reducer,
     routes,

--- a/src/applications/verify-your-enrollment/routes.jsx
+++ b/src/applications/verify-your-enrollment/routes.jsx
@@ -11,14 +11,18 @@ const routes = (
       exact
       key="EnrollmentVerificationPage"
       path="/"
-      component={EnrollmentVerificationPageWrapper}
-    />
+      // component={EnrollmentVerificationPageWrapper}
+    >
+      <EnrollmentVerificationPageWrapper />
+    </Route>
     <Route
       exact
       key="BenefitsProfilePage"
       path={`${BENEFITS_PROFILE_RELATIVE_URL}`}
-      component={BenefitsProfileWrapper}
-    />
+      // component={BenefitsProfileWrapper}
+    >
+      <BenefitsProfileWrapper />
+    </Route>
   </Switch>
 );
 


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
- - changes made to the import of startAppFromIndex in the app-entry.jsx inside the verify-your-enrollment repo
- _(If bug, how to reproduce)_ N/A
- _(What is the solution, why is this the solution)_
- - the wrong import was being used, changed import from import { startAppFromIndex } from '@department-of-veterans-affairs/platform-startup/exports'; to import startApp from '@department-of-veterans-affairs/platform-startup/router';
- _(Which team do you work for, does your team own the maintenance of this component?)_
- - I work for GovCIO and we are the code owners
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
- - no flipper, environment variable keeps all changes into staging

## Related issue(s)

Previous PR - https://github.com/department-of-veterans-affairs/vets-website/pull/27588

## Testing done

- _Describe what the old behavior was prior to the change_
- - In staging the routing does not work. A 504 error is received
- _Describe the steps required to verify your changes are working as expected_
- - Once changes are in staging, the user should be able to access https://staging.va.gov/education/verify-your-enrollment/ and click on the "Manage your benefits profile" link and be taken to that page.
- _Describe the tests completed and the results_
- - test conducted on local machine, all is working.
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

code before the import change
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/88905347/cc104961-c38b-49ad-bb66-c59a0dbd359a)

code after import change
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/88905347/48df1b04-5edd-420d-a1e1-8be8573cdd9c)

## What areas of the site does it impact?
this impacts staging only. App not in prod.
*(Describe what parts of the site are impacted **if** code touched other areas)*
N/A

## Acceptance criteria
- User can navigate to the benefits profile page in staging from here https://staging.va.gov/education/verify-your-enrollment/

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
