### PR TITLE
Update web component patterns to allow for useFormsPattern

### DIFF
--- a/src/applications/simple-forms/mock-simple-forms-patterns/config/form.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/config/form.js
@@ -146,14 +146,14 @@ const formConfig = {
       pages: {
         formsPatternSingleRadio: {
           path: 'forms-pattern-single-radio',
-          title: 'Forms Pattern Single title for review page',
+          title: 'Forms Pattern Single Radio title for review page',
           uiSchema: formsPatternSingleRadio.uiSchema,
           schema: formsPatternSingleRadio.schema,
           depends: includeChapter('formsPattern'),
         },
         formsPatternSingleCheckboxGroup: {
           path: 'forms-pattern-single-checkbox-group',
-          title: 'Forms Pattern Single title for review page',
+          title: 'Forms Pattern Single Checkbox group title for review page',
           uiSchema: formsPatternSingleCheckboxGroup.uiSchema,
           schema: formsPatternSingleCheckboxGroup.schema,
           depends: includeChapter('formsPattern'),

--- a/src/applications/simple-forms/mock-simple-forms-patterns/config/form.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/config/form.js
@@ -18,6 +18,9 @@ import radio from '../pages/mockRadio';
 import radioRelationshipToVeteran from '../pages/mockRadioRelationshipToVeteran';
 import select from '../pages/mockSelect';
 import date from '../pages/mockDate';
+import formsPatternSingleRadio from '../pages/mockFormsPatternSingleRadio';
+import formsPatternSingleCheckboxGroup from '../pages/mockFormsPatternSingleCheckboxGroup';
+import formsPatternMultiple from '../pages/mockFormsPatternMultiple';
 import arraySinglePage from '../pages/mockArraySinglePage';
 import arrayMultiPageAggregateStart from '../pages/mockArrayMultiPageAggregateStart';
 import arrayMultiPageAggregateItem from '../pages/mockArrayMultiPageAggregateItem';
@@ -34,6 +37,7 @@ const chapterSelectInitialData = {
   chapterSelect: {
     textInput: true,
     numberInput: true,
+    formsPattern: true,
     checkbox: true,
     radio: true,
     select: true,
@@ -134,6 +138,32 @@ const formConfig = {
           uiSchema: numberInput.uiSchema,
           schema: numberInput.schema,
           depends: includeChapter('numberInput'),
+        },
+      },
+    },
+    formsPattern: {
+      title: 'Forms Pattern',
+      pages: {
+        formsPatternSingleRadio: {
+          path: 'forms-pattern-single-radio',
+          title: 'Forms Pattern Single title for review page',
+          uiSchema: formsPatternSingleRadio.uiSchema,
+          schema: formsPatternSingleRadio.schema,
+          depends: includeChapter('formsPattern'),
+        },
+        formsPatternSingleCheckboxGroup: {
+          path: 'forms-pattern-single-checkbox-group',
+          title: 'Forms Pattern Single title for review page',
+          uiSchema: formsPatternSingleCheckboxGroup.uiSchema,
+          schema: formsPatternSingleCheckboxGroup.schema,
+          depends: includeChapter('formsPattern'),
+        },
+        formsPatternMultiple: {
+          path: 'forms-pattern-multiple',
+          title: 'Forms Pattern Multiple title for review page',
+          uiSchema: formsPatternMultiple.uiSchema,
+          schema: formsPatternMultiple.schema,
+          depends: includeChapter('formsPattern'),
         },
       },
     },

--- a/src/applications/simple-forms/mock-simple-forms-patterns/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/containers/IntroductionPage.jsx
@@ -44,6 +44,21 @@ class IntroductionPage extends React.Component {
               <Link to="/text-input-address">Text input address</Link>
             </li>
             <li>
+              <Link to="/forms-pattern-single-radio">
+                Forms pattern - single - radio
+              </Link>
+            </li>
+            <li>
+              <Link to="/forms-pattern-single-checkbox-group">
+                Forms pattern - single - checkbox group
+              </Link>
+            </li>
+            <li>
+              <Link to="/forms-pattern-multiple">
+                Forms pattern - multiple - text
+              </Link>
+            </li>
+            <li>
               <Link to="/number-input">Number input</Link>
             </li>
             <li>

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/chapterSelect.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/chapterSelect.js
@@ -27,6 +27,7 @@ export default {
       labels: {
         textInput: 'Text input',
         numberInput: 'Number input',
+        formsPattern: 'Forms pattern',
         checkbox: 'Checkbox',
         select: 'Select',
         radio: 'Radio',
@@ -43,6 +44,7 @@ export default {
       chapterSelect: checkboxGroupSchema([
         'textInput',
         'numberInput',
+        'formsPattern',
         'checkbox',
         'radio',
         'select',

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockDate.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockDate.js
@@ -1,29 +1,24 @@
-import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import {
-  currentOrPastDateUI as currentOrPastDateUIWC,
+  currentOrPastDateUI,
   currentOrPastDateSchema,
-  inlineTitleSchema,
-  inlineTitleUI,
   titleUI,
+  dateOfBirthSchema,
+  dateOfBirthUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    ...titleUI('RJSF'),
-    dateDefault: currentOrPastDateUI('RJSF - Date of birth'),
-    'view:inlineTitle': inlineTitleUI('V3 web components'),
-    dateWCV3: currentOrPastDateUIWC('WC V3 - Date of birth'),
+    ...titleUI('Date web components'),
+    dateWCV3: currentOrPastDateUI('Web component - Generic'),
+    dateOfBirthWCV3: dateOfBirthUI('Web component - Date of birth'),
   },
   schema: {
     type: 'object',
     properties: {
-      dateDefault: {
-        $ref: '#/definitions/date',
-      },
-      'view:inlineTitle': inlineTitleSchema,
       dateWCV3: currentOrPastDateSchema,
+      dateOfBirthWCV3: dateOfBirthSchema,
     },
-    required: ['dateDefault', 'dateWCV3'],
+    required: ['dateWCV3'],
   },
 };

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockFormsPatternMultiple.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockFormsPatternMultiple.js
@@ -25,7 +25,7 @@ export default {
       },
     },
     formsPatternOtherField: {
-      'ui:title': 'ui:title',
+      'ui:title': 'Other field',
       'ui:webComponentField': VaTextInputField,
     },
   },

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockFormsPatternMultiple.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockFormsPatternMultiple.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import VaTextInputField from 'platform/forms-system/src/js/web-component-fields/VaTextInputField';
+
+/** @type {PageSchema} */
+export default {
+  uiSchema: {
+    formsPatternMultiple: {
+      'ui:title': 'Text input',
+      'ui:webComponentField': VaTextInputField,
+      'ui:options': {
+        useFormsPattern: 'multiple',
+        formHeadingLevel: 3,
+        formHeading: 'Forms pattern - multiple',
+        formDescription: (
+          <>
+            <p>
+              Use this when you want the title and description to be attached to
+              the first field, which can include JSX elements, and still be read
+              out by screen readers (for the top field of multiple fields on a
+              page)
+            </p>
+            <p>The error will show only on the field</p>
+          </>
+        ),
+      },
+    },
+    formsPatternOtherField: {
+      'ui:title': 'ui:title',
+      'ui:webComponentField': VaTextInputField,
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      formsPatternMultiple: {
+        type: 'string',
+      },
+      formsPatternOtherField: {
+        type: 'string',
+      },
+    },
+    required: ['formsPatternMultiple', 'formsPatternOtherField'],
+  },
+};

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockFormsPatternSingleCheckboxGroup.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockFormsPatternSingleCheckboxGroup.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import {
+  checkboxGroupSchema,
+  checkboxGroupUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+/** @type {PageSchema} */
+export default {
+  uiSchema: {
+    formsPatternSingleCheckboxGroup: checkboxGroupUI({
+      title: 'Checkbox group',
+      required: true,
+      useFormsPattern: 'single',
+      formHeading: 'Forms pattern - single - checkbox group',
+      formDescription: (
+        <>
+          <p>
+            Use this when you want the title and description to be attached to
+            the first field, which can include JSX elements, and still be read
+            out by screen readers (for a single field on the page)
+          </p>
+          <p>The error will show on the entire block</p>
+        </>
+      ),
+      formHeadingLevel: 3,
+      labels: {
+        '1': 'One',
+        '2': 'Two',
+        '3': 'Three',
+      },
+    }),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      formsPatternSingleCheckboxGroup: checkboxGroupSchema(['1', '2', '3']),
+    },
+    required: ['formsPatternSingleCheckboxGroup'],
+  },
+};

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockFormsPatternSingleRadio.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockFormsPatternSingleRadio.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+  radioSchema,
+  radioUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+/** @type {PageSchema} */
+export default {
+  uiSchema: {
+    formsPatternSingleRadio: radioUI({
+      title: 'Radio',
+      useFormsPattern: 'single',
+      formHeading: 'Forms pattern - single - radio',
+      formDescription: (
+        <>
+          <p>
+            Use this when you want the title and description to be attached to
+            the first field, which can include JSX elements, and still be read
+            out by screen readers (for a single field on the page)
+          </p>
+          <p>The error will show on the entire block</p>
+        </>
+      ),
+      formHeadingLevel: 3,
+      labels: {
+        '1': 'One',
+        '2': 'Two',
+        '3': 'Three',
+      },
+    }),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      formsPatternSingleRadio: radioSchema(['1', '2', '3']),
+    },
+    required: ['formsPatternSingleRadio'],
+  },
+};

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/fixtures/data/default.json
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/fixtures/data/default.json
@@ -76,6 +76,36 @@
     "checkboxGroupTiledWithHeaderLabel":{
       "hasB": true
     },
+    "formsPatternSingleRadio": "1",
+    "formsPatternSingleCheckboxGroup": {
+      "1": true
+    },
+    "formsPatternMultiple": "Test",
+    "formsPatternOtherField": "Test",
+    "exampleArrayOne": [
+      {
+        "facilityName": "facility a",
+        "from": "2000-01-09",
+        "to": "2001-02-09"
+      },
+      {
+        "facilityName": "facility b",
+        "from": "2010-03-03",
+        "to": "2011-12-19"
+      }
+    ],
+    "exampleArrayOne": [
+      {
+        "facilityName": "facility a",
+        "from": "2000-01-09",
+        "to": "2001-02-09"
+      },
+      {
+        "facilityName": "facility b",
+        "from": "2010-03-03",
+        "to": "2011-12-19"
+      }
+    ],
     "exampleArrayOne": [
       {
         "facilityName": "facility a",

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockFormsPatternMultiple.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockFormsPatternMultiple.unit.spec.jsx
@@ -1,14 +1,15 @@
 import {
-  testNumberOfErrorsOnSubmit,
   testNumberOfErrorsOnSubmitForWebComponents,
-  testNumberOfFields,
   testNumberOfWebComponentFields,
 } from '../../../shared/tests/pages/pageTests.spec';
 import formConfig from '../../config/form';
 
-const { schema, uiSchema } = formConfig.chapters.date.pages.date;
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.formsPattern.pages.formsPatternMultiple;
 
-const pageTitle = 'mock date inputs';
+const pageTitle = 'mock forms pattern multiple';
 
 const expectedNumberOfWebComponentFields = 2;
 testNumberOfWebComponentFields(
@@ -19,29 +20,11 @@ testNumberOfWebComponentFields(
   pageTitle,
 );
 
-const expectedNumberOfWebComponentErrors = 1;
+const expectedNumberOfWebComponentErrors = 2;
 testNumberOfErrorsOnSubmitForWebComponents(
   formConfig,
   schema,
   uiSchema,
   expectedNumberOfWebComponentErrors,
-  pageTitle,
-);
-
-const expectedNumberOfFields = 0;
-testNumberOfFields(
-  formConfig,
-  schema,
-  uiSchema,
-  expectedNumberOfFields,
-  pageTitle,
-);
-
-const expectedNumberOfErrors = 0;
-testNumberOfErrorsOnSubmit(
-  formConfig,
-  schema,
-  uiSchema,
-  expectedNumberOfErrors,
   pageTitle,
 );

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockFormsPatternSingleCheckboxGroup.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockFormsPatternSingleCheckboxGroup.unit.spec.jsx
@@ -1,16 +1,17 @@
 import {
-  testNumberOfErrorsOnSubmit,
   testNumberOfErrorsOnSubmitForWebComponents,
-  testNumberOfFields,
   testNumberOfWebComponentFields,
 } from '../../../shared/tests/pages/pageTests.spec';
 import formConfig from '../../config/form';
 
-const { schema, uiSchema } = formConfig.chapters.date.pages.date;
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.formsPattern.pages.formsPatternSingleCheckboxGroup;
 
-const pageTitle = 'mock date inputs';
+const pageTitle = 'mock forms pattern single - checkbox group';
 
-const expectedNumberOfWebComponentFields = 2;
+const expectedNumberOfWebComponentFields = 3;
 testNumberOfWebComponentFields(
   formConfig,
   schema,
@@ -25,23 +26,5 @@ testNumberOfErrorsOnSubmitForWebComponents(
   schema,
   uiSchema,
   expectedNumberOfWebComponentErrors,
-  pageTitle,
-);
-
-const expectedNumberOfFields = 0;
-testNumberOfFields(
-  formConfig,
-  schema,
-  uiSchema,
-  expectedNumberOfFields,
-  pageTitle,
-);
-
-const expectedNumberOfErrors = 0;
-testNumberOfErrorsOnSubmit(
-  formConfig,
-  schema,
-  uiSchema,
-  expectedNumberOfErrors,
   pageTitle,
 );

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockFormsPatternSingleRadio.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockFormsPatternSingleRadio.unit.spec.jsx
@@ -1,16 +1,17 @@
 import {
-  testNumberOfErrorsOnSubmit,
   testNumberOfErrorsOnSubmitForWebComponents,
-  testNumberOfFields,
   testNumberOfWebComponentFields,
 } from '../../../shared/tests/pages/pageTests.spec';
 import formConfig from '../../config/form';
 
-const { schema, uiSchema } = formConfig.chapters.date.pages.date;
+const {
+  schema,
+  uiSchema,
+} = formConfig.chapters.formsPattern.pages.formsPatternSingleRadio;
 
-const pageTitle = 'mock date inputs';
+const pageTitle = 'mock forms pattern single - radio';
 
-const expectedNumberOfWebComponentFields = 2;
+const expectedNumberOfWebComponentFields = 1;
 testNumberOfWebComponentFields(
   formConfig,
   schema,
@@ -25,23 +26,5 @@ testNumberOfErrorsOnSubmitForWebComponents(
   schema,
   uiSchema,
   expectedNumberOfWebComponentErrors,
-  pageTitle,
-);
-
-const expectedNumberOfFields = 0;
-testNumberOfFields(
-  formConfig,
-  schema,
-  uiSchema,
-  expectedNumberOfFields,
-  pageTitle,
-);
-
-const expectedNumberOfErrors = 0;
-testNumberOfErrorsOnSubmit(
-  formConfig,
-  schema,
-  uiSchema,
-  expectedNumberOfErrors,
   pageTitle,
 );

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -227,6 +227,9 @@
  * @property {boolean} [expandContentFocus] Used with expandUnder. When the field expands under, it exclusively shows a vertical, blue bar, is indented, and focuses on the field's input.
  * @property {boolean | (value: string, formData: any) => boolean} [expandUnderCondition] `expandUnderCondition: (value, formData) => !!value`
  * @property {boolean} [forceDivWrapper] Used as an a11y helper when you need to wrap a field in a div
+ * @property {string | JSX.Element} [formDescription] Used with `useFormsPattern`. A JSX or string description that it is also a11y (screen reader) friendly. useFormsPattern and uswds must be true.
+ * @property {string} [formHeading] Used with `useFormsPattern`. Intended to be used as the form page header. useFormsPattern and uswds must be true.
+ * @property {number} [formHeadingLevel] Used with `useFormsPattern`. The header level of the formHeading. useFormsPattern and uswds must be true.
  * @property {boolean} [freeInput] for AutoSuggest widget
  * @property {boolean} [generateIndividualItemHeaders] For array field generation that would use the "new item" logic. Items created before it will now have "item" headers attached to them if there are multiple and it is not the final one in the series.
  * @property {boolean} [hideEmptyValueInReview] Field will not be displayed in review page if empty if set to true
@@ -251,6 +254,7 @@
  * @property {boolean} [reflectInputError] Whether or not to add usa-input--error as class if error message is outside of component.
  * @property {string} [reviewItemHeaderLevel] Optional level for the item-header on Review page - for arrays. Defaults to '5' for a <h5> header-tag.
  * @property {boolean} [useDlWrap] On the review page, moves \<dl\> tag to immediately surrounding the \<dt\> field instead of using a \<div\>. \<dt\> fields should be wrapped in \<dl\> fields, so this fixes that a11y issue. Formats fields horizontally.
+ * @property {'single' | 'multiple'} [useFormsPattern] Used if you want to define the formHeading and formDescription for the web component field, which can include JSX, so it can be read out by screen readers. Accepts 'single' for a single field on the page where the error will show on the entire block, or 'multiple' for multiple fields on the page where the error will show only on the field.
  * @property {boolean} [useHeaderStyling] Enables developer to implement and use alternate style classes for auto generated html elements such as in ObjectField or ArrayField
  * @property {boolean} [uswds] For web components. `true` will use the v3 web components and is the default option for `'ui:webComponentField'` if omitted. `false` will use the v1 web components.
  * @property {React.ReactNode} [viewComponent]

--- a/src/platform/forms-system/src/js/web-component-fields/VaCheckboxGroupField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaCheckboxGroupField.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { VaCheckboxGroup } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import commonFieldMapping from './commonFieldMapping';
+import formsPatternFieldMapping from './formsPatternFieldMapping';
 
 // Combines schema, uiSchema, and formData together
 // for each checkbox for easier access
@@ -60,9 +61,14 @@ export default function VaCheckboxGroupField(props) {
     props.childrenProps.onChange(newVal);
   };
 
+  const { formsPatternProps, formDescriptionSlot } = formsPatternFieldMapping(
+    props,
+  );
+
   return (
     <VaCheckboxGroup
       {...commonFieldMapping(props)}
+      {...formsPatternProps}
       label={props.label}
       labelHeaderLevel={props.uiOptions?.labelHeaderLevel}
       onVaChange={onGroupChange}
@@ -71,6 +77,7 @@ export default function VaCheckboxGroupField(props) {
     >
       <>
         <>
+          {formDescriptionSlot}
           {/* known a11y issue: this will not be read out */}
           {props.textDescription && <p>{props.textDescription}</p>}
           {props.DescriptionField && (

--- a/src/platform/forms-system/src/js/web-component-fields/VaRadioField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaRadioField.jsx
@@ -47,6 +47,7 @@ export default function VaRadioField(props) {
         props.childrenProps.onChange(newVal);
       }}
     >
+      {mappedProps?.children}
       {enumOptions.map((option, index) => {
         return (
           <va-radio-option

--- a/src/platform/forms-system/src/js/web-component-fields/formsPatternFieldMapping.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/formsPatternFieldMapping.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+/** @param {WebComponentFieldProps} props */
+export default function formsPatternFieldMapping(props) {
+  const { uiOptions } = props;
+  let formsPatternProps = {};
+
+  if (uiOptions?.useFormsPattern) {
+    formsPatternProps = {
+      useFormsPattern: uiOptions?.useFormsPattern,
+      formHeading: uiOptions?.formHeading,
+      formHeadingLevel: uiOptions?.formHeadingLevel,
+    };
+  }
+
+  const formDescriptionSlot = uiOptions?.formDescription && (
+    <div slot="form-description">{uiOptions.formDescription}</div>
+  );
+
+  return { formsPatternProps, formDescriptionSlot };
+}

--- a/src/platform/forms-system/src/js/web-component-fields/formsPatternFieldMapping.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/formsPatternFieldMapping.jsx
@@ -2,20 +2,40 @@ import React from 'react';
 
 /** @param {WebComponentFieldProps} props */
 export default function formsPatternFieldMapping(props) {
-  const { uiOptions } = props;
+  const { uiOptions = {} } = props;
+  const {
+    useFormsPattern,
+    formHeading,
+    formHeadingLevel,
+    formDescription,
+  } = uiOptions;
   let formsPatternProps = {};
+  let formDescriptionSlot = null;
 
-  if (uiOptions?.useFormsPattern) {
-    formsPatternProps = {
-      useFormsPattern: uiOptions?.useFormsPattern,
-      formHeading: uiOptions?.formHeading,
-      formHeadingLevel: uiOptions?.formHeadingLevel,
-    };
+  if (
+    !useFormsPattern &&
+    (formHeading || formHeadingLevel || formDescription)
+  ) {
+    throw new Error(
+      '`useFormsPattern` must set when using `formHeading`, `formHeadingLevel`, `formDescription`',
+    );
   }
 
-  const formDescriptionSlot = uiOptions?.formDescription && (
-    <div slot="form-description">{uiOptions.formDescription}</div>
-  );
+  if (useFormsPattern) {
+    if (useFormsPattern !== 'single' && useFormsPattern !== 'multiple') {
+      throw new Error('`useFormsPattern` must set to "single" or "multiple"');
+    }
+
+    formsPatternProps = {
+      useFormsPattern,
+      formHeading,
+      formHeadingLevel,
+    };
+
+    formDescriptionSlot = formDescription && (
+      <div slot="form-description">{formDescription}</div>
+    );
+  }
 
   return { formsPatternProps, formDescriptionSlot };
 }

--- a/src/platform/forms-system/src/js/web-component-fields/vaMemorableDateFieldMapping.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/vaMemorableDateFieldMapping.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import commonFieldMapping from './commonFieldMapping';
+import formsPatternFieldMapping from './formsPatternFieldMapping';
 
 /** @param {WebComponentFieldProps} props */
 export default function vaMemorableDateFieldMapping(props) {
@@ -12,8 +13,13 @@ export default function vaMemorableDateFieldMapping(props) {
     childrenProps,
   } = props;
 
+  const { formsPatternProps, formDescriptionSlot } = formsPatternFieldMapping(
+    props,
+  );
+
   return {
     ...commonFieldMapping(props),
+    ...formsPatternProps,
     value:
       typeof childrenProps.formData === 'undefined'
         ? ''
@@ -21,6 +27,7 @@ export default function vaMemorableDateFieldMapping(props) {
     'month-select': uiOptions?.monthSelect ?? true,
     children: (
       <>
+        {formDescriptionSlot}
         {textDescription && <p>{textDescription}</p>}
         {DescriptionField && (
           <DescriptionField options={uiOptions} index={index} />

--- a/src/platform/forms-system/src/js/web-component-fields/vaRadioFieldMapping.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/vaRadioFieldMapping.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import commonFieldMapping from './commonFieldMapping';
+import formsPatternFieldMapping from './formsPatternFieldMapping';
 
 /** @param {WebComponentFieldProps} props */
 export default function vaRadioFieldMapping(props) {
@@ -12,23 +13,32 @@ export default function vaRadioFieldMapping(props) {
     childrenProps,
   } = props;
 
+  const { formsPatternProps, formDescriptionSlot } = formsPatternFieldMapping(
+    props,
+  );
+
   return {
     ...commonFieldMapping(props),
+    ...formsPatternProps,
     description: textDescription,
     value:
       typeof childrenProps.formData === 'undefined'
         ? false
         : childrenProps.formData,
     labelHeaderLevel: uiOptions?.labelHeaderLevel,
+    headerAriaDescribedby: uiOptions?.headerAriaDescribedby,
     onBlur: () => childrenProps.onBlur(childrenProps.idSchema.$id),
     children: (
-      <div slot="description">
-        {textDescription && <p>{textDescription}</p>}
-        {DescriptionField && (
-          <DescriptionField options={uiOptions} index={index} />
-        )}
-        {!textDescription && !DescriptionField && description}
-      </div>
+      <>
+        {formDescriptionSlot}
+        <div slot="description">
+          {textDescription && <p>{textDescription}</p>}
+          {DescriptionField && (
+            <DescriptionField options={uiOptions} index={index} />
+          )}
+          {!textDescription && !DescriptionField && description}
+        </div>
+      </>
     ),
   };
 }

--- a/src/platform/forms-system/src/js/web-component-fields/vaTextInputFieldMapping.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/vaTextInputFieldMapping.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import commonFieldMapping from './commonFieldMapping';
+import formsPatternFieldMapping from './formsPatternFieldMapping';
 
 /** @param {WebComponentFieldProps} props */
 export default function vaTextInputFieldMapping(props) {
@@ -20,9 +21,13 @@ export default function vaTextInputFieldMapping(props) {
   }
 
   const commonFieldProps = commonFieldMapping(props);
+  const { formsPatternProps, formDescriptionSlot } = formsPatternFieldMapping(
+    props,
+  );
 
   return {
     ...commonFieldProps,
+    ...formsPatternProps,
     autocomplete:
       childrenProps.uiSchema['ui:autocomplete'] || uiOptions?.autocomplete,
     value:
@@ -45,6 +50,7 @@ export default function vaTextInputFieldMapping(props) {
     onBlur: () => childrenProps.onBlur(childrenProps.idSchema.$id),
     children: (
       <>
+        {formDescriptionSlot}
         {textDescription && <p>{textDescription}</p>}
         {DescriptionField && (
           <DescriptionField options={uiOptions} index={index} />

--- a/src/platform/forms-system/src/js/web-component-fields/vaTextareaFieldMapping.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/vaTextareaFieldMapping.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import commonFieldMapping from './commonFieldMapping';
+import formsPatternFieldMapping from './formsPatternFieldMapping';
 
 /** @param {WebComponentFieldProps} props */
 export default function vaTextareaFieldMapping(props) {
@@ -13,9 +14,13 @@ export default function vaTextareaFieldMapping(props) {
   } = props;
 
   const commonFieldProps = commonFieldMapping(props);
+  const { formsPatternProps, formDescriptionSlot } = formsPatternFieldMapping(
+    props,
+  );
 
   return {
     ...commonFieldProps,
+    ...formsPatternProps,
     value:
       typeof childrenProps.formData === 'undefined'
         ? ''
@@ -34,6 +39,7 @@ export default function vaTextareaFieldMapping(props) {
     onBlur: () => childrenProps.onBlur(childrenProps.idSchema.$id),
     children: (
       <>
+        {formDescriptionSlot}
         {textDescription && <p>{textDescription}</p>}
         {DescriptionField && (
           <DescriptionField options={uiOptions} index={index} />


### PR DESCRIPTION
## Summary

- Add `useFormsPattern` properties for web components (Useful for scenarios where you need jsx of a form description read when you focus the header or the field)

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#885

## Testing done

- Browser, unit, e2e testing

## Screenshots

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/ba78113c-18f3-4f0c-90da-320ab133f7e9)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/fa99ee09-b0b9-4e73-8981-6bc3b811df36)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/5951daea-3131-4570-8df5-a7fec63b4beb)

## What areas of the site does it impact?

New feature
Developer is using web component patterns that have complex form descriptions that one to be read out by screen readers

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
