### PR TITLE
VACMS-11877 Remove sharable_link flipper

### DIFF
--- a/src/applications/mhv/secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
+++ b/src/applications/mhv/secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
@@ -1319,10 +1319,6 @@
         "value": true
       },
       {
-        "name": "sharable_link",
-        "value": true
-      },
-      {
         "name": "show526Wizard",
         "value": true
       },


### PR DESCRIPTION
## Summary
Removing sharable_link flipper

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11877