### PR TITLE
VFEP-1198 refreshing the 5490 page on the information page will cause the app to crash.

### DIFF
--- a/src/applications/edu-benefits/5490/Form5490App.jsx
+++ b/src/applications/edu-benefits/5490/Form5490App.jsx
@@ -20,8 +20,8 @@ export default function Form5490Entry({ location, children }) {
         }
       };
 
-      if (location.pathname === '/applicant/information') {
-        checkbox.addEventListener('change', disableSsnField);
+      if (checkbox && location.pathname === '/applicant/information') {
+        checkbox?.addEventListener('change', disableSsnField);
       }
       return () => checkbox?.removeEventListener('change', disableSsnField);
     },


### PR DESCRIPTION
## Summary

-  VFEP-1198 refreshing the 5490 page on the information page will cause the app to crash.

## Staging and Prod Error since 2021

<img width="1512" alt="Screenshot 2024-02-24 at 2 20 32 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/95312667/cf6bb968-fa5f-4e02-b66d-fb41dcbf0ac5">

## Problem


<img width="941" alt="Screenshot 2024-02-24 at 2 16 44 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/95312667/cd65157a-f89b-431e-b89a-f75f7db67dc5">

## Solution

<img width="897" alt="Screenshot 2024-02-24 at 2 16 33 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/95312667/e9ae1044-e443-404d-bb52-e6d64d9497ea">


