### PR TITLE
Web component pattern validation fix

### DIFF
--- a/src/platform/forms-system/src/js/web-component-fields/vaTextInputFieldMapping.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/vaTextInputFieldMapping.jsx
@@ -40,8 +40,12 @@ export default function vaTextInputFieldMapping(props) {
     width: uiOptions?.width,
     charcount: uiOptions?.charcount,
     onInput: (event, value) => {
-      // redux value or input value
+      // redux value or input value.
       let newVal = value || event.target.value;
+      // always a string onChange - converts to integer to validate if using number pattern
+      if (['number', 'integer'].includes(inputType)) {
+        newVal = Number(newVal);
+      }
       // pattern validation will trigger if you have '',
       // so set as undefined instead.
       newVal = newVal === '' ? undefined : newVal;


### PR DESCRIPTION
## Summary

- Addresses a bug stemming from `vaTextInputFieldMapping.jsx` web component pattern
- This bug would produce a type error when it anything was put in the field. This is because the validation expects a number, so the string input had to be converted to pass validation
- Checks input type and renders `text` or `number` versions of the `vaTextInputField` accordingly

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2540

## Testing done

- Manual / Axe / Unit

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |<img src="https://github.com/department-of-veterans-affairs/vets-design-system-documentation/assets/57480791/7fc10b58-4bdb-4186-ba2d-741d1f3c4c50)" width="500">|       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
