### PR TITLE
[Rated Disabilities] - Update files that have va components without the uswds prop for rated-disabilities

### DIFF
--- a/src/applications/rated-disabilities/components/FeatureFlagsLoaded.jsx
+++ b/src/applications/rated-disabilities/components/FeatureFlagsLoaded.jsx
@@ -6,6 +6,7 @@ const loadingIndicator = (
     <va-loading-indicator
       data-testid="feature-flags-loading"
       message="Loading your information..."
+      uswds="false"
     />
   </div>
 );

--- a/src/applications/rated-disabilities/components/Learn.jsx
+++ b/src/applications/rated-disabilities/components/Learn.jsx
@@ -18,6 +18,7 @@ export default function Learn() {
       <va-link
         href="/disability/about-disability-ratings"
         text="About VA disability ratings"
+        uswds="false"
       />
     </div>
   );

--- a/src/applications/rated-disabilities/components/MVIError.jsx
+++ b/src/applications/rated-disabilities/components/MVIError.jsx
@@ -9,7 +9,7 @@ export const headline =
 
 export default function MVIError() {
   return (
-    <va-alert status="warning">
+    <va-alert status="warning" uswds="false">
       <h2 slot="headline">{headline}</h2>
       <div>
         <p>
@@ -28,6 +28,7 @@ export default function MVIError() {
           <va-link
             href={facilityLocatorUrl}
             text="Find your nearest VA medical center"
+            uswds="false"
           />
         </p>
       </div>

--- a/src/applications/rated-disabilities/components/NeedHelp.jsx
+++ b/src/applications/rated-disabilities/components/NeedHelp.jsx
@@ -3,12 +3,14 @@ import { CONTACTS } from '@department-of-veterans-affairs/component-library/cont
 
 export default function NeedHelp() {
   return (
-    <va-need-help class="vads-u-margin-y--3">
+    <va-need-help class="vads-u-margin-y--3" uswds="false">
       <div slot="content">
         <p>
-          You can call us at <va-telephone contact={CONTACTS.VA_BENEFITS} />.
+          You can call us at{' '}
+          <va-telephone contact={CONTACTS.VA_BENEFITS} uswds="false" />. We’re
           We’re here Monday through Friday, 8:00 a.m to 9:00 p.m. ET. If you
-          have hearing loss, call <va-telephone contact={CONTACTS['711']} tty />
+          have hearing loss, call{' '}
+          <va-telephone contact={CONTACTS['711']} tty uswds="false" />
         </p>
       </div>
     </va-need-help>

--- a/src/applications/rated-disabilities/components/RatedDisabilityList.jsx
+++ b/src/applications/rated-disabilities/components/RatedDisabilityList.jsx
@@ -42,8 +42,8 @@ const noDisabilityRatingContent = errorCode => {
         </p>
         <p className="vads-u-font-size--base">
           If you get this error again, please call the VA.gov help desk at{' '}
-          <va-telephone contact={CONTACTS.VA_311} /> (
-          <va-telephone contact={CONTACTS['711']} tty />
+          <va-telephone contact={CONTACTS.VA_311} uswds="false" /> (
+          <va-telephone contact={CONTACTS['711']} tty uswds="false" />
           ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
         </p>
       </>
@@ -73,7 +73,9 @@ const noDisabilityRatingContent = errorCode => {
 
   return (
     <div className="vads-u-margin-y--5">
-      <va-alert status={status}>{content}</va-alert>
+      <va-alert status={status} uswds="false">
+        {content}
+      </va-alert>
     </div>
   );
 };
@@ -101,7 +103,12 @@ const RatedDisabilityList = ({
   };
 
   if (!ratedDisabilities) {
-    return <va-loading-indicator message="Loading your information..." />;
+    return (
+      <va-loading-indicator
+        message="Loading your information..."
+        uswds="false"
+      />
+    );
   }
 
   if (

--- a/src/applications/rated-disabilities/components/RatedDisabilityListItem.jsx
+++ b/src/applications/rated-disabilities/components/RatedDisabilityListItem.jsx
@@ -17,7 +17,7 @@ const RatedDisabilityListItem = ({ ratedDisability }) => {
   const headingText = getHeadingText(ratedDisability);
 
   return (
-    <va-card class="vads-u-margin-bottom--2">
+    <va-card class="vads-u-margin-bottom--2" uswds="false">
       <h4 className="vads-u-margin-y--0 vads-u-font-size--h3">{headingText}</h4>
       {effectiveDate !== null && (
         <div className="vads-u-margin-top--2">

--- a/src/applications/rated-disabilities/components/SortSelect.jsx
+++ b/src/applications/rated-disabilities/components/SortSelect.jsx
@@ -33,6 +33,7 @@ const SortSelect = ({ onSelect, sortBy }) => {
       name="sort-by"
       value={sortBy}
       onVaSelect={handleSelect}
+      uswds="false"
     >
       {sortOptions.map(({ label, value }, i) => (
         <option key={i} value={value}>

--- a/src/applications/rated-disabilities/components/TotalRatedDisabilities.jsx
+++ b/src/applications/rated-disabilities/components/TotalRatedDisabilities.jsx
@@ -17,7 +17,10 @@ const TotalRatedDisabilities = ({ error, loading, totalDisabilityRating }) => {
   // If there is a rating, display the rating and content
   if (loading) {
     content = (
-      <va-loading-indicator message="Loading your total disability rating..." />
+      <va-loading-indicator
+        message="Loading your total disability rating..."
+        uswds="false"
+      />
     );
   } else if (errorCode && isServerError(errorCode)) {
     content = errorMessage();

--- a/src/applications/rated-disabilities/components/TotalRatingStates.jsx
+++ b/src/applications/rated-disabilities/components/TotalRatingStates.jsx
@@ -3,7 +3,7 @@ import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 export const errorMessage = () => (
-  <va-alert status="error">
+  <va-alert status="error" uswds="false">
     <h2 slot="headline" className="vads-u-margin-y--0 vads-u-font-size--h3">
       We’re sorry. Something went wrong on our end
     </h2>
@@ -13,15 +13,15 @@ export const errorMessage = () => (
     </p>
     <p className="vads-u-font-size--base">
       If you get this error again, please call the VA.gov help desk at{' '}
-      <va-telephone contact={CONTACTS.VA_311} /> (
-      <va-telephone contact={CONTACTS['711']} tty />
+      <va-telephone contact={CONTACTS.VA_311} uswds="false" /> (
+      <va-telephone contact={CONTACTS['711']} tty uswds="false" />
       ). We’re here Monday though Friday, 8:00 a.m. to 8:00 p.m. ET.
     </p>
   </va-alert>
 );
 
 export const missingTotalMessage = () => (
-  <va-alert status="info">
+  <va-alert status="info" uswds="false">
     <h2 slot="headline" className="vads-u-margin-y--0 vads-u-font-size--h3">
       We don’t have a combined disability rating on file for you
     </h2>
@@ -33,6 +33,7 @@ export const missingTotalMessage = () => (
     <va-link
       href="/disability/how-to-file-claim"
       text="Learn how to file a claim for disability compensation"
+      uswds="false"
     />
   </va-alert>
 );
@@ -41,7 +42,7 @@ export const totalRatingMessage = totalDisabilityRating => {
   const heading = `Your combined disability rating is ${totalDisabilityRating}%`;
 
   return (
-    <va-featured-content>
+    <va-featured-content uswds="false">
       <h3 slot="headline">{heading}</h3>
       <p>
         This rating doesn’t include any conditions from claims that we’re still


### PR DESCRIPTION
## Summary
February 16th the design team will be upgrading all web-component to their V3 versions. If we would like to be able to use the existing versions (V1), then we will have to manually opt the components out individually using uswds="false".

Did an audit of all files/va components in rated-disabilities that don't have uswds enabled [here](https://docs.google.com/spreadsheets/d/1ajKjN6dr-2PzpgEbfX1OqxAupvbqoHwqh7ml1m5a1Fo/edit?usp=sharing) and then updated the ones that didnt to have uswds="false".

Updated the following files to have uswds="false":
- src/applications/rated-disabilities/components/FeatureFlagsLoaded.jsx
- src/applications/rated-disabilities/components/Learn.jsx
- src/applications/rated-disabilities/components/MVIError.jsx
- src/applications/rated-disabilities/components/NeedHelp.jsx
- src/applications/rated-disabilities/components/RatedDisabilityList.jsx
- src/applications/rated-disabilities/components/RatedDisabilityListItem.jsx
- src/applications/rated-disabilities/components/SortSelect.jsx
- src/applications/rated-disabilities/components/TotalRatedDisabilities.jsx
- src/applications/rated-disabilities/components/TotalRatedDisabilities.jsx
- src/applications/rated-disabilities/components/TotalRatingStates.jsx

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#75050

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## What areas of the site does it impact?

Rated Disabilities

## Acceptance criteria

- [x]  Identify which (if any components) are not utilizing V3 components as part of our design changes for new feature rollouts.
- [x] Ensure that the Rated Disabilities app doesn't break due to V3 component migration
- [x] Update every component to set USDWS to false
- [ ] Communicate with platform team why we're not migrating our components to V3

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
