### PR TITLE
Added feature flag for yellow_ribbon_automated_date_on_school_search

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -278,4 +278,5 @@ export default Object.freeze({
   virtualAgentEnableMsftPvaTesting: 'virtual_agent_enable_msft_pva_testing',
   virtualAgentEnableNluPvaTesting: 'virtual_agent_enable_nlu_pva_testing',
   yellowRibbonEnhancements: 'yellow_ribbon_mvp_enhancement',
+  yellowRibbonAutomatedDateOnSchoolSearch: 'yellow_ribbon_automated_date_on_school_search',
 });


### PR DESCRIPTION
## Summary

- A new feature toggle has been added for switching front end changes
- Team IIR, we own the Find a Yellow Ribbon Tool
- The success criteria being targeted in displaying an auto-generated date in the search results

## Related issue(s)

https://app.zenhub.com/workspaces/va-iir-6508c0bd79e64e0fb5855caf/issues/gh/department-of-veterans-affairs/va-iir/381

https://github.com/department-of-veterans-affairs/vets-api/pull/15637

## Testing done

- None

## What areas of the site does it impact?

This only impacts flipper

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
