### PR TITLE
Remove Redirect logic for type of care page

### DIFF
--- a/src/applications/vaos/new-appointment/index.jsx
+++ b/src/applications/vaos/new-appointment/index.jsx
@@ -60,7 +60,9 @@ export function NewAppointment() {
 
   const shouldRedirectToStart = useFormRedirectToStart({
     shouldRedirect: () =>
-      !isNewAppointmentStarted && !location.pathname.endsWith('confirmation'),
+      !isNewAppointmentStarted &&
+      !location.pathname.endsWith('confirmation') &&
+      !location.pathname.endsWith('type-of-care'),
   });
 
   useVariantSortMethodTracking({ skip: shouldRedirectToStart });


### PR DESCRIPTION
## Summary
Handled After summary link error states.



## Related issue(s)

- https://app.zenhub.com/workspaces/appointments-team-603fdef281af6500110a1691/issues/gh/department-of-veterans-affairs/va.gov-team/72066

## Testing done
Tested landing directly on the type of care landing page without redirect


Tested that error message displays when api response returns Error.









## Acceptance criteria
- [x] file coverage for Branches, functions, lines and statements is 100%
