### PR TITLE
fix footer help when check in travel complete

### DIFF
--- a/src/applications/check-in/components/layout/Footer.jsx
+++ b/src/applications/check-in/components/layout/Footer.jsx
@@ -29,7 +29,7 @@ const Footer = ({ router, isPreCheckIn }) => {
       return true;
     }
 
-    if (currentPage.includes('complete') && !isPreCheckIn) {
+    if (currentPage?.includes('complete') && !isPreCheckIn) {
       return true;
     }
 

--- a/src/applications/check-in/components/layout/Footer.jsx
+++ b/src/applications/check-in/components/layout/Footer.jsx
@@ -29,7 +29,7 @@ const Footer = ({ router, isPreCheckIn }) => {
       return true;
     }
 
-    if (currentPage === 'complete' && !isPreCheckIn) {
+    if (currentPage.includes('complete') && !isPreCheckIn) {
       return true;
     }
 


### PR DESCRIPTION
## Summary

- Fixes a bug where travel help wasn't showing on check in complete

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/72617

## Testing done

- Visual

## Screenshots
![Screenshot 2024-01-23 at 10 35 29 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/2982977/ff2ce684-1d27-4ec1-a4aa-cd501f0883d5)

## What areas of the site does it impact?

Check-in /complete

## Acceptance criteria

- [ ] needs help section looks correct for check in complete