### PR TITLE
ARF-77687 fix ARP feature toggle

### DIFF
--- a/src/applications/representatives/containers/App.jsx
+++ b/src/applications/representatives/containers/App.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { VaLoadingIndicator } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { useFeatureToggle } from '~/platform/utilities/feature-toggles/useFeatureToggle';
 
@@ -24,7 +25,7 @@ function App({ children }) {
     );
   }
 
-  if (!appEnabled) {
+  if (!appEnabled && environment.isProduction()) {
     return document.location.replace('/');
   }
 

--- a/src/applications/representatives/tests/e2e/representatives.cypress.spec.js
+++ b/src/applications/representatives/tests/e2e/representatives.cypress.spec.js
@@ -1,57 +1,78 @@
-describe('Representatives', () => {
-  const togglePortal = value => {
-    beforeEach(() => {
-      cy.intercept('GET', '/v0/feature_toggles*', {
-        data: {
-          features: [{ name: 'representatives_portal_frontend', value }],
-        },
-      });
+const togglePortal = value => {
+  beforeEach(() => {
+    cy.intercept('GET', '/v0/feature_toggles*', {
+      data: {
+        features: [{ name: 'representatives_portal_frontend', value }],
+      },
     });
-  };
+  });
+};
 
-  describe('when feature is toggled off', () => {
-    togglePortal(false);
+describe('Representatives', () => {
+  describe('feature toggling in production', () => {
+    // During CI, the environment is production, so we can test our global
+    // feature toggling behavior there. But when running this test locally, the
+    // environment is localhost, so we can't test our global feature toggling
+    // behavior there without doing some more complex test setup.
+    before(function skipOutsideCI() {
+      if (!Cypress.env('CI')) {
+        this.skip();
+      }
+    });
 
-    it('gates', () => {
-      cy.visit('/representatives');
-      cy.injectAxe();
-      cy.axeCheck();
+    describe('when feature is toggled off', () => {
+      togglePortal(false);
 
-      cy.location('pathname').should('equal', '/');
+      it('does redirect to root', () => {
+        cy.visit('/representatives');
+        cy.injectAxe();
+        cy.axeCheck();
+
+        cy.location('pathname').should('equal', '/');
+      });
     });
   });
 
-  describe('when feature is toggled on', () => {
-    togglePortal(true);
+  // In CI, the feature toggle applies so we need to toggle it on to test
+  // behavior past the guard. On localhost, the feature toggle doesn't apply so
+  // toggling the feature on is redundant.
+  togglePortal(true);
 
-    it('allows navigation from landing page to dashboard to poa requests', () => {
-      cy.visit('/representatives');
-      cy.injectAxe();
-      cy.axeCheck();
+  it('does not redirect to root', () => {
+    cy.visit('/representatives');
+    cy.injectAxe();
+    cy.axeCheck();
 
-      cy.contains('Welcome to Representative.VA.gov');
-      cy.contains('Until sign in is added use this to see dashboard').click();
+    cy.location('pathname').should('equal', '/representatives/');
+  });
 
-      cy.url().should('include', '/representatives/dashboard');
-      cy.axeCheck();
+  it('allows navigation from landing page to unified sign-in page', () => {
+    cy.visit('/representatives');
+    cy.injectAxe();
+    cy.axeCheck();
 
-      cy.contains('Accredited Representative Portal');
-      cy.contains('Manage power of attorney requests').click();
+    cy.contains('Sign in or create an account').click();
+    cy.url().should('include', '/sign-in/?application=arp&oauth=true');
+  });
 
-      cy.url().should('include', '/representatives/poa-requests');
-      cy.axeCheck();
+  it('allows navigation from landing page to dashboard to poa requests', () => {
+    cy.visit('/representatives');
+    cy.injectAxe();
+    cy.axeCheck();
 
-      cy.contains('Power of attorney requests');
-      cy.get('[data-testid=poa-requests-table]').should('exist');
-    });
+    cy.contains('Welcome to Representative.VA.gov');
+    cy.contains('Until sign in is added use this to see dashboard').click();
 
-    it('allows navigation from landing page to unified sign-in page', () => {
-      cy.visit('/representatives');
-      cy.injectAxe();
-      cy.axeCheck();
+    cy.url().should('include', '/representatives/dashboard');
+    cy.axeCheck();
 
-      cy.contains('Sign in or create an account').click();
-      cy.url().should('include', '/sign-in/?application=arp&oauth=true');
-    });
+    cy.contains('Accredited Representative Portal');
+    cy.contains('Manage power of attorney requests').click();
+
+    cy.url().should('include', '/representatives/poa-requests');
+    cy.axeCheck();
+
+    cy.contains('Power of attorney requests');
+    cy.get('[data-testid=poa-requests-table]').should('exist');
   });
 });


### PR DESCRIPTION
We want the global ARP feature toggle to apply only in production. This created some difficulty around testing that behavior depending on the environment that the test ran. For now, the solution here is to only run the test of that behavior in CI which has the production environment and skip it elsewhere like on localhost.