### PR TITLE
VACMS-11874 Remove flipper logic for PDF modal in Find Forms

### DIFF
--- a/src/applications/find-forms/components/FormTitle.jsx
+++ b/src/applications/find-forms/components/FormTitle.jsx
@@ -35,7 +35,7 @@ const FormTitle = ({ id, formUrl, title, lang, recordGAEvent, formName }) => (
         </p>
         <h3
           aria-describedby={id}
-          className="vads-u-font-family--serif vads-u-font-size--base vads-u-margin--0"
+          className="vads-u-font-family--serif vads-u-font-size--base vads-u-margin--0 vads-u-margin-top--1p5"
           lang={lang}
         >
           {title}

--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -135,7 +135,6 @@ const deriveRelatedTo = ({
 const SearchResult = ({
   form,
   formMetaInfo,
-  showPDFInfoVersionOne,
   toggleModalState,
   setPrevFocusedLink,
 }) => {
@@ -176,17 +175,13 @@ const SearchResult = ({
   const pdfDownloadHandler = () => {
     setPrevFocusedLink(`pdf-link-${id}`);
 
-    if (showPDFInfoVersionOne) {
-      recordEvent({
-        event: 'int-modal-click',
-        'modal-status': 'opened',
-        'modal-title': 'Download this PDF and open it in Acrobat Reader',
-      });
+    recordEvent({
+      event: 'int-modal-click',
+      'modal-status': 'opened',
+      'modal-title': 'Download this PDF and open it in Acrobat Reader',
+    });
 
-      toggleModalState(formName, url, pdfLabel);
-    } else {
-      recordGAEvent(`Download VA form ${formName} ${pdfLabel}`, url, 'pdf');
-    }
+    toggleModalState(formName, url, pdfLabel);
   };
 
   return (
@@ -229,19 +224,18 @@ const SearchResult = ({
         </div>
       ) : null}
       <div className="vads-u-margin-y--0">
-        <a
-          className="find-forms-max-content vads-u-text-decoration--none"
+        <button
+          className="find-forms-max-content vads-u-text-decoration--none va-button-link"
           data-testid={`pdf-link-${id}`}
           id={`pdf-link-${id}`}
           rel="noreferrer noopener"
-          href={showPDFInfoVersionOne ? null : url}
           tabIndex="0"
           onKeyDown={event => {
-            if (event.keyCode === 13) {
+            if (event === 13) {
               pdfDownloadHandler();
             }
           }}
-          onClick={() => pdfDownloadHandler()}
+          onClick={pdfDownloadHandler}
           {...linkProps}
         >
           <i
@@ -253,7 +247,7 @@ const SearchResult = ({
           <span lang={language} className="vads-u-text-decoration--underline">
             {deriveLanguageTranslation(language, 'downloadVaForm', formName)}
           </span>
-        </a>
+        </button>
       </div>
     </li>
   );
@@ -263,7 +257,6 @@ SearchResult.propTypes = {
   form: customPropTypes.Form.isRequired,
   formMetaInfo: customPropTypes.FormMetaInfo,
   setPrevFocusedLink: PropTypes.func,
-  showPDFInfoVersionOne: PropTypes.bool,
   toggleModalState: PropTypes.func,
 };
 

--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -14,7 +14,7 @@ import {
   updatePaginationAction,
 } from '../actions';
 import { deriveDefaultModalState } from '../helpers';
-import { showPDFModal, getFindFormsAppState } from '../helpers/selectors';
+import { getFindFormsAppState } from '../helpers/selectors';
 import { FAF_SORT_OPTIONS } from '../constants';
 import SearchResult from '../components/SearchResult';
 
@@ -49,7 +49,6 @@ export const SearchResults = ({
   sortByPropertyName,
   hasOnlyRetiredForms,
   startIndex,
-  showPDFInfoVersionOne,
   updatePagination,
   updateSortByPropertyName,
 }) => {
@@ -199,7 +198,6 @@ export const SearchResults = ({
         key={form.id}
         form={form}
         formMetaInfo={{ ...formMetaInfo, currentPositionOnPage: index + 1 }}
-        showPDFInfoVersionOne={showPDFInfoVersionOne}
         toggleModalState={toggleModalState}
         setPrevFocusedLink={setPrevFocusedLink}
       />
@@ -263,7 +261,7 @@ export const SearchResults = ({
               Adobe Acrobat Reader to open and fill out the form. Don’t try to
               open the PDF on a mobile device or fill it out in your browser.
             </p>{' '}
-            <p>
+            <p className="vads-u-margin-top--0">
               If you want to fill out a paper copy, open the PDF in your browser
               and print it from there.
             </p>{' '}
@@ -322,7 +320,6 @@ SearchResults.propTypes = {
   startIndex: PropTypes.number.isRequired,
   updatePagination: PropTypes.func.isRequired,
   results: PropTypes.arrayOf(customPropTypes.Form.isRequired),
-  showPDFInfoVersionOne: PropTypes.bool,
   sortByPropertyName: PropTypes.string,
   updateSortByPropertyName: PropTypes.func,
 };
@@ -336,7 +333,6 @@ const mapStateToProps = state => ({
   query: getFindFormsAppState(state).query,
   results: getFindFormsAppState(state).results,
   startIndex: getFindFormsAppState(state).startIndex,
-  showPDFInfoVersionOne: showPDFModal(state),
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/applications/find-forms/helpers/selectors.js
+++ b/src/applications/find-forms/helpers/selectors.js
@@ -1,6 +1,1 @@
-import { toggleValues } from '~/platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from '~/platform/utilities/feature-toggles/featureFlagNames';
-
 export const getFindFormsAppState = state => state.findVAFormsReducer;
-export const showPDFModal = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.findFormsShowPdfModal];

--- a/src/applications/find-forms/tests/e2e/find-forms-required.cypress.spec.js
+++ b/src/applications/find-forms/tests/e2e/find-forms-required.cypress.spec.js
@@ -21,17 +21,6 @@ const SELECTORS = {
 
 describe('functionality of Find Forms', () => {
   beforeEach(() => {
-    cy.intercept('GET', '/v0/feature_toggles*', {
-      data: {
-        type: 'feature_toggles',
-        features: [
-          {
-            name: 'find_forms_show_pdf_modal',
-            value: true,
-          },
-        ],
-      },
-    });
     cy.intercept('GET', '/v0/forms?query=health', stub).as('getFindAForm');
   });
 
@@ -76,7 +65,7 @@ describe('functionality of Find Forms', () => {
 
     pages.forEach((page, pageNumber) => {
       page.forEach(form => {
-        cy.get(`a[data-testid="pdf-link-${form.id}"]`).should('exist');
+        cy.get(`button[data-testid="pdf-link-${form.id}"]`).should('exist');
       });
 
       const nextPage = pageNumber + 1;
@@ -105,7 +94,7 @@ describe('functionality of Find Forms', () => {
 
   it('opens PDF modal - C12431', () => {
     cy.visit('/find-forms/?q=health');
-    cy.get('a[data-testid^="pdf-link"]').then($links => {
+    cy.get('button[data-testid^="pdf-link"]').then($links => {
       const randomIndex = Math.floor(Math.random() * $links.length);
       cy.wrap($links)
         .eq(randomIndex)

--- a/src/applications/find-forms/tests/widgets/DownloadPDFGuidance.unit.spec.js
+++ b/src/applications/find-forms/tests/widgets/DownloadPDFGuidance.unit.spec.js
@@ -3,37 +3,88 @@ import ReactDOM from 'react-dom';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import DownloadPDFGuidance from '../../widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFGuidance';
-import featureFlagNames from '~/platform/utilities/feature-toggles/featureFlagNames';
 
 describe('DownloadPDFGuidance', () => {
   const insertSpy = sinon.spy();
-  const removeSpy = sinon.spy();
   const clickSpy = sinon.spy();
   const removeChildSpy = sinon.spy();
+  let domStub;
 
-  describe('if the feature flag is on', () => {
-    let domStub;
-    let reduxStore;
+  before(() => {
+    domStub = sinon.stub(ReactDOM, 'render').returns(<div />);
+  });
 
-    before(() => {
-      domStub = sinon.stub(ReactDOM, 'render').returns(<div />);
+  after(() => {
+    domStub.restore();
+  });
 
-      reduxStore = {
-        getState: () => {
-          return {
-            featureToggles: {
-              [featureFlagNames.findFormsShowPdfModal]: true,
-            },
-          };
+  it('should render the download pdf modal when everything is valid and retrieved', () => {
+    DownloadPDFGuidance({
+      downloadUrl: 'https://test.com',
+      form: {},
+      formNumber: 10109,
+      formPdfIsValid: true,
+      formPdfUrlIsValid: true,
+      link: {
+        parentNode: {
+          insertBefore: insertSpy,
         },
-      };
+        click: clickSpy,
+      },
+      netWorkRequestError: null,
     });
 
-    after(() => {
-      domStub.restore();
-    });
+    expect(domStub.called).to.be.true;
+  });
 
-    it('should render the download pdf modal when everything is valid and retrieved', () => {
+  describe('if the PDF is not valid', () => {
+    it('should not render the PDF', () => {
+      DownloadPDFGuidance({
+        downloadUrl: 'https://test.com',
+        form: {},
+        formNumber: 10109,
+        formPdfIsValid: false,
+        formPdfUrlIsValid: false,
+        link: {
+          parentNode: {
+            insertBefore: insertSpy,
+            removeChild: removeChildSpy,
+          },
+          click: clickSpy,
+        },
+        netWorkRequestError: null,
+      });
+
+      expect(insertSpy.called).to.be.true;
+      expect(removeChildSpy.called).to.be.true;
+    });
+  });
+
+  describe('if the PDF is not valid', () => {
+    it('should not render the PDF', () => {
+      DownloadPDFGuidance({
+        downloadUrl: 'https://test.com',
+        form: {},
+        formNumber: 10109,
+        formPdfIsValid: true,
+        formPdfUrlIsValid: false,
+        link: {
+          parentNode: {
+            insertBefore: insertSpy,
+            removeChild: removeChildSpy,
+          },
+          click: clickSpy,
+        },
+        netWorkRequestError: null,
+      });
+
+      expect(insertSpy.called).to.be.true;
+      expect(removeChildSpy.called).to.be.true;
+    });
+  });
+
+  describe('if there is a network error', () => {
+    it('should not render the PDF', () => {
       DownloadPDFGuidance({
         downloadUrl: 'https://test.com',
         form: {},
@@ -43,122 +94,15 @@ describe('DownloadPDFGuidance', () => {
         link: {
           parentNode: {
             insertBefore: insertSpy,
+            removeChild: removeChildSpy,
           },
-          removeEventListener: removeSpy,
           click: clickSpy,
         },
-        listenerFunction: () => {},
-        netWorkRequestError: null,
-        reduxStore,
+        netWorkRequestError: true,
       });
 
-      expect(domStub.called).to.be.true;
-    });
-  });
-
-  describe('if the feature flag is off', () => {
-    describe('if the PDF is valid', () => {
-      it('should not render the PDF', () => {
-        DownloadPDFGuidance({
-          downloadUrl: 'https://test.com',
-          form: {},
-          formNumber: 10109,
-          formPdfIsValid: true,
-          formPdfUrlIsValid: true,
-          link: {
-            parentNode: {
-              insertBefore: insertSpy,
-              removeChild: removeChildSpy,
-            },
-            removeEventListener: removeSpy,
-            click: clickSpy,
-          },
-          listenerFunction: () => {},
-          netWorkRequestError: null,
-          reduxStore: {},
-        });
-
-        expect(removeSpy.called).to.be.true;
-        expect(clickSpy.called).to.be.true;
-      });
-    });
-
-    describe('if the PDF is not valid', () => {
-      it('should not render the PDF', () => {
-        DownloadPDFGuidance({
-          downloadUrl: 'https://test.com',
-          form: {},
-          formNumber: 10109,
-          formPdfIsValid: false,
-          formPdfUrlIsValid: false,
-          link: {
-            parentNode: {
-              insertBefore: insertSpy,
-              removeChild: removeChildSpy,
-            },
-            removeEventListener: removeSpy,
-            click: clickSpy,
-          },
-          listenerFunction: () => {},
-          netWorkRequestError: null,
-          reduxStore: {},
-        });
-
-        expect(insertSpy.called).to.be.true;
-        expect(removeChildSpy.called).to.be.true;
-      });
-    });
-
-    describe('if the PDF is not valid', () => {
-      it('should not render the PDF', () => {
-        DownloadPDFGuidance({
-          downloadUrl: 'https://test.com',
-          form: {},
-          formNumber: 10109,
-          formPdfIsValid: true,
-          formPdfUrlIsValid: false,
-          link: {
-            parentNode: {
-              insertBefore: insertSpy,
-              removeChild: removeChildSpy,
-            },
-            removeEventListener: removeSpy,
-            click: clickSpy,
-          },
-          listenerFunction: () => {},
-          netWorkRequestError: null,
-          reduxStore: {},
-        });
-
-        expect(insertSpy.called).to.be.true;
-        expect(removeChildSpy.called).to.be.true;
-      });
-    });
-
-    describe('if there is a network error', () => {
-      it('should not render the PDF', () => {
-        DownloadPDFGuidance({
-          downloadUrl: 'https://test.com',
-          form: {},
-          formNumber: 10109,
-          formPdfIsValid: true,
-          formPdfUrlIsValid: true,
-          link: {
-            parentNode: {
-              insertBefore: insertSpy,
-              removeChild: removeChildSpy,
-            },
-            removeEventListener: removeSpy,
-            click: clickSpy,
-          },
-          listenerFunction: () => {},
-          netWorkRequestError: true,
-          reduxStore: {},
-        });
-
-        expect(insertSpy.called).to.be.true;
-        expect(removeChildSpy.called).to.be.true;
-      });
+      expect(insertSpy.called).to.be.true;
+      expect(removeChildSpy.called).to.be.true;
     });
   });
 });

--- a/src/applications/find-forms/tests/widgets/createInvalidPdfAlert.unit.spec.js
+++ b/src/applications/find-forms/tests/widgets/createInvalidPdfAlert.unit.spec.js
@@ -33,13 +33,6 @@ describe('createInvalidPdfAlert', () => {
       ],
     });
   });
-  const reduxStore = {
-    getState: () => {
-      return {
-        featureToggles: {},
-      };
-    },
-  };
 
   it('shows an alert banner for invalid forms', async () => {
     const link = {
@@ -59,7 +52,7 @@ describe('createInvalidPdfAlert', () => {
       preventDefault: sinon.stub(),
     };
 
-    await onDownloadLinkClick(event, reduxStore, sinon.stub());
+    await onDownloadLinkClick(event);
 
     expect(link.click.called).to.be.false;
     expect(link.parentNode.insertBefore.called).to.be.true;
@@ -74,13 +67,13 @@ describe('createInvalidPdfAlert', () => {
   it('does not show an alert banner for valid forms', async () => {
     const link = {
       click: sinon.stub(),
-      removeEventListener: sinon.stub(),
       href: 'https://www.va.gov/vaforms/medical/pdf/10-10EZ-fillable.pdf',
       dataset: {
         formNumber: '10-10EZ',
       },
       parentNode: {
         removeChild: sinon.stub(),
+        insertBefore: sinon.stub(),
       },
     };
 
@@ -89,10 +82,13 @@ describe('createInvalidPdfAlert', () => {
       preventDefault: sinon.stub(),
     };
 
-    await onDownloadLinkClick(event, reduxStore, sinon.stub());
+    await onDownloadLinkClick(event);
 
     expect(link.parentNode.removeChild.called).to.be.false;
-    expect(link.removeEventListener.called).to.be.true;
-    expect(link.click.called).to.be.true;
+    expect(link.parentNode.insertBefore.called).to.be.true;
+
+    const alertBox = link.parentNode.insertBefore.firstCall.args[0];
+
+    expect(alertBox.innerHTML).to.include('Download this PDF');
   });
 });

--- a/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFGuidance.js
+++ b/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFGuidance.js
@@ -1,11 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Provider } from 'react-redux';
 import recordEvent from '~/platform/monitoring/record-event';
 import DownloadPDFModal from './DownloadPDFModal';
 import InvalidFormDownload from './InvalidFormAlert';
 import { sentryLogger } from './index';
-import { showPDFModal } from '../../helpers/selectors';
 
 const removeReactRoot = () => {
   const pdf = document.querySelector('.faf-pdf-alert-modal-root');
@@ -20,40 +18,29 @@ const DownloadPDFGuidance = ({
   formPdfIsValid,
   formPdfUrlIsValid,
   link,
-  listenerFunction,
   netWorkRequestError,
-  reduxStore,
 }) => {
   const div = document.createElement('div');
   div.className = 'faf-pdf-alert-modal-root';
   const parentEl = link.parentNode;
 
   if (formPdfIsValid && formPdfUrlIsValid && !netWorkRequestError) {
-    // feature flag
-    if (reduxStore?.getState && showPDFModal(reduxStore.getState())) {
-      ReactDOM.render(
-        <Provider store={reduxStore}>
-          <DownloadPDFModal
-            formNumber={formNumber}
-            removeNode={removeReactRoot}
-            url={downloadUrl}
-          />
-        </Provider>,
-        div,
-      );
+    ReactDOM.render(
+      <DownloadPDFModal
+        formNumber={formNumber}
+        removeNode={removeReactRoot}
+        url={downloadUrl}
+      />,
+      div,
+    );
 
-      parentEl.insertBefore(div, link); // Insert modal on DOM
+    parentEl.insertBefore(div, link); // Insert modal on DOM
 
-      recordEvent({
-        event: 'int-modal-click',
-        'modal-status': 'opened',
-        'modal-title': 'Download this PDF and open it in Acrobat Reader',
-      });
-    } else {
-      // if the Feature Flag for the Modal is turned off
-      link.removeEventListener('click', listenerFunction);
-      link.click();
-    }
+    recordEvent({
+      event: 'int-modal-click',
+      'modal-status': 'opened',
+      'modal-title': 'Download this PDF and open it in Acrobat Reader',
+    });
   } else {
     let errorMessage = 'Find Forms - Form Detail - invalid PDF accessed';
 

--- a/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/InvalidFormAlert.jsx
+++ b/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/InvalidFormAlert.jsx
@@ -10,7 +10,7 @@ const InvalidFormDownload = ({ downloadUrl }) => {
   const mailto = `mailto:VaFormsManagers@va.gov?subject=${subject}&body=${body}`;
 
   return (
-    <va-alert status="error" uswds={false}>
+    <va-alert status="error" uswds>
       <h3 slot="headline">This form link isn’t working</h3>
       <div className="usa-alert-text vads-u-font-size--base">
         We’re sorry, but the form you’re trying to download appears to have an

--- a/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/index.js
+++ b/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/index.js
@@ -12,7 +12,7 @@ export function sentryLogger(form, formNumber, downloadUrl, message) {
   });
 }
 
-export async function onDownloadLinkClick(event, reduxStore, listenerFunction) {
+export async function onDownloadLinkClick(event) {
   // This function purpose is to determine if the PDF is valid on click.
   // Once it's done, it passes information to DownloadPDFGuidance() which determines what to render.
   event.preventDefault();
@@ -29,18 +29,22 @@ export async function onDownloadLinkClick(event, reduxStore, listenerFunction) {
 
   try {
     const forms = await fetchFormsApi(formNumber);
+
     form = forms.results.find(
       f => f?.attributes?.formName === link?.dataset?.formNumber,
     );
+
     formPdfIsValid = form?.attributes.validPdf;
 
     const isSameOrigin = downloadUrl?.startsWith(window.location.origin);
+
     if (formPdfIsValid && isSameOrigin) {
       // URLS can be entered invalid, 400 is returned, this checks to make sure href is valid
       // NOTE: There are Forms URLS under the https://www.vba.va.gov/ domain, we don't have a way currently to check if URL is valid on FE because of CORS
       const response = await fetch(downloadUrl, {
         method: 'HEAD', // HEAD METHOD SHOULD NOT RETURN BODY, WE ONLY CARE IF REQ WAS SUCCESSFUL
       });
+
       if (!response.ok) formPdfUrlIsValid = false;
     }
   } catch (err) {
@@ -61,20 +65,16 @@ export async function onDownloadLinkClick(event, reduxStore, listenerFunction) {
     formPdfIsValid,
     formPdfUrlIsValid,
     link,
-    listenerFunction,
     netWorkRequestError,
-    reduxStore,
   });
 }
 
-export default (reduxStore, widgetType) => {
+export default widgetType => {
   const downloadLinks = document.querySelectorAll(
     `[data-widget-type="${widgetType}"]`,
   );
 
   for (const downloadLink of [...downloadLinks]) {
-    downloadLink.addEventListener('click', function handleDownloadClick(e) {
-      onDownloadLinkClick(e, reduxStore, handleDownloadClick);
-    });
+    downloadLink.addEventListener('click', e => onDownloadLinkClick(e));
   }
 };

--- a/src/applications/mhv/secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
+++ b/src/applications/mhv/secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
@@ -763,10 +763,6 @@
         "value": false
       },
       {
-        "name": "findFormsShowPdfModal",
-        "value": true
-      },
-      {
         "name": "find_forms_show_pdf_modal",
         "value": true
       },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -87,7 +87,6 @@ export default Object.freeze({
   facilityLocatorShowCommunityCares: 'facility_locator_show_community_cares', // Facilities team has deprecated this flag for the frontEnd logic, there is still backend support though.
   facilityLocatorShowOperationalHoursSpecialInstructions:
     'facility_locator_show_operational_hours_special_instructions',
-  findFormsShowPdfModal: 'find_forms_show_pdf_modal',
   fileUploadShortWorkflowEnabled: 'file_upload_short_workflow_enabled',
   financialStatusReportDebtsApiModule:
     'financial_status_report_debts_api_module',


### PR DESCRIPTION
## Summary
The `find_forms_show_pdf_modal` feature flipper was previously used to show a download modal for a form if the feature flipper was on. In the search results screenshot below, when `Download VA Form 10-10M` was clicked and the feature flipper is on, the modal from the second screenshot would be shown. Clicking on the `Download VA Form 10-10M` link on the modal would lead to the prod page for the form shown in the third screenshot.

The fallback behavior (if the flipper was off) would be to show the prod page for the form when clicking `Download VA Form 10-10M` on the search result.

### Result in find forms search results
<img width="280" alt="Screenshot 2024-02-20 at 12 46 33 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/9cf4e2c5-ebac-4b28-a675-e355225cbc9d">

### Modal to show
<img width="427" alt="Screenshot 2024-02-20 at 12 46 37 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/50e59741-b3c7-4e93-95c8-849a9eb866d1">

### Prod page for form
<img width="1386" alt="Screenshot 2024-02-20 at 12 46 49 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/e810250d-882d-4157-9ffa-cf40ec0f5437">

## Desired behavior
We want to continue the behavior of first showing the modal before the Download button is clicked, and remove the fallback behavior.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11867
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11874

## Testing done
Tested manually on desktop and mobile.

## Screenshots
See screenshots in the description.

## Acceptance criteria
- [x] https://github.com/department-of-veterans-affairs/va.gov-cms/issues/11874 is complete, and modal shows when clicking to download a form from search results on https://www.va.gov/find-forms/ with find_forms_show_pdf_modal, with flipper disabled
 All references to the flipper in vets-website, if any, are removed (should happen via 11874)

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed