### PR TITLE
[55085] removes new appointment use of va online scheduling status improvement flag

### DIFF
--- a/src/applications/vaos/new-appointment/components/ClinicChoicePage/RequestEligibilityMessage.jsx
+++ b/src/applications/vaos/new-appointment/components/ClinicChoicePage/RequestEligibilityMessage.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
 import ErrorMessage from '../../../components/ErrorMessage';
 import FacilityAddress from '../../../components/FacilityAddress';
 import InfoAlert from '../../../components/InfoAlert';
-import { selectFeatureStatusImprovement } from '../../../redux/selectors';
 import { ELIGIBILITY_REASONS } from '../../../utils/constants';
 
 export default function RequestEligibilityMessage({
@@ -20,9 +18,6 @@ export default function RequestEligibilityMessage({
         365) *
       12
     : '12-24';
-  const featureStatusImprovement = useSelector(state =>
-    selectFeatureStatusImprovement(state),
-  );
 
   if (requestReason === ELIGIBILITY_REASONS.error) {
     return <ErrorMessage />;
@@ -79,11 +74,7 @@ export default function RequestEligibilityMessage({
               <li>
                 Go to{' '}
                 <va-link
-                  href={
-                    featureStatusImprovement
-                      ? '/my-health/appointments/pending'
-                      : '/my-health/appointments/requested'
-                  }
+                  href="/my-health/appointments/pending"
                   text="your appointment list"
                   data-testid="appointment-list-link"
                 />{' '}

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/EligibilityModal.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/EligibilityModal.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import PropTypes from 'prop-types';
 import { FETCH_STATUS } from '../../../utils/constants';
 import getEligibilityMessage from './getEligibilityMessage';
-import { selectFeatureStatusImprovement } from '../../../redux/selectors';
 
 export default function EligibilityModal({
   onClose,
@@ -12,14 +10,9 @@ export default function EligibilityModal({
   facilityDetails,
   typeOfCare,
 }) {
-  const featureStatusImprovement = useSelector(state =>
-    selectFeatureStatusImprovement(state),
-  );
-
   const { title, content } = getEligibilityMessage({
     eligibility,
     facilityDetails,
-    featureStatusImprovement,
     typeOfCare,
     includeFacilityContactInfo: true,
   });

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/SingleFacilityEligibilityCheckMessage.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/SingleFacilityEligibilityCheckMessage.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 import State from '../../../components/State';
 import InfoAlert from '../../../components/InfoAlert';
 import getEligibilityMessage from './getEligibilityMessage';
-import { selectFeatureStatusImprovement } from '../../../redux/selectors';
 
 export default function SingleFacilityEligibilityCheckMessage({
   facility,
@@ -12,15 +10,11 @@ export default function SingleFacilityEligibilityCheckMessage({
 }) {
   const title =
     'We found one facility that accepts online scheduling for this care';
-  const featureStatusImprovement = useSelector(state =>
-    selectFeatureStatusImprovement(state),
-  );
 
   const { content } = getEligibilityMessage({
     eligibility,
     typeOfCare,
     facilityDetails: facility,
-    featureStatusImprovement,
   });
 
   return (

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/getEligibilityMessage.js
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/getEligibilityMessage.js
@@ -9,7 +9,6 @@ export default function getEligibilityMessage({
   eligibility,
   facilityDetails,
   includeFacilityContactInfo = false,
-  featureStatusImprovement,
 }) {
   let content = null;
   let title = null;
@@ -95,11 +94,7 @@ export default function getEligibilityMessage({
           Call this facility to schedule or cancel an open appointment request.
           You can also cancel a request from{' '}
           <va-link
-            href={
-              featureStatusImprovement
-                ? '/my-health/appointments/pending'
-                : '/my-health/appointments/requested'
-            }
+            href="/my-health/appointments/pending"
             text="your appointment list"
             data-testid="appointment-list-link"
           />


### PR DESCRIPTION
## Summary
This removes the use of the `va_online_scheduling_status_improvement` feature flag from the `/src/applications/vaos/new-appointment` component and child components within VA online scheduling. It is part of a set of PR's to address https://github.com/department-of-veterans-affairs/va.gov-team/issues/55085

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/55085

## Testing done
- Unit testing
- e2e testing

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user