### PR TITLE
77432 cleanup toxic exposure toggle logic and add tests

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import { checkboxGroupSchema } from 'platform/forms-system/src/js/web-component-patterns';
-import {
-  capitalizeEachWord,
-  isClaimingNew,
-  showToxicExposurePages,
-  sippableId,
-} from '../utils';
-import { NULL_CONDITION_STRING } from '../constants';
+import { capitalizeEachWord, isClaimingNew, sippableId } from '../utils';
+import { NULL_CONDITION_STRING, SHOW_TOXIC_EXPOSURE } from '../constants';
+
+/**
+ * Checks if the toxic exposure pages should be displayed. Note: toggle is currently read
+ * from the redux store by Form526EZApp and stored in sessions storage since not all form
+ * aspects have ready access to the store.
+ * @returns true if the toggle is enabled and Veteran is claiming at least one new condition, false otherwise
+ */
+export const showToxicExposurePages = formData =>
+  window.sessionStorage.getItem(SHOW_TOXIC_EXPOSURE) === 'true' &&
+  formData?.newDisabilities?.length > 0;
 
 /**
  * Checks if

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
@@ -11,7 +11,8 @@ export const toxicExposurePages = {
   toxicExposureConditions: {
     title: conditionsPageTitle,
     path: 'toxic-exposure-conditions',
-    depends: formData => isClaimingNew(formData) && showToxicExposurePages(),
+    depends: formData =>
+      isClaimingNew(formData) && showToxicExposurePages(formData),
     uiSchema: toxicExposureConditions.uiSchema,
     schema: toxicExposureConditions.schema,
   },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
@@ -3,14 +3,15 @@ import {
   conditionsPageTitle,
   gulfWar1990PageTitle,
   isClaimingTECondition,
+  showToxicExposurePages,
 } from '../../content/toxicExposure';
-import { isClaimingNew, showToxicExposurePages } from '../../utils/index';
+import { isClaimingNew } from '../../utils/index';
 
 export const toxicExposurePages = {
   toxicExposureConditions: {
     title: conditionsPageTitle,
     path: 'toxic-exposure-conditions',
-    depends: () => isClaimingNew && showToxicExposurePages,
+    depends: formData => isClaimingNew(formData) && showToxicExposurePages(),
     uiSchema: toxicExposureConditions.uiSchema,
     schema: toxicExposureConditions.schema,
   },

--- a/src/applications/disability-benefits/all-claims/tests/content/toxicExposure.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/toxicExposure.unit.spec.jsx
@@ -4,6 +4,7 @@ import {
   isClaimingTECondition,
   makeTEConditionsSchema,
   makeTEConditionsUISchema,
+  showToxicExposurePages,
   validateTEConditions,
 } from '../../content/toxicExposure';
 import { SHOW_TOXIC_EXPOSURE } from '../../constants';
@@ -11,6 +12,109 @@ import { SHOW_TOXIC_EXPOSURE } from '../../constants';
 describe('toxicExposure', () => {
   afterEach(() => {
     window.sessionStorage.removeItem(SHOW_TOXIC_EXPOSURE);
+  });
+
+  describe('showToxicExposurePages', () => {
+    it('returns false when toggle disabled and claim type is new', () => {
+      const formData = {
+        'view:claimType': {
+          'view:claimingIncrease': false,
+          'view:claimingNew': true,
+        },
+        newDisabilities: [
+          {
+            cause: 'NEW',
+            primaryDescription: 'Test description',
+            'view:serviceConnectedDisability': {},
+            condition: 'anemia',
+          },
+        ],
+      };
+
+      expect(showToxicExposurePages(formData)).to.be.false;
+    });
+
+    it('returns false when toggle disabled and claiming cfi', () => {
+      const formData = {
+        'view:claimType': {
+          'view:claimingIncrease': true,
+          'view:claimingNew': false,
+        },
+      };
+
+      expect(showToxicExposurePages(formData)).to.be.false;
+    });
+
+    it('returns false when toggle disabled and both claim types', () => {
+      const formData = {
+        'view:claimType': {
+          'view:claimingIncrease': true,
+          'view:claimingNew': true,
+        },
+        newDisabilities: [
+          {
+            cause: 'NEW',
+            primaryDescription: 'Test description',
+            'view:serviceConnectedDisability': {},
+            condition: 'anemia',
+          },
+        ],
+      };
+
+      expect(showToxicExposurePages(formData)).to.be.false;
+    });
+
+    it('returns true when toggle enabled and claiming one or more new conditions', () => {
+      window.sessionStorage.setItem(SHOW_TOXIC_EXPOSURE, true);
+      const formData = {
+        'view:claimType': {
+          'view:claimingIncrease': false,
+          'view:claimingNew': true,
+        },
+        newDisabilities: [
+          {
+            cause: 'NEW',
+            primaryDescription: 'Test description',
+            'view:serviceConnectedDisability': {},
+            condition: 'anemia',
+          },
+        ],
+      };
+
+      expect(showToxicExposurePages(formData)).to.be.true;
+    });
+
+    it('returns false when toggle enabled and claiming cfi', () => {
+      window.sessionStorage.setItem(SHOW_TOXIC_EXPOSURE, true);
+      const formData = {
+        'view:claimType': {
+          'view:claimingIncrease': true,
+          'view:claimingNew': false,
+        },
+      };
+
+      expect(showToxicExposurePages(formData)).to.be.false;
+    });
+
+    it('returns true when toggle enabled and claiming one or more new conditions and cfi', () => {
+      window.sessionStorage.setItem(SHOW_TOXIC_EXPOSURE, true);
+      const formData = {
+        'view:claimType': {
+          'view:claimingIncrease': true,
+          'view:claimingNew': true,
+        },
+        newDisabilities: [
+          {
+            cause: 'NEW',
+            primaryDescription: 'Test description',
+            'view:serviceConnectedDisability': {},
+            condition: 'anemia',
+          },
+        ],
+      };
+
+      expect(showToxicExposurePages(formData)).to.be.true;
+    });
   });
 
   describe('isClaimingTECondition', () => {

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -29,7 +29,6 @@ import {
   START_TEXT,
   FORM_STATUS_BDD,
   CHAR_LIMITS,
-  SHOW_TOXIC_EXPOSURE,
 } from '../constants';
 import { getBranches } from './serviceBranches';
 
@@ -323,9 +322,6 @@ export const isDisabilityPtsd = disability => {
 
 export const hasRatedDisabilities = formData =>
   formData?.ratedDisabilities?.length > 0;
-
-export const showToxicExposurePages = () =>
-  window.sessionStorage.getItem(SHOW_TOXIC_EXPOSURE) === true;
 
 export const isClaimingNew = formData =>
   _.get(


### PR DESCRIPTION
## Summary
Toxic exposure conditions page is displaying when it should not be. Cleanup the toggle logic and add additional unit tests.

- _(If bug, how to reproduce)_
set toggle appropriately, start a new claim, set claim type and verify as follows

**toggle disabled**
1. claim type new
NO te page displayed 

2. claim type cfi
NO te page displayed 

3. both
NO te page displayed 

**toggle enabled**
1. claim type new
te page displayed 

2. claim type cfi
NO te page displayed 

3. both claim types
te page displayed 


- _(Which team do you work for, does your team own the maintenance of this component?)_
@department-of-veterans-affairs/dbex-trex 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#77432


## Testing done
- Unit tests added and manual testing following notes above

## Screenshots
n/a

## What areas of the site does it impact?
526ez

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
