### PR TITLE
74348d Add OHI Custom Page

### DIFF
--- a/src/applications/ivc-champva/10-10D/pages/ApplicantOhiStatusPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantOhiStatusPage.jsx
@@ -1,0 +1,161 @@
+import React, { useState, useEffect } from 'react';
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
+import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import PropTypes from 'prop-types';
+import { CustomCheckboxRadioReviewPage } from '../components/CustomCheckboxRadioReviewPage';
+
+import { applicantWording } from '../helpers/wordingCustomization';
+
+const keyname = 'applicantHasOhi';
+
+function generateOptions({ data, pagePerItemIndex }) {
+  const applicant = applicantWording(
+    data?.applicants?.[pagePerItemIndex],
+  ).slice(0, -3); // remove 's_
+
+  const useFirstPerson =
+    data?.certifierRole === 'applicant' && +pagePerItemIndex === 0;
+
+  const options = [
+    {
+      label: `Yes, ${
+        useFirstPerson ? 'I have' : `${applicant} has `
+      } other health insurance`,
+      value: 'yes',
+    },
+    {
+      label: `No, ${
+        useFirstPerson ? "I don't have" : `${applicant} doesn't have `
+      } other health insurance`,
+      value: 'no',
+    },
+  ];
+  return {
+    options,
+    useFirstPerson,
+    applicant,
+    keyname,
+    description: 'Has other health insurance',
+  };
+}
+
+export function ApplicantOhiStatusReviewPage(props) {
+  return CustomCheckboxRadioReviewPage({
+    ...props,
+    useLabels: false,
+    generateOptions,
+  });
+}
+
+export default function ApplicantOhiStatusPage({
+  data,
+  goBack,
+  goForward,
+  pagePerItemIndex,
+  setFormData,
+  updatePage,
+  onReviewPage,
+}) {
+  const [checkValue, setCheckValue] = useState(
+    data?.applicants?.[pagePerItemIndex]?.[keyname],
+  );
+  const [dirty, setDirty] = useState(false);
+  const [error, setError] = useState(undefined);
+  const navButtons = <FormNavButtons goBack={goBack} submitToContinue />;
+  // eslint-disable-next-line @department-of-veterans-affairs/prefer-button-component
+  const updateButton = <button type="submit">Update page</button>;
+  const { options, useFirstPerson, applicant } = generateOptions({
+    data,
+    pagePerItemIndex,
+  });
+
+  const handlers = {
+    validate() {
+      let isValid = true;
+      if (!checkValue) {
+        setError('This field is required');
+        isValid = false;
+      } else {
+        setError(null); // Clear any existing err msg
+      }
+      return isValid;
+    },
+    radioUpdate: ({ detail }) => {
+      setCheckValue(detail.value);
+      setDirty(true);
+    },
+
+    onGoForward: event => {
+      setDirty(true);
+      event.preventDefault();
+      if (!handlers.validate()) return;
+      const testVal = { ...data };
+      testVal.applicants[pagePerItemIndex][keyname] = checkValue;
+      setFormData(testVal); // Commit changes to the actual formdata
+      if (onReviewPage) updatePage();
+      goForward(data);
+    },
+  };
+
+  useEffect(
+    () => {
+      if (dirty) handlers.validate();
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [checkValue],
+  );
+
+  return (
+    <>
+      {
+        titleUI(
+          `${
+            useFirstPerson ? 'Your' : `${applicant}'s`
+          } other health insurance status`,
+        )['ui:title']
+      }
+
+      <form onSubmit={handlers.onGoForward}>
+        <VaRadio
+          class="vads-u-margin-y--2"
+          label={`${
+            useFirstPerson ? 'Do you' : `Does ${applicant}`
+          } have other health insurance (that is not Medicare)?`}
+          required
+          error={error}
+          onVaValueChange={handlers.radioUpdate}
+        >
+          {options.map(option => (
+            <va-radio-option
+              key={option.value}
+              name="describes-you"
+              label={option.label}
+              value={option.value}
+              checked={checkValue === option.value}
+              aria-describedby={
+                checkValue === option.value ? option.value : null
+              }
+            />
+          ))}
+        </VaRadio>
+
+        {onReviewPage ? updateButton : navButtons}
+      </form>
+    </>
+  );
+}
+
+ApplicantOhiStatusReviewPage.propTypes = {
+  data: PropTypes.object,
+};
+
+ApplicantOhiStatusPage.propTypes = {
+  data: PropTypes.object,
+  goBack: PropTypes.func,
+  goForward: PropTypes.func,
+  pagePerItemIndex: PropTypes.string || PropTypes.number,
+  setFormData: PropTypes.func,
+  updatePage: PropTypes.func,
+  onReviewPage: PropTypes.bool,
+};


### PR DESCRIPTION
## Summary

This PR introduces a custom page component for use in form 10-10D. A custom page component was created because this section of the form needed dynamic wording functionality. This component will be added to form 10-10D's Applicant Information section in an upcoming PR. For now, it is just being added without being integrated so that the PR stays within a reasonable size. Additional unit testing is planned in a followup PR.

- Added a custom page for collecting whether or not the applicant has other health insurance
- Team: IVC-CHAMPVA
- Flipper: NA, form not set to go to prod 

## Related issue(s)
Part of a continued effort to break up this issue: 
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/74348

## Testing done

- Manual testing
- Ran `yarn test:coverage-app ivc-champva/10-10D` to verify existing tests run and pass

## Screenshots

|         | Scenario 1 | Scenario 2 |
| ------- | ------ | ----- |
| Desktop |![Screenshot 2024-02-16 at 10 34 00](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/5ee10f12-342e-4dfd-9c54-a13cd1b8c9c4) | ![Screenshot 2024-02-16 at 10 34 47](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/28f45623-7d8b-458c-9886-4a97614b5fc8) |

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
