### PR TITLE
Fix: Update artifact upload/download. Rework Mochawesome reports across CI to be compatible

### DIFF
--- a/.github/workflows/checks-action/action.yml
+++ b/.github/workflows/checks-action/action.yml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Unit test results
       if: ${{ always() }}
-      uses: LouisBrunner/checks-action@v1.1.1
+      uses: LouisBrunner/checks-action@v2.0.0
       with:
         token: ${{ inputs.token }}
         name: ${{ inputs.name }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1046,7 +1046,7 @@ jobs:
         uses: ./.github/workflows/upload-artifact
         with:
           name: unit-test-coverage-merged
-          path: coverage
+          path: qa-standards-dashboard-data/coverage
 
       - name: Create Unit Test report
         run: yarn unit-mochawesome-to-bigquery

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -931,16 +931,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install dependencies
-        uses: ./.github/workflows/install
-        timeout-minutes: 30
-        with:
-          key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-
       # ----------------
       # | Notify Slack |
       # ----------------
@@ -1163,6 +1153,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        timeout-minutes: 30
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
       # ------------------------
       # | Upload BigQuery Data |
       # ------------------------

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1035,12 +1035,12 @@ jobs:
       - name: Generate coverage report by app
         run: node script/app-coverage-report.js > qa-standards-dashboard-data/coverage/coverage_report.txt
 
-      - name: Archive unit test results
+      - name: Archive coverage txt
         if: ${{ always() }}
         uses: ./.github/workflows/upload-artifact
         with:
-          name: unit-test-report-merged
-          path: qa-standards-dashboard-data/src/testing-reports/data/
+          name: unit-test-coverage-txt
+          path: qa-standards-dashboard-data/coverage/coverage_report.txt
       
       - name: Archive unit test coverage
         if: ${{ always() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -684,21 +684,21 @@ jobs:
         if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && failure() }}
         uses: ./.github/workflows/upload-artifact
         with:
-          name: cypress-video-artifacts
+          name: cypress-video-artifacts-${{ matrix.ci_node_index }}
           path: cypress/videos
 
       - name: Archive test screenshots
         if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && failure() }}
         uses: ./.github/workflows/upload-artifact
         with:
-          name: cypress-screenshot-artifacts
+          name: cypress-screenshot-artifacts-${{ matrix.ci_node_index }}
           path: cypress/screenshots
 
       - name: Archive Mochawesome test results
         if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && always() }}
         uses: ./.github/workflows/upload-artifact
         with:
-          name: cypress-mochawesome-test-results
+          name: cypress-mochawesome-test-results-${{ matrix.ci_node_index }}
           path: cypress/results
           retention-days: 1
 
@@ -1337,15 +1337,17 @@ jobs:
       - name: Download Cypress E2E Mochawesome test results
         uses: ./.github/workflows/download-artifact
         with:
-          name: cypress-mochawesome-test-results
+          pattern: cypress-mochawesome-test-results-*
           path: qa-standards-dashboard-data/src/testing-reports/data
+          merge-multiple: true
 
       - name: Download Cypress E2E video artifacts
         if: ${{ needs.cypress-tests.result == 'failure' }}
         uses: ./.github/workflows/download-artifact
         with:
-          name: cypress-video-artifacts
+          pattern: cypress-mochawesome-test-results-*
           path: qa-standards-dashboard-data/videos/${{ env.UUID }}
+          merge-multiple: true
 
       - name: Create Cypress E2E Mochawesome report
         run: yarn cypress-mochawesome-to-bigquery

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -256,7 +256,10 @@ jobs:
 
       - name: List and merge test results
         run: |
-          cd mocha/results
+          ls -a
+          cd mocha
+          ls -a
+          cd results
           ls -a
           jq -s 'reduce .[] as $item ({}; . * $item)' > test-results-${{ matrix.ci_node_index }}.json
           ls -a

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -326,7 +326,7 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/workflows/upload-artifact
         with:
-          name: unit-test-stress-test-results
+          name: unit-test-stress-test-results-${{ matrix.ci_node_index }}
           path: mocha/results
 
   update-unit-test-allow-list:
@@ -784,14 +784,14 @@ jobs:
         if: ${{ needs.cypress-tests-prep.outputs.tests != '[]' && failure() }}
         uses: ./.github/workflows/upload-artifact
         with:
-          name: cypress-stress-test-videos
+          name: cypress-stress-test-videos-${{ matrix.ci_node_index }}
           path: cypress/videos
 
       - name: Archive Mochawesome test results
         if: ${{ needs.cypress-tests-prep.outputs.tests-to-stress-test != '[]' && always() }}
         uses: ./.github/workflows/upload-artifact
         with:
-          name: cypress-stress-test-results
+          name: cypress-stress-test-results-${{ matrix.ci_node_index }}
           path: cypress/results
           retention-days: 1
 
@@ -1113,8 +1113,9 @@ jobs:
       - name: Download Unit Test Mochawesome test results
         uses: ./.github/workflows/download-artifact
         with:
-          name: unit-test-stress-test-results
+          pattern: unit-test-stress-test-results-*
           path: qa-standards-dashboard-data/src/testing-reports/data
+          merge-multiple: true
 
       - name: Create Unit Test report
         run: yarn unit-mochawesome-to-bigquery
