### PR TITLE
NOD | Move header into legend for new pages

### DIFF
--- a/src/applications/appeals/10182/content/extensionReason.jsx
+++ b/src/applications/appeals/10182/content/extensionReason.jsx
@@ -5,12 +5,15 @@ import { MAX_LENGTH } from '../../shared/constants';
 const title = 'Reason for extension';
 
 export const content = {
-  title: <h3 className="vads-u-margin-y--0">{title}</h3>,
-  description: (
-    <p className="vads-u-margin-y--0">
-      Tell us why you have good cause for an extension.
-    </p>
+  title: (
+    <>
+      <h3 className="vads-u-margin-y--0">{title}</h3>
+      <div className="vads-u-margin-top--2 vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-size--md vads-u-font-weight--normal">
+        Tell us why you have good cause for an extension.
+      </div>
+    </>
   ),
+  description: '',
   label: 'Reason for requesting an extension:',
   hint: `${MAX_LENGTH.NOD_EXTENSION_REASON} characters max.`,
   errorMessage: 'This field cannot be left blank.',

--- a/src/applications/appeals/10182/content/extensionRequest.jsx
+++ b/src/applications/appeals/10182/content/extensionRequest.jsx
@@ -28,14 +28,14 @@ export const ShowAlert = () => {
 };
 
 export const content = {
-  title: <ShowAlert />,
-  description: (
+  title: (
     <>
+      <ShowAlert />
       <h3 className="vads-u-margin-top--0">{title}</h3>
-      <p className="vads-u-margin-y--0">
+      <div className="vads-u-margin-top--2 vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-size--md vads-u-font-weight--normal">
         If you request an extension (extra time) to file VA Form 10182 for good
         cause, you’ll need to tell us why you have good cause.
-      </p>
+      </div>
     </>
   ),
   label: 'Are you requesting an extension?',

--- a/src/applications/appeals/10182/pages/extensionReason.jsx
+++ b/src/applications/appeals/10182/pages/extensionReason.jsx
@@ -12,7 +12,6 @@ import { MAX_LENGTH } from '../../shared/constants';
 const requestExtension = {
   uiSchema: {
     'ui:title': content.title,
-    'ui:description': content.description,
     extensionReason: {
       'ui:title': content.label,
       'ui:reviewField': ExtensionReasonReviewField,

--- a/src/applications/appeals/10182/pages/extensionRequest.js
+++ b/src/applications/appeals/10182/pages/extensionRequest.js
@@ -8,12 +8,10 @@ import { SHOW_PART3, SHOW_PART3_REDIRECT } from '../constants';
 
 const requestExtension = {
   uiSchema: {
-    'ui:title': ' ',
+    'ui:title': content.title,
     'view:requestExtensionInfo': {
-      'ui:title': content.title,
-      'ui:description': content.description,
-      'ui:options': {
-        forceDivWrap: true,
+      'ui:option': {
+        forceDivWrapper: true,
       },
     },
     requestingExtension: yesNoUI({

--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -207,3 +207,7 @@ article[data-location="review-and-submit"] {
 .widget-checkbox-wrap label:before {
   box-shadow: rgb(27, 27, 27) 0px 0px 0px 2px;
 }
+
+.rjsf-object-field:empty {
+  display: none;
+}


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > During collaboration cycle, a nested `fieldset` was noted on the request extension page with content that was not associated with the radio buttons. The header and hint text were moved inside the `legend` to ensure it's read out by screen readers. A similar pattern, without the nested `fieldset`, was also noticed on the extension reason page, and the header and hint text were also moved inside the `legend`
  >
  > I also added CSS to hide the empty `rjsf-object-field` because it adds extra margin
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Review
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- [#76909](https://github.com/department-of-veterans-affairs/va.gov-team/issues/76909)
- [#76953](https://github.com/department-of-veterans-affairs/va.gov-team/issues/76953)
- [#76482](https://github.com/department-of-veterans-affairs/va.gov-team/issues/76482)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         |  | 
| ------- | ------ |
| Before request extension with nested fieldset not containing the radios | <img width="451" alt="before: request for extension with wrapping fieldset and nested fieldset plus legend with header and hint text that doesn't contain the radio buttons" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/8f0a0eb3-0c23-4dae-823f-415c5abb1076"> |
| After request extension with single fieldset and legend containing radios | <img width="451" alt="after: request for extension with single wrapping fieldset; and header and hint text inside the legend" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/59318749-5962-4b52-9f1e-d759c8be7218"> |
| Before extension reason with header inside legend, but hint text outside | <img width="456" alt="before: reason for extension " src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/fecd60a0-2abd-411a-be17-4de17c611dfc"> |
| After extension reason with header and hint text inside legend | <img width="422" alt="after: reason for extension with single wrapping fieldset; and header and hint text inside the legend" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/4ec183d7-80aa-4ce3-8ebd-dcf5e53ac2e5"> |

## What areas of the site does it impact?

Notice of Disagreement v3 pages

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
