### PR TITLE
Update Pension income types

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,8 +249,8 @@
   "dependencies": {
     "@babel/runtime": "^7.15.4",
     "@datadog/browser-rum": "^4.49.0",
-    "@department-of-veterans-affairs/css-library": "^0.3.0",
     "@department-of-veterans-affairs/component-library": "^34.2.0",
+    "@department-of-veterans-affairs/css-library": "^0.3.0",
     "@department-of-veterans-affairs/formation": "^10.1.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.6.1",
@@ -317,7 +317,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#a9b60b42d102ced877d87e406a9d028b853ef923"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d11fa23200e236042ffab9230fa0f62f20054b09"
   },
   "resolutions": {
     "**/lodash": "4.17.21",

--- a/src/applications/pensions/config/chapters/05-financial-information/incomeSources.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/incomeSources.js
@@ -16,8 +16,8 @@ import IncomeSourceView from '../../../components/IncomeSourceView';
 const typeOfIncomeOptions = {
   SOCIAL_SECURITY: 'Social Security',
   INTEREST_DIVIDEND: 'Interest or dividend income',
-  RETIREMENT: 'Retirement income',
-  PENSION: 'Pension income',
+  CIVIL_SERVICE: 'Civil Service',
+  PENSION_RETIREMENT: 'Pension or retirement income',
   OTHER: 'Other income',
 };
 

--- a/src/applications/pensions/tests/e2e/fixtures/data/overflow-test.json
+++ b/src/applications/pensions/tests/e2e/fixtures/data/overflow-test.json
@@ -405,7 +405,7 @@
         "amount": 3278.75
       },
       {
-        "typeOfIncome": "PENSION",
+        "typeOfIncome": "PENSION_RETIREMENT",
         "receiver": "VETERAN",
         "payer": "John Doe",
         "amount": 55.27

--- a/yarn.lock
+++ b/yarn.lock
@@ -20370,9 +20370,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#a9b60b42d102ced877d87e406a9d028b853ef923":
-  version "20.33.7"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#a9b60b42d102ced877d87e406a9d028b853ef923"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#d11fa23200e236042ffab9230fa0f62f20054b09":
+  version "20.35.1"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d11fa23200e236042ffab9230fa0f62f20054b09"
   dependencies:
     minimist "^1.2.3"
 


### PR DESCRIPTION
## Summary

The list of income types for the question What types of income is updated to match the PDF: Social Security,
Interest or dividend income, Civil Service, Pension or retirement income, and Other income.

- PR to update [json-schema PR](https://github.com/department-of-veterans-affairs/vets-json-schema/pull/833) is merged. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/74698

## Testing done

- Run the vets-api and vets-website on branch `pensions-74698-monthly-income`
- Select 'yes' on `/financial/receives-income`
- On `/financial/income-sources`, fill out at least two sources of income completely. 
- Fill out the rest of the form and submit
- The submission should be successful

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |  <img width="560" alt="Screenshot 2024-01-29 at 9 53 52 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/21046714/3eec506a-df8a-4857-9c0e-7b6aaa0e026d"> |     <img width="611" alt="Screenshot 2024-01-29 at 9 55 58 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/21046714/e070e77e-87eb-453a-bc93-67e11e575364">  |

## What areas of the site does it impact?

Pension benefits

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
