### PR TITLE
NOD | Update board review option radios

### DIFF
--- a/src/applications/appeals/10182/content/boardReview.jsx
+++ b/src/applications/appeals/10182/content/boardReview.jsx
@@ -3,55 +3,31 @@ import React from 'react';
 export const boardReviewErrorMessage =
   'Choose a Board review option to proceed';
 
-const title = 'Select a Board review option:';
+export const boardReviewTitle = 'Select a Board review option:';
 
-export const boardReviewTitle = (
-  <h3 className="vads-u-display--inline">{title}</h3>
-);
+// export const boardReviewTitle = (
+//   <h3 className="vads-u-display--inline">{title}</h3>
+// );
 
 /* eslint-disable camelcase */
-export const boardReviewContent = {
-  direct_review: (
-    <>
-      <strong>Request a direct review</strong>
-      <p className="hide-on-review">
-        A Veterans Law Judge will review your appeal based on evidence already
-        submitted. Because the Board has all your evidence, choosing this option
-        will often result in a faster decision.
-      </p>
-    </>
-  ),
-
-  evidence_submission: (
-    <>
-      <strong>Submit more evidence</strong>
-      <p className="hide-on-review">
-        You can submit additional evidence within 90 days after submitting your
-        Board appeal. Choose this option if you want to turn in additional
-        evidence but don’t want to wait for a hearing with a Veterans Law Judge.
-        Choosing this option will extend the time it takes for the Board to
-        decide your appeal.
-      </p>
-    </>
-  ),
-
-  hearing: (
-    <>
-      <strong>Request a hearing</strong>
-      <p className="hide-on-review">
-        You can request a Board hearing with a Veterans Law Judge and submit
-        additional evidence within 90 days after your hearing. Keep in mind that
-        this option has the longest wait time for a decision because there are
-        currently tens of thousands of pending hearing requests.
-      </p>
-    </>
-  ),
+export const boardReviewLabels = {
+  direct_review: 'Request a direct review',
+  evidence_submission: 'Submit more evidence',
+  hearing: 'Request a hearing',
+};
+export const boardReviewDescriptions = {
+  direct_review:
+    'A Veterans Law Judge will review your appeal based on evidence already submitted. Because the Board has all your evidence, choosing this option will often result in a faster decision.',
+  evidence_submission:
+    'You can submit additional evidence within 90 days after submitting your Board appeal. Choose this option if you want to turn in additional evidence but don’t want to wait for a hearing with a Veterans Law Judge. Choosing this option will extend the time it takes for the Board to decide your appeal.',
+  hearing:
+    'You can request a Board hearing with a Veterans Law Judge and submit additional evidence within 90 days after your hearing. Keep in mind that this option has the longest wait time for a decision because there are currently tens of thousands of pending hearing requests.',
 };
 /* eslint-enable camelcase */
 
 export const BoardReviewReviewField = ({ children }) => (
   <div className="review-row">
-    <dt>{title}</dt>
+    <dt>{boardReviewTitle}</dt>
     <dd>
       {children?.props?.formData ? (
         children

--- a/src/applications/appeals/10182/pages/boardReview.js
+++ b/src/applications/appeals/10182/pages/boardReview.js
@@ -1,6 +1,12 @@
 import {
+  radioSchema,
+  radioUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+import {
   boardReviewTitle,
-  boardReviewContent,
+  boardReviewLabels,
+  boardReviewDescriptions,
   boardReviewErrorMessage,
   BoardReviewReviewField,
 } from '../content/boardReview';
@@ -8,27 +14,41 @@ import {
 const boardReview = {
   uiSchema: {
     boardReviewOption: {
-      'ui:title': boardReviewTitle,
-      'ui:reviewField': BoardReviewReviewField,
-      'ui:widget': 'radio',
-      'ui:options': {
-        labels: boardReviewContent,
+      ...radioUI({
+        title: boardReviewTitle,
+        labelHeaderLevel: '3',
+        labels: boardReviewLabels,
+        descriptions: boardReviewDescriptions,
         enableAnalytics: true,
-      },
-      'ui:errorMessages': {
-        required: boardReviewErrorMessage,
-      },
+        errorMessages: {
+          required: boardReviewErrorMessage,
+        },
+      }),
+      'ui:reviewField': BoardReviewReviewField,
     },
+    // boardReviewOption: {
+    //   'ui:title': boardReviewTitle,
+    //   'ui:reviewField': BoardReviewReviewField,
+    //   'ui:widget': 'radio',
+    //   'ui:options': {
+    //     labels: boardReviewContent,
+    //     enableAnalytics: true,
+    //   },
+    //   'ui:errorMessages': {
+    //     required: boardReviewErrorMessage,
+    //   },
+    // },
   },
 
   schema: {
     type: 'object',
     required: ['boardReviewOption'],
     properties: {
-      boardReviewOption: {
-        type: 'string',
-        enum: ['direct_review', 'evidence_submission', 'hearing'],
-      },
+      boardReviewOption: radioSchema([
+        'direct_review',
+        'evidence_submission',
+        'hearing',
+      ]),
     },
   },
 };

--- a/src/applications/appeals/10182/tests/pages/boardReview.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/pages/boardReview.unit.spec.jsx
@@ -27,7 +27,7 @@ describe('NOD board review page', () => {
       />,
     );
 
-    expect($$('input', container).length).to.equal(3);
+    expect($$('va-radio-option', container).length).to.equal(3);
   });
 
   it('should allow submit', () => {
@@ -43,10 +43,14 @@ describe('NOD board review page', () => {
       />,
     );
 
-    fireEvent.click($('input[value="direct_review"]', container));
+    // fireEvent.click($('va-radio-option[value="direct_review"]', container));
+    $('va-radio', container).__events.vaValueChange({
+      detail: { value: 'direct_review' },
+    });
+
     fireEvent.submit($('form', container));
 
-    expect($$('.usa-input-error-message').length).to.equal(0);
+    expect($$('[error]').length).to.equal(0);
     expect(onSubmit.called).to.be.true;
   });
 
@@ -66,7 +70,7 @@ describe('NOD board review page', () => {
 
     fireEvent.submit($('form', container));
 
-    expect($$('.usa-input-error-message').length).to.equal(1);
+    expect($$('[error]').length).to.equal(1);
     expect(onSubmit.called).to.be.false;
   });
 });

--- a/src/platform/forms-system/src/js/web-component-fields/VaRadioField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaRadioField.jsx
@@ -35,6 +35,7 @@ export default function VaRadioField(props) {
     Array.isArray(props.childrenProps.schema.enum) &&
     optionsList(props.childrenProps.schema);
   const labels = props.uiOptions?.labels || {};
+  const descriptions = props.uiOptions.descriptions || {};
 
   const selectedValue =
     props.childrenProps.formData ?? props.childrenProps.schema.default ?? null;
@@ -56,6 +57,7 @@ export default function VaRadioField(props) {
             value={option.value}
             checked={selectedValue === option.value}
             label={labels[option.value] || option.label}
+            description={descriptions[option.value]}
             uswds={mappedProps?.uswds}
             tile={props.uiOptions?.tile}
           />


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Update Notice of Disagreement (NOD) board review option page to use USWDS v3 web components. This change required some updates to the platform web component field code to include option descriptions. The text is much narrower, but the design system team has plans to extend this max width
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Using new web component fields to render v3 web components instead of the original React component
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#73829](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73829)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Page previously used React radio widget
- _Describe the steps required to verify your changes are working as expected_
  > Navigate to Board option page - v3 components do not have bold labels and the radio buttons have thicker darker circles
- _Describe the tests completed and the results_
  > Updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Board review option  | <img width="577" alt="NOD-board-review-option-before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/61581267-37cb-478b-a3c6-6b825ee0d268"> | <img width="580" alt="NOD-board-review-option-after" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/56b69ed5-0cc1-4036-9a3b-cef9b150d4ab"> |

## What areas of the site does it impact?

Notice of Disagreement

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
