### PR TITLE
NOD | Prototype update submitted date and contested year

### DIFF
--- a/src/applications/appeals/download/containers/ViewAppeal.jsx
+++ b/src/applications/appeals/download/containers/ViewAppeal.jsx
@@ -21,7 +21,9 @@ const ViewAppeal = () => {
   const { data } = testData;
   const { fullName } = extraData;
 
-  const submitted = new Date('2023-12-1');
+  const submitted = new Date();
+  const dateExpires = new Date();
+  dateExpires.setDate(dateExpires.getDate() + 7);
 
   const borderLine = [
     'vads-u-border-bottom--1px',
@@ -62,8 +64,8 @@ const ViewAppeal = () => {
           </h3>
           <p>
             If you’d like a PDF copy of your completed Board Appeal, you can
-            download it now. The download link is only available until December
-            8, 2023.
+            download it now. The download link is only available until{' '}
+            <span>{format(dateExpires, 'MMMM d, yyyy')}</span>
           </p>
 
           <va-link

--- a/src/applications/appeals/download/tests/fixtures/data/test-data.json
+++ b/src/applications/appeals/download/tests/fixtures/data/test-data.json
@@ -36,7 +36,7 @@
         "type": "contestableIssue",
         "attributes": {
           "ratingIssueSubjectText": "tinnitus",
-          "approxDecisionDate": "2021-6-1",
+          "approxDecisionDate": "2023-6-1",
           "decisionIssueId": 1,
           "ratingIssueReferenceId": "2",
           "ratingDecisionReferenceId": "3",
@@ -47,7 +47,7 @@
         "type": "contestableIssue",
         "attributes": {
           "ratingIssueSubjectText": "left knee",
-          "approxDecisionDate": "2021-6-2",
+          "approxDecisionDate": "2023-6-2",
           "decisionIssueId": 4,
           "ratingIssueReferenceId": "5"
         }
@@ -58,7 +58,7 @@
         "type": "contestableIssue",
         "attributes": {
           "ratingIssueSubjectText": "tinnitus",
-          "approxDecisionDate": "2021-6-1"
+          "approxDecisionDate": "2023-6-1"
         },
         "disagreementOptions": {
           "serviceConnection": true,
@@ -71,7 +71,7 @@
         "type": "contestableIssue",
         "attributes": {
           "ratingIssueSubjectText": "left knee",
-          "approxDecisionDate": "2021-6-2"
+          "approxDecisionDate": "2023-6-2"
         },
         "disagreementOptions": {
           "serviceConnection": false,


### PR DESCRIPTION
## Summary

_(Summarize the changes that have been made to the platform)_
  - The submitted date on the view-appeal page was updated to match the dynamic date that shows up on the confirmation page so that it is consistent and doesn't cause confusion during testing. 
  - The expiry date was updated to be 7 days from submitted date (7 days from today).  
  - The year was updated from 2021 to 2023 for an accurate contested year (less than a year from today's date)
 
_(If bug, how to reproduce)_
  - not a bug

_(Which team do you work for, does your team own the maintenance of this component?)_
  - Benefits Team - Decision Reviews

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#65936

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before |
| ------- |
| ![viewappeal-before](https://github.com/department-of-veterans-affairs/vets-website/assets/37054305/e054599c-6044-4a39-803c-6fe609d660f5) |   

| After |
| ------ |
| ![viewappeal-after](https://github.com/department-of-veterans-affairs/vets-website/assets/37054305/9f638871-e238-4ad3-834c-9bdec95e87eb) |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*
- NOD view appeal prototype page