### PR TITLE
Remove HCA cross-app import from Mock Radio page

### DIFF
--- a/src/applications/simple-forms/mock-simple-forms-patterns/components/formDescriptions.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/components/formDescriptions.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+export const CompensationTypeDescription = (
+  <va-additional-info
+    trigger="Why we ask for this information"
+    class="vads-u-margin-top--2 vads-u-margin-bottom--3"
+    uswds
+  >
+    <div>
+      <p className="vads-u-margin-top--0">
+        We use this information to help us decide these 4 things:
+      </p>
+
+      <ul>
+        <li>
+          If you can fill out a shorter application, <strong>and</strong>
+        </li>
+        <li>
+          What types of VA health care benefits you’re eligible for,{' '}
+          <strong>and</strong>
+        </li>
+        <li>
+          How soon we enroll you in VA health care, <strong>and</strong>
+        </li>
+        <li>
+          How much (if anything) you’ll have to pay toward the cost of your care
+        </li>
+      </ul>
+
+      <p className="vads-u-margin-bottom--0">
+        We give veterans with service-connected disabilities the highest
+        priority.
+      </p>
+    </div>
+  </va-additional-info>
+);

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockRadio.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockRadio.js
@@ -7,7 +7,7 @@ import {
   yesNoUI,
   yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { CompensationTypeDescription } from 'applications/hca/components/FormDescriptions';
+import { CompensationTypeDescription } from '../components/formDescriptions';
 
 /** @type {PageSchema} */
 export default {

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/components/formDescriptions.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/components/formDescriptions.unit.spec.jsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import { CompensationTypeDescription } from '../../components/formDescriptions';
+
+describe('CompensationTypeDescription', () => {
+  it('should render', () => {
+    const { container } = render(CompensationTypeDescription);
+    const selector = container.querySelector('va-additional-info');
+    expect(selector).to.exist;
+  });
+});


### PR DESCRIPTION
## Summary
The 1010 team is looking to move it's applications to the CD pipeline. In order to do so, we cannot have any cross-app imports with our applications. This PR converts an imported component to its own local file to remove the cross-app import.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#76209

## Acceptance criteria

- Form description successfully renders using local component
- HCA contains no cross-app imports

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution