### PR TITLE
Pension 73300 Add item button and header update

### DIFF
--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -411,7 +411,7 @@ export default class ArrayField extends React.Component {
                     <div className="small-12 columns va-growable-expanded">
                       {isLast && multipleRows ? (
                         <h3 className="vads-u-font-size--h5">
-                          New {uiItemName}
+                          Add {uiItemName}
                         </h3>
                       ) : null}
                       {!isLast &&
@@ -534,7 +534,7 @@ export default class ArrayField extends React.Component {
               )}
               onClick={this.handleAdd}
             >
-              Add another {uiItemName}
+              Add {uiItemName}
             </button>
           )}
           {/* Show an alert when no more items can be added */}

--- a/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
@@ -141,7 +141,7 @@ describe('Schemaform <ArrayField>', () => {
     // no remove button
     expect(button.length).to.equal(2);
     expect(button[0].text()).to.equal('Save');
-    expect(button[1].text()).to.contain('Add another');
+    expect(button[1].text()).to.equal('Add item');
   });
   it('should render save button with showSave option', () => {
     const idSchema = {
@@ -188,7 +188,7 @@ describe('Schemaform <ArrayField>', () => {
     expect(button[0].text()).to.equal('Edit');
     expect(button[1].text()).to.equal('Save');
     expect(button[2].text()).to.equal('Remove');
-    expect(button[3].text()).to.contain('Add another');
+    expect(button[3].text()).to.equal('Add item');
   });
 
   it('should render unique aria-labels on buttons from ui option key in item', () => {
@@ -266,7 +266,7 @@ describe('Schemaform <ArrayField>', () => {
     expect(button[1].props['aria-label']).to.equal('Save bar');
     expect(button[2].text()).to.equal('Remove');
     expect(button[2].props['aria-label']).to.equal('Remove bar');
-    expect(button[3].text()).to.contain('Add another');
+    expect(button[3].text()).to.equal('Add itemz');
   });
 
   it('should render invalid items', () => {
@@ -527,7 +527,7 @@ describe('should handle generateIndividualItemHeaders boolean', () => {
       'item',
     );
     expect(tree.everySubTree('.vads-u-font-size--h5')[1].text()).to.equal(
-      'New item',
+      'Add item',
     );
   });
 });


### PR DESCRIPTION
## Summary

change ArrayField add item button text and new item header

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/73300

## Testing done

begin pension form, proceed to financial information, enter multiple items for income source

## Screenshots

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/5315216/04265831-56b3-44a1-838b-5f1f5c9e2af1)

## What areas of the site does it impact?

All forms using ArrayField, ie. item lists

## Acceptance criteria

button and header changed to 'Add {itemName}'

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
