### PR TITLE
Add migration to 10-10EZ form for TERA redirects

### DIFF
--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -126,7 +126,7 @@ const formConfig = {
       saved: 'Your health care benefits application has been saved.',
     },
   },
-  version: 7,
+  version: migrations.length,
   migrations,
   prefillEnabled: true,
   prefillTransformer,

--- a/src/applications/hca/config/migrations.js
+++ b/src/applications/hca/config/migrations.js
@@ -225,8 +225,8 @@ export default [
       metadata: newMetaData,
     };
   },
-
-  // 6 -> 7, send user back to fields with only spaces
+  // 6 -> 7, we fully adopted a revised household section and need update the URLs from
+  // the to remove the `v2` reference
   ({ formData, metadata }) => {
     const url = metadata.returnUrl || metadata.return_url;
     let newMetadata = metadata;
@@ -240,6 +240,14 @@ export default [
       newMetadata = set('returnUrl', returnUrl, newMetadata);
     }
 
+    return { formData, metadata: newMetadata };
+  },
+  // 7 -> 8, with the addition of the Toxic Exposure questions, we need to ensure all
+  // users go through these, so we will send users back to the start of the form
+  ({ formData, metadata }) => {
+    const returnUrl = '/veteran-information/personal-information';
+    let newMetadata = metadata;
+    newMetadata = set('returnUrl', returnUrl, newMetadata);
     return { formData, metadata: newMetadata };
   },
 ];

--- a/src/applications/hca/containers/App.jsx
+++ b/src/applications/hca/containers/App.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import RoutedSavableApp from '@department-of-veterans-affairs/platform-forms/RoutedSavableApp';
 import { setData } from '@department-of-veterans-affairs/platform-forms-system/actions';
 import { isLOA3, isLoggedIn, selectProfile } from 'platform/user/selectors';
-import { VA_FORM_IDS } from 'platform/forms/constants';
 import recordEvent from 'platform/monitoring/record-event';
 
 import { fetchTotalDisabilityRating } from '../utils/actions';
@@ -23,20 +22,15 @@ const App = props => {
     isSigiEnabled,
     isTeraEnabled,
   } = useSelector(selectFeatureToggles);
-  const {
-    savedForms,
-    dob: veteranDob,
-    loading: isLoadingProfile,
-  } = useSelector(selectProfile);
+  const { dob: veteranDob, loading: isLoadingProfile } = useSelector(
+    selectProfile,
+  );
   const { totalDisabilityRating } = useSelector(state => state.totalRating);
   const { data: formData } = useSelector(state => state.form);
   const loggedIn = useSelector(isLoggedIn);
   const isLOA3User = useSelector(isLOA3);
   const { veteranFullName } = formData;
   const isAppLoading = isLoadingFeatureFlags || isLoadingProfile;
