### PR TITLE
Cleanup for edit as subtask

### DIFF
--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -165,9 +165,7 @@ class Profile extends Component {
 
     const routes = getRoutes({
       profileContactsPage: toggles.profileContacts,
-      useFieldEditingPage: toggles.profileUseFieldEditingPage,
       profileUseHubPage: toggles.profileUseHubPage,
-      profileShowProofOfVeteranStatus: toggles.profileShowProofOfVeteranStatus,
     });
 
     return (

--- a/src/applications/personalization/profile/components/edit/Edit.jsx
+++ b/src/applications/personalization/profile/components/edit/Edit.jsx
@@ -11,7 +11,6 @@ import getProfileInfoFieldAttributes from '@@vap-svc/util/getProfileInfoFieldAtt
 import ProfileInformationFieldController from '@@vap-svc/components/ProfileInformationFieldController';
 import InitializeVAPServiceIDContainer from '@@vap-svc/containers/InitializeVAPServiceID';
 
-import { Toggler } from '~/platform/utilities/feature-toggles';
 import { hasVAPServiceConnectionError } from '~/platform/user/selectors';
 
 import { EditFallbackContent } from './EditFallbackContent';
@@ -180,60 +179,50 @@ export const Edit = () => {
 
   return (
     <EditContext.Provider value={{ onCancel: handlers.cancel }}>
-      <Toggler toggleName={Toggler.TOGGLE_NAMES.profileUseFieldEditingPage}>
-        <Toggler.Enabled>
-          {fieldInfo && !hasVAPServiceError ? (
-            <>
-              {/* this modal is triggered by breadcrumb being clicked with unsaved edits */}
-              <EditConfirmCancelModal
-                isVisible={showConfirmCancelModal}
-                activeSection={fieldInfo.fieldName.toLowerCase()}
-                onHide={() => setShowConfirmCancelModal(false)}
-              />
-              <div
-                className="vads-u-display--block medium-screen:vads-u-display--block"
-                id="profile-edit-field-page"
-              >
-                <EditBreadcrumb
-                  className="vads-u-margin-top--2 vads-u-margin-bottom--3"
-                  onClickHandler={handlers.breadCrumbClick}
-                  href={returnPath}
-                >
-                  {`Back to ${returnPathName}`}
-                </EditBreadcrumb>
+      {fieldInfo && !hasVAPServiceError ? (
+        <>
+          {/* this modal is triggered by breadcrumb being clicked with unsaved edits */}
+          <EditConfirmCancelModal
+            isVisible={showConfirmCancelModal}
+            activeSection={fieldInfo.fieldName.toLowerCase()}
+            onHide={() => setShowConfirmCancelModal(false)}
+          />
+          <div
+            className="vads-u-display--block medium-screen:vads-u-display--block"
+            id="profile-edit-field-page"
+          >
+            <EditBreadcrumb
+              className="vads-u-margin-top--2 vads-u-margin-bottom--3"
+              onClickHandler={handlers.breadCrumbClick}
+              href={returnPath}
+            >
+              {`Back to ${returnPathName}`}
+            </EditBreadcrumb>
 
-                <p className="vads-u-margin-bottom--0p5">
-                  NOTIFICATION SETTINGS
-                </p>
+            <p className="vads-u-margin-bottom--0p5">NOTIFICATION SETTINGS</p>
 
-                <h1 className="vads-u-font-size--h2 vads-u-margin-bottom--2">
-                  {editPageHeadingString}
-                </h1>
+            <h1 className="vads-u-font-size--h2 vads-u-margin-bottom--2">
+              {editPageHeadingString}
+            </h1>
 
-                <InitializeVAPServiceIDContainer>
-                  {/* the EditConfirmCancelModal is passed here as props to allow a custom modal to be used
+            <InitializeVAPServiceIDContainer>
+              {/* the EditConfirmCancelModal is passed here as props to allow a custom modal to be used
                   for when the user clicks 'cancel' on the form with unsaved edits */}
-                  <ProfileInformationFieldController
-                    fieldName={fieldInfo.fieldName}
-                    forceEditView
-                    isDeleteDisabled
-                    saveButtonText="Save to profile"
-                    successCallback={handlers.success}
-                    cancelCallback={handlers.cancel}
-                    CustomConfirmCancelModal={EditConfirmCancelModal}
-                  />
-                </InitializeVAPServiceIDContainer>
-              </div>
-            </>
-          ) : (
-            <EditFallbackContent routesForNav={routesForNav} />
-          )}
-        </Toggler.Enabled>
-
-        <Toggler.Disabled>
-          <EditFallbackContent routesForNav={routesForNav} />
-        </Toggler.Disabled>
-      </Toggler>
+              <ProfileInformationFieldController
+                fieldName={fieldInfo.fieldName}
+                forceEditView
+                isDeleteDisabled
+                saveButtonText="Save to profile"
+                successCallback={handlers.success}
+                cancelCallback={handlers.cancel}
+                CustomConfirmCancelModal={EditConfirmCancelModal}
+              />
+            </InitializeVAPServiceIDContainer>
+          </div>
+        </>
+      ) : (
+        <EditFallbackContent routesForNav={routesForNav} />
+      )}
     </EditContext.Provider>
   );
 };

--- a/src/applications/personalization/profile/components/notification-settings/AddContactInfoLink.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/AddContactInfoLink.jsx
@@ -5,37 +5,24 @@ import PropTypes from 'prop-types';
 import { getContactInfoDeepLinkURL } from '@@profile/helpers';
 
 import { FIELD_NAMES, MISSING_CONTACT_INFO } from '@@vap-svc/constants';
-import { useFeatureToggle } from '~/platform/utilities/feature-toggles/useFeatureToggle';
 
 const AddContactInfoLink = ({ missingInfo }) => {
-  const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
-  const useEditingPage = useToggleValue(
-    TOGGLE_NAMES.profileUseFieldEditingPage,
-  );
   const linkInfo = React.useMemo(
     () => {
       const linkMap = {
         [MISSING_CONTACT_INFO.EMAIL]: {
           linkText: 'Add your email address',
-          linkTarget: getContactInfoDeepLinkURL(
-            FIELD_NAMES.EMAIL,
-            true,
-            useEditingPage,
-          ),
+          linkTarget: getContactInfoDeepLinkURL(FIELD_NAMES.EMAIL),
         },
         [MISSING_CONTACT_INFO.MOBILE]: {
           linkText: 'Add your mobile phone number',
-          linkTarget: getContactInfoDeepLinkURL(
-            FIELD_NAMES.MOBILE_PHONE,
-            true,
-            useEditingPage,
-          ),
+          linkTarget: getContactInfoDeepLinkURL(FIELD_NAMES.MOBILE_PHONE),
         },
       };
 
       return linkMap[missingInfo];
     },
-    [missingInfo, useEditingPage],
+    [missingInfo],
   );
   return <Link to={linkInfo.linkTarget}>{linkInfo.linkText}</Link>;
 };

--- a/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/ContactInfoOnFile.jsx
@@ -28,7 +28,6 @@ const ContactInfoOnFile = ({
             <Link
               to={generateContactInfoLink({
                 fieldName: FIELD_NAMES.EMAIL,
-                focusOnEditButton: true,
                 returnPath: encodeURIComponent(
                   PROFILE_PATHS.NOTIFICATION_SETTINGS,
                 ),
@@ -56,7 +55,6 @@ const ContactInfoOnFile = ({
           <va-link
             href={generateContactInfoLink({
               fieldName: FIELD_NAMES.MOBILE_PHONE,
-              focusOnEditButton: true,
               returnPath: encodeURIComponent(
                 PROFILE_PATHS.NOTIFICATION_SETTINGS,
               ),

--- a/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlertLink.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/MissingContactInfoAlertLink.jsx
@@ -16,7 +16,6 @@ const MissingContactInfoAlertLink = ({ missingInfo }) => {
           linkText: 'Add an email address to your profile',
           linkTarget: generateContactInfoLink({
             fieldName: FIELD_NAMES.EMAIL,
-            focusOnEditButton: true,
             returnPath: encodeURIComponent(PROFILE_PATHS.NOTIFICATION_SETTINGS),
           }),
           linkTestId: 'add-email-address-link',
@@ -25,7 +24,6 @@ const MissingContactInfoAlertLink = ({ missingInfo }) => {
           linkText: 'Add a phone number to your profile',
           linkTarget: generateContactInfoLink({
             fieldName: FIELD_NAMES.MOBILE_PHONE,
-            focusOnEditButton: true,
             returnPath: encodeURIComponent(PROFILE_PATHS.NOTIFICATION_SETTINGS),
           }),
           linkTestId: 'add-mobile-phone-link',

--- a/src/applications/personalization/profile/components/notification-settings/MissingContactInfoExpandable.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/MissingContactInfoExpandable.jsx
@@ -65,7 +65,6 @@ const AddYourInfoLink = ({ channel }) => {
     <Link
       to={generateContactInfoLink({
         fieldName: fieldNames[channel.id],
-        focusOnEditButton: true,
         returnPath: encodeURIComponent(PROFILE_PATHS.NOTIFICATION_SETTINGS),
       })}
     >

--- a/src/applications/personalization/profile/constants.js
+++ b/src/applications/personalization/profile/constants.js
@@ -4,7 +4,6 @@ export const PROFILE_TOGGLES = {
   profileShowPronounsAndSexualOrientation: false,
   profileHideDirectDepositCompAndPen: false,
   profileShowPaymentsNotificationSetting: false,
-  profileUseFieldEditingPage: false,
   profileUseHubPage: false,
   profileShowMhvNotificationSettings: false,
   profileLighthouseDirectDeposit: false,

--- a/src/applications/personalization/profile/helpers.js
+++ b/src/applications/personalization/profile/helpers.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import moment from 'moment';
-import { FIELD_IDS } from '@@vap-svc/constants';
 import { PROFILE_PATHS, USA_MILITARY_BRANCHES } from './constants';
 
 /**
@@ -57,15 +56,5 @@ export const transformServiceHistoryEntryIntoTableRow = entry => {
   };
 };
 
-export const getContactInfoDeepLinkURL = (
-  fieldName,
-  focusOnEditButton = false,
-  useUniqueEditPageURL = false,
-) => {
-  const targetId = FIELD_IDS[fieldName];
-  const fragment = focusOnEditButton ? `edit-${targetId}` : targetId;
-  if (useUniqueEditPageURL) {
-    return `${PROFILE_PATHS.EDIT}?fieldName=${fieldName}`;
-  }
-  return `${PROFILE_PATHS.CONTACT_INFORMATION}#${fragment}`;
-};
+export const getContactInfoDeepLinkURL = fieldName =>
+  `${PROFILE_PATHS.EDIT}?fieldName=${fieldName}`;

--- a/src/applications/personalization/profile/hooks/useContactInfoDeepLink.js
+++ b/src/applications/personalization/profile/hooks/useContactInfoDeepLink.js
@@ -1,30 +1,14 @@
 import { useCallback } from 'react';
-import { FIELD_IDS } from '@@vap-svc/constants';
-import { useFeatureToggle } from '~/platform/utilities/feature-toggles/useFeatureToggle';
 import { PROFILE_PATHS } from '../constants';
 
 export const useContactInfoDeepLink = () => {
-  const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
-
-  const useFieldEditingPage = useToggleValue(
-    TOGGLE_NAMES.profileUseFieldEditingPage,
-  );
-
   const generateContactInfoLink = useCallback(
-    ({ fieldName, focusOnEditButton = false, returnPath = null }) => {
-      const targetId = FIELD_IDS[fieldName];
-
-      const fragment = focusOnEditButton ? `edit-${targetId}` : targetId;
-
-      if (useFieldEditingPage) {
-        const fieldNameQuery = `?fieldName=${fieldName}`;
-        const returnPathQuery = returnPath ? `&returnPath=${returnPath}` : '';
-        return `${PROFILE_PATHS.EDIT}${fieldNameQuery}${returnPathQuery}`;
-      }
-
-      return `${PROFILE_PATHS.CONTACT_INFORMATION}#${fragment}`;
+    ({ fieldName, returnPath = null }) => {
+      const fieldNameQuery = `?fieldName=${fieldName}`;
+      const returnPathQuery = returnPath ? `&returnPath=${returnPath}` : '';
+      return `${PROFILE_PATHS.EDIT}${fieldNameQuery}${returnPathQuery}`;
     },
-    [useFieldEditingPage],
+    [],
   );
 
   return { generateContactInfoLink };

--- a/src/applications/personalization/profile/mocks/endpoints/feature-toggles/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/feature-toggles/index.js
@@ -8,7 +8,6 @@ const profileToggles = {
   profileShowPronounsAndSexualOrientation: false,
   profileHideDirectDepositCompAndPen: false,
   profileShowPaymentsNotificationSetting: false,
-  profileUseFieldEditingPage: false,
   profileUseHubPage: false,
   profileShowMhvNotificationSettings: false,
   profileUseExperimental: false,

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -62,7 +62,6 @@ const responses = {
           generateFeatureToggles({
             authExpVbaDowntimeMessage: false,
             profileContacts: true,
-            profileUseFieldEditingPage: true,
             profileUseHubPage: true,
             profileShowEmailNotificationSettings: true,
             profileShowMhvNotificationSettings: true,

--- a/src/applications/personalization/profile/routes.js
+++ b/src/applications/personalization/profile/routes.js
@@ -3,28 +3,22 @@ import { Edit } from './components/edit/Edit';
 import { getRoutesForNav } from './routesForNav';
 import { Hub } from './components/hub/Hub';
 
-// conditionally add the edit route based on feature toggle
 // conditionally add the profile hub route based on feature toggle
 const getRoutes = (
-  { profileContactsPage, useFieldEditingPage, profileUseHubPage } = {
+  { profileContactsPage, profileUseHubPage } = {
     profileContactsPage: false,
-    useFieldEditingPage: false,
     profileUseHubPage: false,
   },
 ) => {
   return [
     ...getRoutesForNav(profileContactsPage),
-    ...(useFieldEditingPage
-      ? [
-          {
-            component: Edit,
-            name: PROFILE_PATH_NAMES.EDIT,
-            path: PROFILE_PATHS.EDIT,
-            requiresLOA3: true,
-            requiresMVI: true,
-          },
-        ]
-      : []),
+    {
+      component: Edit,
+      name: PROFILE_PATH_NAMES.EDIT,
+      path: PROFILE_PATHS.EDIT,
+      requiresLOA3: true,
+      requiresMVI: true,
+    },
     ...(profileUseHubPage
       ? [
           {

--- a/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
+++ b/src/applications/personalization/profile/tests/components/Profile.unit.spec.js
@@ -46,9 +46,7 @@ describe('Profile', () => {
         pathname: '/profile/personal-information',
       },
       togglesLoaded: true,
-      profileToggles: {
-        profileUseFieldEditingPage: true,
-      },
+      profileToggles: {},
     };
   });
 

--- a/src/applications/personalization/profile/tests/components/edit/Edit.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/edit/Edit.unit.spec.jsx
@@ -1,19 +1,14 @@
 import React from 'react';
 import { expect } from 'chai';
-import { Toggler } from '~/platform/utilities/feature-toggles/Toggler';
 import { renderWithStoreAndRouter } from '~/platform/testing/unit/react-testing-library-helpers';
 import vapService from '~/platform/user/profile/vap-svc/reducers';
 
 import { Edit } from '../../../components/edit/Edit';
 
 describe('<Edit>', () => {
-  it('renders form with toggle `profileUseFieldEditingPage` turned ON and valid fieldName query present', async () => {
+  it('renders form with valid fieldName query present', async () => {
     const view = renderWithStoreAndRouter(<Edit />, {
-      initialState: {
-        featureToggles: {
-          [Toggler.TOGGLE_NAMES.profileUseFieldEditingPage]: true,
-        },
-      },
+      initialState: {},
       reducers: { vapService },
       path:
         '/profile/edit?fieldName=mobilePhone&returnPath=%2Fprofile%2Fnotifications',
@@ -25,13 +20,9 @@ describe('<Edit>', () => {
       .exist;
   });
 
-  it('renders fallback with toggle `profileUseFieldEditingPage` turned ON and invalid fieldName query present', async () => {
+  it('renders fallback when invalid fieldName query present', async () => {
     const view = renderWithStoreAndRouter(<Edit />, {
-      initialState: {
-        featureToggles: {
-          [Toggler.TOGGLE_NAMES.profileUseFieldEditingPage]: true,
-        },
-      },
+      initialState: {},
       reducers: { vapService },
       path:
         '/profile/edit?fieldName=someFakeField&returnPath=%2Fprofile%2Fnotifications',
@@ -41,30 +32,9 @@ describe('<Edit>', () => {
     expect(await view.findByText(/Choose a section to get started/i)).to.exist;
   });
 
-  // this should never happen, but just in case, we want to have some fallback behavior
-  it('renders fallback with toggle `profileUseFieldEditingPage` turned OFF', async () => {
+  it('renders fallback when invalid returnPath in query params', async () => {
     const view = renderWithStoreAndRouter(<Edit />, {
-      initialState: {
-        featureToggles: {
-          [Toggler.TOGGLE_NAMES.profileUseFieldEditingPage]: false,
-        },
-      },
-      reducers: { vapService },
-      path:
-        '/profile/edit?fieldName=mobilePhone&returnPath=%2Fprofile%2Fnotifications',
-    });
-
-    expect(await view.findByText(/Edit your profile information/i)).to.exist;
-    expect(await view.findByText(/Choose a section to get started/i)).to.exist;
-  });
-
-  it('renders fallback with toggle `profileUseFieldEditingPage` turned ON and invalid returnPath in query params', async () => {
-    const view = renderWithStoreAndRouter(<Edit />, {
-      initialState: {
-        featureToggles: {
-          [Toggler.TOGGLE_NAMES.profileUseFieldEditingPage]: true,
-        },
-      },
+      initialState: {},
       reducers: { vapService },
       path: '/profile/edit?fieldName=mobilePhone&returnPath=fakeReturnPath',
     });
@@ -78,9 +48,6 @@ describe('<Edit>', () => {
 
   it('renders the "Update" heading when there is field data', async () => {
     const initialStateWithData = {
-      featureToggles: {
-        [Toggler.TOGGLE_NAMES.profileUseFieldEditingPage]: true,
-      },
       user: {
         profile: {
           vapContactInfo: {

--- a/src/applications/personalization/profile/tests/e2e/post-delete-mobile-phone-alert.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/post-delete-mobile-phone-alert.cypress.spec.js
@@ -36,10 +36,8 @@ describe('Contact info update success alert', () => {
     });
   });
   it('should be shown after deleting mobile phone number', () => {
-    cy.visit(PROFILE_PATHS.NOTIFICATION_SETTINGS);
-    cy.contains('Update').click({
-      waitForAnimations: true,
-    });
+    cy.visit(PROFILE_PATHS.CONTACT_INFORMATION);
+
     cy.findByRole('button', { name: /remove mobile phone/i }).click({
       waitForAnimations: true,
     });
@@ -53,9 +51,6 @@ describe('Contact info update success alert', () => {
     cy.injectAxeThenAxeCheck();
 
     cy.findByText(/update saved/i).should('exist');
-    cy.findByRole('link', { name: /manage text notifications/i }).should(
-      'not.exist',
-    );
 
     cy.injectAxeThenAxeCheck();
   });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -170,7 +170,6 @@ export default Object.freeze({
   profileShowQuickSubmitNotificationSetting:
     'profile_show_quick_submit_notification_setting',
   profileUseExperimental: 'profile_use_experimental',
-  profileUseFieldEditingPage: 'profile_use_field_editing_page',
   profileUseHubPage: 'profile_use_hub_page',
   pwEhrCtaUseSlo: 'pw_ehr_cta_use_slo',
   ratedDisabilitiesSortAbTest: 'rated_disabilities_sort_ab_test',


### PR DESCRIPTION
## Summary

- Removes feature toggle `profile_use_field_editing_page`
- Removes conditional addition of the edit route, and has it included by default now
- Updates helper for creating edit link to always use query string parameters

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/53549

## Testing done

- Updated unit tests for edit and profile
- Updated e2e test for edit page being used by default

## Screenshots

No UI changes

## What areas of the site does it impact?

Profile Application

## Acceptance criteria

Feature toggle removed
Edit page used throughout profile for updating single fields, especially the notification settings page

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution