### PR TITLE
74348a add supporting components for applicant section

### DIFF
--- a/src/applications/ivc-champva/10-10D/components/AdditionalDocumentationAlert.jsx
+++ b/src/applications/ivc-champva/10-10D/components/AdditionalDocumentationAlert.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+export default function AdditionalDocumentationAlert() {
+  return (
+    <VaAlert status="info" visible uswds>
+      <h2>
+        Depending on your response, additional documentation may be required to
+        determine eligibility
+      </h2>
+    </VaAlert>
+  );
+}

--- a/src/applications/ivc-champva/10-10D/components/customRelationshipPattern.jsx
+++ b/src/applications/ivc-champva/10-10D/components/customRelationshipPattern.jsx
@@ -1,0 +1,111 @@
+import {
+  radioUI,
+  radioSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import VaTextInputField from 'platform/forms-system/src/js/web-component-fields/VaTextInputField';
+
+/**
+ * Web component uiSchema for relationship to veteran
+ *
+ * Pattern recommendation: Use as a standalone on the page
+ *
+ * set `labelHeaderLevel: ''` if you just want to use it as a standard field instead
+ *
+ * ```js
+ * relationshipToVeteran: relationshipToVeteran() // 'Veteran'
+ * relationshipAsField: relationshipToVeteran({
+ *  personTitle: 'claimant',
+ *  labelHeaderLevel: ''
+ * })
+ * ```
+ *
+ * @param {string | {
+ *   personTitle?: string,
+ *   relativeTitle?: string,
+ *   tense?: string,
+ *   labelHeaderLevel?: UISchemaOptions['ui:options']['labelHeaderLevel'],
+ * }} options - a string representing the person type, or an object with options
+ * @returns {UISchemaOptions}
+ */
+
+export const relationshipToVeteranUI = options => {
+  const { personTitle, relativeTitle, tense, labelHeaderLevel } =
+    typeof options === 'object' ? options : { personTitle: options };
+
+  const person = personTitle ?? 'Veteran';
+
+  const isRelativeFn = typeof relativeTitle === 'function';
+  const relativeTitleVal = isRelativeFn
+    ? props => relativeTitle(props)
+    : relativeTitle;
+
+  const conjugatedVerbThirdPerson = tense && tense === 'past' ? 'was' : 'is';
+  const conjugatedVerbFirstPerson = tense && tense === 'past' ? 'I was' : 'I’m';
+
+  const relativeBeingVerb = `${`${
+    relativeTitleVal
+      ? `${relativeTitleVal} ${conjugatedVerbThirdPerson}`
+      : conjugatedVerbFirstPerson
+  }`}`;
+
+  const relativePossessive = `${`${
+    relativeTitleVal ? `${relativeTitleVal}’s` : 'your'
+  }`}`;
+
+  return {
+    relationshipToVeteran: radioUI({
+      title: `What’s ${relativePossessive} relationship to the ${person}?`,
+      labels: {
+        spouse: `${relativeBeingVerb} the ${person}’s spouse`,
+        child: `${relativeBeingVerb} the ${person}’s child`,
+        caretaker: `${relativeBeingVerb} the ${person}’s caretaker`,
+        other: `${`${
+          relativeTitleVal ? `${relativeTitleVal} doesn’t` : 'We don’t'
+        }`} have a relationship that’s listed here`,
+      },
+      errorMessages: {
+        required: `Please enter ${relativePossessive} relationship to the ${person}`,
+      },
+      labelHeaderLevel: labelHeaderLevel ?? '3',
+    }),
+    otherRelationshipToVeteran: {
+      'ui:title': `Since ${relativePossessive} relationship with the ${person} was not listed, please describe it here`,
+      'ui:webComponentField': VaTextInputField,
+      'ui:options': {
+        expandUnder: 'relationshipToVeteran',
+        expandUnderCondition: 'other',
+        expandedContentFocus: true,
+      },
+      'ui:errorMessages': {
+        required: `Please enter ${relativePossessive} relationship to the ${person}`,
+      },
+    },
+    'ui:options': {
+      updateSchema: (formData, formSchema) => {
+        if (formSchema.properties.otherRelationshipToVeteran['ui:collapsed']) {
+          return { ...formSchema, required: ['relationshipToVeteran'] };
+        }
+        return {
+          ...formSchema,
+          required: ['relationshipToVeteran', 'otherRelationshipToVeteran'],
+        };
+      },
+    },
+  };
+};
+
+export const relationshipToVeteranSchema = {
+  type: 'object',
+  properties: {
+    relationshipToVeteran: radioSchema([
+      'spouse',
+      'child',
+      'caretaker',
+      'other',
+    ]),
+    otherRelationshipToVeteran: {
+      type: 'string',
+    },
+  },
+  required: ['relationshipToVeteran'],
+};

--- a/src/applications/ivc-champva/10-10D/helpers/wordingCustomization.js
+++ b/src/applications/ivc-champva/10-10D/helpers/wordingCustomization.js
@@ -1,5 +1,21 @@
+import get from '@department-of-veterans-affairs/platform-forms-system/get';
+
 // Extracting this to a function so there aren't a thousand identical
 // ternaries we have to change later
 export function sponsorWording(formData) {
   return formData?.certifierRole === 'sponsor' ? 'Your' : "Sponsor's";
+}
+
+export function applicantWording(formData) {
+  return `${`${formData?.applicantName?.first || ''} ${
+    formData?.applicantName?.last
+  }` || 'Applicant'}'s `;
+}
+
+export function firstPersonLanguage(formData, index) {
+  return get('certifierRole', formData) === 'applicant' && (index || 0) === 0;
+}
+
+export function thirdPersonLanguage(formData, index) {
+  return get('certifierRole', formData) !== 'applicant' || index !== 0;
 }


### PR DESCRIPTION
## Summary

This PR is part 1 of a multi-part effort to break up a larger pull request (see #27853). This PR contains a few UI helpers that adjust wording choices based on form contents, plus a customized version of the relationshipToVeteran component that features updated wording flexibility and different options. Additional unit tests will be included in the main PR.

- New wording helper functions for use in 10-10d
- Customized relationship to veteran component
- New alert component for use in form
- **Team**: IVC-CHAMPVA
- **Flipper**: NA

## Related issue(s)

-  https://github.com/department-of-veterans-affairs/va.gov-team/issues/74348

## Testing done

- Manual testing
- Ran `yarn test:coverage-app ivc-champva/10-10D` to verify existing tests run and pass

## Screenshots

NA

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
