### PR TITLE
Separate other service names

### DIFF
--- a/src/applications/pensions/config/chapters/02-military-history/generalHistory.js
+++ b/src/applications/pensions/config/chapters/02-military-history/generalHistory.js
@@ -1,14 +1,12 @@
 import fullSchemaPensions from 'vets-json-schema/dist/21P-527EZ-schema.json';
 
 import {
-  fullNameUI,
   yesNoUI,
   yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import FullNameField from 'platform/forms-system/src/js/fields/FullNameField';
 import { VaTextInputField } from 'platform/forms-system/src/js/web-component-fields';
 
-const { placeOfSeparation, previousNames } = fullSchemaPensions.properties;
+const { placeOfSeparation } = fullSchemaPensions.properties;
 
 /** @type {PageSchema} */
 export default {
@@ -19,17 +17,6 @@ export default {
       uswds: true,
       classNames: 'vads-u-margin-bottom--2',
     }),
-    previousNames: {
-      'ui:options': {
-        itemName: 'Previous name',
-        expandUnder: 'serveUnderOtherNames',
-        viewField: FullNameField,
-        reviewTitle: 'Previous names',
-        keepInPageOnReview: true,
-        useDlWrap: true,
-      },
-      items: fullNameUI(),
-    },
     placeOfSeparation: {
       'ui:title':
         'Place of your last separation (City, state or foreign country)',
@@ -41,10 +28,6 @@ export default {
     required: ['serveUnderOtherNames'],
     properties: {
       serveUnderOtherNames: yesNoSchema,
-      previousNames: {
-        ...previousNames,
-        minItems: 1,
-      },
       placeOfSeparation,
     },
   },

--- a/src/applications/pensions/config/chapters/02-military-history/previousNames.js
+++ b/src/applications/pensions/config/chapters/02-military-history/previousNames.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  fullNameUI,
+  fullNameSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import ListItemView from '../../../components/ListItemView';
+
+export const PreviousNameView = ({ formData }) => {
+  const { first = '', middle = '', last = '', suffix = '' } =
+    formData.previousFullName || {};
+
+  // Filter out empty strings and join non-empty parts with a space
+  const fullName = [first, middle, last, suffix].filter(Boolean).join(' ');
+
+  return <ListItemView title={fullName} />;
+};
+
+PreviousNameView.propTypes = {
+  formData: PropTypes.shape({
+    previousFullName: PropTypes.string,
+  }),
+};
+
+/** @type {PageSchema} */
+export default {
+  uiSchema: {
+    'ui:title': 'Add other service names',
+    previousNames: {
+      'ui:options': {
+        itemName: 'Name',
+        viewField: PreviousNameView,
+        reviewTitle: 'Previous names',
+        keepInPageOnReview: true,
+        useDlWrap: true,
+      },
+      items: {
+        previousFullName: fullNameUI(),
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      previousNames: {
+        type: 'array',
+        minItems: 1,
+        items: {
+          type: 'object',
+          required: ['previousFullName'],
+          properties: {
+            previousFullName: fullNameSchema,
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/medicalCenters.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/medicalCenters.js
@@ -36,7 +36,7 @@ const generateMedicalCentersSchemas = (
       [medicalCentersKey]: {
         'ui:title': medicalCenterMessage,
         'ui:options': {
-          itemName: 'medical center',
+          itemName: 'Medical center',
           viewField: MedicalCenterView,
           reviewTitle: medicalCentersReviewTitle,
           keepInPageOnReview: true,

--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -53,6 +53,7 @@ import documentUpload from './chapters/06-additional-information/documentUpload'
 import fasterClaimProcessing from './chapters/06-additional-information/fasterClaimProcessing';
 import federalTreatmentHistory from './chapters/03-health-and-employment-information/federalTreatmentHistory';
 import generalHistory from './chapters/02-military-history/generalHistory';
+import previousNames from './chapters/02-military-history/previousNames';
 import generateEmployersSchemas from './chapters/03-health-and-employment-information/employmentHistory';
 import generateMedicalCentersSchemas from './chapters/03-health-and-employment-information/medicalCenters';
 import hasCareExpenses from './chapters/05-financial-information/hasCareExpenses';
@@ -213,6 +214,10 @@ export function isUnemployedUnder65(formData) {
   return formData.currentEmployment === false && isUnder65(formData);
 }
 
+export function doesHavePreviousNames(formData) {
+  return formData.serveUnderOtherNames === true;
+}
+
 export function doesReceiveIncome(formData) {
   return formData.receivesIncome === true;
 }
@@ -348,6 +353,13 @@ const formConfig = {
           title: 'General history',
           uiSchema: generalHistory.uiSchema,
           schema: generalHistory.schema,
+        },
+        previousNames: {
+          path: 'military/general/add',
+          title: 'Previous names',
+          depends: doesHavePreviousNames,
+          uiSchema: previousNames.uiSchema,
+          schema: previousNames.schema,
         },
         pow: {
           path: 'military/pow',

--- a/src/applications/pensions/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/pensions/tests/e2e/fixtures/data/maximal-test.json
@@ -22,8 +22,10 @@
     "serveUnderOtherNames": true,
     "previousNames": [
       {
-        "first": "John",
-        "last": "Doe"
+        "previousFullName": {
+          "first": "Joseph",
+          "last": "Doe"
+        }
       }
     ],
     "placeOfSeparation": "West Brookfield, MA",

--- a/src/applications/pensions/tests/e2e/fixtures/data/overflow-test.json
+++ b/src/applications/pensions/tests/e2e/fixtures/data/overflow-test.json
@@ -22,12 +22,16 @@
     "serveUnderOtherNames": true,
     "previousNames": [
       {
-        "first": "John",
-        "last": "Doe"
+        "previousFullName": {
+          "first": "Joseph",
+          "last": "Doe"
+        }
       },
       {
-        "first": "Johnny",
-        "last": "Doe"
+        "previousFullName": {
+          "first": "Jarrod",
+          "last": "Doe"
+        }
       }
     ],
     "placeOfSeparation": "West Brookfield, MA",

--- a/src/applications/pensions/tests/unit/chapters/02-military-history/generalHistory.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/chapters/02-military-history/generalHistory.unit.spec.jsx
@@ -1,18 +1,3 @@
-import React from 'react';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
-import { expect } from 'chai';
-import sinon from 'sinon';
-import { render, fireEvent, waitFor } from '@testing-library/react';
-
-import {
-  $,
-  $$,
-} from '@department-of-veterans-affairs/platform-forms-system/ui';
-
-import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
-import getData from '../../../fixtures/mocks/mockStore';
-
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfWebComponentFields,
@@ -20,11 +5,9 @@ import {
 import formConfig from '../../../../config/form';
 import generalHistory from '../../../../config/chapters/02-military-history/generalHistory';
 
-const definitions = formConfig.defaultDefinitions;
-
 const { schema, uiSchema } = generalHistory;
 
-describe('web component tests', () => {
+describe('pensions military general history page', () => {
   const pageTitle = 'military history';
   const expectedNumberOfFields = 2;
   testNumberOfWebComponentFields(
@@ -43,93 +26,4 @@ describe('web component tests', () => {
     expectedNumberOfErrors,
     pageTitle,
   );
-});
-
-describe('pension applicant information page', () => {
-  const middleware = [];
-  const mockStore = configureStore(middleware);
-  it('should submit with no errors when No is selected', async () => {
-    const onSubmit = sinon.spy();
-    const { data } = getData({ loggedIn: false });
-    const { queryByText, container } = render(
-      <Provider store={mockStore(data)}>
-        <DefinitionTester
-          definitions={definitions}
-          schema={schema}
-          uiSchema={uiSchema}
-          data={{}}
-          formData={{}}
-          onSubmit={onSubmit}
-        />
-      </Provider>,
-    );
-    const submitBtn = queryByText('Submit');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: 'N' },
-    });
-    $('va-radio', container).__events.vaValueChange(changeEvent);
-
-    fireEvent.click(submitBtn);
-    await waitFor(() => {
-      expect(onSubmit.called).to.be.true;
-    });
-  });
-  it('should not submit with errors when Yes is selected', async () => {
-    const onSubmit = sinon.spy();
-    const { data } = getData({ loggedIn: false });
-    const { queryByText, container } = render(
-      <Provider store={mockStore(data)}>
-        <DefinitionTester
-          definitions={definitions}
-          schema={schema}
-          uiSchema={uiSchema}
-          data={{}}
-          formData={{}}
-          onSubmit={onSubmit}
-        />
-      </Provider>,
-    );
-    const submitBtn = queryByText('Submit');
-    const changeEvent = new CustomEvent('selected', {
-      detail: { value: 'Y' },
-    });
-    $('va-radio', container).__events.vaValueChange(changeEvent);
-
-    fireEvent.click(submitBtn);
-    await waitFor(() => {
-      expect(onSubmit.called).to.be.false;
-    });
-  });
-  it('should reveal name fields', async () => {
-    const onSubmit = sinon.spy();
-    const { data } = getData({ loggedIn: false });
-    const store = mockStore(data);
-    const { container } = render(
-      <Provider store={store}>
-        <DefinitionTester
-          definitions={definitions}
-          schema={schema}
-          uiSchema={uiSchema}
-          data={{}}
-          formData={{}}
-          onSubmit={onSubmit}
-        />
-      </Provider>,
-    );
-
-    waitFor(() => {
-      expect($$('input', container).length).to.equal(1);
-      expect($$('va-radio', container).length).to.equal(1);
-      expect($('button[type="submit"]', container)).to.exist;
-
-      const changeEvent = new CustomEvent('selected', {
-        detail: { value: 'Y' },
-      });
-      $('va-radio', container).__events.vaValueChange(changeEvent);
-
-      expect($$('va-radio-option', container).length).to.eq(2);
-      // Verify fields are now visible
-      expect($$('input', container).length).to.equal(4);
-    });
-  });
 });

--- a/src/applications/pensions/tests/unit/chapters/02-military-history/previousNames.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/chapters/02-military-history/previousNames.unit.spec.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+
+import {
+  testNumberOfErrorsOnSubmitForWebComponents,
+  testNumberOfWebComponentFields,
+} from '../pageTests.spec';
+import formConfig from '../../../../config/form';
+import previousNames, {
+  PreviousNameView,
+} from '../../../../config/chapters/02-military-history/previousNames';
+
+const { schema, uiSchema } = previousNames;
+
+describe('pensions military history', () => {
+  const pageTitle = 'add previous names';
+  const expectedNumberOfFields = 4;
+  testNumberOfWebComponentFields(
+    formConfig,
+    schema,
+    uiSchema,
+    expectedNumberOfFields,
+    pageTitle,
+  );
+
+  const expectedNumberOfErrors = 2;
+  testNumberOfErrorsOnSubmitForWebComponents(
+    formConfig,
+    schema,
+    uiSchema,
+    expectedNumberOfErrors,
+    pageTitle,
+  );
+
+  describe('PreviousNameView', () => {
+    it('should render a list view', () => {
+      const { container } = render(
+        <PreviousNameView
+          formData={{
+            previousFullName: { first: 'Jamie', middle: 'Andrew', last: 'Doe' },
+          }}
+        />,
+      );
+      const text = container.querySelector('h3');
+      expect(text.innerHTML).to.equal('Jamie Andrew Doe');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
On the Pension Benefits application(21P-527EZ), update the 'Military history' chapter so that 'Other service names' is a separate list loop page

## How to run in local environment
1. Check out this branch locally
2. In your local environment, set the `pension_form_enabled` flipper to 'enabled' at http://localhost:3000/flipper/features/pension_form_enabled
3. Run `vets-website` and `vets-api`

## How to verify
1. Go to `http://localhost:3001/pension/application/527EZ` in your browser
2. Start or continue the application
3. Go to the 'Military history' chapter
4. Continue to the 'Other service names' page
5. Select 'Yes' and continue to the 'Add other service names' page
6. Verify that the page collects and validates multiple names
7.  Select 'No' on the 'Other service names' page and validate that it goes to 'POW status' page
8. Verify that the form data is saved to the redux store and submitted to the api

## Related issue(s)
[Ticket in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73944)
[Epic in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/63349)

## Testing done
- [x] Existing unit tests updated
- [x] New unit tests added

## Screenshots

### Desktop
| Before | After | Invalid | Valid | Review application
| ------ | ------ | ------ | ------ | ------ |
|![localhost_3001_pension_application_527EZ_resume](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/7f411c0a-3152-416b-b4ce-bad74dc72b67)|![localhost_3001_pension_application_527EZ_ (1)](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/a9107bbd-e52a-402f-bbd6-44eda05cd3cc)|![localhost_3001_pension_application_527EZ_review-and-submit (7)](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/33e14f59-ebef-4519-90b8-9b73e1ade4c9)|![localhost_3001_pension_application_527EZ_review-and-submit (6)](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/444713f7-1565-4bd2-aa2c-ca7c36314c70)|![localhost_3001_pension_application_527EZ_review-and-submit (5)](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/c6572a2f-e744-48d0-b1d0-db071d7285db)

## What areas of the site does it impact?
Pension Benefits Application

## Acceptance criteria
[Ticket in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73944)

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

