### PR TITLE
Removes erroneous quotes from VAOS breadcrumbs 

### DIFF
--- a/src/applications/vaos/components/Breadcrumbs.jsx
+++ b/src/applications/vaos/components/Breadcrumbs.jsx
@@ -54,7 +54,7 @@ export default function VAOSBreadcrumbs({ children }) {
         VA.gov home
       </a>
       <a href="/my-health" key="/my-health" onClick={handleClick('/my-health')}>
-        'My HealtheVet'
+        My HealtheVet
       </a>
       <NavLink to="/" id="vaos-home">
         Appointments


### PR DESCRIPTION
## Summary

This removes erroneous quotes from the VAOS breadcrumb component, they were mistakenly included. This is only a copy change.

## Related issue(s)

N/A

## Testing done
- Existing unit tests
- Existing e2e tests

## Acceptance criteria

### Quality Assurance & Testing

- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

