### PR TITLE
Revert sign in modal changes

### DIFF
--- a/src/platform/forms/save-in-progress/FormSignInModal.jsx
+++ b/src/platform/forms/save-in-progress/FormSignInModal.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import Modal from '@department-of-veterans-affairs/component-library/Modal';
 
 import recordEvent from '../../monitoring/record-event';
 import { APP_TYPE_DEFAULT } from '../../forms-system/src/js/constants';
@@ -19,29 +19,36 @@ class FormSignInModal extends React.Component {
   };
 
   render() {
+    const primaryButton = {
+      action: this.handleClose,
+      text: 'Finish applying',
+    };
+
+    const secondaryButton = {
+      action: this.handleSignIn,
+      text: 'Sign in and start over',
+    };
     const { formConfig } = this.props;
     const appType = formConfig?.customText?.appType || APP_TYPE_DEFAULT;
 
     return (
-      <VaModal
+      <Modal
         id="form-sign-in-modal"
-        primaryButtonText="Finish applying"
-        secondaryButtonText="Sign in and start over"
-        onPrimaryButtonClick={this.handleClose}
-        onSecondaryButtonClick={this.handleSignIn}
+        primaryButton={primaryButton}
+        secondaryButton={secondaryButton}
         visible={this.props.visible}
-        forcedModal
-        onCloseEvent={this.props.onClose}
+        focusSelector="button"
+        hideCloseButton
+        onClose={this.props.onClose}
         status="warning"
-        modalTitle="If you sign in now, you’ll lose any information you’ve filled in"
-        uswds
+        title="If you sign in now, you’ll lose any information you’ve filled in"
       >
         <p>
           Since you didn’t sign in before you started, we can’t save your
           in-progress {appType}.
         </p>
         <p>If you sign in now, you’ll need to start over.</p>
-      </VaModal>
+      </Modal>
     );
   }
 }

--- a/src/platform/forms/tests/save-in-progress/FormSignInModal.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/FormSignInModal.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { render } from '@testing-library/react';
+import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
 import FormSignInModal from '../../save-in-progress/FormSignInModal';
@@ -27,24 +27,26 @@ describe('<FormSignInModal>', () => {
   });
 
   it('should render', () => {
-    const { container } = render(<FormSignInModal {...props} />);
-    expect(container.querySelector('va-modal')).to.exist;
+    const wrapper = shallow(<FormSignInModal {...props} />);
+    expect(wrapper).to.exist;
+    wrapper.unmount();
   });
 
   it('should close as a primary action', () => {
-    const { container } = render(<FormSignInModal {...props} />);
-    container.querySelector('va-modal').__events.primaryButtonClick();
+    const wrapper = shallow(<FormSignInModal {...props} />);
+    wrapper.prop('primaryButton').action();
     expect(props.onClose.calledOnce).to.be.true;
     expect(
       global.window.dataLayer.some(
         ({ event }) => event === 'no-login-finish-form',
       ),
     ).to.be.true;
+    wrapper.unmount();
   });
 
   it('should start the sign-in process as a secondary action', () => {
-    const { container } = render(<FormSignInModal {...props} />);
-    container.querySelector('va-modal').__events.secondaryButtonClick();
+    const wrapper = shallow(<FormSignInModal {...props} />);
+    wrapper.prop('secondaryButton').action();
     expect(props.onClose.calledOnce).to.be.true;
     expect(props.onSignIn.calledOnce).to.be.true;
     expect(
@@ -52,5 +54,6 @@ describe('<FormSignInModal>', () => {
         ({ event }) => event === 'login-link-restart-form',
       ),
     ).to.be.true;
+    wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Changing the sign in `Modal` to `va-modal` v3 caused some issues with the header on va.gov pages (see screenshot). This PR reverts the change made in [this previous PR](https://github.com/department-of-veterans-affairs/vets-website/pull/27986/files#diff-eb248ccc868a08c841d476b0db8f9f95c4a548f47ecd6ea4760fdcca19a5a369)
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#73829](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73829)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Sign in modal was a React component
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/ae58a35e-45dd-4b9c-8e74-2fdf83eb9458)

## What areas of the site does it impact?

All pages within the www.va.gov domain (injected headers)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
