### PR TITLE
[21-0966] Update statement of truth signature function

### DIFF
--- a/src/applications/simple-forms/21-0966/config/helpers.js
+++ b/src/applications/simple-forms/21-0966/config/helpers.js
@@ -70,6 +70,9 @@ export const statementOfTruthFullNamePath = ({ formData } = {}) => {
     return 'thirdPartyPreparerFullName';
   }
   if (preparerIsVeteran({ formData })) {
+    if (hasVeteranPrefill({ formData })) {
+      return 'view:veteranPrefillStore.fullName';
+    }
     return 'veteranFullName';
   }
   return 'survivingDependentFullName';

--- a/src/applications/simple-forms/21-0966/tests/config/helpers.unit.spec.js
+++ b/src/applications/simple-forms/21-0966/tests/config/helpers.unit.spec.js
@@ -307,6 +307,24 @@ describe('statementOfTruthFullNamePath', () => {
     );
   });
 
+  it('returns the required signature formData path for veterans with prefill', () => {
+    const formData = {
+      preparerIdentification: preparerIdentifications.veteran,
+      'view:veteranPrefillStore': {
+        fullName: {
+          first: 'Cheesy',
+          last: 'Grits',
+        },
+        dateOfBirth: '1995-12-21',
+        ssn: '555221111',
+      },
+    };
+
+    expect(statementOfTruthFullNamePath({ formData })).to.equal(
+      'view:veteranPrefillStore.fullName',
+    );
+  });
+
   it('returns the required signature formData path for non-third party surviving dependents', () => {
     const formData = {
       preparerIdentification: preparerIdentifications.survivingDependent,


### PR DESCRIPTION
## Summary
This fixes an oversight with the statement of truth signature validation logic on the review page. Because there is a flow with prefill where the user does not manually enter their name, the validation needs to check for this prefilled value.

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#1079