### PR TITLE
No longer setting csrf token based on response token.

### DIFF
--- a/src/applications/representative-search/api/RepresentativeFinderApi.js
+++ b/src/applications/representative-search/api/RepresentativeFinderApi.js
@@ -46,8 +46,6 @@ class RepresentativeFinderApi {
           if (!response.ok) {
             throw Error(response.statusText);
           }
-          const csrf = response.headers.get('X-CSRF-Token');
-          localStorage.setItem('csrfToken', csrf);
 
           return response.json();
         })


### PR DESCRIPTION
## Summary

Had previously introduced two lines that explicitly set the CSRF token in local storage based on response header token. Around the same time, I replaced the `fetchAndUpdateSessionExpiration` method with `apiRequest`, which seemed to fix the issue on its own. Manually setting the csrf token re-introduced the error, which is being corrected with this PR. 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75311

## Testing done

Simulated mock data locally - 403 token error was circumvented. 
