### PR TITLE
Add additional user props to Datadog RUM user session

### DIFF
--- a/src/applications/hca/containers/App.jsx
+++ b/src/applications/hca/containers/App.jsx
@@ -5,10 +5,10 @@ import PropTypes from 'prop-types';
 import RoutedSavableApp from '@department-of-veterans-affairs/platform-forms/RoutedSavableApp';
 import { setData } from '@department-of-veterans-affairs/platform-forms-system/actions';
 import { isLOA3, isLoggedIn, selectProfile } from 'platform/user/selectors';
-import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import recordEvent from 'platform/monitoring/record-event';
 
 import { fetchTotalDisabilityRating } from '../utils/actions';
+import { selectFeatureToggles } from '../utils/selectors/feature-toggles';
 import { useBrowserMonitoring } from '../hooks/useBrowserMonitoring';
 import { parseVeteranDob } from '../utils/helpers';
 import formConfig from '../config/form';
@@ -17,22 +17,19 @@ const App = props => {
   const { children, location, setFormData, getTotalDisabilityRating } = props;
 
   const {
-    TOGGLE_NAMES,
-    useToggleValue,
-    useToggleLoadingValue,
-  } = useFeatureToggle();
-  const isFacilitiesApiEnabled = useToggleValue(
-    TOGGLE_NAMES.hcaUseFacilitiesApi,
+    isLoadingFeatureFlags,
+    isFacilitiesApiEnabled,
+    isSigiEnabled,
+  } = useSelector(selectFeatureToggles);
+  const { dob: veteranDob, loading: isLoadingProfile } = useSelector(
+    selectProfile,
   );
-  const isSigiEnabled = useToggleValue(TOGGLE_NAMES.hcaSigiEnabled);
-  const isLoading = useToggleLoadingValue();
-
   const { totalDisabilityRating } = useSelector(state => state.totalRating);
   const { data: formData } = useSelector(state => state.form);
-  const { dob: veteranDob } = useSelector(selectProfile);
   const loggedIn = useSelector(isLoggedIn);
   const isLOA3User = useSelector(isLOA3);
   const { veteranFullName } = formData;
+  const isAppLoading = isLoadingFeatureFlags || isLoadingProfile;
 
   // Attempt to fetch disability rating for LOA3 users
   useEffect(
@@ -92,7 +89,7 @@ const App = props => {
   // Attach analytics events to all yes/no radio inputs
   useEffect(
     () => {
-      if (!isLoading) {
+      if (!isAppLoading) {
         const radios = document.querySelectorAll(
           'input[id$=Yes], input[id$=No]',
         );
@@ -108,13 +105,19 @@ const App = props => {
         }
       }
     },
-    [isLoading, location],
+    [isAppLoading, location],
   );
 
   // Add Datadog UX monitoring to the application
   useBrowserMonitoring();
 
-  return (
+  return isAppLoading ? (
+    <va-loading-indicator
+      message="Loading application..."
+      class="vads-u-margin-y--4"
+      set-focus
+    />
+  ) : (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
       {children}
     </RoutedSavableApp>

--- a/src/applications/hca/tests/utils/selectors/datadog-rum.unit.spec.js
+++ b/src/applications/hca/tests/utils/selectors/datadog-rum.unit.spec.js
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import { selectRumUser } from '../../../utils/selectors/datadog-rum';
+
+describe('hca DatadogRUM selector', () => {
+  const state = {
+    hcaEnrollmentStatus: {
+      enrollmentStatus: 'noneOfTheAbove',
+    },
+    totalRating: {
+      totalDisabilityRating: 0,
+    },
+    user: {
+      profile: {
+        loa: { current: 3 },
+        signIn: { serviceName: 'IDme' },
+      },
+      login: {
+        currentlyLoggedIn: true,
+      },
+    },
+  };
+
+  describe('when `selectRumUser` executes', () => {
+    it('should return correct user properties', () => {
+      expect(selectRumUser(state)).to.eql({
+        disabilityRating: 0,
+        isSignedIn: true,
+        serviceProvider: 'IDme',
+        loa: 3,
+        enrollmentStatus: 'noneOfTheAbove',
+      });
+    });
+  });
+});

--- a/src/applications/hca/tests/utils/selectors/feature-toggles.unit.spec.js
+++ b/src/applications/hca/tests/utils/selectors/feature-toggles.unit.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { makeSelectFeatureToggles } from '../../../utils/selectors/feature-toggles';
+import { selectFeatureToggles } from '../../../utils/selectors/feature-toggles';
 
 describe('hca FeatureToggles selector', () => {
   const state = {
@@ -13,9 +13,8 @@ describe('hca FeatureToggles selector', () => {
     },
   };
 
-  describe('when `makeSelectFeatureToggles` executes', () => {
+  describe('when `selectFeatureToggles` executes', () => {
     it('should return feature toggles', () => {
-      const selectFeatureToggles = makeSelectFeatureToggles();
       expect(selectFeatureToggles(state)).to.eql({
         isLoadingFeatureFlags: false,
         isBrowserMonitoringEnabled: true,

--- a/src/applications/hca/utils/selectors/datadog-rum.js
+++ b/src/applications/hca/utils/selectors/datadog-rum.js
@@ -3,17 +3,14 @@ export const selectRumUser = state => {
   const { enrollmentStatus } = hcaEnrollmentStatus;
   const { totalDisabilityRating } = totalRating;
   const {
-    profile: {
-      loa: { current: currentLOA },
-      signIn: { serviceName },
-    },
+    profile: { loa, signIn },
     login: { currentlyLoggedIn },
   } = user;
   return {
     disabilityRating: totalDisabilityRating,
     isSignedIn: currentlyLoggedIn,
-    serviceProvider: serviceName,
-    loa: currentLOA,
+    serviceProvider: signIn?.serviceName,
+    loa: loa?.current,
     enrollmentStatus,
   };
 };

--- a/src/applications/hca/utils/selectors/datadog-rum.js
+++ b/src/applications/hca/utils/selectors/datadog-rum.js
@@ -1,0 +1,19 @@
+export const selectRumUser = state => {
+  const { user, hcaEnrollmentStatus, totalRating } = state;
+  const { enrollmentStatus } = hcaEnrollmentStatus;
+  const { totalDisabilityRating } = totalRating;
+  const {
+    profile: {
+      loa: { current: currentLOA },
+      signIn: { serviceName },
+    },
+    login: { currentlyLoggedIn },
+  } = user;
+  return {
+    disabilityRating: totalDisabilityRating,
+    isSignedIn: currentlyLoggedIn,
+    serviceProvider: serviceName,
+    loa: currentLOA,
+    enrollmentStatus,
+  };
+};

--- a/src/applications/hca/utils/selectors/feature-toggles.js
+++ b/src/applications/hca/utils/selectors/feature-toggles.js
@@ -1,24 +1,15 @@
-import { createSelector } from 'reselect';
 import { toggleValues } from '@department-of-veterans-affairs/platform-site-wide/selectors';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 
-const selectFeatureToggles = createSelector(
-  state => ({
-    isLoadingFeatureFlags: state?.featureToggles?.loading,
-    isBrowserMonitoringEnabled: toggleValues(state)[
-      FEATURE_FLAG_NAMES.hcaBrowserMonitoringEnabled
-    ],
-    isESOverrideEnabled: toggleValues(state)[
-      FEATURE_FLAG_NAMES.hcaEnrollmentStatusOverrideEnabled
-    ],
-    isFacilitiesApiEnabled: toggleValues(state)[
-      FEATURE_FLAG_NAMES.hcaUseFacilitiesApi
-    ],
-    isSigiEnabled: toggleValues(state)[FEATURE_FLAG_NAMES.hcaSigiEnabled],
-  }),
-  toggles => toggles,
-);
-
-const makeSelectFeatureToggles = () => selectFeatureToggles;
-
-export { makeSelectFeatureToggles };
+export const selectFeatureToggles = state => {
+  const toggles = toggleValues(state);
+  return {
+    isLoadingFeatureFlags: toggles.loading,
+    isBrowserMonitoringEnabled:
+      toggles[FEATURE_FLAG_NAMES.hcaBrowserMonitoringEnabled],
+    isESOverrideEnabled:
+      toggles[FEATURE_FLAG_NAMES.hcaEnrollmentStatusOverrideEnabled],
+    isFacilitiesApiEnabled: toggles[FEATURE_FLAG_NAMES.hcaUseFacilitiesApi],
+    isSigiEnabled: toggles[FEATURE_FLAG_NAMES.hcaSigiEnabled],
+  };
+};


### PR DESCRIPTION
## Summary
We are seeking to track additional (non-PII) user properties in our Datadog RUM user sessions. Included in these props is the users LOA status, authentication status, login service provider, enrollment status and total disability rating. This PR adds those props into the RUM initializer to be tracked in sessions.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#76235

## Acceptance criteria

- User properties are trackable in RUM user sessions

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution