### PR TITLE
Create POST for declining POA request

### DIFF
--- a/src/applications/representatives/actions/poaRequests.js
+++ b/src/applications/representatives/actions/poaRequests.js
@@ -1,0 +1,26 @@
+import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
+
+const apiBasePath = 'poa_requests';
+
+const settings = {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+};
+
+export const declinePOARequest = async veteranId => {
+  try {
+    const resource = `${apiBasePath}/${veteranId}`;
+    const response = await apiRequest(resource, settings);
+
+    if (!response.ok) {
+      throw new Error(`Server responded with status: ${response.status}`);
+    }
+
+    return { status: 'success' };
+  } catch (error) {
+    const errorMessage = error.message || 'An unexpected error occurred.';
+    return { status: 'error', error: errorMessage };
+  }
+};


### PR DESCRIPTION
## Summary
- The declinePOARequest function has been implemented to allow accredited representatives to decline a Power of Attorney (POA) request from a veteran referencing that veteran's id. This function sends a POST request to a yet to be created API endpoint and handles the response to determine the success or failure.

## Related issue(s)
- [#74424 Add mock call to backend to decline a 21-22 request](https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/74424)

## Testing done
- Before this implementation, the representatives application did not have any fetch requests
- Implementing this first fetch involved assessing the following: 
  - The folder structure of other applications for storing fetch requests
  - Use of the apiRequest function
  - Use of then/catch (ES6) vs async/await (ES7)
  - Error handling
- To assess if these are the patterns we want to start with looking at examples for these four areas would be useful
- Testing with a UI component will be in a follow on issue as the POA Requests table will be the component that accepts/declines POA requests - [#76825 Placeholder POA Requests Table](https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/76825)

## Acceptance criteria
- [x] A decline POA request POST function exists that can be wired to a UI button in a follow on issue
- [x] The team has established an initial pattern for fetch functionality

### Quality Assurance & Testing
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed

### Error Handling
- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
