### PR TITLE
Review & submit | Fix focus management on pages

### DIFF
--- a/src/applications/appeals/995/components/EvidenceSummaryReview.jsx
+++ b/src/applications/appeals/995/components/EvidenceSummaryReview.jsx
@@ -31,7 +31,7 @@ const EvidenceSummaryReview = ({ data, editPage }) => {
       ) {
         // focus on edit button _after_ editing and returning
         window.sessionStorage.removeItem(SUMMARY_EDIT);
-        setTimeout(() => focusElement(editRef.current));
+        setTimeout(() => focusElement('button', {}, editRef.current));
       }
     },
     [editRef],

--- a/src/applications/appeals/995/components/EvidenceSummaryReview.jsx
+++ b/src/applications/appeals/995/components/EvidenceSummaryReview.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
-import { focusElement } from 'platform/utilities/ui';
+import { focusElement } from '@department-of-veterans-affairs/platform-forms-system/ui';
 
 import {
   hasVAEvidence,

--- a/src/applications/appeals/shared/components/AreaOfDisagreement.jsx
+++ b/src/applications/appeals/shared/components/AreaOfDisagreement.jsx
@@ -9,7 +9,8 @@ import {
 import cloneDeep from 'platform/utilities/data/cloneDeep';
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import { waitForRenderThenFocus } from 'platform/utilities/ui';
-import { scrollToFirstError } from 'platform/forms-system/src/js/utilities//ui';
+import { focusOnChange } from 'platform/forms-system/src/js/utilities//ui';
+import { ERROR_ELEMENTS } from 'platform/utilities/constants';
 
 import { DISAGREEMENT_TYPES, MAX_LENGTH } from '../constants';
 import {
@@ -104,16 +105,13 @@ const AreaOfDisagreement = ({
     },
     updatePage: () => {
       const disagreement = data.areaOfDisagreement[pagePerItemIndex] || {};
+      const scrollKey = `areaOfDisagreementFollowUp${pagePerItemIndex}`;
       if (!setMaxError(disagreement) && !setCheckboxError(disagreement)) {
-        waitForRenderThenFocus(
-          `[name="areaOfDisagreementFollowUp${pagePerItemIndex}ScrollElement"] + form va-button[text="Edit"]`,
-          undefined, // root
-          250, // timeInterval
-          'button', // shadow DOM selector
-        );
-        updatePage();
+        focusOnChange(scrollKey, 'va-button', 'button');
+        updatePage(data);
       } else {
-        scrollToFirstError();
+        // replaces scrollToFirstError()
+        focusOnChange(scrollKey, ERROR_ELEMENTS.join(','));
       }
     },
   };

--- a/src/applications/appeals/shared/components/AreaOfDisagreement.jsx
+++ b/src/applications/appeals/shared/components/AreaOfDisagreement.jsx
@@ -6,11 +6,11 @@ import {
   VaTextInput,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
-import cloneDeep from 'platform/utilities/data/cloneDeep';
-import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
-import { waitForRenderThenFocus } from 'platform/utilities/ui';
-import { focusOnChange } from 'platform/forms-system/src/js/utilities//ui';
-import { ERROR_ELEMENTS } from 'platform/utilities/constants';
+import cloneDeep from '~/platform/utilities/data/cloneDeep';
+import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
+import { waitForRenderThenFocus } from '~/platform/utilities/ui';
+import { focusOnChange } from '~/platform/forms-system/src/js/utilities//ui';
+import { ERROR_ELEMENTS } from '~/platform/utilities/constants';
 
 import { DISAGREEMENT_TYPES, MAX_LENGTH } from '../constants';
 import {

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -17,6 +17,7 @@ import {
 } from '../../../../utilities/ui';
 
 import { FILE_UPLOAD_NETWORK_ERROR_MESSAGE } from '../constants';
+import { ERROR_ELEMENTS } from '../../../../utilities/constants';
 import { $ } from '../utilities/ui';
 import {
   ShowPdfPassword,
@@ -475,7 +476,7 @@ const FileField = props => {
                 } else if (showPasswordInput) {
                   focusElement(`#${fileListId} .usa-input-error-message`);
                 } else {
-                  focusElement('.usa-input-error, .input-error-date, [error]');
+                  focusElement(ERROR_ELEMENTS.join(','));
                 }
               }, 250);
             } else if (showPasswordInput) {

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -2,25 +2,31 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
-import Scroll from 'react-scroll';
-import uniqueId from 'lodash/uniqueId';
+import { Element } from 'react-scroll';
 import classNames from 'classnames';
 import get from '../../../../utilities/data/get';
 import set from '../../../../utilities/data/set';
+import {
+  ERROR_ELEMENTS,
+  FOCUSABLE_ELEMENTS,
+  SCROLL_ELEMENT_SUFFIX,
+} from '../../../../utilities/constants';
 
 import ProgressButton from '../components/ProgressButton';
-import { focusOnChange, getFocusableElements } from '../utilities/ui';
+import {
+  focusOnChange,
+  getFocusableElements,
+  fixSelector,
+} from '../utilities/ui';
 import SchemaForm from '../components/SchemaForm';
 import { getArrayFields, getNonArraySchema, showReviewField } from '../helpers';
 import ArrayField from './ArrayField';
 import { getPreviousPagePath, checkValidPagePath } from '../routing';
 
+import { focusableWebComponentList } from '../web-component-fields/webComponentList';
 import { isValidForm } from '../validation';
 import { reduceErrors } from '../utilities/data/reduceErrors';
 import { setFormErrors } from '../actions';
-
-const { Element } = Scroll;
-
 /*
  * Displays all the pages in a chapter on the review page
  */
@@ -30,17 +36,46 @@ class ReviewCollapsibleChapter extends React.Component {
     this.handleEdit = this.handleEdit.bind(this);
   }
 
-  /* eslint-disable-next-line camelcase */
-  UNSAFE_componentWillMount() {
-    this.id = uniqueId();
-  }
-
   handleEdit(key, editing, index = null) {
-    this.props.onEdit(key, editing, index);
-    if (editing) {
-      // pressing "Update page" will call handleSubmit, which moves focus from
-      // the edit button to the this target
-      this.focusOnPage(`${key}${index === null ? '' : index}`);
+    if (editing || !this.hasValidationError(key, index)) {
+      this.props.onEdit(key, editing, index);
+      const name = fixSelector(key);
+
+      // Wait for edit view to render
+      setTimeout(() => {
+        const scrollElement = document.querySelector(
+          `[name="${name}${SCROLL_ELEMENT_SUFFIX}"]`,
+        );
+
+        if (scrollElement && scrollElement?.nextElementSibling) {
+          const [target] = getFocusableElements(
+            scrollElement.nextElementSibling,
+            {
+              returnWebComponent: true,
+              focusableWebComponents: focusableWebComponentList,
+            },
+          );
+
+          if (target) {
+            let selector = target.tagName;
+            // File upload pages may only show a delete va-button (form 10182)
+            const shadowSelector = selector.startsWith('VA-')
+              ? [...FOCUSABLE_ELEMENTS, ...focusableWebComponentList].join(',')
+              : null;
+
+            // Sets focus on the first focusable error or element
+            if (target.id) {
+              // id may include a colon, e.g. #root_view:foo
+              selector = `#${target.id}`;
+            } else if (target.className) {
+              selector = `${target.tagName}.${target.className
+                .split(' ')
+                .join('.')}`;
+            }
+            focusOnChange(name, fixSelector(selector), shadowSelector);
+          }
+        }
+      }, 100);
     }
   }
 
@@ -53,6 +88,11 @@ class ReviewCollapsibleChapter extends React.Component {
   }
 
   handleSubmit = (formData, key, path = null, index = null) => {
+    // recheck _all_ validations after the user clicks the
+    // update page button - needed to dynamically update
+    // accordion headers
+    const hasError = this.hasValidationError(key, index);
+
     // This makes sure defaulted data on a page with no changes is saved
     // Probably safe to do this for regular pages, too, but it hasn’t been necessary
     if (path) {
@@ -60,7 +100,9 @@ class ReviewCollapsibleChapter extends React.Component {
       this.props.setData(newData);
     }
 
-    this.handleEdit(key, false, index);
+    if (!hasError) {
+      this.handleEdit(key, false, index);
+    }
   };
 
   goToPath = customPath => {
@@ -79,13 +121,36 @@ class ReviewCollapsibleChapter extends React.Component {
     expandedPages.length === 1 &&
     (chapterTitle || '').toLowerCase() === pageTitle.toLowerCase();
 
-  checkValidation = () => {
+  hasValidationError = (key, index) => {
     const { form, pageList, reviewErrors = {} } = this.props;
+    const scrollElementKey = `${key}${index ?? ''}`;
+
+    // Update form errors & rawErrors in redux state
     const { errors } = isValidForm(form, pageList);
+    const cleanedErrors = reduceErrors(errors, pageList, reviewErrors);
     this.props.setFormErrors({
       rawErrors: errors,
-      errors: reduceErrors(errors, pageList, reviewErrors),
+      errors: cleanedErrors,
     });
+
+    // check if current page has any errors; reviewErrors override needed for
+    // custom pages
+    const pageKey = reviewErrors?.__override?.(key) || key;
+    const hasErrors = cleanedErrors.some(error => {
+      const errorPageKey =
+        reviewErrors?.__override?.(error.pageKey) || error.pageKey;
+      return errorPageKey === pageKey;
+    });
+
+    if (hasErrors) {
+      // Focus on first error message on page
+      focusOnChange(scrollElementKey, ERROR_ELEMENTS.join(','));
+    } else {
+      // no error, focus on page edit button after page switches back to review
+      // mode
+      focusOnChange(scrollElementKey, 'va-button', 'button');
+    }
+    return hasErrors;
   };
 
   getChapterTitle = chapterFormConfig => {
@@ -133,11 +198,11 @@ class ReviewCollapsibleChapter extends React.Component {
     } = props;
 
     const pageState = form.pages[page.pageKey];
+    const fullPageKey = `${page.pageKey}${page.index ?? ''}`;
     let pageSchema;
     let pageUiSchema;
     let pageData;
     let arrayFields;
-    let fullPageKey;
 
     if (page.showPagePerItem) {
       pageSchema =
@@ -145,7 +210,6 @@ class ReviewCollapsibleChapter extends React.Component {
       pageUiSchema = pageState.uiSchema[page.arrayPath].items;
       pageData = get([page.arrayPath, page.index], form.data);
       arrayFields = [];
-      fullPageKey = `${page.pageKey}${page.index}`;
     } else {
       // TODO: support array fields inside of an array page?
       // Our pattern is to separate out array fields (growable tables) from
@@ -161,7 +225,6 @@ class ReviewCollapsibleChapter extends React.Component {
       pageSchema = pageSchemaObjects.schema;
       pageUiSchema = pageSchemaObjects.uiSchema;
       pageData = form.data;
-      fullPageKey = page.pageKey;
     }
 
     const hasError = props.form.formErrors?.errors?.some(
@@ -196,7 +259,7 @@ class ReviewCollapsibleChapter extends React.Component {
 
     return (
       <div key={`${fullPageKey}`} className={classes}>
-        <Element name={`${fullPageKey}ScrollElement`} />
+        <Element name={`${fullPageKey}${SCROLL_ELEMENT_SUFFIX}`} />
         <SchemaForm
           name={page.pageKey}
           title={title}
@@ -245,14 +308,15 @@ class ReviewCollapsibleChapter extends React.Component {
                 // recheck _all_ validations after the user clicks the
                 // update page button - needed to dynamically update
                 // accordion headers
-                this.checkValidation();
-                focusOnChange(
-                  `${page.pageKey}${
-                    typeof page.index === 'number' ? page.index : ''
-                  }`,
-                  'va-button',
-                  'button',
-                );
+                if (!this.hasValidationError(page.pageKey, page.index)) {
+                  focusOnChange(
+                    `${page.pageKey}${
+                      typeof page.index === 'number' ? page.index : ''
+                    }`,
+                    'va-button',
+                    'button',
+                  );
+                }
               }}
               buttonText="Update page"
               buttonClass="usa-button-primary"
@@ -307,41 +371,54 @@ class ReviewCollapsibleChapter extends React.Component {
       pageUiSchema = pageSchemaObjects.uiSchema;
     }
 
+    const fullPageKey = `${page.pageKey}${page.index ?? ''}`;
+
     if (editing) {
       // noop defined as a function for unit tests
       const noop = function noop() {};
       return (
-        <page.CustomPage
-          key={`${page.pageKey}${page.index ?? ''}`}
-          name={page.pageKey}
-          title={page.title}
-          trackingPrefix={props.form.trackingPrefix}
-          uploadFile={props.uploadFile}
-          onReviewPage
-          setFormData={props.setData}
-          data={props.form.data}
-          updatePage={() => this.handleEdit(page.pageKey, false, page.index)}
-          pagePerItemIndex={page.index}
-          schema={pageSchema}
-          uiSchema={pageUiSchema}
-          // noop for navigation to prevent JS error
-          goBack={noop}
-          goForward={noop}
-          goToPath={this.goToPath}
-        />
+        <React.Fragment key={fullPageKey}>
+          <Element name={`${fullPageKey}${SCROLL_ELEMENT_SUFFIX}`} />
+          <div>
+            <page.CustomPage
+              name={page.pageKey}
+              title={page.title}
+              trackingPrefix={props.form.trackingPrefix}
+              uploadFile={props.uploadFile}
+              onReviewPage
+              setFormData={props.setData}
+              data={props.form.data}
+              updatePage={() =>
+                this.handleEdit(page.pageKey, false, page.index)
+              }
+              pagePerItemIndex={page.index}
+              schema={pageSchema}
+              uiSchema={pageUiSchema}
+              // noop for navigation to prevent JS error
+              goBack={noop}
+              goForward={noop}
+              goToPath={this.goToPath}
+            />
+          </div>
+        </React.Fragment>
       );
     }
 
     return (
-      <page.CustomPageReview
-        key={`${page.pageKey}Review${page.index ?? ''}`}
-        editPage={() => this.handleEdit(page.pageKey, !editing, page.index)}
-        name={page.pageKey}
-        title={page.title}
-        data={props.form.data}
-        pagePerItemIndex={page.index}
-        goToPath={this.goToPath}
-      />
+      <React.Fragment key={fullPageKey}>
+        <Element name={`${fullPageKey}${SCROLL_ELEMENT_SUFFIX}`} />
+        <div>
+          <page.CustomPageReview
+            key={`${page.pageKey}Review${page.index ?? ''}`}
+            editPage={() => this.handleEdit(page.pageKey, !editing, page.index)}
+            name={page.pageKey}
+            title={page.title}
+            data={props.form.data}
+            pagePerItemIndex={page.index}
+            goToPath={this.goToPath}
+          />
+        </div>
+      </React.Fragment>
     );
   };
 
@@ -383,37 +460,15 @@ class ReviewCollapsibleChapter extends React.Component {
     );
   };
 
-  /**
-   * Focuses on the first focusable element
-   * @param {string} key - The specific page key used to find the element to focus on
-   */
-  focusOnPage = key => {
-    const name = `${key.replace(/:/g, '\\:')}`;
-
-    // Wait for edit view to render
-    setTimeout(() => {
-      const scrollElement = document.querySelector(
-        `[name="${name}ScrollElement"]`,
-      );
-
-      if (scrollElement && scrollElement.parentElement) {
-        const focusableElements = getFocusableElements(
-          scrollElement.parentElement,
-        );
-
-        // Sets focus on the first focusable element
-        focusOnChange(name, `[id="${focusableElements[0].id}"]`);
-      }
-    }, 0);
-  };
-
   render() {
     const chapterTitle = this.getChapterTitle(this.props.chapterFormConfig);
     const subHeader = 'Some information has changed. Please review.';
 
     return (
       <>
-        <Element name={`chapter${this.props.chapterKey}ScrollElement`} />
+        <Element
+          name={`chapter${this.props.chapterKey}${SCROLL_ELEMENT_SUFFIX}`}
+        />
         <va-accordion-item
           data-chapter={this.props.chapterKey}
           header={chapterTitle}
@@ -455,10 +510,13 @@ ReviewCollapsibleChapter.propTypes = {
   location: PropTypes.shape({
     pathname: PropTypes.string,
   }),
+  open: PropTypes.bool,
   reviewErrors: PropTypes.shape({}),
   router: PropTypes.shape({
     push: PropTypes.func,
   }),
+  uploadFile: PropTypes.func,
+  onBlur: PropTypes.func,
 };
 
 export default withRouter(

--- a/src/platform/forms-system/src/js/utilities/review/index.js
+++ b/src/platform/forms-system/src/js/utilities/review/index.js
@@ -1,4 +1,5 @@
-import { $, scrollElementName, scrollToElement } from '../ui';
+import { $, scrollToElement } from '../ui';
+import { SCROLL_ELEMENT_SUFFIX } from '../../../../../utilities/constants';
 
 /**
  * @typedef FormUtility~findTargetsOptions
@@ -22,9 +23,9 @@ const findTargets = error => {
   // find scroll element first
   const el = $(
     [
-      `[name$="${error.pageKey}${scrollElementName}"]`,
+      `[name$="${error.pageKey}${SCROLL_ELEMENT_SUFFIX}"]`,
       // index value indicates an array instance (saved as a string, e.g. '0')
-      `[name$="${error.pageKey}${error.index || ''}${scrollElementName}"]`,
+      `[name$="${error.pageKey}${error.index || ''}${SCROLL_ELEMENT_SUFFIX}"]`,
     ].join(','),
   );
 
@@ -36,7 +37,7 @@ const findTargets = error => {
 /**
  * Open the accordion for the specified chapter and click on the "Edit" button
  * to go into edit mode. This will also result in the focusing of the first
- * interacrtive element in the content.
+ * interactive element in the content.
  * @param {String} chapterKey - a chapter key
  */
 export const openAndEditChapter = error => {

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -44,7 +44,7 @@ export const getFocusableElements = (
     returnWebComponent = false,
     focusableElements = FOCUSABLE_ELEMENTS,
     focusableWebComponents = webComponentList,
-  },
+  } = {},
 ) => {
   let elements = [];
 
@@ -55,6 +55,7 @@ export const getFocusableElements = (
       ),
     ]
       .map(el => {
+        // TODO: Fix this to ignore disabled web components
         if (el.shadowRoot && !returnWebComponent) {
           return getFocusableElements(el.shadowRoot, {
             focusableElements,

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -3,9 +3,8 @@ import {
   focusElement,
   focusByOrder,
   getScrollOptions,
-} from 'platform/utilities/ui';
-import { webComponentList } from 'platform/forms-system/src/js/web-component-fields/webComponentList';
-
+} from '../../../../../utilities/ui';
+import { webComponentList } from '../../web-component-fields/webComponentList';
 import {
   SCROLL_ELEMENT_SUFFIX,
   FOCUSABLE_ELEMENTS,

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -6,6 +6,12 @@ import {
 } from 'platform/utilities/ui';
 import { webComponentList } from 'platform/forms-system/src/js/web-component-fields/webComponentList';
 
+import {
+  SCROLL_ELEMENT_SUFFIX,
+  FOCUSABLE_ELEMENTS,
+  ERROR_ELEMENTS,
+} from '../../../../../utilities/constants';
+
 export const $ = (selectorOrElement, root) =>
   typeof selectorOrElement === 'string'
     ? (root || document).querySelector(selectorOrElement)
@@ -15,49 +21,45 @@ export const $$ = (selector, root) => [
   ...(root || document).querySelectorAll(selector),
 ];
 
-export { focusElement, focusByOrder };
+/**
+ * fixSelector
+ * When a page name includes a color, e.g. "view:exampleFoo", the name ends up
+ * in a scroll element with name="view:exampleFooScrollElement". Using
+ * querySelector without escaping the colon will fail to find the target
+ * Note: We shouldn't be passing in something like `:not([name="test"])`
+ */
+const REGEXP_COLON = /:/g;
+export const fixSelector = selector => selector.replace(REGEXP_COLON, '\\:');
 
-// List from https://html.spec.whatwg.org/dev/dom.html#interactive-content
-const focusableElements = [
-  '[href]',
-  'button',
-  'details',
-  'input:not([type="hidden"])',
-  'select',
-  'textarea',
-  /* focusable, but not tabbable */
-  '[tabindex]:not([tabindex="-1"])',
-  /* label removed from list, because you can't programmically focus it
-   * unless it has a tabindex of 0 or -1; clicking on it shifts focus to the
-   * associated focusable form element
-   */
-  // 'label[for]',
-  /* focusable elements not used in our form system */
-  // 'audio[controls]',
-  // 'embed',
-  // 'iframe',
-  // 'img[usemap]',
-  // 'object[usemap]',
-  // 'video[controls]',
-];
+export { focusElement, focusByOrder };
 
 /**
  * Find all the focusable elements within a block
  * @param {HTMLElement|node} block - wrapping element
  * @return {HTMLElement[]}
  */
-export const getFocusableElements = block => {
+export const getFocusableElements = (
+  block,
+  {
+    returnWebComponent = false,
+    focusableElements = FOCUSABLE_ELEMENTS,
+    focusableWebComponents = webComponentList,
+  },
+) => {
   let elements = [];
 
   if (block) {
     elements = [
       ...block.querySelectorAll(
-        [...focusableElements, ...webComponentList].join(','),
+        [...focusableElements, ...focusableWebComponents].join(','),
       ),
     ]
       .map(el => {
-        if (el.shadowRoot) {
-          return getFocusableElements(el.shadowRoot);
+        if (el.shadowRoot && !returnWebComponent) {
+          return getFocusableElements(el.shadowRoot, {
+            focusableElements,
+            focusableWebComponents,
+          });
         }
         return el;
       })
@@ -72,15 +74,20 @@ export const getFocusableElements = block => {
   return elements;
 };
 
-export const scrollElementName = 'ScrollElement';
-
-// Set focus on target _after_ the content has been updated
+/**
+ * Set focus on target _after_ the content has been updated; used on the review
+ * & submit page after editing a page, and then after updating the page and
+ * setting focus back on the page's edit button
+ * @param {*} name - page name which is added to the associated scroll element
+ * @param {*} target - target within the named target page
+ * @param {*} shadowTarget - target within shadow DOM within target
+ */
 export function focusOnChange(name, target, shadowTarget = undefined) {
   setTimeout(() => {
-    const el = $(`va-accordion-item[data-chapter="${name}"]`);
-    const focusTarget = el?.querySelector(target);
+    const el = $(`[name="${fixSelector(name)}${SCROLL_ELEMENT_SUFFIX}"]`);
+    const focusTarget = el?.nextElementSibling?.querySelector(target);
     if (focusTarget && shadowTarget) {
-      focusElement(focusTarget.shadowRoot?.querySelector(shadowTarget));
+      focusElement(shadowTarget, {}, focusTarget);
     } else if (focusTarget) {
       focusElement(focusTarget);
     }
@@ -88,10 +95,12 @@ export function focusOnChange(name, target, shadowTarget = undefined) {
 }
 
 export const scrollToElement = name => {
-  if (name) {
-    const el =
-      typeof name === 'string' && name.includes('name=') ? $(name) : name;
+  const el =
+    typeof name === 'string' && name.includes('name=')
+      ? $(fixSelector(name))
+      : name;
 
+  if (name && el) {
     Scroll.scroller.scrollTo(
       el, // pass a string key + 'ScrollElement' or DOM element
       window.Forms.scroll || {
@@ -116,9 +125,7 @@ export function setGlobalScroll() {
 // Duplicate of function in platform/utilities/ui/scroll
 export function scrollToFirstError() {
   // [error] will focus any web-components with an error message
-  const errorEl = document.querySelector(
-    '.usa-input-error, .input-error-date, [error]',
-  );
+  const errorEl = document.querySelector(ERROR_ELEMENTS.join(','));
   if (errorEl) {
     // document.body.scrollTop doesn’t work with all browsers, so we’ll cover them all like so:
     const currentPosition =

--- a/src/platform/forms-system/src/js/web-component-fields/webComponentList.js
+++ b/src/platform/forms-system/src/js/web-component-fields/webComponentList.js
@@ -16,3 +16,23 @@ export const webComponentList = [
   'va-text-input',
   'va-textarea',
 ];
+
+// Commented out components are wrappers that have an open shadow DOM
+export const focusableWebComponentList = [
+  'va-accordion-item',
+  // 'va-accordion',
+  'va-alert',
+  // 'va-breadcrumbs',
+  // 'va-button-pair',
+  'va-button',
+  // 'va-checkbox-group',
+  'va-checkbox',
+  // 'va-memorable-date',
+  'va-number-input',
+  // 'va-privacy-agreement',
+  'va-radio-option',
+  // 'va-radio',
+  'va-select',
+  'va-text-input',
+  'va-textarea',
+];

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -11,6 +11,8 @@ import { ReviewCollapsibleChapter } from '../../../src/js/review/ReviewCollapsib
 describe('<ReviewCollapsibleChapter>', () => {
   it('should add a data-attribute with the chapterKey', () => {
     const onEdit = sinon.spy();
+    const setData = sinon.spy();
+    const setFormErrors = sinon.spy();
     const pages = [
       {
         title: '',
@@ -41,6 +43,10 @@ describe('<ReviewCollapsibleChapter>', () => {
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
         form={form}
+        pageList={pages}
+        hasUnviewedPages={false}
+        setData={setData}
+        setFormErrors={setFormErrors}
       />,
     );
 
@@ -51,6 +57,8 @@ describe('<ReviewCollapsibleChapter>', () => {
   });
   it('should handle editing', () => {
     const onEdit = sinon.spy();
+    const setData = sinon.spy();
+    const setFormErrors = sinon.spy();
     const pages = [
       {
         title: '',
@@ -81,6 +89,10 @@ describe('<ReviewCollapsibleChapter>', () => {
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
         form={form}
+        pageList={pages}
+        hasUnviewedPages={false}
+        setData={setData}
+        setFormErrors={setFormErrors}
       />,
     );
 
@@ -91,6 +103,8 @@ describe('<ReviewCollapsibleChapter>', () => {
 
   it('should handle editing array page', () => {
     const onEdit = sinon.spy();
+    const setData = sinon.spy();
+    const setFormErrors = sinon.spy();
     const chapterKey = 'test';
     const chapter = {};
     const form = {
@@ -110,6 +124,12 @@ describe('<ReviewCollapsibleChapter>', () => {
         testing: [{}],
       },
     };
+    const pages = [
+      {
+        title: '',
+        pageKey: 'test',
+      },
+    ];
 
     const tree = SkinDeep.shallowRender(
       <ReviewCollapsibleChapter
@@ -118,6 +138,10 @@ describe('<ReviewCollapsibleChapter>', () => {
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
         form={form}
+        pageList={pages}
+        hasUnviewedPages={false}
+        setData={setData}
+        setFormErrors={setFormErrors}
       />,
     );
 
@@ -128,6 +152,8 @@ describe('<ReviewCollapsibleChapter>', () => {
 
   it('should handle editing of view:keys', () => {
     const onEdit = sinon.spy();
+    const setData = sinon.spy();
+    const setFormErrors = sinon.spy();
     const pages = [
       {
         title: '',
@@ -158,6 +184,10 @@ describe('<ReviewCollapsibleChapter>', () => {
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
         form={form}
+        pageList={pages}
+        hasUnviewedPages={false}
+        setData={setData}
+        setFormErrors={setFormErrors}
       />,
     );
 
@@ -168,6 +198,8 @@ describe('<ReviewCollapsibleChapter>', () => {
 
   it('should display a page for each item for an array page', () => {
     const onEdit = sinon.spy();
+    const setData = sinon.spy();
+    const setFormErrors = sinon.spy();
     const pages = [
       {
         title: '',
@@ -226,6 +258,10 @@ describe('<ReviewCollapsibleChapter>', () => {
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
         form={form}
+        pageList={pages}
+        hasUnviewedPages={false}
+        setData={setData}
+        setFormErrors={setFormErrors}
       />,
     );
 
@@ -233,6 +269,9 @@ describe('<ReviewCollapsibleChapter>', () => {
   });
 
   it('should not display conditional pages with unfulfilled conditions', () => {
+    const onEdit = sinon.spy();
+    const setData = sinon.spy();
+    const setFormErrors = sinon.spy();
     const pages = [
       {
         pageKey: 'test1',
@@ -285,12 +324,16 @@ describe('<ReviewCollapsibleChapter>', () => {
     const tree = SkinDeep.shallowRender(
       <ReviewCollapsibleChapter
         viewedPages={new Set()}
-        onEdit={() => {}}
+        onEdit={onEdit}
         pageKeys={['test1', 'test2', 'test3']}
         expandedPages={pages}
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
         form={form}
+        pageList={pages}
+        hasUnviewedPages={false}
+        setData={setData}
+        setFormErrors={setFormErrors}
       />,
     );
 
@@ -298,6 +341,9 @@ describe('<ReviewCollapsibleChapter>', () => {
   });
 
   it('should display condition pages with fulfilled conditions', () => {
+    const onEdit = sinon.spy();
+    const setData = sinon.spy();
+    const setFormErrors = sinon.spy();
     const pages = [
       {
         pageKey: 'test1',
@@ -354,11 +400,15 @@ describe('<ReviewCollapsibleChapter>', () => {
     const tree = SkinDeep.shallowRender(
       <ReviewCollapsibleChapter
         viewedPages={new Set()}
-        onEdit={() => {}}
+        onEdit={onEdit}
         expandedPages={pages}
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
         form={form}
+        pageList={pages}
+        hasUnviewedPages={false}
+        setData={setData}
+        setFormErrors={setFormErrors}
       />,
     );
 
@@ -366,6 +416,8 @@ describe('<ReviewCollapsibleChapter>', () => {
   });
   it('should mark chapter and page as unviewed', () => {
     const onEdit = sinon.spy();
+    const setData = sinon.spy();
+    const setFormErrors = sinon.spy();
     const pages = [
       {
         pageKey: 'test',
@@ -407,6 +459,9 @@ describe('<ReviewCollapsibleChapter>', () => {
         chapterFormConfig={chapter}
         hasUnviewedPages
         form={form}
+        pageList={pages}
+        setData={setData}
+        setFormErrors={setFormErrors}
       />,
     );
 
@@ -418,6 +473,7 @@ describe('<ReviewCollapsibleChapter>', () => {
   it('should handle submitting array page', () => {
     const onEdit = sinon.spy();
     const setData = sinon.spy();
+    const setFormErrors = sinon.spy();
     const pages = [
       {
         title: '',
@@ -433,7 +489,11 @@ describe('<ReviewCollapsibleChapter>', () => {
           arrayPath: 'testing',
           title: '',
           schema: {
-            properties: {},
+            properties: {
+              testing: {
+                items: {},
+              },
+            },
           },
           uiSchema: {},
           editMode: [false],
@@ -453,6 +513,9 @@ describe('<ReviewCollapsibleChapter>', () => {
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
         form={form}
+        pageList={pages}
+        hasUnviewedPages={false}
+        setFormErrors={setFormErrors}
       />,
     );
 
@@ -473,6 +536,8 @@ describe('<ReviewCollapsibleChapter>', () => {
     const testChapterTitle = 'test chapter title';
 
     const onEdit = sinon.spy();
+    const setData = sinon.spy();
+    const setFormErrors = sinon.spy();
     const pages = [
       {
         pageKey: 'test',
@@ -511,6 +576,10 @@ describe('<ReviewCollapsibleChapter>', () => {
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
         form={form}
+        pageList={pages}
+        hasUnviewedPages={false}
+        setData={setData}
+        setFormErrors={setFormErrors}
       />,
     );
 
@@ -530,6 +599,8 @@ describe('<ReviewCollapsibleChapter>', () => {
     const testChapterTitle = 'test chapter title';
 
     const onEdit = sinon.spy();
+    const setData = sinon.spy();
+    const setFormErrors = sinon.spy();
     const pages = [
       {
         pageKey: 'test',
@@ -568,6 +639,10 @@ describe('<ReviewCollapsibleChapter>', () => {
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
         form={form}
+        pageList={pages}
+        hasUnviewedPages={false}
+        setData={setData}
+        setFormErrors={setFormErrors}
       />,
     );
 
@@ -590,6 +665,8 @@ describe('<ReviewCollapsibleChapter>', () => {
     const testChapterTitleFromFunction = `${testChapterTitle} [from function]`;
 
     const onEdit = sinon.spy();
+    const setData = sinon.spy();
+    const setFormErrors = sinon.spy();
     const pages = [
       {
         pageKey: 'test',
@@ -634,6 +711,10 @@ describe('<ReviewCollapsibleChapter>', () => {
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
         form={form}
+        pageList={pages}
+        hasUnviewedPages={false}
+        setData={setData}
+        setFormErrors={setFormErrors}
       />,
     );
 
@@ -645,6 +726,9 @@ describe('<ReviewCollapsibleChapter>', () => {
   });
 
   it('does not display page if all fields are hidden on review', () => {
+    const onEdit = sinon.spy();
+    const setData = sinon.spy();
+    const setFormErrors = sinon.spy();
     const pages = [
       {
         pageKey: 'test1',
@@ -705,11 +789,15 @@ describe('<ReviewCollapsibleChapter>', () => {
     const tree = shallow(
       <ReviewCollapsibleChapter
         viewedPages={new Set()}
-        onEdit={() => {}}
+        onEdit={onEdit}
         expandedPages={pages}
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
         form={form}
+        pageList={pages}
+        hasUnviewedPages={false}
+        setData={setData}
+        setFormErrors={setFormErrors}
       />,
     );
 
@@ -719,6 +807,8 @@ describe('<ReviewCollapsibleChapter>', () => {
   });
 
   it('should add error class to pages with form errors', () => {
+    const onEdit = sinon.spy();
+    const setData = sinon.spy();
     const setFormErrors = sinon.spy();
     const pages = [
       {
@@ -754,12 +844,14 @@ describe('<ReviewCollapsibleChapter>', () => {
       <ReviewCollapsibleChapter
         viewedPages={new Set()}
         pageList={pages}
-        onEdit={() => {}}
+        onEdit={onEdit}
         setFormErrors={setFormErrors}
         expandedPages={pages}
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
         form={form}
+        hasUnviewedPages={false}
+        setData={setData}
       />,
     );
 
@@ -770,6 +862,8 @@ describe('<ReviewCollapsibleChapter>', () => {
   });
 
   it('should add error class to pages with unviewed pages', () => {
+    const onEdit = sinon.spy();
+    const setData = sinon.spy();
     const setFormErrors = sinon.spy();
     const pages = [
       {
@@ -803,12 +897,14 @@ describe('<ReviewCollapsibleChapter>', () => {
       <ReviewCollapsibleChapter
         viewedPages={new Set()}
         pageList={pages}
-        onEdit={() => {}}
+        onEdit={onEdit}
         setFormErrors={setFormErrors}
         expandedPages={pages}
         chapterKey={chapterKey}
         chapterFormConfig={chapter}
         form={form}
+        hasUnviewedPages={false}
+        setData={setData}
       />,
     );
 
@@ -820,7 +916,9 @@ describe('<ReviewCollapsibleChapter>', () => {
 
   describe('updateFormData', () => {
     it('should be called on normal pages', () => {
+      const onEdit = sinon.spy();
       const setData = sinon.spy();
+      const setFormErrors = sinon.spy();
       const pages = [
         {
           title: '',
@@ -852,12 +950,15 @@ describe('<ReviewCollapsibleChapter>', () => {
       const tree = shallow(
         <ReviewCollapsibleChapter
           viewedPages={new Set()}
-          onEdit={() => {}}
+          onEdit={onEdit}
           setData={setData}
           expandedPages={pages}
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
+          pageList={pages}
+          hasUnviewedPages={false}
+          setFormErrors={setFormErrors}
         />,
       );
 
@@ -868,7 +969,9 @@ describe('<ReviewCollapsibleChapter>', () => {
       tree.unmount();
     });
     it('should be called on normal pages and pass an index', () => {
+      const onEdit = sinon.spy();
       const setData = sinon.spy();
+      const setFormErrors = sinon.spy();
       const pages = [
         {
           title: '',
@@ -905,12 +1008,15 @@ describe('<ReviewCollapsibleChapter>', () => {
       const tree = shallow(
         <ReviewCollapsibleChapter
           viewedPages={new Set()}
-          onEdit={() => {}}
+          onEdit={onEdit}
           setData={setData}
           expandedPages={pages}
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
+          pageList={pages}
+          hasUnviewedPages={false}
+          setFormErrors={setFormErrors}
         />,
       );
 
@@ -922,7 +1028,9 @@ describe('<ReviewCollapsibleChapter>', () => {
     });
 
     it('should be called on array pages', () => {
+      const onEdit = sinon.spy();
       const setData = sinon.spy();
+      const setFormErrors = sinon.spy();
       const pages = [
         {
           title: '',
@@ -959,12 +1067,15 @@ describe('<ReviewCollapsibleChapter>', () => {
       const tree = shallow(
         <ReviewCollapsibleChapter
           viewedPages={new Set()}
-          onEdit={() => {}}
+          onEdit={onEdit}
           setData={setData}
           expandedPages={pages}
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
+          pageList={pages}
+          hasUnviewedPages={false}
+          setFormErrors={setFormErrors}
         />,
       );
 
@@ -979,7 +1090,9 @@ describe('<ReviewCollapsibleChapter>', () => {
     });
 
     it('should be called on array pages and pass an index', () => {
+      const onEdit = sinon.spy();
       const setData = sinon.spy();
+      const setFormErrors = sinon.spy();
       const pages = [
         {
           title: '',
@@ -1021,12 +1134,15 @@ describe('<ReviewCollapsibleChapter>', () => {
       const tree = shallow(
         <ReviewCollapsibleChapter
           viewedPages={new Set()}
-          onEdit={() => {}}
+          onEdit={onEdit}
           setData={setData}
           expandedPages={pages}
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
+          pageList={pages}
+          hasUnviewedPages={false}
+          setFormErrors={setFormErrors}
         />,
       );
 
@@ -1043,6 +1159,8 @@ describe('<ReviewCollapsibleChapter>', () => {
 
   describe('update page', () => {
     it('should validate page upon updating', () => {
+      const onEdit = sinon.spy();
+      const setData = sinon.spy();
       const setFormErrors = sinon.spy();
       const pages = [
         {
@@ -1075,12 +1193,14 @@ describe('<ReviewCollapsibleChapter>', () => {
         <ReviewCollapsibleChapter
           viewedPages={new Set()}
           pageList={pages}
-          onEdit={() => {}}
+          onEdit={onEdit}
           setFormErrors={setFormErrors}
           expandedPages={pages}
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
+          hasUnviewedPages={false}
+          setData={setData}
         />,
       );
 
@@ -1164,6 +1284,8 @@ describe('<ReviewCollapsibleChapter>', () => {
 
     it('should render array of CustomPage in edit mode', () => {
       const onEdit = sinon.spy();
+      const setData = sinon.spy();
+      const setFormErrors = sinon.spy();
       const { chapterKey, chapter } = getProps();
       // Can't check array `key` so we're checking the index instead
       const CustomPage = ({ pagePerItemIndex }) => (
@@ -1234,6 +1356,10 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterKey={chapterKey}
           chapterFormConfig={chapter}
           form={form}
+          pageList={pages}
+          hasUnviewedPages={false}
+          setData={setData}
+          setFormErrors={setFormErrors}
         />,
       );
 
@@ -1366,11 +1492,13 @@ describe('<ReviewCollapsibleChapter>', () => {
 
     it('should pass the edit button function to the custom review component', () => {
       const onEdit = sinon.spy();
+      const setData = sinon.spy();
+      const setFormErrors = sinon.spy();
       const CustomPageReview = ({ editPage }) => (
         <div data-testid="custom-page-review">
-          <button onClick={editPage} data-testid="edit-button">
+          <va-button onClick={editPage} data-testid="edit-button">
             Edit
-          </button>
+          </va-button>
         </div>
       );
       const { pages, chapterKey, chapter, form } = getProps();
@@ -1384,6 +1512,10 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterFormConfig={chapter}
           form={form}
           onEdit={onEdit}
+          pageList={pages}
+          hasUnviewedPages={false}
+          setData={setData}
+          setFormErrors={setFormErrors}
         />,
       );
       // Poke the edit button
@@ -1393,11 +1525,13 @@ describe('<ReviewCollapsibleChapter>', () => {
 
     it('should pass the update button function to the custom page component', () => {
       const onEdit = sinon.spy();
+      const setData = sinon.spy();
+      const setFormErrors = sinon.spy();
       const CustomPage = ({ updatePage }) => (
         <div data-testid="custom-page-review">
-          <button onClick={updatePage} data-testid="update-button">
+          <va-button onClick={updatePage} data-testid="update-button">
             Update page
-          </button>
+          </va-button>
         </div>
       );
       const { pages, chapterKey, chapter, form } = getProps();
@@ -1412,6 +1546,10 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterFormConfig={chapter}
           form={form}
           onEdit={onEdit}
+          pageList={pages}
+          hasUnviewedPages={false}
+          setData={setData}
+          setFormErrors={setFormErrors}
         />,
       );
 
@@ -1468,15 +1606,17 @@ describe('<ReviewCollapsibleChapter>', () => {
 
     it('should pass the setFormData function to the custom page component', () => {
       const onSetData = sinon.spy();
+      const onEdit = sinon.spy();
+      const setFormErrors = sinon.spy();
       const CustomPage = ({ setFormData }) => (
         <div data-testid="custom-page-review">
-          <button
+          <va-button
             type="button"
             onClick={setFormData}
             data-testid="set-form-data-button"
           >
             setFormData
-          </button>
+          </va-button>
         </div>
       );
       const { pages, chapterKey, chapter, form } = getProps();
@@ -1491,6 +1631,10 @@ describe('<ReviewCollapsibleChapter>', () => {
           chapterFormConfig={chapter}
           form={form}
           setData={onSetData}
+          onEdit={onEdit}
+          pageList={pages}
+          hasUnviewedPages={false}
+          setFormErrors={setFormErrors}
         />,
       );
 

--- a/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
@@ -6,11 +6,28 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import {
+  fixSelector,
   focusElement,
   focusOnChange,
   getFocusableElements,
 } from '../../../src/js/utilities/ui';
 import { ReviewCollapsibleChapter } from '../../../src/js/review/ReviewCollapsibleChapter';
+
+describe('fixSelector', () => {
+  it('should return an unmodified string', () => {
+    expect(fixSelector('va-accordion')).to.eq('va-accordion');
+    expect(fixSelector('.test')).to.eq('.test');
+    expect(fixSelector('#test')).to.eq('#test');
+    expect(fixSelector('[name="test"]')).to.eq('[name="test"]');
+  });
+  it('should escape colons withing the selector', () => {
+    // we shouldn't be passing in `:not([name="test"])` as a selector
+    expect(fixSelector('[name="view:test"]')).to.eq('[name="view\\:test"]');
+    expect(fixSelector('[name="view:test:foo"]')).to.eq(
+      '[name="view\\:test\\:foo"]',
+    );
+  });
+});
 
 describe('focusElement', () => {
   it('should focus on header element using tabindex -1, and remove it on blur', async () => {
@@ -267,7 +284,7 @@ describe('getFocuableElements', () => {
     setOffset('offsetWidth', offsets.width);
   });
 
-  it.skip('should return an array of focusable elements', () => {
+  it('should return an array of focusable elements', async () => {
     setOffset('offsetHeight', { configurable: true, value: 10 });
     setOffset('offsetWidth', { configurable: true, value: 10 });
     /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
@@ -285,16 +302,60 @@ describe('getFocuableElements', () => {
         </select>
         <textarea />
         <div tabIndex="0" />
+        <va-button />
+        <va-select />
+        <va-radio-option />
+        <va-checkbox />
+        <va-text-input />
+        <va-textarea />
       </form>,
     );
     /* eslint-enable jsx-a11y/no-noninteractive-tabindex */
     const dom = findDOMNode(tree);
     global.document = dom;
-    const focusableElements = getFocusableElements(dom);
+    const focusableElements = await getFocusableElements(dom);
+    // This is supposed to return focusable elements within the web component
+    // shadow DOM;
+    expect(focusableElements.length).to.eq(13);
+  });
+
+  it('should return an array and ignore focusable web components', async () => {
+    setOffset('offsetHeight', { configurable: true, value: 10 });
+    setOffset('offsetWidth', { configurable: true, value: 10 });
+    /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
+    const tree = ReactTestUtils.renderIntoDocument(
+      <form>
+        <a href="http://test.com">x</a>
+        <button type="button" aria-label="button" />
+        <details>
+          <summary>foo</summary>
+          baz
+        </details>
+        <input type="text" />
+        <select>
+          <option>bar</option>
+        </select>
+        <textarea />
+        <div tabIndex="0" />
+        <va-button />
+        <va-select />
+        <va-radio-option />
+        <va-checkbox />
+        <va-text-input />
+        <va-textarea />
+      </form>,
+    );
+    /* eslint-enable jsx-a11y/no-noninteractive-tabindex */
+    const dom = findDOMNode(tree);
+    global.document = dom;
+    const focusableElements = await getFocusableElements(dom, {
+      returnWebComponent: true,
+      focusableWebComponents: [],
+    });
     expect(focusableElements.length).to.eq(7);
   });
 
-  it.skip('should return an empty array from non-focusable elements', () => {
+  it('should return an empty array from non-focusable elements', async () => {
     setOffset('offsetHeight', { configurable: true, value: 10 });
     setOffset('offsetWidth', { configurable: true, value: 10 });
     /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
@@ -314,10 +375,10 @@ describe('getFocuableElements', () => {
     /* eslint-enable jsx-a11y/label-has-associated-control */
     const dom = findDOMNode(tree);
     global.document = dom;
-    const focusableElements = getFocusableElements(dom);
+    const focusableElements = await getFocusableElements(dom);
     expect(focusableElements.length).to.eq(0);
   });
-  it.skip('should return an empty array from hidden elements', () => {
+  it('should return an empty array from hidden elements', async () => {
     setOffset('offsetHeight', offsets.height);
     setOffset('offsetWidth', offsets.width);
     /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
@@ -342,7 +403,7 @@ describe('getFocuableElements', () => {
     /* eslint-enable jsx-a11y/no-noninteractive-tabindex */
     const dom = findDOMNode(tree);
     global.document = dom;
-    const focusableElements = getFocusableElements(dom);
+    const focusableElements = await getFocusableElements(dom);
     expect(focusableElements.length).to.eq(0);
   });
 });

--- a/src/platform/utilities/constants.js
+++ b/src/platform/utilities/constants.js
@@ -5,3 +5,36 @@ export const requestStates = {
   succeeded: 'succeeded',
   failed: 'failed',
 };
+
+export const SCROLL_ELEMENT_SUFFIX = 'ScrollElement';
+
+// Focus on error message/component selectors
+export const ERROR_ELEMENTS = [
+  '.usa-input-error',
+  'input-error-date',
+  '[error]',
+];
+
+// List from https://html.spec.whatwg.org/dev/dom.html#interactive-content
+export const FOCUSABLE_ELEMENTS = [
+  '[href]',
+  'button',
+  'details',
+  'input:not([type="hidden"])',
+  'select',
+  'textarea',
+  /* focusable, but not tabbable */
+  '[tabindex]:not([tabindex="-1"])',
+  /* label removed from list, because you can't programmically focus it
+    * unless it has a tabindex of 0 or -1; clicking on it shifts focus to the
+    * associated focusable form element
+    */
+  // 'label[for]',
+  /* focusable elements not used in our form system */
+  // 'audio[controls]',
+  // 'embed',
+  // 'iframe',
+  // 'img[usemap]',
+  // 'object[usemap]',
+  // 'video[controls]',
+];

--- a/src/platform/utilities/ui/index.js
+++ b/src/platform/utilities/ui/index.js
@@ -13,6 +13,7 @@ import {
   scrollToFirstError,
   scrollAndFocus,
 } from './scroll';
+import { ERROR_ELEMENTS, FOCUSABLE_ELEMENTS } from '../constants';
 
 export {
   focusElement,
@@ -24,6 +25,8 @@ export {
   scrollToTop,
   scrollToFirstError,
   scrollAndFocus,
+  ERROR_ELEMENTS,
+  FOCUSABLE_ELEMENTS,
 };
 
 export function displayFileSize(size) {

--- a/src/platform/utilities/ui/scroll.js
+++ b/src/platform/utilities/ui/scroll.js
@@ -1,6 +1,7 @@
 import Scroll from 'react-scroll';
 
 import { focusElement } from './focus';
+import { ERROR_ELEMENTS } from '../constants';
 
 const { scroller } = Scroll;
 
@@ -28,9 +29,7 @@ export function scrollToTop(position = 0, options = getScrollOptions()) {
 // Duplicate of function in platform/forms-system/src/js/utilities/ui/index
 export function scrollToFirstError() {
   // [error] will focus any web-components with an error message
-  const errorEl = document.querySelector(
-    '.usa-input-error, .input-error-date, [error]',
-  );
+  const errorEl = document.querySelector(ERROR_ELEMENTS.join(','));
   if (errorEl) {
     // document.body.scrollTop doesn’t work with all browsers, so we’ll cover them all like so:
     const currentPosition =


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > With recent updates to the review & submit page accordion, the alteration of markup and attempt to fix focus lead to breaking focus management entirely. When a page is edited, focus needs to move to either a page header or first focusable form element. After activating the "Update page" button, focus needs to return to the edit button for the page. None of these focus shifts are currently happening.
  > This PR fixes _most_ of the focus management issues. The only remaining problem is shifting focus to a form element nested within two levels of web components, e.g. `va-radio` > `va-radio-option` > `input`. This will take some additional time and effort to get working correctly.
- _(If bug, how to reproduce)_
  > In any form, edit any page on the review & submit page. Focus is lost. And after updating the page, focus is lost again.
- _(What is the solution, why is this the solution)_
  > Prior to the accordion changes, after activating the editing a page, focus shifts to the first focusable element. Then after activating "Update page" focus needs to shift to the page edit button.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#73919](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73919)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated & added unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ----- | ------ |
| Focus | ![focus-before](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/dd478924-a159-4fc3-b666-0a138f81b299) | ![focus-after](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/92326570-964d-4886-8fba-4c40f415f078) |

## What areas of the site does it impact?

All forms that use the current review & submit page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
