### PR TITLE
VACMS-11875 Remove show_header_v2 flipper

### DIFF
--- a/src/applications/mhv/secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
+++ b/src/applications/mhv/secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
@@ -1463,10 +1463,6 @@
         "value": true
       },
       {
-        "name": "show_header_v2",
-        "value": true
-      },
-      {
         "name": "showMebUnverifiedUserAlert",
         "value": true
       },


### PR DESCRIPTION
## Summary
Remove show_header_v2 flipper as it is not in use.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11875

## Testing done
[Searched the DSVA Github repos for code instances](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+show_header_v2&type=code) and removed the relevant code.