### PR TITLE
VACMS-11871 Remove show_new_secure_messaging_page flipper

### DIFF
--- a/src/applications/mhv/secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
+++ b/src/applications/mhv/secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
@@ -1503,14 +1503,6 @@
         "value": true
       },
       {
-        "name": "showNewSecureMessagingPage",
-        "value": true
-      },
-      {
-        "name": "show_new_secure_messaging_page",
-        "value": true
-      },
-      {
         "name": "showUpdatedFryDeaApp",
         "value": false
       },

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
@@ -155,10 +155,6 @@
         "value": false
       },
       {
-        "name": "show_new_secure_messaging_page",
-        "value": false
-      },
-      {
         "name": "show526Wizard",
         "value": false
       }

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
@@ -155,10 +155,6 @@
         "value": true
       },
       {
-        "name": "show_new_secure_messaging_page",
-        "value": true
-      },
-      {
         "name": "show526Wizard",
         "value": true
       }

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.unit.spec.js
@@ -10,10 +10,7 @@ import { App } from './index';
 describe('Get Medical Records Page <App>', () => {
   it('renders what we expect when not a Cerner patient', () => {
     const wrapper = shallow(
-      <App
-        showNewSecureMessagingPage
-        facilities={[{ usesCernerMessaging: false }]}
-      />,
+      <App facilities={[{ usesCernerMessaging: false }]} />,
     );
     expect(wrapper.find(UnauthContent)).to.have.lengthOf(1);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(0);
@@ -22,10 +19,7 @@ describe('Get Medical Records Page <App>', () => {
 
   it('renders what we expect when a Cerner patient', () => {
     const wrapper = shallow(
-      <App
-        showNewSecureMessagingPage
-        facilities={[{ usesCernerMessaging: true }]}
-      />,
+      <App facilities={[{ usesCernerMessaging: true }]} />,
     );
     expect(wrapper.find(UnauthContent)).to.have.lengthOf(0);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(1);

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -223,7 +223,6 @@ export default Object.freeze({
     'show_new_refill_track_prescriptions_page',
   showNewScheduleViewAppointmentsPage:
     'show_new_schedule_view_appointments_page',
-  showNewSecureMessagingPage: 'show_new_secure_messaging_page',
   showUpdatedFryDeaApp: 'show_updated_fry_dea_app',
   signInServiceEnabled: 'sign_in_service_enabled',
   stemAutomatedDecision: 'stem_automated_decision',


### PR DESCRIPTION
## Summary
Remove show_new_secure_messaging_page flipper

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11871