### PR TITLE
Removed JSON.parse() call from local storage read

### DIFF
--- a/src/applications/representative-search/config.js
+++ b/src/applications/representative-search/config.js
@@ -33,7 +33,7 @@ const baseUrl =
 export const getApi = (endpoint, method = 'GET', requestBody) => {
   const requestUrl = `${baseUrl}${endpoint}`;
 
-  const csrfToken = JSON.parse(localStorage.getItem('csrfToken'));
+  const csrfToken = localStorage.getItem('csrfToken');
 
   const apiSettings = {
     mode: 'cors',

--- a/src/applications/representative-search/sass/find-a-representative.scss
+++ b/src/applications/representative-search/sass/find-a-representative.scss
@@ -32,7 +32,7 @@
               min-width: 10rem;
 
               .location-input {
-                min-width: 46rem;
+                min-width: 48rem;
               }
 
               .use-my-location-button-container {
@@ -44,7 +44,7 @@
             }
 
             .representative-name-input {
-              min-width: 46rem;
+              min-width: 48rem;
             }
           }
         }

--- a/src/applications/representative-search/tests/api-url-parameters.railsEngine.unit.spec.js
+++ b/src/applications/representative-search/tests/api-url-parameters.railsEngine.unit.spec.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { resolveParamsWithUrl, getApi } from '../config';
 
@@ -79,6 +78,12 @@ describe('Locator url and parameters builder', () => {
         environment.API_URL
       }/services/veteran/v0/other_accredited_representatives?address=43210&lat=40.17887&long=-99.27246&name=test&page=2&per_page=7&sort=distance_asc&type=attorney`,
     );
+  });
+
+  it('should set csrfToken in request headers', () => {
+    localStorage.setItem('csrfToken', '12345');
+    const { apiSettings } = getApi('/flag_accredited_representatives');
+    expect(apiSettings?.headers?.['X-CSRF-Token']).to.eql('12345');
   });
 
   it('should exclude null params from request', () => {


### PR DESCRIPTION
## Summary
The getApi() method reads a session token from local storage for inclusion in POST request headers. It included a JSON.parse() call which was causing a syntax error when being called on a regular string. 

This PR also contains a minor styling correction. 

## Testing done

- Wrote unit test to verify csrfToken is being properly read + included in headers

