### PR TITLE
[55085] Removes vaOnlineSchedulingStatusImprovement feature flag

### DIFF
--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -64,9 +64,6 @@ export const selectFeatureVAOSServiceCCAppointments = state =>
 export const selectFeatureFacilitiesServiceV2 = state =>
   toggleValues(state).vaOnlineSchedulingFacilitiesServiceV2;
 
-export const selectFeatureStatusImprovement = state =>
-  toggleValues(state).vaOnlineSchedulingStatusImprovement;
-
 export const selectFeatureStatusImprovementCanceled = state =>
   toggleValues(state).vaOnlineSchedulingStatusImprovementCanceled;
 

--- a/src/applications/vaos/utils/featureFlags.js
+++ b/src/applications/vaos/utils/featureFlags.js
@@ -13,7 +13,6 @@ module.exports = [
   { name: 'vaOnlineSchedulingVAOSServiceVAAppointments', value: true },
   { name: 'vaOnlineSchedulingFacilitiesServiceV2', value: true },
   { name: 'vaOnlineSchedulingVAOSServiceCCAppointments', value: true },
-  { name: 'vaOnlineSchedulingStatusImprovement', value: true },
   { name: 'vaOnlineSchedulingStatusImprovementCanceled', value: true },
   { name: 'vaOnlineSchedulingVAOSV2Next', value: true },
   { name: 'vaOnlineSchedulingAppointmentList', value: true },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -250,8 +250,6 @@ export default Object.freeze({
     'va_online_scheduling_vaos_service_va_appointments',
   vaOnlineSchedulingFacilitiesServiceV2:
     'va_online_scheduling_facilities_service_v2',
-  vaOnlineSchedulingStatusImprovement:
-    'va_online_scheduling_status_improvement',
   vaOnlineSchedulingStatusImprovementCanceled:
     'va_online_scheduling_status_improvement_canceled',
   vaOnlineSchedulingClinicLocation: 'va_online_scheduling_clinic_location',


### PR DESCRIPTION
**This should be merged AFTER all other PR's for [the issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/55085) are merged in**

## Summary
This removes the use of the `va_online_scheduling_status_improvement` feature flag from VA online scheduling. It is part of a set of PR's to address https://github.com/department-of-veterans-affairs/va.gov-team/issues/55085

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/55085

## Testing done
- Unit testing
- e2e testing

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user