### PR TITLE
Removes vaOnlineSchedulingStatusImprovement feature flag from past ap…

### DIFF
--- a/src/applications/vaos/appointment-list/components/PastAppointmentsList/PastAppointmentsDateDropdown.jsx
+++ b/src/applications/vaos/appointment-list/components/PastAppointmentsList/PastAppointmentsDateDropdown.jsx
@@ -1,30 +1,14 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
 import classNames from 'classnames';
 import Select from '../../../components/Select';
-import { selectFeatureStatusImprovement } from '../../../redux/selectors';
 
-function handleClick(currentRange, dateRangeIndex, callback) {
-  return () => {
-    if (currentRange !== dateRangeIndex) {
-      callback(dateRangeIndex);
-    }
-  };
-}
-
-function handleChange({
-  updateDateRangeIndex,
-  callback,
-  featureStatusImprovement,
-}) {
+function handleChange({ updateDateRangeIndex, callback }) {
   return e => {
     const dateRange = Number(e.detail.value);
 
     updateDateRangeIndex(dateRange);
-    if (featureStatusImprovement) {
-      callback(dateRange);
-    }
+    callback(dateRange);
   };
 }
 
@@ -34,9 +18,6 @@ export default function PastAppointmentsDateDropdown({
   options,
 }) {
   const [dateRangeIndex, updateDateRangeIndex] = useState(currentRange);
-  const featureStatusImprovement = useSelector(state =>
-    selectFeatureStatusImprovement(state),
-  );
 
   return (
     <>
@@ -47,7 +28,6 @@ export default function PastAppointmentsDateDropdown({
           dateRangeIndex,
           updateDateRangeIndex,
           callback: onChange,
-          featureStatusImprovement,
         })}
         id="date-dropdown"
         value={dateRangeIndex.toString()}
@@ -56,16 +36,6 @@ export default function PastAppointmentsDateDropdown({
           'xsmall-screen:vads-u-margin-bottom--3 small-screen:vads-u-margin-bottom--4 vaos-hide-for-print',
         )}
       />
-      {!featureStatusImprovement && (
-        <button
-          type="button"
-          aria-label="Update my appointments list"
-          className="usa-button vaos-hide-for-print"
-          onClick={handleClick(currentRange, dateRangeIndex, onChange)}
-        >
-          Update
-        </button>
-      )}
     </>
   );
 }

--- a/src/applications/vaos/appointment-list/components/PastAppointmentsList/tests/PastAppointmentsDateDropdown.unit.spec.js
+++ b/src/applications/vaos/appointment-list/components/PastAppointmentsList/tests/PastAppointmentsDateDropdown.unit.spec.js
@@ -2,19 +2,16 @@ import React from 'react';
 import { expect } from 'chai';
 import moment from 'moment';
 import sinon from 'sinon';
-import userEvent from '@testing-library/user-event';
 import PastAppointmentsDateDropdown from '../PastAppointmentsDateDropdown';
 import { getPastAppointmentDateRangeOptions } from '..';
 import { renderWithStoreAndRouter } from '../../../../tests/mocks/setup';
 
 const ranges = getPastAppointmentDateRangeOptions(moment('2020-02-02'));
 
-describe('VAOS Component: PastAppointmentsDateDropDown with Status Improvement flag on', () => {
+describe('VAOS Component: PastAppointmentsDateDropDown', () => {
   it('should trigger spy when a new date range is selected', async () => {
     const initialState = {
-      featureToggles: {
-        vaOnlineSchedulingStatusImprovement: true,
-      },
+      featureToggles: {},
     };
 
     const callback = sinon.spy();
@@ -38,38 +35,6 @@ describe('VAOS Component: PastAppointmentsDateDropDown with Status Improvement f
         detail: { value: '4' },
       });
     await selectDate;
-    expect(callback.calledOnce).to.be.true;
-  });
-});
-
-describe('VAOS Component: PastAppointmentsDateDropDown with Status Improvement flag off', () => {
-  it('should trigger spy when the update button is clicked', async () => {
-    const initialState = {
-      featureToggles: { vaOnlineSchedulingStatusImprovement: false },
-    };
-
-    const callback = sinon.spy();
-
-    const screen = renderWithStoreAndRouter(
-      <PastAppointmentsDateDropdown
-        currentRange={0}
-        onChange={callback}
-        options={ranges}
-      />,
-      {
-        initialState,
-      },
-    );
-    expect(screen.getAllByRole('option')).to.have.length(6);
-    expect(screen.getByRole('button', { name: /Update/ })).to.exist;
-    // select a different date range
-    const selectDate = screen.container
-      .querySelector('#date-dropdown')
-      .__events.vaSelect({
-        detail: { value: '4' },
-      });
-    await selectDate;
-    userEvent.click(screen.getByRole('button'), { name: /Update/ });
     expect(callback.calledOnce).to.be.true;
   });
 });


### PR DESCRIPTION

**Note**: This is part of a series of smaller PRs that breaks up the [original large PR](https://github.com/department-of-veterans-affairs/vets-website/pull/27685) into more logical and reviewable chunks.

## Summary
This removes the use of the `va_online_scheduling_status_improvement` feature flag from the `src/applications/vaos/appointment-list/components/PastAppointmentsList/PastAppointmentsDateDropdown.jsx` component within VA online scheduling. It is part of a set of PR's to address https://github.com/department-of-veterans-affairs/va.gov-team/issues/55085. We no longer use this feature flag, so code behind this flag can be removed.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/55085

## Testing done
- Unit testing
- e2e testing
- Manual local testing 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I updated unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
