### PR TITLE
Update pow page

### DIFF
--- a/src/applications/pensions/config/chapters/02-military-history/pow.js
+++ b/src/applications/pensions/config/chapters/02-military-history/pow.js
@@ -12,7 +12,7 @@ const { powDateRange } = fullSchemaPensions.properties;
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    'ui:title': 'P. O. W. Status',
+    'ui:title': 'Prisoner of War status',
     powStatus: yesNoUI({
       title: 'Have you ever been a prisoner of war?',
       classNames: 'vads-u-margin-bottom--2',


### PR DESCRIPTION
## Summary
Update POW page on the Pension Benefits form (21P-527EZ) to improve context for screen reader support.

## How to run in local environment
1. Check out this branch locally
2. In your local environment, set the `pension_form_enabled` flipper to 'enabled' at http://localhost:3000/flipper/features/pension_form_enabled
3. Run `vets-website` and `vets-api`

## How to verify
1. Go to `http://localhost:3001/pension/application/527EZ` in your browser
2. Turn on a browser screen reader (Voiceover for MacOS)
3. Go to the 'Military history' chapter and 'Prisoner of War' page
4. Verify the text header of the page is 'Prisoner of War status'

## Acceptance criteria
[Issue in Github - 74871](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73969)

## Related issue(s)
n/a

## Testing done
- [x] Existing unit tests updated
- [ ] New unit tests added

## Screenshots
n/a

## What areas of the site does it impact?
Pension Benefits Application

### Quality Assurance & Testing
- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

