### PR TITLE
Fix date range validation for Toxic Exposure questions in Health Care Application

### DIFF
--- a/src/applications/hca/config/chapters/militaryService/gulfWarServiceDates.js
+++ b/src/applications/hca/config/chapters/militaryService/gulfWarServiceDates.js
@@ -23,11 +23,11 @@ export default {
         ...currentOrPastMonthYearUI('Service end date'),
         'ui:description': ServiceDateRangeDescription,
       },
+      'ui:validations': [validateGulfWarDates],
     },
     'view:dateRange': {
       'ui:description': DateRangeDescription,
     },
-    'ui:validations': [validateGulfWarDates],
   },
   schema: {
     type: 'object',

--- a/src/applications/hca/config/chapters/militaryService/otherToxicExposureDates.js
+++ b/src/applications/hca/config/chapters/militaryService/otherToxicExposureDates.js
@@ -26,11 +26,11 @@ export default {
         ...currentOrPastMonthYearUI('Exposure end date'),
         'ui:description': ServiceDateRangeDescription,
       },
+      'ui:validations': [validateExposureDates],
     },
     'view:dateRange': {
       'ui:description': DateRangeDescription,
     },
-    'ui:validations': [validateExposureDates],
   },
   schema: {
     type: 'object',

--- a/src/applications/hca/tests/unit/config/militaryService/gulfWarServiceDates.unit.spec.js
+++ b/src/applications/hca/tests/unit/config/militaryService/gulfWarServiceDates.unit.spec.js
@@ -9,6 +9,7 @@ import {
   submitForm,
 } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
 import formConfig from '../../../../config/form';
+import { simulateInputChange } from '../../../helpers';
 
 describe('hca Gulf War Service Dates config', () => {
   const {
@@ -44,5 +45,81 @@ describe('hca Gulf War Service Dates config', () => {
 
     expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(0);
     expect(onSubmit.called).to.be.true;
+  });
+
+  it('should not submit when service start date is greater than service end date', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        schema={schema}
+        definitions={definitions}
+        onSubmit={onSubmit}
+        uiSchema={uiSchema}
+      />,
+    );
+    const formDOM = findDOMNode(form);
+
+    simulateInputChange(
+      formDOM,
+      '#root_view\\3A gulfWarServiceDates_gulfWarStartDateMonth',
+      '5',
+    );
+    simulateInputChange(
+      formDOM,
+      '#root_view\\3A gulfWarServiceDates_gulfWarStartDateYear',
+      '1990',
+    );
+    simulateInputChange(
+      formDOM,
+      '#root_view\\3A gulfWarServiceDates_gulfWarEndDateMonth',
+      '5',
+    );
+    simulateInputChange(
+      formDOM,
+      '#root_view\\3A gulfWarServiceDates_gulfWarEndDateYear',
+      '1989',
+    );
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should not submit when service start date is equal to service end date', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        schema={schema}
+        definitions={definitions}
+        onSubmit={onSubmit}
+        uiSchema={uiSchema}
+      />,
+    );
+    const formDOM = findDOMNode(form);
+
+    simulateInputChange(
+      formDOM,
+      '#root_view\\3A gulfWarServiceDates_gulfWarStartDateMonth',
+      '5',
+    );
+    simulateInputChange(
+      formDOM,
+      '#root_view\\3A gulfWarServiceDates_gulfWarStartDateYear',
+      '1990',
+    );
+    simulateInputChange(
+      formDOM,
+      '#root_view\\3A gulfWarServiceDates_gulfWarEndDateMonth',
+      '5',
+    );
+    simulateInputChange(
+      formDOM,
+      '#root_view\\3A gulfWarServiceDates_gulfWarEndDateYear',
+      '1990',
+    );
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
   });
 });

--- a/src/applications/hca/tests/unit/config/militaryService/otherToxicExposureDates.unit.spec.js
+++ b/src/applications/hca/tests/unit/config/militaryService/otherToxicExposureDates.unit.spec.js
@@ -9,6 +9,7 @@ import {
   submitForm,
 } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
 import formConfig from '../../../../config/form';
