### PR TITLE
MHV-53632 removes rendering of array length

### DIFF
--- a/src/applications/mhv/secure-messaging/components/MessageList/FolderHeader.jsx
+++ b/src/applications/mhv/secure-messaging/components/MessageList/FolderHeader.jsx
@@ -112,7 +112,7 @@ const FolderHeader = props => {
         )}
 
       {folder.folderId === Folders.INBOX.id &&
-        cernerFacilities?.length && (
+        cernerFacilities?.length > 0 && (
           <CernerFacilityAlert cernerFacilities={cernerFacilities} />
         )}
 


### PR DESCRIPTION
## Summary
Fixes a small issue where the length of an array was being rendered to the user.

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-53632
> User association with Cerner facility do not see the banner notifying them that they have association with Cerner facilities and need to navigate to VA Health to access their records. This scenario only happens when a user is assigned to a facility that is not coming back from a Facility API response. 
> 
> GIVEN An authenticated user has associations with Cerner Facilities
> 
> WHEN A user lands on SM pages
> 
> AND Application sends a request to Facility API https://api.va.gov/v1/facilities/va?ids=vha_989,vha_123 to retrieve information about that facility to display a full facility name in a banner
> 
> THEN Certain Facilities are not included in the response. Due to code logic, the banner is not displayed
> 
> We need to research to understand why Facility API is not including some facilities in a response
> Need to handle the scenario above in our code. Although the information about facility was not received from Facility API, we still need to inform a user about their association with Cerner and include banner with navigation button to VA Health
> need specific content for this scenario 
> restructure the logic in SM app to handle this 
> 
> Acceptance Criteria:
> 
> AC1 We need to research to understand why Facility API is not including some facilities in a response
> 
> AC2 Need to handle the scenario above in our code. Although the information about facility was not received from Facility API, we still need to inform a user about their association with Cerner and include banner with navigation button to VA Health

need specific content for this scenario 
restructure the logic in SM app to handle this

## Testing done
all unit tests passing

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/108146636/a1903831-f899-4224-814f-e11c8135d973)

## What areas of the site does it impact?
secure-messaging

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
