### PR TITLE
Update e2e testing for Toxic Exposure tests for added utils

### DIFF
--- a/src/applications/hca/tests/e2e/hca-toxic-exposure.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-toxic-exposure.cypress.spec.js
@@ -5,6 +5,7 @@ import mockUser from './fixtures/mocks/mockUser';
 import mockEnrollmentStatus from './fixtures/mocks/mockEnrollmentStatus.json';
 import mockPrefill from './fixtures/mocks/mockPrefill.json';
 import {
+  acceptPrivacyAgreement,
   advanceToToxicExposure,
   advanceFromToxicExposureToReview,
   goToNextPage,
@@ -61,11 +62,7 @@ describe('HCA-Toxic-Exposure-Non-Disclosure', () => {
     advanceFromToxicExposureToReview();
 
     // accept the privacy agreement
-    cy.get('va-checkbox[name="privacyAgreementAccepted"]')
-      .scrollIntoView()
-      .shadow()
-      .find('label')
-      .click();
+    acceptPrivacyAgreement();
 
     // submit form
     cy.findByText(/submit/i, { selector: 'button' }).click();
@@ -146,11 +143,7 @@ describe('HCA-Toxic-Exposure-Disclosure', () => {
     advanceFromToxicExposureToReview();
 
     // accept the privacy agreement
-    cy.get('va-checkbox[name="privacyAgreementAccepted"]')
-      .scrollIntoView()
-      .shadow()
-      .find('label')
-      .click();
+    acceptPrivacyAgreement();
 
     // submit form
     cy.findByText(/submit/i, { selector: 'button' }).click();
@@ -206,11 +199,7 @@ describe('HCA-Toxic-Exposure-Disclosure', () => {
     advanceFromToxicExposureToReview();
 
     // accept the privacy agreement
-    cy.get('va-checkbox[name="privacyAgreementAccepted"]')
-      .scrollIntoView()
-      .shadow()
-      .find('label')
-      .click();
+    acceptPrivacyAgreement();
 
     // submit form
     cy.findByText(/submit/i, { selector: 'button' }).click();
@@ -267,11 +256,7 @@ describe('HCA-Toxic-Exposure-Disclosure', () => {
     advanceFromToxicExposureToReview();
 
     // accept the privacy agreement
-    cy.get('va-checkbox[name="privacyAgreementAccepted"]')
-      .scrollIntoView()
-      .shadow()
-      .find('label')
-      .click();
+    acceptPrivacyAgreement();
 
     // submit form
     cy.findByText(/submit/i, { selector: 'button' }).click();


### PR DESCRIPTION
## Summary
This PR replaces repetitive `cy.` calls in the Toxic Exposure end-to-end testing with a helper util that was created in a previous PR.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#74969

## Acceptance criteria

- Cypress testing is cleaned up and does not contain overly repititive calls.

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution