### PR TITLE
Add demographics confirmed uuid for local testing

### DIFF
--- a/src/applications/check-in/README.md
+++ b/src/applications/check-in/README.md
@@ -29,6 +29,7 @@ There are several different mock UUIDs that can be used as a value for the `id` 
   - allAppointmentTypesUUID: `bb48c558-7b35-44ec-8ab7-32b7d49364fc`
   - missingUUID: `a5895713-ca42-4244-9f38-f8b5db020d04`
   - noFacilityAddressUUID: `5d5a26cd-fb0b-4c5b-931e-2957bfc4b9d3`
+  - demographicsConfirmedUUID: `3f93c0e0-319a-4642-91b3-750e0aec0388`
 
 ### Pre-check-in
   - defaultUUID: `46bebc0a-b99c-464f-a5c5-560bc9eae287`

--- a/src/applications/check-in/api/local-mock-api/index.js
+++ b/src/applications/check-in/api/local-mock-api/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 const delay = require('mocker-api/lib/delay');
-
+const dateFns = require('date-fns');
 const commonResponses = require('../../../../platform/testing/local-dev-mock-api/common');
 const checkInData = require('./mocks/v2/check-in-data/index');
 const preCheckInData = require('./mocks/v2/pre-check-in-data/index');
@@ -16,6 +16,8 @@ const mockUser = Object.freeze({
   dob: '1935-04-07',
 });
 const missingUUID = 'a5895713-ca42-4244-9f38-f8b5db020d04';
+
+const demographicsConfirmedUUID = '3f93c0e0-319a-4642-91b3-750e0aec0388';
 
 const responses = {
   ...commonResponses,
@@ -53,6 +55,20 @@ const responses = {
   },
   'GET /check_in/v2/patient_check_ins/:uuid': (req, res) => {
     const { uuid } = req.params;
+    if (uuid === demographicsConfirmedUUID) {
+      const yesterday = dateFns.sub(new Date(), { days: -1 }).toISOString();
+      return res.json(
+        sharedData.get.createAppointments(
+          uuid,
+          false,
+          yesterday,
+          false,
+          yesterday,
+          false,
+          yesterday,
+        ),
+      );
+    }
     if (hasBeenValidated) {
       hasBeenValidated = false;
       return res.json(sharedData.get.createAppointments(uuid));


### PR DESCRIPTION
## Summary

- Adds a uuid to test when all demographics are up to date for day of check in
- `3f93c0e0-319a-4642-91b3-750e0aec0388`

## Related issue(s)

- [department-of-veterans-affairs/va.gov-team#72829](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72829)

## Testing done

- Local