### PR TITLE
Removes vaOnlineSchedulingStatusImprovement feature flag from requested appointments list

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/RequestListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/RequestListItem.jsx
@@ -7,10 +7,7 @@ import PropTypes from 'prop-types';
 import { sentenceCase } from '../../../utils/formatters';
 import { getPreferredCommunityCareProviderName } from '../../../services/appointment';
 import { APPOINTMENT_STATUS, SPACE_BAR } from '../../../utils/constants';
-import {
-  selectFeatureStatusImprovement,
-  selectFeatureBreadcrumbUrlUpdate,
-} from '../../../redux/selectors';
+import { selectFeatureBreadcrumbUrlUpdate } from '../../../redux/selectors';
 
 function handleClick({ history, link, idClickable }) {
   return () => {
@@ -40,9 +37,6 @@ export default function RequestListItem({ appointment, facility }) {
     'MMMM D, YYYY',
   );
   const idClickable = `id-${appointment.id?.replace('.', '\\.')}`;
-  const featureStatusImprovement = useSelector(state =>
-    selectFeatureStatusImprovement(state),
-  );
 
   const featureBreadcrumbUrlUpdate = useSelector(state =>
     selectFeatureBreadcrumbUrlUpdate(state),
@@ -67,13 +61,11 @@ export default function RequestListItem({ appointment, facility }) {
           history,
           link,
           idClickable,
-          featureStatusImprovement,
         })}
         onKeyDown={handleKeyDown({
           history,
           link,
           idClickable,
-          featureStatusImprovement,
         })}
       >
         <div className="vads-u-flex--1 vads-u-margin-y--neg0p5">

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentsList.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentsList.jsx
@@ -11,7 +11,6 @@ import { FETCH_STATUS, GA_PREFIX } from '../../utils/constants';
 import NoAppointments from './NoAppointments';
 import InfoAlert from '../../components/InfoAlert';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
-import { selectFeatureStatusImprovement } from '../../redux/selectors';
 import RequestAppointmentLayout from './AppointmentsPage/RequestAppointmentLayout';
 
 export default function RequestedAppointmentsList({ hasTypeChanged }) {
@@ -22,9 +21,6 @@ export default function RequestedAppointmentsList({ hasTypeChanged }) {
   } = useSelector(
     state => getRequestedAppointmentListInfo(state),
     shallowEqual,
-  );
-  const featureStatusImprovement = useSelector(state =>
-    selectFeatureStatusImprovement(state),
   );
 
   const dispatch = useDispatch();
@@ -67,12 +63,8 @@ export default function RequestedAppointmentsList({ hasTypeChanged }) {
       </InfoAlert>
     );
   }
-  let paragraphText =
-    'Appointments that you request will show here until staff review and schedule them.';
-  if (featureStatusImprovement) {
-    paragraphText =
-      'Your appointment requests that haven’t been scheduled yet.';
-  }
+  const paragraphText =
+    'Your appointment requests that haven’t been scheduled yet.';
 
   return (
     <>

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentsListGroup.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentsListGroup.jsx
@@ -17,7 +17,6 @@ import {
 import NoAppointments from './NoAppointments';
 import InfoAlert from '../../components/InfoAlert';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
-import { selectFeatureStatusImprovement } from '../../redux/selectors';
 import RequestAppointmentLayout from './AppointmentsPage/RequestAppointmentLayout';
 import BackendAppointmentServiceAlert from './BackendAppointmentServiceAlert';
 
@@ -29,10 +28,6 @@ export default function RequestedAppointmentsListGroup({ hasTypeChanged }) {
   } = useSelector(
     state => getRequestedAppointmentListInfo(state),
     shallowEqual,
-  );
-
-  const featureStatusImprovement = useSelector(state =>
-    selectFeatureStatusImprovement(state),
   );
 
   const dispatch = useDispatch();
@@ -99,12 +94,9 @@ export default function RequestedAppointmentsListGroup({ hasTypeChanged }) {
     if (a[0].toLowerCase() > b[0].toLowerCase()) return -1;
     return 0;
   });
-  let paragraphText =
-    'Appointments that you request will show here until staff review and schedule them.';
-  if (featureStatusImprovement) {
-    paragraphText =
-      'Your appointment requests that haven’t been scheduled yet.';
-  }
+
+  const paragraphText =
+    'Your appointment requests that haven’t been scheduled yet.';
 
   return (
     <>

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPageV2/index.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPageV2/index.unit.spec.js
@@ -28,9 +28,10 @@ const initialState = {
     vaOnlineSchedulingCancel: true,
     vaOnlineSchedulingRequests: true,
     vaOnlineSchedulingPast: true,
-    vaOnlineSchedulingStatusImprovement: false,
     // eslint-disable-next-line camelcase
     show_new_schedule_view_appointments_page: true,
+    vaOnlineSchedulingDirect: true,
+    vaOnlineSchedulingCommunityCare: false,
   },
 };
 
@@ -99,239 +100,225 @@ describe('VAOS Page: AppointmentsPage', () => {
     );
   });
 
-  describe('when appointment status improvement flag is on', () => {
-    const defaultState = {
-      featureToggles: {
-        ...initialState.featureToggles,
-        vaOnlineSchedulingDirect: true,
-        vaOnlineSchedulingCommunityCare: false,
-        vaOnlineSchedulingStatusImprovement: true,
-      },
-      user: userState,
+  it('should display updated upcoming appointments page', async () => {
+    // Given the veteran lands on the VAOS homepage
+    mockPastAppointmentInfo({});
+
+    // When the page displays
+    const screen = renderWithStoreAndRouter(<AppointmentsPage />, {
+      initialState,
+    });
+
+    // Then it should display the upcoming appointments
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: 'Appointments',
+      }),
+    );
+    await waitFor(() => {
+      expect(global.document.title).to.equal(
+        `Appointments | VA online scheduling | Veterans Affairs`,
+      );
+    });
+
+    // and breadcrumbs should be updated
+    const navigation = screen.getByRole('navigation', {
+      name: 'Breadcrumbs',
+    });
+    expect(navigation).to.be.ok;
+    expect(
+      within(navigation).queryByRole('link', {
+        name: 'Pending appointments',
+      }),
+    ).not.to.exist;
+    expect(
+      within(navigation).queryByRole('link', { name: 'Past appointments' }),
+    ).not.to.exist;
+
+    // and scheduling button should be displayed
+    expect(
+      screen.getByRole('button', { name: 'Start scheduling an appointment' }),
+    ).to.be.ok;
+
+    // and appointment list navigation should be displayed
+    expect(
+      screen.getByRole('navigation', { name: 'Appointment list navigation' }),
+    ).to.be.ok;
+    expect(screen.getByRole('link', { name: 'Upcoming' })).to.be.ok;
+    expect(screen.getByRole('link', { name: /Pending \(\d\)/ })).to.be.ok;
+    expect(screen.getByRole('link', { name: 'Past' })).to.be.ok;
+
+    // and status dropdown should not be displayed
+    expect(screen.queryByLabelText('Show by status')).not.to.exists;
+  });
+
+  it('should display updated appointment request page', async () => {
+    // Given the veteran lands on the VAOS homepage
+    const appointment = getVAOSRequestMock();
+    appointment.id = '1';
+    appointment.attributes = {
+      id: '1',
+      kind: 'clinic',
+      locationId: '983',
+      requestedPeriods: [{}],
+      serviceType: 'primaryCare',
+      status: 'proposed',
     };
 
-    it('should display updated upcoming appointments page', async () => {
-      // Given the veteran lands on the VAOS homepage
-      mockPastAppointmentInfo({});
+    mockVAOSAppointmentsFetch({
+      start: moment()
+        .subtract(1, 'month')
+        .format('YYYY-MM-DD'),
+      end: moment()
+        .add(395, 'days')
+        .format('YYYY-MM-DD'),
+      statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      requests: [appointment],
+    });
+    mockVAOSAppointmentsFetch({
+      start: moment()
+        .subtract(120, 'days')
+        .format('YYYY-MM-DD'),
+      end: moment().format('YYYY-MM-DD'),
+      statuses: ['proposed', 'cancelled'],
+      requests: [appointment],
+    });
 
-      // When the page displays
-      const screen = renderWithStoreAndRouter(<AppointmentsPage />, {
-        initialState: defaultState,
-      });
+    // When the page displays
+    const screen = renderWithStoreAndRouter(<AppointmentsPage />, {
+      initialState,
+    });
 
-      // Then it should display the upcoming appointments
-      expect(
-        await screen.findByRole('heading', {
-          level: 1,
-          name: 'Appointments',
-        }),
+    // Then it should display upcoming appointments
+    await screen.findByRole('heading', { name: 'Appointments' });
+
+    // When the veteran clicks the Pending button
+    let navigation = await screen.findByRole('link', {
+      name: /^Pending \(1\)/,
+    });
+    userEvent.click(navigation);
+    await waitFor(() => {
+      expect(screen.history.push.lastCall.args[0].pathname).to.equal(
+        '/pending',
       );
-      await waitFor(() => {
-        expect(global.document.title).to.equal(
-          `Appointments | VA online scheduling | Veterans Affairs`,
-        );
-      });
+    });
 
-      // and breadcrumbs should be updated
-      const navigation = screen.getByRole('navigation', {
-        name: 'Breadcrumbs',
-      });
-      expect(navigation).to.be.ok;
+    // Then it should display the requested appointments
+    await waitFor(() => {
       expect(
-        within(navigation).queryByRole('link', {
+        screen.findByRole('heading', {
+          level: 1,
           name: 'Pending appointments',
         }),
-      ).not.to.exist;
-      expect(
-        within(navigation).queryByRole('link', { name: 'Past appointments' }),
-      ).not.to.exist;
-
-      // and scheduling button should be displayed
-      expect(
-        screen.getByRole('button', { name: 'Start scheduling an appointment' }),
-      ).to.be.ok;
-
-      // and appointment list navigation should be displayed
-      expect(
-        screen.getByRole('navigation', { name: 'Appointment list navigation' }),
-      ).to.be.ok;
-      expect(screen.getByRole('link', { name: 'Upcoming' })).to.be.ok;
-      expect(screen.getByRole('link', { name: /Pending \(\d\)/ })).to.be.ok;
-      expect(screen.getByRole('link', { name: 'Past' })).to.be.ok;
-
-      // and status dropdown should not be displayed
-      expect(screen.queryByLabelText('Show by status')).not.to.exists;
+      );
     });
-
-    it('should display updated appointment request page', async () => {
-      // Given the veteran lands on the VAOS homepage
-      const appointment = getVAOSRequestMock();
-      appointment.id = '1';
-      appointment.attributes = {
-        id: '1',
-        kind: 'clinic',
-        locationId: '983',
-        requestedPeriods: [{}],
-        serviceType: 'primaryCare',
-        status: 'proposed',
-      };
-
-      mockVAOSAppointmentsFetch({
-        start: moment()
-          .subtract(1, 'month')
-          .format('YYYY-MM-DD'),
-        end: moment()
-          .add(395, 'days')
-          .format('YYYY-MM-DD'),
-        statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
-        requests: [appointment],
-      });
-      mockVAOSAppointmentsFetch({
-        start: moment()
-          .subtract(120, 'days')
-          .format('YYYY-MM-DD'),
-        end: moment().format('YYYY-MM-DD'),
-        statuses: ['proposed', 'cancelled'],
-        requests: [appointment],
-      });
-
-      // When the page displays
-      const screen = renderWithStoreAndRouter(<AppointmentsPage />, {
-        initialState: defaultState,
-      });
-
-      // Then it should display upcoming appointments
-      await screen.findByRole('heading', { name: 'Appointments' });
-
-      // When the veteran clicks the Pending button
-      let navigation = await screen.findByRole('link', {
-        name: /^Pending \(1\)/,
-      });
-      userEvent.click(navigation);
-      await waitFor(() => {
-        expect(screen.history.push.lastCall.args[0].pathname).to.equal(
-          '/pending',
-        );
-      });
-
-      // Then it should display the requested appointments
-      await waitFor(() => {
-        expect(
-          screen.findByRole('heading', {
-            level: 1,
-            name: 'Pending appointments',
-          }),
-        );
-      });
-      await waitFor(() => {
-        expect(global.document.title).to.equal(
-          `Pending appointments | VA online scheduling | Veterans Affairs`,
-        );
-      });
-
-      // and breadcrumbs should be updated
-      navigation = screen.getByRole('navigation', { name: 'Breadcrumbs' });
-      expect(navigation).to.exist;
-      const crumb =
-        navigation.breadcrumbList[navigation.breadcrumbList.length - 1].label;
-      expect(crumb).to.equal('Pending appointments');
-
-      expect(
-        screen.getByText(
-          'Your appointment requests that haven’t been scheduled yet.',
-        ),
-      ).to.be.ok;
-
-      // and scheduling button should not be displayed
-      expect(
-        screen.queryByRole('button', {
-          name: 'Start scheduling an appointment',
-        }),
-      ).not.to.exist;
-
-      // and status dropdown should not be displayed
-      expect(screen.queryByLabelText('Show by status')).not.to.exists;
-
-      expect(
-        global.window.dataLayer.some(
-          e => e === `vaos-status-pending-link-clicked`,
-        ),
+    await waitFor(() => {
+      expect(global.document.title).to.equal(
+        `Pending appointments | VA online scheduling | Veterans Affairs`,
       );
     });
 
-    it('should display updated past appointment page', async () => {
-      // Given the veteran lands on the VAOS homepage
-      const pastDate = moment().subtract(3, 'months');
-      const data = {
-        id: '1234',
-        kind: 'clinic',
-        clinic: 'fake',
-        start: pastDate.format(),
-        locationId: '983GC',
-        status: 'booked',
-      };
-      const appointment = createMockAppointmentByVersion({
-        version: 0,
-        ...data,
-      });
-      mockPastAppointmentInfo({ va: [appointment] });
+    // and breadcrumbs should be updated
+    navigation = screen.getByRole('navigation', { name: 'Breadcrumbs' });
+    expect(navigation).to.exist;
+    const crumb =
+      navigation.breadcrumbList[navigation.breadcrumbList.length - 1].label;
+    expect(crumb).to.equal('Pending appointments');
 
-      // When the page displays
-      const screen = renderWithStoreAndRouter(<AppointmentsPage />, {
-        initialState: defaultState,
-      });
+    expect(
+      screen.getByText(
+        'Your appointment requests that haven’t been scheduled yet.',
+      ),
+    ).to.be.ok;
 
-      // Then it should display the upcoming appointments
-      await screen.findByRole('heading', { name: 'Appointments' });
+    // and scheduling button should not be displayed
+    expect(
+      screen.queryByRole('button', {
+        name: 'Start scheduling an appointment',
+      }),
+    ).not.to.exist;
 
-      // When the veteran clicks the Past button
-      let navigation = screen.getByRole('link', { name: 'Past' });
-      userEvent.click(navigation);
-      await waitFor(() =>
-        expect(screen.history.push.lastCall.args[0].pathname).to.equal('/past'),
-      );
+    // and status dropdown should not be displayed
+    expect(screen.queryByLabelText('Show by status')).not.to.exists;
 
-      // Then it should display the past appointments
-      expect(
-        await screen.findByRole('heading', {
-          level: 1,
-          name: 'Past appointments',
-        }),
-      ).to.be.ok;
-      await waitFor(() => {
-        expect(global.document.title).to.equal(
-          `Past appointments | VA online scheduling | Veterans Affairs`,
-        );
-      });
+    expect(
+      global.window.dataLayer.some(
+        e => e === `vaos-status-pending-link-clicked`,
+      ),
+    );
+  });
 
-      // and breadcrumbs should be updated
-      navigation = screen.getByRole('navigation', { name: 'Breadcrumbs' });
-      expect(navigation).to.exist;
-      const crumb =
-        navigation.breadcrumbList[navigation.breadcrumbList.length - 1].label;
-      expect(crumb).to.equal('Past appointments');
+  it('should display updated past appointment page', async () => {
+    // Given the veteran lands on the VAOS homepage
+    const pastDate = moment().subtract(3, 'months');
+    const data = {
+      id: '1234',
+      kind: 'clinic',
+      clinic: 'fake',
+      start: pastDate.format(),
+      locationId: '983GC',
+      status: 'booked',
+    };
+    const appointment = createMockAppointmentByVersion({
+      version: 0,
+      ...data,
+    });
+    mockPastAppointmentInfo({ va: [appointment] });
 
-      const dropdown = await screen.findByTestId('vaosSelect');
+    // When the page displays
+    const screen = renderWithStoreAndRouter(<AppointmentsPage />, {
+      initialState,
+    });
 
-      // and date range dropdown should be displayed
-      expect(dropdown).to.have.attribute('label', 'Select a date range');
+    // Then it should display the upcoming appointments
+    await screen.findByRole('heading', { name: 'Appointments' });
 
-      // and scheduling button should not be displayed
-      expect(
-        screen.queryByRole('button', {
-          name: 'Start scheduling an appointment',
-        }),
-      ).not.to.exist;
+    // When the veteran clicks the Past button
+    let navigation = screen.getByRole('link', { name: 'Past' });
+    userEvent.click(navigation);
+    await waitFor(() =>
+      expect(screen.history.push.lastCall.args[0].pathname).to.equal('/past'),
+    );
 
-      // and status dropdown should not be displayed
-      expect(screen.queryByLabelText('Show by status')).not.to.exists;
-
-      expect(
-        global.window.dataLayer.some(
-          e => e === `vaos-status-past-link-clicked`,
-        ),
+    // Then it should display the past appointments
+    expect(
+      await screen.findByRole('heading', {
+        level: 1,
+        name: 'Past appointments',
+      }),
+    ).to.be.ok;
+    await waitFor(() => {
+      expect(global.document.title).to.equal(
+        `Past appointments | VA online scheduling | Veterans Affairs`,
       );
     });
+
+    // and breadcrumbs should be updated
+    navigation = screen.getByRole('navigation', { name: 'Breadcrumbs' });
+    expect(navigation).to.exist;
+    const crumb =
+      navigation.breadcrumbList[navigation.breadcrumbList.length - 1].label;
+    expect(crumb).to.equal('Past appointments');
+
+    const dropdown = await screen.findByTestId('vaosSelect');
+
+    // and date range dropdown should be displayed
+    expect(dropdown).to.have.attribute('label', 'Select a date range');
+
+    // and scheduling button should not be displayed
+    expect(
+      screen.queryByRole('button', {
+        name: 'Start scheduling an appointment',
+      }),
+    ).not.to.exist;
+
+    // and status dropdown should not be displayed
+    expect(screen.queryByLabelText('Show by status')).not.to.exists;
+
+    expect(
+      global.window.dataLayer.some(e => e === `vaos-status-past-link-clicked`),
+    );
   });
 
   it('should show tertiary print button', async () => {

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPageV2/index.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPageV2/index.unit.spec.js
@@ -4,7 +4,10 @@ import { expect } from 'chai';
 import moment from 'moment';
 import { waitFor, within } from '@testing-library/dom';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
-import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
+import {
+  mockFetch,
+  setFetchJSONResponse,
+} from '@department-of-veterans-affairs/platform-testing/helpers';
 import userEvent from '@testing-library/user-event';
 import {
   createTestStore,


### PR DESCRIPTION

**Note**: This is part of a series of smaller PRs that breaks up the [original large PR](https://github.com/department-of-veterans-affairs/vets-website/pull/27685) into more logical and reviewable chunks.

## Summary
This removes the use of the `va_online_scheduling_status_improvement` feature flag from the requested appointment list components within VA online scheduling. It is part of a set of PR's to address https://github.com/department-of-veterans-affairs/va.gov-team/issues/55085. We no longer use this feature flag, so code behind this flag can be removed.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/55085

## Testing done
- Unit testing
- e2e testing
- Manual local testing 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I updated unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
