### PR TITLE
[AVS] Ensure that only 10 digit phone numbers are clickable

### DIFF
--- a/src/applications/avs/components/MoreInformation.jsx
+++ b/src/applications/avs/components/MoreInformation.jsx
@@ -4,11 +4,16 @@ import PropTypes from 'prop-types';
 import ItemsBlock from './ItemsBlock';
 import ParagraphBlock from './ParagraphBlock';
 
+import { normalizePhoneNumber, numberIsClickable } from '../utils/phone';
+
 const MoreInformation = props => {
   const { avs } = props;
   const { clinicalServices, clinicsVisited, moreHelpAndInformation } = avs;
 
   const renderClinicalService = service => {
+    const servicePhone = normalizePhoneNumber(service.phone);
+    const phoneNotClickable = !numberIsClickable(servicePhone);
+
     return (
       <>
         <h4>{service.name}</h4>
@@ -17,7 +22,11 @@ const MoreInformation = props => {
           <br />
           Hours of operation: {service.hours}
           <br />
-          Phone: <va-telephone contact={service.phone.replace(/\D/g, '')} />
+          Phone:{' '}
+          <va-telephone
+            contact={servicePhone}
+            not-clickable={phoneNotClickable}
+          />
           <br />
           Comment: {service.comment}
         </p>

--- a/src/applications/avs/components/YourHealthInformation.jsx
+++ b/src/applications/avs/components/YourHealthInformation.jsx
@@ -21,6 +21,7 @@ import {
   getMedicationsTaking,
   getMedicationsNotTaking,
 } from '../utils/medications';
+import { normalizePhoneNumber, numberIsClickable } from '../utils/phone';
 
 import ItemsBlock from './ItemsBlock';
 import MedicationTerms from './MedicationTerms';
@@ -298,6 +299,9 @@ const renderFieldWithBreak = (field, prefix = '') => {
 };
 
 const renderVaMedication = medication => {
+  const facilityPhone = normalizePhoneNumber(medication.facilityPhone);
+  const phoneNotClickable = !numberIsClickable(facilityPhone);
+
   return (
     <>
       <p>
@@ -313,7 +317,8 @@ const renderVaMedication = medication => {
           <>
             Main phone: [
             <va-telephone
-              contact={medication.facilityPhone.replace(/\D/g, '')}
+              contact={facilityPhone}
+              not-clickable={phoneNotClickable}
             />
             ] (<va-telephone contact={CONTACTS['711']} tty />)<br />
           </>

--- a/src/applications/avs/tests/utils/phone.test.unit.spec.js
+++ b/src/applications/avs/tests/utils/phone.test.unit.spec.js
@@ -1,0 +1,46 @@
+import { assert, expect } from 'chai';
+import { normalizePhoneNumber, numberIsClickable } from '../../utils/phone';
+
+describe('avs', () => {
+  describe('phone utils', () => {
+    describe('normalize phone number', () => {
+      it('correctly removes non-digit characters', () => {
+        const phoneWithAlpha = '2392A123';
+        const expected = '2392123';
+        const result = normalizePhoneNumber(phoneWithAlpha);
+        assert.deepEqual(result, expected);
+      });
+
+      it('removes leading 1 characters', () => {
+        const phoneWithLeading1 = '15055553939';
+        const expected = '5055553939';
+        const result = normalizePhoneNumber(phoneWithLeading1);
+        assert.deepEqual(result, expected);
+      });
+
+      it('returns 10 digit numbers unchanged', () => {
+        const tenDigitPhone = '5055553939';
+        const expected = '5055553939';
+        const result = normalizePhoneNumber(tenDigitPhone);
+        assert.deepEqual(result, expected);
+      });
+    });
+
+    describe('number is clickable', () => {
+      it('returns true for a 10 digit number', () => {
+        const tenDigitPhone = '5055553939';
+        expect(numberIsClickable(tenDigitPhone)).to.be.true;
+      });
+
+      it('returns false for longer numbers', () => {
+        const twelveDigitPhone = '505555393912';
+        expect(numberIsClickable(twelveDigitPhone)).to.be.false;
+      });
+
+      it('returns false for shorter numbers', () => {
+        const sevenDigitPhone = '5553939';
+        expect(numberIsClickable(sevenDigitPhone)).to.be.false;
+      });
+    });
+  });
+});

--- a/src/applications/avs/utils/phone.js
+++ b/src/applications/avs/utils/phone.js
@@ -1,0 +1,10 @@
+const normalizePhoneNumber = number => {
+  const digitsOnly = number.replace(/\D/g, '');
+  return digitsOnly.replace(/^1/, '');
+};
+
+const numberIsClickable = number => {
+  return number.length === 10;
+};
+
+export { normalizePhoneNumber, numberIsClickable };


### PR DESCRIPTION
## Summary

- Changes app to only allow full 10 digit numbers to be clicked. Also normalizes numbers 11 digit numbers with a leading "1" to 10 digit numbers.

## Related issue(s)

- Slack thread: https://dsva.slack.com/archives/C04UBETRY8N/p1707763681965839

## Testing done

- local testing
- updated unit tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |    ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/101649/c8f64250-b0bd-4e96-ac04-3e883ccbc216)    |   ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/101649/ca0c4c33-188a-4b9b-9082-734c4f8c8b8e)    |

## What areas of the site does it impact?

AVS application only 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
