### PR TITLE
MHV-54809-Update-Refill-Button-Text

### DIFF
--- a/src/applications/mhv/medications/components/shared/FillRefillButton.jsx
+++ b/src/applications/mhv/medications/components/shared/FillRefillButton.jsx
@@ -18,6 +18,9 @@ const FillRefillButton = rx => {
   } = rx;
 
   const [isLoading, setIsLoading] = useState(false);
+  const hasBeenDispensed =
+    dispensedDate ||
+    rx.rxRfRecords?.[0]?.[1].find(record => record.dispensedDate);
 
   useEffect(
     () => {
@@ -79,7 +82,7 @@ const FillRefillButton = rx => {
             setIsLoading(true);
             dispatch(fillPrescription(prescriptionId));
           }}
-          text={`Request ${dispensedDate ? 'a refill' : 'the first fill'}`}
+          text={`Request ${hasBeenDispensed ? 'a refill' : 'the first fill'}`}
         />
       </div>
     );

--- a/src/applications/mhv/medications/tests/components/shared/FillRefillButton.unit.spec.jsx
+++ b/src/applications/mhv/medications/tests/components/shared/FillRefillButton.unit.spec.jsx
@@ -77,4 +77,27 @@ describe('Fill Refill Button component', () => {
     );
     expect(screen.queryByTestId('refill-request-button')).to.not.exist;
   });
+
+  it('renders the correct text when dispensedDate is null', () => {
+    const screen = renderWithStoreAndRouter(
+      <FillRefillButton {...{ ...rx, dispensedDate: null }} />,
+      {
+        initialState: {},
+        reducers: reducer,
+        path: '/1234567890',
+      },
+    );
+    const button = screen.getByTestId('refill-request-button');
+    expect(button).to.have.property('text', 'Request the first fill');
+  });
+
+  it('renders the correct text when dispensedDate exists', () => {
+    const screen = renderWithStoreAndRouter(<FillRefillButton {...rx} />, {
+      initialState: {},
+      reducers: reducer,
+      path: '/1234567890',
+    });
+    const button = screen.getByTestId('refill-request-button');
+    expect(button).to.have.property('text', 'Request a refill');
+  });
 });


### PR DESCRIPTION
## Summary

Updated button text to show 'Request the first fill' or 'Request a fill' appropriately. Also added unit test to check button text.

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-54809
>The refill button for each medication on the list page is currently showing 'Request the first fill' even if the medication was filled previously. The text needs to be updated to show 'Request a refill' if it has already been filled, otherwise it should show 'Request the first fill'.

## Testing done

- Tested locally
- Added unit test
- Ran unit tests

## Screenshots

![Screenshot 2024-02-08 at 9 55 24 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/146013972/78c3b2f0-f0ac-4fd0-8dc7-c2acbee5145c)

## What areas of the site does it impact?

MHV medications list page

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
