### PR TITLE
[DowntimeNotification] Handle edge case around multiple upcoming maintenance windows

### DIFF
--- a/src/platform/monitoring/DowntimeNotification/tests/helpers.unit.spec.js
+++ b/src/platform/monitoring/DowntimeNotification/tests/helpers.unit.spec.js
@@ -23,6 +23,18 @@ const pastDowntime = {
   },
 };
 
+const futureDowntimeForSameService = {
+  attributes: {
+    externalService: 'evss',
+    startTime: moment()
+      .add(1, 'day')
+      .toISOString(),
+    endTime: moment()
+      .add(2, 'day')
+      .toISOString(),
+  },
+};
+
 const activeDowntime = {
   attributes: {
     externalService: 'evss',
@@ -74,6 +86,7 @@ const lessUrgentApproachingDowntime = {
 const maintenanceWindows = [
   pastDowntime,
   activeDowntime,
+  futureDowntimeForSameService,
   distantFutureDowntime,
   approachingDowntime,
   lessUrgentApproachingDowntime,

--- a/src/platform/monitoring/DowntimeNotification/util/helpers.js
+++ b/src/platform/monitoring/DowntimeNotification/util/helpers.js
@@ -68,6 +68,7 @@ export function createServiceMap(maintenanceWindows = []) {
   // so that when a single externalService has multiple upcoming
   // maintenance windows, we can easily grab the one with the
   // earliest startTime and ignore any others that we encounter
+  // Expected format for `attributes.startTime`: YYYY-MM-DDTHH:MM:SS.SSSZ
   const sortedMaintenanceWindows = maintenanceWindows.sort((a, b) => {
     const aStart = a.attributes.startTime;
     const bStart = b.attributes.startTime;

--- a/src/platform/monitoring/DowntimeNotification/util/helpers.js
+++ b/src/platform/monitoring/DowntimeNotification/util/helpers.js
@@ -60,10 +60,22 @@ export function createGlobalMaintenanceWindow({
  * @param {Array} maintenanceWindows The raw JSON data from the API
  * @returns {Map}
  */
+
 export function createServiceMap(maintenanceWindows = []) {
   const serviceMap = new Map();
 
-  for (const maintenanceWindow of maintenanceWindows) {
+  // Maintenance windows should be sorted in ascending order
+  // so that when a single externalService has multiple upcoming
+  // maintenance windows, we can easily grab the one with the
+  // earliest startTime and ignore any others that we encounter
+  const sortedMaintenanceWindows = maintenanceWindows.sort((a, b) => {
+    const aStart = a.attributes.startTime;
+    const bStart = b.attributes.startTime;
+
+    return aStart.localeCompare(bStart);
+  });
+
+  for (const maintenanceWindow of sortedMaintenanceWindows) {
     const {
       attributes: {
         externalService,
@@ -77,13 +89,19 @@ export function createServiceMap(maintenanceWindows = []) {
     const endTime = endTimeRaw && moment(endTimeRaw);
     const status = getStatusForTimeframe(startTime, endTime);
 
-    serviceMap.set(externalService, {
-      externalService,
-      status,
-      startTime,
-      endTime,
-      description,
-    });
+    // For each externalService, we only care about the maintenance
+    // window with the earliest startTime (the sorting above should
+    // guarantee that the first one we encounter has the earliest
+    // startTime)
+    if (!serviceMap.has(externalService)) {
+      serviceMap.set(externalService, {
+        externalService,
+        status,
+        startTime,
+        endTime,
+        description,
+      });
+    }
   }
 
   return serviceMap;


### PR DESCRIPTION
## Summary
I noticed that some upcoming maintenance windows are ignored when there are multiple of them scheduled for the same external service. If there is more than one scheduled maintenance window for a service like EVSS, then depending on the order that they are returned by the backend in, then the earliest one may be ignored. I went into greater depth in the Github Issue linked below. This PR updates the `createServiceMap` method to:
* Sort the incoming maintenance windows by their start dates
* When they are added to the `serviceMap`, adding a check to see if there is already a downtime assigned to that service, and if not, then assigning one. (We should be able to ignore any downtimes that are encountered after the first one for each service because of the sorting mentioned above

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team/issues/74702

## Testing done
Added a test to make sure that downtimes get sorted properly and that the correct one gets assigned to each external service key) in `serviceMap`

## What areas of the site does it impact?
Any application that uses the `DowntimeNotification` component

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
