### PR TITLE
Update VaBreadcrumbs to temporarily opt out V3

### DIFF
--- a/src/applications/vaos/components/Breadcrumbs.jsx
+++ b/src/applications/vaos/components/Breadcrumbs.jsx
@@ -53,6 +53,7 @@ export default function VAOSBreadcrumbs({ children }) {
       aria-label="Breadcrumbs"
       ref={breadcrumbsRef}
       class="vaos-hide-for-print"
+      uswds={false}
     >
       <a href="/" key="home" onClick={handleClick('home')}>
         {featureBreadcrumbUrlUpdate ? 'VA.gov home' : 'Home'}


### PR DESCRIPTION

## Summary

The PR sets the va-breadcrumbs uswds = false to temporarily opt out of V3 to meet 2/16 deadline.  Update to V2 will be address on another branch. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#75308


## Testing done

n/a

## Screenshots


## What areas of the site does it impact?

va-breadcrumbs web component

## Acceptance criteria


### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

