### PR TITLE
removes experiment lga feature flag

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -227,7 +227,6 @@ export default Object.freeze({
   showNewViewTestLabResultsPage: 'show_new_view_test_lab_results_page',
   showUpdatedFryDeaApp: 'show_updated_fry_dea_app',
   signInServiceEnabled: 'sign_in_service_enabled',
-  signInPageAndModalExperimentLga: 'sign_in_page_and_modal_experiment_lga',
   stemAutomatedDecision: 'stem_automated_decision',
   stemSCOEmail: 'stem_sco_email',
   subform89404192: 'subform_8940_4192',


### PR DESCRIPTION
In this [ticket](https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/gh/department-of-veterans-affairs/va.gov-team/74147) we were asked to remove the ```sign_in_page_and_modal_experiment_lga``` feature flag from ```vets-website``` as it is not being used anymore.