### PR TITLE
Modify maximal-test to not have any overflow

### DIFF
--- a/src/applications/pensions/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/pensions/tests/e2e/fixtures/data/maximal-test.json
@@ -93,20 +93,6 @@
       },
       {
         "spouseFullName": {
-          "first": "Jennie",
-          "middle": "Middle",
-          "last": "Dane"
-        },
-        "dateOfMarriage": "1983-03-02",
-        "locationOfMarriage": "Dallas",
-        "view:pastMarriage": {
-          "reasonForSeparation": "Divorce",
-          "dateOfSeparation": "1984-03-02",
-          "locationOfSeparation": "San Antonio, TX"
-        }
-      },
-      {
-        "spouseFullName": {
           "first": "Meg",
           "middle": "Middle",
           "last": "Doe"


### PR DESCRIPTION
## Summary

- Small update to the maximal_test.json to prevent overflow from occurring in the generated test PDF.
- Removed one of the veteran's prior spouses from the history.
- Pension benefits owns this work

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#73619
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website/pull/27603
- [_Link to epic if not included in ticket_](https://app.zenhub.com/workspaces/benefits-pension-64e775aaa6b1ca1ed49b2ede/issues/gh/department-of-veterans-affairs/va.gov-team/73619)


## Testing done

- This data is run through our e2e Cypress tests and will be synced to our backend test fixtures for PDF generation testing.

## What areas of the site does it impact?

This won't have any visible effect to the site, since it's a test fixture.