### PR TITLE
74196 temporarily opt out of v3 radio buttons

### DIFF
--- a/src/applications/disability-benefits/all-claims/subtask/pages/appeals.jsx
+++ b/src/applications/disability-benefits/all-claims/subtask/pages/appeals.jsx
@@ -77,6 +77,7 @@ const AppealsPage = ({ data = {}, error, setPageData }) => {
             value={value}
             label={label}
             checked={value === data[dataKey]}
+            uswds={false}
           />
         ))}
       </VaRadio>

--- a/src/applications/disability-benefits/all-claims/subtask/pages/start.jsx
+++ b/src/applications/disability-benefits/all-claims/subtask/pages/start.jsx
@@ -82,6 +82,7 @@ const ActiveDuty = ({ data = {}, error, setPageData }) => {
             value={value}
             label={label}
             checked={value === data[dataKey]}
+            uswds={false}
           />
         ))}
       </VaRadio>

--- a/src/applications/disability-benefits/wizard/pages/appeals.jsx
+++ b/src/applications/disability-benefits/wizard/pages/appeals.jsx
@@ -49,6 +49,7 @@ const AppealsPage = ({ setPageState, state = {} }) => {
             aria-describedby={
               state.selected === option.value ? option.value : null
             }
+            uswds={false}
           />
         ))}
       </VaRadio>

--- a/src/applications/disability-benefits/wizard/pages/start.jsx
+++ b/src/applications/disability-benefits/wizard/pages/start.jsx
@@ -40,6 +40,7 @@ const StartPage = ({ setPageState, state = {} }) => {
           aria-describedby={
             state.selected === option.value ? option.value : null
           }
+          uswds={false}
         />
       ))}
     </VaRadio>


### PR DESCRIPTION
## Summary
To maintain UI/UX consistency with the rest of the form, opt out of v3 radio buttons

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#74196

## Testing done
- Verified unit and e2e tests still successfully run
- Manually stepped through pages containing the radio buttons and confirmed they are still working as expected.

**Two flows to check this on**
1. Wizard
1.1 Sign in and go to /disability/file-disability-claim-form-21-526ez/start
1.2 For 'Are you on active duty right now?' select 'No' which will reveal additional radio buttons regarding appeals
1.3 Select 'I’m filing a claim for a new condition or for a condition that’s gotten worse.'
1.4 Verify both sets of radio buttons are using v1 styling
1.5 Verify you are able to start a 526 form (regression)

<img width="881" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/e05b30dc-b049-4f8d-9b94-0c0648c4bd6d">


2. SubTask (unreleased code. we won't be committing these changes)
2.1 in routes.jsx, line 14, comment out `WizardContainer` and uncomment `SubTaskContainer` along with its import
2.2 Step through the flow, answering same questions and verify same as 1.1 to 1.5. However, it will be 1 question per page.
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/34c981db-46d4-49c7-9491-fe9698dad0c1)



## Screenshots
Included above

## What areas of the site does it impact?
526EZ

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
