### PR TITLE
Pensions: remove dependent data if no dependents

### DIFF
--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -235,6 +235,19 @@ function usingDirectDeposit(formData) {
   return formData['view:noDirectDeposit'] !== true;
 }
 
+export function doesHaveDependents(formData) {
+  return get(['view:hasDependents'], formData) === true;
+}
+
+export function dependentIsOutsideHousehold(formData, index) {
+  // if 'view:hasDependents' is false,
+  // all checks requiring dependents must be false
+  return (
+    doesHaveDependents(formData) &&
+    !get(['dependents', index, 'childInHousehold'], formData)
+  );
+}
+
 const marriageProperties = marriages.items.properties;
 
 const marriageType = {
@@ -777,14 +790,14 @@ const formConfig = {
         dependents: {
           title: 'Dependent children',
           path: 'household/dependents/add',
-          depends: form => get(['view:hasDependents'], form) === true,
+          depends: doesHaveDependents,
           uiSchema: dependentChildren.uiSchema,
           schema: dependentChildren.schema,
         },
         dependentChildInformation: {
           path: 'household/dependents/children/information/:index',
           title: item => getDependentChildTitle(item, 'information'),
-          depends: form => get(['view:hasDependents'], form) === true,
+          depends: doesHaveDependents,
           showPagePerItem: true,
           arrayPath: 'dependents',
           schema: dependentChildInformation.schema,
@@ -793,7 +806,7 @@ const formConfig = {
         dependentChildInHousehold: {
           path: 'household/dependents/children/inhousehold/:index',
           title: item => getDependentChildTitle(item, 'household'),
-          depends: form => get(['view:hasDependents'], form) === true,
+          depends: doesHaveDependents,
           showPagePerItem: true,
           arrayPath: 'dependents',
           schema: {
@@ -824,8 +837,7 @@ const formConfig = {
         dependentChildAddress: {
           path: 'household/dependents/children/address/:index',
           title: item => getDependentChildTitle(item, 'address'),
-          depends: (form, index) =>
-            !get(['dependents', index, 'childInHousehold'], form),
+          depends: dependentIsOutsideHousehold,
           showPagePerItem: true,
           arrayPath: 'dependents',
           schema: {
@@ -852,8 +864,7 @@ const formConfig = {
                 childAddress: address.uiSchema(
                   '',
                   false,
-                  (form, index) =>
-                    !get(['dependents', index, 'childInHousehold'], form),
+                  dependentIsOutsideHousehold,
                 ),
                 personWhoLivesWithChild: merge({}, fullNameUI, {
                   'ui:title': 'Who do they live with?',
@@ -870,10 +881,8 @@ const formConfig = {
                     'ui:title': 'Suffix',
                   },
                   'ui:options': {
-                    updateSchema: (form, UISchema, schema, index) => {
-                      if (
-                        !get(['dependents', index, 'childInHousehold'], form)
-                      ) {
+                    updateSchema: (form, _UISchema, _schema, index) => {
+                      if (dependentIsOutsideHousehold(form, index)) {
                         return fullName;
                       }
                       return nonRequiredFullName;
@@ -886,8 +895,7 @@ const formConfig = {
                     "How much do you contribute per month to your child's support?",
                   ),
                   {
-                    'ui:required': (form, index) =>
-                      !get(['dependents', index, 'childInHousehold'], form),
+                    'ui:required': dependentIsOutsideHousehold,
                   },
                 ),
               },

--- a/src/applications/pensions/helpers.jsx
+++ b/src/applications/pensions/helpers.jsx
@@ -92,7 +92,7 @@ function pollStatus(
   }, window.VetsGov.pollTimeout || POLLING_INTERVAL);
 }
 
-function transform(formConfig, form) {
+export function transform(formConfig, form) {
   const formData = transformForSubmit(formConfig, form, replacer);
   return JSON.stringify({
     pensionClaim: {

--- a/src/applications/pensions/tests/unit/config/form.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/config/form.unit.spec.jsx
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import { expect } from 'chai';
 
-import {
+import formConfig, {
   currentSpouseHasFormerMarriages,
   isSeparated,
   isUnder65,
@@ -17,7 +17,12 @@ import {
   doesReceiveIncome,
   doesHaveCareExpenses,
   doesHaveMedicalExpenses,
+  doesHaveDependents,
+  dependentIsOutsideHousehold,
 } from '../../../config/form';
+
+import { transform } from '../../../helpers';
+import overflowForm from '../../e2e/fixtures/data/overflow-test.json';
 
 describe('Pensions isUnder65', () => {
   it('should return false if date of birth and isOver65 indicate veteran is over 65', () => {
@@ -179,5 +184,77 @@ describe('Pensions doesHaveCareExpenses', () => {
 describe('Pensions doesHaveMedicalExpenses', () => {
   it('returns true if veteran has medical expenses', () => {
     expect(doesHaveMedicalExpenses({ hasMedicalExpenses: true })).to.be.true;
+  });
+});
+
+describe('Pensions doesHaveDependents', () => {
+  it('returns true if veteran has dependents', () => {
+    expect(doesHaveDependents({ 'view:hasDependents': true })).to.be.true;
+  });
+
+  it('returns false if veteran has no dependents', () => {
+    expect(doesHaveDependents({ 'view:hasDependents': false })).to.be.false;
+  });
+});
+
+describe('Pensions dependentIsOutsideHousehold', () => {
+  const dependents = [{ childInHousehold: false }, { childInHousehold: true }];
+
+  it('returns true if veteran has dependents and dependent is outside household', () => {
+    expect(
+      dependentIsOutsideHousehold(
+        { 'view:hasDependents': true, dependents },
+        0,
+      ),
+    ).to.be.true;
+  });
+
+  it('returns false if veteran has dependents and dependent is inside household', () => {
+    expect(
+      dependentIsOutsideHousehold(
+        { 'view:hasDependents': true, dependents },
+        1,
+      ),
+    ).to.be.false;
+  });
+
+  it('returns false if veteran has no dependents', () => {
+    expect(
+      dependentIsOutsideHousehold(
+        { 'view:hasDependents': false, dependents },
+        0,
+      ),
+    ).to.be.false;
+    expect(
+      dependentIsOutsideHousehold(
+        { 'view:hasDependents': false, dependents },
+        1,
+      ),
+    ).to.be.false;
+  });
+});
+
+describe('Pensions formConfig', () => {
+  it('when transformed for submit, should remove dependents if veteran has no dependents', () => {
+    const formData = {
+      data: {
+        'view:hasDependents': false,
+        dependents: overflowForm.data.dependents,
+      },
+    };
+    const result = transform(formConfig, formData);
+    expect(JSON.parse(result).pensionClaim.form).to.equal(JSON.stringify({}));
+  });
+  it('when transformed for submit, should keep dependents if veteran has dependents', () => {
+    const formData = {
+      data: {
+        'view:hasDependents': true,
+        dependents: overflowForm.data.dependents,
+      },
+    };
+    const result = transform(formConfig, formData);
+    expect(JSON.parse(result).pensionClaim.form).to.equal(
+      JSON.stringify({ dependents: overflowForm.data.dependents }),
+    );
   });
 });


### PR DESCRIPTION
## Summary

The following error was being thrown from a pension submission in production:
`Lighthouse::PensionBenefitIntakeJob FAILED! undefined method 'values' for nil:NilClass NoMethodError: undefined method 'values' for nil:NilClass /app/lib/pdf_fill/forms/va21p527ez.rb:1523: in 'build_custodian_hash_from_dependent': undefined method 'values' for nil:NilClass (NoMethodError)`. 

(I use 'children' instead of 'dependents' below to avoid confusion between code dependencies and veteran dependents.)

This happened because we have a view field, 'view:hasDependents', which the first set of children data depends on, such as the child's name and whether they live in the household. Additional child data depends on the first set of child data (for example, we ask the child's address only if they don't live with the veteran). If the veteran said they had children and added all the child's data, but then on the review page changed their answer to say they had no children, the first set of child data (name/etc) which directly depends on whether the veteran has children, was removed on submission. However, the second set of child data (address/etc) which indirectly depends on whether the veteran has children, was NOT removed on submission, causing invalid partial children data to be submitted.

This PR makes all data about the veteran's children directly dependent on 'view:hasDependents' to ensure it's cleanly removed if the veteran changes their response. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75864

## Testing done

Before the change, if a veteran added dependents, then changed 'view:hasDependents' to false on the review page, some dependent data wasn't removed.

After the change:
- Fill out the form, and say that you have dependents. 
- Completely fill out all dependent data. For at least one dependent, say they don't live with you, and fill out address data.
- On the review page, change your answer to say that you don't have any dependents. 
- Submit the form. It should submit cleanly. In the network tab, you should see that the submission which was sent had no dependent data. 

## What areas of the site does it impact?

Pension Benefits

## Acceptance criteria

A null dependent full name should not be possible to generate when filling in the form client side.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

