### PR TITLE
Deprecate the Design System ExpandingGroup React component - Burial POC v6

### DIFF
--- a/src/applications/burial-poc-v6/components/ExpandingGroup.jsx
+++ b/src/applications/burial-poc-v6/components/ExpandingGroup.jsx
@@ -1,0 +1,65 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { ReactCSSTransitionGroup } from 'react-transition-group';
+import classnames from 'classnames';
+
+/*
+ * Component that expands to show a hidden child element with a fade in/slide down animation
+ *
+ * Props:
+ * children - expects 2 children, the first is always shown, the second is shown if open is true
+ * open - determines if the second child is displayed
+ * additionalClass - A string added as a class to the parent element of the second child
+ * showPlus - Boolean to display a "+" or "-" icon based on open status
+ */
+export default function ExpandingGroup({
+  children,
+  open,
+  showPlus,
+  additionalClass,
+  expandedContentId,
+}) {
+  const classNames = classnames(
+    'form-expanding-group',
+    { 'form-expanding-group-open': open },
+    { 'form-expanding-group-plus': showPlus },
+  );
+
+  return (
+    <div className={classNames}>
+      {children[0]}
+      <ReactCSSTransitionGroup>
+        id=
+        {expandedContentId}
+        transitionName="form-expanding-group-inner" transitionEnterTimeout=
+        {700}
+        transitionLeave=
+        {false}>
+        {open ? (
+          <div key="removable-group" className={additionalClass}>
+            {children[1]}
+          </div>
+        ) : null}
+      </ReactCSSTransitionGroup>
+    </div>
+  );
+}
+
+ExpandingGroup.propTypes = {
+  /**
+   * Show second child if true
+   */
+  open: PropTypes.bool.isRequired,
+  /**
+   * Class added to parent element of second child component
+   */
+  additionalClass: PropTypes.string,
+  /**
+   * `id` attribute for ReactCSSTransitionGroup
+   */
+  expandedContentId: PropTypes.string,
+  /**
+   * Show a `+` or `-` icon indicating second child's visibility
+   */
+  showPlus: PropTypes.bool,
+};

--- a/src/applications/burial-poc-v6/components/ExpandingGroup.jsx
+++ b/src/applications/burial-poc-v6/components/ExpandingGroup.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { ReactCSSTransitionGroup } from 'react-transition-group';
+import { TransitionGroup } from 'react-transition-group';
 import classnames from 'classnames';
 
 /*
@@ -28,7 +28,7 @@ export default function ExpandingGroup({
   return (
     <div className={classNames}>
       {children[0]}
-      <ReactCSSTransitionGroup>
+      <TransitionGroup>
         id=
         {expandedContentId}
         transitionName="form-expanding-group-inner" transitionEnterTimeout=
@@ -40,7 +40,7 @@ export default function ExpandingGroup({
             {children[1]}
           </div>
         ) : null}
-      </ReactCSSTransitionGroup>
+      </TransitionGroup>
     </div>
   );
 }

--- a/src/applications/burial-poc-v6/pages/ClaimantInformation.jsx
+++ b/src/applications/burial-poc-v6/pages/ClaimantInformation.jsx
@@ -7,7 +7,7 @@ import {
   CheckboxField,
 } from '@department-of-veterans-affairs/va-forms-system-core';
 import { useFormikContext } from 'formik';
-import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
+import ExpandingGroup from '../components/ExpandingGroup';
 
 export default function ClaimantInformation(props) {
   const { values, setFieldValue } = useFormikContext();

--- a/src/applications/burial-poc-v6/pages/PlotAllowance.jsx
+++ b/src/applications/burial-poc-v6/pages/PlotAllowance.jsx
@@ -6,7 +6,7 @@ import {
   NumberField,
 } from '@department-of-veterans-affairs/va-forms-system-core';
 import { useFormikContext } from 'formik';
-import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
+import ExpandingGroup from '../components/ExpandingGroup';
 
 export default function PlotAllowance(props) {
   const formikContext = useFormikContext();

--- a/src/applications/burial-poc-v6/pages/PreviousNames.jsx
+++ b/src/applications/burial-poc-v6/pages/PreviousNames.jsx
@@ -5,7 +5,7 @@ import {
   RadioGroup,
 } from '@department-of-veterans-affairs/va-forms-system-core';
 import { useFormikContext } from 'formik';
-import ExpandingGroup from '@department-of-veterans-affairs/component-library/ExpandingGroup';
+import ExpandingGroup from '../components/ExpandingGroup';
 
 export default function PreviousNames(props) {
   const { values, setFieldValue } = useFormikContext();

--- a/src/applications/burial-poc-v6/tests/ExpandingGroup.unit.spec.jsx
+++ b/src/applications/burial-poc-v6/tests/ExpandingGroup.unit.spec.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import ExpandingGroup from '../components/ExpandingGroup';
+
+describe('<ExpandingGroup>', () => {
+  it('renders only first child when open is false', () => {
+    const wrapper = shallow(
+      <ExpandingGroup open={false}>
+        <div className="first" />
+        <div className="second" />
+      </ExpandingGroup>,
+    );
+
+    const first = wrapper.find('.first');
+    const second = wrapper.find('.second');
+    expect(first).to.have.lengthOf(1);
+    expect(second).to.have.lengthOf(0);
+    wrapper.unmount();
+  });
+
+  it('renders both children when open is true', () => {
+    const wrapper = shallow(
+      <ExpandingGroup open>
+        <div className="first" />
+        <div className="second" />
+      </ExpandingGroup>,
+    );
+
+    const first = wrapper.find('.first');
+    const second = wrapper.find('.second');
+    expect(first).to.have.lengthOf(1);
+    expect(second).to.have.lengthOf(1);
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

The Design System's `ExpandingGroup` React component is deprecated and we need to remove instances of it in vets-website but there is no direct web component equivalent.

This PR adds the ExpandingGroup React component into the app itself so that it will continue to load while also alllowing the Design System Team to remove it from our libary but ideally this component pattern should be replaced with something else. It's our understanding that this application that never made it to production though.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1659

## Testing done

made sure that tests are passing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