-  const hasSavedForm = savedForms.some(
-    o => o.form === VA_FORM_IDS.FORM_10_10EZ,
-  );
 
   // Attempt to fetch disability rating for LOA3 users
   useEffect(
@@ -64,27 +58,21 @@ const App = props => {
       const defaultViewFields = {
         'view:isLoggedIn': loggedIn,
         'view:isSigiEnabled': isSigiEnabled,
+        'view:isTeraEnabled': isTeraEnabled,
         'view:isFacilitiesApiEnabled': isFacilitiesApiEnabled,
         'view:totalDisabilityRating': parseInt(totalDisabilityRating, 10) || 0,
       };
 
-      if (hasSavedForm || typeof hasSavedForm === 'undefined') {
-        setFormData({
-          ...formData,
-          ...defaultViewFields,
-        });
-      } else if (loggedIn) {
+      if (loggedIn) {
         setFormData({
           ...formData,
           ...defaultViewFields,
           'view:userDob': parseVeteranDob(veteranDob),
-          'view:isTeraEnabled': isTeraEnabled,
         });
       } else {
         setFormData({
           ...formData,
           ...defaultViewFields,
-          'view:isTeraEnabled': isTeraEnabled,
         });
       }
     },
@@ -92,7 +80,6 @@ const App = props => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       loggedIn,
-      hasSavedForm,
       veteranDob,
       veteranFullName,
       isSigiEnabled,

--- a/src/applications/hca/tests/unit/config/migrations.unit.spec.js
+++ b/src/applications/hca/tests/unit/config/migrations.unit.spec.js
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 import formConfig from '../../../config/form';
 
-describe('HCA migrations', () => {
+describe('hca migrations', () => {
   const { migrations } = formConfig;
 
-  describe('when first migration runs', () => {
+  context('when v1 migration runs', () => {
     it('should remove hispanic property and add in view: object', () => {
       const data = {
         formData: {
@@ -39,7 +39,7 @@ describe('HCA migrations', () => {
     });
   });
 
-  describe('when second migration runs', () => {
+  context('when v2 migration runs', () => {
     const migration = migrations[1];
 
     it('should convert report children field', () => {
@@ -94,7 +94,7 @@ describe('HCA migrations', () => {
     });
   });
 
-  describe('when third migration runs', () => {
+  context('when v3 migration runs', () => {
     const migration = migrations[2];
 
     it('should update url when it matches', () => {
@@ -128,7 +128,7 @@ describe('HCA migrations', () => {
     });
   });
 
-  describe('when fourth migration runs', () => {
+  context('when v4 migration runs', () => {
     const migration = migrations[3];
 
     it('should leave data alone if not set', () => {
@@ -257,7 +257,7 @@ describe('HCA migrations', () => {
     });
   });
 
-  describe('when fifth migration runs', () => {
+  context('when v5 migration runs', () => {
     const migration = migrations[4];
 
     it('should unset required fields that are blank strings', () => {
@@ -290,7 +290,7 @@ describe('HCA migrations', () => {
     });
   });
 
-  describe('when sixth migration runs', () => {
+  context('when v6 migration runs', () => {
     const migration = migrations[5];
 
     it('should unset insurance fields that are blank strings', () => {
@@ -314,20 +314,27 @@ describe('HCA migrations', () => {
     });
   });
 
-  describe('when deventh migration runs', () => {
+  context('when v7 migration runs', () => {
     const migration = migrations[6];
 
-    it('should set household-information-v2 url to household-information', () => {
-      const data = {
-        formData: {},
-        metadata: {
-          returnUrl: 'household-information-v2/spouse-contact-information',
-        },
-      };
+    it('should update any `household-information` return URLs to remove the `v2` reference', () => {
+      const returnUrl = '/household-information-v2/spouse-contact-information';
+      const desiredUrl = '/household-information/spouse-contact-information';
+      const data = { formData: {}, metadata: { returnUrl } };
       const { metadata } = migration(data);
-      expect(metadata.returnUrl).to.equal(
-        'household-information/spouse-contact-information',
-      );
+      expect(metadata.returnUrl).to.eq(desiredUrl);
+    });
+  });
+
+  context('when v8 migration runs', () => {
+    const migration = migrations[7];
+
+    it('should update the return URL to the person information URL', () => {
+      const returnUrl = '/household-information/spouse-contact-information';
+      const desiredUrl = '/veteran-information/personal-information';
+      const data = { formData: {}, metadata: { returnUrl } };
+      const { metadata } = migration(data);
+      expect(metadata.returnUrl).to.eq(desiredUrl);
     });
   });
 });


### PR DESCRIPTION
## Summary
With the addition of the Toxic Exposure questions to the Health Care Application, we need to ensure that all Veterans who have a form saved in progress get an opportunity to answer these questions. This PR creates a migration for the 10-10EZ form to redirect users back to the beginning of the form to ensure they have the opportunity to view and answer the additional questions if they so choose.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#77332

## Testing done

- [x] Created unit testing for the migration to ensure the URL value is correct.

## Acceptance criteria

- All in-progress forms are redirected back to the start of the form to ensure access to the Toxic Exposure questions.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution