### PR TITLE
VYE-197  updated PageLink.jsx

### DIFF
--- a/src/applications/verify-your-enrollment/app-entry.jsx
+++ b/src/applications/verify-your-enrollment/app-entry.jsx
@@ -1,8 +1,6 @@
 import '@department-of-veterans-affairs/platform-polyfills';
 import './sass/verify-your-enrollment.scss';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment/index';
-
-// import { startAppFromIndex } from '@department-of-veterans-affairs/platform-startup/exports';
 import startApp from '@department-of-veterans-affairs/platform-startup/router';
 
 import routes from './routes';
@@ -11,7 +9,6 @@ import manifest from './manifest.json';
 
 // eslint-disable-next-line no-unused-expressions
 !environment.isProduction() &&
-  // startAppFromIndex({
   startApp({
     url: manifest.rootUrl,
     reducer,

--- a/src/applications/verify-your-enrollment/components/PageLink.jsx
+++ b/src/applications/verify-your-enrollment/components/PageLink.jsx
@@ -5,9 +5,8 @@ const PageLink = ({ linkText, relativeURL, URL }) => {
   const history = useHistory();
 
   const handleClick = useCallback(
-    event => {
+    () => {
       if (history) {
-        event.preventDefault();
         history.push(relativeURL);
       }
     },


### PR DESCRIPTION
## Summary

- When clicking the link "Manage your benefits profile", when the benefits profile page comes up, the screen currently does not scroll to the top of the page. The issue is on the clickHandler the event was set to preventDefault. This has been deleted and the code works as it should with this change. 

- _(Summarize the changes that have been made to the platform)_
- - Changes made to the PageLink.jsx file within the verify-your-enrollment folder. Minor clean-up of unused code was also preformed in this PR in the app-entry file.
- _(If bug, how to reproduce)_ N/A
- _(What is the solution, why is this the solution)_
- - Solution was to delete the preventDefault in the clickHandler. This is the solution since we do not want to prevent the default action of scrolling to the top of the page.
- _(Which team do you work for, does your team own the maintenance of this component?)_
- I work for GovCIO and we are the code owners
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
- No flipper. Environment variable in use to keep app out of prod at this time.

## Related issue(s)

- previous PRs related 
- 1. https://github.com/department-of-veterans-affairs/vets-website/pull/27588
- 2. https://github.com/department-of-veterans-affairs/vets-website/pull/27601

## Testing done

- _Describe what the old behavior was prior to the change_
- - the page did not scroll to the top when the user clicked on the Manage your benefits profile link
- _Describe the steps required to verify your changes are working as expected_
- - Once this code is in staging, go here (https://staging.va.gov/education/verify-your-enrollment/) and click on the Manage your benefits profile and the screen should scroll up to the top of the page.
- _Describe the tests completed and the results_
- - Testing was done on local machine. Once in staging QA will be preformed as well.
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

Code prior to change (PageLink.jsx)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/88905347/4e05cb99-2689-4411-bd9d-13b5bd618ad8)

Code after change (PageLink.jsx)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/88905347/01745cb5-c0c2-495e-81de-534ffe3009ec)


## What areas of the site does it impact?
- This only impacts staging / https://staging.va.gov/education/verify-your-enrollment/
*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria
- Page scrolls to the top when user click on link for benefits profile page
### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
