### PR TITLE
Updated API endpoint URL for flagging representatives in Find a Rep

### DIFF
--- a/src/applications/representative-search/api/RepresentativeFinderApi.js
+++ b/src/applications/representative-search/api/RepresentativeFinderApi.js
@@ -1,5 +1,5 @@
 import { fetchAndUpdateSessionExpiration as fetch } from '@department-of-veterans-affairs/platform-utilities/api';
-import { getApi, resolveParamsWithUrl } from '../config';
+import { getApi, resolveParamsWithUrl, endpointOptions } from '../config';
 
 class RepresentativeFinderApi {
   /**
@@ -30,8 +30,8 @@ class RepresentativeFinderApi {
 
     const endpoint =
       type === 'veteran_service_officer'
-        ? '/vso_accredited_representatives'
-        : '/other_accredited_representatives';
+        ? endpointOptions.fetchVSOReps
+        : endpointOptions.fetchOtherReps;
 
     const { requestUrl, apiSettings } = getApi(endpoint);
     const startTime = new Date().getTime();
@@ -74,7 +74,7 @@ class RepresentativeFinderApi {
     }
 
     const { requestUrl, apiSettings } = getApi(
-      '/flag_accredited_representatives',
+      endpointOptions.flagReps,
       'POST',
       reportRequestBody,
     );

--- a/src/applications/representative-search/config.js
+++ b/src/applications/representative-search/config.js
@@ -23,6 +23,12 @@ export const searchAreaOptions = {
   'Show all': 'Show all',
 };
 
+export const endpointOptions = {
+  fetchVSOReps: `/services/veteran/v0/vso_accredited_representatives`,
+  fetchOtherReps: `/services/veteran/v0/other_accredited_representatives`,
+  flagReps: `/representation_management/v0/flag_accredited_representatives`,
+};
+
 /*
  * Toggle true for local development
  */
@@ -30,8 +36,8 @@ export const useStagingDataLocally = true;
 
 const baseUrl =
   useStagingDataLocally && environment.BASE_URL === 'http://localhost:3001'
-    ? `https://staging-api.va.gov/services/veteran/v0`
-    : `${environment.API_URL}/services/veteran/v0`;
+    ? `https://staging-api.va.gov`
+    : `${environment.API_URL}`;
 
 /**
  * Build requestUrl and settings for api calls

--- a/src/applications/representative-search/tests/api-url-parameters.railsEngine.unit.spec.js
+++ b/src/applications/representative-search/tests/api-url-parameters.railsEngine.unit.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
-import { resolveParamsWithUrl, getApi } from '../config';
+import { resolveParamsWithUrl, getApi, endpointOptions } from '../config';
 
 describe('Locator url and parameters builder', () => {
   const address = '43210';
@@ -13,7 +13,7 @@ describe('Locator url and parameters builder', () => {
   it('should build VA request with type=veteran_service_officer', () => {
     const type = 'veteran_service_officer';
 
-    const { requestUrl } = getApi('/vso_accredited_representatives');
+    const { requestUrl } = getApi(endpointOptions.fetchVSOReps);
 
     const params = resolveParamsWithUrl({
       address,
@@ -38,7 +38,7 @@ describe('Locator url and parameters builder', () => {
   it('should build VA request with type=claim_agents', () => {
     const type = 'claim_agents';
 
-    const { requestUrl } = getApi('/other_accredited_representatives');
+    const { requestUrl } = getApi(endpointOptions.fetchOtherReps);
 
     const params = resolveParamsWithUrl({
       address,
@@ -62,7 +62,7 @@ describe('Locator url and parameters builder', () => {
 
   it('should build VA request with type=attorney and page = 2 and perPage = 7', () => {
     const type = 'attorney';
-    const { requestUrl } = getApi('/other_accredited_representatives');
+    const { requestUrl } = getApi(endpointOptions.fetchOtherReps);
 
     const params = resolveParamsWithUrl({
       address,
@@ -86,12 +86,12 @@ describe('Locator url and parameters builder', () => {
 
   it('should set csrfToken in request headers', () => {
     localStorage.setItem('csrfToken', '12345');
-    const { apiSettings } = getApi('/flag_accredited_representatives');
+    const { apiSettings } = getApi(endpointOptions.flagReps);
     expect(apiSettings?.headers?.['X-CSRF-Token']).to.eql('12345');
   });
 
   it('should exclude null params from request', () => {
-    const { requestUrl } = getApi('/other_accredited_representatives');
+    const { requestUrl } = getApi(endpointOptions.fetchOtherReps);
 
     const params = resolveParamsWithUrl({
       address: null,


### PR DESCRIPTION
## Summary

- The endpoint for flagging representatives was moved outside of Lighthouse into our own module. 
- Frontend is now pointed at `/representation_management/v0/flag_accredited_representatives`
- Slight refactor to url construction

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75311

## Testing done

- Updated unit tests to make use of endpointOptions config