### PR TITLE
Added fix to hyphen bug

### DIFF
--- a/src/applications/ezr/config/chapters/householdInformation/spouseContactInformation.js
+++ b/src/applications/ezr/config/chapters/householdInformation/spouseContactInformation.js
@@ -17,7 +17,13 @@ export default {
   uiSchema: {
     ...titleUI(content['household-spouse-contact-info-title']),
     spouseAddress: addressUI({ omit: ['isMilitary'] }),
-    spousePhone: phoneUI(content['household-sponse-phone-label']),
+    spousePhone: {
+      ...phoneUI(content['household-sponse-phone-label']),
+      'ui:errorMessages': {
+        required: content['phone-number-error-message'],
+        pattern: content['phone-number-error-message'],
+      },
+    },
   },
   schema: {
     type: 'object',

--- a/src/applications/ezr/config/chapters/veteranInformation/contactInformation.js
+++ b/src/applications/ezr/config/chapters/veteranInformation/contactInformation.js
@@ -3,22 +3,33 @@ import PrefillMessage from 'platform/forms/save-in-progress/PrefillMessage';
 import {
   emailUI,
   phoneUI,
-  phoneSchema,
   descriptionUI,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import ContactInfoDescription from '../../../components/FormDescriptions/ContactInfoDescription';
 import content from '../../../locales/en/content.json';
 
-const { email } = ezrSchema.properties;
+const { email, homePhone, mobilePhone } = ezrSchema.properties;
 
 export default {
   uiSchema: {
     ...descriptionUI(PrefillMessage, { hideOnReview: true }),
     'view:contactInformation': {
       ...titleUI(content['vet-contact-info-title'], ContactInfoDescription),
-      homePhone: phoneUI(content['vet-home-phone-label']),
-      mobilePhone: phoneUI(content['vet-mobile-phone-label']),
+      homePhone: {
+        ...phoneUI(content['vet-home-phone-label']),
+        'ui:errorMessages': {
+          required: content['phone-number-error-message'],
+          pattern: content['phone-number-error-message'],
+        },
+      },
+      mobilePhone: {
+        ...phoneUI(content['vet-mobile-phone-label']),
+        'ui:errorMessages': {
+          required: content['phone-number-error-message'],
+          pattern: content['phone-number-error-message'],
+        },
+      },
       email: emailUI(),
     },
   },
@@ -28,8 +39,8 @@ export default {
       'view:contactInformation': {
         type: 'object',
         properties: {
-          homePhone: phoneSchema,
-          mobilePhone: phoneSchema,
+          homePhone,
+          mobilePhone,
           email,
         },
       },

--- a/src/applications/ezr/locales/en/content.json
+++ b/src/applications/ezr/locales/en/content.json
@@ -129,6 +129,7 @@
   "load-enrollment-status": "Verifying your enrollment status...",
   "modal-cancel-button-primary-text": "Yes, cancel %s",
   "modal-cancel-button-secondary-text": "No, continue %s",
+  "phone-number-error-message":"Please enter a 10-digit phone number (Please enter numbers only)",
   "presubmit-error-message": "You must accept the agreement before continuing.",
   "presubmit-checkbox-label": "I confirm that I agree to the statements listed here. The information is true and correct to the best of my knowledge and belief. I\u2019ve read and accept the privacy policy.",
   "review-answer-no": "No", 


### PR DESCRIPTION
## Summary

- Modified phone number input fields to restrict input to numeric characters only.
- Implemented front-end validation to prevent the entry of hyphens and other non-numeric characters.
- Added user-friendly helper text to phone number fields, advising users to enter numbers only.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#74329

## Acceptance criteria
- Ensure phone number input fields only accept numeric characters to match VES/API processing requirements.
- Implement front-end validation to restrict user input to numbers only, preventing the entry of hyphens or other non-numeric characters.
- Include clear, concise helper text near phone number input fields, informing users to "please enter numbers only."
- Collaborate with UX and relevant teams for text clarity and alignment with design standards.