### PR TITLE
[Letters] Hide va-accordion when there are not letters to display

### DIFF
--- a/src/applications/letters/containers/LetterList.jsx
+++ b/src/applications/letters/containers/LetterList.jsx
@@ -8,8 +8,12 @@ import { focusElement } from '@department-of-veterans-affairs/platform-utilities
 import DownloadLetterLink from '../components/DownloadLetterLink';
 import VeteranBenefitSummaryLetter from './VeteranBenefitSummaryLetter';
 
-// eslint-disable-next-line -- LH_MIGRATION
-import { letterContent, bslHelpInstructions, LH_MIGRATION__getOptions } from '../utils/helpers';
+import {
+  letterContent,
+  bslHelpInstructions,
+  //  eslint-disable-next-line -- LH_MIGRATION
+  LH_MIGRATION__getOptions,
+} from '../utils/helpers';
 import { AVAILABILITY_STATUSES, LETTER_TYPES } from '../utils/constants';
 import { lettersUseLighthouse } from '../selectors';
 
@@ -17,14 +21,16 @@ export class LetterList extends React.Component {
   constructor(props) {
     super(props);
     // eslint-disable-next-line -- LH_MIGRATION
-    this.state = { LH_MIGRATION__options: LH_MIGRATION__getOptions(false) }
+    this.state = { LH_MIGRATION__options: LH_MIGRATION__getOptions(false) };
   }
 
   componentDidMount() {
     const { shouldUseLighthouse } = this.props;
     focusElement('h2#nav-form-header');
-    // eslint-disable-next-line -- LH_MIGRATION
-    this.setState({ LH_MIGRATION__options: LH_MIGRATION__getOptions(shouldUseLighthouse)});
+    this.setState({
+      // eslint-disable-next-line -- LH_MIGRATION
+      LH_MIGRATION__options: LH_MIGRATION__getOptions(shouldUseLighthouse),
+    });
   }
 
   render() {
@@ -53,7 +59,6 @@ export class LetterList extends React.Component {
         conditionalDownloadButton = (
           <DownloadLetterLink
             letterType={letter.letterType}
-            // eslint-disable-next-line -- LH_MIGRATION
             letterName={letter.name}
             downloadStatus={downloadStatus[letter.letterType]}
             // eslint-disable-next-line -- LH_MIGRATION
@@ -117,9 +122,11 @@ export class LetterList extends React.Component {
         <p>
           <Link to="/confirm-address">Go back to edit address</Link>
         </p>
-        <va-accordion bordered uswds="false">
-          {letterItems}
-        </va-accordion>
+        {letterItems.length !== 0 && (
+          <va-accordion bordered uswds="false">
+            {letterItems}
+          </va-accordion>
+        )}
         {eligibilityMessage}
 
         <br />


### PR DESCRIPTION
## Summary
Hiding the `va-accordion` web-component when there are no `va-accordion-item` components to display inside of it. The `va-accordions` empty state is an empty grey rectangle, which looks out of place and should just be hidden / not rendered in the DOM

## Related issue(s)
- department-of-veterans-affairs/va.gov-team#75683

## Screenshots
|         | Before | After |
| ------- | ------ | ----- |
| Desktop | <img width="704" alt="Screenshot 2024-02-08 at 12 49 25 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/bbc11432-9db3-40d3-828a-6f986e394bf7"> | <img width="704" alt="Screenshot 2024-02-08 at 12 49 09 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/43f52db1-f5d8-499c-8bb4-663b5af2e1a9">  |

## What areas of the site does it impact?
Benefits Letters

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
