### PR TITLE
Added page not found for unknown URLs in appointments

### DIFF
--- a/src/applications/vaos/components/EnrolledRoute.jsx
+++ b/src/applications/vaos/components/EnrolledRoute.jsx
@@ -1,30 +1,41 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
 import { useSelector } from 'react-redux';
-import { selectUser } from 'platform/user/selectors';
-import { selectPatientFacilities } from 'platform/user/cerner-dsot/selectors.js';
-import backendServices from 'platform/user/profile/constants/backendServices';
-import { RequiredLoginView } from 'platform/user/authorization/components/RequiredLoginView';
+import { selectUser } from '@department-of-veterans-affairs/platform-user/selectors';
+import { selectPatientFacilities } from '@department-of-veterans-affairs/platform-user/cerner-dsot/selectors';
+import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
+import { RequiredLoginView } from '@department-of-veterans-affairs/platform-user/RequiredLoginView';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import PropTypes from 'prop-types';
 import NoRegistrationMessage from './NoRegistrationMessage';
+import VAOSApp from './VAOSApp';
+import ErrorBoundary from './ErrorBoundary';
 
 export default function EnrolledRoute({ component: RouteComponent, ...rest }) {
   const user = useSelector(selectUser);
   const sites = useSelector(selectPatientFacilities);
   const hasRegisteredSystems = sites?.length > 0;
   return (
-    <RequiredLoginView
-      serviceRequired={[
-        backendServices.USER_PROFILE,
-        backendServices.FACILITIES,
-      ]}
-      user={user}
-      verify={!environment.isLocalhost()}
-    >
-      <Route {...rest}>
-        {!hasRegisteredSystems && <NoRegistrationMessage />}
-        {hasRegisteredSystems && <RouteComponent />}
-      </Route>
-    </RequiredLoginView>
+    <ErrorBoundary fullWidth>
+      <VAOSApp>
+        <RequiredLoginView
+          serviceRequired={[
+            backendServices.USER_PROFILE,
+            backendServices.FACILITIES,
+          ]}
+          user={user}
+          verify={!environment.isLocalhost()}
+        >
+          <Route {...rest}>
+            {!hasRegisteredSystems && <NoRegistrationMessage />}
+            {hasRegisteredSystems && <RouteComponent />}
+          </Route>
+        </RequiredLoginView>
+      </VAOSApp>
+    </ErrorBoundary>
   );
 }
+
+EnrolledRoute.propTypes = {
+  component: PropTypes.func,
+};

--- a/src/applications/vaos/routes.jsx
+++ b/src/applications/vaos/routes.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import { Redirect, Switch } from 'react-router-dom';
+import { Redirect, Switch, Route } from 'react-router-dom';
 // eslint-disable-next-line import/no-unresolved
 import asyncLoader from '@department-of-veterans-affairs/platform-utilities/asyncLoader';
-import VAOSApp from './components/VAOSApp';
-import ErrorBoundary from './components/ErrorBoundary';
+import PageNotFound from '@department-of-veterans-affairs/platform-site-wide/PageNotFound';
 import { captureError } from './utils/error';
 
 import ErrorMessage from './components/ErrorMessage';
