### PR TITLE
Use `PropTypes.node` for children props

### DIFF
--- a/src/applications/mhv/medications/containers/App.jsx
+++ b/src/applications/mhv/medications/containers/App.jsx
@@ -75,7 +75,7 @@ const App = ({ children }) => {
 };
 
 App.propTypes = {
-  children: PropTypes.object,
+  children: PropTypes.node,
 };
 
 export default App;

--- a/src/applications/mhv/medications/containers/PrintOnlyPage.jsx
+++ b/src/applications/mhv/medications/containers/PrintOnlyPage.jsx
@@ -31,7 +31,7 @@ const PrintOnlyPage = props => {
 };
 
 PrintOnlyPage.propTypes = {
-  children: PropTypes.object.isRequired,
+  children: PropTypes.node.isRequired,
   preface: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
   subtitle: PropTypes.string,


### PR DESCRIPTION
## Summary

- Changing some prop-types to mitigate type-checking errors, using the appropriate type listed in https://github.com/facebook/prop-types?tab=readme-ov-file#usage


## Related issue(s)

N/A

## Testing done

- Changed prop-types, reloaded MHV Medications, no longer see validation errors in browser console



## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
