### PR TITLE
Deprecate feature class in coronavirus screener

### DIFF
--- a/src/applications/coronavirus-screener/components/FormQuestion.jsx
+++ b/src/applications/coronavirus-screener/components/FormQuestion.jsx
@@ -47,10 +47,10 @@ export default function FormQuestion({
   ));
 
   return (
-    <div className="feature" id={`question-${question.id}`}>
+    <va-featured-content id={`question-${question.id}`}>
       <Element name={scrollElementName} />
       <h2>{question.text[selectedLanguage]}</h2>
       {options}
-    </div>
+    </va-featured-content>
   );
 }

--- a/src/applications/coronavirus-screener/sass/coronavirus-screener.scss
+++ b/src/applications/coronavirus-screener/sass/coronavirus-screener.scss
@@ -1,6 +1,16 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 
 .covid-screener {
+
+  va-featured-content {
+    margin-top: 24px;
+    margin-bottom: 24px;
+
+    h2 {
+      margin-top: 0;
+    }
+  }
+
   ​ *:not(.fas) {
     font-family: Source Sans Pro, Helvetica Neue, Helvetica, Roboto, Arial,
       sans-serif;


### PR DESCRIPTION
## Summary

The design system team has deprecated the Formation style for .feature in favor of the va-featured-content web component. 

## Related issue(s)
Partial [Formation Deprecation - replace all instances of the .feature class with va-featured-content #2338](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2338)

## Testing done
Tested locally

## Screenshots

Before:
![Screenshot 2024-01-18 at 10 59 00](https://github.com/department-of-veterans-affairs/vets-website/assets/1413938/9ba57194-d81d-4b63-bd33-5494ddde0dc3)

After:
![Screenshot 2024-01-18 at 11 16 48](https://github.com/department-of-veterans-affairs/vets-website/assets/1413938/51ddcabe-7a31-4265-a151-d476e0af0353)

## What areas of the site does it impact?

Coronavirus screener

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
