### PR TITLE
MHV-53812 Fix-The-Link-Style-For-Radiology-Image-Redirection

### DIFF
--- a/src/applications/mhv/medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -97,7 +97,7 @@ ${record.results}`;
               isAuthenticatedWithSSOe(fullState),
               'va-medical-images-and-reports',
             )}
-            text="Request images on the My HealtheVet"
+            text="Request images on the My HealtheVet website"
           />
         </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">

--- a/src/applications/mhv/medical-records/components/LabsAndTests/RadiologyDetails.jsx
+++ b/src/applications/mhv/medical-records/components/LabsAndTests/RadiologyDetails.jsx
@@ -93,12 +93,11 @@ ${record.results}`;
         </h3>
         <p className="no-print">
           <va-link
-            active
             href={mhvUrl(
               isAuthenticatedWithSSOe(fullState),
               'va-medical-images-and-reports',
             )}
-            text="Request images on the My HealtheVet website"
+            text="Request images on the My HealtheVet"
           />
         </p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">


### PR DESCRIPTION
## Summary
Removed link arrow from RadiologyDetails page. 

## Related issue(s)
[MHV-53812](https://jira.devops.va.gov/browse/MHV-53812) - Fix the link style for radiology image redirection

Verify the correct style for the link (arrow vs. no arrow vs. conditional arrow) with UCD and update the link style appropriately.

https://dsva.slack.com/archives/C03Q2UQL1AS/p1706039472538349

## Testing done
Conducted UI testing to ensure the expected behavior. I updated existing unit test for new components.

## Screenshots
![Screenshot 2024-01-26 at 3 11 00 PM (2)](https://github.com/department-of-veterans-affairs/vets-website/assets/8038703/12afc41a-fc57-4668-9b86-10faaf4d0ce6)


## What areas of the site does it impact?

The modification affects the RadiologyDetails page.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user