### PR TITLE
Fixes environment import linting errors within VAOS

### DIFF
--- a/src/applications/vaos/components/EnrolledRoute.jsx
+++ b/src/applications/vaos/components/EnrolledRoute.jsx
@@ -5,7 +5,7 @@ import { selectUser } from 'platform/user/selectors';
 import { selectPatientFacilities } from 'platform/user/cerner-dsot/selectors.js';
 import backendServices from 'platform/user/profile/constants/backendServices';
 import { RequiredLoginView } from 'platform/user/authorization/components/RequiredLoginView';
-import environment from 'platform/utilities/environment';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import NoRegistrationMessage from './NoRegistrationMessage';
 
 export default function EnrolledRoute({ component: RouteComponent, ...rest }) {

--- a/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/formSubmitTransformers.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import environment from 'platform/utilities/environment';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import titleCase from 'platform/utilities/data/titleCase';
 import { selectVAPResidentialAddress } from 'platform/user/selectors';
 import { getTimezoneByFacilityId } from '../../../utils/timezone';

--- a/src/applications/vaos/services/utils.js
+++ b/src/applications/vaos/services/utils.js
@@ -2,7 +2,7 @@
  * @module services/utils
  */
 
-import environment from 'platform/utilities/environment';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { apiRequest } from 'platform/utilities/api';
 
 function vaosFHIRRequest(url, ...options) {

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPageV2/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPageV2/index.unit.spec.jsx
@@ -3,7 +3,7 @@ import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
 import { waitFor, within } from '@testing-library/dom';
-import environment from 'platform/utilities/environment';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 import userEvent from '@testing-library/user-event';
 import {

--- a/src/applications/vaos/tests/appointment-list/components/CanceledAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/CanceledAppointmentsList.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import MockDate from 'mockdate';
 import { expect } from 'chai';
 import moment from 'moment';
-import environment from 'platform/utilities/environment';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { mockFetch, setFetchJSONFailure } from 'platform/testing/unit/helpers';
 import reducers from '../../../redux/reducer';
 import { mockAppointmentInfo } from '../../mocks/helpers';

--- a/src/applications/vaos/tests/components/VAOSApp/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/VAOSApp/index.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { waitFor } from '@testing-library/dom';
 import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
-import environment from 'platform/utilities/environment';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 
 import backendServices from 'platform/user/profile/constants/backendServices';
 import moment from 'moment';

--- a/src/applications/vaos/tests/mocks/fetch.js
+++ b/src/applications/vaos/tests/mocks/fetch.js
@@ -1,6 +1,6 @@
 /** @module testing/mocks/fetch */
 import sinon from 'sinon';
-import environment from 'platform/utilities/environment';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { setFetchJSONResponse } from 'platform/testing/unit/helpers';
 import { mockEligibilityFetches } from './helpers';
 import { getV2ClinicMock, getVAOSAppointmentMock } from './v2';

--- a/src/applications/vaos/tests/mocks/helpers.js
+++ b/src/applications/vaos/tests/mocks/helpers.js
@@ -1,7 +1,7 @@
 /** @module testing/mocks/helpers */
 
 import moment from 'moment';
-import environment from 'platform/utilities/environment';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import {
   mockFetch,
   setFetchJSONResponse,

--- a/src/applications/vaos/tests/mocks/helpers.v2.js
+++ b/src/applications/vaos/tests/mocks/helpers.v2.js
@@ -1,5 +1,5 @@
 /** @module testing/mocks/helpers/vaos */
-import environment from 'platform/utilities/environment';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import {
   setFetchJSONFailure,
   setFetchJSONResponse,

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfCarePage.unit.spec.jsx
@@ -9,7 +9,7 @@ import set from 'platform/utilities/data/set';
 import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 
 import moment from 'moment';
-import environment from 'platform/utilities/environment';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
 import { mockParentSites } from '../../mocks/helpers';
 import {

--- a/src/applications/vaos/utils/error.js
+++ b/src/applications/vaos/utils/error.js
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/browser';
-import environment from 'platform/utilities/environment';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { recordVaosError } from './events';
 
 export function captureError(


### PR DESCRIPTION
## Summary

Replaces `import environment from 'platform/utilities/environment';` with `
import environment from '@department-of-veterans-affairs/platform-utilities/environment';` within VAOS to fix ongoing linting error.




## Related issue(s)

N/A 

## Testing done

- Existing unit tests
- Existing e2e tests

## Acceptance criteria

### Quality Assurance & Testing

- [x] I updated unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.


### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user