### PR TITLE
Opt into v3 alert component

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -172,15 +172,12 @@ class IntroductionPage extends React.Component {
                 </li>
               </ul>
               {isBDDForm ? (
-                <va-alert
-                  class="vads-u-margin-bottom--1"
-                  slim
-                  status="info"
-                  uswds
-                >
-                  Please be aware that you’ll need to be available for 45 days
-                  after you file a BDD claim to complete a VA exam.
-                </va-alert>
+                <va-featured-content class="vads-u-margin-bottom--1" uswds>
+                  <strong>
+                    Please be aware that you’ll need to be available for 45 days
+                    after you file a BDD claim to complete a VA exam.
+                  </strong>
+                </va-featured-content>
               ) : (
                 <>
                   <p>

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -172,12 +172,7 @@ class IntroductionPage extends React.Component {
                 </li>
               </ul>
               {isBDDForm ? (
-                <va-alert
-                  class="vads-u-margin-bottom--1"
-                  slim
-                  status="info"
-                  uswds
-                >
+                <va-alert slim status="info" uswds>
                   Please be aware that you’ll need to be available for 45 days
                   after you file a BDD claim to complete a VA exam.
                 </va-alert>

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -137,7 +137,7 @@ class IntroductionPage extends React.Component {
                     this required form:{' '}
                     <a href={DBQ_URL} target="_blank" rel="noreferrer">
                       Separation Health Assessment - Part A Self-Assessment
-                      (opens in a new tab)
+                      (opens in new tab)
                     </a>
                     . We recommend you download and fill out this form on a
                     desktop computer or laptop. Then return to this page to
@@ -172,12 +172,15 @@ class IntroductionPage extends React.Component {
                 </li>
               </ul>
               {isBDDForm ? (
-                <div className="usa-alert usa-alert-info background-color-only vads-u-margin-bottom--4">
-                  <strong className="usa-alert-body">
-                    Please be aware that you’ll need to be available for 45 days
-                    after you file a BDD claim to complete a VA exam.
-                  </strong>
-                </div>
+                <va-alert
+                  class="vads-u-margin-bottom--1"
+                  slim
+                  status="info"
+                  uswds
+                >
+                  Please be aware that you’ll need to be available for 45 days
+                  after you file a BDD claim to complete a VA exam.
+                </va-alert>
               ) : (
                 <>
                   <p>
@@ -216,27 +219,25 @@ class IntroductionPage extends React.Component {
                 .
               </p>
               {!isBDDForm && (
-                <div>
-                  <div className="usa-alert usa-alert-info">
-                    <div className="usa-alert-body">
-                      <h4 className="vads-u-font-size--h6">
-                        Disability ratings
-                      </h4>
-                      <p>
-                        For each disability, we assign a rating from 0% to 100%.
-                        We base this rating on the evidence you turn in with
-                        your claim. In some cases we may also ask you to have an
-                        exam to help us rate your disability.
-                      </p>
-                      <p>
-                        Before filing a claim for increase, you might want to
-                        check to see if you’re already receiving the maximum
-                        disability rating for your condition.
-                      </p>
-                    </div>
-                  </div>
-                  <br />
-                </div>
+                <va-alert
+                  class="vads-u-margin-bottom--1"
+                  slim
+                  status="info"
+                  uswds
+                >
+                  <h4 className="vads-u-font-size--h6">Disability ratings</h4>
+                  <p>
+                    For each disability, we assign a rating from 0% to 100%. We
+                    base this rating on the evidence you turn in with your
+                    claim. In some cases we may also ask you to have an exam to
+                    help us rate your disability.
+                  </p>
+                  <p className="vads-u-margin-y--0">
+                    Before filing a claim for increase, you might want to check
+                    to see if you’re already receiving the maximum disability
+                    rating for your condition.
+                  </p>
+                </va-alert>
               )}
             </li>
             <li className="process-step list-two">

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -172,7 +172,12 @@ class IntroductionPage extends React.Component {
                 </li>
               </ul>
               {isBDDForm ? (
-                <va-alert slim status="info" uswds>
+                <va-alert
+                  class="vads-u-margin-bottom--1"
+                  slim
+                  status="info"
+                  uswds
+                >
                   Please be aware that you’ll need to be available for 45 days
                   after you file a BDD claim to complete a VA exam.
                 </va-alert>
@@ -214,12 +219,7 @@ class IntroductionPage extends React.Component {
                 .
               </p>
               {!isBDDForm && (
-                <va-alert
-                  class="vads-u-margin-bottom--1"
-                  slim
-                  status="info"
-                  uswds
-                >
+                <va-alert slim status="info" uswds>
                   <h4 className="vads-u-font-size--h6">Disability ratings</h4>
                   <p>
                     For each disability, we assign a rating from 0% to 100%. We

--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -12,7 +12,9 @@ const Alert = ({ content, title }) => (
   <div className="vads-l-grid-container vads-u-padding-left--0 vads-u-padding-bottom--5">
     <div className="usa-content">
       <h1>{title}</h1>
-      <va-alert status="error">{content}</va-alert>
+      <va-alert status="error" uswds>
+        {content}
+      </va-alert>
     </div>
   </div>
 );

--- a/src/applications/disability-benefits/all-claims/content/adaptiveBenefits.jsx
+++ b/src/applications/disability-benefits/all-claims/content/adaptiveBenefits.jsx
@@ -36,5 +36,7 @@ const doubleAllowanceAlertContent = (
 );
 
 export const doubleAllowanceAlert = (
-  <va-alert status="warning">{doubleAllowanceAlertContent}</va-alert>
+  <va-alert status="warning" uswds>
+    {doubleAllowanceAlertContent}
+  </va-alert>
 );

--- a/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
@@ -56,7 +56,7 @@ export const increaseAndNewAlert = ({ formContext }) => {
   );
 
   return (
-    <va-alert status="error">
+    <va-alert status="error" uswds>
       <h3 slot="headline">We need you to add a disability</h3>
       {alertContent}
     </va-alert>

--- a/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/addDisabilities.jsx
@@ -21,7 +21,7 @@ export const newOnlyAlert = ({ formContext }) => {
   // Display only after the user tries to submit with no disabilities
   if (!formContext.submitted) return null;
   return (
-    <va-alert status="error">
+    <va-alert status="error" uswds>
       <h3 slot="headline">We need you to add a disability</h3>
       <p className="vads-u-font-size--base">
         You need to add a new disability to claim. We can’t process your claim

--- a/src/applications/disability-benefits/all-claims/content/bddConfirmationAlert.jsx
+++ b/src/applications/disability-benefits/all-claims/content/bddConfirmationAlert.jsx
@@ -18,7 +18,7 @@ export const bddConfirmationHeadline =
 export const BddConfirmationAlert = () => {
   return (
     <div className="vads-u-margin-top--2">
-      <va-alert status="warning">
+      <va-alert status="warning" uswds>
         <h3 slot="headline">{bddConfirmationHeadline}</h3>
         {alertContent}
       </va-alert>

--- a/src/applications/disability-benefits/all-claims/content/bddEvidenceSubmitLater.jsx
+++ b/src/applications/disability-benefits/all-claims/content/bddEvidenceSubmitLater.jsx
@@ -5,7 +5,7 @@ const alertContent = (
   <p className="vads-u-font-size--base">
     You’ll need to submit your completed{' '}
     <a href={DBQ_URL} target="_blank" rel="noreferrer">
-      Separation Health Assessment - Part A Self-Assessment (opens in a new tab)
+      Separation Health Assessment - Part A Self-Assessment (opens in new tab)
     </a>{' '}
     so we can request your VA exams. You can submit this form on VA.gov after
     you file your BDD claim.
@@ -14,7 +14,7 @@ const alertContent = (
 
 export const BddEvidenceSubmitLater = () => {
   return (
-    <va-alert id="submit-evidence-later" status="warning">
+    <va-alert id="submit-evidence-later" status="warning" uswds>
       <h3 slot="headline">
         Submit your Separation Health Assessment - Part A Self-Assessment as
         soon as you can

--- a/src/applications/disability-benefits/all-claims/content/claimExamsInfo.jsx
+++ b/src/applications/disability-benefits/all-claims/content/claimExamsInfo.jsx
@@ -61,8 +61,7 @@ export const claimExamsFAQ = (
             rel="noreferrer"
           >
             {' '}
-            contact an Overseas Military Services Coordinator (opens in a new
-            tab)
+            contact an Overseas Military Services Coordinator (opens in new tab)
           </a>{' '}
           for help scheduling a claim exam.
         </p>

--- a/src/applications/disability-benefits/all-claims/content/claimExamsInfo.jsx
+++ b/src/applications/disability-benefits/all-claims/content/claimExamsInfo.jsx
@@ -7,7 +7,7 @@ export const claimExamsDescription = (
       (also known as a C&P exam).
     </p>
 
-    <va-alert status="warning">
+    <va-alert status="warning" uswds>
       <h3 slot="headline">
         You might receive a phone call from an unfamiliar number to schedule
         your exam
@@ -20,7 +20,7 @@ export const claimExamsDescription = (
       <p>
         You can go to your{' '}
         <a href="/profile" target="_blank" rel="noreferrer">
-          VA.gov profile (opens in a new tab)
+          VA.gov profile (opens in new tab)
         </a>{' '}
         to confirm your phone number.
       </p>

--- a/src/applications/disability-benefits/all-claims/content/common.jsx
+++ b/src/applications/disability-benefits/all-claims/content/common.jsx
@@ -53,8 +53,7 @@ export const bddAlertBegin = (
     <p className="vads-u-font-size--base">
       You’ll need to upload your completed{' '}
       <a href={DBQ_URL} target="_blank" rel="noreferrer">
-        Separation Health Assessment - Part A Self-Assessment (opens in a new
-        tab)
+        Separation Health Assessment - Part A Self-Assessment (opens in new tab)
       </a>{' '}
       so we can request your VA exams. Use a desktop computer or laptop to
       download and fill out the form.

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -32,7 +32,7 @@ const template = (props, title, content, submissionMessage, messageType) => {
   if (messageType === 'error') {
     return (
       <>
-        <va-alert visible status={messageType}>
+        <va-alert visible status={messageType} uswds>
           <h2 slot="headline">{title}</h2>
           {content}
         </va-alert>
@@ -53,7 +53,7 @@ const template = (props, title, content, submissionMessage, messageType) => {
         <h2>{pageTitle}</h2>
       </div>
 
-      <va-alert visible status={messageType}>
+      <va-alert visible status={messageType} uswds>
         <h2 slot="headline">{title}</h2>
         {content}
       </va-alert>

--- a/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
@@ -19,7 +19,7 @@ export const itfMessage = (headline, content, status) => (
   // Inline style to match .full-page-alert bottom margin because usa-grid > :last-child has a
   //  bottom margin of 0 and overrides it
   <div className="full-page-alert itf-wrapper">
-    <va-alert visible status={status}>
+    <va-alert visible status={status} uswds>
       <h2 slot="headline">{headline}</h2>
       {content}
     </va-alert>

--- a/src/applications/disability-benefits/all-claims/content/ratedDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ratedDisabilities.jsx
@@ -65,7 +65,7 @@ export const disabilitiesClarification = (
 export const ratedDisabilitiesAlert = ({ formContext }) => {
   if (!formContext.submitted) return null;
   return (
-    <va-alert status="error">
+    <va-alert status="error" uswds>
       <h3 slot="headline">We need you to add a disability</h3>
       <p className="vads-u-font-size--base">
         You’ll need to add a new disability or choose a rated disability to

--- a/src/applications/disability-benefits/all-claims/content/selfAssessmentAlert.jsx
+++ b/src/applications/disability-benefits/all-claims/content/selfAssessmentAlert.jsx
@@ -17,7 +17,7 @@ export const selfAssessmentHeadline =
 export const selfAssessmentAlert = () => {
   return (
     <>
-      <va-alert status="warning">
+      <va-alert status="warning" uswds>
         <h3 slot="headline">{selfAssessmentHeadline}</h3>
         {alertContent}
       </va-alert>

--- a/src/applications/disability-benefits/all-claims/content/serviceTreatmentRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/serviceTreatmentRecords.jsx
@@ -10,7 +10,7 @@ const alertContent = (
 
 export const serviceTreatmentRecordsSubmitLater = (
   <div id="submit-str-asap" className="service-treatment-records-submit-later">
-    <va-alert status="warning">
+    <va-alert status="warning" uswds>
       <h3 slot="headline">
         Please submit your service treatment records as soon as possible
       </h3>

--- a/src/applications/disability-benefits/all-claims/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -98,7 +98,7 @@ describe('ConfirmationPage', () => {
       'Submit your Separation Health Assessment - Part A Self-Assessment now if you haven’t already',
     );
     tree.getByText(
-      'Separation Health Assessment - Part A Self-Assessment (opens in a new tab)',
+      'Separation Health Assessment - Part A Self-Assessment (opens in new tab)',
     );
   });
 


### PR DESCRIPTION
## Summary
-Opt in to v3 styling for alert components in 526
-Minor content updates to align with [content guidance](https://design.va.gov/content-style-guide/links#linking-to-external-sites) 
-Two changes to convert from markup + utility styling to v3 component for ui/ux consistency and future maintainability

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#74189

## Testing done
-Manual, visual verification. Updated unit test and verified e2e tests still pass

## Screenshots & Manual testing
Before and after screenshots. (before on the left, after on the right)
1. MissingServices.jsx
	This can be reproduced by logging in locally with mock user 1
<img width="1445" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/6b7d98d6-5ace-4514-836e-51f4462afeb0">

2. adaptive-benefits > adaptiveBenefits.jsx
On the adpative-benefits page, select
	Do you need help buying or modifying your car? -> Yes
	Have you ever been granted an automobile allowance? -> Yes
<img width="1167" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/2ea70555-88a6-4b3a-8510-2a03680d910c">

3. new-disabilities/add > addDisabilities.jsx > newOnlyAlert
On the new-disabilities page, do not add any new conditions. Click Continue button
<img width="1172" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/e790c3f9-9711-4a00-964d-8b604a12dc9e">

4. new-disabilities/add > addDisabilities.jsx > increaseAndNewAlert
For claim type, make sure to set both new and CFI.
Couldn't find a local test user with RD, so couldn't reproduce this manually. e2e produces the validation error, by setting the following data in `src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json`, and run `all-claims.cypress.spec.js`
```	    
"view:claimType": {
   "view:claimingIncrease": true,
  "view:claimingNew": true
},
...		
newDisabilities: []
```
<img width="1311" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/91eaba9d-cbc7-44c8-b138-aa6faed25e87">

5. disabilities/rated-disabilities > ratedDisabilities.jsx > ratedDisabilitiesAlert
repro similar to item 4 above

```
"view:claimType": {
   "view:claimingIncrease": true,
   "view:claimingNew": false
 },
```

for each item in `ratedDisabilities[]`, set `"view:selected": false`
<img width="1486" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/fc077cf3-2dd5-4993-bd64-675b27848537">

6. /supporting-evidence/additional-evidence 
Start bdd claim. On the /supporting-evidence/evidence-types-bdd page, select 'Yes' and check 'Required Separation Health Assessment - Part A Self-Assessment'    
<img width="1356" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/5fd9d6a9-10c3-4d70-8bcb-6dcef5c85ec1">

7. confirmation
Displayed after successful submit of BDD claim
<img width="1360" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/fbe56463-fa5e-46f4-b766-238904de508f">

8. supporting-evidence/evidence-types-bdd
Start bdd claim. In the '/supporting-evidence/evidence-types-bdd page select 'No, I will submit more information later'
<img width="1414" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/56dbbb24-73b4-4026-a96a-9ee4d716bd1f">

9. how-claims-exams-work
no special instructions, just navigate to the page
<img width="1353" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/d8013196-40ab-4a8c-9ee9-b96bb737d3ce">

10. confirmation-page (retryable error)
Submit a claim. This warning happens often on local and staging.
<img width="1423" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/d03d14d4-4024-4dab-bb6c-7512a9da9996">

11. confirmation-page (error)
not sure how to repro this one 

12. itf wrapper
Start a new claim or come back to an in progress application
<img width="1420" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/b56247ab-bf16-4da6-9df9-4c0a6ffdcb19">

13. /supporting-evidence/service-treatment-records
Start a BDD claim. On the service-treatment-records page, select 'No, I will submit them later'
<img width="1427" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/ef7acb22-5475-492f-a830-7da5d48fcfb7">

14. introduction
No need to sign in, just go to the intro page. This one includes a change from markup + utility classes to using the `va-alert` component. This is using the `slim` version of the alert component since there is already another alert component higher up on the page.
<img width="1423" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/4a4b42d8-077d-41b7-9ecc-f4072b95f0cb">

15. introduction
Start bdd flow. Change from markup + utility classes to `va-featured-content` component
<img width="1433" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/737b070c-1baa-49b2-930e-5cfb3199ea8a">


## What areas of the site does it impact?
526ez

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
