### PR TITLE
VACMS-17274 Redirects for legacy FDC pages

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -261,6 +261,16 @@
   },
   {
     "domain": "www.benefits.va.gov",
+    "src": "/FDC/walkthrough.asp",
+    "dest": "/disability/how-to-file-claim/evidence-needed/fully-developed-claims/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/FDC/checklist.asp",
+    "dest": "/disability/how-to-file-claim/evidence-needed/fully-developed-claims/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
     "src": "/compensation/effective_dates.asp",
     "dest": "/disability/about-disability-ratings/effective-date/"
   },


### PR DESCRIPTION
## Summary
Add cross-domain redirects for legacy FDC pages

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17274