@@ -34,38 +33,36 @@ export default function createRoutesWithStore(store) {
   ];
 
   return (
-    <ErrorBoundary fullWidth>
-      <VAOSApp>
-        <Switch>
-          <EnrolledRoute
-            path={vaccinePaths}
-            component={asyncLoader(() =>
-              import(/* webpackChunkName: "covid-19-vaccine" */ './covid-19-vaccine')
-                .then(({ NewBookingSection, reducer }) => {
-                  store.injectReducer('covid19Vaccine', reducer);
-                  return NewBookingSection;
-                })
-                .catch(handleLoadError),
-            )}
-          />
-          <EnrolledRoute
-            path={newAppointmentPaths}
-            component={asyncLoader(() =>
-              import(/* webpackChunkName: "vaos-form" */ './new-appointment')
-                .then(({ NewAppointment, reducer }) => {
-                  store.injectReducer('newAppointment', reducer);
-                  return NewAppointment;
-                })
-                .catch(handleLoadError),
-            )}
-          />
-          <Redirect
-            from="/new-covid-19-vaccine-booking"
-            to="/new-appointment"
-          />
-          <EnrolledRoute path="/" component={AppointmentList} />
-        </Switch>
-      </VAOSApp>
-    </ErrorBoundary>
+    <Switch>
+      <EnrolledRoute
+        exact
+        path={vaccinePaths}
+        component={asyncLoader(() =>
+          import(/* webpackChunkName: "covid-19-vaccine" */ './covid-19-vaccine')
+            .then(({ NewBookingSection, reducer }) => {
+              store.injectReducer('covid19Vaccine', reducer);
+              return NewBookingSection;
+            })
+            .catch(handleLoadError),
+        )}
+      />
+      <EnrolledRoute
+        exact
+        path={newAppointmentPaths}
+        component={asyncLoader(() =>
+          import(/* webpackChunkName: "vaos-form" */ './new-appointment')
+            .then(({ NewAppointment, reducer }) => {
+              store.injectReducer('newAppointment', reducer);
+              return NewAppointment;
+            })
+            .catch(handleLoadError),
+        )}
+      />
+      <Redirect from="/new-covid-19-vaccine-booking" to="/new-appointment" />
+      <EnrolledRoute exact path="/" component={AppointmentList} />
+      <Route>
+        <PageNotFound />
+      </Route>
+    </Switch>
   );
 }

--- a/src/applications/vaos/tests/e2e/workflows/general/page-not-found.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/workflows/general/page-not-found.cypress.spec.js
@@ -1,0 +1,13 @@
+import { notFoundHeading } from '@department-of-veterans-affairs/platform-site-wide/PageNotFound';
+import { rootUrl } from '../../../../manifest.json';
+
+describe('Page Not Found', () => {
+  it('Visit an unsupported URL and get a page not found', () => {
+    cy.visit(`${rootUrl}/path1`);
+    cy.injectAxeThenAxeCheck();
+    cy.findByRole('heading', { name: notFoundHeading }).should.exist;
+
+    cy.visit(`${rootUrl}/path1/path2`);
+    cy.findByRole('heading', { name: notFoundHeading }).should.exist;
+  });
+});


### PR DESCRIPTION
## Summary
Show page not found for unknown URLs in the Appointments App. Note that the page not found works for users that are not logged in vs the rest of the app that requires a login. The changes moves common components from the top level route to the EnrollmentRoute component to wrap the apps components with the required parents like authentication to allow the page-not-found to be shown to unauthenticated users as well as displaying without other UI components present.

The valid paths in this app are as follows:
- /new-appointment
- /schedule
- /new-covid-19-vaccine-appointment
- /schedule/covid-vaccine
- /new-covid-19-vaccine-booking
- /

## Related issue(s)
https://app.zenhub.com/workspaces/mhv-on-vagov-top-level-view-62619a987d74510018ecc546/issues/gh/department-of-veterans-affairs/va.gov-team/75878

## Testing done
- Added e2e test

## Screenshots
The following screenshots are for the sample URL of `/my-health/appointments/dummy`.

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |    ![localhost_3001_my-health_appointments_dummy(iPhone 14 Pro Max) (1)](https://github.com/department-of-veterans-affairs/vets-website/assets/63804190/c662c163-8a85-4e31-a764-e179a71a93f8)    |  ![localhost_3001_my-health_appointments_dummy(iPhone 14 Pro Max)](https://github.com/department-of-veterans-affairs/vets-website/assets/63804190/037e08ef-8b42-43d3-b2a3-98091257afad)     |
| Desktop |   ![localhost_3001_my-health_appointments_dummy (1)](https://github.com/department-of-veterans-affairs/vets-website/assets/63804190/da5a8256-88de-4030-9fe9-601d238ef9b9)     |   ![localhost_3001_my-health_appointments_dummy](https://github.com/department-of-veterans-affairs/vets-website/assets/63804190/6d3f7a26-12e4-426f-812c-3e7b47a31057)    |

## What areas of the site does it impact?
- /my-health/appointments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
