### PR TITLE
DR | Cleanup appeals confirmation page code

### DIFF
--- a/src/applications/appeals/10182/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/10182/containers/ConfirmationPage.jsx
@@ -1,122 +1,51 @@
-import React, { useEffect, useRef } from 'react';
-import moment from 'moment';
-import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
+import React from 'react';
 
-import { selectProfile } from 'platform/user/selectors';
-import scrollTo from 'platform/utilities/ui/scrollTo';
-import { waitForRenderThenFocus } from 'platform/utilities/ui';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
-import { DateSubmitted } from '../../shared/components/DateSubmitted';
-import { IssuesSubmitted } from '../../shared/components/IssuesSubmitted';
-import { getIssuesListItems } from '../../shared/utils/issues';
-import { renderFullName } from '../../shared/utils/data';
+import ConfirmationDecisionReviews from '../../shared/components/ConfirmationDecisionReviews';
 
-export const ConfirmationPage = () => {
-  const alertRef = useRef(null);
-
-  const form = useSelector(state => state.form || {});
-  const name = useSelector(state => selectProfile(state)?.userFullName || {});
-
-  useEffect(
-    () => {
-      if (alertRef?.current) {
-        scrollTo('topScrollElement');
-        // delay focus for Safari
-        waitForRenderThenFocus('h2', alertRef.current);
-      }
-    },
-    [alertRef],
-  );
-
-  const { submission, data } = form;
-  const issues = data ? getIssuesListItems(data) : [];
-  const submitDate = moment(submission?.timestamp);
-
-  return (
-    <div>
-      <div className="print-only">
-        <img
-          src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
-          alt="VA logo"
-          width="300"
-        />
-        <h2>Request for Board Appeal</h2>
-      </div>
-      <va-alert status="success" ref={alertRef} uswds>
-        <h2 slot="headline">We’ve received your Board Appeal request</h2>
-        <p>
-          After we’ve completed our review, we’ll mail you a decision packet
-          with the details of our decision.
-        </p>
-      </va-alert>
-      <div className="inset">
-        <h3 className="vads-u-margin-top--0">
-          Your information for this claim
-        </h3>
-        <h4>Your name</h4>
-        {renderFullName(name)}
-
-        {submitDate.isValid() && <DateSubmitted submitDate={submitDate} />}
-        <IssuesSubmitted issues={issues} />
-      </div>
-
-      <h2 className="vads-u-font-size--h3">
-        After you request a decision review
-      </h2>
-      <p>
-        When we’ve completed your review, we will physically mail you a decision
-        packet that includes details about our decision.{' '}
-        <a href="/decision-reviews/after-you-request-review/">
-          Learn more about what happens after you request a review
-        </a>
-        .
-      </p>
-
-      <h2 className="vads-u-font-size--h3">What should I do while I wait?</h2>
-      <p>
-        You don’t need to do anything unless we send you a letter asking for
-        more information. If we schedule any exams for you, be sure not to miss
-        them.
-      </p>
-      <p>
-        If you requested an appeal and haven’t heard back from us yet, please
-        don’t request another appeal. Call us at{' '}
-        <va-telephone contact={CONTACTS.VA_BENEFITS} /> (
-        <va-telephone contact={CONTACTS[711]} tty />
-        ).
-      </p>
-      <br role="presentation" />
-      <a
-        href="/claim-or-appeal-status/"
-        className="vads-c-action-link--green"
-        aria-describedby="delay-note"
-      >
-        Check the status of your appeal
+export const ConfirmationPage = () => (
+  <ConfirmationDecisionReviews
+    pageTitle="Request for Board Appeal"
+    alertTitle="We’ve received your Board Appeal request"
+  >
+    <h2 className="vads-u-font-size--h3">
+      After you request a decision review
+    </h2>
+    <p>
+      When we’ve completed your review, we will physically mail you a decision
+      packet that includes details about our decision.{' '}
+      <a href="/decision-reviews/after-you-request-review/">
+        Learn more about what happens after you request a review
       </a>
-      <p id="delay-note">
-        <strong>Note</strong>: It may take 7 to 10 days for your Board Appeal
-        request to appear online.
-      </p>
-    </div>
-  );
-};
+      .
+    </p>
 
-ConfirmationPage.propTypes = {
-  form: PropTypes.shape({
-    data: PropTypes.shape({}),
-    formId: PropTypes.string,
-    submission: PropTypes.shape({
-      timestamp: PropTypes.instanceOf(Date),
-    }),
-  }),
-  name: PropTypes.shape({
-    first: PropTypes.string,
-    middle: PropTypes.string,
-    last: PropTypes.string,
-    suffix: PropTypes.string,
-  }),
-};
+    <h2 className="vads-u-font-size--h3">What should I do while I wait?</h2>
+    <p>
+      You don’t need to do anything unless we send you a letter asking for more
+      information. If we schedule any exams for you, be sure not to miss them.
+    </p>
+    <p>
+      If you requested an appeal and haven’t heard back from us yet, please
+      don’t request another appeal. Call us at{' '}
+      <va-telephone contact={CONTACTS.VA_BENEFITS} /> (
+      <va-telephone contact={CONTACTS[711]} tty />
+      ).
+    </p>
+    <br role="presentation" />
+    <a
+      href="/claim-or-appeal-status/"
+      className="vads-c-action-link--green"
+      aria-describedby="delay-note"
+    >
+      Check the status of your appeal
+    </a>
+    <p id="delay-note">
+      <strong>Note</strong>: It may take 7 to 10 days for your Board Appeal
+      request to appear online.
+    </p>
+  </ConfirmationDecisionReviews>
+);
 
 export default ConfirmationPage;

