### PR TITLE
MHV-40453 enforces max 50 chars. on subject line

### DIFF
--- a/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv/secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -714,6 +714,8 @@ const ComposeForm = props => {
                 error={subjectError}
                 data-dd-privacy="mask"
                 data-dd-action-name="Compose Message Subject Input Field"
+                maxlength="50"
+                uswds
               />
             )}
           </div>

--- a/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-compose.cypress.spec.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/secure-messaging-compose.cypress.spec.js
@@ -2,16 +2,18 @@ import SecureMessagingSite from './sm_site/SecureMessagingSite';
 import PatientInboxPage from './pages/PatientInboxPage';
 import PatientComposePage from './pages/PatientComposePage';
 import requestBody from './fixtures/message-compose-request-body.json';
-import { AXE_CONTEXT } from './utils/constants';
+import { AXE_CONTEXT, Locators } from './utils/constants';
 
 describe('Secure Messaging Compose', () => {
-  it('can send message', () => {
-    const landingPage = new PatientInboxPage();
-    const composePage = new PatientComposePage();
-    const site = new SecureMessagingSite();
+  const landingPage = new PatientInboxPage();
+  const composePage = new PatientComposePage();
+  const site = new SecureMessagingSite();
+  beforeEach(() => {
     site.login();
     landingPage.loadInboxMessages();
     landingPage.navigateToComposePage();
+  });
+  it('verify user can send a message', () => {
     composePage.selectRecipient(requestBody.recipientId);
     composePage
       .getCategory(requestBody.category)
@@ -24,7 +26,46 @@ describe('Secure Messaging Compose', () => {
     composePage.sendMessage(requestBody);
     composePage.verifySendMessageConfirmationMessageText();
     composePage.verifySendMessageConfirmationMessageHasFocus();
+
     cy.injectAxe();
-    cy.axeCheck(AXE_CONTEXT, {});
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('verify subject field max size', () => {
+    const charsLimit = 50;
+    const normalText = 'Qwerty1234';
+    const maxText = 'Qwerty1234Qwerty1234Qwerty1234Qwerty1234Qwerty1234';
+
+    cy.get(Locators.FIELDS.SUBJECT).should(
+      'have.attr',
+      'maxlength',
+      `${charsLimit}`,
+    );
+
+    composePage
+      .getMessageSubjectField()
+      .type(normalText, { waitForAnimations: true });
+    cy.get(Locators.INFO.SUBJECT_LIMIT).should(
+      'have.text',
+      `${charsLimit - normalText.length} characters left`,
+    );
+
+    composePage
+      .getMessageSubjectField()
+      .clear()
+      .type(maxText, { waitForAnimations: true });
+    cy.get(Locators.INFO.SUBJECT_LIMIT).should(
+      'have.text',
+      `${charsLimit - maxText.length} characters left`,
+    );
+
+    composePage
+      .getMessageSubjectField()
+      .clear()
+      .type(maxText, { waitForAnimations: true });
+    cy.get('#message-subject').should('have.attr', 'value', `${maxText}`);
+
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
   });
 });

--- a/src/applications/mhv/secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv/secure-messaging/tests/e2e/utils/constants.js
@@ -52,6 +52,14 @@ export const Locators = {
     SAVE_DRAFT: '#messagetext',
     BLOCKED_GROUP: '[data-testid="blocked-triage-group-alert"]',
   },
+  FIELDS: {
+    RECIPIENT: '#select',
+    SUBJECT: '#inputField',
+    MESSAGE: '#textarea',
+  },
+  INFO: {
+    SUBJECT_LIMIT: '#charcount-message',
+  },
 };
 
 export const Alerts = {


### PR DESCRIPTION
## Summary
Adds the maxlength="50" and uswds props to subject line input for compose message screen.

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-40453

> 50 character limit validation on our front-end.  (Subject line)
> 
> From Bhanu:  50 chars is what MHV classic allows for the patient to enter and for the clinician application to display. If there is a need to increase it to more than 50 chars - we need to get that approved by business and will require changes for both API and SM clinician application.
> 
> User Story:  As a SM team, we want to validate the 50 character limit so that we do not need to create other unneeded changes in the project unless deemed necessary.

## Testing done
All unit tests passing. Tested manually for expected behavior

## Screenshots
![Screen Shot 2024-02-21 at 1 29 11 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/108146636/9d204525-2ade-48c5-a90c-a1b03b45c177)

## What areas of the site does it impact?
secure-messaging

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
