### PR TITLE
Add error key to user api failure GA event

### DIFF
--- a/src/applications/personalization/profile/components/alerts/LoadFail.jsx
+++ b/src/applications/personalization/profile/components/alerts/LoadFail.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 export const defaultFailureMessage = (
   <span>
@@ -25,10 +24,6 @@ export default function LoadFail() {
     </va-alert>
   );
 }
-
-LoadFail.propTypes = {
-  information: PropTypes.string.isRequired,
-};
 
 // Helper function to determine which message to render
 // If no props are passed, return the default failure message

--- a/src/applications/personalization/profile/mocks/endpoints/user/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/user/index.js
@@ -1399,6 +1399,13 @@ const mockErrorResponses = {
             'VET360_502, 502, Bad Gateway, Received an an invalid response from the upstream server',
           status: 502,
         },
+        {
+          externalService: 'Vet360',
+          startTime: '2020-11-19T17:32:54Z',
+          endTime: null,
+          description: 'Second error message',
+          status: 502,
+        },
       ],
     },
   },

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -76,19 +76,19 @@ const responses = {
     );
   },
   'GET /v0/user': (_req, res) => {
+    // return res.status(403).json(genericErrors.error500);
     // example user data cases
     return res.json(user.loa3User72); // default user (success)
     // return res.json(user.loa1User); // user with loa1
     // return res.json(user.badAddress); // user with bad address
     // return res.json(user.loa3User); // user with loa3
     // return res.json(user.nonVeteranUser); // non-veteran user
-    // return res.json(user.externalServiceError); // external service error
+    /// return res.json(user.externalServiceError); // external service error
     // return res.json(user.loa3UserWithNoMobilePhone); // user with no mobile phone number
     // return res.json(user.loa3UserWithNoEmail); // user with no email address
     // return res.json(user.loa3UserWithNoEmailOrMobilePhone); // user without email or mobile phone
     // return res.json(user.loa3UserWithNoHomeAddress); // home address is null
     // return res.json(user.loa3UserWithoutMailingAddress); // user with no mailing address
-
     // data claim users
     // return res.json(user.loa3UserWithNoRatingInfoClaim);
     // return res.json(user.loa3UserWithNoMilitaryHistoryClaim);
@@ -157,7 +157,7 @@ const responses = {
     //   .json(serviceHistory.generateServiceHistoryError('403'));
   },
   'GET /v0/disability_compensation_form/rating_info':
-    ratingInfo.success.serviceConnected40,
+    ratingInfo.success.serviceConnectedNoRating,
   'PUT /v0/profile/telephones': (req, res) => {
     if (req?.body?.phoneNumber === '1111111') {
       return res.json(phoneNumber.transactions.receivedNoChangesDetected);

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -83,7 +83,7 @@ const responses = {
     // return res.json(user.badAddress); // user with bad address
     // return res.json(user.loa3User); // user with loa3
     // return res.json(user.nonVeteranUser); // non-veteran user
-    /// return res.json(user.externalServiceError); // external service error
+    // return res.json(user.externalServiceError); // external service error
     // return res.json(user.loa3UserWithNoMobilePhone); // user with no mobile phone number
     // return res.json(user.loa3UserWithNoEmail); // user with no email address
     // return res.json(user.loa3UserWithNoEmailOrMobilePhone); // user without email or mobile phone

--- a/src/platform/user/profile/actions/index.js
+++ b/src/platform/user/profile/actions/index.js
@@ -41,15 +41,18 @@ export function profileError() {
 const hasError = dataPayload =>
   dataPayload?.errors?.length > 0 || dataPayload?.meta?.errors?.length > 0;
 
-const extractProfileErrors = dataPayload => {
+export const extractProfileErrors = dataPayload => {
   const metaDescriptions = dataPayload?.meta?.errors?.reduce(
-    (acc, error) =>
-      error?.description ? `${acc} | ${error.description}` : acc,
+    (acc, error, index) =>
+      error?.description
+        ? `${acc}${index > 0 ? ' | ' : ''}${error.description}`
+        : acc,
     '',
   );
 
   const mainErrors = dataPayload?.errors?.reduce(
-    (acc, error) => (error?.title ? `${acc} | ${error.title}` : acc),
+    (acc, error, index) =>
+      error?.title ? `${acc}${index > 0 ? ' | ' : ''}${error.title}` : acc,
     '',
   );
 
@@ -64,6 +67,7 @@ const extractProfileErrors = dataPayload => {
 export function refreshProfile(
   forceCacheClear = false,
   localQuery = { local: 'none' },
+  recordAnalyticsEvent = recordEvent,
 ) {
   const query = {
     now: new Date().getTime(),
@@ -94,7 +98,7 @@ export function refreshProfile(
       eventData['error-key'] = errorKey;
     }
 
-    recordEvent(eventData);
+    recordAnalyticsEvent(eventData);
 
     dispatch(updateProfileFields(payload));
     return payload;

--- a/src/platform/user/tests/profile/actions/index.unit.spec.js
+++ b/src/platform/user/tests/profile/actions/index.unit.spec.js
@@ -1,0 +1,117 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import * as actions from 'platform/user/profile/actions'; // Replace with actual path
+import { mockApiRequest } from 'platform/testing/unit/helpers';
+
+describe('profile actions', () => {
+  let dispatch;
+  let recordEventSpy;
+
+  beforeEach(() => {
+    dispatch = sinon.spy();
+    recordEventSpy = sinon.spy();
+  });
+
+  it('creates UPDATE_PROFILE_FIELDS when updating profile fields', () => {
+    const expectedAction = {
+      type: actions.UPDATE_PROFILE_FIELDS,
+      payload: { test: 'data' },
+    };
+    expect(actions.updateProfileFields({ test: 'data' })).to.deep.equal(
+      expectedAction,
+    );
+  });
+
+  // Testing thunk around refreshProfile user request
+  it('handles successful profile refresh, and triggers successful GA event', async () => {
+    const mockResponse = {
+      data: { attributes: { profile: { signIn: { serviceName: 'idme' } } } },
+    };
+    mockApiRequest(mockResponse);
+
+    const expectedActions = [
+      { type: actions.UPDATE_PROFILE_FIELDS, payload: mockResponse },
+    ];
+
+    const resultOfFetch = await actions.refreshProfile(
+      false,
+      {
+        local: 'none',
+      },
+      recordEventSpy,
+    )(dispatch);
+
+    expect(dispatch.firstCall.args[0]).to.eql(expectedActions[0]);
+
+    expect(resultOfFetch).to.deep.equal(mockResponse);
+
+    expect(recordEventSpy.firstCall.args[0]).to.eql({
+      event: 'api_call',
+      'api-name': 'GET /v0/user',
+      'api-status': 'successful',
+    });
+  });
+
+  it('handles failed profile refresh, and triggers failure GA event', async () => {
+    const errorResponse = { errors: [{ title: 'API Error' }] };
+    mockApiRequest(errorResponse); // Simulate API failure
+
+    const expectedActions = [
+      { type: actions.UPDATE_PROFILE_FIELDS, payload: errorResponse },
+    ];
+
+    await actions.refreshProfile(false, { local: 'none' }, recordEventSpy)(
+      dispatch,
+    );
+
+    expect(dispatch.firstCall.args[0]).to.eql(expectedActions[0]);
+
+    expect(recordEventSpy.firstCall.args[0]).to.eql({
+      event: 'api_call',
+      'api-name': 'GET /v0/user',
+      'api-status': 'failed',
+      'error-key': 'API Error',
+    });
+  });
+});
+
+describe('extractProfileErrors', () => {
+  it('extracts errors from meta object', () => {
+    const mockDataPayload = {
+      meta: {
+        errors: [
+          { description: 'Meta error 1' },
+          { description: 'Meta error 2' },
+        ],
+      },
+    };
+    const result = actions.extractProfileErrors(mockDataPayload);
+    expect(result).to.equal('Meta error 1 | Meta error 2');
+  });
+
+  it('extracts errors from main errors object', () => {
+    const mockDataPayload = {
+      errors: [{ title: 'Main error 1' }, { title: 'Main error 2' }],
+    };
+    const result = actions.extractProfileErrors(mockDataPayload);
+    expect(result).to.equal('Main error 1 | Main error 2');
+  });
+
+  it('extracts errors from both meta and main errors object', () => {
+    const mockDataPayload = {
+      meta: {
+        errors: [{ description: 'Meta error' }],
+      },
+      errors: [{ title: 'Main error' }],
+    };
+    const result = actions.extractProfileErrors(mockDataPayload);
+    expect(result).to.equal('Meta errorMain error');
+  });
+
+  it('returns default message if no errors found', () => {
+    const mockDataPayload = {};
+    const result = actions.extractProfileErrors(mockDataPayload);
+    expect(result).to.equal('No error messages found');
+  });
+});


### PR DESCRIPTION
## Summary

- GA events for the User endpoint are firing for success and failures, but there aren't any error keys being sent with the failures.
- Created a function to extract any potential error messages from vets-api OR the downstream systems systems.
- Adds error key string if possible to the GA event

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/69598

## Testing done

- added unit tests for extracting the error messages from various error response formats
- also added unit tests for the refreshProfile fetch action/thunk, since there weren't any

## Screenshots

No UI changes

## What areas of the site does it impact?

Profile and instances when user endpoint is requested and GA events fire for the request result.

## Acceptance criteria

Error key sent to GA when user endpoint request returns an error

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution