### PR TITLE
Add custom labels property to relationshipToVeteran

### DIFF
--- a/src/platform/forms-system/src/js/web-component-patterns/relationshipToVeteranPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/relationshipToVeteranPattern.jsx
@@ -15,24 +15,30 @@ import VaTextInputField from '../web-component-fields/VaTextInputField';
  *  personTitle: 'claimant',
  *  labelHeaderLevel: ''
  * })
+ * customRelationshipToVeteran: relationshipToVeteranUI({
+ *   customLabels: {
+ *     caretaker: "I’m the Veteran’s caretaker"
+ *   }
+ * })
  * ```
  *
  * @param {string | {
  *   personTitle?: string,
  *   labelHeaderLevel?: UISchemaOptions['ui:options']['labelHeaderLevel'],
+ *   customLabels?: object
  * }} options - a string representing the person type, or an object with options
  * @returns {UISchemaOptions}
  */
 
 export const relationshipToVeteranUI = options => {
-  const { personTitle, labelHeaderLevel } =
+  const { personTitle, labelHeaderLevel, customLabels } =
     typeof options === 'object' ? options : { personTitle: options };
   const person = personTitle ?? 'Veteran';
 
   return {
     relationshipToVeteran: radioUI({
       title: `What’s your relationship to the ${person}?`,
-      labels: {
+      labels: customLabels || {
         spouse: `I’m the ${person}’s spouse`,
         child: `I’m the ${person}’s child`,
         parent: `I’m the ${person}’s parent`,
@@ -103,6 +109,35 @@ export const claimantRelationshipToVeteranSpouseOrChildUI = personTitle => {
       },
       labelHeaderLevel: '3',
     }),
+  };
+};
+
+/**
+ * Schema that takes a list of label keys, to be used in
+ * conjunction with customLabels property of relationshipToVeteranUI.
+ *
+ * This provides a way to have customized labels while still
+ * optionally taking advantage of the dropdown "other" behavior without
+ * reinventing the wheel.
+ *
+ * ```js
+ * relationshipToVeteran: customRelationshipSchema([
+ *  'spouse',
+ *  'caretaker',
+ *  'other',     // Include if you want the functionality
+ * ]),
+ * ```
+ * @param {array} labels array of strings that correspond to label keys
+ *   provided to relationshipToVeteranUI
+ * @returns {object}
+ */
+export const customRelationshipSchema = labels => {
+  return {
+    type: 'object',
+    properties: {
+      relationshipToVeteran: radioSchema([...labels]),
+      otherRelationshipToVeteran: { type: 'string' },
+    },
   };
 };
 


### PR DESCRIPTION
## Summary

Adds ability to have custom labels in the relationshipToVeteran pattern while maintaining the "Other" dropdown functionality and existing compatibility.

This enables more flexibility in the relationshipToVeteranUI component. It lets you use the existing component rather than re-rolling a radio interface when you need more or fewer options. It also preserves the "Other" dropdown as you can pass in an "other" key to the schema and render.

- Adds a `customLabels` property to `relationshipToVeteranUI` that can replace all existing values
- Adds a custom schema that takes a corresponding list of key names
- Updated documentation in the file with usage notes
- Team: IVC-CHAMPVA
- Flipper: NA

## Related issue(s)

NA

## Testing done

- Manual testing
- Ran unit tests locally

## Screenshots

These screenshots demonstrate fully custom text and the preserved "other" behavior.

|         | Example 1 | Example 2 |
| ------- | ------ | ----- |
| Desktop | ![1](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/15a9de5c-f12c-4965-8aaa-91c2ef74cc3c) |![2](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/c21635fc-198e-4fc6-b17b-0530a1af8487) |

## What areas of the site does it impact?

Platform/Forms-System relationshipToVeteranUI component. All changes are backwards compatible, so areas of the site that use this component are not affected. 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
