### PR TITLE
download txt on details page

### DIFF
--- a/src/applications/mhv/medications/tests/e2e/medications-download-txt-details-page.cypress.spec.js
+++ b/src/applications/mhv/medications/tests/e2e/medications-download-txt-details-page.cypress.spec.js
@@ -1,4 +1,3 @@
-import moment from 'moment-timezone';
 import MedicationsSite from './med_site/MedicationsSite';
 import MedicationsDetailsPage from './pages/MedicationsDetailsPage';
 import MedicationsListPage from './pages/MedicationsListPage';
@@ -6,7 +5,7 @@ import mockPrescriptionDetails from './fixtures/prescription-details.json';
 import MedicationsLandingPage from './pages/MedicationsLandingPage';
 
 describe('Medications Details Page Download', () => {
-  it('visits Medications Details Page Download PDF Dropdown', () => {
+  it('visits Medications Details Page Download Txt Dropdown', () => {
     const site = new MedicationsSite();
     const listPage = new MedicationsListPage();
     const detailsPage = new MedicationsDetailsPage();
@@ -16,14 +15,9 @@ describe('Medications Details Page Download', () => {
     listPage.clickGotoMedicationsLink();
     detailsPage.clickMedicationHistoryAndDetailsLink(mockPrescriptionDetails);
     listPage.clickPrintOrDownloadThisListDropDown();
-    detailsPage.verifyDownloadMedicationsDetailsAsPDFButtonOnDetailsPage();
-    detailsPage.clickDownloadMedicationDetailsAsPdfOnDetailsPage();
+    detailsPage.clickDownloadMedicationsDetailsAsTxtOnDetailsPage();
     listPage.verifyDownloadCompleteSuccessMessageBanner();
-    site.verifyDownloadedPdfFile(
-      'VA-medications-list-Safari-Mhvtp',
-      moment(),
-      '',
-    );
+    listPage.verifyDownloadTextFileHeadless('Safari', 'Mhvtp', 'Mhvtp, Safari');
     cy.injectAxe();
     cy.axeCheck('main');
   });

--- a/src/applications/mhv/medications/tests/e2e/pages/MedicationsDetailsPage.js
+++ b/src/applications/mhv/medications/tests/e2e/pages/MedicationsDetailsPage.js
@@ -144,10 +144,24 @@ class MedicationsDetailsPage {
       .and('be.enabled');
   };
 
+  clickDownloadMedicationDetailsAsPdfOnDetailsPage = () => {
+    cy.get('[data-testid="download-pdf-button"]').should('be.enabled');
+    cy.get('[data-testid="download-pdf-button"]').click({
+      waitForAnimations: true,
+    });
+  };
+
   verifyDownloadMedicationsDetailsAsPDFButtonOnDetailsPage = () => {
     cy.get('[data-testid="download-pdf-button"]')
       .should('have.text', 'Download a PDF of this page')
       .should('be.enabled');
+  };
+
+  clickDownloadMedicationsDetailsAsTxtOnDetailsPage = () => {
+    cy.get('[data-testid="download-txt-button"]').should('be.enabled');
+    cy.get('[data-testid="download-txt-button"]').click({
+      waitForAnimations: true,
+    });
   };
 
   verifyRefillButtonEnabledOnMedicationsDetailsPage = () => {


### PR DESCRIPTION

# Summary

Automation test scripts are added to verify txt download on details page. When a user navigates to details page, they should be able to click on the print or download button and then click on the pdf or txt download to download the information on the details page. 

## Related issue(s)
Jira link to dev ticket - MHV-51128


## Testing done

Testing is done 150x locally and tests are passing.


## What areas of the site does it impact?

This test is for medications va.gov.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

