### PR TITLE
VACMS-75502: Add Spanish translation toggle for Education eligibility page

### DIFF
--- a/src/applications/static-pages/i18Select/tests/getNonActiveLinkUrls.unit.spec.js
+++ b/src/applications/static-pages/i18Select/tests/getNonActiveLinkUrls.unit.spec.js
@@ -9,7 +9,7 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(esp|tag)/i.test(url)).to.equal(true);
     });
 
-    expect(result.length).to.equal(22);
+    expect(result.length).to.equal(23);
   });
 
   it('should not return any "-esp" suffixed links when "es" is the active language code', () => {
@@ -19,7 +19,7 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(esp)/i.test(url)).to.equal(false);
     });
 
-    expect(result.length).to.equal(22);
+    expect(result.length).to.equal(23);
   });
 
   it('should not return any "-tag" suffixed links when "tl" is the active language code', () => {
@@ -29,6 +29,6 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(tag)/i.test(url)).to.equal(false);
     });
 
-    expect(result.length).to.equal(32);
+    expect(result.length).to.equal(34);
   });
 });

--- a/src/applications/static-pages/i18Select/utilities/urls.js
+++ b/src/applications/static-pages/i18Select/utilities/urls.js
@@ -76,4 +76,8 @@ export default {
     en: '/accessibility-at-va/',
     es: '/accessibility-at-va-esp/',
   },
+  education: {
+    en: '/education/eligibility/',
+    es: '/education/eligibility-esp/',
+  },
 };


### PR DESCRIPTION
## Summary
Add Spanish translation toggle for Education eligibility page

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17171

## Testing Done
Tested locally

<img width="1559" alt="Screenshot 2024-02-08 at 1 38 49 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/737da7ec-29df-4d21-bfb9-dd3407c95a57">
<img width="1559" alt="Screenshot 2024-02-08 at 1 38 57 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/39729fa5-f6ba-4917-9472-ef9b921e3986">