### PR TITLE
Revert segmented progress bar

### DIFF
--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -258,7 +258,7 @@ const formConfig = {
   trackingPrefix: 'pensions-527EZ-',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
-  v3SegmentedProgressBar: true,
+  // v3SegmentedProgressBar: true,
   formId: VA_FORM_IDS.FORM_21P_527EZ,
   saveInProgress: {
     messages: {
@@ -298,7 +298,7 @@ const formConfig = {
   // showReviewErrors: true,
   // when true, initial focus on page to H3s by default, and enable page
   // scrollAndFocusTarget (selector string or function to scroll & focus)
-  useCustomScrollAndFocus: true,
+  // useCustomScrollAndFocus: true,
   footerContent: FormFooter,
   getHelp: GetFormHelp,
   errorText: ErrorText,


### PR DESCRIPTION
## Summary
Revert the segmented progress bar on the Pension Benefits application(21P-527EZ)

## How to run in local environment
1. Check out this branch locally
2. In your local environment, set the `pension_form_enabled` flipper to 'enabled' at http://localhost:3000/flipper/features/pension_form_enabled
3. Run `vets-website` and `vets-api`

## How to verify
1. Go to `http://localhost:3001/pension/application/527EZ` in your browser
2. Start or continue the application
3. Verify the application is able to be saved and submitted

## Screenshots
| Before | After |
| ------ | ------ |
|![localhost_3001_pension_application_527EZ_v3_segmented-progress-bar](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/e7e6196d-b2f7-4aec-b426-ca868fa48426)|![localhost_3001_pension_application_527EZ_segmented-progress-bar](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/21401dfa-3701-485d-b2fd-a56ebd46f3b3)


## Related issue(s)
[Epic in Github]()

## Testing done
- [ ] Existing unit tests updated
- [ ] New unit tests added


## What areas of the site does it impact?
Pension Benefits Application

## Acceptance criteria
[Ticket in Github]()

### Quality Assurance & Testing
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

