### PR TITLE
vfep-1161 fixed the before filters results to show after search resu…

### DIFF
--- a/src/applications/gi/actions/index.js
+++ b/src/applications/gi/actions/index.js
@@ -60,7 +60,7 @@ export const UPDATE_COMPARE_DETAILS = 'UPDATE_COMPARE_DETAILS';
 export const UPDATE_CURRENT_SEARCH_TAB = 'UPDATE_CURRENT_TAB';
 export const UPDATE_ESTIMATED_BENEFITS = 'UPDATE_ESTIMATED_BENEFITS';
 export const SET_ERROR = 'SET_ERROR';
-
+export const FILTER_BEFORE_RESULTS = 'FILTER_BEFORE_RESULTS';
 export const UPDATE_QUERY_PARAMS = 'UPDATE_QUERY_PARAMS';
 
 export function enterPreviewMode(version) {
@@ -534,5 +534,10 @@ export const setError = error => {
   return {
     type: SET_ERROR,
     payload: error,
+  };
+};
+export const filterBeforeResultFlag = () => {
+  return {
+    type: FILTER_BEFORE_RESULTS,
   };
 };

--- a/src/applications/gi/containers/search/NameSearchForm.jsx
+++ b/src/applications/gi/containers/search/NameSearchForm.jsx
@@ -8,6 +8,7 @@ import {
   fetchSearchByNameResults,
   updateAutocompleteName,
   setError,
+  filterBeforeResultFlag,
 } from '../../actions';
 import KeywordSearch from '../../components/search/KeywordSearch';
 import { updateUrlParams } from '../../selectors/search';
@@ -27,10 +28,13 @@ export function NameSearchForm({
   search,
   smallScreen,
   errorReducer,
+  filterBeforeResultsReducer,
+  dispatchShowFiltersBeforeResult,
 }) {
   const { version } = preview;
   const [name, setName] = useState(search.query.name);
-  const [showFiltersBeforeSearch, setShowFiltersBeforeSearch] = useState(true);
+  // const [showFiltersBeforeSearch, setShowFiltersBeforeSearch] = useState(true);
+  const { showFiltersBeforeResult } = filterBeforeResultsReducer;
   // const [error, setError] = useState(null);
   const { error } = errorReducer;
   const history = useHistory();
@@ -90,7 +94,7 @@ export function NameSearchForm({
         'gibct-form-field': 'nameSearch',
         'gibct-form-value': name,
       });
-      setShowFiltersBeforeSearch(false);
+      dispatchShowFiltersBeforeResult();
       doSearch(name);
     }
   };
@@ -147,7 +151,7 @@ export function NameSearchForm({
       </form>
       {!smallScreen &&
         !environment.isProduction() &&
-        showFiltersBeforeSearch && (
+        showFiltersBeforeResult && (
           <div>
             <FilterBeforeResults nameVal={name} searchType="name" />
           </div>
@@ -162,6 +166,7 @@ const mapStateToProps = state => ({
   preview: state.preview,
   search: state.search,
   errorReducer: state.errorReducer,
+  filterBeforeResultsReducer: state.filterBeforeResultsReducer,
 });
 
 const mapDispatchToProps = {
@@ -169,6 +174,7 @@ const mapDispatchToProps = {
   dispatchUpdateAutocompleteName: updateAutocompleteName,
   dispatchFetchSearchByNameResults: fetchSearchByNameResults,
   dispatchError: setError,
+  dispatchShowFiltersBeforeResult: filterBeforeResultFlag,
 };
 
 export default connect(

--- a/src/applications/gi/reducers/filterBeforeResultsReducer.js
+++ b/src/applications/gi/reducers/filterBeforeResultsReducer.js
@@ -1,0 +1,16 @@
+import { FILTER_BEFORE_RESULTS } from '../actions';
+
+const INITIAL_STATE = {
+  showFiltersBeforeResult: true,
+};
+
+const filterBeforeResultsReducer = (state = INITIAL_STATE, action) => {
+  if (action.type === FILTER_BEFORE_RESULTS) {
+    return {
+      ...state,
+      showFiltersBeforeResult: false,
+    };
+  }
+  return state;
+};
+export default filterBeforeResultsReducer;

--- a/src/applications/gi/reducers/index.js
+++ b/src/applications/gi/reducers/index.js
@@ -9,6 +9,7 @@ import preview from './preview';
 import profile from './profile';
 import search from './search';
 import errorReducer from './error';
+import filterBeforeResultsReducer from './filterBeforeResultsReducer';
 
 const rootReducer = {
   autocomplete,
@@ -22,6 +23,7 @@ const rootReducer = {
   profile,
   search,
   errorReducer,
+  filterBeforeResultsReducer,
 };
 
 export default rootReducer;

--- a/src/applications/gi/tests/actions/index.unit.spec.jsx
+++ b/src/applications/gi/tests/actions/index.unit.spec.jsx
@@ -850,4 +850,10 @@ describe('actionCreators', () => {
     fetchStub.returns(Promise.resolve(mockResponse));
     return store.dispatch(actions.beneficiaryZIPCodeChanged('12345'));
   });
+  it('filterBeforeResults should create an action to filter before results', () => {
+    const expectedAction = {
+      type: actions.FILTER_BEFORE_RESULTS,
+    };
+    expect(actions.filterBeforeResultFlag()).to.deep.equal(expectedAction);
+  });
 });

--- a/src/applications/gi/tests/reducers/filterBeforeResultsReducer.unit.spec.js
+++ b/src/applications/gi/tests/reducers/filterBeforeResultsReducer.unit.spec.js
@@ -1,0 +1,21 @@
+import { createStore } from 'redux';
+import { expect } from 'chai';
+import filterBeforeResultsReducer from '../../reducers/filterBeforeResultsReducer';
+import { FILTER_BEFORE_RESULTS } from '../../actions';
+
+describe('filterBeforeResultsReducer', () => {
+  let store;
+
+  beforeEach(() => {
+    store = createStore(filterBeforeResultsReducer);
+  });
+
+  it('should return the initial state', () => {
+    expect(store.getState()).to.deep.equal({ showFiltersBeforeResult: true });
+  });
+
+  it('should handle FILTER_BEFORE_RESULTS action', () => {
+    store.dispatch({ type: FILTER_BEFORE_RESULTS });
+    expect(store.getState()).to.deep.equal({ showFiltersBeforeResult: false });
+  });
+});


### PR DESCRIPTION
…lt is selected. Also added unit tests.

## Summary
Fixed SMF Filter before results to show twice after back button has been clicked. In addition, more unit tests were added.

## Screenshots
<img width="977" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/145523589/14a646bb-703e-4a12-81d8-bf88e011d5ef">

<img width="1728" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/145523589/8ddec0b6-490f-43b1-8076-09bd84a889a4">


