### PR TITLE
Remove deprecated Design System components from eslint rule and GA script

### DIFF
--- a/.eslintrc.changed.js
+++ b/.eslintrc.changed.js
@@ -17,11 +17,6 @@ module.exports = {
         name: '@department-of-veterans-affairs/component-library/TextInput',
         use: '<va-text-input>',
       },
-      {
-        name:
-          '@department-of-veterans-affairs/component-library/ExpandingGroup',
-        use: 'a custom solution',
-      },
     ],
   },
 };

--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -9,17 +9,6 @@ import environment from 'platform/utilities/environment';
 
 const analyticsEvents = {
   Modal: [{ action: 'show', event: 'int-modal-show', prefix: 'modal' }],
-  Accordion: [
-    { action: 'expand', event: 'int-accordion-expand', prefix: 'accordion' },
-    {
-      action: 'collapse',
-      event: 'int-accordion-collapse',
-      prefix: 'accordion',
-    },
-  ],
-  TextInput: [
-    { action: 'blur', event: 'int-text-input-blur', prefix: 'text-input' },
-  ],
   'va-accordion': [
     {
       action: 'expand',


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

This PR removes the eslint and GA code that references design system components that are now deprecated and removed from vets-website.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/1659
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2439

## Testing done

N/A

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
