### PR TITLE
MHV 53639 Secure Messaging content for North Chicago transition to Cerner 

### DIFF
--- a/src/applications/mhv/secure-messaging/components/Alerts/CernerTransitioningFacilityAlert.jsx
+++ b/src/applications/mhv/secure-messaging/components/Alerts/CernerTransitioningFacilityAlert.jsx
@@ -4,6 +4,7 @@ import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utiliti
 import { selectUser } from '@department-of-veterans-affairs/platform-user/selectors';
 import { mhvUrl } from '@department-of-veterans-affairs/platform-site-wide/utilities';
 import { getCernerURL } from '~/platform/utilities/cerner';
+import { CernerTransitioningFacilities } from '../../util/constants';
 
 const CernerTransitioningFacilityAlert = () => {
   const { featureToggles } = useSelector(state => state);
@@ -21,8 +22,12 @@ const CernerTransitioningFacilityAlert = () => {
 
   const isTranstioningFacility = useMemo(
     () => {
-      const transitioningFacilities = [556];
-
+      const transitioningFacilities = [
+        CernerTransitioningFacilities.NORTH_CHICAGO,
+      ];
+      if (!facilities) {
+        return false;
+      }
       return facilities?.some(
         facility =>
           !facility.isCerner &&

--- a/src/applications/mhv/secure-messaging/components/Alerts/CernerTransitioningFacilityAlert.jsx
+++ b/src/applications/mhv/secure-messaging/components/Alerts/CernerTransitioningFacilityAlert.jsx
@@ -1,30 +1,22 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import { selectUser } from '@department-of-veterans-affairs/platform-user/selectors';
-import { mhvUrl } from '@department-of-veterans-affairs/platform-site-wide/utilities';
-import { getCernerURL } from '~/platform/utilities/cerner';
 import { CernerTransitioningFacilities } from '../../util/constants';
 
 const CernerTransitioningFacilityAlert = () => {
-  const { featureToggles } = useSelector(state => state);
   const user = useSelector(selectUser);
   const { facilities } = user.profile;
+  const { vistaFacilities } = useSelector(
+    state => state.drupalStaticData.vamcEhrData.data,
+  );
 
-  const cernerTransition556T30 = useMemo(
-    () => {
-      return featureToggles[FEATURE_FLAG_NAMES.cernerTransition556T30]
-        ? featureToggles[FEATURE_FLAG_NAMES.cernerTransition556T30]
-        : false;
-    },
-    [featureToggles],
+  const transitioningFacilities = useMemo(
+    () => [CernerTransitioningFacilities.NORTH_CHICAGO],
+    [],
   );
 
   const isTranstioningFacility = useMemo(
     () => {
-      const transitioningFacilities = [
-        CernerTransitioningFacilities.NORTH_CHICAGO,
-      ];
       if (!facilities) {
         return false;
       }
@@ -32,32 +24,40 @@ const CernerTransitioningFacilityAlert = () => {
         transitioningFacilities.includes(parseInt(facility.facilityId, 10)),
       );
     },
-    [facilities],
+    [facilities, transitioningFacilities],
+  );
+
+  const transitioningFacilitiesName = useMemo(
+    () => {
+      if (!vistaFacilities) {
+        return [];
+      }
+      return vistaFacilities.filter(facility =>
+        transitioningFacilities.includes(parseInt(facility.vhaId, 10)),
+      )[0].vamcSystemName;
+    },
+    [vistaFacilities, transitioningFacilities],
   );
 
   return (
-    cernerTransition556T30 &&
     isTranstioningFacility && (
-      <va-alert status="warning" class="vads-u-margin-top--2">
-        <h2 slot="headline">
-          New: Portions of My HealtheVet Transitioning to My VA Health
-        </h2>
+      <va-alert status="warning" class="vads-u-margin-y--2">
+        <h1 slot="headline">Your health facility is moving to My VA Health</h1>
         <div>
           <p>
-            Your VA health record or portions of it may be managed on My VA
-            Health.{' '}
-            <a href={mhvUrl(false, 'transitioning-to-my-va-health-learn-more')}>
-              Learn more
-            </a>{' '}
-            about steps you may take in your My HealtheVet account, such as
-            getting a list of scheduled appointments.
-          </p>
-          <p>
-            Visit <strong>My VA Health</strong> at{' '}
-            <a href={getCernerURL('')} rel="noreferrer" target="_blank">
-              {getCernerURL('').split('?')[0]}
-            </a>
-            .
+            <strong>{transitioningFacilitiesName}</strong> is moving to our My
+            VA Health portal.
+            <ul>
+              <li>
+                Starting on <strong>March 4,</strong> you won’t be able to use
+                this My HealtheVet tool to send messages to care teams at this
+                facility.
+              </li>
+              <li>
+                Starting on <strong>March 9,</strong> you can use the new My VA
+                Health portal to send messages to these care teams.
+              </li>
+            </ul>
           </p>
         </div>
       </va-alert>

--- a/src/applications/mhv/secure-messaging/components/Alerts/CernerTransitioningFacilityAlert.jsx
+++ b/src/applications/mhv/secure-messaging/components/Alerts/CernerTransitioningFacilityAlert.jsx
@@ -28,10 +28,8 @@ const CernerTransitioningFacilityAlert = () => {
       if (!facilities) {
         return false;
       }
-      return facilities?.some(
-        facility =>
-          !facility.isCerner &&
-          transitioningFacilities.includes(parseInt(facility.facilityId, 10)),
+      return facilities?.some(facility =>
+        transitioningFacilities.includes(parseInt(facility.facilityId, 10)),
       );
     },
     [facilities],

--- a/src/applications/mhv/secure-messaging/components/Alerts/CernerTransitioningFacilityAlert.jsx
+++ b/src/applications/mhv/secure-messaging/components/Alerts/CernerTransitioningFacilityAlert.jsx
@@ -40,7 +40,7 @@ const CernerTransitioningFacilityAlert = () => {
   return (
     cernerTransition556T30 &&
     isTranstioningFacility && (
-      <va-alert status="warning">
+      <va-alert status="warning" class="vads-u-margin-top--2">
         <h2 slot="headline">
           New: Portions of My HealtheVet Transitioning to My VA Health
         </h2>

--- a/src/applications/mhv/secure-messaging/components/Alerts/CernerTransitioningFacilityAlert.jsx
+++ b/src/applications/mhv/secure-messaging/components/Alerts/CernerTransitioningFacilityAlert.jsx
@@ -1,8 +1,13 @@
 import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
+import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 
 const CernerTransitioningFacilityAlert = props => {
   const { recipients } = props;
+  const cernerTransition556T30 = useSelector(
+    state => state.featureToggles[FEATURE_FLAG_NAMES.cernerTransition556T30],
+  );
 
   const isTranstioningFacility = useMemo(
     () => {
@@ -16,6 +21,7 @@ const CernerTransitioningFacilityAlert = props => {
   );
 
   return (
+    cernerTransition556T30 &&
     isTranstioningFacility && (
       <va-alert status="warning">
         <h2 slot="headline">Cerner Transition Alert</h2>

--- a/src/applications/mhv/secure-messaging/components/Alerts/CernerTransitioningFacilityAlert.jsx
+++ b/src/applications/mhv/secure-messaging/components/Alerts/CernerTransitioningFacilityAlert.jsx
@@ -2,6 +2,8 @@ import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
+import { mhvUrl } from '@department-of-veterans-affairs/platform-site-wide/utilities';
+import { getCernerURL } from '~/platform/utilities/cerner';
 
 const CernerTransitioningFacilityAlert = props => {
   const { recipients } = props;
@@ -24,9 +26,26 @@ const CernerTransitioningFacilityAlert = props => {
     cernerTransition556T30 &&
     isTranstioningFacility && (
       <va-alert status="warning">
-        <h2 slot="headline">Cerner Transition Alert</h2>
+        <h2 slot="headline">
+          New: Portions of My HealtheVet Transitioning to My VA Health
+        </h2>
         <div>
-          <p>This facility will be transitioning to Cerner</p>
+          <p>
+            Your VA health record or portions of it may be managed on My VA
+            Health.{' '}
+            <a href={mhvUrl(false, 'transitioning-to-my-va-health-learn-more')}>
+              Learn more
+            </a>{' '}
+            about steps you may take in your My HealtheVet account, such as
+            getting a list of scheduled appointments.
+          </p>
+          <p>
+            Visit <strong>My VA Health</strong> at{' '}
+            <a href={getCernerURL('')} rel="noreferrer" target="_blank">
+              {getCernerURL('').split('?')[0]}
+            </a>
+            .
+          </p>
         </div>
       </va-alert>
     )

--- a/src/applications/mhv/secure-messaging/components/Alerts/CernerTransitioningFacilityAlert.jsx
+++ b/src/applications/mhv/secure-messaging/components/Alerts/CernerTransitioningFacilityAlert.jsx
@@ -1,0 +1,34 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+
+const CernerTransitioningFacilityAlert = props => {
+  const { recipients } = props;
+
+  const isTranstioningFacility = useMemo(
+    () => {
+      const transitioningFacilities = [556];
+
+      return recipients.some(recipient =>
+        transitioningFacilities.includes(parseInt(recipient.stationNumber, 10)),
+      );
+    },
+    [recipients],
+  );
+
+  return (
+    isTranstioningFacility && (
+      <va-alert status="warning">
+        <h2 slot="headline">Cerner Transition Alert</h2>
+        <div>
+          <p>This facility will be transitioning to Cerner</p>
+        </div>
+      </va-alert>
+    )
+  );
+};
+
+CernerTransitioningFacilityAlert.propTypes = {
+  recipients: PropTypes.array.isRequired,
+};
+
+export default CernerTransitioningFacilityAlert;

--- a/src/applications/mhv/secure-messaging/components/Alerts/CernerTransitioningFacilityAlert.jsx
+++ b/src/applications/mhv/secure-messaging/components/Alerts/CernerTransitioningFacilityAlert.jsx
@@ -1,25 +1,35 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import PropTypes from 'prop-types';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
+import { selectUser } from '@department-of-veterans-affairs/platform-user/selectors';
 import { mhvUrl } from '@department-of-veterans-affairs/platform-site-wide/utilities';
 import { getCernerURL } from '~/platform/utilities/cerner';
 
-const CernerTransitioningFacilityAlert = props => {
-  const { recipients } = props;
-  const cernerTransition556T30 = useSelector(
-    state => state.featureToggles[FEATURE_FLAG_NAMES.cernerTransition556T30],
+const CernerTransitioningFacilityAlert = () => {
+  const { featureToggles } = useSelector(state => state);
+  const user = useSelector(selectUser);
+  const { facilities } = user.profile;
+
+  const cernerTransition556T30 = useMemo(
+    () => {
+      return featureToggles[FEATURE_FLAG_NAMES.cernerTransition556T30]
+        ? featureToggles[FEATURE_FLAG_NAMES.cernerTransition556T30]
+        : false;
+    },
+    [featureToggles],
   );
 
   const isTranstioningFacility = useMemo(
     () => {
       const transitioningFacilities = [556];
 
-      return recipients.some(recipient =>
-        transitioningFacilities.includes(parseInt(recipient.stationNumber, 10)),
+      return facilities?.some(
+        facility =>
+          !facility.isCerner &&
+          transitioningFacilities.includes(parseInt(facility.facilityId, 10)),
       );
     },
-    [recipients],
+    [facilities],
   );
 
   return (
@@ -50,10 +60,6 @@ const CernerTransitioningFacilityAlert = props => {
       </va-alert>
     )
   );
-};
-
-CernerTransitioningFacilityAlert.propTypes = {
-  recipients: PropTypes.array.isRequired,
 };
 
 export default CernerTransitioningFacilityAlert;

--- a/src/applications/mhv/secure-messaging/components/MessageList/CernerFacilityAlert.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageList/CernerFacilityAlert.jsx
@@ -26,7 +26,7 @@ const CernerFacilityAlert = () => {
     <>
       {cernerFacilities?.length > 0 && (
         <va-alert
-          className="vads-u-margin-bottom--2"
+          class="vads-u-margin-bottom--2"
           status="warning"
           background-only
           close-btn-aria-label="Close notification"

--- a/src/applications/mhv/secure-messaging/components/MessageList/FolderHeader.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageList/FolderHeader.jsx
@@ -20,6 +20,7 @@ import CernerTransitioningFacilityAlert from '../Alerts/CernerTransitioningFacil
 const FolderHeader = props => {
   const { folder, searchProps, threadCount } = props;
   const location = useLocation();
+  const { featureToggles } = useSelector(state => state);
 
   const cernerFacilitiesPresent = useSelector(
     state => state.sm.facilities.cernerFacilities.length > 0,
@@ -34,6 +35,15 @@ const FolderHeader = props => {
       state.featureToggles[
         FEATURE_FLAG_NAMES.mhvSecureMessagingBlockedTriageGroup1p0
       ],
+  );
+
+  const cernerTransition556T30 = useMemo(
+    () => {
+      return featureToggles[FEATURE_FLAG_NAMES.cernerTransition556T30]
+        ? featureToggles[FEATURE_FLAG_NAMES.cernerTransition556T30]
+        : false;
+    },
+    [featureToggles],
   );
 
   const folderDescription = useMemo(
@@ -84,12 +94,13 @@ const FolderHeader = props => {
         {handleHeader(folder.folderId, folder)}
       </h1>
 
+      {cernerTransition556T30 &&
+        folder.folderId === Folders.INBOX.id && (
+          <CernerTransitioningFacilityAlert />
+        )}
+
       {folder.folderId === Folders.INBOX.id &&
         cernerFacilitiesPresent && <CernerFacilityAlert />}
-
-      {folder.folderId === Folders.INBOX.id && (
-        <CernerTransitioningFacilityAlert />
-      )}
 
       {mhvSecureMessagingBlockedTriageGroup1p0 ? (
         <>

--- a/src/applications/mhv/secure-messaging/components/MessageList/FolderHeader.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageList/FolderHeader.jsx
@@ -22,9 +22,7 @@ const FolderHeader = props => {
   const location = useLocation();
   const { featureToggles } = useSelector(state => state);
 
-  const cernerFacilitiesPresent = useSelector(
-    state => state.sm.facilities.cernerFacilities.length > 0,
-  );
+  const cernerFacilities = useSelector(state => state.user.profile.facilities);
 
   const { noAssociations, allTriageGroupsBlocked } = useSelector(
     state => state.sm.recipients,
@@ -44,6 +42,19 @@ const FolderHeader = props => {
         : false;
     },
     [featureToggles],
+  );
+
+  const cernerFacilitiesPresent = useMemo(
+    () => {
+      if (cernerTransition556T30) {
+        const facilities = cernerFacilities.filter(
+          facility => facility.isCerner && facility.facilityId !== '556',
+        );
+        return facilities.length > 0;
+      }
+      return cernerFacilities?.length > 0;
+    },
+    [cernerFacilities, cernerTransition556T30],
   );
 
   const folderDescription = useMemo(

--- a/src/applications/mhv/secure-messaging/components/MessageList/FolderHeader.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageList/FolderHeader.jsx
@@ -15,6 +15,7 @@ import SearchForm from '../Search/SearchForm';
 import ComposeMessageButton from '../MessageActionButtons/ComposeMessageButton';
 import CernerFacilityAlert from './CernerFacilityAlert';
 import BlockedTriageGroupAlert from '../shared/BlockedTriageGroupAlert';
+import CernerTransitioningFacilityAlert from '../Alerts/CernerTransitioningFacilityAlert';
 
 const FolderHeader = props => {
   const { folder, searchProps, threadCount } = props;
@@ -85,6 +86,10 @@ const FolderHeader = props => {
 
       {folder.folderId === Folders.INBOX.id &&
         cernerFacilitiesPresent && <CernerFacilityAlert />}
+
+      {folder.folderId === Folders.INBOX.id && (
+        <CernerTransitioningFacilityAlert />
+      )}
 
       {mhvSecureMessagingBlockedTriageGroup1p0 ? (
         <>

--- a/src/applications/mhv/secure-messaging/containers/LandingPageAuth.jsx
+++ b/src/applications/mhv/secure-messaging/containers/LandingPageAuth.jsx
@@ -10,9 +10,10 @@ Assumptions that may need to be addressed:
 then additional functionality will need to be added to account for this.
 */
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
+import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import { retrieveFolder } from '../actions/folders';
 import { DefaultFolders as Folder, PageTitles } from '../util/constants';
 import { updatePageTitle } from '../util/helpers';
@@ -28,7 +29,17 @@ const LandingPageAuth = () => {
   const dispatch = useDispatch();
   const fullState = useSelector(state => state);
   const inbox = useSelector(state => state.sm.folders?.folder);
+  const { featureToggles } = useSelector(state => state);
   const [prefLink, setPrefLink] = useState('');
+
+  const cernerTransition556T30 = useMemo(
+    () => {
+      return featureToggles[FEATURE_FLAG_NAMES.cernerTransition556T30]
+        ? featureToggles[FEATURE_FLAG_NAMES.cernerTransition556T30]
+        : false;
+    },
+    [featureToggles],
+  );
 
   useEffect(
     () => {
@@ -53,7 +64,9 @@ const LandingPageAuth = () => {
     <div className="dashboard">
       <AlertBackgroundBox />
       <h1>Messages</h1>
-      <CernerTransitioningFacilityAlert />
+
+      {cernerTransition556T30 && <CernerTransitioningFacilityAlert />}
+
       <p className="va-introtext">
         Communicate privately and securely with your VA health care team online.
       </p>

--- a/src/applications/mhv/secure-messaging/containers/LandingPageAuth.jsx
+++ b/src/applications/mhv/secure-messaging/containers/LandingPageAuth.jsx
@@ -28,7 +28,6 @@ const LandingPageAuth = () => {
   const dispatch = useDispatch();
   const fullState = useSelector(state => state);
   const inbox = useSelector(state => state.sm.folders?.folder);
-  const { allRecipients } = fullState.sm.recipients;
   const [prefLink, setPrefLink] = useState('');
 
   useEffect(
@@ -54,7 +53,7 @@ const LandingPageAuth = () => {
     <div className="dashboard">
       <AlertBackgroundBox />
       <h1>Messages</h1>
-      <CernerTransitioningFacilityAlert recipients={allRecipients} />
+      <CernerTransitioningFacilityAlert />
       <p className="va-introtext">
         Communicate privately and securely with your VA health care team online.
       </p>

--- a/src/applications/mhv/secure-messaging/containers/LandingPageAuth.jsx
+++ b/src/applications/mhv/secure-messaging/containers/LandingPageAuth.jsx
@@ -22,11 +22,13 @@ import FrequentlyAskedQuestions from '../components/FrequentlyAskedQuestions';
 import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
 import { isAuthenticatedWithSSOe } from '~/platform/user/authentication/selectors';
 import AlertBackgroundBox from '../components/shared/AlertBackgroundBox';
+import CernerTransitioningFacilityAlert from '../components/Alerts/CernerTransitioningFacilityAlert';
 
 const LandingPageAuth = () => {
   const dispatch = useDispatch();
   const fullState = useSelector(state => state);
   const inbox = useSelector(state => state.sm.folders?.folder);
+  const { allRecipients } = fullState.sm.recipients;
   const [prefLink, setPrefLink] = useState('');
 
   useEffect(
@@ -52,6 +54,7 @@ const LandingPageAuth = () => {
     <div className="dashboard">
       <AlertBackgroundBox />
       <h1>Messages</h1>
+      <CernerTransitioningFacilityAlert recipients={allRecipients} />
       <p className="va-introtext">
         Communicate privately and securely with your VA health care team online.
       </p>

--- a/src/applications/mhv/secure-messaging/tests/components/Alerts/CernerTransitioningFacilityAlert.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/Alerts/CernerTransitioningFacilityAlert.unit.spec.jsx
@@ -6,13 +6,33 @@ import { CernerTransitioningFacilities } from '../../../util/constants';
 
 describe('CernerTransitioningFacilityAlert', () => {
   const initialState = {
-    featureToggles: {},
+    drupalStaticData: {
+      vamcEhrData: {
+        data: {
+          vistaFacilities: [
+            {
+              vhaId: '556',
+              vamcSystemName: 'Lovell Federal health care - VA',
+            },
+          ],
+        },
+      },
+    },
+    featureToggles: [],
     user: {
       profile: {
         facilities: [],
       },
     },
   };
+
+  const alertTitle = 'Your health facility is moving to My VA Health';
+  const alertContent =
+    'Lovell Federal health care - VA is moving to our My VA Health portal.';
+  const alertContent2 =
+    'Starting on March 4, you won’t be able to use this My HealtheVet tool to send messages to care teams at this facility.';
+  const alertContent3 =
+    'Starting on March 9, you can use the new My VA Health portal to send messages to these care teams.';
 
   const setup = (state = initialState) => {
     return renderWithStoreAndRouter(<CernerTransitioningFacilityAlert />, {
@@ -22,7 +42,7 @@ describe('CernerTransitioningFacilityAlert', () => {
 
   it('should render the alert when feature toggle is enabled and user has transitioning facilities', () => {
     const customState = {
-      featureToggles: [],
+      ...initialState,
       user: {
         profile: {
           facilities: [
@@ -36,56 +56,17 @@ describe('CernerTransitioningFacilityAlert', () => {
     };
     customState.featureToggles[`${'cerner_transition_556_t30'}`] = true;
 
-    const { getByText, findByText } = setup(customState);
+    const { findByText, container } = setup(customState);
 
-    expect(
-      findByText(
-        'New: Portions of My HealtheVet Transitioning to My VA Health',
-      ),
-    ).to.exist;
-    expect(
-      getByText(
-        'Your VA health record or portions of it may be managed on My VA Health.',
-        { exact: false },
-      ),
-    ).to.exist;
-    expect(getByText('Learn more')).to.exist;
-  });
-
-  it('should not render the alert when feature toggle is disabled', () => {
-    const customState = {
-      featureToggles: [],
-      user: {
-        profile: {
-          facilities: [
-            {
-              facilityId: CernerTransitioningFacilities.NORTH_CHICAGO,
-              isCerner: false,
-            },
-          ],
-        },
-      },
-    };
-    customState.featureToggles[`${'cerner_transition_556_t30'}`] = false;
-
-    const { queryByText } = setup(customState);
-    expect(
-      queryByText(
-        'New: Portions of My HealtheVet Transitioning to My VA Health',
-      ),
-    ).to.be.null;
-    expect(
-      queryByText(
-        'Your VA health record or portions of it may be managed on My VA Health.',
-      ),
-    ).to.be.null;
-    expect(queryByText('Learn more')).to.be.null;
-    expect(queryByText('Visit My VA Health at')).to.be.null;
+    expect(findByText(alertTitle)).to.exist;
+    expect(container.textContent).to.contain(alertContent);
+    expect(container.textContent).to.contain(alertContent2);
+    expect(container.textContent).to.contain(alertContent3);
   });
 
   it('should not render the alert when user does not have transitioning facilities', () => {
     const customState = {
-      featureToggles: [],
+      ...initialState,
       user: {
         profile: {
           facilities: [
@@ -99,24 +80,16 @@ describe('CernerTransitioningFacilityAlert', () => {
     };
     customState.featureToggles[`${'cerner_transition_556_t30'}`] = true;
 
-    const { queryByText } = setup(customState);
-
-    expect(
-      queryByText(
-        'New: Portions of My HealtheVet Transitioning to My VA Health',
-      ),
-    ).to.be.null;
-    expect(
-      queryByText(
-        'Your VA health record or portions of it may be managed on My VA Health.',
-      ),
-    ).to.be.null;
-    expect(queryByText('Learn more')).to.be.null;
-    expect(queryByText('Visit My VA Health at')).to.be.null;
+    const { queryByText, container } = setup(customState);
+    expect(queryByText(alertTitle)).to.be.null;
+    expect(container.textContent).to.not.contain(alertContent);
+    expect(container.textContent).to.not.contain(alertContent2);
+    expect(container.textContent).to.not.contain(alertContent3);
   });
 
   it('should not render when no facilites are fetched', () => {
     const customState = {
+      ...initialState,
       featureToggles: [],
       user: {
         profile: {
@@ -126,51 +99,10 @@ describe('CernerTransitioningFacilityAlert', () => {
     };
     customState.featureToggles[`${'cerner_transition_556_t30'}`] = true;
 
-    const { queryByText } = setup(customState);
-
-    expect(
-      queryByText(
-        'New: Portions of My HealtheVet Transitioning to My VA Health',
-      ),
-    ).to.be.null;
-    expect(
-      queryByText(
-        'Your VA health record or portions of it may be managed on My VA Health.',
-      ),
-    ).to.be.null;
-    expect(queryByText('Learn more')).to.be.null;
-    expect(queryByText('Visit My VA Health at')).to.be.null;
-  });
-
-  it('should not render the alert post transition', () => {
-    const customState = {
-      featureToggles: [],
-      user: {
-        profile: {
-          facilities: [
-            {
-              facilityId: CernerTransitioningFacilities.NORTH_CHICAGO,
-              isCerner: true,
-            },
-          ],
-        },
-      },
-    };
-    customState.featureToggles[`${'cerner_transition_556_t30'}`] = true;
-
-    const { queryByText } = setup(customState);
-
-    expect(
-      queryByText(
-        'New: Portions of My HealtheVet Transitioning to My VA Health',
-      ),
-    ).to.be.null;
-    expect(
-      queryByText(
-        'Your VA health record or portions of it may be managed on My VA Health.',
-      ),
-    ).to.be.null;
-    expect(queryByText('Learn more')).to.be.null;
-    expect(queryByText('Visit My VA Health at')).to.be.null;
+    const { queryByText, container } = setup(customState);
+    expect(queryByText(alertTitle)).to.be.null;
+    expect(container.textContent).to.not.contain(alertContent);
+    expect(container.textContent).to.not.contain(alertContent2);
+    expect(container.textContent).to.not.contain(alertContent3);
   });
 });

--- a/src/applications/mhv/secure-messaging/tests/components/Alerts/CernerTransitioningFacilityAlert.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/components/Alerts/CernerTransitioningFacilityAlert.unit.spec.jsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
+import { expect } from 'chai';
+import CernerTransitioningFacilityAlert from '../../../components/Alerts/CernerTransitioningFacilityAlert';
+import { CernerTransitioningFacilities } from '../../../util/constants';
+
+describe('CernerTransitioningFacilityAlert', () => {
+  const initialState = {
+    featureToggles: {},
+    user: {
+      profile: {
+        facilities: [],
+      },
+    },
+  };
+
+  const setup = (state = initialState) => {
+    return renderWithStoreAndRouter(<CernerTransitioningFacilityAlert />, {
+      initialState: state,
+    });
+  };
+
+  it('should render the alert when feature toggle is enabled and user has transitioning facilities', () => {
+    const customState = {
+      featureToggles: [],
+      user: {
+        profile: {
+          facilities: [
+            {
+              facilityId: CernerTransitioningFacilities.NORTH_CHICAGO,
+              isCerner: false,
+            },
+          ],
+        },
+      },
+    };
+    customState.featureToggles[`${'cerner_transition_556_t30'}`] = true;
+
+    const { getByText, findByText } = setup(customState);
+
+    expect(
+      findByText(
+        'New: Portions of My HealtheVet Transitioning to My VA Health',
+      ),
+    ).to.exist;
+    expect(
+      getByText(
+        'Your VA health record or portions of it may be managed on My VA Health.',
+        { exact: false },
+      ),
+    ).to.exist;
+    expect(getByText('Learn more')).to.exist;
+  });
+
+  it('should not render the alert when feature toggle is disabled', () => {
+    const customState = {
+      featureToggles: [],
+      user: {
+        profile: {
+          facilities: [
+            {
+              facilityId: CernerTransitioningFacilities.NORTH_CHICAGO,
+              isCerner: false,
+            },
+          ],
+        },
+      },
+    };
+    customState.featureToggles[`${'cerner_transition_556_t30'}`] = false;
+
+    const { queryByText } = setup(customState);
+    expect(
+      queryByText(
+        'New: Portions of My HealtheVet Transitioning to My VA Health',
+      ),
+    ).to.be.null;
+    expect(
+      queryByText(
+        'Your VA health record or portions of it may be managed on My VA Health.',
+      ),
+    ).to.be.null;
+    expect(queryByText('Learn more')).to.be.null;
+    expect(queryByText('Visit My VA Health at')).to.be.null;
+  });
+
+  it('should not render the alert when user does not have transitioning facilities', () => {
+    const customState = {
+      featureToggles: [],
+      user: {
+        profile: {
+          facilities: [
+            {
+              facilityId: '998',
+              isCerner: false,
+            },
+          ],
+        },
+      },
+    };
+    customState.featureToggles[`${'cerner_transition_556_t30'}`] = true;
+
+    const { queryByText } = setup(customState);
+
+    expect(
+      queryByText(
+        'New: Portions of My HealtheVet Transitioning to My VA Health',
+      ),
+    ).to.be.null;
+    expect(
+      queryByText(
+        'Your VA health record or portions of it may be managed on My VA Health.',
+      ),
+    ).to.be.null;
+    expect(queryByText('Learn more')).to.be.null;
+    expect(queryByText('Visit My VA Health at')).to.be.null;
+  });
+
+  it('should not render when no facilites are fetched', () => {
+    const customState = {
+      featureToggles: [],
+      user: {
+        profile: {
+          facilities: [],
+        },
+      },
+    };
+    customState.featureToggles[`${'cerner_transition_556_t30'}`] = true;
+
+    const { queryByText } = setup(customState);
+
+    expect(
+      queryByText(
+        'New: Portions of My HealtheVet Transitioning to My VA Health',
+      ),
+    ).to.be.null;
+    expect(
+      queryByText(
+        'Your VA health record or portions of it may be managed on My VA Health.',
+      ),
+    ).to.be.null;
+    expect(queryByText('Learn more')).to.be.null;
+    expect(queryByText('Visit My VA Health at')).to.be.null;
+  });
+
+  it('should not render the alert post transition', () => {
+    const customState = {
+      featureToggles: [],
+      user: {
+        profile: {
+          facilities: [
+            {
+              facilityId: CernerTransitioningFacilities.NORTH_CHICAGO,
+              isCerner: true,
+            },
+          ],
+        },
+      },
+    };
+    customState.featureToggles[`${'cerner_transition_556_t30'}`] = true;
+
+    const { queryByText } = setup(customState);
+
+    expect(
+      queryByText(
+        'New: Portions of My HealtheVet Transitioning to My VA Health',
+      ),
+    ).to.be.null;
+    expect(
+      queryByText(
+        'Your VA health record or portions of it may be managed on My VA Health.',
+      ),
+    ).to.be.null;
+    expect(queryByText('Learn more')).to.be.null;
+    expect(queryByText('Visit My VA Health at')).to.be.null;
+  });
+});

--- a/src/applications/mhv/secure-messaging/tests/containers/CernerFacilityAlert.unit.spec.jsx
+++ b/src/applications/mhv/secure-messaging/tests/containers/CernerFacilityAlert.unit.spec.jsx
@@ -45,7 +45,28 @@ describe('Cerner Facility Alert', () => {
   });
 
   it(`renders CernerFacilityAlert with list of facilities if cernerFacilities.length > 1`, async () => {
-    const screen = setup(initialStateMock, Paths.INBOX, {
+    const customState = {
+      ...initialStateMock,
+      user: {
+        profile: {
+          facilities: [
+            {
+              facilityId: '463',
+              isCerner: true,
+            },
+            {
+              facilityId: '583',
+              isCerner: true,
+            },
+            {
+              facilityId: '668',
+              isCerner: true,
+            },
+          ],
+        },
+      },
+    };
+    const screen = setup(customState, Paths.INBOX, {
       facilities: [],
       cernerFacilities,
     });
@@ -57,7 +78,20 @@ describe('Cerner Facility Alert', () => {
   });
 
   it(`renders CernerFacilityAlert with 1 facility if cernerFacilities.length === 1`, async () => {
-    const screen = setup(initialStateMock, Paths.INBOX, {
+    const customState = {
+      ...initialStateMock,
+      user: {
+        profile: {
+          facilities: [
+            {
+              facilityId: '668',
+              isCerner: true,
+            },
+          ],
+        },
+      },
+    };
+    const screen = setup(customState, Paths.INBOX, {
       facilities: [],
       cernerFacilities: [
         {

--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-message-thread-details.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-message-thread-details.cypress.spec.js
@@ -39,7 +39,6 @@ describe('Secure Messaging Message Details AXE Check', () => {
     // detailsPage.verifyExpandedMessageFromDisplay(mockParentMessageDetails); // TODO need to check the logic on displaying triage grop name only on received messages
     // detailsPage.verifyExpandedMessageIDDisplay(mockParentMessageDetails); //TODO UCD is still determining whether to display this
     detailsPage.verifyExpandedMessageDateDisplay(messageDetails);
-    // cy.get('@messageDetails.all').should('have.length', 4); // TODO leaving it here for SDET review, from my understanding we are not calling for message details 4 times, as we are not expanding all accordions
     // detailsPage.verifyUnexpandedMessageAttachment(1); //TODO attachment icons will be added in a future story
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT, {

--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-message-thread-details.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-message-thread-details.cypress.spec.js
@@ -13,10 +13,17 @@ describe('Secure Messaging Message Details AXE Check', () => {
     const detailsPage = new PatientMessageDetailsPage();
     const site = new SecureMessagingSite();
     site.login();
-    const messageDetails = mockMessageDetails;
     const date = new Date();
     date.setDate(date.getDate() - 2);
-    messageDetails.data.attributes.sentDate = date.toISOString();
+    const messageDetails = {
+      data: {
+        ...mockMessageDetails.data,
+        attributes: {
+          ...mockMessageDetails.data.attributes,
+          sentDate: date.toISOString(),
+        },
+      },
+    };
     cy.log(`New Message Details ==== ${JSON.stringify(messageDetails)}`);
     landingPage.loadInboxMessages(inboxMessages, messageDetails);
     detailsPage.loadMessageDetails(
@@ -31,8 +38,8 @@ describe('Secure Messaging Message Details AXE Check', () => {
     detailsPage.verifyExpandedMessageToDisplay(mockParentMessageDetails);
     // detailsPage.verifyExpandedMessageFromDisplay(mockParentMessageDetails); // TODO need to check the logic on displaying triage grop name only on received messages
     // detailsPage.verifyExpandedMessageIDDisplay(mockParentMessageDetails); //TODO UCD is still determining whether to display this
-    detailsPage.verifyExpandedMessageDateDisplay(mockParentMessageDetails);
-    cy.get('@messageDetails.all').should('have.length', 4);
+    detailsPage.verifyExpandedMessageDateDisplay(messageDetails);
+    // cy.get('@messageDetails.all').should('have.length', 4); // TODO leaving it here for SDET review, from my understanding we are not calling for message details 4 times, as we are not expanding all accordions
     // detailsPage.verifyUnexpandedMessageAttachment(1); //TODO attachment icons will be added in a future story
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT, {

--- a/src/applications/mhv/secure-messaging/util/constants.js
+++ b/src/applications/mhv/secure-messaging/util/constants.js
@@ -383,3 +383,5 @@ export const FormLabels = {
   MESSAGE: 'Message',
   SUBJECT: 'Subject',
 };
+
+export const CernerTransitioningFacilities = { NORTH_CHICAGO: 556 };

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -7,6 +7,8 @@ export default Object.freeze({
   benefitsDocumentsUseLighthouse: 'benefits_documents_use_lighthouse',
   burialFormEnabled: 'burial_form_enabled',
   caregiverUseFacilitiesApi: 'caregiver_use_facilities_API',
+  cernerTransition556T30: 'cerner_transition_556_t30',
+  cernerTransition556T5: 'cerner_transition_556_t5',
   cernerOverride463: 'cerner_override_463',
   cernerOverride531: 'cerner_override_531',
   cernerOverride648: 'cerner_override_648',


### PR DESCRIPTION
## Summary

SM on VA.gov Implement the pre-transition content logic for OH transitions T-30

February 6, 1 AM CT

This includes research and implementation

User Story:  As a Veteran users of a transitioning facility, I want to have limited functionality on messages associated with the transitioning facility so that I do not accidentally send messages that could be lost.

- any SM users that have associations with North Chicago facility station# 556 should start seeing a warning banner notifying them about the upcoming transition of EHR to Cerner
- content should be displayed on My Health SM Landing page and My Health SM Inbox page
-  this functionality is behind a feature flag `cerner_transition_556_t30`, which will be toggled on T-30 as per requirements. The same feature flag should be used for testing in RI 
-  ~~❗ pending final content version~~ Updated content per https://github.com/department-of-veterans-affairs/va.gov-team/issues/74052

## Related issue(s)

- https://jira.devops.va.gov/browse/MHV-53639

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |<img src="https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/3c7a136e-c7b8-47eb-8fe7-fbf41a906390"/> <img src="https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/62204ac6-a8ca-47ed-af66-1584fe2583c4"/>|<img src="https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/68e46947-35f2-4b12-bdfc-3895c5390e96"/><img src="https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/ca0bf951-5a34-45ab-9027-e561d7357698"/>|

## What areas of the site does it impact?

My Health - Secure Messaging

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
