### PR TITLE
Add new relationship field to main UI pattern

### DIFF
--- a/src/platform/forms-system/src/js/web-component-patterns/relationshipToVeteranPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/relationshipToVeteranPattern.jsx
@@ -19,33 +19,43 @@ import VaTextInputField from '../web-component-fields/VaTextInputField';
  *
  * @param {string | {
  *   personTitle?: string,
+ *   relativeTitle?: string,
  *   labelHeaderLevel?: UISchemaOptions['ui:options']['labelHeaderLevel'],
  * }} options - a string representing the person type, or an object with options
  * @returns {UISchemaOptions}
  */
 
 export const relationshipToVeteranUI = options => {
-  const { personTitle, labelHeaderLevel } =
+  const { personTitle, relativeTitle, labelHeaderLevel } =
     typeof options === 'object' ? options : { personTitle: options };
   const person = personTitle ?? 'Veteran';
 
+  const relativeBeingVerb = `${`${
+    relativeTitle ? `${relativeTitle} is` : 'I’m'
+  }`}`;
+  const relativePossessive = `${`${
+    relativeTitle ? `${relativeTitle}’s` : 'your'
+  }`}`;
+
   return {
     relationshipToVeteran: radioUI({
-      title: `What’s your relationship to the ${person}?`,
+      title: `What’s ${relativePossessive} relationship to the ${person}?`,
       labels: {
-        spouse: `I’m the ${person}’s spouse`,
-        child: `I’m the ${person}’s child`,
-        parent: `I’m the ${person}’s parent`,
-        executor: `I’m the ${person}’s executor or administrator of estate`,
-        other: 'We don’t have a relationship that’s listed here',
+        spouse: `${relativeBeingVerb} the ${person}’s spouse`,
+        child: `${relativeBeingVerb} the ${person}’s child`,
+        parent: `${relativeBeingVerb} the ${person}’s parent`,
+        executor: `${relativeBeingVerb} the ${person}’s executor or administrator of estate`,
+        other: `${`${
+          relativeTitle ? `${relativeTitle} doesn’t` : 'We don’t'
+        }`} have a relationship that’s listed here`,
       },
       errorMessages: {
-        required: `Please select your relationship to the ${person}`,
+        required: `Please enter ${relativePossessive} relationship to the ${person}`,
       },
       labelHeaderLevel: labelHeaderLevel ?? '3',
     }),
     otherRelationshipToVeteran: {
-      'ui:title': `Since your relationship with the ${person} was not listed, please describe it here`,
+      'ui:title': `Since ${relativePossessive} relationship with the ${person} was not listed, please describe it here`,
       'ui:webComponentField': VaTextInputField,
       'ui:options': {
         expandUnder: 'relationshipToVeteran',
@@ -53,7 +63,7 @@ export const relationshipToVeteranUI = options => {
         expandedContentFocus: true,
       },
       'ui:errorMessages': {
-        required: `Please enter your relationship to the ${person}`,
+        required: `Please enter ${relativePossessive} relationship to the ${person}`,
       },
     },
     'ui:options': {


### PR DESCRIPTION
## Summary

This PR proposes an update to the web-component version of the Relationship to Veteran pattern. The key change is that it accepts an extra (optional) argument `relativeTitle` that allows for more customization of the wording featured in the component. This adds flexibility to the component by enabling third person phrasing without changing the existing usage patterns.

- Added a new argument `relativeTitle` to relationshipToVeteranUI
- Adjusted wording throughout that component to reflect new use case
- Team: IVC-CHAMPVA
- Flipper: NA

## Related issue(s)

NA

## Testing done

- Manual testing so far

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | ![before1](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/507ad6bc-7150-45c7-b032-065605d72816) | ![after1](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/68ebc23e-5bd5-4f36-af74-6bfb74f85132) |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
