### PR TITLE
My VA - appointment code cleanup

### DIFF
--- a/src/applications/personalization/appointments/actions/index.js
+++ b/src/applications/personalization/appointments/actions/index.js
@@ -142,12 +142,14 @@ export function fetchConfirmedFutureAppointmentsV2() {
       const formatted = appointments.map(appointment => {
         return vaosV2Helpers.transformAppointment(appointment);
       });
-      // sort by date
-      const sorted = vaosV2Helpers.sortAppointments(formatted);
+
+      // filter out past appointments
+      const onlyUpcoming = formatted.filter(appt => appt.isUpcoming);
+
       // update redux
       dispatch({
         type: FETCH_CONFIRMED_FUTURE_APPOINTMENTS_SUCCEEDED,
-        appointments: sorted,
+        appointments: onlyUpcoming,
       });
     } catch (error) {
       recordEvent({

--- a/src/applications/personalization/appointments/actions/utils.unit.spec.js
+++ b/src/applications/personalization/appointments/actions/utils.unit.spec.js
@@ -43,11 +43,11 @@ describe('My VA Dashboard', () => {
       });
     });
     describe('sortAppointments', () => {
-      it('sorts appointments by startAt time, descending order', () => {
+      it('sorts appointments by startsAt time, descending order', () => {
         const appointments = [
-          { id: 1, startAt: new Date('2020-01-03T00:00:00.000Z') },
-          { id: 2, startAt: new Date('2020-01-01T00:00:00.000Z') },
-          { id: 3, startAt: new Date('2020-01-02T00:00:00.000Z') },
+          { id: 1, startsAt: '2020-01-03T00:00:00.000Z' },
+          { id: 2, startsAt: '2020-01-01T00:00:00.000Z' },
+          { id: 3, startsAt: '2020-01-02T00:00:00.000Z' },
         ];
         const sorted = vaosV2Helpers.sortAppointments(appointments);
         expect(sorted[0].id).to.equal(2);

--- a/src/applications/personalization/dashboard/components/health-care/AppointmentsCard.jsx
+++ b/src/applications/personalization/dashboard/components/health-care/AppointmentsCard.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { format } from 'date-fns';
-import { utcToZonedTime } from 'date-fns-tz';
+import { format, utcToZonedTime } from 'date-fns-tz';
 import recordEvent from '~/platform/monitoring/record-event';
 import { Toggler } from '~/platform/utilities/feature-toggles';
 import CTALink from '../CTALink';
@@ -9,13 +8,11 @@ import { getAppointmentTimezone } from '../../utils/timezone';
 
 export const AppointmentsCard = ({ appointments }) => {
   const nextAppointment = appointments?.[0];
-  const startsAt = nextAppointment?.startsAt;
-
+  const localStartTime = nextAppointment?.localStartTime;
   let locationName;
 
   const timeZone = getAppointmentTimezone(nextAppointment);
   const timeZoneId = timeZone.description;
-  const localStartTime = utcToZonedTime(startsAt, timeZoneId);
 
   if (nextAppointment?.isVideo) {
     locationName = 'VA Video Connect';
@@ -33,12 +30,16 @@ export const AppointmentsCard = ({ appointments }) => {
     <>
       <h3 className="vads-u-margin-top--0">Next appointment</h3>
       <p className="vads-u-margin-bottom--1">
-        {format(localStartTime, 'eeee, MMMM d, yyyy')}
+        {format(
+          utcToZonedTime(localStartTime, timeZoneId),
+          'eeee, MMMM d, yyyy',
+        )}
       </p>
       <p className="vads-u-margin-bottom--1 vads-u-margin-top--1">
-        {`Time: ${format(localStartTime, 'h:mm aaaa')} ${
-          timeZone.abbreviation
-        }`}
+        {`Time: ${format(
+          utcToZonedTime(localStartTime, timeZoneId),
+          'h:mm aaaa',
+        )} ${timeZone.abbreviation}`}
       </p>
       {locationName && <p className="vads-u-margin-top--1">{locationName}</p>}
       <CTALink

--- a/src/applications/personalization/dashboard/mocks/appointments/vaos-v2.js
+++ b/src/applications/personalization/dashboard/mocks/appointments/vaos-v2.js
@@ -1,5 +1,6 @@
-const format = require('date-fns/format');
+// const format = require('date-fns/format');
 const add = require('date-fns/add');
+const { format, utcToZonedTime } = require('date-fns-tz');
 
 const createVaosAppointment = ({
   startsInDays = 1,
@@ -64,14 +65,17 @@ const createVaosAppointment = ({
         },
       },
     },
-    get localStartTime() {
-      return format(now, "yyyy-MM-dd'T'HH:mm:ss", {
-        timeZone: this.location.attributes.timezone.timeZoneId,
-      });
-    },
     start: format(now, "yyyy-MM-dd'T'HH:mm:ss"),
-    startsAt: format(now, "yyyy-MM-dd'T'HH:mm:ssxxx"),
     end: format(add(now, { hours: 3 }), "yyyy-MM-dd'T'HH:mm:ss"),
+    get localStartTime() {
+      return format(
+        utcToZonedTime(now, this.location.attributes.timezone.timeZoneId),
+        "yyyy-MM-dd'T'HH:mm:ssXXX",
+        {
+          timeZone: this.location.attributes.timezone.timeZoneId,
+        },
+      );
+    },
   };
   return appointment;
 };

--- a/src/applications/personalization/dashboard/tests/components/health-care/AppointmentsCard.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/health-care/AppointmentsCard.unit.spec.jsx
@@ -17,13 +17,13 @@ describe('<AppointmentsCard />', () => {
         additionalInfo: 'yada yada yada',
         isVideo: true,
         providerName: 'test provider',
-        startsAt: '2024-01-11T06:30:00-07:00',
+        localStartTime: '2024-01-11T06:30:00-07:00',
         timeZone: 'MT',
         type: 'regular',
       },
     ];
 
-    const startFns = parseISO(appointments[0].startsAt);
+    const startFns = parseISO(appointments[0].localStartTime);
     const startFormatted = format(startFns, 'eeee, MMMM d, yyyy');
     const tree = renderInReduxProvider(
       <AppointmentsCard appointments={appointments} />,
@@ -53,7 +53,7 @@ describe('<AppointmentsCard />', () => {
     it('when the appointment is a video appointment', () => {
       const appointments = [
         {
-          startsAt: '2023-12-04T10:00:00-05:00',
+          localStartTime: '2023-12-04T10:00:00-05:00',
           isVideo: true,
           additionalInfo: 'testing',
         },
@@ -85,7 +85,7 @@ describe('<AppointmentsCard />', () => {
       const providerName = 'test provider';
       const appointments = [
         {
-          startsAt: '2023-12-04T10:00:00-05:00',
+          localStartTime: '2023-12-04T10:00:00-05:00',
           isVideo: false,
           providerName,
         },


### PR DESCRIPTION
## Summary

This PR:
- updates AppointmentsCard to use `localStartTime` instead of `start` (per Simi's suggestion)
- fix `isUpcoming` function
- updates unit tests and mock data 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/72297
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/73088

## Testing done
- locally, visually
- all unit and e2e still pass?

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

My VA - Health care - Next appointments

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
