### PR TITLE
[#1302] Fix button and Rx session event tracking

### DIFF
--- a/src/applications/virtual-agent/components/webchat/helpers/tracking.js
+++ b/src/applications/virtual-agent/components/webchat/helpers/tracking.js
@@ -25,11 +25,14 @@ export const recordRxSession = isRXSkill => {
 };
 
 export const recordButtonClick = event => {
-  if (event.target.classList.contains('webchat__suggested-action')) {
+  if (
+    event.target.classList.contains('webchat__suggested-action') ||
+    event.target.classList.contains('webchat__suggested-action__text')
+  ) {
     // This is a click event on a button
     const buttonText = event.target.innerText;
     const isRxSkill = sessionStorage.getItem(IS_RX_SKILL);
-    if (isRxSkill) {
+    if (isRxSkill === 'true') {
       recordEvent({
         event: 'chatbot-button-click',
         clickText: buttonText,

--- a/src/applications/virtual-agent/tests/components/webchat/helpers/tracking.unit.spec.js
+++ b/src/applications/virtual-agent/tests/components/webchat/helpers/tracking.unit.spec.js
@@ -90,4 +90,51 @@ describe('recordButtonClick', () => {
     expect(recordEventStub.calledOnce).to.be.true;
     expect(recordEventStub.firstCall.args[0]).to.eql(recordEventData);
   });
+  it('should call recordEvent when a user clicks a quickReply button text span with prescriptions topic when in Rx skill', () => {
+    sessionStorage.setItem(IS_RX_SKILL, 'true');
+
+    const recordEventStub = sandbox.stub(recordEventObject, 'default');
+
+    const recordEventData = {
+      event: 'chatbot-button-click',
+      clickText: 'Mock Button Text',
+      topic: 'prescriptions',
+    };
+    const mockButtonClickEvent = {
+      target: {
+        classList: {
+          contains(className) {
+            return this.value.split(' ').includes(className);
+          },
+          value: 'webchat__suggested-action__text',
+        },
+        innerText: 'Mock Button Text',
+      },
+    };
+    recordButtonClick(mockButtonClickEvent);
+
+    expect(recordEventStub.calledOnce).to.be.true;
+    expect(recordEventStub.firstCall.args[0]).to.eql(recordEventData);
+  });
+  it('should not call recordEvent when a user clicks a button without the correct CSS class', () => {
+    sessionStorage.setItem(IS_RX_SKILL, 'true');
+
+    const recordEventStub = sandbox.stub(recordEventObject, 'default');
+
+    const mockButtonClickEvent = {
+      target: {
+        classList: {
+          contains(className) {
+            return this.value.split(' ').includes(className);
+          },
+          value: 'unrecognized_classname',
+        },
+        innerText: 'Mock Button Text',
+      },
+    };
+    recordButtonClick(mockButtonClickEvent);
+
+    expect(recordEventStub.notCalled).to.be.true;
+    expect(recordEventStub.firstCall).to.equal(null);
+  });
 });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- _(Summarize the changes that have been made to the platform)_
  - We made some changes to our chatbot tracking events for button clicks and prescriptions feature usage after reviewing our last implementation with the platform analytics team and finding these issues.
- _(If bug, how to reproduce)_
  - Button click tracking events are not firing when the user clicks the text within the button element inside the chatbot. Only when the user clicks the button element itself.
- _(What is the solution, why is this the solution)_
  - Adding a conditional check for the classname associated with the text span inside the button ensures that recordEvents with fire when the user clicks both the button element or the text inside it. We also tweaked the conditional statement checking whether the user is within the prescriptions feature of the chatbot to check that the flag in session storage indicating if the user is in the feature to evaluate the flag equals "true" (as in type string) instead of true (bool) as everything retrieved from session storage is returned as a string value.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  - I work with the Virtual Agent Chatbot team which owns the maintenance of the component.
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va-virtual-agent#1302
- _Link to Google Analytics Implementation Request in va.gov-team repo_
https://github.com/department-of-veterans-affairs/va.gov-team/issues/72863

## Testing done

- _Describe what the old behavior was prior to the change_
  - Button click tracking events are not firing when the user clicks the text within the button element inside the chatbot. Only when the user clicks the button element itself. Events tracking sessions of users who connect to the prescription skill did not seem to fire at all.
- _Describe the steps required to verify your changes are working as expected_
  - We reviewed our implementation with the analytics team to determine what events were being sent successfully. We found the issue testing locally logging to the browser and wrote additional unit tests to ensure the behavior is what we expect.
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?
These changes are not visual and impact the chatbot exclusively.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
