### PR TITLE
[VA-IIR 394] Change SearchResult Link Format

### DIFF
--- a/src/applications/yellow-ribbon/components/SearchResult/index.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.jsx
@@ -1,7 +1,6 @@
 // Node modules.
 import React from 'react';
 import PropTypes from 'prop-types';
-import toLower from 'lodash/toLower';
 import startsWith from 'lodash/startsWith';
 // Relative imports.
 import { capitalize, titleCase } from '../../helpers';
@@ -92,9 +91,11 @@ export const deriveInstURLLabel = (school = {}, onSearchResultClick) => {
       onClick={onSearchResultClick(school)}
       rel="noreferrer noopener"
       target="_blank"
-      aria-label={`${school?.insturl} Opens in a new window`}
+      aria-label={`Visit ${titleCase(
+        school?.nameOfInstitution,
+      )} website opens in a new window`}
     >
-      {toLower(school?.insturl)}
+      Visit {titleCase(school?.nameOfInstitution)} website
     </a>
   );
 };

--- a/src/applications/yellow-ribbon/components/SearchResult/index.unit.spec.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.unit.spec.jsx
@@ -33,7 +33,9 @@ describe('Yellow Ribbon <SearchResult>', () => {
 
     expect(text).to.include(props.school.city);
     expect(text).to.include(props.school.contributionAmount);
-    expect(text).to.include(props.school.insturl);
+    expect(text).to.include(
+      `Visit ${titleCase(props.school.nameOfInstitution)} website`,
+    );
     expect(text).to.include(props.school.numberOfStudents);
     expect(text).to.include(titleCase(props.school.nameOfInstitution));
     expect(text).to.include(props.school.state);

--- a/src/applications/yellow-ribbon/e2e/tests/yellow-ribbon.cypress.spec.js
+++ b/src/applications/yellow-ribbon/e2e/tests/yellow-ribbon.cypress.spec.js
@@ -23,6 +23,8 @@ function axeTestPage() {
 }
 
 describe('functionality of Yellow Ribbons', () => {
+  // cy.axeCheck() is required at least once, is wrapped in axeTestPage() above for DRYness, and used throughout these tests
+  // eslint-disable-next-line @department-of-veterans-affairs/axe-check-required
   it('search the form and expect dom to have elements on success', () => {
     cy.intercept(
       'GET',
@@ -67,7 +69,7 @@ describe('functionality of Yellow Ribbons', () => {
       .should('contain', 'All eligible students')
       .should('contain', 'Undergraduate')
       // Check website link.
-      .should('contain', 'www.concordia.edu');
+      .should('contain', 'Visit Concordia University-Texas website');
 
     // Ensure Tool Tip exists
     cy.get(`${SELECTORS.APP} va-additional-info`).click();
@@ -88,6 +90,7 @@ describe('functionality of Yellow Ribbons', () => {
       .should('not.exist');
   });
 
+  // eslint-disable-next-line @department-of-veterans-affairs/axe-check-required
   it('search the form and expect dom to have elements on error', () => {
     cy.intercept(
       'GET',


### PR DESCRIPTION
## Summary

- The following code updates the [Yellow Ribbon Search tool's](https://www.va.gov/education/yellow-ribbon-participating-schools/) SearchResult links.
- I work for the VA-IIR (a.k.a., "Iterate, Innovate, and Run") contractor team under Oddball (primary) and Ad Hoc.

## Related issue(s)

- [VA-IIR Zenhub ticket 394](https://app.zenhub.com/workspaces/va-iir-6508c0bd79e64e0fb5855caf/issues/gh/department-of-veterans-affairs/va-iir/394)

## Testing done

- Relevant test has been updated.
- Also conducted a visual check that the links have the correct format.
## Screenshots

| Before | After |
| ------ | ------ |
![Yellow Ribbon SearchResult with raw text link](https://github.com/department-of-veterans-affairs/vets-website/assets/146031450/ff33f46c-85ed-43e7-8bb6-3d17e7bd9531 "Before") | ![Yellow Ribbon SearchResult with natural language link text](https://github.com/department-of-veterans-affairs/vets-website/assets/146031450/d83e70de-b520-49b0-8496-f544a361c482 "After")


## Acceptance criteria

- [ ] Update link under "School website" portion of each YR result to read "Visit [SCHOOL NAME] website"
- [ ] **If, no website is available display?** continue to use "Not provided"