### PR TITLE
NOD and SC | Fix maximum attachment size to match Lighthouse's API limits

### DIFF
--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -155,8 +155,6 @@ export const CLAIMANT_TYPES = [
 
 export const SUPPORTED_UPLOAD_TYPES = ['pdf'];
 
-export const MAX_FILE_SIZE_MB = 100;
-
 export const ITF_STATUSES = {
   active: 'active',
   expired: 'expired',

--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -156,7 +156,6 @@ export const CLAIMANT_TYPES = [
 export const SUPPORTED_UPLOAD_TYPES = ['pdf'];
 
 export const MAX_FILE_SIZE_MB = 100;
-export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 ** 2; // binary based
 
 export const ITF_STATUSES = {
   active: 'active',

--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -153,8 +153,6 @@ export const CLAIMANT_TYPES = [
   // 'other',
 ];
 
-export const SUPPORTED_UPLOAD_TYPES = ['pdf'];
-
 export const ITF_STATUSES = {
   active: 'active',
   expired: 'expired',

--- a/src/applications/appeals/995/content/evidenceUpload.jsx
+++ b/src/applications/appeals/995/content/evidenceUpload.jsx
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 
 import readableList from 'platform/forms-system/src/js/utilities/data/readableList';
 
-import { MAX_FILE_SIZE_MB, SUPPORTED_UPLOAD_TYPES } from '../constants';
+import { SUPPORTED_UPLOAD_TYPES } from '../constants';
+
+import { MAX_FILE_SIZE_MB } from '../../shared/constants';
 
 export const UploadDescription = () => {
   const types = SUPPORTED_UPLOAD_TYPES.map(text => text.toUpperCase());

--- a/src/applications/appeals/995/content/evidenceUpload.jsx
+++ b/src/applications/appeals/995/content/evidenceUpload.jsx
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 
 import readableList from 'platform/forms-system/src/js/utilities/data/readableList';
 
-import { SUPPORTED_UPLOAD_TYPES } from '../constants';
-
-import { MAX_FILE_SIZE_MB } from '../../shared/constants';
+import {
+  MAX_FILE_SIZE_MB,
+  SUPPORTED_UPLOAD_TYPES,
+} from '../../shared/constants';
 
 export const UploadDescription = () => {
   const types = SUPPORTED_UPLOAD_TYPES.map(text => text.toUpperCase());

--- a/src/applications/appeals/995/utils/upload.js
+++ b/src/applications/appeals/995/utils/upload.js
@@ -5,12 +5,9 @@ import _ from 'platform/utilities/data';
 
 import fullSchema from '../config/form-0995-schema.json';
 
-import {
-  EVIDENCE_UPLOAD_API,
-  MAX_FILE_SIZE_BYTES,
-  SUPPORTED_UPLOAD_TYPES,
-} from '../constants';
+import { EVIDENCE_UPLOAD_API, SUPPORTED_UPLOAD_TYPES } from '../constants';
 
+import { MAX_FILE_SIZE_BYTES } from '../../shared/constants';
 import { createPayload } from '../../shared/utils/upload';
 
 export const fileUploadUi = content => {
@@ -33,7 +30,7 @@ export const fileUploadUi = content => {
     buttonText: 'Upload file',
     fileTypes: SUPPORTED_UPLOAD_TYPES,
     maxSize: MAX_FILE_SIZE_BYTES,
-    minSize: 1,
+    minSize: 1, // curious why minsize is 1 vs in 10182 it's 1024
     createPayload,
     parseResponse: (response, file) => {
       setTimeout(() => {

--- a/src/applications/appeals/995/utils/upload.js
+++ b/src/applications/appeals/995/utils/upload.js
@@ -33,7 +33,7 @@ export const fileUploadUi = content => {
     buttonText: 'Upload file',
     fileTypes: SUPPORTED_UPLOAD_TYPES,
     maxSize: MAX_FILE_SIZE_BYTES,
-    minSize: 1, // curious why minsize is 1 vs in 10182 it's 1024
+    minSize: 1,
     createPayload,
     parseResponse: (response, file) => {
       setTimeout(() => {

--- a/src/applications/appeals/995/utils/upload.js
+++ b/src/applications/appeals/995/utils/upload.js
@@ -5,9 +5,12 @@ import _ from 'platform/utilities/data';
 
 import fullSchema from '../config/form-0995-schema.json';
 
-import { EVIDENCE_UPLOAD_API, SUPPORTED_UPLOAD_TYPES } from '../constants';
+import { EVIDENCE_UPLOAD_API } from '../constants';
 
-import { MAX_FILE_SIZE_BYTES } from '../../shared/constants';
+import {
+  MAX_FILE_SIZE_BYTES,
+  SUPPORTED_UPLOAD_TYPES,
+} from '../../shared/constants';
 import { createPayload } from '../../shared/utils/upload';
 
 export const fileUploadUi = content => {

--- a/src/applications/appeals/shared/constants.js
+++ b/src/applications/appeals/shared/constants.js
@@ -68,7 +68,7 @@ export const AMA_DATE = '2019-02-19'; // Appeals Modernization Act in effect
 export const SUPPORTED_UPLOAD_TYPES = ['pdf'];
 
 export const MAX_FILE_SIZE_MB = 100;
-export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 ** 2; // binary based
+export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1000 ** 2; // binary based
 
 /**
  **** MAX LENGTH ****

--- a/src/applications/appeals/shared/constants.js
+++ b/src/applications/appeals/shared/constants.js
@@ -68,7 +68,7 @@ export const AMA_DATE = '2019-02-19'; // Appeals Modernization Act in effect
 export const SUPPORTED_UPLOAD_TYPES = ['pdf'];
 
 export const MAX_FILE_SIZE_MB = 100;
-export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1000 ** 2; // binary based
+export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1000 ** 2;
 
 /**
  **** MAX LENGTH ****


### PR DESCRIPTION
## Summary

_(Summarize the changes that have been made)_
  - Due to errors with file uploads to lighthouse, we noticed we needed to update the MAX_FILE_SIZE in BYTES to match that of Lighthouse API.
      - update `1024` to be `1000`
      - remove `MAX_FILE_SIZE_BYTES` from 995 constants and import from shared
      - _**extra**_: import `MAX_FILE_SIZE_MB` & `SUPPORTED_UPLOAD_TYPES` from shared for 995 - remove from 995
- _(If bug, how to reproduce)_
  - add a file size in between 100,000,000 and 104,857,600 bytes and notice a validation error DOES NOT appear
- _(What is the solution, why is this the solution)_
  - Update file size on frontend so that validation error does show up for that range of MBs in file size
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - Benefits Team 1 - Decision Reviews - Squad 2

## Related issue
 
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#74457

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Supplemental Claims  | <img width="600" alt="SC_File-size_Before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/37054305/627fa46c-d056-4c13-ae4c-bea6ca38dac6"> | <img width="700" alt="SC_File-size_After" src="https://github.com/department-of-veterans-affairs/vets-website/assets/37054305/bec9bac6-43d5-4cd4-9318-476aba1868e9"> |
| Board Appeal (NOD) | <img width="600" alt="NOD_File-size_Before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/37054305/0b765dff-6da2-4f6a-9942-2393dac307d0"> | <img width="700" alt="NOD_File-size_After" src="https://github.com/department-of-veterans-affairs/vets-website/assets/37054305/c02c322d-dc24-491b-8269-c91256c01571"> |

## Testing done

- _Describe what the old behavior was prior to the change_
  - files would not upload because they would exceed file size but an error would not show
- _Describe the steps required to verify your changes are working as expected_
  - In both NOD and SC - upload evidence with the specified file size to test this bug

## What areas of the site does it impact?

* Appeals forms - Supplemental Claims and Notice of Disagreement

## Acceptance criteria

- File size between 100,000,000 and 104,857,600 bytes renders an error:
``` We couldn't upload your flie because it's too big. Please make sure the file is 100MB or less and try again. ```

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed