### PR TITLE
Check in/75717/already filed

### DIFF
--- a/src/applications/check-in/actions/travel-claim/index.js
+++ b/src/applications/check-in/actions/travel-claim/index.js
@@ -6,3 +6,12 @@ export const receivedTravelData = payload => {
     payload,
   };
 };
+
+export const RECEIVED_FILTERED_APPOINTMENTS = 'RECEIVED_FILTERED_APPOINTMENTS';
+
+export const receivedFilteredAppointments = payload => {
+  return {
+    type: RECEIVED_FILTERED_APPOINTMENTS,
+    payload,
+  };
+};

--- a/src/applications/check-in/actions/travel-claim/index.js
+++ b/src/applications/check-in/actions/travel-claim/index.js
@@ -7,11 +7,11 @@ export const receivedTravelData = payload => {
   };
 };
 
-export const RECEIVED_FILTERED_APPOINTMENTS = 'RECEIVED_FILTERED_APPOINTMENTS';
+export const SET_FILTERED_APPOINTMENTS = 'SET_FILTERED_APPOINTMENTS';
 
-export const receivedFilteredAppointments = payload => {
+export const setFilteredAppointments = payload => {
   return {
-    type: RECEIVED_FILTERED_APPOINTMENTS,
+    type: SET_FILTERED_APPOINTMENTS,
     payload,
   };
 };

--- a/src/applications/check-in/actions/travel-claim/travel-claim.actions.unit.spec.js
+++ b/src/applications/check-in/actions/travel-claim/travel-claim.actions.unit.spec.js
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+
+import {
+  receivedTravelData,
+  RECEIVED_TRAVEL_DATA,
+  setFilteredAppointments,
+  SET_FILTERED_APPOINTMENTS,
+} from './index';
+
+describe('travel-claim', () => {
+  describe('actions', () => {
+    describe('receivedTravelData', () => {
+      it('should return correct action', () => {
+        const action = receivedTravelData({});
+        expect(action.type).to.equal(RECEIVED_TRAVEL_DATA);
+      });
+      it('should return correct structure', () => {
+        const action = receivedTravelData({
+          appointments: [
+            { appointmentIen: 'abc-123' },
+            {
+              appointmentIen: 'def-456',
+            },
+          ],
+          address: '123 fake st.',
+        });
+        expect(action.payload.appointments).to.be.an('array');
+        expect(action.payload.appointments).to.deep.equal([
+          { appointmentIen: 'abc-123' },
+          { appointmentIen: 'def-456' },
+        ]);
+
+        expect(action.payload.address).to.be.an('string');
+        expect(action.payload.address).to.equal('123 fake st.');
+      });
+    });
+    describe('setFilteredAppointments', () => {
+      it('should return correct action', () => {
+        const action = setFilteredAppointments({});
+        expect(action.type).to.equal(SET_FILTERED_APPOINTMENTS);
+      });
+      it('should return correct structure', () => {
+        const action = setFilteredAppointments({
+          alreadyFiled: [],
+          eligibleToFile: [],
+        });
+        expect(action.payload).to.be.an('object');
+        expect(action.payload).to.deep.equal({
+          alreadyFiled: [],
+          eligibleToFile: [],
+        });
+
+        expect(action.payload.alreadyFiled).to.be.an('array');
+        expect(action.payload.eligibleToFile).to.be.an('array');
+      });
+    });
+  });
+});

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/shared/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/shared/get.js
@@ -352,7 +352,7 @@ const createAppointmentsOH = (token = defaultUUID) => {
         appointmentIen: '6767',
         startTime: dateFns.addHours(new Date(), 4).toISOString(),
         type: 'Neurology',
-        station: '622',
+        stationNo: '622',
         facility: 'VA Facility 3',
       }),
     );

--- a/src/applications/check-in/components/layout/Wrapper.jsx
+++ b/src/applications/check-in/components/layout/Wrapper.jsx
@@ -36,9 +36,25 @@ const Wrapper = props => {
 
   const selectApp = useMemo(makeSelectApp, []);
   const { app } = useSelector(selectApp);
-  const downtimeDependency =
-    app === APP_NAMES.CHECK_IN ? externalServices.cie : externalServices.pcie;
-  const appTitle = app === APP_NAMES.CHECK_IN ? 'Check in' : 'Pre-check in';
+  // @TODO we need to add a pagerduty switch and external serivce for travel-claim app
+  let downtimeDependency;
+  let appTitle;
+  switch (app) {
+    case APP_NAMES.CHECK_IN:
+      appTitle = 'check in';
+      downtimeDependency = externalServices.cie;
+      break;
+    case APP_NAMES.PRE_CHECK_IN:
+      appTitle = 'pre-check in';
+      downtimeDependency = externalServices.pcie;
+      break;
+    case APP_NAMES.TRAVEL_CLAIM:
+      appTitle = 'travel claim';
+      break;
+    default:
+      appTitle = 'appointments';
+      break;
+  }
   return (
     <>
       <div

--- a/src/applications/check-in/components/layout/tests/Wrapper.unit.spec.jsx
+++ b/src/applications/check-in/components/layout/tests/Wrapper.unit.spec.jsx
@@ -64,7 +64,7 @@ describe('Wrapper component', () => {
     const mockStore = configureStore(middleware);
     const initState = {
       checkInData: {
-        app: 'PreCheckIn',
+        app: 'preCheckIn',
         form: {
           pages: [],
         },

--- a/src/applications/check-in/hooks/useGetCheckInData.jsx
+++ b/src/applications/check-in/hooks/useGetCheckInData.jsx
@@ -19,7 +19,7 @@ import {
 
 import {
   receivedTravelData,
-  receivedFilteredAppointments,
+  setFilteredAppointments,
 } from '../actions/travel-claim';
 
 import {
@@ -147,7 +147,7 @@ const useGetCheckInData = ({
       });
       batch(() => {
         dispatch(receivedTravelData(payload));
-        dispatch(receivedFilteredAppointments(filteredAppointments));
+        dispatch(setFilteredAppointments(filteredAppointments));
       });
     },
     [dispatch, getTravelPaySentTravelClaim],

--- a/src/applications/check-in/reducers/index.js
+++ b/src/applications/check-in/reducers/index.js
@@ -37,9 +37,15 @@ import {
   additionalContextHandler,
 } from './day-of';
 
-import { RECEIVED_TRAVEL_DATA } from '../actions/travel-claim';
+import {
+  RECEIVED_TRAVEL_DATA,
+  RECEIVED_FILTERED_APPOINTMENTS,
+} from '../actions/travel-claim';
 
-import { receivedTravelDataHandler } from './travel-claim';
+import {
+  receivedTravelDataHandler,
+  receivedFilteredAppointmentsHandler,
+} from './travel-claim';
 
 import { setAppHandler, setErrorHandler, setFormHandler } from './universal';
 
@@ -74,6 +80,7 @@ const handler = Object.freeze({
   [SET_FORM]: setFormHandler,
   [ADDITIONAL_CONTEXT]: additionalContextHandler,
   [RECEIVED_TRAVEL_DATA]: receivedTravelDataHandler,
+  [RECEIVED_FILTERED_APPOINTMENTS]: receivedFilteredAppointmentsHandler,
 
   default: state => {
     return { ...state };

--- a/src/applications/check-in/reducers/index.js
+++ b/src/applications/check-in/reducers/index.js
@@ -39,12 +39,12 @@ import {
 
 import {
   RECEIVED_TRAVEL_DATA,
-  RECEIVED_FILTERED_APPOINTMENTS,
+  SET_FILTERED_APPOINTMENTS,
 } from '../actions/travel-claim';
 
 import {
   receivedTravelDataHandler,
-  receivedFilteredAppointmentsHandler,
+  setFilteredAppointmentsHandler,
 } from './travel-claim';
 
 import { setAppHandler, setErrorHandler, setFormHandler } from './universal';
@@ -80,7 +80,7 @@ const handler = Object.freeze({
   [SET_FORM]: setFormHandler,
   [ADDITIONAL_CONTEXT]: additionalContextHandler,
   [RECEIVED_TRAVEL_DATA]: receivedTravelDataHandler,
-  [RECEIVED_FILTERED_APPOINTMENTS]: receivedFilteredAppointmentsHandler,
+  [SET_FILTERED_APPOINTMENTS]: setFilteredAppointmentsHandler,
 
   default: state => {
     return { ...state };

--- a/src/applications/check-in/reducers/travel-claim/index.js
+++ b/src/applications/check-in/reducers/travel-claim/index.js
@@ -7,4 +7,11 @@ const receivedTravelDataHandler = (state, action) => {
   };
 };
 
-export { receivedTravelDataHandler };
+const receivedFilteredAppointmentsHandler = (state, action) => {
+  return {
+    ...state,
+    context: { ...state.context, ...action.payload },
+  };
+};
+
+export { receivedTravelDataHandler, receivedFilteredAppointmentsHandler };

--- a/src/applications/check-in/reducers/travel-claim/index.js
+++ b/src/applications/check-in/reducers/travel-claim/index.js
@@ -7,11 +7,11 @@ const receivedTravelDataHandler = (state, action) => {
   };
 };
 
-const receivedFilteredAppointmentsHandler = (state, action) => {
+const setFilteredAppointmentsHandler = (state, action) => {
   return {
     ...state,
     context: { ...state.context, ...action.payload },
   };
 };
 
-export { receivedTravelDataHandler, receivedFilteredAppointmentsHandler };
+export { receivedTravelDataHandler, setFilteredAppointmentsHandler };

--- a/src/applications/check-in/reducers/travel-claim/travel-claim.reducers.unit.spec.js
+++ b/src/applications/check-in/reducers/travel-claim/travel-claim.reducers.unit.spec.js
@@ -1,7 +1,13 @@
 import { expect } from 'chai';
 
-import { receivedTravelDataHandler } from './index';
-import { receivedTravelData } from '../../actions/travel-claim';
+import {
+  receivedTravelDataHandler,
+  setFilteredAppointmentsHandler,
+} from './index';
+import {
+  receivedTravelData,
+  setFilteredAppointments,
+} from '../../actions/travel-claim';
 
 import appReducer from '../index';
 
@@ -18,6 +24,18 @@ describe('check in', () => {
         },
       ],
       address: '111 fake st.',
+    };
+    const filteredAppointments = {
+      alreadyFiled: [
+        {
+          stationNo: '555',
+        },
+      ],
+      eligibleToFile: [
+        {
+          stationNo: '444',
+        },
+      ],
     };
     describe('receivedTravelDataHandler', () => {
       it('should create basic structure', () => {
@@ -37,18 +55,46 @@ describe('check in', () => {
         );
         expect(state.veteranData.address).to.equal('111 fake st.');
       });
+      describe('reducer is called;', () => {
+        it('finds the correct handler', () => {
+          const action = receivedTravelData(data);
+          const state = appReducer.checkInData(undefined, action);
+          expect(state.appointments[0].startTime).to.equal(
+            '2021-08-19T13:56:31',
+          );
+          expect(state.appointments[0].facility).to.equal(
+            'LOMA LINDA VA CLINIC',
+          );
+          expect(state.appointments[0].clinicPhoneNumber).to.equal(
+            '5551234567',
+          );
+          expect(state.appointments[0].clinicFriendlyName).to.equal(
+            'TEST CLINIC',
+          );
+          expect(state.veteranData.address).to.equal('111 fake st.');
+        });
+      });
     });
-    describe('reducer is called;', () => {
-      it('finds the correct handler', () => {
-        const action = receivedTravelData(data);
-        const state = appReducer.checkInData(undefined, action);
-        expect(state.appointments[0].startTime).to.equal('2021-08-19T13:56:31');
-        expect(state.appointments[0].facility).to.equal('LOMA LINDA VA CLINIC');
-        expect(state.appointments[0].clinicPhoneNumber).to.equal('5551234567');
-        expect(state.appointments[0].clinicFriendlyName).to.equal(
-          'TEST CLINIC',
-        );
-        expect(state.veteranData.address).to.equal('111 fake st.');
+    describe('setFilteredAppointments', () => {
+      it('should create basic structure', () => {
+        const action = setFilteredAppointments(filteredAppointments);
+        const state = setFilteredAppointmentsHandler({}, action);
+        expect(state.context.alreadyFiled).to.be.an('array');
+        expect(state.context.eligibleToFile).to.be.an('array');
+      });
+      it('should set the correct values', () => {
+        const action = setFilteredAppointments(filteredAppointments);
+        const state = setFilteredAppointmentsHandler({}, action);
+        expect(state.context.alreadyFiled[0].stationNo).to.equal('555');
+        expect(state.context.eligibleToFile[0].stationNo).to.equal('444');
+      });
+      describe('reducer is called;', () => {
+        it('finds the correct handler', () => {
+          const action = setFilteredAppointments(filteredAppointments);
+          const state = appReducer.checkInData(undefined, action);
+          expect(state.context.alreadyFiled[0].stationNo).to.equal('555');
+          expect(state.context.eligibleToFile[0].stationNo).to.equal('444');
+        });
       });
     });
   });

--- a/src/applications/check-in/tests/unit/utils/initState.js
+++ b/src/applications/check-in/tests/unit/utils/initState.js
@@ -35,6 +35,8 @@ const createStore = ({
   features = {},
   error = null,
   seeStaffMessage = null,
+  eligibleToFile = null,
+  alreadyFiled = null,
 } = {}) => {
   const middleware = [];
   const mockStore = configureStore(middleware);
@@ -43,6 +45,8 @@ const createStore = ({
       app,
       context: {
         token: 'some-token',
+        eligibleToFile,
+        alreadyFiled,
       },
       form: {
         pages: formPages,

--- a/src/applications/check-in/travel-claim/pages/LoadingPage/LoadingPage.unit.spec.js
+++ b/src/applications/check-in/travel-claim/pages/LoadingPage/LoadingPage.unit.spec.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
+import * as useGetCheckInDataModule from '../../../hooks/useGetCheckInData';
+import * as useUpdateErrorModule from '../../../hooks/useUpdateError';
+import LoadingPage from '.';
+
+describe('travel-claim', () => {
+  const store = {
+    formPages: ['loading-appointments', 'travel-pay'],
+    app: 'travelClaim',
+  };
+  describe('LoadingPage', () => {
+    it('routes to next page with eligible appointments', () => {
+      const push = sinon.spy();
+      const sandbox = sinon.createSandbox();
+      sandbox.stub(useGetCheckInDataModule, 'useGetCheckInData').returns({
+        checkInDataError: false,
+        isComplete: true,
+      });
+      store.eligibleToFile = [
+        {
+          stationNo: '500',
+        },
+      ];
+      render(
+        <CheckInProvider
+          store={store}
+          router={{
+            push,
+            currentPage: '/loading-appointments',
+            params: {},
+          }}
+        >
+          <LoadingPage />
+        </CheckInProvider>,
+      );
+      expect(push.calledWith('travel-pay')).to.be.true;
+      sandbox.restore();
+    });
+    it('routes to an error page on fetch error', () => {
+      const sandbox = sinon.createSandbox();
+      const updateErrorSpy = sinon.spy();
+      sandbox.stub(useUpdateErrorModule, 'useUpdateError').returns({
+        updateError: updateErrorSpy,
+      });
+      sandbox.stub(useGetCheckInDataModule, 'useGetCheckInData').returns({
+        checkInDataError: true,
+      });
+      render(
+        <CheckInProvider store={store}>
+          <LoadingPage />
+        </CheckInProvider>,
+      );
+      expect(updateErrorSpy.calledOnce).to.be.true;
+      sandbox.restore();
+    });
+    it('routes to error with already field with no eligible appointments', () => {
+      const sandbox = sinon.createSandbox();
+      const updateErrorSpy = sinon.spy();
+      sandbox.stub(useUpdateErrorModule, 'useUpdateError').returns({
+        updateError: updateErrorSpy,
+      });
+      sandbox.stub(useGetCheckInDataModule, 'useGetCheckInData').returns({
+        checkInDataError: false,
+        isComplete: true,
+      });
+      store.eligibleToFile = [];
+      render(
+        <CheckInProvider store={store}>
+          <LoadingPage />
+        </CheckInProvider>,
+      );
+      expect(updateErrorSpy.calledOnce).to.be.true;
+      expect(updateErrorSpy.calledWith('already-filed-claim')).to.be.true;
+      sandbox.restore();
+    });
+  });
+});

--- a/src/applications/check-in/travel-claim/pages/LoadingPage/LoadingPage.unit.spec.js
+++ b/src/applications/check-in/travel-claim/pages/LoadingPage/LoadingPage.unit.spec.js
@@ -57,7 +57,7 @@ describe('travel-claim', () => {
       expect(updateErrorSpy.calledOnce).to.be.true;
       sandbox.restore();
     });
-    it('routes to error with already field with no eligible appointments', () => {
+    it('routes to error with already filed with no eligible appointments', () => {
       const sandbox = sinon.createSandbox();
       const updateErrorSpy = sinon.spy();
       sandbox.stub(useUpdateErrorModule, 'useUpdateError').returns({

--- a/src/applications/check-in/travel-claim/pages/LoadingPage/index.jsx
+++ b/src/applications/check-in/travel-claim/pages/LoadingPage/index.jsx
@@ -6,7 +6,6 @@ import { APP_NAMES } from '../../../utils/appConstants';
 import { useGetCheckInData } from '../../../hooks/useGetCheckInData';
 import { useFormRouting } from '../../../hooks/useFormRouting';
 import { useUpdateError } from '../../../hooks/useUpdateError';
-import { useStorage } from '../../../hooks/useStorage';
 import { makeSelectCurrentContext } from '../../../selectors';
 
 const LoadingPage = props => {
@@ -16,9 +15,6 @@ const LoadingPage = props => {
   const { eligibleToFile } = useSelector(selectCurrentContext);
 
   const { goToNextPage } = useFormRouting(router);
-
-  const { getTravelPaySent } = useStorage(APP_NAMES.TRAVEL_CLAIM, true);
-  const travelPaySent = getTravelPaySent(window);
 
   const { checkInDataError, isComplete } = useGetCheckInData({
     refreshNeeded: true,
@@ -35,7 +31,6 @@ const LoadingPage = props => {
     },
     [checkInDataError, updateError],
   );
-
   useEffect(
     () => {
       if (isComplete) {
@@ -46,7 +41,7 @@ const LoadingPage = props => {
         }
       }
     },
-    [isComplete, goToNextPage, travelPaySent, eligibleToFile, updateError],
+    [isComplete, goToNextPage, eligibleToFile, updateError],
   );
   window.scrollTo(0, 0);
 

--- a/src/applications/check-in/travel-claim/pages/LoadingPage/index.jsx
+++ b/src/applications/check-in/travel-claim/pages/LoadingPage/index.jsx
@@ -42,11 +42,11 @@ const LoadingPage = props => {
         if (eligibleToFile && eligibleToFile.length) {
           goToNextPage();
         } else {
-          updateError('already-filed');
+          updateError('already-filed-claim');
         }
       }
     },
-    [isComplete, goToNextPage, travelPaySent],
+    [isComplete, goToNextPage, travelPaySent, eligibleToFile, updateError],
   );
   window.scrollTo(0, 0);
 

--- a/src/applications/check-in/travel-claim/pages/LoadingPage/index.jsx
+++ b/src/applications/check-in/travel-claim/pages/LoadingPage/index.jsx
@@ -1,16 +1,24 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 import { APP_NAMES } from '../../../utils/appConstants';
 import { useGetCheckInData } from '../../../hooks/useGetCheckInData';
 import { useFormRouting } from '../../../hooks/useFormRouting';
 import { useUpdateError } from '../../../hooks/useUpdateError';
+import { useStorage } from '../../../hooks/useStorage';
+import { makeSelectCurrentContext } from '../../../selectors';
 
 const LoadingPage = props => {
   const { router } = props;
   const { t } = useTranslation();
+  const selectCurrentContext = useMemo(makeSelectCurrentContext, []);
+  const { eligibleToFile } = useSelector(selectCurrentContext);
 
   const { goToNextPage } = useFormRouting(router);
+
+  const { getTravelPaySent } = useStorage(APP_NAMES.TRAVEL_CLAIM, true);
+  const travelPaySent = getTravelPaySent(window);
 
   const { checkInDataError, isComplete } = useGetCheckInData({
     refreshNeeded: true,
@@ -31,10 +39,14 @@ const LoadingPage = props => {
   useEffect(
     () => {
       if (isComplete) {
-        goToNextPage();
+        if (eligibleToFile && eligibleToFile.length) {
+          goToNextPage();
+        } else {
+          updateError('already-filed');
+        }
       }
     },
-    [isComplete, goToNextPage],
+    [isComplete, goToNextPage, travelPaySent],
   );
   window.scrollTo(0, 0);
 


### PR DESCRIPTION
## Summary

This PR adds a check against local storage and context that splits the appointments payload into `eligibleToFile` and `alreadyFiled` arrays that get stored in `checkInData.context`. The original payload is still stored in `checkInData.appointments`, the loading page looks at the `eligibleToFile` array to route the user to either continue with filing if there are appointments to file for or to the error page with the `already-filed-claim` error type if there are no eligible to file appointments.

**Note: the content for the error page is being handled in the error ticket not in this PR**

To test this, you can add this key to your local storage in browser `my.health.travel-claim.travel.pay.sent` with a value of a station and timestamp that is sometime today i.e `{"530":"2024-03-01T18:19:32.230Z"}` 

Now you can visit with UUID `46bebc0a-b99c-464f-a5c5-560bc9eae287` and get routed to `my-health/appointment-travel-claim/error?error=already-filed-claim` after auth. If you visit with UUID `8379d4b5-b9bc-4f3f-84a2-9cb9983a1af0` you will be taken to the intro page after auth. Now you can inspect redux and see the appointments filed and eligible split out in `checkInData.context`, plus the full payload in `checkInData.appointments`.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#75717

## Testing done

Added unit tests

## What areas of the site does it impact?

Travel claim application for Oracle Health appointments.

## Acceptance criteria

 - [ ] user gets routed to error if localStorage shows that all appointments have already been filed today
 - [ ] user can still get into app if only some of the appointments have already been filed today
 - [ ] user can get into the app if there are no appointments in localStorage for today
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

