### PR TITLE
74348e Add applicant relationship custom page

### DIFF
--- a/src/applications/ivc-champva/10-10D/pages/ApplicantRelationshipPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantRelationshipPage.jsx
@@ -47,9 +47,9 @@ function generateOptions({ data, pagePerItemIndex }) {
       value: 'caretaker',
     },
     {
-      label: `${`${
+      label: `${
         applicant && !useFirstPerson ? `${applicant} doesn’t` : 'We don’t'
-      }`} have a relationship that’s listed here`,
+      } have a relationship that’s listed here`,
       value: 'other',
     },
   ];
@@ -231,6 +231,7 @@ export default function ApplicantRelationshipPage({
               label={option.label}
               value={option.value}
               checked={checkValue.relationshipToVeteran === option.value}
+              uswds
               aria-describedby={
                 checkValue.relationshipToVeteran === option.value
                   ? option.value

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantRelationshipPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantRelationshipPage.jsx
@@ -1,0 +1,284 @@
+import React, { useState, useEffect } from 'react';
+import {
+  VaButton,
+  VaRadio,
+  VaTextInput,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
+import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import PropTypes from 'prop-types';
+
+import { applicantWording } from '../helpers/wordingCustomization';
+
+const keyname = 'applicantRelationshipToSponsor';
+
+function generateOptions({ data, pagePerItemIndex }) {
+  const currentListItem = data?.applicants?.[pagePerItemIndex];
+  const personTitle = 'Sponsor';
+  const applicant = applicantWording(currentListItem).slice(0, -3); // remove 's_
+
+  // Determine what tense/person the phrasing should be in
+  const useFirstPerson =
+    data?.certifierRole === 'applicant' && +pagePerItemIndex === 0;
+
+  // Set up grammatically appropriate articles
+  const relativeBeingVerb = `${`${
+    !useFirstPerson
+      ? `${applicant} ${data.sponsorIsDeceased ? 'was' : 'is'}`
+      : `${data.sponsorIsDeceased ? 'I was' : 'I’m'}`
+  }`}`;
+
+  const relativePossessive = `${`${
+    useFirstPerson ? 'your' : `${applicant}’s`
+  }`}`;
+
+  // Create dynamic radio labels based on above phrasing
+  const options = [
+    {
+      label: `${relativeBeingVerb} the ${personTitle}'s spouse`,
+      value: 'spouse',
+    },
+    {
+      label: `${relativeBeingVerb} the ${personTitle}'s child`,
+      value: 'child',
+    },
+    {
+      label: `${relativeBeingVerb} the ${personTitle}'s caretaker`,
+      value: 'caretaker',
+    },
+    {
+      label: `${`${
+        applicant && !useFirstPerson ? `${applicant} doesn’t` : 'We don’t'
+      }`} have a relationship that’s listed here`,
+      value: 'other',
+    },
+  ];
+
+  return {
+    options,
+    useFirstPerson,
+    relativePossessive,
+    relativeBeingVerb,
+    applicant,
+    personTitle,
+    keyname,
+    currentListItem,
+    description: `Relationship to ${personTitle}`,
+  };
+}
+
+const relationshipStructure = {
+  relationshipToVeteran: undefined,
+  otherRelationshipToVeteran: undefined,
+};
+
+export function ApplicantRelationshipReviewPage(props) {
+  const { data } = props || {};
+  const {
+    currentListItem,
+    options,
+    description,
+    useFirstPerson,
+    applicant,
+    personTitle,
+  } = generateOptions(props);
+  const other = currentListItem?.[keyname]?.otherRelationshipToVeteran;
+  return data ? (
+    <div className="form-review-panel-page">
+      <div className="form-review-panel-page-header-row">
+        <h4 className="form-review-panel-page-header vads-u-font-size--h5">
+          {props.title(currentListItem)}
+        </h4>
+        <VaButton secondary onClick={props.editPage} text="Edit" uswds />
+      </div>
+      <dl className="review">
+        <div className="review-row">
+          <dt>{description}</dt>
+          <dd>
+            {options.map(
+              opt =>
+                opt.value === currentListItem?.[keyname]?.relationshipToVeteran
+                  ? opt.label
+                  : '',
+            )}
+          </dd>
+        </div>
+
+        {other ? (
+          <div className="review-row">
+            <dt>
+              Since {useFirstPerson ? 'your' : `${applicant}'s `} relationship
+              with the {personTitle} was not listed, please describe it here
+            </dt>
+            <dd>{other}</dd>
+          </div>
+        ) : null}
+      </dl>
+    </div>
+  ) : null;
+}
+
+export default function ApplicantRelationshipPage({
+  data,
+  setFormData,
+  goBack,
+  goForward,
+  pagePerItemIndex,
+  updatePage,
+  onReviewPage,
+}) {
+  const [checkValue, setCheckValue] = useState(
+    data?.applicants?.[pagePerItemIndex]?.[keyname] || relationshipStructure,
+  );
+  const [checkError, setCheckError] = useState(undefined);
+  const [inputError, setInputError] = useState(undefined);
+  const [dirty, setDirty] = useState(false);
+  const navButtons = <FormNavButtons goBack={goBack} submitToContinue />;
+  // eslint-disable-next-line @department-of-veterans-affairs/prefer-button-component
+  const updateButton = <button type="submit">Update page</button>;
+  const {
+    options,
+    relativePossessive,
+    useFirstPerson,
+    applicant,
+    personTitle,
+  } = generateOptions({
+    data,
+    pagePerItemIndex,
+  });
+
+  const handlers = {
+    validate() {
+      let isValid = true;
+      if (!checkValue.relationshipToVeteran) {
+        setCheckError('This field is required');
+        isValid = false;
+      } else {
+        setCheckError(null); // Clear any existing err msg
+      }
+      if (
+        checkValue.relationshipToVeteran === 'other' &&
+        !checkValue.otherRelationshipToVeteran
+      ) {
+        setInputError('This field is required');
+        isValid = false;
+      } else {
+        setInputError(null);
+      }
+      return isValid;
+    },
+    radioUpdate: ({ detail }) => {
+      const val =
+        detail.value === 'other'
+          ? {
+              relationshipToVeteran: detail.value,
+              otherRelationshipToVeteran: undefined,
+            }
+          : { relationshipToVeteran: detail.value };
+      setDirty(true);
+      setCheckValue(val);
+      handlers.validate();
+    },
+    inputUpdate: ({ target }) => {
+      const val = checkValue;
+      val.otherRelationshipToVeteran = target.value;
+      setDirty(true);
+      setCheckValue(val);
+      handlers.validate();
+    },
+    onGoForward: event => {
+      event.preventDefault();
+      if (!handlers.validate()) return;
+      const testVal = { ...data };
+      testVal.applicants[pagePerItemIndex][keyname] = checkValue;
+      setFormData(testVal);
+      if (onReviewPage) updatePage();
+      goForward(data);
+    },
+  };
+
+  useEffect(
+    () => {
+      if (dirty) handlers.validate();
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [data, checkValue],
+  );
+  return (
+    <>
+      {
+        titleUI(
+          `${
+            useFirstPerson ? `Your` : `${applicant}'s`
+          } relationship to the ${personTitle}`,
+        )['ui:title']
+      }
+
+      <form onSubmit={handlers.onGoForward}>
+        <VaRadio
+          class="vads-u-margin-y--2"
+          label={`What's ${
+            useFirstPerson ? `your` : `${applicant}'s`
+          } relationship to the ${personTitle}?`}
+          required
+          error={checkError}
+          onVaValueChange={handlers.radioUpdate}
+        >
+          {options.map(option => (
+            <va-radio-option
+              key={option.value}
+              name="describes-you"
+              label={option.label}
+              value={option.value}
+              checked={checkValue.relationshipToVeteran === option.value}
+              aria-describedby={
+                checkValue.relationshipToVeteran === option.value
+                  ? option.value
+                  : null
+              }
+            />
+          ))}
+        </VaRadio>
+        {checkValue.relationshipToVeteran === 'other' && (
+          <div
+            className={
+              checkValue.relationshipToVeteran === 'other'
+                ? 'form-expanding-group form-expanding-group-open'
+                : ''
+            }
+          >
+            <div className="form-expanding-group-inner-enter-done">
+              <div className="schemaform-expandUnder-indent">
+                <VaTextInput
+                  label={`Since ${relativePossessive} relationship with the ${personTitle} was not listed, please describe it here`}
+                  onInput={handlers.inputUpdate}
+                  required={checkValue.relationshipToVeteran === 'other'}
+                  error={inputError}
+                  value={checkValue.otherRelationshipToVeteran}
+                  uswds
+                />
+              </div>
+            </div>
+          </div>
+        )}
+        {onReviewPage ? updateButton : navButtons}
+      </form>
+    </>
+  );
+}
+
+ApplicantRelationshipReviewPage.propTypes = {
+  data: PropTypes.object,
+  editPage: PropTypes.func,
+  title: PropTypes.func,
+};
+
+ApplicantRelationshipPage.propTypes = {
+  data: PropTypes.object,
+  goBack: PropTypes.func,
+  goForward: PropTypes.func,
+  pagePerItemIndex: PropTypes.string || PropTypes.number,
+  setFormData: PropTypes.func,
+  updatePage: PropTypes.func,
+  onReviewPage: PropTypes.bool,
+};


### PR DESCRIPTION
## Summary

This PR introduces a custom relationship page component for use in form 10-10D. A custom page component was created because this section of the form needed dynamic wording functionality. This component will be added to form 10-10D's Applicant Information section in an upcoming PR. For now, it is just being added without being integrated so that the PR stays within a reasonable size. Additional unit testing is planned in a followup PR.

- Added a custom page for collecting applicant's relationship to sponsor w/ dynamic wording
- Team: IVC-CHAMPVA
- Flipper: NA, not set to go to prod

## Related issue(s)
Part of ongoing work to split up this PR:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/74348

## Testing done

- Manual testing
- Ran `yarn test:coverage-app ivc-champva/10-10D` to verify existing tests run and pass

## Screenshots

|         | Scenario 1 | Scenario 2 |
| ------- | ------ | ----- |
| Desktop |![1](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/5887e807-4a88-4fc7-a997-ace51159802e)|![2](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/e32199bc-45b8-40a8-b233-892f36cf6912)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
