### PR TITLE
Pension: Add new tab warning

### DIFF
--- a/src/applications/pensions/components/FormAlerts/index.jsx
+++ b/src/applications/pensions/components/FormAlerts/index.jsx
@@ -52,27 +52,32 @@ export const IncomeInformationAlert = () => (
   </va-alert-expandable>
 );
 
-const RequestFormAlert = ({ title, formName, formLink, children }) => (
-  <va-alert status="warning" uswds slim>
-    <p className="vads-u-margin-y--0">
-      You’ll need to submit an {title} (
-      <a href={formLink} rel="noopener noreferrer" target="_blank">
-        {formName}
-      </a>
-      ).
-    </p>
-    <p>{children}</p>
-    <p>
-      We’ll ask you to upload this form at the end of this application. Or you
-      can send it to us by mail.
-    </p>
-    <p>
-      <a href={formLink} rel="noopener noreferrer" target="_blank">
-        Get {formName} to download
-      </a>
-    </p>
-  </va-alert>
-);
+const RequestFormAlert = ({ title, formName, formLink, children }) => {
+  const linkText = `Get ${formName} to download (opens in new tab)`;
+  return (
+    <va-alert status="warning" uswds slim>
+      <p className="vads-u-margin-y--0">
+        You’ll need to submit an {title} ({formName}
+        ).
+      </p>
+      <p>{children}</p>
+      <p>
+        We’ll ask you to upload this form at the end of this application. Or you
+        can send it to us by mail.
+      </p>
+      <p>
+        <a
+          href={formLink}
+          rel="noopener noreferrer"
+          target="_blank"
+          aria-label={linkText}
+        >
+          {linkText}
+        </a>
+      </p>
+    </va-alert>
+  );
+};
 
 RequestFormAlert.propTypes = {
   children: PropTypes.node.isRequired,
@@ -83,9 +88,9 @@ RequestFormAlert.propTypes = {
 
 export const RequestIncomeAndAssetInformationAlert = () => (
   <RequestFormAlert
-    title="Income and Asset Statement in Support of Claim for Pension or Parents"
+    title="Income and Asset Statement in Support of Claim for Pension or Parents' Dependency and Indemnity Compensation"
     formName="VA Form 21P-0969"
-    formLink="https://www.vba.va.gov/pubs/forms/VBA-21P-0969-ARE.pdf"
+    formLink="https://www.va.gov/find-forms/about-form-21p-0969/"
   />
 );
 
@@ -94,7 +99,7 @@ export const RequestNursingHomeInformationAlert = () => (
     title="Nursing Home Information in Connection with Claim
     for Aid and Attendance"
     formName="VA Form 21-0779"
-    formLink="https://www.vba.va.gov/pubs/forms/vba-21-0779-are.pdf"
+    formLink="https://www.va.gov/find-forms/about-form-21-0779/"
   >
     An official from your nursing home must complete the form.
   </RequestFormAlert>
@@ -105,7 +110,7 @@ export const SpecialMonthlyPensionEvidenceAlert = () => (
     title="Examination for Household Status or Permanent
     Need for Regular Aid and Attendance"
     formName="VA Form 21-2680"
-    formLink="https://www.vba.va.gov/pubs/forms/vba-21-2680-are.pdf"
+    formLink="https://www.va.gov/find-forms/about-form-21-2680/"
   >
     Make sure every box is complete and has a signature from a physician,
     physician assistant, certified nurse practitioner (CNP), or clinical nurse
@@ -113,65 +118,47 @@ export const SpecialMonthlyPensionEvidenceAlert = () => (
   </RequestFormAlert>
 );
 
-export const TotalNetWorthOverTwentyFiveThousandAlert = () => (
-  <va-alert status="warning" uswds slim>
-    <p className="vads-u-margin-y--0">
-      You answered that you have more than $25,000 in assets. You’ll need to
-      submit an Income and Asset Statement in Support of Claim for Pension or
-      Parents' Dependency and Indemnity Compensation (
-      <a
-        href="https://www.vba.va.gov/pubs/forms/VBA-21P-0969-ARE.pdf"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        VA Form 21P-0969
-      </a>
-      ).
-    </p>
-    <p>
-      We’ll ask you to upload this form at the end of this application. Or you
-      can send it to us by mail.
-    </p>
-    <p>
-      <a
-        href="https://www.vba.va.gov/pubs/forms/VBA-21P-0969-ARE.pdf"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        Get VA Form 21P-0969 to download.
-      </a>
-    </p>
-  </va-alert>
-);
+export const TotalNetWorthOverTwentyFiveThousandAlert = () => {
+  const linkText = 'Get VA Form 21P-0969 to download (opens in new tab)';
+  return (
+    <va-alert status="warning" uswds slim>
+      <p className="vads-u-margin-y--0">
+        You answered that you have more than $25,000 in assets. You’ll need to
+        submit an Income and Asset Statement in Support of Claim for Pension or
+        Parents' Dependency and Indemnity Compensation (
+        <a
+          href="https://www.va.gov/find-forms/about-form-21-2680/"
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          VA Form 21P-0969
+        </a>
+        ).
+      </p>
+      <p>
+        We’ll ask you to upload this form at the end of this application. Or you
+        can send it to us by mail.
+      </p>
+      <p>
+        <a
+          href="https://www.va.gov/find-forms/about-form-21p-0969/"
+          rel="noopener noreferrer"
+          target="_blank"
+          aria-label={linkText}
+        >
+          {linkText}
+        </a>
+      </p>
+    </va-alert>
+  );
+};
 
 export const IncomeAssetStatementFormAlert = () => (
-  <va-alert status="warning" uswds slim>
-    <p className="vads-u-margin-y--0">
-      You’ll need to submit an Income and Asset Statement in Support of Claim
-      for Pension or Parents' Dependency and Indemnity Compensation (
-      <a
-        href="https://www.vba.va.gov/pubs/forms/VBA-21P-0969-ARE.pdf"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        VA Form 21P-0969
-      </a>
-      ).
-    </p>
-    <p>
-      We’ll ask you to upload this form at the end of this application. Or you
-      can mail it to us.
-    </p>
-    <p>
-      <a
-        href="https://www.vba.va.gov/pubs/forms/VBA-21P-0969-ARE.pdf"
-        rel="noopener noreferrer"
-        target="_blank"
-      >
-        Get VA Form 21P-0969 to download.
-      </a>
-    </p>
-  </va-alert>
+  <RequestFormAlert
+    title="Income and Asset Statement in Support of Claim for Pension or Parents' Dependency and Indemnity Compensation"
+    formName="VA Form 21P-0969"
+    formLink="https://www.va.gov/find-forms/about-form-21p-0969/"
+  />
 );
 
 export const LandMarketableAlert = () => (
@@ -187,4 +174,12 @@ export const LandMarketableAlert = () => (
       </li>
     </ul>
   </va-alert>
+);
+
+export const SchoolAttendanceAlert = (
+  <RequestFormAlert
+    title="Request for Approval of School Attendance"
+    formName="VA Form 21-674"
+    formLink="https://www.va.gov/find-forms/about-form-21-674/"
+  />
 );

--- a/src/applications/pensions/config/chapters/04-household-information/dependentChildInformation.js
+++ b/src/applications/pensions/config/chapters/04-household-information/dependentChildInformation.js
@@ -18,8 +18,8 @@ import {
   dependentSeriouslyDisabledDescription,
   dependentWarning,
   disabilityDocs,
-  schoolAttendanceWarning,
 } from '../../../helpers';
+import { SchoolAttendanceAlert } from '../../../components/FormAlerts';
 
 const { dependents } = fullSchemaPensions.properties;
 
@@ -88,7 +88,7 @@ export default {
           },
         ),
         'view:schoolWarning': {
-          'ui:description': schoolAttendanceWarning,
+          'ui:description': SchoolAttendanceAlert,
           'ui:options': {
             expandUnder: 'attendingCollege',
           },

--- a/src/applications/pensions/config/chapters/06-additional-information/fasterClaimProcessing.js
+++ b/src/applications/pensions/config/chapters/06-additional-information/fasterClaimProcessing.js
@@ -4,6 +4,8 @@ import fullSchemaPensions from 'vets-json-schema/dist/21P-527EZ-schema.json';
 
 const { noRapidProcessing } = fullSchemaPensions.properties;
 
+const fullyDevelopedClaimsLinkText =
+  'Learn more about fully developed claims (opens in new tab)';
 const Description = (
   <div className="vads-u-margin-bottom--1">
     <p>
@@ -12,8 +14,13 @@ const Description = (
       (FDC) program.
     </p>
 
-    <a href="https://www.va.gov/disability/how-to-file-claim/evidence-needed/fully-developed-claims/">
-      Learn more about fully developed claims
+    <a
+      rel="noopener noreferrer"
+      target="_blank"
+      href="https://www.va.gov/disability/how-to-file-claim/evidence-needed/fully-developed-claims/"
+      aria-label={fullyDevelopedClaimsLinkText}
+    >
+      {fullyDevelopedClaimsLinkText}
     </a>
   </div>
 );

--- a/src/applications/pensions/config/chapters/06-additional-information/supportingDocuments.js
+++ b/src/applications/pensions/config/chapters/06-additional-information/supportingDocuments.js
@@ -3,12 +3,28 @@ import React from 'react';
 export const childAttendsCollege = child => child.attendingCollege;
 export const childIsDisabled = child => child.disabled;
 
+const SupportingDocument = ({ formId, formName }) => {
+  const linkText = `Get VA Form ${formId} to download (opens in new tab)`;
+  return (
+    <li>
+      a completed {formName} (VA Form {formId})<br />
+      <a
+        rel="noopener noreferrer"
+        target="_blank"
+        href={`https://www.va.gov/find-forms/about-form-${formId.toLowerCase()}`}
+        aria-label={linkText}
+      >
+        {linkText}
+      </a>
+    </li>
+  );
+};
+
 function Description({ formData }) {
   const hasDisabledChild = (formData.dependents || []).some(childIsDisabled);
   const hasSchoolChild = (formData.dependents || []).some(childAttendsCollege);
   const hasSpecialMonthlyPension = formData.specialMonthlyPension;
   const livesInNursingHome = formData.nursingHome;
-
   const assetsOverThreshold = formData.totalNetWorth; // over $25,000 in assets
   const homeAcreageMoreThanTwo =
     formData.homeOwnership && formData.homeAcreageMoreThanTwo;
@@ -37,39 +53,26 @@ function Description({ formData }) {
 
           <ul>
             {hasSpecialMonthlyPension && (
-              <li>
-                a completed Examination for Housebound Status or Permanent Need
-                for Regular Aid and Attendance (VA Form 21-2680)
-                <br />
-                <va-link
-                  href="https://www.va.gov/find-forms/about-form-21-2680"
-                  text="Get VA Form 21-2680 to download"
-                />
-              </li>
+              <SupportingDocument
+                formName="Examination for Housebound Status or Permanent Need
+              for Regular Aid and Attendance"
+                formId="21-2680"
+              />
             )}
 
             {livesInNursingHome && (
-              <li>
-                a completed Request for Nursing Home Information in Connection
-                with Claim for Aid and Attendance (VA Form 21-0779)
-                <br />
-                <va-link
-                  href="https://www.va.gov/find-forms/about-form-21-0779"
-                  text="Get VA Form 21-0779 to download"
-                />
-              </li>
+              <SupportingDocument
+                formName="Request for Nursing Home Information in Connection
+              with Claim for Aid and Attendance"
+                formId="21-0779"
+              />
             )}
 
             {hasSchoolChild && (
-              <li>
-                a completed Request for Approval of School Attendance (VA Form
-                21-674)
-                <br />
-                <va-link
-                  href="https://www.vba.va.gov/pubs/forms/VBA-21-674-ARE.pdf"
-                  text="Get VA Form 21-674 to download"
-                />
-              </li>
+              <SupportingDocument
+                formName="Request for Approval of School Attendance"
+                formId="21-674"
+              />
             )}
 
             {hasDisabledChild && (
@@ -80,16 +83,11 @@ function Description({ formData }) {
             )}
 
             {needsIncomeAndAssetStatement && (
-              <li>
-                a completed Income and Asset Statement in Support of Claim for
-                Pension or Parents' Dependency and Indemnity Compensation (VA
-                Form 21P-0969)
-                <br />
-                <va-link
-                  href="https://www.va.gov/find-forms/about-form-21p-0969/"
-                  text="Get VA Form 21P-0969 to download"
-                />
-              </li>
+              <SupportingDocument
+                formName="Income and Asset Statement in Support of Claim for
+              Pension or Parents' Dependency and Indemnity Compensation"
+                formId="21P-0969"
+              />
             )}
           </ul>
         </>

--- a/src/applications/pensions/helpers.jsx
+++ b/src/applications/pensions/helpers.jsx
@@ -198,22 +198,45 @@ export const formatCurrency = num => `$${num.toLocaleString()}`;
 
 export const directDepositWarning = (
   <div className="pension-dd-warning">
-    The Department of Treasury requires all federal benefit payments be made by
-    electronic funds transfer (EFT), also called direct deposit. If you don’t
-    have a bank account, you must get your payment through Direct Express Debit
-    MasterCard. To request a Direct Express Debit MasterCard you must apply at{' '}
-    <a
-      href="http://www.usdirectexpress.com"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      www.usdirectexpress.com
-    </a>{' '}
-    or by telephone at <va-telephone contact="8003331795" />. If you chose not
-    to enroll, you must contact representatives handling waiver requests for the
-    Department of Treasury at <va-telephone contact="8882242950" />. They will
-    address any questions or concerns you may have and encourage your
-    participation in EFT.
+    <div>
+      <p>
+        The Department of Treasury requires all federal benefit payments be made
+        by electronic funds transfer (EFT), also called direct deposit.
+      </p>
+    </div>
+    <div>
+      <h3>If you don’t have a bank account</h3>
+      <p>
+        If you don’t have a bank account, you must get your payment through
+        Direct Express Debit MasterCard. To request a Direct Express Debit
+        MasterCard, you’ll need to apply one of these two ways:
+      </p>
+      <ul>
+        <li>
+          <a
+            href="http://www.usdirectexpress.com"
+            rel="noopener noreferrer"
+            target="_blank"
+            aria-label="Apply online for a Direct Express Debit MasterCard (opens in new tab)"
+          >
+            Apply online for a Direct Express Debit MasterCard (opens in new
+            tab)
+          </a>
+        </li>
+        <li>
+          Call <va-telephone contact="8003331795" /> to apply by phone
+        </li>
+      </ul>
+    </div>
+    <div>
+      <h3>If you want to opt out of direct deposit</h3>
+      <p>
+        If you chose not to enroll, you must contact representatives handling
+        waiver requests for the Department of Treasury at{' '}
+        <va-telephone contact="8882242950" />. They will address any questions
+        or concerns you may have and encourage your participation in EFT.
+      </p>
+    </div>
   </div>
 );
 
@@ -269,25 +292,6 @@ export const disabilityDocs = (
       <div className="usa-alert-text">
         You’ll need to provide all private medical records for your child’s
         disability.
-      </div>
-    </div>
-  </div>
-);
-
-export const schoolAttendanceWarning = (
-  <div className="usa-alert usa-alert-warning">
-    <div className="usa-alert-body">
-      <div className="usa-alert-text">
-        Since your child is between 18 and 23 years old, you’ll need to fill out
-        a Request for Approval of School Attendance (
-        <a
-          href="https://www.vba.va.gov/pubs/forms/VBA-21-674-ARE.pdf"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          VA Form 21-674
-        </a>
-        ). <strong>You can send us this form later.</strong>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Several pages in the form flow link out to additional forms to complete, either as PDFs or web pages. These links should open in a new tab and should include a visual and aria indicator that they open in a new tab.

Included pages:

- /medical/history/monthly-pension
- /household/dependents/children/information/1
- /financial/total-net-worth
- /financial/transferred-assets
- /financial/land-marketable
- /additional-information/direct-deposit
- /additional-information/supporting-documents
- /additional-information/document-upload
- /additional-information/faster-claim-processing

## Related issue(s)

- [Link to main ticket on GitHub](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73986)
- [Link to dependents ticket on GitHub](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73290)

## Testing done

All listed links should open in a new tab, have the text '(open in new tab)', and have an aria-label that indicates they open in a new tab. 

- Run the application and fill out 21P-527EZ with the data from 
[sample_data.json](https://github.com/department-of-veterans-affairs/vets-website/files/14043919/sample_data.json) using the save-in-progress tool. 
- Confirm the link `/medical/history/monthly-pension` is correct (must select 'yes')
- Confirm the link in `/household/dependents/children/information/1` is correct (must have a child between 18 and 23 years old who attends school). Confirm the alert text matches the new copy. 
- Confirm the link in `/financial/total-net-worth` is correct (must select 'yes')
- Confirm the link in `/financial/transferred-assets` is correct (must select 'yes'
- Confirm the link in `/financial/land-marketable` is correct (must select 'yes')
- Confirm the link in `/additional-information/direct-deposit` is correct (must select 'I don’t want to use direct deposit'). Confirm the design matches the wireframe from the issue. 
- Confirm the links in `/additional-information/supporting-documents` are correct (there should be four links, if using sample_data.json)
- Confirm the link in `/additional-information/document-upload` is correct
- Confirm the link in `/additional-information/faster-claim-processing` is correct

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Direct Deposit |    <img width="685" alt="Screenshot 2024-01-24 at 3 00 10 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/21046714/5e063781-116f-4e87-aa82-3db4f8892415">    |   <img width="485" alt="direct_deposit" src="https://github.com/department-of-veterans-affairs/vets-website/assets/21046714/68314ee4-6265-4925-b579-32992f740f90">    |
| Attendance Alert |  <img width="590" alt="Screenshot 2024-01-24 at 4 58 50 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/21046714/134718ba-e868-4608-bbd8-ce8d9383deed">  | <img width="499" alt="attendance_alert" src="https://github.com/department-of-veterans-affairs/vets-website/assets/21046714/0da0d91f-dcdf-4b22-824c-1aacb938b899"> |

## What areas of the site does it impact?

Pension Benefits

## Acceptance criteria

- [Link to main ticket on GitHub](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73986)
- [Link to dependents ticket on GitHub](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73290)

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
