### PR TITLE
MHV-54542 Fix inadvertent redirection from MR

### DIFF
--- a/src/applications/mhv/medical-records/containers/App.jsx
+++ b/src/applications/mhv/medical-records/containers/App.jsx
@@ -17,7 +17,7 @@ import PhrRefresh from '../components/shared/PhrRefresh';
 import Navigation from '../components/Navigation';
 import { useDatadogRum } from '../../shared/hooks/useDatadogRum';
 import {
-  selectMhvMrEnabledFlag,
+  flagsLoadedAndMhvEnabled,
   selectSidenavFlag,
   selectVaccinesFlag,
   selectNotesFlag,
@@ -26,14 +26,15 @@ import { resetPagination } from '../actions/pagination';
 
 const App = ({ children }) => {
   const user = useSelector(selectUser);
-  const featureTogglesLoading = useSelector(
-    state => state.featureToggles.loading,
+  const { featureTogglesLoading, appEnabled } = useSelector(
+    flagsLoadedAndMhvEnabled,
+    state => state.featureToggles,
   );
+
   const history = useHistory();
   const dispatch = useDispatch();
 
   // Individual feature flags
-  const appEnabled = useSelector(selectMhvMrEnabledFlag);
   const showSideNav = useSelector(selectSidenavFlag);
   const showVaccines = useSelector(selectVaccinesFlag);
   const showNotes = useSelector(selectNotesFlag);

--- a/src/applications/mhv/medical-records/util/selectors.js
+++ b/src/applications/mhv/medical-records/util/selectors.js
@@ -1,12 +1,22 @@
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 
 // App-level Feature Toggles
+
+/** Keep these two in the same selector to prevent a race-condition when loading. */
+export const flagsLoadedAndMhvEnabled = state => {
+  return {
+    featureTogglesLoading: state.featureToggles.loading,
+    appEnabled:
+      state.featureToggles[FEATURE_FLAG_NAMES.mhvMedicalRecordsToVaGovRelease],
+  };
+};
 export const selectMhvMrEnabledFlag = state =>
   state.featureToggles[FEATURE_FLAG_NAMES.mhvMedicalRecordsToVaGovRelease];
 export const selectSidenavFlag = state =>
   state.featureToggles[FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplaySidenav];
 
 // Domain-level Feature Toggles
+
 export const selectVaccinesFlag = state =>
   state.featureToggles[FEATURE_FLAG_NAMES.mhvMedicalRecordsDisplayVaccines];
 export const selectNotesFlag = state =>


### PR DESCRIPTION
## Summary

I had previously split up the useSelector that loads the `featureTogglesLoading` and `appEnabled` states. By splitting them up I inadvertently caused a race condition that can load the feature toggles, then redirect the page before appEnabled gets set to true. This PR just puts them back together.

## Related issue(s)

### [MHV-54542](https://jira.devops.va.gov/browse/MHV-54542) - Occasionally when loading MR, user is redirected to Health Care ###

> This is happening because of a race-condition in the App.jsx selectors. If the featureTogglesLoading selector is updated before the appEnabled selector, then the application will load and immediately redirect to the Health Care page.
> 
> Merging the two selectors into one should fix this.
> 

## Testing done

- This was caused by a race condition between two redux selectors. I don't believe it can be programmatically tested.
- Manually verified that the feature flag and selectors still work properly. (We also have existing unit tests for this.)

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

MHV MR

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
