### PR TITLE
1634 deprecate react modal 1

### DIFF
--- a/src/applications/combined-debt-portal/medical-copays/components/Modals.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/Modals.jsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react';
-import Modal from '@department-of-veterans-affairs/component-library/Modal';
+import {
+  VaModal,
+  VaButton,
+} from '@department-of-veterans-affairs/web-components/react-bindings';
 import PropTypes from 'prop-types';
 
 const Modals = ({ children, title }) => {
@@ -7,20 +10,16 @@ const Modals = ({ children, title }) => {
 
   return (
     <div className="vads-u-margin-top--3 vads-u-margin-bottom--3">
-      <button
-        type="button"
-        className="usa-button-secondary"
-        onClick={() => setVisible(true)}
-      >
-        {title}
-      </button>
-      <Modal
-        onClose={() => setVisible(false)}
+      <VaButton secondary onClick={() => setVisible(true)} text={title} />
+      <VaModal
+        onCloseEvent={() => setVisible(false)}
         visible={visible}
-        title={title}
-        cssClass="va-modal-large"
-        contents={children}
-      />
+        modalTitle={title}
+        large
+        uswds
+      >
+        {children}
+      </VaModal>
     </div>
   );
 };

--- a/src/applications/edu-benefits/1990s/content/OMBInfo.jsx
+++ b/src/applications/edu-benefits/1990s/content/OMBInfo.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Modal from '@department-of-veterans-affairs/component-library/Modal';
+import { VaModal } from '@department-of-veterans-affairs/web-components/react-bindings';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 class OMBInfo extends React.Component {
@@ -96,17 +96,17 @@ class OMBInfo extends React.Component {
           </button>
         </div>
 
-        <Modal
-          cssClass="va-modal-large"
-          contents={
-            this.props.children
-              ? this.props.children
-              : this.modalContents(resBurden)
-          }
+        <VaModal
+          large
           id="omb-modal"
           visible={this.state.modalOpen}
-          onClose={this.closeModal}
-        />
+          onCloseEvent={this.closeModal}
+          uswds
+        >
+          {this.props.children
+            ? this.props.children
+            : this.modalContents(resBurden)}
+        </VaModal>
       </div>
     );
   }

--- a/src/applications/edu-benefits/components/OptOutWizard.jsx
+++ b/src/applications/edu-benefits/components/OptOutWizard.jsx
@@ -27,6 +27,7 @@ export default class OptOutWizard extends React.Component {
           onCloseEvent={this.closeModal}
           modalTitle="Are you sure you want to opt out?"
           visible={this.state.modalOpen}
+          uswds
         >
           <div>
             Here are some things that’ll change if you ask VA to not share your

--- a/src/applications/edu-benefits/components/OptOutWizard.jsx
+++ b/src/applications/edu-benefits/components/OptOutWizard.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Modal from '@department-of-veterans-affairs/component-library/Modal';
+import { VaModal } from '@department-of-veterans-affairs/web-components/react-bindings';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 export default class OptOutWizard extends React.Component {
@@ -20,12 +20,12 @@ export default class OptOutWizard extends React.Component {
     return (
       <div>
         <va-button onClick={this.openModal} text="Opt Out" />
-        <Modal
+        <VaModal
           clickToClose
-          cssClass="va-modal va-modal-large"
+          large
           id="opt-out-alert"
-          onClose={this.closeModal}
-          title="Are you sure you want to opt out?"
+          onCloseEvent={this.closeModal}
+          modalTitle="Are you sure you want to opt out?"
           visible={this.state.modalOpen}
         >
           <div>
@@ -61,7 +61,7 @@ export default class OptOutWizard extends React.Component {
             </a>
             <va-button onClick={this.closeModal} secondary text="Cancel" />
           </div>
-        </Modal>
+        </VaModal>
       </div>
     );
   }

--- a/src/applications/edu-benefits/tests/components/OptOutWizard.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/components/OptOutWizard.unit.spec.jsx
@@ -8,7 +8,7 @@ describe('<OptOutWizard>', () => {
   it('should show opt out button', () => {
     const component = mount(<OptOutWizard />);
 
-    expect(component.find('va-button').length).to.equal(1);
+    expect(component.find('va-button').length).to.equal(2);
     expect(component.state('modalOpen')).to.be.false;
     component.unmount();
   });
@@ -20,7 +20,10 @@ describe('<OptOutWizard>', () => {
 
     const component = mount(<OptOutWizard />);
 
-    component.find('va-button').simulate('click');
+    component
+      .find('va-button')
+      .first()
+      .simulate('click');
     component.update();
     expect(component.state('modalOpen')).to.be.true;
     expect(component.find('va-button').length).to.equal(2);
@@ -38,7 +41,10 @@ describe('<OptOutWizard>', () => {
 
     const component = mount(<OptOutWizard />);
 
-    component.find('va-button').simulate('click');
+    component
+      .find('va-button')
+      .first()
+      .simulate('click');
     component.update();
     component
       .find('va-button')
@@ -46,7 +52,7 @@ describe('<OptOutWizard>', () => {
       .simulate('click');
     component.update();
 
-    expect(component.find('va-button').length).to.equal(1);
+    expect(component.find('va-button').length).to.equal(2);
     expect(component.state('modalOpen')).to.be.false;
 
     delete global.document.focus;


### PR DESCRIPTION
## Summary
Replace react-component versions of modal with web-components version (uswds v3)


## Related issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1634

## Testing done
- updated unit tests, local testing

## What areas of the site does it impact?
- edu_benefits
- combined_debt_portal

## Acceptance criteria

### Quality Assurance & Testing

- [x ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x ] Linting warnings have been addressed
- [x ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x ] Screenshot of the developed feature is added
- [x ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x ] Browser console contains no warnings or errors.
- [x ] Events are being sent to the appropriate logging solution
- [ x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [x ] The vets-website header does not contain any web-components
- [x ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [x ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
