### PR TITLE
[DO NOT MERGE] (PoC) added  a second app, using the same code at a different url

### DIFF
--- a/src/applications/mhv/secure-messaging copy/app-entry.jsx
+++ b/src/applications/mhv/secure-messaging copy/app-entry.jsx
@@ -1,0 +1,20 @@
+import 'platform/polyfills';
+import '../secure-messaging/sass/compose.scss';
+import '../secure-messaging/sass/message-details.scss';
+import '../secure-messaging/sass/message-list.scss';
+import '../secure-messaging/sass/search.scss';
+import '../secure-messaging/sass/secure-messaging.scss';
+import '../secure-messaging/sass/message-thread.scss';
+import '../secure-messaging/sass/dashboard.scss';
+
+import startApp from 'platform/startup/router';
+import routes from './routes';
+import reducer from '../secure-messaging/reducers';
+import manifest from './manifest.json';
+
+startApp({
+  url: manifest.rootUrl,
+  entryName: manifest.entryName,
+  reducer,
+  routes,
+});

--- a/src/applications/mhv/secure-messaging copy/manifest.json
+++ b/src/applications/mhv/secure-messaging copy/manifest.json
@@ -1,0 +1,7 @@
+{
+  "appName": "MHV Secure Messaging - OH Pilot",
+  "entryFile": "./app-entry.jsx",
+  "entryName": "secure-messaging-pilot",
+  "rootUrl": "/my-health/secure-messages/pilot-test",
+  "productId": "c1486f38-a24e-4211-bf6b-258df6e63cd3"
+}

--- a/src/applications/mhv/secure-messaging copy/routes.jsx
+++ b/src/applications/mhv/secure-messaging copy/routes.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Switch, Route } from 'react-router-dom';
+import App from '../secure-messaging/containers/App';
+
+const routes = (
+  <Switch>
+    <Route path="/" key="App">
+      <App isPilot />
+    </Route>
+  </Switch>
+);
+
+export default routes;

--- a/src/applications/mhv/secure-messaging/containers/App.jsx
+++ b/src/applications/mhv/secure-messaging/containers/App.jsx
@@ -17,7 +17,7 @@ import { useDatadogRum } from '../../shared/hooks/useDatadogRum';
 import { getAllFacilities } from '../actions/facilities';
 import { getAllTriageTeamRecipients } from '../actions/recipients';
 
-const App = () => {
+const App = ({ isPilot }) => {
   const dispatch = useDispatch();
   const user = useSelector(selectUser);
   const userServices = user.profile.services; // mhv_messaging_policy.rb defines if messaging service is avaialble when a user is in Premium status upon structuring user services from the user profile in services.rb
@@ -32,6 +32,14 @@ const App = () => {
       };
     },
     state => state.featureToggles,
+  );
+
+  useEffect(
+    () => {
+      // could be a feature flag or redux. I just used local storage for proof of concept
+      localStorage.setItem('isPilot', isPilot);
+    },
+    [isPilot],
   );
 
   const userFacilities = useMemo(

--- a/src/applications/mhv/secure-messaging/containers/LandingPageAuth.jsx
+++ b/src/applications/mhv/secure-messaging/containers/LandingPageAuth.jsx
@@ -48,10 +48,12 @@ const LandingPageAuth = () => {
     updatePageTitle(PageTitles.DEFAULT_PAGE_TITLE_TAG);
   }, []);
 
+  const isPilot = localStorage.getItem('isPilot') === 'true';
+
   return (
     <div className="dashboard">
       <AlertBackgroundBox />
-      <h1>Messages</h1>
+      <h1>{isPilot ? 'OH Pilot Messages' : 'Messages'}</h1>
       <p className="va-introtext">
         Communicate privately and securely with your VA health care team online.
       </p>


### PR DESCRIPTION
## Summary
- Quick PoC that demostrates how we use multiple apps in the registory config to run small pilots and data validation with affecting the main experience. 
- The idea is that we a seperate application that uses the same components and we can pass in a config into the App.jsx and have the application react accordingly. 
- E2E tests are critical to have to validate thet core experience does not break or is affected by a change
- Some of the finer details still should tested, but this is the general idea. 

Related Content-build pr: https://github.com/department-of-veterans-affairs/content-build/pull/1889
## Related issue(s)

- N/A

## Testing done

- manual, 
- Should have e2e tests

## Screenshots

Base experience:
<img width="470" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/1793923/3aa79b24-f002-4817-8298-c70dd60cb711">


Pilot Expeirence:
<img width="444" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/1793923/f5ed8596-e520-4892-a8fa-4caa2ca510ff">


## What areas of the site does it impact?

SM

