### PR TITLE
VACMS-11861 Remove cerner_allow_partial_facilities flipper

### DIFF
--- a/src/applications/mhv/secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
+++ b/src/applications/mhv/secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
@@ -91,14 +91,6 @@
         "value": true
       },
       {
-        "name": "cernerAllowPartialFacilities",
-        "value": false
-      },
-      {
-        "name": "cerner_allow_partial_facilities",
-        "value": false
-      },
-      {
         "name": "cernerOverride463",
         "value": false
       },


### PR DESCRIPTION
## Summary
Remove cerner_allow_partial_facilities flipper as it is not in use.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11861

## Testing done
Searched the DSVA Github repos for code instances ([for "cerner_allow_partial_facilities"](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+cerner_allow_partial_facilities&type=code) and ["cernerAllowPartialFacilities"](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+cernerAllowPartialFacilities&type=code)) and removed the relevant code.