--- a/src/applications/appeals/10182/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -105,7 +105,7 @@ describe('Confirmation page', () => {
         <ConfirmationPage />
       </Provider>,
     );
-    expect($('.inset', container).textContent).to.contain(date);
+    expect($('va-summary-box', container).textContent).to.contain(date);
   });
   it('should render the selected contested issue', () => {
     const { container } = render(

--- a/src/applications/appeals/995/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/995/containers/ConfirmationPage.jsx
@@ -1,69 +1,18 @@
-import React, { useEffect, useRef } from 'react';
-import moment from 'moment';
-import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
+import React from 'react';
 
-import { selectProfile } from 'platform/user/selectors';
-import scrollTo from 'platform/utilities/ui/scrollTo';
-import { waitForRenderThenFocus } from 'platform/utilities/ui';
 import { resetStoredSubTask } from 'platform/forms/sub-task';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
-import { DateSubmitted } from '../../shared/components/DateSubmitted';
-import { IssuesSubmitted } from '../../shared/components/IssuesSubmitted';
-import { getIssuesListItems } from '../../shared/utils/issues';
-import { renderFullName } from '../../shared/utils/data';
+import ConfirmationDecisionReviews from '../../shared/components/ConfirmationDecisionReviews';
 
 export const ConfirmationPage = () => {
-  const alertRef = useRef(null);
-
-  const form = useSelector(state => state.form || {});
-  const name = useSelector(state => selectProfile(state)?.userFullName || {});
-
-  useEffect(
-    () => {
-      if (alertRef?.current) {
-        scrollTo('topScrollElement');
-        // delay focus for Safari
-        waitForRenderThenFocus('h2', alertRef.current);
-      }
-    },
-    [alertRef],
-  );
-
-  const { submission, data } = form;
-  const issues = data ? getIssuesListItems(data) : [];
-  const submitDate = moment(submission?.timestamp);
   resetStoredSubTask();
 
   return (
-    <div>
-      <div className="print-only">
-        <img
-          src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
-          alt="VA logo"
-          width="300"
-        />
-        <h2>Application for Supplemental Claim</h2>
-      </div>
-      <va-alert status="success" ref={alertRef} uswds>
-        <h2 slot="headline">Thank you for filing a Supplemental Claim</h2>
-        <p>
-          After we’ve completed our review, we’ll mail you a decision packet
-          with the details of our decision.
-        </p>
-      </va-alert>
-      <div className="inset">
-        <h3 className="vads-u-margin-top--0">
-          Your information for this claim
-        </h3>
-        <h4>Your name</h4>
-        {renderFullName(name)}
-
-        {submitDate.isValid() && <DateSubmitted submitDate={submitDate} />}
-        <IssuesSubmitted issues={issues} />
-      </div>
-
+    <ConfirmationDecisionReviews
+      pageTitle="File a Supplemental Claim"
+      alertTitle="Thank you for filing a Supplemental Claim"
+    >
       <h3>What to expect next</h3>
       <p>
         If we need more information, we’ll contact you to tell you what other
@@ -104,24 +53,8 @@ export const ConfirmationPage = () => {
         <strong>Note</strong>: It may take 7 to 10 days for your Supplemental
         Claim request to appear online.
       </p>
-    </div>
+    </ConfirmationDecisionReviews>
   );
-};
-
-ConfirmationPage.propTypes = {
-  form: PropTypes.shape({
-    data: PropTypes.shape({}),
-    formId: PropTypes.string,
-    submission: PropTypes.shape({
-      timestamp: PropTypes.instanceOf(Date),
-    }),
-  }),
-  name: PropTypes.shape({
-    first: PropTypes.string,
-    middle: PropTypes.string,
-    last: PropTypes.string,
-    suffix: PropTypes.string,
-  }),
 };
 
 export default ConfirmationPage;

--- a/src/applications/appeals/995/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -106,7 +106,7 @@ describe('Confirmation page', () => {
         <ConfirmationPage />
       </Provider>,
     );
-    expect($('.inset', container).textContent).to.contain(date);
+    expect($('va-summary-box', container).textContent).to.contain(date);
   });
   it('should render the selected contested issue', () => {
     const { container } = render(

--- a/src/applications/appeals/996/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/996/containers/ConfirmationPage.jsx
@@ -1,72 +1,22 @@
-import React, { useEffect, useRef } from 'react';
-import moment from 'moment';
-import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
-
-import { selectProfile } from 'platform/user/selectors';
-import scrollTo from 'platform/utilities/ui/scrollTo';
-import { waitForRenderThenFocus } from 'platform/utilities/ui';
+import React, { useEffect } from 'react';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 import { SAVED_CLAIM_TYPE, WIZARD_STATUS } from '../constants';
 
-import { DateSubmitted } from '../../shared/components/DateSubmitted';
-import { IssuesSubmitted } from '../../shared/components/IssuesSubmitted';
-import { getIssuesListItems } from '../../shared/utils/issues';
-import { renderFullName } from '../../shared/utils/data';
+import ConfirmationDecisionReviews from '../../shared/components/ConfirmationDecisionReviews';
 
 export const ConfirmationPage = () => {
-  const alertRef = useRef(null);
-
-  const form = useSelector(state => state.form || {});
-  const name = useSelector(state => selectProfile(state)?.userFullName || {});
-
-  useEffect(
-    () => {
-      if (alertRef?.current) {
-        scrollTo('topScrollElement');
-        // delay focus for Safari
-        waitForRenderThenFocus('h2', alertRef.current);
-        // reset the wizard
-        window.sessionStorage.removeItem(WIZARD_STATUS);
-        window.sessionStorage.removeItem(SAVED_CLAIM_TYPE);
-      }
-    },
-    [alertRef],
-  );
-
-  const { submission, data } = form;
-  const issues = data ? getIssuesListItems(data) : [];
-  const submitDate = moment(submission?.timestamp);
+  useEffect(() => {
+    // reset the wizard
+    window.sessionStorage.removeItem(WIZARD_STATUS);
+    window.sessionStorage.removeItem(SAVED_CLAIM_TYPE);
+  });
 
   return (
-    <div>
-      <div className="print-only">
-        <img
-          src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
-          alt="VA logo"
-          width="300"
-        />
-        <h2>Request for Higher-Level Review</h2>
-      </div>
-      <va-alert status="success" ref={alertRef} uswds>
-        <h2 slot="headline">We’ve received your Higher-Level Review</h2>
-        <p>
-          After we’ve completed our review, we’ll mail you a decision packet
-          with the details of our decision.
-        </p>
-      </va-alert>
-      <div className="inset">
-        <h3 className="vads-u-margin-top--0">
-          Your information for this claim
-        </h3>
-        <h4>Your name</h4>
-        {renderFullName(name)}
-
-        {submitDate.isValid() && <DateSubmitted submitDate={submitDate} />}
-        <IssuesSubmitted issues={issues} />
-      </div>
-
+    <ConfirmationDecisionReviews
+      pageTitle="Request a Higher-Level Review"
+      alertTitle="We’ve received your Higher-Level Review"
+    >
       <h2 className="vads-u-font-size--h3">
         After you request a decision review
       </h2>
@@ -104,24 +54,8 @@ export const ConfirmationPage = () => {
         <strong>Note</strong>: It may take 7 to 10 days for your Higher-Level
         Review request to appear online.
       </p>
-    </div>
+    </ConfirmationDecisionReviews>
   );
-};
-
-ConfirmationPage.propTypes = {
-  form: PropTypes.shape({
-    data: PropTypes.shape({}),
-    formId: PropTypes.string,
-    submission: PropTypes.shape({
-      timestamp: PropTypes.instanceOf(Date),
-    }),
-  }),
-  name: PropTypes.shape({
-    first: PropTypes.string,
-    middle: PropTypes.string,
-    last: PropTypes.string,
-    suffix: PropTypes.string,
-  }),
 };
 
 export default ConfirmationPage;

--- a/src/applications/appeals/download/containers/Confirmation.jsx
+++ b/src/applications/appeals/download/containers/Confirmation.jsx
@@ -82,8 +82,7 @@ const Confirmation = () => {
           </p>
         </va-alert>
 
-        {/* <va-summary-box uswds class="vads-u-margin-y--2"> */}
-        <div className="inset">
+        <va-summary-box uswds class="vads-u-margin-y--2">
           <h3 slot="headline" className="vads-u-margin-top--0">
             Save a PDF copy of your Board Appeal
           </h3>
@@ -98,8 +97,7 @@ const Confirmation = () => {
             href="#"
             text="Download a copy of your Board Appeal (PDF)"
           />
-        </div>
-        {/* </va-summary-box> */}
+        </va-summary-box>
 
         <h3 className="vads-u-margin-top--0">
           {`You submitted the following information for Board Appeal on ${format(

--- a/src/applications/appeals/download/containers/ViewAppeal.jsx
+++ b/src/applications/appeals/download/containers/ViewAppeal.jsx
@@ -74,7 +74,7 @@ const ViewAppeal = () => {
           your records.
         </p>
 
-        <div className="inset">
+        <va-summary-box uswds class="vads-u-margin-y--2">
           <h3 className="vads-u-margin-top--0 vads-u-font-size--h4">
             Download a copy of your Board Appeal (PDF)
           </h3>
@@ -89,7 +89,7 @@ const ViewAppeal = () => {
             href="#"
             text="Download a copy of your Board Appeal (PDF)"
           />
-        </div>
+        </va-summary-box>
 
         <h3 className="vads-u-margin-top--0">
           You submitted the following information for Board Appeal

--- a/src/applications/appeals/download/sass/submitted-appeal.scss
+++ b/src/applications/appeals/download/sass/submitted-appeal.scss
@@ -14,12 +14,6 @@
   }
 }
 
-.inset {
-  font-size: 16px;
-  border-radius: 4px;
-  border: 1px solid rgb(153, 222, 234)
-}
-
 h5 {
   font-weight: normal;
   font-family: "Source Sans Pro", sans-serif;

--- a/src/applications/appeals/shared/components/ConfirmationDecisionReviews.jsx
+++ b/src/applications/appeals/shared/components/ConfirmationDecisionReviews.jsx
@@ -1,0 +1,95 @@
+import React, { useEffect, useRef } from 'react';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+
+import { selectProfile } from 'platform/user/selectors';
+import scrollTo from 'platform/utilities/ui/scrollTo';
+import { waitForRenderThenFocus } from 'platform/utilities/ui';
+
+import { DateSubmitted } from './DateSubmitted';
+import { IssuesSubmitted } from './IssuesSubmitted';
+import { getIssuesListItems } from '../utils/issues';
+import { renderFullName } from '../utils/data';
+
+export const ConfirmationDecisionReviews = ({
+  pageTitle,
+  alertTitle,
+  children,
+}) => {
+  const alertRef = useRef(null);
+
+  const form = useSelector(state => state.form || {});
+  const name = useSelector(state => selectProfile(state)?.userFullName || {});
+
+  useEffect(
+    () => {
+      if (alertRef?.current) {
+        scrollTo('topScrollElement');
+        // delay focus for Safari
+        waitForRenderThenFocus('h2', alertRef.current);
+      }
+    },
+    [alertRef],
+  );
+
+  const { submission, data } = form;
+  const issues = data ? getIssuesListItems(data) : [];
+  const submitDate = moment(submission?.timestamp);
+
+  return (
+    <div>
+      <div className="print-only">
+        <img
+          src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
+          alt="VA logo"
+          width="300"
+        />
+        <h2>{pageTitle}</h2>
+      </div>
+
+      <va-alert status="success" ref={alertRef} uswds>
+        <h2 slot="headline">{alertTitle}</h2>
+        <p>
+          When we’ve completed our review, we’ll mail you a decision packet with
+          the details of our decision.
+        </p>
+      </va-alert>
+
+      <va-summary-box uswds class="vads-u-margin-top--2">
+        <h3 className="vads-u-margin-top--0">
+          Your information for this claim
+        </h3>
+
+        <h4>Your name</h4>
+        {renderFullName(name)}
+        {submitDate.isValid() && <DateSubmitted submitDate={submitDate} />}
+        <IssuesSubmitted issues={issues} />
+      </va-summary-box>
+
+      {children}
+    </div>
+  );
+};
+
+ConfirmationDecisionReviews.propTypes = {
+  alertDescription: PropTypes.element,
+  alertTitle: PropTypes.string,
+  children: PropTypes.element,
+  form: PropTypes.shape({
+    data: PropTypes.shape({}),
+    formId: PropTypes.string,
+    submission: PropTypes.shape({
+      timestamp: PropTypes.instanceOf(Date),
+    }),
+  }),
+  name: PropTypes.shape({
+    first: PropTypes.string,
+    middle: PropTypes.string,
+    last: PropTypes.string,
+    suffix: PropTypes.string,
+  }),
+  pageTitle: PropTypes.string,
+};
+
+export default ConfirmationDecisionReviews;

--- a/src/applications/appeals/shared/tests/components/ConfirmationDecisionReivews.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/ConfirmationDecisionReivews.unit.spec.jsx
@@ -8,11 +8,8 @@ import moment from 'moment';
 
 import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
-import formConfig from '../../config/form';
-
-import ConfirmationPage from '../../containers/ConfirmationPage';
-import { WIZARD_STATUS, SAVED_CLAIM_TYPE } from '../../constants';
-import { SELECTED } from '../../../shared/constants';
+import ConfirmationDecisionReviews from '../../components/ConfirmationDecisionReviews';
+import { SELECTED } from '../../constants';
 
 const getData = ({ renderName = true, suffix = 'Esq.' } = {}) => ({
   user: {
@@ -23,7 +20,7 @@ const getData = ({ renderName = true, suffix = 'Esq.' } = {}) => ({
     },
   },
   form: {
-    formId: formConfig.formId,
+    formId: '12345',
     submission: {
       response: Date.now(),
     },
@@ -50,19 +47,34 @@ describe('Confirmation page', () => {
   const middleware = [thunk];
   const mockStore = configureStore(middleware);
 
-  it('should render the confirmation page', () => {
+  it('should render the confirmation page with children', () => {
     const { container } = render(
       <Provider store={mockStore(getData())}>
-        <ConfirmationPage />
+        <ConfirmationDecisionReviews
+          pageTitle="Request a snack"
+          alertTitle="You have successfully requested a snack"
+        >
+          <div id="content">
+            <h3>After your snack</h3>
+            <p>Take a nap</p>
+          </div>
+        </ConfirmationDecisionReviews>
       </Provider>,
     );
-    expect($('va-alert[status="success"]', container)).to.exist;
+    const alert = $('va-alert[status="success"]', container);
+    expect(alert).to.exist;
+    expect(alert.innerHTML).to.contain('successfully requested a snack');
+
     expect($$('.dd-privacy-hidden[data-dd-action-name]').length).to.eq(2);
+    expect($('h2', container).textContent).to.eq('Request a snack');
+    expect($('#content h3', container).textContent).to.eq('After your snack');
+    expect($('#content p', container).textContent).to.eq('Take a nap');
   });
+
   it('should render with no data', () => {
     const { container } = render(
       <Provider store={mockStore({})}>
-        <ConfirmationPage />
+        <ConfirmationDecisionReviews />
       </Provider>,
     );
     expect($('va-alert[status="success"]', container)).to.exist;
@@ -71,7 +83,7 @@ describe('Confirmation page', () => {
   it('should render the user name', () => {
     const { container } = render(
       <Provider store={mockStore(getData())}>
-        <ConfirmationPage />
+        <ConfirmationDecisionReviews alertTitle="test" />
       </Provider>,
     );
     expect($('.dd-privacy-hidden', container).textContent).to.contain(
@@ -81,7 +93,7 @@ describe('Confirmation page', () => {
   it('should render the user name without suffix', () => {
     const { container } = render(
       <Provider store={mockStore(getData({ suffix: '' }))}>
-        <ConfirmationPage />
+        <ConfirmationDecisionReviews alertTitle="test" />
       </Provider>,
     );
     expect($('.dd-privacy-hidden', container).textContent).to.contain(
@@ -91,7 +103,7 @@ describe('Confirmation page', () => {
   it('should not render the user name', () => {
     const { container } = render(
       <Provider store={mockStore(getData({ renderName: false }))}>
-        <ConfirmationPage />
+        <ConfirmationDecisionReviews />
       </Provider>,
     );
     expect($('[data-dd-action-name="Veteran full name"]', container)).to.not
@@ -103,15 +115,15 @@ describe('Confirmation page', () => {
     const date = moment(data.form.submission.response).format('MMMM D, YYYY');
     const { container } = render(
       <Provider store={mockStore(data)}>
-        <ConfirmationPage />
+        <ConfirmationDecisionReviews />
       </Provider>,
     );
-    expect($('va-summary-box', container).textContent).to.contain(date);
+    expect($('va-summary-box', container).innerHTML).to.contain(date);
   });
   it('should render the selected contested issue', () => {
     const { container } = render(
       <Provider store={mockStore(getData())}>
-        <ConfirmationPage />
+        <ConfirmationDecisionReviews alertTitle="test" />
       </Provider>,
     );
     const list = $('ul', container);
@@ -122,25 +134,12 @@ describe('Confirmation page', () => {
   it('should focus on H2 inside va-alert', async () => {
     const { container } = render(
       <Provider store={mockStore(getData())}>
-        <ConfirmationPage />
+        <ConfirmationDecisionReviews />
       </Provider>,
     );
     const h2 = $('va-alert h2', container);
     await waitFor(() => {
       expect(document.activeElement).to.eq(h2);
-    });
-  });
-  it('should reset the wizard sessionStorage', async () => {
-    sessionStorage.setItem(WIZARD_STATUS, 'foo');
-    sessionStorage.setItem(SAVED_CLAIM_TYPE, 'bar');
-    render(
-      <Provider store={mockStore(getData())}>
-        <ConfirmationPage />
-      </Provider>,
-    );
-    await waitFor(() => {
-      expect(sessionStorage.getItem(WIZARD_STATUS)).to.be.null;
-      expect(sessionStorage.getItem(SAVED_CLAIM_TYPE)).to.be.null;
     });
   });
 
@@ -150,7 +149,7 @@ describe('Confirmation page', () => {
         profile: {},
       },
       form: {
-        formId: formConfig.formId,
+        formId: '12345',
         submission: {
           response: Date.now(),
         },
@@ -159,9 +158,10 @@ describe('Confirmation page', () => {
     });
     const { container } = render(
       <Provider store={mockStore(getEmptyData())}>
-        <ConfirmationPage />
+        <ConfirmationDecisionReviews />
       </Provider>,
     );
-    expect(container.textContent).to.contain('We’ve received your');
+    expect($('va-alert', container)).to.exist;
+    expect($('va-summary-box', container)).to.exist;
   });
 });

--- a/src/applications/appeals/testing/containers/ConfirmationPage.jsx
+++ b/src/applications/appeals/testing/containers/ConfirmationPage.jsx
@@ -39,7 +39,8 @@ export const ConfirmationPage = ({ data }) => {
       <h1>Your request has been submitted</h1>
       <p>We may contact you for more information or documents.</p>
       <p className="screen-only">Print this page for your records.</p>
-      <div className="inset">
+
+      <va-summary-box uswds class="vads-u-margin-y--2">
         <h1 className="vads-u-margin-top--0">
           Request a Board Appeal{' '}
           <span className="additional">(Form 10182)</span>
@@ -66,7 +67,7 @@ export const ConfirmationPage = ({ data }) => {
           text="Print this for your records"
           uswds
         />
-      </div>
+      </va-summary-box>
 
       <h2>After you request a decision review</h2>
       <p>


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > To improve code climate scores, this work combines the common parts of our 3 Decision Review (DR) form confirmation pages. It also replaces the use of `inset` to use the USWDS v3 `va-summary-box`. 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Lots of duplicate code & content on the confirmation pages
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#74981](https://github.com/department-of-veterans-affairs/va.gov-team/issues/74981)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
  > Check CodeClimate after merging
  > - [NOD confirmation page](https://codeclimate.com/github/department-of-veterans-affairs/vets-website/src/applications/appeals/10182/containers/ConfirmationPage.jsx)
  > - [HLR confirmation page](https://codeclimate.com/github/department-of-veterans-affairs/vets-website/src/applications/appeals/996/containers/ConfirmationPage.jsx)
  > - [Supplemental Claim confirmation page](https://codeclimate.com/github/department-of-veterans-affairs/vets-website/src/applications/appeals/995/containers/ConfirmationPage.jsx)
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| NOD  | <img width="721" alt="NOD-confirmation" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/b86122ca-729a-4311-a482-219ba5650a6f"> | <img width="685" alt="NOD after" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/7b3287ae-31b2-4d11-abf7-4aadcceadc9b"> |
| HLR  | <img width="691" alt="HLR-confirmation" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/03bdf1cc-9fcb-4ad9-8b77-4168733197d4"> | <img width="684" alt="HLR after" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/3ac8f576-2576-490d-b433-5973d89908e5"> |
| SC | <img width="688" alt="Supplemental Claim-confirmation" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/6bd4e620-1fd8-4572-b335-abf8fabbcad7"> | <img width="691" alt="Supplemental Claims after" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/b045ee4c-6164-4186-877a-456941e712a0"> |

## What areas of the site does it impact?

All Decision Review forms, and prototypes (updated to use `va-summary-box`)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
