### PR TITLE
Opt in to v3 breadcrumb

### DIFF
--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -6,7 +6,7 @@ import * as Sentry from '@sentry/browser';
 import { createSelector } from 'reselect';
 import fastLevenshtein from 'fast-levenshtein';
 
-import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
+import { apiRequest } from 'platform/utilities/api';
 import _ from 'platform/utilities/data';
 import { toggleValues } from '@department-of-veterans-affairs/platform-site-wide/selectors';
 import { isValidYear } from 'platform/forms-system/src/js/utilities/validations';

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -679,17 +679,19 @@ export const show526MaxRating = state =>
 
 export const wrapWithBreadcrumb = (title, component) => (
   <>
-    <VaBreadcrumbs
-      uswds
-      breadcrumbList={[
-        { href: '/', label: 'Home' },
-        { href: '/disability', label: 'Disability Benefits' },
-        {
-          href: '/disability/file-disability-claim-form-21-526ez',
-          label: title,
-        },
-      ]}
-    />
+    <div className="row">
+      <VaBreadcrumbs
+        uswds
+        breadcrumbList={[
+          { href: '/', label: 'Home' },
+          { href: '/disability', label: 'Disability Benefits' },
+          {
+            href: '/disability/file-disability-claim-form-21-526ez',
+            label: title,
+          },
+        ]}
+      />
+    </div>
     {component}
   </>
 );

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -1,15 +1,16 @@
 /* eslint-disable react/jsx-key */
+import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
 import * as Sentry from '@sentry/browser';
 import { createSelector } from 'reselect';
 import fastLevenshtein from 'fast-levenshtein';
 
-import { apiRequest } from 'platform/utilities/api';
+import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 import _ from 'platform/utilities/data';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import { toggleValues } from '@department-of-veterans-affairs/platform-site-wide/selectors';
 import { isValidYear } from 'platform/forms-system/src/js/utilities/validations';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import {
@@ -173,6 +174,10 @@ export const ReservesGuardDescription = ({ formData }) => {
       {formatDate(to)}.
     </div>
   );
+};
+
+ReservesGuardDescription.propTypes = {
+  formData: PropTypes.object,
 };
 
 export const title10DatesRequired = formData =>

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -10,6 +10,7 @@ import _ from 'platform/utilities/data';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import { isValidYear } from 'platform/forms-system/src/js/utilities/validations';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import {
   DATA_PATHS,
@@ -678,11 +679,17 @@ export const show526MaxRating = state =>
 
 export const wrapWithBreadcrumb = (title, component) => (
   <>
-    <va-breadcrumbs>
-      <a href="/">Home</a>
-      <a href="/disability">Disability Benefits</a>
-      <a href="/disability/file-disability-claim-form-21-526ez">{title}</a>
-    </va-breadcrumbs>
+    <VaBreadcrumbs
+      uswds
+      breadcrumbList={[
+        { href: '/', label: 'Home' },
+        { href: '/disability', label: 'Disability Benefits' },
+        {
+          href: '/disability/file-disability-claim-form-21-526ez',
+          label: title,
+        },
+      ]}
+    />
     {component}
   </>
 );


### PR DESCRIPTION
## Summary
- Opting into v3 version of breadcrumb component which requires changing the input data from markup to a prop with array of objects
- Some v1 styling was not carried forward to v3, so wrapping the breadcrumbs in a row to retain margins (without this styling the breadcrumbs land way to the left)

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#74193

## Testing done
- Manual visual and a11y testing. Verified unit and e2e tests working.

## Screenshots
desktop
<img width="1348" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/c9897a4f-4a86-4a4f-bef2-8fdec60e4685">

mobile (no visible or functional changes)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/194bc760-5c2a-4927-982c-ec5b0a0fa6d0)


## What areas of the site does it impact?
526ez

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
