### PR TITLE
update va-featured-content to va-summary-box

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1091,7 +1091,7 @@ jobs:
         uses: ./.github/workflows/checks-action
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          check_name: Unit Tests Summary
+          name: Unit Tests Summary
           conclusion: ${{ needs.unit-tests.result }}
           output: |
             {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -779,6 +779,10 @@ jobs:
       CI_NODE_INDEX: ${{ needs.cypress-tests-prep.outputs.ci_node_index }}
 
     steps:
+      - name: Checkout vets-website
+        if: needs.cypress-tests-prep.outputs.tests-to-stress-test != '[]'
+        uses: actions/checkout@v4
+
       - name: Configure AWS credentials
         if: needs.cypress-tests-prep.outputs.tests-to-stress-test != '[]'
         uses: ./.github/workflows/configure-aws-credentials
@@ -786,11 +790,6 @@ jobs:
           aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-gov-west-1
-          
-
-      - name: Checkout vets-website
-        if: needs.cypress-tests-prep.outputs.tests-to-stress-test != '[]'
-        uses: actions/checkout@v4
 
       - name: Download production build artifact
         if: needs.cypress-tests-prep.outputs.tests-to-stress-test != '[]'

--- a/src/applications/check-in/travel-claim/pages/travel-intro/index.jsx
+++ b/src/applications/check-in/travel-claim/pages/travel-intro/index.jsx
@@ -85,7 +85,7 @@ const TravelIntro = props => {
             </a>
           </va-process-list-item>
         </va-process-list>
-        <va-featured-content class="vads-u-margin-bottom--1" uswds>
+        <va-summary-box class="vads-u-margin-bottom--1" uswds>
           <h2
             className="vads-u-font-family--sans vads-u-margin-top--0"
             slot="headline"
@@ -96,7 +96,7 @@ const TravelIntro = props => {
           <a href="https://www.va.gov/resources/how-to-set-up-direct-deposit-for-va-travel-pay-reimbursement/">
             {t('set-up-direct-deposit')}
           </a>
-        </va-featured-content>
+        </va-summary-box>
       </Wrapper>
     </>
   );

--- a/src/applications/rated-disabilities/tests/e2e/rated-disabilities-lighthouse.cypress.spec.js
+++ b/src/applications/rated-disabilities/tests/e2e/rated-disabilities-lighthouse.cypress.spec.js
@@ -25,7 +25,7 @@ describe('View rated disabilities', () => {
       cy.findByText(
         'We don’t have a combined disability rating on file for you',
       ).should('exist');
-      cy.get('va-featured-content').should('not.exist');
+      cy.get('va-summary-box').should('not.exist');
 
       cy.injectAxeThenAxeCheck();
     });


### PR DESCRIPTION
## Summary

Design system is renaming the component va-featured-content to va-summary-box. This PR is to update current instances to the new name. No functional changes have been made.

These changes seem to have slipped through during the long process to merge the [last PR](https://github.com/department-of-veterans-affairs/vets-website/pull/27945) to make this update.

## Related issue(s)

[Update naming to Summary Box #2336](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2336)

