### PR TITLE
74347 update sponsor info section to match latest design

### DIFF
--- a/src/applications/ivc-champva/10-10D/helpers/wordingCustomization.js
+++ b/src/applications/ivc-champva/10-10D/helpers/wordingCustomization.js
@@ -1,0 +1,5 @@
+// Extracting this to a function so there aren't a thousand identical
+// ternaries we have to change later
+export function sponsorWording(formData) {
+  return formData?.certifierRole === 'sponsor' ? 'Your' : "Sponsor's";
+}

--- a/src/applications/ivc-champva/10-10D/tests/config/form.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10D/tests/config/form.unit.spec.jsx
@@ -21,7 +21,7 @@ testNumberOfWebComponentFields(
   formConfig,
   formConfig.chapters.sponsorInformation.pages.page11.schema,
   formConfig.chapters.sponsorInformation.pages.page11.uiSchema,
-  2,
+  1,
   "Sponsor's phone number",
   { sponsorIsDeceased: false },
 );


### PR DESCRIPTION
## Summary

This PR updates the sponsor information section of the form with new conditional representations of certain pages. Specifically, we update the language across several pages to use personal pronouns when we know the applicant is the Sponsoring individual.

- Added conditional logic for some page titles to either display "Your" or "The Sponsor"
- Added new pages with updated wording based on sponsor status (e.g., "your phone #" vs "the sponsor's phone #")
- Updated a unit test to reflect that we only collect one phone number and not two
- **Team**: IVC-CHAMPVA
- **Flipper**: Not in use, form is not set to go to prod

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/74347

## Testing done

- Manual testing to verify fields behave as expected
- Updated unit tests to match reality of new field layout
- Ran `yarn test:coverage-app ivc-champva/10-10D` to verify existing and updated tests run and pass

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | ![mobile0](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/0de80fc1-6b23-4dbb-a5d2-34bd237cd4f7) | ![mobile](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/d4972189-88b8-411c-87e8-858aeed6e9bf) |
| Desktop | ![desktop0](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/212d81e5-4581-4300-b7ef-5bdf10c3ecb9) | ![desktop](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/42e91e64-3a6c-4704-97ed-ab22c9e73c61) |

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
