### PR TITLE
MHVDowntime should render children when downtime is approaching

### DIFF
--- a/src/platform/mhv/downtime/containers/MHVDowntime.jsx
+++ b/src/platform/mhv/downtime/containers/MHVDowntime.jsx
@@ -34,7 +34,12 @@ function MHVDowntime({
     timeInterval,
   };
   if (status === externalServiceStatus.downtimeApproaching) {
-    return <MHVDowntimeApproaching {...props} />;
+    return (
+      <>
+        <MHVDowntimeApproaching {...props} />
+        {children}
+      </>
+    );
   }
 
   if (status === externalServiceStatus.down) {

--- a/src/platform/mhv/downtime/tests/containers/MHVDowntime.unit.spec.jsx
+++ b/src/platform/mhv/downtime/tests/containers/MHVDowntime.unit.spec.jsx
@@ -25,7 +25,7 @@ describe('MHVDowntime', () => {
     getByText(/some of our health tools/i);
   });
 
-  it('renders MHVDowntimeApproaching when a service is going down within an hour', () => {
+  it('renders MHVDowntimeApproaching and children when a service is going down within an hour', () => {
     // Create a starting datetime 30 minutes into the future, though `status` is what really controls what renders
     const soon = new Date(Date.now());
     soon.setMinutes(soon.getMinutes() + 30);
@@ -38,6 +38,7 @@ describe('MHVDowntime', () => {
     };
     const mockProps = {
       status: externalServiceStatus.downtimeApproaching,
+      children: <p>Child content lives here.</p>,
       ...mockServiceProps,
     };
     const { getByRole, getByText } = render(<MHVDowntime {...mockProps} />);
@@ -46,6 +47,7 @@ describe('MHVDowntime', () => {
       name: 'Upcoming maintenance on My HealtheVet',
     });
     getByText(/you may have trouble using some of our health tools/i);
+    getByText(/child content lives here/i);
   });
 
   it('renders child content when no matching services are down', () => {


### PR DESCRIPTION
## Summary

- When downtime is approaching, but not arrived, the MHVDowntime component should render children passed to it

## Related issue(s)

None

## Testing done

- Children weren't rendering during downtime approaching, children render now. Test updated to check that children are rendered 


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I updated unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
