### PR TITLE
VACMS-17200 PACT Act web components

### DIFF
--- a/src/applications/pact-act/containers/HomePage.jsx
+++ b/src/applications/pact-act/containers/HomePage.jsx
@@ -48,9 +48,10 @@ const HomePage = ({ router, setIntroPageViewed }) => {
       </p>
       <p>
         Are you the surviving family member of a Veteran?{' '}
-        <a href="/resources/the-pact-act-and-your-va-benefits/#information-for-survivors">
-          Get PACT Act information for survivors
-        </a>
+        <va-link
+          href="/resources/the-pact-act-and-your-va-benefits/#information-for-survivors"
+          text="Get PACT Act information for survivors"
+        />
       </p>
     </>
   );

--- a/src/applications/pact-act/containers/questions/CheckboxGroup.jsx
+++ b/src/applications/pact-act/containers/questions/CheckboxGroup.jsx
@@ -83,14 +83,12 @@ const CheckboxGroup = ({
 
   return (
     <>
-      <h1 className="pact-act-form-question-header" id="pact-act-form-question">
-        {h1}
-      </h1>
       <VaCheckboxGroup
         data-testid={testId}
         error={formError ? 'Select a location.' : null}
-        label="Select all that apply."
-        label-header-level="2"
+        hint="Select all that apply."
+        label={h1}
+        label-header-level="1"
         uswds
       >
         {createCheckboxes()}

--- a/src/applications/pact-act/containers/questions/CheckboxGroup.jsx
+++ b/src/applications/pact-act/containers/questions/CheckboxGroup.jsx
@@ -88,7 +88,6 @@ const CheckboxGroup = ({
       <VaCheckboxGroup
         data-testid={testId}
         error={formError ? 'Select a location.' : null}
-        hint="Select all that apply."
         id="paw-checkbox"
         label={h1}
         label-header-level="1"
@@ -99,6 +98,10 @@ const CheckboxGroup = ({
         )}
         uswds
       >
+        <div className="usa-hint">
+          <br />
+          Select all that apply.
+        </div>
         {createCheckboxes()}
       </VaCheckboxGroup>
       <VaButtonPair

--- a/src/applications/pact-act/containers/questions/CheckboxGroup.jsx
+++ b/src/applications/pact-act/containers/questions/CheckboxGroup.jsx
@@ -1,10 +1,10 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import {
   VaButtonPair,
   VaCheckbox,
+  VaCheckboxGroup,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import {
   navigateBackward,
@@ -57,6 +57,7 @@ const CheckboxGroup = ({
           name={shortName}
           value={response}
           onVaChange={onValueChange}
+          uswds
         />
       );
     });
@@ -82,33 +83,20 @@ const CheckboxGroup = ({
 
   return (
     <>
-      <div
-        className={classNames('vads-u-margin-bottom--3', {
-          'pact-act-form-question-error': formError,
-        })}
+      <h1 className="pact-act-form-question-header" id="pact-act-form-question">
+        {h1}
+      </h1>
+      <VaCheckboxGroup
+        data-testid={testId}
+        error={formError ? 'Select a location.' : null}
+        label="Select all that apply."
+        label-header-level="2"
+        uswds
       >
-        <h1
-          className="pact-act-form-question-header"
-          id="pact-act-form-question"
-        >
-          {h1}
-        </h1>
-        <fieldset
-          aria-labelledby="pact-act-form-question pact-act-form-instructions"
-          data-testid={testId}
-        >
-          {formError && (
-            <span className="usa-error-message" role="alert">
-              <div className="pact-act-form-text-error">
-                <span className="usa-sr-only">Error</span> Select a location.
-              </div>
-            </span>
-          )}
-          <p id="pact-act-form-instructions">Select all that apply.</p>
-          {createCheckboxes()}
-        </fieldset>
-      </div>
+        {createCheckboxes()}
+      </VaCheckboxGroup>
       <VaButtonPair
+        class="vads-u-margin-top--3"
         data-testid="paw-buttonPair"
         onPrimaryClick={onContinueClick}
         onSecondaryClick={onBackClick}

--- a/src/applications/pact-act/containers/questions/CheckboxGroup.jsx
+++ b/src/applications/pact-act/containers/questions/CheckboxGroup.jsx
@@ -12,6 +12,7 @@ import {
 } from '../../utilities/page-navigation';
 import { updateFormStore } from '../../actions';
 import { cleanUpAnswers } from '../../utilities/answer-cleanup';
+import { applyFocus } from '../../utilities/page-setup';
 
 /**
  * Produces a variable group of checkboxes
@@ -33,6 +34,7 @@ const CheckboxGroup = ({
   valueSetter,
 }) => {
   const [valueHasChanged, setValueHasChanged] = useState(false);
+  const [headerHasFocused, setHeaderHasFocused] = useState(false);
 
   const onValueChange = event => {
     const { value } = event?.target;
@@ -87,8 +89,14 @@ const CheckboxGroup = ({
         data-testid={testId}
         error={formError ? 'Select a location.' : null}
         hint="Select all that apply."
+        id="paw-checkbox"
         label={h1}
         label-header-level="1"
+        onLoad={applyFocus(
+          'paw-checkbox',
+          headerHasFocused,
+          setHeaderHasFocused,
+        )}
         uswds
       >
         {createCheckboxes()}

--- a/src/applications/pact-act/containers/questions/CheckboxGroup.jsx
+++ b/src/applications/pact-act/containers/questions/CheckboxGroup.jsx
@@ -88,6 +88,7 @@ const CheckboxGroup = ({
       <VaCheckboxGroup
         data-testid={testId}
         error={formError ? 'Select a location.' : null}
+        hint="Select all that apply"
         id="paw-checkbox"
         label={h1}
         label-header-level="1"
@@ -98,10 +99,6 @@ const CheckboxGroup = ({
         )}
         uswds
       >
-        <div className="usa-hint">
-          <br />
-          Select all that apply.
-        </div>
         {createCheckboxes()}
       </VaCheckboxGroup>
       <VaButtonPair

--- a/src/applications/pact-act/containers/questions/TernaryRadios.jsx
+++ b/src/applications/pact-act/containers/questions/TernaryRadios.jsx
@@ -82,43 +82,38 @@ const TernaryRadios = ({
     });
   };
 
-  const ariaLabelledBy = `aria-labelledby="pact-act-form-instructions"`;
-
   return (
     <>
-      <h1 className="pact-act-form-question-header" id="pact-act-form-question">
-        {h1}
-      </h1>
-      {shortName === SHORT_NAME_MAP.ORANGE_2_2_2 && (
-        <div
-          className="vads-u-margin-top--1"
-          data-testid="paw-orange-2-2-2-info"
-        >
-          <va-additional-info trigger="Learn more about C-123 airplanes" uswds>
-            <p className="vads-u-margin-top--0">
-              The U.S. Air Force used C-123 planes to spray Agent Orange to
-              clear jungles that provided enemy cover in Vietnam. After 1971,
-              the Air Force reassigned the remaining C-123 planes to Air Force
-              Reserve units in the U.S. for routine cargo and medical evacuation
-              missions. Veterans, including some Reservists, who flew, trained,
-              or worked on C-123 planes anytime from 1969 to 1986 may have had
-              exposure to Agent Orange.
-            </p>
-          </va-additional-info>
-        </div>
-      )}
-      {locationList ? (
-        <div id="pact-act-form-instructions">{locationList}</div>
-      ) : null}
       <VaRadio
-        aria-labelledby="pact-act-form-question"
         data-testid={testId}
+        form-heading={h1}
+        form-heading-level={1}
         error={formError ? 'Select a response.' : null}
+        id="form-pattern-single-radio"
         onVaValueChange={e => onValueChange(e.detail.value)}
+        use-forms-pattern="single"
         uswds
-        {...(locationList?.length ? ariaLabelledBy : {})}
       >
+        {shortName === SHORT_NAME_MAP.ORANGE_2_2_2 && (
+          <div id="paw-orange-2-2-2-info" data-testid="paw-orange-2-2-2-info">
+            <va-additional-info
+              trigger="Learn more about C-123 airplanes"
+              uswds
+            >
+              <p className="vads-u-margin-top--0">
+                The U.S. Air Force used C-123 planes to spray Agent Orange to
+                clear jungles that provided enemy cover in Vietnam. After 1971,
+                the Air Force reassigned the remaining C-123 planes to Air Force
+                Reserve units in the U.S. for routine cargo and medical
+                evacuation missions. Veterans, including some Reservists, who
+                flew, trained, or worked on C-123 planes anytime from 1969 to
+                1986 may have had exposure to Agent Orange.
+              </p>
+            </va-additional-info>
+          </div>
+        )}
         {renderRadioOptions()}
+        <div slot="form-description">{locationList}</div>
       </VaRadio>
       <VaButtonPair
         class="vads-u-margin-top--3"

--- a/src/applications/pact-act/containers/questions/TernaryRadios.jsx
+++ b/src/applications/pact-act/containers/questions/TernaryRadios.jsx
@@ -13,6 +13,7 @@ import {
 import { updateFormStore } from '../../actions';
 import { cleanUpAnswers } from '../../utilities/answer-cleanup';
 import { SHORT_NAME_MAP } from '../../constants/question-data-map';
+import { applyFocus } from '../../utilities/page-setup';
 
 /**
  * Produces a set of 3 radio options
@@ -35,6 +36,7 @@ const TernaryRadios = ({
   valueSetter,
 }) => {
   const [valueHasChanged, setValueHasChanged] = useState(false);
+  const [headerHasFocused, setHeaderHasFocused] = useState(false);
 
   const onContinueClick = () => {
     if (!formValue) {
@@ -89,8 +91,9 @@ const TernaryRadios = ({
         form-heading={h1}
         form-heading-level={1}
         error={formError ? 'Select a response.' : null}
-        id="form-pattern-single-radio"
+        id="paw-radio"
         onVaValueChange={e => onValueChange(e.detail.value)}
+        onLoad={applyFocus('paw-radio', headerHasFocused, setHeaderHasFocused)}
         use-forms-pattern="single"
         uswds
       >

--- a/src/applications/pact-act/containers/questions/TernaryRadios.jsx
+++ b/src/applications/pact-act/containers/questions/TernaryRadios.jsx
@@ -1,8 +1,11 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { snakeCase } from 'lodash';
-import { VaButtonPair } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import {
+  VaButtonPair,
+  VaRadio,
+  VaRadioOption,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import {
   navigateBackward,
   navigateForward,
@@ -66,85 +69,59 @@ const TernaryRadios = ({
   const renderRadioOptions = () => {
     return responses.map((response, index) => {
       return (
-        <div key={index}>
-          <input
-            type="radio"
-            checked={formValue === response}
-            data-testid="va-radio-option"
-            id={snakeCase(`${response}_input`)}
-            name={shortName}
-            onChange={() => onValueChange(response)}
-            value={response}
-          />
-          <label
-            className="pact-act-form-label"
-            htmlFor={snakeCase(`${response}_input`)}
-          >
-            <span>{response}</span>
-          </label>
-        </div>
+        <VaRadioOption
+          key={index}
+          checked={formValue === response}
+          data-testid="va-radio-option"
+          label={response}
+          name="group"
+          value={response}
+          uswds
+        />
       );
     });
   };
 
+  const ariaLabelledBy = `aria-labelledby="pact-act-form-instructions"`;
+
   return (
     <>
-      <div
-        className={
-          formError
-            ? 'vads-u-margin-bottom--3 pact-act-form-question-error'
-            : 'vads-u-margin-bottom--3'
-        }
+      <h1 className="pact-act-form-question-header" id="pact-act-form-question">
+        {h1}
+      </h1>
+      {shortName === SHORT_NAME_MAP.ORANGE_2_2_2 && (
+        <div
+          className="vads-u-margin-top--1"
+          data-testid="paw-orange-2-2-2-info"
+        >
+          <va-additional-info trigger="Learn more about C-123 airplanes" uswds>
+            <p className="vads-u-margin-top--0">
+              The U.S. Air Force used C-123 planes to spray Agent Orange to
+              clear jungles that provided enemy cover in Vietnam. After 1971,
+              the Air Force reassigned the remaining C-123 planes to Air Force
+              Reserve units in the U.S. for routine cargo and medical evacuation
+              missions. Veterans, including some Reservists, who flew, trained,
+              or worked on C-123 planes anytime from 1969 to 1986 may have had
+              exposure to Agent Orange.
+            </p>
+          </va-additional-info>
+        </div>
+      )}
+      {locationList ? (
+        <div id="pact-act-form-instructions">{locationList}</div>
+      ) : null}
+      <VaRadio
+        aria-labelledby="pact-act-form-question"
+        data-testid={testId}
+        error={formError ? 'Select a response.' : null}
+        onVaValueChange={e => onValueChange(e.detail.value)}
+        uswds
+        {...(locationList?.length ? ariaLabelledBy : {})}
       >
-        <h1
-          className="pact-act-form-question-header"
-          id="pact-act-form-question"
-        >
-          {h1}
-        </h1>
-        {shortName === SHORT_NAME_MAP.ORANGE_2_2_2 && (
-          <div
-            className="vads-u-margin-top--1"
-            data-testid="paw-orange-2-2-2-info"
-          >
-            <va-additional-info
-              trigger="Learn more about C-123 airplanes"
-              uswds
-            >
-              <p className="vads-u-margin-top--0">
-                The U.S. Air Force used C-123 planes to spray Agent Orange to
-                clear jungles that provided enemy cover in Vietnam. After 1971,
-                the Air Force reassigned the remaining C-123 planes to Air Force
-                Reserve units in the U.S. for routine cargo and medical
-                evacuation missions. Veterans, including some Reservists, who
-                flew, trained, or worked on C-123 planes anytime from 1969 to
-                1986 may have had exposure to Agent Orange.
-              </p>
-            </va-additional-info>
-          </div>
-        )}
-        {locationList ? (
-          <div id="pact-act-form-instructions">{locationList}</div>
-        ) : null}
-        <fieldset
-          aria-labelledby={
-            locationList
-              ? 'pact-act-form-question pact-act-form-instructions'
-              : 'pact-act-form-question'
-          }
-          data-testid={testId}
-        >
-          {formError && (
-            <span className="usa-error-message" role="alert">
-              <div className="pact-act-form-text-error">
-                <span className="usa-sr-only">Error</span> Select a response.
-              </div>
-            </span>
-          )}
-          {renderRadioOptions()}
-        </fieldset>
-      </div>
+        {renderRadioOptions()}
+      </VaRadio>
       <VaButtonPair
+        class="vads-u-margin-top--3"
         data-testid="paw-buttonPair"
         onPrimaryClick={onContinueClick}
         onSecondaryClick={onBackClick}

--- a/src/applications/pact-act/sass/pact-act.scss
+++ b/src/applications/pact-act/sass/pact-act.scss
@@ -46,12 +46,6 @@
   }
 
   va-button-pair {
-    margin-left: -4px;
-    margin-right: -4px;
-
-    @media screen and (min-width: 480px) {
-      margin-left: 4px;
-      margin-right: 4px;
-    }
+    margin-left: 4px;
   }
 }

--- a/src/applications/pact-act/sass/pact-act.scss
+++ b/src/applications/pact-act/sass/pact-act.scss
@@ -1,7 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 
 .pact-act-app {
-
   h1:focus {
     outline: none;
   }
@@ -22,22 +21,8 @@
     }
   }
 
-  .pact-act-form-question-header {
-    font-family: "Bitter", "Georgia", "Cambria", "Times New Roman", "Times", serif;
-    font-size: 2em;
-    line-height: 1.5;
-    margin-bottom: 0;
-  }
-
-  .pact-act-form-question-error {
-    border-left: 0.4rem solid $color-secondary-dark;
-    padding-left: 2rem;
-    position: relative;
-  }
-
-  .pact-act-form-text-error {
-    color: $color-secondary-dark;
-    font-weight: bold;
+  #paw-orange-2-2-2-info {
+    margin-top: -22px;
   }
 
   .pact-act-form-label {

--- a/src/applications/pact-act/sass/pact-act.scss
+++ b/src/applications/pact-act/sass/pact-act.scss
@@ -25,12 +25,11 @@
     margin-top: -22px;
   }
 
-  .pact-act-form-label {
-    margin-top: 1rem;
-    padding-left: 6px;
-  }
-
   va-button-pair {
     margin-left: 4px;
+  }
+
+  .usa-hint {
+    color: $color-gray-medium;
   }
 }

--- a/src/applications/pact-act/tests/cypress/helpers.js
+++ b/src/applications/pact-act/tests/cypress/helpers.js
@@ -86,12 +86,6 @@ export const verifyFormErrorNotShown = selector =>
   cy
     .findByTestId(selector)
     .get('span[role="alert"]')
-    .should('not.exist');
-
-export const verifyFormErrorNotShownCheckBox = selector =>
-  cy
-    .findByTestId(selector)
-    .get('span[role="alert"]')
     .should('have.text', '');
 
 export const checkFormAlertText = (selector, expectedValue) =>

--- a/src/applications/pact-act/tests/cypress/service-period-during-both/form-validation.cypress.spec.js
+++ b/src/applications/pact-act/tests/cypress/service-period-during-both/form-validation.cypress.spec.js
@@ -70,13 +70,13 @@ describe('PACT Act', () => {
 
       // ORANGE_2_2_B --------------------------------
       h.verifyUrl(ROUTES.ORANGE_2_2_B);
-      h.verifyFormErrorNotShownCheckBox(h.ORANGE_2_2_B_INPUT);
+      h.verifyFormErrorNotShown(h.ORANGE_2_2_B_INPUT);
 
       h.clickContinue();
-      h.checkFormAlertText(h.ORANGE_2_2_B_INPUT, 'Error Select a location.');
+      h.checkFormAlertText(h.ORANGE_2_2_B_INPUT, 'ErrorSelect a location.');
 
       h.selectCheckbox(h.ORANGE_2_2_B_INPUT, 0);
-      h.verifyFormErrorNotShownCheckBox(h.ORANGE_2_2_B_INPUT);
+      h.verifyFormErrorNotShown(h.ORANGE_2_2_B_INPUT);
       h.clickBack();
 
       // ORANGE_2_2_A --------------------------------
@@ -98,13 +98,13 @@ describe('PACT Act', () => {
 
       // ORANGE_2_2_1_B -----------------------------
       h.verifyUrl(ROUTES.ORANGE_2_2_1_B);
-      h.verifyFormErrorNotShownCheckBox(h.ORANGE_2_2_1_B_INPUT);
+      h.verifyFormErrorNotShown(h.ORANGE_2_2_1_B_INPUT);
 
       h.clickContinue();
-      h.checkFormAlertText(h.ORANGE_2_2_1_B_INPUT, 'Error Select a location.');
+      h.checkFormAlertText(h.ORANGE_2_2_1_B_INPUT, 'ErrorSelect a location.');
 
       h.selectCheckbox(h.ORANGE_2_2_1_B_INPUT, 0);
-      h.verifyFormErrorNotShownCheckBox(h.ORANGE_2_2_1_B_INPUT);
+      h.verifyFormErrorNotShown(h.ORANGE_2_2_1_B_INPUT);
       h.clickBack();
 
       // ORANGE_2_2_1_A ------------------------------
@@ -146,13 +146,13 @@ describe('PACT Act', () => {
 
       // RADIATION_2_3_B -----------------------------
       h.verifyUrl(ROUTES.RADIATION_2_3_B);
-      h.verifyFormErrorNotShownCheckBox(h.RADIATION_2_3_B_INPUT);
+      h.verifyFormErrorNotShown(h.RADIATION_2_3_B_INPUT);
 
       h.clickContinue();
-      h.checkFormAlertText(h.RADIATION_2_3_B_INPUT, 'Error Select a location.');
+      h.checkFormAlertText(h.RADIATION_2_3_B_INPUT, 'ErrorSelect a location.');
 
       h.selectCheckbox(h.RADIATION_2_3_B_INPUT, 0);
-      h.verifyFormErrorNotShownCheckBox(h.RADIATION_2_3_B_INPUT);
+      h.verifyFormErrorNotShown(h.RADIATION_2_3_B_INPUT);
       h.clickBack();
 
       // RADIATION_2_3_A ------------------------------

--- a/src/applications/pact-act/utilities/page-setup.js
+++ b/src/applications/pact-act/utilities/page-setup.js
@@ -25,10 +25,14 @@ export const applyFocus = (parentId, headerHasFocused, setHeaderHasFocused) => {
             );
           }
         }
-      }
 
-      header?.focus();
-      setHeaderHasFocused(true);
+        header.addEventListener('focus', () => {
+          header.style.outline = 'none';
+        });
+
+        header?.focus();
+        setHeaderHasFocused(true);
+      }
     }, 500);
   }
 };

--- a/src/applications/pact-act/utilities/page-setup.js
+++ b/src/applications/pact-act/utilities/page-setup.js
@@ -1,6 +1,37 @@
 import { waitForRenderThenFocus } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { customizeTitle } from './customize-title';
 
+// source: https://github.com/department-of-veterans-affairs/component-library/blob/main/packages/storybook/stories/wc-helpers.jsx#L285-L290
+export const applyFocus = (parentId, headerHasFocused, setHeaderHasFocused) => {
+  if (!headerHasFocused) {
+    setTimeout(() => {
+      const header = document
+        .getElementById(parentId)
+        ?.shadowRoot?.querySelector('h1');
+
+      if (header) {
+        const tabindex = header.getAttribute('tabindex');
+
+        if (header.tabIndex !== 0) {
+          header.setAttribute('tabindex', '-1');
+
+          if (typeof tabindex === 'undefined' || tabindex === null) {
+            header.addEventListener(
+              'blur',
+              () => {
+                header.removeAttribute('tabindex');
+              },
+              { once: true },
+            );
+          }
+        }
+      }
+
+      header?.focus();
+      setHeaderHasFocused(true);
+    }, 500);
+  }
+};
 export const pageSetup = H1 => {
   window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
   waitForRenderThenFocus('h1');


### PR DESCRIPTION
## Summary
Adding web components to the PACT Act wizard where they are available. Required adding custom focus behavior to the h1s for the checkbox and radio components, as well as custom focus styles.

**Note**: the font mismatch on the h1 on radio buttons is a known DST issue. They're working on pushing out a fix soon.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17200

## Testing done
Manual testing locally.

## Screenshots
1. `<va-link>` <br/>
<img width="549" alt="Screenshot 2024-02-28 at 10 16 25 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/ad67bf12-a425-4135-96b6-5a741e7ad6ed">

<img width="422" alt="Screenshot 2024-02-28 at 10 16 31 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/a2c8f086-6918-4873-9409-477172435687">
<br/><br/>

2. `<va-radio>`<br/>
<img width="635" alt="Screenshot 2024-03-01 at 10 07 00 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/72f3dc69-0c3d-4b4c-b532-035e73aa5826">
<img width="401" alt="Screenshot 2024-03-01 at 10 07 09 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/715d4d4d-77ad-4331-ab67-331098249cdc">
<img width="440" alt="Screenshot 2024-02-28 at 10 16 54 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/79a32955-d1e5-4037-9c6b-b0261473d871">

<br/>
<br/>

3. `<va-checkbox>`<br/>
<img width="451" alt="Screenshot 2024-03-01 at 10 07 16 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/8c6e78e8-221d-464d-ae51-b1826eb7619c">
<img width="402" alt="Screenshot 2024-03-01 at 10 07 38 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/3027ac51-b654-4cbc-9fb6-1859b142bb85">
<img width="431" alt="Screenshot 2024-02-28 at 10 17 09 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/79bb78c0-1cb3-4264-abcf-40d1dcfb38a2">

## Acceptance criteria

 - [x] Links use V1
 - [x] Radio buttons use V3
 - [x] Check box group uses V3
 - [x] other features display correctly
 - [x] verify/review the E2E tests
 - [x] check desktop and mobile
 a11y review

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed