### PR TITLE
Make secondary hub links anchors

### DIFF
--- a/src/applications/personalization/profile/components/ProfileLink.jsx
+++ b/src/applications/personalization/profile/components/ProfileLink.jsx
@@ -7,39 +7,47 @@ import PropTypes from 'prop-types';
 import { PROFILE_PATHS } from '../constants';
 import { normalizePath } from '../../common/helpers';
 
-// sets up same styles for icon as va-link with active prop
-const StyledRouterLink = styled(Link)`
+const linkAndAnchorStyles = `
+i {
+  &:before {
+    content: '\f105';
+    display: inline-block;
+    margin-bottom: 0.1rem;
+    margin-left: 0.8rem;
+    margin-right: 0;
+    vertical-align: middle;
+    moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    font-family: 'Font Awesome 5 Free';
+    font-size: 1.6rem;
+    font-style: normal;
+    font-variant: normal;
+    font-weight: 900;
+    line-height: 1;
+    text-rendering: auto;
+  }
+}
+
+&:hover,
+&:focus {
   i {
     &:before {
-      content: '\f105';
-      display: inline-block;
-      margin-bottom: 0.1rem;
-      margin-left: 0.8rem;
-      margin-right: 0;
-      vertical-align: middle;
-      moz-osx-font-smoothing: grayscale;
-      -webkit-font-smoothing: antialiased;
-      font-family: 'Font Awesome 5 Free';
-      font-size: 1.6rem;
-      font-style: normal;
-      font-variant: normal;
-      font-weight: 900;
-      line-height: 1;
-      text-rendering: auto;
+      margin-left: 1.2rem;
+      transition-duration: 0.3s;
+      transition-timing-function: ease-in-out;
+      transition-property: margin;
     }
   }
+}
+`;
 
-  &:hover,
-  &:focus {
-    i {
-      &:before {
-        margin-left: 1.2rem;
-        transition-duration: 0.3s;
-        transition-timing-function: ease-in-out;
-        transition-property: margin;
-      }
-    }
-  }
+// sets up same styles for icon as va-link with active prop
+const StyledRouterLink = styled(Link)`
+  ${linkAndAnchorStyles};
+`;
+
+const StyledAnchor = styled.a`
+  ${linkAndAnchorStyles};
 `;
 
 export const ProfileLink = ({ href, active = true, className = '', text }) => {
@@ -61,13 +69,14 @@ export const ProfileLink = ({ href, active = true, className = '', text }) => {
       {active && <i />}
     </StyledRouterLink>
   ) : (
-    <va-link
-      active={active}
-      text={text}
+    <StyledAnchor
       href={href}
-      class={className}
+      className={`${classes}`}
       data-testid="profile-link-external"
-    />
+    >
+      {text}
+      {active && <i />}
+    </StyledAnchor>
   );
 };
 

--- a/src/applications/personalization/profile/components/hub/Hub.jsx
+++ b/src/applications/personalization/profile/components/hub/Hub.jsx
@@ -81,7 +81,7 @@ export const Hub = () => {
               href={PROFILE_PATHS.MILITARY_INFORMATION}
             />
             <ProfileLink
-              className="medium-screen--line-break-at-50-characters"
+              className="medium-screen--line-break-at-40-characters"
               text="Learn how to request your DD214 and other military records"
               href="/records/get-military-service-records/"
             />

--- a/src/applications/personalization/profile/sass/hub-cards.scss
+++ b/src/applications/personalization/profile/sass/hub-cards.scss
@@ -28,12 +28,12 @@
   }
 }
 
-.medium-screen--line-break-at-50-characters {
+.medium-screen--line-break-at-40-characters {
   display: unset;
   max-width: unset;
 
   @include media($medium-screen) {
     display: inline-block;
-    max-width: 50ch;
+    max-width: 40ch;
   }
 }

--- a/src/applications/personalization/profile/tests/components/hub/Hub.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/hub/Hub.unit.spec.jsx
@@ -72,13 +72,11 @@ describe('<Hub />', () => {
 
   Object.values(SERVICE_PROVIDERS).forEach(service => {
     it('should render with the correct service name and link', () => {
-      const { container } = setup({
+      const { container, getByText } = setup({
         signInServiceName: service.policy,
       });
       expect(
-        container.querySelector(
-          `[text="Update your sign-in info on the ${service.label} website"]`,
-        ),
+        getByText(`Update your sign-in info on the ${service.label} website`),
       ).to.exist;
       expect(container.querySelector(`[href="${service.link}"]`)).to.exist;
     });


### PR DESCRIPTION
## Summary

- Analytics folks suggested we change the links on the hub page to be plain anchor tags instead of using the va-link component.
- Adjust the styling since an anchor tag doesn't have the active styling by default
- Updated tests

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75426

## Testing done

- Updated tests for the hub

## Screenshots

No visual changes, just changing the va-link to an <a>

## What areas of the site does it impact?

Profile -> Hub page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
