### PR TITLE
[CST] - Update text styling for Claim Status Header Descriptions

### DIFF
--- a/src/applications/claims-status/components/ClaimFileHeader.jsx
+++ b/src/applications/claims-status/components/ClaimFileHeader.jsx
@@ -4,7 +4,7 @@ function ClaimFileHeader() {
   return (
     <div className="claim-file-header-container">
       <h2 className="vads-u-margin-y--0">Claim files</h2>
-      <p className="vads-u-margin-top--1 vads-u-margin-bottom--4">
+      <p className="vads-u-margin-top--1 vads-u-margin-bottom--4 va-introtext">
         If you need to add evidence, you can do that here. You can also see the
         files associated with this claim.
       </p>

--- a/src/applications/claims-status/components/ClaimOverviewHeader.jsx
+++ b/src/applications/claims-status/components/ClaimOverviewHeader.jsx
@@ -4,7 +4,7 @@ function ClaimOverviewHeader() {
   return (
     <div className="claim-overview-header-container">
       <h2 className="vads-u-margin-y--0">Overview of the claim process</h2>
-      <p className="vads-u-margin-top--1 vads-u-margin-bottom--4">
+      <p className="vads-u-margin-top--1 vads-u-margin-bottom--4 va-introtext">
         Learn about the VA claim process and what happens after you file your
         claim.
       </p>

--- a/src/applications/claims-status/components/ClaimStatusHeader.jsx
+++ b/src/applications/claims-status/components/ClaimStatusHeader.jsx
@@ -20,10 +20,10 @@ function ClaimStatusHeader({ claim }) {
   return (
     <div className="claim-status-header-container">
       <h2 className="vads-u-margin-y--0">Claim status</h2>
-      <p className="vads-u-margin-top--1 vads-u-margin-bottom--2">
+      <p className="vads-u-margin-top--1 vads-u-margin-bottom--3 va-introtext">
         Here’s the latest information on your claim.{' '}
       </p>
-      <div className="vads-u-margin-top--1 vads-u-margin-bottom--4">
+      <div className="vads-u-margin-top--0 vads-u-margin-bottom--4">
         {inProgress && <span className="usa-label">{inProgress}</span>}
         <p className="vads-u-margin-top--1 vads-u-margin-bottom--0">
           {getLastUpdated(claim)}


### PR DESCRIPTION
## Summary

- Updated the text styling to match the new figma designs
- Overview, Status and Files tabs now have header descriptions with the class name `va-introtext`
- Updated padding around elements for the Status Tab Header

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#76295

## Screenshots
![Screenshot 2024-02-15 at 1 38 22 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/3591d065-334a-40b5-af7d-ba617737d2ed)

![Screenshot 2024-02-15 at 1 35 08 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/8fdd845e-2e48-4234-b461-fa391acfe4a2)

![Screenshot 2024-02-15 at 1 34 55 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/afcb58c6-383b-4b76-966e-68ee554352cb)


## Acceptance criteria

- [x] Tab headers descriptions in Status, Files, Overview tabs show the correct text style (va-introtext)

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
