### PR TITLE
updated depends funcs to check for undef index

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -688,7 +688,6 @@ const formConfig = {
           showPagePerItem: true,
           title: item => `${applicantWording(item)} gender`,
           uiSchema: {
-            'ui:title': 'Applicant Gender',
             applicants: {
               'ui:options': { viewField: ApplicantField },
               items: {
@@ -741,11 +740,13 @@ const formConfig = {
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} birth certificate`,
-          depends: (formData, index) =>
-            get(
-              'applicantRelationshipToSponsor',
-              formData?.applicants?.[`${index || 0}`],
-            )?.relationshipToVeteran === 'child',
+          depends: (formData, index) => {
+            if (index === undefined) return true;
+            return (
+              formData.applicants[index]?.applicantRelationshipToSponsor
+                ?.relationshipToVeteran === 'child'
+            );
+          },
           uiSchema: {
             applicants: {
               'ui:options': { viewField: ApplicantField },
@@ -779,21 +780,18 @@ const formConfig = {
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} school documents`,
-          depends: (formData, index) =>
-            get(
-              'applicantRelationshipToSponsor',
-              formData?.applicants?.[`${index || 0}`],
-            )?.relationshipToVeteran === 'child' &&
-            // Calculate the current app's age and check if it's between
-            // 18-23. Did this isInRange method bc can't store temp age value
-            // and didn't want to calculate age twice to do comparison
-            isInRange(
-              getAgeInYears(
-                get('applicantDOB', formData?.applicants?.[`${index || 0}`]),
-              ),
-              18,
-              23,
-            ),
+          depends: (formData, index) => {
+            if (index === undefined) return true;
+            return (
+              formData.applicants[index]?.applicantRelationshipToSponsor
+                ?.relationshipToVeteran === 'child' &&
+              isInRange(
+                getAgeInYears(formData.applicants[index]?.applicantDOB),
+                18,
+                23,
+              )
+            );
+          },
           uiSchema: {
             applicants: {
               'ui:options': { viewField: ApplicantField },
@@ -827,11 +825,15 @@ const formConfig = {
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} relationship to sponsor`,
-          depends: (formData, index) =>
-            get(
-              'applicantRelationshipToSponsor',
-              formData?.applicants?.[`${index || 0}`],
-            )?.relationshipToVeteran === 'child',
+          depends: (formData, index) => {
+            if (index === undefined) return true;
+            return (
+              get(
+                'applicantRelationshipToSponsor.relationshipToVeteran',
+                formData?.applicants?.[index],
+              ) === 'child'
+            );
+          },
           uiSchema: {
             applicants: {
               'ui:options': { viewField: ApplicantField },
@@ -868,15 +870,19 @@ const formConfig = {
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} adoption documents`,
-          depends: (formData, index) =>
-            get(
-              'applicantRelationshipToSponsor',
-              formData?.applicants?.[`${index || 0}`],
-            )?.relationshipToVeteran === 'child' &&
-            get(
-              'applicantRelationshipOrigin',
-              formData?.applicants?.[`${index || 0}`],
-            ) === 'adoption',
+          depends: (formData, index) => {
+            if (index === undefined) return true;
+            return (
+              get(
+                'applicantRelationshipToSponsor.relationshipToVeteran',
+                formData?.applicants?.[index],
+              ) === 'child' &&
+              get(
+                'applicantRelationshipOrigin',
+                formData?.applicants?.[index],
+              ) === 'adoption'
+            );
+          },
           uiSchema: {
             applicants: {
               'ui:options': { viewField: ApplicantField },
@@ -911,15 +917,19 @@ const formConfig = {
           showPagePerItem: true,
           title: item =>
             `${applicantWording(item)} parental marriage documents`,
-          depends: (formData, index) =>
-            get(
-              'applicantRelationshipToSponsor',
-              formData?.applicants?.[`${index || 0}`],
-            )?.relationshipToVeteran === 'child' &&
-            get(
-              'applicantRelationshipOrigin',
-              formData?.applicants?.[`${index || 0}`],
-            ) === 'step',
+          depends: (formData, index) => {
+            if (index === undefined) return true;
+            return (
+              get(
+                'applicantRelationshipToSponsor.relationshipToVeteran',
+                formData?.applicants?.[index],
+              ) === 'child' &&
+              get(
+                'applicantRelationshipOrigin',
+                formData?.applicants?.[index],
+              ) === 'step'
+            );
+          },
           uiSchema: {
             applicants: {
               'ui:options': { viewField: ApplicantField },
@@ -955,11 +965,15 @@ const formConfig = {
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} marriage documents`,
-          depends: (formData, index) =>
-            get(
-              'applicantRelationshipToSponsor',
-              formData?.applicants?.[`${index || 0}`],
-            )?.relationshipToVeteran === 'spouse',
+          depends: (formData, index) => {
+            if (index === undefined) return true;
+            return (
+              get(
+                'applicantRelationshipToSponsor.relationshipToVeteran',
+                formData?.applicants?.[index],
+              ) === 'spouse'
+            );
+          },
           uiSchema: {
             applicants: {
               'ui:options': { viewField: ApplicantField },
@@ -1010,11 +1024,13 @@ const formConfig = {
           showPagePerItem: true,
           title: item =>
             `${applicantWording(item)} Medicare status (continued)`,
-          depends: (formData, index) =>
-            get(
-              'applicantMedicareStatus',
-              formData?.applicants?.[`${index || 0}`],
-            ) === 'enrolled',
+          depends: (formData, index) => {
+            if (index === undefined) return true;
+            return (
+              get('applicantMedicareStatus', formData?.applicants?.[index]) ===
+              'enrolled'
+            );
+          },
           CustomPage: ApplicantMedicareStatusContinuedPage,
           CustomPageReview: ApplicantMedicareStatusContinuedReviewPage,
           schema: applicantListSchema([], {
@@ -1031,17 +1047,19 @@ const formConfig = {
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} medicare card (parts A/B)`,
-          depends: (formData, index) =>
-            get(
-              'applicantMedicareStatus',
-              formData?.applicants?.[`${index || 0}`],
-            ) === 'enrolled' &&
-            ['partA', 'partB'].some(part =>
-              get(
-                'applicantMedicarePart',
-                formData?.applicants?.[`${index || 0}`],
-              )?.includes(part),
-            ),
+          depends: (formData, index) => {
+            if (index === undefined) return true;
+            return (
+              get('applicantMedicareStatus', formData?.applicants?.[index]) ===
+                'enrolled' &&
+              ['partA', 'partB'].some(part =>
+                get(
+                  'applicantMedicarePart',
+                  formData?.applicants?.[index],
+                )?.includes(part),
+              )
+            );
+          },
           uiSchema: {
             applicants: {
               'ui:options': { viewField: ApplicantField },
@@ -1077,15 +1095,17 @@ const formConfig = {
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} medicare card (part D)`,
-          depends: (formData, index) =>
-            get(
-              'applicantMedicareStatus',
-              formData?.applicants?.[`${index || 0}`],
-            ) === 'enrolled' &&
-            get(
-              'applicantMedicarePart',
-              formData?.applicants?.[`${index || 0}`],
-            )?.includes('partD'),
+          depends: (formData, index) => {
+            if (index === undefined) return true;
+            return (
+              get('applicantMedicareStatus', formData?.applicants?.[index]) ===
+                'enrolled' &&
+              get(
+                'applicantMedicarePart',
+                formData?.applicants?.[index],
+              )?.includes('partD')
+            );
+          },
           uiSchema: {
             applicants: {
               'ui:options': { viewField: ApplicantField },
@@ -1135,9 +1155,12 @@ const formConfig = {
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} other health insurance`,
-          depends: (formData, index) =>
-            get('applicantHasOhi', formData?.applicants?.[`${index || 0}`]) ===
-            'yes',
+          depends: (formData, index) => {
+            if (index === undefined) return true;
+            return (
+              get('applicantHasOhi', formData?.applicants?.[index]) === 'yes'
+            );
+          },
           uiSchema: {
             applicants: {
               'ui:options': { viewField: ApplicantField },
@@ -1171,13 +1194,14 @@ const formConfig = {
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} 10-7959C upload`,
-          depends: (formData, index) =>
-            get('applicantHasOhi', formData?.applicants?.[`${index || 0}`]) ===
-              'yes' ||
-            get(
-              'applicantMedicareStatus',
-              formData?.applicants?.[`${index || 0}`],
-            ) === 'enrolled',
+          depends: (formData, index) => {
+            if (index === undefined) return true;
+            return (
+              get('applicantHasOhi', formData?.applicants?.[index]) === 'yes' ||
+              get('applicantMedicareStatus', formData?.applicants?.[index]) ===
+                'enrolled'
+            );
+          },
           uiSchema: {
             applicants: {
               'ui:options': { viewField: ApplicantField },


### PR DESCRIPTION
## Summary

Fixes bug where checks on list-and-loop item properties failed when the `index` value was initially undefined. This behavior was obscured by the previous implementation's defaulting to the first list item; it has been corrected.

Previously, a depends function looked like this:

```javascript
{
  depends: (data, index) => get('someProperty', data.applicants[`${index || 0}`]),
}
```
This appeared to work as long as subsequent list-and-loop entries followed the same structure as item at index `[0]`. 

However, when subsequent list entries diverged from the properties held by item `[0]`, these conditional `depends` checks would fail (`index` is `undefined` quite often, it turns out). To fix this, all depends functions have a new check that returns true if index is undefined. On subsequent renders, the proper value for index is eventually available, the check is bypassed, and the actual `depends` check can run:

```javascript
{
  depends: (data, index) => {
    if (index === true) return true; 
    get('someProperty', data.applicants[index]);
  },
}
```

`index` no longer defaults to `[0]`, which prevents the breakage when list item structures differ, and allows the conditional pages to render appropriately.

Changes:
- List and loop `depends` functions in form now check if `index` is undefined
- Team: IVC-CHAMPVA
- Flipper: NA

## Related issue(s)

NA

## Testing done

- Manual testing
- Ran `yarn test:coverage-app ivc-champva/10-10D` to verify existing tests run and pass

## Screenshots

NA

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