@@ -1141,128 +1142,128 @@ jobs:
           output: |
             {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
 
-  testing-reports-unit-tests-coverage:
-    name: Testing Reports - Unit Tests Coverage
-    runs-on: ubuntu-latest
-    needs: [testing-reports-prep, unit-tests]
-    if: ${{ always() && (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'failure') }}
-    continue-on-error: true
-    env:
-      APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+  # testing-reports-unit-tests-coverage:
+  #   name: Testing Reports - Unit Tests Coverage
+  #   runs-on: ubuntu-latest
+  #   needs: [testing-reports-prep, unit-tests]
+  #   if: ${{ always() && (needs.unit-tests.result == 'success' || needs.unit-tests.result == 'failure') }}
+  #   continue-on-error: true
+  #   env:
+  #     APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
 
-      - name: Install dependencies
-        uses: ./.github/workflows/install
-        timeout-minutes: 30
-        with:
-          key: ${{ hashFiles('yarn.lock') }}
-          yarn_cache_folder: .cache/yarn
-          path: |
-            .cache/yarn
-            node_modules
-      # ------------------------
-      # | Upload BigQuery Data |
-      # ------------------------
+  #     - name: Install dependencies
+  #       uses: ./.github/workflows/install
+  #       timeout-minutes: 30
+  #       with:
+  #         key: ${{ hashFiles('yarn.lock') }}
+  #         yarn_cache_folder: .cache/yarn
+  #         path: |
+  #           .cache/yarn
+  #           node_modules
+  #     # ------------------------
+  #     # | Upload BigQuery Data |
+  #     # ------------------------
 
-      - name: Configure AWS credentials
-        uses: ./.github/workflows/configure-aws-credentials
-        with:
-          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: us-gov-west-1
+  #     - name: Configure AWS credentials
+  #       uses: ./.github/workflows/configure-aws-credentials
+  #       with:
+  #         aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws_region: us-gov-west-1
           
 
-      - name: Get va-vsp-bot token
-        uses: ./.github/workflows/inject-secrets
-        with:
-          ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
-          env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
+  #     - name: Get va-vsp-bot token
+  #       uses: ./.github/workflows/inject-secrets
+  #       with:
+  #         ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
+  #         env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
-      - name: Init Dashboard Data Repo
-        uses: ./.github/workflows/init-data-repo
+  #     - name: Init Dashboard Data Repo
+  #       uses: ./.github/workflows/init-data-repo
 
-      - name: Set Up BigQuery Creds
-        uses: ./.github/workflows/configure-bigquery
+  #     - name: Set Up BigQuery Creds
+  #       uses: ./.github/workflows/configure-bigquery
 
-      - name: Get AWS IAM role
-        uses: ./.github/workflows/inject-secrets
-        with:
-          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
+  #     - name: Get AWS IAM role
+  #       uses: ./.github/workflows/inject-secrets
+  #       with:
+  #         ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
+  #         env_variable_name: AWS_FRONTEND_NONPROD_ROLE
 
-      - name: Set UUID for Mochawesome reports
-        run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
+  #     - name: Set UUID for Mochawesome reports
+  #       run: echo "UUID=$(uuidgen)" >> $GITHUB_ENV
 
-      - name: Configure AWS Credentials (2)
-        uses: ./.github/workflows/configure-aws-credentials
-        with:
-          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: us-gov-west-1
-          role: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-          role_duration: 900
-          session_name: vsp-frontendteam-githubaction
+  #     - name: Configure AWS Credentials (2)
+  #       uses: ./.github/workflows/configure-aws-credentials
+  #       with:
+  #         aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  #         aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  #         aws_region: us-gov-west-1
+  #         role: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
+  #         role_duration: 900
+  #         session_name: vsp-frontendteam-githubaction
           
 
-      # --------------------------------------
-      # | Publish Unit Test Coverage Report       |
-      # -------------------------------------
-      - name: Download Unit Test coverage results
-        uses: ./.github/workflows/download-artifact
-        with:
-          pattern: unit-test-coverage-*
-          path: qa-standards-dashboard-data/coverage
-          merge-multiple: true
+  #     # --------------------------------------
+  #     # | Publish Unit Test Coverage Report       |
+  #     # -------------------------------------
+  #     - name: Download Unit Test coverage results
+  #       uses: ./.github/workflows/download-artifact
+  #       with:
+  #         pattern: unit-test-coverage-*
+  #         path: qa-standards-dashboard-data/coverage
+  #         merge-multiple: true
 
-      # - name: Download Unit Test Coverage Report
-      #   uses: ./.github/workflows/download-artifact
-      #   with:
-      #     name: unit-test-coverage-report
-      #     path: qa-standards-dashboard-data/src/testing-reports/data
+  #     # - name: Download Unit Test Coverage Report
+  #     #   uses: ./.github/workflows/download-artifact
+  #     #   with:
+  #     #     name: unit-test-coverage-report
+  #     #     path: qa-standards-dashboard-data/src/testing-reports/data
 
-      - name: Generate coverage report by app
-        run: node script/app-coverage-report.js > qa-standards-dashboard-data/coverage/coverage_report.txt
+  #     - name: Generate coverage report by app
+  #       run: node script/app-coverage-report.js > qa-standards-dashboard-data/coverage/coverage_report.txt
 
-      - name: Archive coverage txt
-        if: ${{ always() }}
-        uses: ./.github/workflows/upload-artifact
-        with:
-          name: unit-test-coverage-txt
-          path: qa-standards-dashboard-data/coverage/coverage_report.txt
+  #     - name: Archive coverage txt
+  #       if: ${{ always() }}
+  #       uses: ./.github/workflows/upload-artifact
+  #       with:
+  #         name: unit-test-coverage-txt
+  #         path: qa-standards-dashboard-data/coverage/coverage_report.txt
 
-      - name: Process Coverage Report and post results to BigQuery
-        run: yarn unit-coverage-to-bigquery
-        working-directory: qa-standards-dashboard-data
+  #     - name: Process Coverage Report and post results to BigQuery
+  #       run: yarn unit-coverage-to-bigquery
+  #       working-directory: qa-standards-dashboard-data
 
-      - name: Upload coverage report to S3
-        if: ${{ github.ref == 'refs/heads/main' && needs.unit-tests.outputs.app_folders == '' }}
-        run: |
-          if [ -f qa-standards-dashboard-data/coverage/test-coverage-report.json ]; then
-            aws s3 cp qa-standards-dashboard-data/coverage/test-coverage-report.json s3://vetsgov-website-builds-s3-upload-test/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
-          else
-            echo 'No coverage report exists as no tests were run.'
-          fi
+  #     - name: Upload coverage report to S3
+  #       if: ${{ github.ref == 'refs/heads/main' && needs.unit-tests.outputs.app_folders == '' }}
+  #       run: |
+  #         if [ -f qa-standards-dashboard-data/coverage/test-coverage-report.json ]; then
+  #           aws s3 cp qa-standards-dashboard-data/coverage/test-coverage-report.json s3://vetsgov-website-builds-s3-upload-test/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
+  #         else
+  #           echo 'No coverage report exists as no tests were run.'
+  #         fi
       
-      # -------------------------
-      # | Unit Tests Summary |
-      # -------------------------
-      - name: Get code coverage
-        if: ${{ always() }}
-        id: code-coverage
-        run: echo MARKDOWN=$(node ./script/github-actions/code-coverage-format-report.js) >> $GITHUB_OUTPUT
+  #     # -------------------------
+  #     # | Unit Tests Summary |
+  #     # -------------------------
+  #     - name: Get code coverage
+  #       if: ${{ always() }}
+  #       id: code-coverage
+  #       run: echo MARKDOWN=$(node ./script/github-actions/code-coverage-format-report.js) >> $GITHUB_OUTPUT
 
-      - name: Publish test results
-        if: ${{ always() }}
-        continue-on-error: true
-        uses: ./.github/workflows/publish-test-results
-        with:
-          check_name: 'Unit Tests Summary'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: 'test-results/unit-tests.xml'
-          summary: ${{ steps.code-coverage.outputs.MARKDOWN }}
-          fail_on_failure: 'true'
+  #     - name: Publish test results
+  #       if: ${{ always() }}
+  #       continue-on-error: true
+  #       uses: ./.github/workflows/publish-test-results
+  #       with:
+  #         check_name: 'Unit Tests Summary'
+  #         token: ${{ secrets.GITHUB_TOKEN }}
+  #         report_paths: 'test-results/unit-tests.xml'
+  #         summary: ${{ steps.code-coverage.outputs.MARKDOWN }}
+  #         fail_on_failure: 'true'
 
   testing-reports-cypress:
     name: Testing Reports - Cypress E2E Tests
@@ -1460,15 +1461,17 @@ jobs:
       - name: Download Cypress E2E Mochawesome test results
         uses: ./.github/workflows/download-artifact
         with:
-          name: cypress-stress-test-results
+          pattern: cypress-stress-test-results-*
           path: qa-standards-dashboard-data/src/testing-reports/data
+          merge-multiple: true
 
       - name: Download Cypress E2E video artifacts
         if: ${{ needs.cypress-tests.result == 'failure' }}
         uses: ./.github/workflows/download-artifact
         with:
-          name: cypress-stress-test-videos
+          pattern: cypress-stress-test-videos-*
           path: qa-standards-dashboard-data/videos/${{ env.UUID }}
+          merge-multiple: true
 
       - name: Create Cypress E2E Mochawesome report
         run: yarn cypress-mochawesome-to-bigquery

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -254,27 +254,15 @@ jobs:
           IS_STRESS_TEST: false
           NUM_CONTAINERS: 10
 
-      - name: List and merge test results
-        run: |
-          cd mocha/results
-          jq -s 'reduce .[] as $item ({}; . * $item)' > test-results-${{ matrix.ci_node_index }}.json
-          ls -a
-
       - name: Archive unit test results
         if: ${{ always() }}
         uses: ./.github/workflows/upload-artifact
         with:
           name: unit-test-report-${{ matrix.ci_node_index }}
-          path: mocha/results/test-results-${{ matrix.ci_node_index }}.json
+          path: mocha/results
 
-      - name: Generate coverage report by app
-        run: node script/app-coverage-report.js > test-results/coverage_report-${{ matrix.ci_node_index }}.txt
-
-      - name: List and merge test results
-        run: |
-          cd coverage
-          jq -s 'reduce .[] as $item ({}; . * $item)' > coverage-report-${{ matrix.ci_node_index }}.json
-          ls -a
+      # - name: Generate coverage report by app
+      #   run: node script/app-coverage-report.js > test-results/coverage_report-${{ matrix.ci_node_index }}.txt
 
       - name: Upload Coverage Report Artifact
         uses: ./.github/workflows/upload-artifact
@@ -282,7 +270,7 @@ jobs:
         with:
           name: unit-test-coverage-report-${{ matrix.ci_node_index }}
           # path: test-results/coverage_report-${{ matrix.ci_node_index }}.txt
-          path: coverage/coverage-report-${{ matrix.ci_node_index }}.json
+          path: coverage
 
   unit-tests-stress-test:
     name: Unit Test Stability Review
@@ -1021,6 +1009,18 @@ jobs:
           pattern: unit-test-coverage-*
           path: qa-standards-dashboard-data/coverge
           merge-multiple: true
+
+      - name: Log directories
+        run: |
+          ls -a
+          cd qa-standards-dashboard-data/src/testing-reports/data
+          ls -a
+
+      - name: Log directories
+        run: |
+          ls -a
+          cd qa-standards-dashboard-data/coverage
+          ls -a 
 
       - name: Merge Test results
         run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1023,14 +1023,14 @@ jobs:
       - name: Merge Test results
         run: |
           cd qa-standards-dashboard-data/src/testing-reports/data
-          jq -s 'reduce .[] as $item ({}; . unit-test-report* $item)' > test-results-${{ matrix.ci_node_index }}.json
+          jq -s 'reduce .[] as $item ({}; . unit-test-report-* $item)' > test-results-${{ matrix.ci_node_index }}.json
           ls -a
       
 
       - name: Merge coverage results
         run: |
           cd qa-standards-dashboard-data/src/testing-reports/data
-          jq -s 'reduce .[] as $item ({}; . unit-test-coverage* $item)' > test-results-${{ matrix.ci_node_index }}.json
+          jq -s 'reduce .[] as $item ({}; . unit-test-coverage-* $item)' > test-results-${{ matrix.ci_node_index }}.json
           ls -a
   
       - name: Log directory

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1039,14 +1039,14 @@ jobs:
         uses: ./.github/workflows/upload-artifact
         with:
           name: unit-test-report-merged
-          path: mocha/results/test-results.json
+          path: qa-standards-dashboard-data/src/testing-reports/data/test-results.json
       
       - name: Archive unit test coverage
         if: ${{ always() }}
         uses: ./.github/workflows/upload-artifact
         with:
           name: unit-test-coverage-merged
-          path: mocha/results/test-coverage.json
+          path: coverage/test-coverage.json
 
       - name: Create Unit Test report
         run: yarn unit-mochawesome-to-bigquery

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1019,7 +1019,10 @@ jobs:
           pattern: unit-test-report-*
           path: qa-standards-dashboard-data/src/testing-reports/data
           merge-multiple: true
-        
+      
+      - name: Log directory
+        run: ls -a
+            
       - name: Merge Test results
         run: |
           cd qa-standards-dashboard-data/src/testing-reports/data

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -272,7 +272,7 @@ jobs:
 
       - name: List and merge test results
         run: |
-          cd mocha/results
+          cd coverage
           jq -s 'reduce .[] as $item ({}; . * $item)' > coverage-report-${{ matrix.ci_node_index }}.json
           ls -a
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1021,8 +1021,11 @@ jobs:
           merge-multiple: true
       
       - name: Log directory
-        run: ls -a
-            
+        run: |
+          ls -a
+          cd qa-standards-dashboard-data/src/testing-reports/data
+          ls -a
+
       - name: Merge Test results
         run: |
           cd qa-standards-dashboard-data/src/testing-reports/data

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1035,18 +1035,6 @@ jobs:
       # - name: Generate coverage report by app
       #   run: node script/app-coverage-report.js > qa-standards-dashboard-data/coverage/coverage_report.txt
 
-      - name: Merge Test results
-        run: |
-          cd qa-standards-dashboard-data/src/testing-reports/data
-          jq -s 'reduce .[] as $item ({}; . * $item)' > test-results.json
-          ls -a
-
-      - name: Merge coverage results
-        run: |
-          cd qa-standards-dashboard-data/coverage
-          jq -s 'reduce .[] as $item ({}; . * $item)' > test-coverage.json
-          ls -a
-
       - name: Archive unit test results
         if: ${{ always() }}
         uses: ./.github/workflows/upload-artifact

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1039,14 +1039,14 @@ jobs:
         uses: ./.github/workflows/upload-artifact
         with:
           name: unit-test-report-merged
-          path: qa-standards-dashboard-data/src/testing-reports/data/test-results.json
+          path: qa-standards-dashboard-data/src/testing-reports/data/
       
       - name: Archive unit test coverage
         if: ${{ always() }}
         uses: ./.github/workflows/upload-artifact
         with:
           name: unit-test-coverage-merged
-          path: coverage/test-coverage.json
+          path: coverage
 
       - name: Create Unit Test report
         run: yarn unit-mochawesome-to-bigquery

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -266,17 +266,17 @@ jobs:
         uses: ./.github/workflows/upload-artifact
         with:
           name: unit-test-report-${{ matrix.ci_node_index }}
-          path: mocha/results
+          path: mocha/results/test-results-${{ matrix.ci_node_index }}.json
 
       - name: Generate coverage report by app
-        run: node script/app-coverage-report.js > test-results/coverage_report.txt
+        run: node script/app-coverage-report.js > test-results/coverage_report-${{ matrix.ci_node_index }}.txt
 
       - name: Upload Coverage Report Artifact
         uses: ./.github/workflows/upload-artifact
         if: ${{ always() }}
         with:
           name: unit-test-coverage-report-${{ matrix.ci_node_index }}
-          path: coverage/test-coverage-report.json
+          path: test-results/coverage_report-${{ matrix.ci_node_index }}.txt
 
   unit-tests-stress-test:
     name: Unit Test Stability Review

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -258,7 +258,7 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/workflows/upload-artifact
         with:
-          name: unit-test-report
+          name: unit-test-report-${{ matrix.ci_node_index }}
           path: mocha/results
 
       - name: Generate coverage report by app
@@ -268,61 +268,8 @@ jobs:
         uses: ./.github/workflows/upload-artifact
         if: ${{ always() }}
         with:
-          name: unit-test-coverage-report
+          name: unit-test-coverage-report-${{ matrix.ci_node_index }}
           path: coverage/test-coverage-report.json
-
-      - name: Configure AWS credentials (1)
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: ./.github/workflows/configure-aws-credentials
-        with:
-          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: us-gov-west-1
-          
-
-      - name: Get AWS IAM role
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: ./.github/workflows/inject-secrets
-        with:
-          ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
-          env_variable_name: AWS_FRONTEND_NONPROD_ROLE
-
-      - name: Configure AWS Credentials (2)
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: ./.github/workflows/configure-aws-credentials
-        with:
-          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: us-gov-west-1
-          role: ${{ env.AWS_FRONTEND_NONPROD_ROLE }}
-          role_duration: 900
-          session_name: vsp-frontendteam-githubaction
-          
-
-      - name: Upload coverage report to S3
-        if: ${{ github.ref == 'refs/heads/main' && steps.get-changed-apps.outputs.folders == '' }}
-        run: |
-          if [ -f coverage/test-coverage-report.json ]; then
-            aws s3 cp coverage/test-coverage-report.json s3://vetsgov-website-builds-s3-upload-test/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
-          else
-            echo 'No coverage report exists as no tests were run.'
-          fi
-
-      - name: Get code coverage
-        if: ${{ always() }}
-        id: code-coverage
-        run: echo MARKDOWN=$(node ./script/github-actions/code-coverage-format-report.js) >> $GITHUB_OUTPUT
-
-      - name: Publish test results
-        if: ${{ always() }}
-        continue-on-error: true
-        uses: ./.github/workflows/publish-test-results
-        with:
-          check_name: 'Unit Tests Summary'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: 'test-results/unit-tests.xml'
-          summary: ${{ steps.code-coverage.outputs.MARKDOWN }}
-          fail_on_failure: 'true'
 
   unit-tests-stress-test:
     name: Unit Test Stability Review
@@ -1049,8 +996,16 @@ jobs:
       - name: Download Unit Test Mochawesome test results
         uses: ./.github/workflows/download-artifact
         with:
-          name: unit-test-report
+          pattern: unit-test-report-*
           path: qa-standards-dashboard-data/src/testing-reports/data
+          merge-multiple: true
+
+      - name: Download Unit Test coverage results
+        uses: ./.github/workflows/download-artifact
+        with:
+          pattern: unit-test-report-*
+          path: qa-standards-dashboard-data/src/testing-reports/data
+          merge-multiple: true
 
       - name: Log directory
         run: |
@@ -1083,10 +1038,22 @@ jobs:
       - name: Upload Unit Test report to s3
         run: aws s3 cp qa-standards-dashboard-data/mochawesome-report s3://testing-tools-testing-reports/vets-website-unit-test-reports --acl public-read --region us-gov-west-1 --recursive
 
+      - name: Upload coverage report to S3
+        if: ${{ github.ref == 'refs/heads/main' && needs.unit-tests.outputs.app_folders == '' }}
+        run: |
+          if [ -f coverage/test-coverage-report.json ]; then
+            aws s3 cp coverage/test-coverage-report.json s3://vetsgov-website-builds-s3-upload-test/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
+          else
+            echo 'No coverage report exists as no tests were run.'
+          fi
       # -------------------------
       # | Unit Tests Summary |
       # -------------------------
-
+      - name: Get code coverage
+        if: ${{ always() }}
+        id: code-coverage
+        run: echo MARKDOWN=$(node ./script/github-actions/code-coverage-format-report.js) >> $GITHUB_OUTPUT
+      
       - name: Unit test results
         if: ${{ always() }}
         uses: ./.github/workflows/checks-action
@@ -1096,6 +1063,17 @@ jobs:
           conclusion: ${{ needs.unit-tests.result }}
           output: |
             {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
+
+      # - name: Publish test results
+      #   if: ${{ always() }}
+      #   continue-on-error: true
+      #   uses: ./.github/workflows/publish-test-results
+      #   with:
+      #     check_name: 'Unit Tests Summary'
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     report_paths: 'test-results/unit-tests.xml'
+      #     summary: ${{ steps.code-coverage.outputs.MARKDOWN }}
+      #     fail_on_failure: 'true'
 
   testing-reports-unit-tests-stress-test:
     name: Testing Reports - Unit Test Stability Review

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -268,7 +268,7 @@ jobs:
         uses: ./.github/workflows/upload-artifact
         if: ${{ always() }}
         with:
-          name: unit-test-coverage-report-${{ matrix.ci_node_index }}
+          name: unit-test-coverage-${{ matrix.ci_node_index }}
           # path: test-results/coverage_report-${{ matrix.ci_node_index }}.txt
           path: coverage
 
@@ -1007,7 +1007,7 @@ jobs:
         uses: ./.github/workflows/download-artifact
         with:
           pattern: unit-test-coverage-*
-          path: qa-standards-dashboard-data/coverge
+          path: qa-standards-dashboard-data/coverage
           merge-multiple: true
 
       - name: Log directories

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -254,6 +254,13 @@ jobs:
           IS_STRESS_TEST: false
           NUM_CONTAINERS: 10
 
+      - name: List and merge test results
+        run: |
+          cd mocha/results
+          ls -a
+          jq -s 'reduce .[] as $item ({}; . * $item)' json_files/*
+          ls -a
+
       - name: Archive unit test results
         if: ${{ always() }}
         uses: ./.github/workflows/upload-artifact

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1016,8 +1016,8 @@ jobs:
       - name: Download Unit Test coverage results
         uses: ./.github/workflows/download-artifact
         with:
-          pattern: unit-test-report-*
-          path: qa-standards-dashboard-data/src/testing-reports/data
+          pattern: unit-test-coverage-*
+          path: qa-standards-dashboard-data/coverge
           merge-multiple: true
       
       - name: Log directory
@@ -1029,14 +1029,14 @@ jobs:
       - name: Merge Test results
         run: |
           cd qa-standards-dashboard-data/src/testing-reports/data
-          jq -s 'reduce .[] as $item ({}; . + $item)' unit-test-report* > test-results-${{ matrix.ci_node_index }}.json
+          jq -s 'reduce .[] as $item ({}; . * $item)' > test-results.json
           ls -a
       
 
       - name: Merge coverage results
         run: |
-          cd qa-standards-dashboard-data/src/testing-reports/data
-          jq -s 'reduce .[] as $item ({}; . + $item)' unit-test-coverage* > test-results-${{ matrix.ci_node_index }}.json
+          cd qa-standards-dashboard-data/coverage
+          jq -s 'reduce .[] as $item ({}; . * $item)' > test-coverage.json
           ls -a
   
       - name: Log directory

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -383,8 +383,9 @@ jobs:
       - name: Download Unit Test results
         uses: ./.github/workflows/download-artifact
         with:
-          name: unit-test-stress-test-results
+          pattern: unit-test-stress-test-results-*
           path: qa-standards-dashboard-data/src/allow-list/data
+          merge-multiple: true
 
       - name: Download Unit Test Stability Allow List
         uses: ./.github/workflows/download-artifact
@@ -856,8 +857,9 @@ jobs:
       - name: Download Cypress E2E Mochawesome test results
         uses: ./.github/workflows/download-artifact
         with:
-          name: cypress-stress-test-results
+          pattern: cypress-stress-test-results-*
           path: qa-standards-dashboard-data/src/allow-list/data
+          merge-multiple: true
 
       - name: Copy test results to mochawesome directory
         run: cp -r qa-standards-dashboard-data/src/allow-list/data qa-standards-dashboard-data/src/testing-reports/data
@@ -866,8 +868,9 @@ jobs:
         if: ${{ needs.stress-test-cypress-tests.result == 'failure' }}
         uses: ./.github/workflows/download-artifact
         with:
-          name: cypress-stress-test-videos
+          pattern: cypress-stress-test-videos-*
           path: qa-standards-dashboard-data/videos/${{ env.UUID }}
+          merge-multiple: true
 
       - name: Download E2E Test Stability Allow List
         uses: ./.github/workflows/download-artifact

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1023,14 +1023,14 @@ jobs:
       - name: Merge Test results
         run: |
           cd qa-standards-dashboard-data/src/testing-reports/data
-          jq -s 'reduce .[] as $item ({}; . unit-test-report-* $item)' > test-results-${{ matrix.ci_node_index }}.json
+          jq -s 'reduce .[] as $item ({}; . + $item)' unit-test-report* > test-results-${{ matrix.ci_node_index }}.json
           ls -a
       
 
       - name: Merge coverage results
         run: |
           cd qa-standards-dashboard-data/src/testing-reports/data
-          jq -s 'reduce .[] as $item ({}; . unit-test-coverage-* $item)' > test-results-${{ matrix.ci_node_index }}.json
+          jq -s 'reduce .[] as $item ({}; . + $item)' unit-test-coverage* > test-results-${{ matrix.ci_node_index }}.json
           ls -a
   
       - name: Log directory

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -326,7 +326,7 @@ jobs:
         if: ${{ always() }}
         uses: ./.github/workflows/upload-artifact
         with:
-          name: unit-test-stress-test-results-${{ matrix.ci_node_index }}
+          name: unit-test-stress-test-results-${{ matrix.runs }}
           path: mocha/results
 
   update-unit-test-allow-list:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -256,11 +256,7 @@ jobs:
 
       - name: List and merge test results
         run: |
-          ls -a
-          cd mocha
-          ls -a
-          cd results
-          ls -a
+          cd mocha/results
           jq -s 'reduce .[] as $item ({}; . * $item)' > test-results-${{ matrix.ci_node_index }}.json
           ls -a
 
@@ -274,13 +270,19 @@ jobs:
       - name: Generate coverage report by app
         run: node script/app-coverage-report.js > test-results/coverage_report-${{ matrix.ci_node_index }}.txt
 
+      - name: List and merge test results
+        run: |
+          cd mocha/results
+          jq -s 'reduce .[] as $item ({}; . * $item)' > coverage-report-${{ matrix.ci_node_index }}.json
+          ls -a
+
       - name: Upload Coverage Report Artifact
         uses: ./.github/workflows/upload-artifact
         if: ${{ always() }}
         with:
           name: unit-test-coverage-report-${{ matrix.ci_node_index }}
           # path: test-results/coverage_report-${{ matrix.ci_node_index }}.txt
-          path: coverage/coverage-summary.json
+          path: coverage/coverage-report-${{ matrix.ci_node_index }}.json
 
   unit-tests-stress-test:
     name: Unit Test Stability Review
@@ -954,8 +956,8 @@ jobs:
         with:
           attachments: '[{"mrkdwn_in": ["text"], "color": "danger", "text": "<!here> Unit tests in `vets-website` have failed on the `main` branch, run: <https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}|${{github.run_id}}>"}]'
           channel_id: C026PD47Z19 #gha-test-status
-          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       # ------------------------
       # | Upload BigQuery Data |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1007,14 +1007,16 @@ jobs:
       # --------------------------------------------------
 
       - name: Download Unit Test Mochawesome test results
-        uses: ./.github/workflows/download-artifact
+        # uses: ./.github/workflows/download-artifact
+        uses: actions/download-artifact@v3
         with:
           pattern: unit-test-report-*
           path: qa-standards-dashboard-data/src/testing-reports/data
           merge-multiple: true
 
       - name: Download Unit Test coverage results
-        uses: ./.github/workflows/download-artifact
+        # uses: ./.github/workflows/download-artifact
+        uses: actions/download-artifact@v3
         with:
           pattern: unit-test-report-*
           path: qa-standards-dashboard-data/src/testing-reports/data

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1032,8 +1032,8 @@ jobs:
           cd qa-standards-dashboard-data/coverage
           ls -a 
 
-      # - name: Generate coverage report by app
-      #   run: node script/app-coverage-report.js > qa-standards-dashboard-data/coverage/coverage_report.txt
+      - name: Generate coverage report by app
+        run: node script/app-coverage-report.js > qa-standards-dashboard-data/coverage/coverage_report.txt
 
       - name: Archive unit test results
         if: ${{ always() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -279,7 +279,8 @@ jobs:
         if: ${{ always() }}
         with:
           name: unit-test-coverage-report-${{ matrix.ci_node_index }}
-          path: test-results/coverage_report-${{ matrix.ci_node_index }}.txt
+          # path: test-results/coverage_report-${{ matrix.ci_node_index }}.txt
+          path: coverage/coverage-summary-${{ matrix.ci_node_index }}.json
 
   unit-tests-stress-test:
     name: Unit Test Stability Review

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -280,7 +280,7 @@ jobs:
         with:
           name: unit-test-coverage-report-${{ matrix.ci_node_index }}
           # path: test-results/coverage_report-${{ matrix.ci_node_index }}.txt
-          path: coverage/coverage-summary-${{ matrix.ci_node_index }}.json
+          path: coverage/coverage-summary.json
 
   unit-tests-stress-test:
     name: Unit Test Stability Review

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -258,7 +258,7 @@ jobs:
         run: |
           cd mocha/results
           ls -a
-          jq -s 'reduce .[] as $item ({}; . * $item)' test-results-${{ matrix.ci_node_index }}.json
+          jq -s 'reduce .[] as $item ({}; . * $item)' > test-results-${{ matrix.ci_node_index }}.json
           ls -a
 
       - name: Archive unit test results

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1005,6 +1005,8 @@ jobs:
       # --------------------------------------------------
       # | Publish Unit Test Report and Upload to BigQuery |
       # --------------------------------------------------
+      - name: Create coverage directory
+        run: mkdir -p qa-standards-dashboard-data/coverage
 
       - name: Download Unit Test Mochawesome test results
         uses: ./.github/workflows/download-artifact

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1012,35 +1012,6 @@ jobs:
           pattern: unit-test-report-*
           path: qa-standards-dashboard-data/src/testing-reports/data
           merge-multiple: true
-
-      - name: Download Unit Test coverage results
-        uses: ./.github/workflows/download-artifact
-        with:
-          pattern: unit-test-coverage-*
-          path: qa-standards-dashboard-data/coverage
-          merge-multiple: true
-
-      - name: Log directories
-        run: |
-          ls -a
-          cd qa-standards-dashboard-data/src/testing-reports/data
-          ls -a
-
-      - name: Log directories
-        run: |
-          ls -a
-          cd qa-standards-dashboard-data/coverage
-          ls -a 
-
-      - name: Generate coverage report by app
-        run: node script/app-coverage-report.js > qa-standards-dashboard-data/coverage/coverage_report.txt
-
-      - name: Archive coverage txt
-        if: ${{ always() }}
-        uses: ./.github/workflows/upload-artifact
-        with:
-          name: unit-test-coverage-txt
-          path: qa-standards-dashboard-data/coverage/coverage_report.txt
       
       - name: Archive unit test coverage
         if: ${{ always() }}
@@ -1057,12 +1028,6 @@ jobs:
           UNIT_TEST_EXECUTIONS_TABLE_NAME: unit_test_suite_executions
           TEST_REPORTS_FOLDER_NAME: vets-website-unit-test-reports
 
-      - name: Log directories
-        run: |
-          ls -a
-          cd qa-standards-dashboard-data/src/testing-reports/
-          ls -a
-
       - name: Upload Test Results to BigQuery
         continue-on-error: true
         run: yarn upload-unit-test-results
@@ -1074,21 +1039,7 @@ jobs:
       - name: Upload Unit Test report to s3
         run: aws s3 cp qa-standards-dashboard-data/mochawesome-report s3://testing-tools-testing-reports/vets-website-unit-test-reports --acl public-read --region us-gov-west-1 --recursive
 
-      # - name: Upload coverage report to S3
-      #   if: ${{ github.ref == 'refs/heads/main' && needs.unit-tests.outputs.app_folders == '' }}
-      #   run: |
-      #     if [ -f qa-standards-dashboard-data/coverage/test-coverage-report.json ]; then
-      #       aws s3 cp qa-standards-dashboard-data/coverage/test-coverage-report.json s3://vetsgov-website-builds-s3-upload-test/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
-      #     else
-      #       echo 'No coverage report exists as no tests were run.'
-      #     fi
-      # -------------------------
-      # | Unit Tests Summary |
-      # -------------------------
-      # - name: Get code coverage
-      #   if: ${{ always() }}
-      #   id: code-coverage
-      #   run: echo MARKDOWN=$(node ./script/github-actions/code-coverage-format-report.js) >> $GITHUB_OUTPUT
+
       
       - name: Unit test results
         if: ${{ always() }}
@@ -1100,16 +1051,7 @@ jobs:
           output: |
             {"summary":${{ env.MOCHAWESOME_REPORT_RESULTS }}}
 
-      # - name: Publish test results
-      #   if: ${{ always() }}
-      #   continue-on-error: true
-      #   uses: ./.github/workflows/publish-test-results
-      #   with:
-      #     check_name: 'Unit Tests Summary'
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-      #     report_paths: 'test-results/unit-tests.xml'
-      #     summary: ${{ steps.code-coverage.outputs.MARKDOWN }}
-      #     fail_on_failure: 'true'
+
 
   testing-reports-unit-tests-stress-test:
     name: Testing Reports - Unit Test Stability Review
@@ -1268,16 +1210,60 @@ jobs:
       # --------------------------------------
       # | Publish Unit Test Coverage Report       |
       # -------------------------------------
-
-      - name: Download Unit Test Coverage Report
+      - name: Download Unit Test coverage results
         uses: ./.github/workflows/download-artifact
         with:
-          name: unit-test-coverage-report
-          path: qa-standards-dashboard-data/src/testing-reports/data
+          pattern: unit-test-coverage-*
+          path: qa-standards-dashboard-data/coverage
+          merge-multiple: true
+
+      # - name: Download Unit Test Coverage Report
+      #   uses: ./.github/workflows/download-artifact
+      #   with:
+      #     name: unit-test-coverage-report
+      #     path: qa-standards-dashboard-data/src/testing-reports/data
+
+      - name: Generate coverage report by app
+        run: node script/app-coverage-report.js > qa-standards-dashboard-data/coverage/coverage_report.txt
+
+      - name: Archive coverage txt
+        if: ${{ always() }}
+        uses: ./.github/workflows/upload-artifact
+        with:
+          name: unit-test-coverage-txt
+          path: qa-standards-dashboard-data/coverage/coverage_report.txt
 
       - name: Process Coverage Report and post results to BigQuery
         run: yarn unit-coverage-to-bigquery
         working-directory: qa-standards-dashboard-data
+
+      - name: Upload coverage report to S3
+        if: ${{ github.ref == 'refs/heads/main' && needs.unit-tests.outputs.app_folders == '' }}
+        run: |
+          if [ -f qa-standards-dashboard-data/coverage/test-coverage-report.json ]; then
+            aws s3 cp qa-standards-dashboard-data/coverage/test-coverage-report.json s3://vetsgov-website-builds-s3-upload-test/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
+          else
+            echo 'No coverage report exists as no tests were run.'
+          fi
+      
+      # -------------------------
+      # | Unit Tests Summary |
+      # -------------------------
+      - name: Get code coverage
+        if: ${{ always() }}
+        id: code-coverage
+        run: echo MARKDOWN=$(node ./script/github-actions/code-coverage-format-report.js) >> $GITHUB_OUTPUT
+
+      - name: Publish test results
+        if: ${{ always() }}
+        continue-on-error: true
+        uses: ./.github/workflows/publish-test-results
+        with:
+          check_name: 'Unit Tests Summary'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: 'test-results/unit-tests.xml'
+          summary: ${{ steps.code-coverage.outputs.MARKDOWN }}
+          fail_on_failure: 'true'
 
   testing-reports-cypress:
     name: Testing Reports - Cypress E2E Tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1019,7 +1019,20 @@ jobs:
           pattern: unit-test-report-*
           path: qa-standards-dashboard-data/src/testing-reports/data
           merge-multiple: true
+        
+      - name: Merge Test results
+        run: |
+          cd qa-standards-dashboard-data/src/testing-reports/data
+          jq -s 'reduce .[] as $item ({}; . unit-test-report* $item)' > test-results-${{ matrix.ci_node_index }}.json
+          ls -a
+      
 
+      - name: Merge coverage results
+        run: |
+          cd qa-standards-dashboard-data/src/testing-reports/data
+          jq -s 'reduce .[] as $item ({}; . unit-test-coverage* $item)' > test-results-${{ matrix.ci_node_index }}.json
+          ls -a
+  
       - name: Log directory
         run: |
           ls -a

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1021,31 +1021,32 @@ jobs:
           pattern: unit-test-coverage-*
           path: qa-standards-dashboard-data/coverge
           merge-multiple: true
-      
-      - name: Log directory
-        run: |
-          ls -a
-          cd qa-standards-dashboard-data/src/testing-reports/data
-          ls -a
 
       - name: Merge Test results
         run: |
           cd qa-standards-dashboard-data/src/testing-reports/data
           jq -s 'reduce .[] as $item ({}; . * $item)' > test-results.json
           ls -a
-      
 
       - name: Merge coverage results
         run: |
           cd qa-standards-dashboard-data/coverage
           jq -s 'reduce .[] as $item ({}; . * $item)' > test-coverage.json
           ls -a
-  
-      - name: Log directory
-        run: |
-          ls -a
-          cd qa-standards-dashboard-data/src/testing-reports/data
-          ls -a
+
+      - name: Archive unit test results
+        if: ${{ always() }}
+        uses: ./.github/workflows/upload-artifact
+        with:
+          name: unit-test-report-merged
+          path: mocha/results/test-results.json
+      
+      - name: Archive unit test coverage
+        if: ${{ always() }}
+        uses: ./.github/workflows/upload-artifact
+        with:
+          name: unit-test-coverage-merged
+          path: mocha/results/test-coverage.json
 
       - name: Create Unit Test report
         run: yarn unit-mochawesome-to-bigquery

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -931,6 +931,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Install dependencies
+        uses: ./.github/workflows/install
+        timeout-minutes: 30
+        with:
+          key: ${{ hashFiles('yarn.lock') }}
+          yarn_cache_folder: .cache/yarn
+          path: |
+            .cache/yarn
+            node_modules
+
       # ----------------
       # | Notify Slack |
       # ----------------

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1022,6 +1022,9 @@ jobs:
           cd qa-standards-dashboard-data/coverage
           ls -a 
 
+      - name: Generate coverage report by app
+        run: node script/app-coverage-report.js > qa-standards-dashboard-data/coverage/coverage_report.txt
+
       - name: Merge Test results
         run: |
           cd qa-standards-dashboard-data/src/testing-reports/data
@@ -1076,8 +1079,8 @@ jobs:
       - name: Upload coverage report to S3
         if: ${{ github.ref == 'refs/heads/main' && needs.unit-tests.outputs.app_folders == '' }}
         run: |
-          if [ -f coverage/test-coverage-report.json ]; then
-            aws s3 cp coverage/test-coverage-report.json s3://vetsgov-website-builds-s3-upload-test/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
+          if [ -f qa-standards-dashboard-data/coverage/test-coverage-report.json ]; then
+            aws s3 cp qa-standards-dashboard-data/coverage/test-coverage-report.json s3://vetsgov-website-builds-s3-upload-test/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
           else
             echo 'No coverage report exists as no tests were run.'
           fi

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1032,8 +1032,8 @@ jobs:
           cd qa-standards-dashboard-data/coverage
           ls -a 
 
-      - name: Generate coverage report by app
-        run: node script/app-coverage-report.js > qa-standards-dashboard-data/coverage/coverage_report.txt
+      # - name: Generate coverage report by app
+      #   run: node script/app-coverage-report.js > qa-standards-dashboard-data/coverage/coverage_report.txt
 
       - name: Merge Test results
         run: |
@@ -1086,21 +1086,21 @@ jobs:
       - name: Upload Unit Test report to s3
         run: aws s3 cp qa-standards-dashboard-data/mochawesome-report s3://testing-tools-testing-reports/vets-website-unit-test-reports --acl public-read --region us-gov-west-1 --recursive
 
-      - name: Upload coverage report to S3
-        if: ${{ github.ref == 'refs/heads/main' && needs.unit-tests.outputs.app_folders == '' }}
-        run: |
-          if [ -f qa-standards-dashboard-data/coverage/test-coverage-report.json ]; then
-            aws s3 cp qa-standards-dashboard-data/coverage/test-coverage-report.json s3://vetsgov-website-builds-s3-upload-test/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
-          else
-            echo 'No coverage report exists as no tests were run.'
-          fi
+      # - name: Upload coverage report to S3
+      #   if: ${{ github.ref == 'refs/heads/main' && needs.unit-tests.outputs.app_folders == '' }}
+      #   run: |
+      #     if [ -f qa-standards-dashboard-data/coverage/test-coverage-report.json ]; then
+      #       aws s3 cp qa-standards-dashboard-data/coverage/test-coverage-report.json s3://vetsgov-website-builds-s3-upload-test/coverage/test-coverage-report.json --acl public-read --region us-gov-west-1
+      #     else
+      #       echo 'No coverage report exists as no tests were run.'
+      #     fi
       # -------------------------
       # | Unit Tests Summary |
       # -------------------------
-      - name: Get code coverage
-        if: ${{ always() }}
-        id: code-coverage
-        run: echo MARKDOWN=$(node ./script/github-actions/code-coverage-format-report.js) >> $GITHUB_OUTPUT
+      # - name: Get code coverage
+      #   if: ${{ always() }}
+      #   id: code-coverage
+      #   run: echo MARKDOWN=$(node ./script/github-actions/code-coverage-format-report.js) >> $GITHUB_OUTPUT
       
       - name: Unit test results
         if: ${{ always() }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -258,7 +258,7 @@ jobs:
         run: |
           cd mocha/results
           ls -a
-          jq -s 'reduce .[] as $item ({}; . * $item)' json_files/*
+          jq -s 'reduce .[] as $item ({}; . * $item)' test-results-${{ matrix.ci_node_index }}.json
           ls -a
 
       - name: Archive unit test results

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1007,16 +1007,14 @@ jobs:
       # --------------------------------------------------
 
       - name: Download Unit Test Mochawesome test results
-        # uses: ./.github/workflows/download-artifact
-        uses: actions/download-artifact@v3
+        uses: ./.github/workflows/download-artifact
         with:
           pattern: unit-test-report-*
           path: qa-standards-dashboard-data/src/testing-reports/data
           merge-multiple: true
 
       - name: Download Unit Test coverage results
-        # uses: ./.github/workflows/download-artifact
-        uses: actions/download-artifact@v3
+        uses: ./.github/workflows/download-artifact
         with:
           pattern: unit-test-report-*
           path: qa-standards-dashboard-data/src/testing-reports/data

--- a/.github/workflows/download-artifact/action.yml
+++ b/.github/workflows/download-artifact/action.yml
@@ -23,7 +23,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/.github/workflows/download-artifact/action.yml
+++ b/.github/workflows/download-artifact/action.yml
@@ -4,10 +4,21 @@ description: Download Artifact
 inputs:
   name:
     description: Artifact name you wish to download
-    required: true
+    required: false
+    default: ''
   path:
     description: Path to download artifact to
     required: true
+  merge-multiple:
+    description: Combine multiple artifacts into one directory
+    required: false
+    default: false
+  pattern:
+    description: allow fetching by pattern in place of a name
+    required: false
+    default: ''
+
+    # note that even though name and pattern are both set to false, that is an OR situation where one or the other is required. Absence of both will result in an error.
 
 runs:
   using: composite
@@ -16,3 +27,5 @@ runs:
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}
+        merge-multiple: ${{ inputs.merge-multiple }}
+        pattern: ${{ inputs.pattern }}

--- a/.github/workflows/upload-artifact/action.yml
+++ b/.github/workflows/upload-artifact/action.yml
@@ -8,6 +8,10 @@ inputs:
   path:
     description: Path to upload artifact from
     required: true
+  retention-days:
+    description: Days to retain artifacts for
+    required: false
+    default: 0 # in this case, 0 allows it to inherit repository's default value
 
 runs:
   using: composite

--- a/.github/workflows/upload-artifact/action.yml
+++ b/.github/workflows/upload-artifact/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/script/app-coverage-report.js
+++ b/script/app-coverage-report.js
@@ -118,6 +118,7 @@ if (fs.existsSync(path.join(__dirname, '../coverage/coverage-summary.json'))) {
   const coverageSummaryJson = JSON.parse(
     fs.readFileSync(path.join(__dirname, '../coverage/coverage-summary.json')),
   );
+  console.log(coverageSummaryJson);
   // Generate and print coverage
   const appCoverages = generateCoverage(applicationDir, coverageSummaryJson);
   logCoverage(appCoverages);

--- a/script/app-coverage-report.js
+++ b/script/app-coverage-report.js
@@ -96,7 +96,7 @@ const generateCoverage = (rootDir, coverageSummary) => {
 const logCoverage = coverageResults => {
   // convert coverageResults JSON object to prettified string
   const data = JSON.stringify(coverageResults, null, 4);
-
+  console.log(data);
   // write coverageResults string to file
   const outputFile = path.join(
     __dirname,
@@ -118,7 +118,6 @@ if (fs.existsSync(path.join(__dirname, '../coverage/coverage-summary.json'))) {
   const coverageSummaryJson = JSON.parse(
     fs.readFileSync(path.join(__dirname, '../coverage/coverage-summary.json')),
   );
-  console.log(coverageSummaryJson);
   // Generate and print coverage
   const appCoverages = generateCoverage(applicationDir, coverageSummaryJson);
   logCoverage(appCoverages);

--- a/script/app-coverage-report.js
+++ b/script/app-coverage-report.js
@@ -100,7 +100,7 @@ const logCoverage = coverageResults => {
   // write coverageResults string to file
   const outputFile = path.join(
     __dirname,
-    '../coverage/test-coverage-report.json',
+    '../qa-standards-dashboard-data/coverage/test-coverage-report.json',
   );
   fs.writeFile(outputFile, data, err => {
     if (err) {
@@ -114,14 +114,28 @@ const logCoverage = coverageResults => {
 const applicationDir = path.join(__dirname, '../src/applications/');
 
 // Check if coverage-summary.json exists before generating coverage
-if (fs.existsSync(path.join(__dirname, '../coverage/coverage-summary.json'))) {
+if (
+  fs.existsSync(
+    path.join(
+      __dirname,
+      '../qa-standards-dashboard-data/coverage/coverage-summary.json',
+    ),
+  )
+) {
   const coverageSummaryJson = JSON.parse(
-    fs.readFileSync(path.join(__dirname, '../coverage/coverage-summary.json')),
+    fs.readFileSync(
+      path.join(
+        __dirname,
+        '../qa-standards-dashboard-data/coverage/coverage-summary.json',
+      ),
+    ),
   );
   // Generate and print coverage
   const appCoverages = generateCoverage(applicationDir, coverageSummaryJson);
   logCoverage(appCoverages);
   printCoverage(appCoverages);
 } else {
-  console.log('./coverage/coverage-summary.json not found.');
+  console.log(
+    './qa-standards-dashboard-data/coverage/coverage-summary.json not found.',
+  );
 }

--- a/src/applications/facility-locator/components/Alert.jsx
+++ b/src/applications/facility-locator/components/Alert.jsx
@@ -24,7 +24,7 @@ const Alert = ({ title, description, displayType }) => {
       small-screen-header:vads-u-width--full      
       `}
     >
-      <div className="usa-alertt-body">
+      <div className="usa-alert-body">
         <h4 className="usa-alert-heading">{title}</h4>
         <div className="usa-alert-text">{description}</div>
       </div>

--- a/src/applications/facility-locator/components/Alert.jsx
+++ b/src/applications/facility-locator/components/Alert.jsx
@@ -24,7 +24,7 @@ const Alert = ({ title, description, displayType }) => {
       small-screen-header:vads-u-width--full      
       `}
     >
-      <div className="usa-alert-body">
+      <div className="usa-alertt-body">
         <h4 className="usa-alert-heading">{title}</h4>
         <div className="usa-alert-text">{description}</div>
       </div>


### PR DESCRIPTION
## Summary

- updates actions/upload-artifact to v4
- updates actions/download-artifact to v4
- Reworks artifacts from test reporting to work with the new artifact rules
- Temporarily disables the coverage report while it is reworked to be compatible.

## Related issue(s)

- https://app.zenhub.com/workspaces/reliability-team-633b069d2920b776613c93d8/issues/gh/department-of-veterans-affairs/va.gov-team/77063


