### PR TITLE
Remove eMIS as an external service

### DIFF
--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -10,7 +10,6 @@ import {
 } from '../../authentication/utilities';
 
 const commonServices = {
-  EMIS: 'EMIS',
   MVI: 'MVI',
   VA_PROFILE: 'VAProfile',
 };
@@ -84,9 +83,7 @@ export function mapRawUserDataToState(json) {
 
   if (meta && veteranStatus === null) {
     const errorStatus = meta.errors.find(
-      error =>
-        error.externalService === commonServices.VA_PROFILE ||
-        error.externalService === commonServices.EMIS,
+      error => error.externalService === commonServices.VA_PROFILE,
     ).status;
     userState.veteranStatus.status = getErrorStatusDesc(errorStatus);
   } else {


### PR DESCRIPTION
## Summary
Ever since [these vets-api changes](https://github.com/department-of-veterans-affairs/vets-api/pull/15393/files#diff-64abab86a25a2db0f3b93876d46a4098b13d0a5b689da27c8171c2edb9cd88e5) merged on Friday morning, vets-api is no longer sending `EMIS` as the name of the external service. That means vets-website doesn't have to expect "EMIS" anymore. 

- I am on the Platform Product team
- No flippers in use here. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/76033
- Previous PR related to this: https://github.com/department-of-veterans-affairs/vets-website/pull/27851
- Vets-api PR: https://github.com/department-of-veterans-affairs/vets-api/pull/15393/
- Epic: https://github.com/department-of-veterans-affairs/va.gov-team/issues/63326

## Testing done
- With vets-api server running on `master` and vets-website server running this branch, I logged in as user 16. Login was successful and the error object mentions VAProfile (which is expected for this user).
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/10993987/65cc9664-2fc4-4c92-985e-ebd463ef1d22)
- I also tested with joe user 5, vetsgov user 5, and user 32.

## What areas of the site does it impact?

If there are errors in the `veteran_status` or `vet360_contact_information` portions of the user object, the code that triggers "VAProfile" will get hit. 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user


