### PR TITLE
MHV-54929 MHV SM - additional context for DDRum custom action for blocked TG alerts

### DIFF
--- a/src/applications/mhv/secure-messaging/components/shared/BlockedTriageGroupAlert.jsx
+++ b/src/applications/mhv/secure-messaging/components/shared/BlockedTriageGroupAlert.jsx
@@ -16,6 +16,9 @@ const BlockedTriageGroupAlert = props => {
   const { blockedTriageGroupList, alertStyle, parentComponent } = props;
 
   const { alertTitle, alertMessage } = BlockedTriageAlertText;
+  const MESSAGE_TO_CARE_TEAM = "You can't send messages to";
+  const MESSAGE_TO_CARE_TEAMS = "You can't send messages to care teams at";
+  const ACCOUNT_DISCONNECTED = 'Your account is no longer connected to';
 
   const [alertTitleText, setAlertTitleText] = useState(
     alertTitle.NO_ASSOCIATIONS,
@@ -65,7 +68,17 @@ const BlockedTriageGroupAlert = props => {
   useEffect(
     () => {
       if (alertTitleText !== alertTitle.NO_ASSOCIATIONS) {
-        datadogRum.addAction('Blocked triage group alert');
+        let value = '';
+        if (alertTitleText.includes(MESSAGE_TO_CARE_TEAMS)) {
+          value = `${MESSAGE_TO_CARE_TEAMS} FACILITY`;
+        } else if (alertTitleText.includes(MESSAGE_TO_CARE_TEAM)) {
+          value = `${MESSAGE_TO_CARE_TEAM} TG_NAME`;
+        } else if (alertTitleText.includes(ACCOUNT_DISCONNECTED)) {
+          value = `${ACCOUNT_DISCONNECTED} TG_NAME`;
+        } else {
+          value = alertTitleText;
+        }
+        datadogRum.addAction('Blocked triage group alert', { type: value });
       }
     },
     [alertTitle.NO_ASSOCIATIONS, alertTitleText],
@@ -99,18 +112,14 @@ const BlockedTriageGroupAlert = props => {
     if (blockedTriageList?.length === 1) {
       if (blockedTriageList[0].type === Recipients.FACILITY) {
         setAlertTitleText(
-          `You can't send messages to care teams at ${
-            blockedTriageList[0].name
-          }`,
+          `${MESSAGE_TO_CARE_TEAMS} ${blockedTriageList[0].name}`,
         );
         setAlertInfoText(alertMessage.SINGLE_FACILITY_BLOCKED);
       } else {
         setAlertTitleText(
           blockedTriageList[0].status === RecipientStatus.NOT_ASSOCIATED
-            ? `Your account is no longer connected to ${
-                blockedTriageList[0].name
-              }`
-            : `You can't send messages to ${blockedTriageList[0].name}`,
+            ? `${ACCOUNT_DISCONNECTED} ${blockedTriageList[0].name}`
+            : `${MESSAGE_TO_CARE_TEAM} ${blockedTriageList[0].name}`,
         );
         if (blockedTriageList[0].status === RecipientStatus.BLOCKED) {
           setAlertInfoText(alertMessage.SINGLE_TEAM_BLOCKED);

--- a/src/applications/mhv/secure-messaging/components/shared/BlockedTriageGroupAlert.jsx
+++ b/src/applications/mhv/secure-messaging/components/shared/BlockedTriageGroupAlert.jsx
@@ -62,9 +62,14 @@ const BlockedTriageGroupAlert = props => {
       : sortTriageList(blockedTriageGroupList);
   }, []);
 
-  useEffect(() => {
-    datadogRum.addAction('Blocked triage group alert');
-  }, []);
+  useEffect(
+    () => {
+      if (alertTitleText !== alertTitle.NO_ASSOCIATIONS) {
+        datadogRum.addAction('Blocked triage group alert');
+      }
+    },
+    [alertTitle.NO_ASSOCIATIONS, alertTitleText],
+  );
 
   useEffect(() => {
     if (parentComponent === ParentComponent.FOLDER_HEADER) {


### PR DESCRIPTION
## Summary

- additional context for DD RUM blocked TG custom action 
- ref https://github.com/department-of-veterans-affairs/vets-website/pull/28111

## Related issue(s)

- https://jira.devops.va.gov/browse/MHV-54929

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |        |![image](https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/deb2222a-0d50-4555-867f-f9c8a76cb3da)![image](https://github.com/department-of-veterans-affairs/vets-website/assets/87077843/4abbd77b-87c2-4510-93b5-43161346d7b5)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
