### PR TITLE
VACMS-11872 Remove show_new_view_test_lab_results_page flipper

### DIFF
--- a/src/applications/mhv/secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
+++ b/src/applications/mhv/secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
@@ -1551,14 +1551,6 @@
         "value": true
       },
       {
-        "name": "showNewViewTestLabResultsPage",
-        "value": true
-      },
-      {
-        "name": "show_new_view_test_lab_results_page",
-        "value": true
-      },
-      {
         "name": "showUpdatedFryDeaApp",
         "value": false
       },

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
@@ -159,10 +159,6 @@
         "value": false
       },
       {
-        "name": "show_new_view_test_lab_results_page",
-        "value": false
-      },
-      {
         "name": "show526Wizard",
         "value": false
       }

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
@@ -159,10 +159,6 @@
         "value": true
       },
       {
-        "name": "show_new_view_test_lab_results_page",
-        "value": true
-      },
-      {
         "name": "show526Wizard",
         "value": true
       }

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.unit.spec.js
@@ -10,10 +10,7 @@ import { App } from './index';
 describe('Get Medical Records Page <App>', () => {
   it('renders what we expect when not a Cerner patient', () => {
     const wrapper = shallow(
-      <App
-        showNewViewTestLabResultsPage
-        facilities={[{ usesCernerTestResults: false }]}
-      />,
+      <App facilities={[{ usesCernerTestResults: false }]} />,
     );
     expect(wrapper.find(UnauthContent)).to.have.lengthOf(1);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(0);
@@ -22,10 +19,7 @@ describe('Get Medical Records Page <App>', () => {
 
   it('renders what we expect when a Cerner patient', () => {
     const wrapper = shallow(
-      <App
-        showNewViewTestLabResultsPage
-        facilities={[{ usesCernerTestResults: true }]}
-      />,
+      <App facilities={[{ usesCernerTestResults: true }]} />,
     );
     expect(wrapper.find(UnauthContent)).to.have.lengthOf(0);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(1);

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -225,7 +225,6 @@ export default Object.freeze({
   showNewScheduleViewAppointmentsPage:
     'show_new_schedule_view_appointments_page',
   showNewSecureMessagingPage: 'show_new_secure_messaging_page',
-  showNewViewTestLabResultsPage: 'show_new_view_test_lab_results_page',
   showUpdatedFryDeaApp: 'show_updated_fry_dea_app',
   signInServiceEnabled: 'sign_in_service_enabled',
   stemAutomatedDecision: 'stem_automated_decision',


### PR DESCRIPTION
## Summary
Remove show_new_view_test_lab_results_page flipper as it is not in use.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11872

## Testing done
[Searched the DSVA Github repos for code instances](https://github.com/search?q=org%3Adepartment-of-veterans-affairs+show_new_view_test_lab_results_page&type=code) and removed the relevant code.