### PR TITLE
MHV-55237 Log any errors when fetching/handling Notes data

### DIFF
--- a/src/applications/mhv/medical-records/actions/careSummariesAndNotes.js
+++ b/src/applications/mhv/medical-records/actions/careSummariesAndNotes.js
@@ -10,6 +10,7 @@ export const getCareSummariesAndNotesList = () => async dispatch => {
     dispatch({ type: Actions.CareSummariesAndNotes.GET_LIST, response });
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
+    throw error;
   }
 };
 
@@ -28,6 +29,7 @@ export const getCareSummaryAndNotesDetails = (
     );
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
+    throw error;
   }
 };
 

--- a/src/applications/mhv/medical-records/tests/actions/careSummariesAndNotes.unit.spec.js
+++ b/src/applications/mhv/medical-records/tests/actions/careSummariesAndNotes.unit.spec.js
@@ -26,9 +26,15 @@ describe('Get care summaries and notes list action', () => {
     const mockData = notes;
     mockApiRequest(mockData, false);
     const dispatch = sinon.spy();
-    return getCareSummariesAndNotesList()(dispatch).then(() => {
-      expect(typeof dispatch.firstCall.args[0]).to.equal('function');
-    });
+    return getCareSummariesAndNotesList()(dispatch)
+      .then(() => {
+        throw new Error(
+          'Expected getCareSummariesAndNotesList() to throw an error.',
+        );
+      })
+      .catch(() => {
+        expect(typeof dispatch.firstCall.args[0]).to.equal('function');
+      });
   });
 });
 


### PR DESCRIPTION
## Summary

- Don't eat CS&N errors. Let them propagate up so they can be logged for troubleshooting purposes
- Quick follow-on to https://github.com/department-of-veterans-affairs/vets-website/pull/28187

## Related issue(s)

### [MHV-55237](https://jira.devops.va.gov/browse/MHV-55237) - Bullet-proof the Notes reducer to limit any potential errors ###

> There are holes in the Notes reducer that will cause errors if the data is not exactly as we are expecting. Patch these holes. Here is just one example:
> 
> admittedBy: summary.split('ATTENDING:')[1].split('\n')[0].trim(), 
> 

## Testing done

- Modified tests to check that error is actually thrown.

## Screenshots

<img width="300" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/ec4856c8-ea46-419c-b2e2-71be9a1642bc">


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
