### PR TITLE
Fix formatting when care team member title is missing

### DIFF
--- a/src/applications/avs/components/YourHealthInformation.jsx
+++ b/src/applications/avs/components/YourHealthInformation.jsx
@@ -72,7 +72,8 @@ const primaryCareTeam = avs => {
   if (avs.primaryCareTeamMembers?.length > 0) {
     const teamMembers = avs.primaryCareTeamMembers.map((member, idx) => (
       <li key={idx}>
-        {member.name} - {member.title}
+        {member.name}
+        {member.title && ` - ${member.title}`}
       </li>
     ));
 

--- a/src/applications/avs/tests/components/YourHealthInformation.unit.spec.jsx
+++ b/src/applications/avs/tests/components/YourHealthInformation.unit.spec.jsx
@@ -20,6 +20,9 @@ describe('Avs: Your Health Information', () => {
     expect(screen.getByTestId('primary-care-team').children[2]).to.have.text(
       'NURSE, GREAT - LICENSED PRACTICAL NURSE (LPN)',
     );
+    expect(screen.getByTestId('primary-care-team').children[3]).to.have.text(
+      'PROVIDER, TWO',
+    );
     expect(
       screen.getByTestId('scheduled-appointments').firstChild,
     ).to.have.text(

--- a/src/applications/avs/tests/fixtures/9A7AF40B2BC2471EA116891839113252.json
+++ b/src/applications/avs/tests/fixtures/9A7AF40B2BC2471EA116891839113252.json
@@ -413,7 +413,7 @@
         {
           "T": "PrimaryCareTeamMember",
           "name": "PROVIDER, TWO",
-          "title": "DIETITIAN"
+          "title": ""
         },
         {
           "T": "PrimaryCareTeamMember",


### PR DESCRIPTION
## Summary

I discovered when testing with staging care team data that the provider title may not always be present. This is a small fix to suppress the formatting when title is not available.

## Testing done

- local testing
- added unit test case

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |    ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/101649/9a63d47a-7331-47e9-8d07-70518a0e46f2)    |   ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/101649/9205b86e-659e-40f8-b767-addf9ed84a30)    |

## What areas of the site does it impact?

AVS application

## Acceptance criteria

- [ ] care team provider title is shown when available
- [ ] no extra formatting is shown when care team provider title is not available
