### PR TITLE
Fixes mockFetch linting errrors within VAOS

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/RequestListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/RequestListItem.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import moment from 'moment';
-import { focusElement } from 'platform/utilities/ui';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { sentenceCase } from '../../../utils/formatters';

--- a/src/applications/vaos/tests/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.jsx
@@ -3,7 +3,7 @@ import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import { waitFor } from '@testing-library/dom';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import { renderWithStoreAndRouter, getTestDate } from '../../mocks/setup';
 import { AppointmentList } from '../../../appointment-list';
 import PastAppointmentsList from '../../../appointment-list/components/PastAppointmentsList';

--- a/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import MockDate from 'mockdate';
 import { expect } from 'chai';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import userEvent from '@testing-library/user-event';
 import {
   mockSingleVAOSAppointmentFetch,

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import userEvent from '@testing-library/user-event';
 import sinon from 'sinon';
 import { fireEvent, waitFor } from '@testing-library/react';

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentListGroup.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentListGroup.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import MockDate from 'mockdate';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import { expect } from 'chai';
 import RequestedAppointmentsListGroup from '../../../appointment-list/components/RequestedAppointmentsListGroup';
 import { getVAOSRequestMock } from '../../mocks/v2';

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import { within } from '@testing-library/dom';
 import reducers from '../../../redux/reducer';
 import { getVAOSRequestMock } from '../../mocks/v2';

--- a/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import reducers from '../../../redux/reducer';
 import { getTestDate, renderWithStoreAndRouter } from '../../mocks/setup';
 import UpcomingAppointmentsList from '../../../appointment-list/components/UpcomingAppointmentsList';

--- a/src/applications/vaos/tests/appointment-list/components/UrlAndPageTitleChange.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/UrlAndPageTitleChange.unit.spec.jsx
@@ -3,7 +3,7 @@ import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import { waitFor, within } from '@testing-library/dom';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import userEvent from '@testing-library/user-event';
 import { renderWithStoreAndRouter, getTestDate } from '../../mocks/setup';
 import AppointmentsPage from '../../../appointment-list/components/AppointmentsPage';

--- a/src/applications/vaos/tests/components/EnrolledRoute.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/EnrolledRoute.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Switch } from 'react-router-dom';
 import { expect } from 'chai';
 import { waitFor } from '@testing-library/dom';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 
 import backendServices from 'platform/user/profile/constants/backendServices';
 import { createTestStore, renderWithStoreAndRouter } from '../mocks/setup';

--- a/src/applications/vaos/tests/components/TextareaWidget.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/TextareaWidget.unit.spec.jsx
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { render } from '@testing-library/react';
 
-import TextareaWidget from '../../components/TextareaWidget';
 import userEvent from '@testing-library/user-event';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
+import TextareaWidget from '../../components/TextareaWidget';
 
 describe('VAOS <TextareaWidget>', () => {
   beforeEach(() => mockFetch());

--- a/src/applications/vaos/tests/covid-19-vaccine/components/ClinicChoicePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/ClinicChoicePage.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import {
   createTestStore,
   renderWithStoreAndRouter,

--- a/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ClinicChoicePage.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import {
   createTestStore,
   renderWithStoreAndRouter,

--- a/src/applications/vaos/tests/new-appointment/components/ClosestCityStatePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ClosestCityStatePage.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import userEvent from '@testing-library/user-event';
 
 import { waitFor } from '@testing-library/dom';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import ClosestCityStatePage from '../../../new-appointment/components/ClosestCityStatePage';
 import {
   renderWithStoreAndRouter,

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareLanguagePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareLanguagePage.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import userEvent from '@testing-library/user-event';
 import { cleanup } from '@testing-library/react';
 import { fireEvent, waitFor } from '@testing-library/dom';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
 import CommunityCareLanguagePage from '../../../new-appointment/components/CommunityCareLanguagePage';
 

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCarePreferencesPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCarePreferencesPage.unit.spec.jsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { cleanup } from '@testing-library/react';
 import { waitFor } from '@testing-library/dom';
 
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 
 import {
   createTestStore,

--- a/src/applications/vaos/tests/new-appointment/components/DateTimeRequestPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeRequestPage/index.unit.spec.jsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 
 import { waitFor, within } from '@testing-library/dom';
 import { Route } from 'react-router-dom';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import { FETCH_STATUS } from '../../../../utils/constants';
 import DateTimeRequestPage from '../../../../new-appointment/components/DateTimeRequestPage';
 import {

--- a/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/DateTimeSelectPage/index.unit.spec.jsx
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import moment from 'moment';
 import { waitFor, waitForElementToBeRemoved } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import userEvent from '@testing-library/user-event';
 import MockDate from 'mockdate';
 import {

--- a/src/applications/vaos/tests/new-appointment/components/PreferredDatePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/PreferredDatePage.unit.spec.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { expect } from 'chai';
 import moment from 'moment';
 
-import PreferredDatePage from '../../../new-appointment/components/PreferredDatePage';
-import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
+import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
+import PreferredDatePage from '../../../new-appointment/components/PreferredDatePage';
 
 const initialState = {
   featureToggles: {

--- a/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import { Route } from 'react-router-dom';
 import { cleanup } from '@testing-library/react';

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfAudiologyCare.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfAudiologyCare.unit.spec.jsx
@@ -5,7 +5,7 @@ import { waitFor } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { cleanup } from '@testing-library/react';
 
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 
 import {
   createTestStore,

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mockFetch } from 'platform/testing/unit/helpers';
-import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import { fireEvent, waitFor } from '@testing-library/dom';
-import TypeOfFacilityPage from '../../../new-appointment/components/TypeOfFacilityPage';
 import { Route } from 'react-router-dom';
 import { cleanup } from '@testing-library/react';
+import TypeOfFacilityPage from '../../../new-appointment/components/TypeOfFacilityPage';
+import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
 
 const initialState = {
   featureToggles: {

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfSleepCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfSleepCarePage.unit.spec.jsx
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 
-import { mockFetch } from 'platform/testing/unit/helpers';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 
 import {
   createTestStore,

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfVisitPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfVisitPage.unit.spec.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mockFetch } from 'platform/testing/unit/helpers';
-import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
+import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import { cleanup } from '@testing-library/react';
 import { Route } from 'react-router-dom';
+import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
 
 import TypeOfVisitPage from '../../../new-appointment/components/TypeOfVisitPage';
 


### PR DESCRIPTION
## Summary

Replaces `import { mockFetch } from 'platform/testing/unit/helpers'` with `
import { mockFetch } from '@department-of-veterans-affairs/platform-testing/helpers';` within VAOS to fix ongoing linting error.




## Related issue(s)

N/A 

## Testing done

- Existing unit tests
- Existing e2e tests

## Acceptance criteria

### Quality Assurance & Testing

- [x] I updated unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.


### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user