### PR TITLE
My VA - unread messages - exclude Sent folder

### DIFF
--- a/src/applications/personalization/dashboard/mocks/messaging/index.js
+++ b/src/applications/personalization/dashboard/mocks/messaging/index.js
@@ -128,6 +128,20 @@ const allFoldersWithUnreadMessages = {
       },
     },
     {
+      id: '-1',
+      type: 'folders',
+      attributes: {
+        folderId: -1,
+        name: 'Sent',
+        count: 1098,
+        unreadCount: 51,
+        systemFolder: true,
+      },
+      links: {
+        self: 'https://staging-api.va.gov/my_health/v1/messaging/folders/-1',
+      },
+    },
+    {
       id: '1',
       type: 'folders',
       attributes: {

--- a/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
+++ b/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
@@ -5,8 +5,6 @@ import {
   SIP_ENABLED_FORMS,
 } from '~/platform/forms/constants';
 
-import { replaceDashesWithSlashes } from '../utils/date-formatting/helpers';
-
 describe('profile helpers:', () => {
   describe('FORM_DESCRIPTIONS', () => {
     it('should have description information for each verified form', () => {
@@ -14,11 +12,5 @@ describe('profile helpers:', () => {
         expect(FORM_DESCRIPTIONS[form]).to.exist;
       });
     });
-  });
-});
-
-describe('replaceDashesWithSlashes function', () => {
-  it('should replace the dashes in a string with slashes', () => {
-    expect(replaceDashesWithSlashes('2023-10-23')).to.equal('2023/10/23');
   });
 });

--- a/src/applications/personalization/dashboard/tests/utils/helpers.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/utils/helpers.unit.spec.jsx
@@ -1,0 +1,81 @@
+import { expect } from 'chai';
+import {
+  countUnreadMessages,
+  createUrlWithQuery,
+  currency,
+} from '../../utils/helpers';
+
+describe('createUrlWithQuery function', () => {
+  it('should correctly append query parameters', () => {
+    expect(
+      createUrlWithQuery('/my_health/v1/messaging/folders', {
+        page: 1,
+        useCache: false,
+      }),
+    ).to.equal('/my_health/v1/messaging/folders?page=1&useCache=false');
+  });
+});
+
+describe('currency function', () => {
+  it('should format a number to American dollar', () => {
+    expect(currency(44)).to.equal('$44.00');
+  });
+});
+
+describe('countUnreadMessages function', () => {
+  it('should count all unread messages in all folders, except for those in the Sent folder', () => {
+    expect(
+      countUnreadMessages({
+        data: [
+          {
+            attributes: {
+              folderId: 0,
+              name: 'Inbox',
+              unreadCount: 3,
+            },
+            id: '0',
+          },
+          {
+            attributes: {
+              folderId: -1,
+              name: 'Sent',
+              unreadCount: 2,
+            },
+            id: '-1',
+          },
+          {
+            attributes: {
+              folderId: 435,
+              name: 'Favorites',
+              unreadCount: 3,
+            },
+            id: '435',
+          },
+        ],
+      }),
+    ).to.equal(6);
+  });
+
+  it('should return unread messages if there only exists one folder', () => {
+    expect(
+      countUnreadMessages({
+        data: {
+          attributes: {
+            folderId: 0,
+            name: 'Inbox',
+            unreadCount: 3,
+          },
+          id: '0',
+        },
+      }),
+    ).to.equal(3);
+  });
+
+  it('should return 0 if there are no folders', () => {
+    expect(
+      countUnreadMessages({
+        data: {},
+      }),
+    ).to.equal(0);
+  });
+});

--- a/src/applications/personalization/dashboard/utils/helpers.js
+++ b/src/applications/personalization/dashboard/utils/helpers.js
@@ -47,7 +47,9 @@ export const getFolderList = () => {
 export const countUnreadMessages = folders => {
   if (Array.isArray(folders?.data)) {
     return folders.data.reduce((accumulator, currentFolder) => {
-      return accumulator + currentFolder.attributes?.unreadCount;
+      return currentFolder.id >= 0
+        ? accumulator + currentFolder.attributes?.unreadCount
+        : accumulator;
     }, 0);
   }
 


### PR DESCRIPTION
## Summary

This PR:
- adds mock data for unread messages in Sent folder
- updates logic to exclude the Sent folder

## Related issue(s)
- [My VA ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/74388)
- [My VA discovery ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/71864)
- [MHV landing page PR](https://github.com/department-of-veterans-affairs/vets-website/pull/27344)

## Testing done
- locally, visually
- all unit and e2e tests still pass

## What areas of the site does it impact?
My VA - Health care - unread messages

## Acceptance criteria
- [ ] user has unread messages in their Sent folder, but dot indicator does not show up

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