+import { simulateInputChange } from '../../../helpers';
 
 describe('hca Other Toxic Exposure Dates config', () => {
   const {
@@ -44,5 +45,81 @@ describe('hca Other Toxic Exposure Dates config', () => {
 
     expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(0);
     expect(onSubmit.called).to.be.true;
+  });
+
+  it('should not submit when exposure start date is greater than exposure end date', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        schema={schema}
+        definitions={definitions}
+        onSubmit={onSubmit}
+        uiSchema={uiSchema}
+      />,
+    );
+    const formDOM = findDOMNode(form);
+
+    simulateInputChange(
+      formDOM,
+      '#root_view\\3A toxicExposureDates_toxicExposureStartDateMonth',
+      '5',
+    );
+    simulateInputChange(
+      formDOM,
+      '#root_view\\3A toxicExposureDates_toxicExposureStartDateYear',
+      '1990',
+    );
+    simulateInputChange(
+      formDOM,
+      '#root_view\\3A toxicExposureDates_toxicExposureEndDateMonth',
+      '5',
+    );
+    simulateInputChange(
+      formDOM,
+      '#root_view\\3A toxicExposureDates_toxicExposureEndDateYear',
+      '1989',
+    );
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+  });
+
+  it('should not submit when service start date is equal to service end date', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        schema={schema}
+        definitions={definitions}
+        onSubmit={onSubmit}
+        uiSchema={uiSchema}
+      />,
+    );
+    const formDOM = findDOMNode(form);
+
+    simulateInputChange(
+      formDOM,
+      '#root_view\\3A toxicExposureDates_toxicExposureStartDateMonth',
+      '5',
+    );
+    simulateInputChange(
+      formDOM,
+      '#root_view\\3A toxicExposureDates_toxicExposureStartDateYear',
+      '1990',
+    );
+    simulateInputChange(
+      formDOM,
+      '#root_view\\3A toxicExposureDates_toxicExposureEndDateMonth',
+      '5',
+    );
+    simulateInputChange(
+      formDOM,
+      '#root_view\\3A toxicExposureDates_toxicExposureEndDateYear',
+      '1990',
+    );
+    submitForm(form);
+
+    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
   });
 });

--- a/src/applications/hca/tests/unit/utils/helpers/form-config.unit.spec.js
+++ b/src/applications/hca/tests/unit/utils/helpers/form-config.unit.spec.js
@@ -183,8 +183,7 @@ describe('hca form config helpers', () => {
   });
 
   context('when `teraInformationEnabled` executes', () => {
-    const getData = ({ enabled = false, disabilityRating = 0 }) => ({
-      'view:totalDisabilityRating': disabilityRating,
+    const getData = ({ enabled = false }) => ({
       'view:isTeraEnabled': enabled,
     });
 
@@ -196,11 +195,6 @@ describe('hca form config helpers', () => {
     it('should return `true` when feature flag is enabled', () => {
       const formData = getData({ enabled: true });
       expect(teraInformationEnabled(formData)).to.be.true;
-    });
-
-    it('should return `false` when user is short form eligible', () => {
-      const formData = getData({ disabilityRating: 80 });
-      expect(teraInformationEnabled(formData)).to.be.false;
     });
   });
 

--- a/src/applications/hca/utils/helpers/form-config.js
+++ b/src/applications/hca/utils/helpers/form-config.js
@@ -100,7 +100,7 @@ export function hasDifferentHomeAddress(formData) {
  */
 export function teraInformationEnabled(formData) {
   const { 'view:isTeraEnabled': isTeraEnabled } = formData;
-  return notShortFormEligible(formData) && isTeraEnabled;
+  return isTeraEnabled;
 }
 
 /**


### PR DESCRIPTION
## Summary
This PR updates the `uiSchema` for the various date ranges for the toxic exposure questions in the Health Care Application to apply validation at the correct level. This PR also remove the short form conditional from being checked for the questions to allow all applicants access to those.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#74969

## Testing done

- Updated unit tests where applicable and manually tested validation fix.

## Screenshots

![Screenshot 2024-02-29 at 15 24 08](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/b74e0381-0139-4c43-b9e6-e64aa3563b37)

## Acceptance criteria

- Date ranges successfully validate as needed

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution