### PR TITLE
VACMS-17252 Discharge Upgrade Wizard component upgradeS

### DIFF
--- a/src/applications/discharge-wizard/components/AirForcePortalLink.jsx
+++ b/src/applications/discharge-wizard/components/AirForcePortalLink.jsx
@@ -3,17 +3,10 @@ import React from 'react';
 const AirForcePortalLink = () => (
   <section className="vads-u-margin-bottom--9">
     <a
-      className="airForce-portal-link vads-u-display--flex vads-u-align-items--center vads-u-text-decoration--none"
+      className="vads-c-action-link--green"
       href="https://afrba-portal.cce.af.mil/#portal"
     >
-      <i
-        aria-hidden="true"
-        className="fas fa-chevron-circle-right fa-2x vads-u-margin-right--1 vads-u-color--green"
-        role="presentation"
-      />
-      <span className="vads-u-text-decoration--underline vads-u-font-weight--bold">
-        Get the form on the Air Force portal
-      </span>
+      Get the form on the Air Force portal
     </a>
   </section>
 );

--- a/src/applications/discharge-wizard/components/AlertMessage.jsx
+++ b/src/applications/discharge-wizard/components/AlertMessage.jsx
@@ -14,9 +14,7 @@ import PropTypes from 'prop-types';
 const AlertMessage = ({ content, isVisible, status }) => {
   return (
     <va-alert visible={isVisible} status={status} uswds>
-      <div className="usa-alert-text vads-u-font-size--base">
-        {content || null}
-      </div>
+      {content || null}
     </va-alert>
   );
 };

--- a/src/applications/discharge-wizard/components/AnswerReview.jsx
+++ b/src/applications/discharge-wizard/components/AnswerReview.jsx
@@ -42,6 +42,7 @@ const AnswerReview = ({ formValues, handleScrollTo }) => {
               <div key={k} className="answer-review">
                 <p className="vads-u-padding-right--2">{reviewLabel}</p>
                 <va-link
+                  disable-analytics
                   href="#"
                   onClick={handleScrollTo}
                   name={k}
@@ -53,8 +54,8 @@ const AnswerReview = ({ formValues, handleScrollTo }) => {
           );
         })}
       </div>
-      <Link to="/guidance" className="usa-button-primary va-button">
-        Get my results »
+      <Link to="/guidance" className="vads-c-action-link--green">
+        Get my results
       </Link>
     </div>
   );

--- a/src/applications/discharge-wizard/components/Breadcrumbs.jsx
+++ b/src/applications/discharge-wizard/components/Breadcrumbs.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { VaBreadcrumbs } from '@department-of-veterans-affairs/web-components/react-bindings';
+
+const Breadcrumbs = () => (
+  <VaBreadcrumbs
+    class="vads-u-padding--0"
+    label="Breadcrumbs"
+    uswds
+    breadcrumbList={[
+      {
+        href: '/',
+        label: 'Home',
+      },
+      {
+        href: '/discharge-upgrade-instructions',
+        label: 'Discharge upgrade',
+      },
+    ]}
+  />
+);
+
+export default Breadcrumbs;

--- a/src/applications/discharge-wizard/components/CarefulConsiderationStatement.jsx
+++ b/src/applications/discharge-wizard/components/CarefulConsiderationStatement.jsx
@@ -47,7 +47,8 @@ const reasonStatement = formValues => {
             punishment for those events.
           </p>
         );
-      } else if (dischargeType === '1') {
+      }
+      if (dischargeType === '1') {
         return (
           <p>
             Many Veterans have received general or honorable discharges due to
@@ -93,7 +94,7 @@ const priorServiceStatement = formValues => {
           isVisible
           status="info"
           content={
-            <div>
+            <>
               <h4 className="usa-alert-heading">
                 You can apply for VA benefits using your honorable
                 characterization.
@@ -110,7 +111,7 @@ const priorServiceStatement = formValues => {
                 for an upgrade or correction to your final, less than honorable
                 period of service.
               </p>
-            </div>
+            </>
           }
         />
       );
@@ -120,7 +121,7 @@ const priorServiceStatement = formValues => {
           isVisible
           status="info"
           content={
-            <div className="usa-alert-text">
+            <>
               <h4 className="usa-alert-heading">
                 You can apply for VA benefits using your honorable
                 characterization.
@@ -154,7 +155,7 @@ const priorServiceStatement = formValues => {
                   </Link>
                 </p>
               </div>
-            </div>
+            </>
           }
         />
       );

--- a/src/applications/discharge-wizard/components/DischargeWizardApp.jsx
+++ b/src/applications/discharge-wizard/components/DischargeWizardApp.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import Breadcrumbs from './Breadcrumbs';
 
 export default function DischargeWizardApp({ children }) {
   return (
     <div className="row discharge-wizard vads-u-padding-x--1 large-screen:vads-u-padding-x--0">
+      <Breadcrumbs />
       {children}
     </div>
   );

--- a/src/applications/discharge-wizard/components/FormQuestions.jsx
+++ b/src/applications/discharge-wizard/components/FormQuestions.jsx
@@ -1,10 +1,7 @@
-// Dependencies.
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-
-// Relative Imports
-import { focusElement, getScrollOptions } from 'platform/utilities/ui';
 import recordEvent from 'platform/monitoring/record-event';
+import { focusElement, getScrollOptions } from 'platform/utilities/ui';
 import scrollTo from 'platform/utilities/ui/scrollTo';
 import AnswerReview from './AnswerReview';
 import Questions from './questions';

--- a/src/applications/discharge-wizard/components/InstructionsPage.jsx
+++ b/src/applications/discharge-wizard/components/InstructionsPage.jsx
@@ -1,22 +1,7 @@
-// Dependencies
-import React, { useState } from 'react';
+import React from 'react';
 import { Link } from 'react-router';
 
-// Relative imports
-import recordEvent from 'platform/monitoring/record-event';
-
 const InstructionsPage = () => {
-  const [accordionQuestionsState, setAccordionQuestionsState] = useState({});
-
-  const handleFAQToggle = e => {
-    e.preventDefault();
-    recordEvent({ event: 'discharge-upgrade-faq-toggle' });
-    setAccordionQuestionsState({
-      ...accordionQuestionsState,
-      [e.target.name]: !accordionQuestionsState[e.target.name],
-    });
-  };
-
   return (
     <section
       className="dw-instructions"
@@ -64,300 +49,184 @@ const InstructionsPage = () => {
                     confidential.
                   </p>
                   <p>
-                    <Link
-                      className="usa-button-primary va-button"
-                      to="questions"
-                    >
-                      Get started »
+                    <Link className="vads-c-action-link--green" to="questions">
+                      Get started
                     </Link>
                   </p>
                 </div>
               </div>
               <div className="row">
                 <div className="small-12 columns">
-                  <div className="usa-accordion">
-                    {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
-                    <ul className="usa-unstyled-list" role="list">
-                      <li
-                        itemProp="mainEntity"
-                        itemScope
-                        itemType="http://schema.org/Question"
-                      >
-                        <button
-                          id="other-options"
-                          className="usa-button-unstyled usa-accordion-button"
-                          aria-controls="dbq4"
-                          itemProp="name"
-                          aria-expanded={
-                            !!accordionQuestionsState['other-options']
-                          }
-                          onClick={handleFAQToggle}
-                          name="other-options"
-                        >
-                          Can I get VA benefits without a discharge upgrade?
-                        </button>
-                        <div
-                          id="dbq4"
-                          className="usa-accordion-content"
-                          itemProp="acceptedAnswer"
-                          itemScope
-                          itemType="http://schema.org/Answer"
-                          aria-hidden={
-                            !accordionQuestionsState['other-options']
-                          }
-                        >
-                          <div itemProp="text">
-                            <p>
-                              Even with a less than honorable discharge, you may
-                              be able to access some VA benefits through the
-                              Character of Discharge review process. When you
-                              apply for VA benefits, we’ll review your record to
-                              determine if your service was “honorable for VA
-                              purposes.” This review can take up to a year.
-                              Please provide us with documents supporting your
-                              case, similar to the evidence you’d send with an
-                              application to upgrade your discharge.
-                            </p>
-                            <p>
-                              You may want to consider finding someone to
-                              advocate on your behalf, depending on the
-                              complexity of your case. A lawyer or Veterans
-                              Service Organization (VSO) can collect and submit
-                              supporting documents for you.{' '}
-                              <a href="https://www.benefits.va.gov/vso/varo.asp">
-                                Find a VSO near you.
-                              </a>
-                            </p>
-                            <p>
-                              <strong>Note:</strong> You can ask for a VA
-                              Character of Discharge review while at the same
-                              time applying for a discharge upgrade from the
-                              Department of Defense (DoD) or the Coast Guard.
-                            </p>
-                            <p>
-                              If you need mental health services related to PTSD
-                              or other mental health problems linked to your
-                              service (including conditions related to an
-                              experience of military sexual trauma), you may
-                              qualify for VA health benefits right away, even
-                              without a VA Character of Discharge review or a
-                              discharge upgrade.
-                            </p>
-                            <p>Learn more about:</p>
-                            <ul>
-                              <li>
-                                <a href="/health-care/health-needs-conditions/military-sexual-trauma/">
-                                  VA health benefits for Veterans who’ve
-                                  experienced military sexual trauma
-                                </a>
-                              </li>
-                              <li>
-                                <a href="/health-care/health-needs-conditions/mental-health/">
-                                  VA health benefits for Veterans with mental
-                                  health conditions
-                                </a>
-                              </li>
-                              <li>
-                                <a href="/health-care/health-needs-conditions/mental-health/ptsd/">
-                                  VA health benefits for Veterans with PTSD
-                                </a>
-                              </li>
-                            </ul>
-                          </div>
-                        </div>
-                      </li>
-                      <li itemScope itemType="http://schema.org/Question">
-                        <button
-                          className="usa-button-unstyled usa-accordion-button"
-                          aria-controls="dbq1"
-                          itemProp="name"
-                          aria-expanded={!!accordionQuestionsState.q2}
-                          onClick={handleFAQToggle}
-                          name="q2"
-                        >
-                          What if I already applied for an upgrade or correction
-                          and was denied?
-                        </button>
-                        <div
-                          id="dbq1"
-                          className="usa-accordion-content"
-                          itemProp="acceptedAnswer"
-                          itemScope
-                          itemType="http://schema.org/Answer"
-                          aria-hidden={!accordionQuestionsState.q2}
-                        >
-                          <div itemProp="text">
-                            <p>
-                              If your previous upgrade application was denied,
-                              you can apply again, but you may have to follow a
-                              different process. Click the{' '}
-                              <strong>Get Started</strong> button above. When
-                              you’re asked if you’ve applied before, select{' '}
-                              <strong>Yes</strong>. After you’ve answered all
-                              the questions, you’ll see application instructions
-                              specific to your situation.
-                            </p>
-                            <p>
-                              Applying again is most likely to be successful if
-                              your application is significantly different from
-                              when you last applied. For example, you may have
-                              additional evidence that wasn’t available to you
-                              when you last applied, or the Departent of Defense
-                              (DoD) may have issued new rules regarding
-                              discharges. DoD rules changed for discharges
-                              related to PTSD, TBI, and mental health in 2014,
-                              military sexual harassment and assault in 2017,
-                              and sexual orientation in 2011.
-                            </p>
-                          </div>
-                        </div>
-                      </li>
-                      <li itemScope itemType="http://schema.org/Question">
-                        <button
-                          className="usa-button-unstyled usa-accordion-button"
-                          aria-controls="dbq2"
-                          itemProp="name"
-                          aria-expanded={!!accordionQuestionsState.q3}
-                          onClick={handleFAQToggle}
-                          name="q3"
-                        >
-                          What if I have discharges for more than one period of
-                          service?
-                        </button>
-                        <div
-                          id="dbq2"
-                          className="usa-accordion-content"
-                          itemProp="acceptedAnswer"
-                          itemScope
-                          itemType="http://schema.org/Answer"
-                          aria-hidden={!accordionQuestionsState.q3}
-                        >
-                          <div itemProp="text">
-                            <p>
-                              If the Department of Defense (DoD) or the Coast
-                              Guard determined you served honorably in one
-                              period of service, you may use that honorable
-                              characterization to establish eligibility for VA
-                              benefits, even if you later received a less than
-                              honorable discharge. You earned your benefits
-                              during the period in which you served honorably.
-                              Make sure you specifically mention your period of
-                              honorable service when applying for VA benefits.
-                            </p>
-                            <p>
-                              <strong>Note:</strong> The only exception is for
-                              service-connected disability compensation. You’re
-                              only eligible to earn disability compensation for
-                              disabilities you suffered during a period of
-                              honorable service. You can’t use an honorable
-                              discharge from one period of service to establish
-                              eligibility for a service-connected disability
-                              from a different period of service.
-                            </p>
-                          </div>
-                        </div>
-                      </li>
-                      <li itemScope itemType="http://schema.org/Question">
-                        <button
-                          className="usa-button-unstyled usa-accordion-button"
-                          aria-controls="dbq3"
-                          itemProp="name"
-                          aria-expanded={!!accordionQuestionsState.q4}
-                          onClick={handleFAQToggle}
-                          name="q4"
-                        >
-                          What if I served honorably, but didn’t receive
-                          discharge paperwork?
-                        </button>
-                        <div
-                          id="dbq3"
-                          className="usa-accordion-content"
-                          itemProp="acceptedAnswer"
-                          itemScope
-                          itemType="http://schema.org/Answer"
-                          aria-hidden={!accordionQuestionsState.q4}
-                        >
-                          <div itemProp="text">
-                            <p>
-                              You’re eligible for VA benefits at the end of a
-                              period of honorable service, even if you didn’t
-                              receive a discharge in the form of a DD214. If you
-                              completed your original contract period without
-                              any disciplinary problems, you can use this period
-                              of service to establish your eligibility, even if
-                              you re-enlisted or extended your service and did
-                              not receive an “honorable” DD214 at the end of
-                              your second period of service. If you completed a
-                              period of honorable service that’s not reflected
-                              on a DD214, make sure you specifically mention
-                              this period of service when you apply for VA
-                              benefits. We may do a Character of Discharge
-                              review to confirm your eligibility.
-                            </p>
-                            <p>
-                              You can also apply to the Department of Defense
-                              (DoD) or the Coast Guard for a second DD214 only
-                              for that honorable period of service. Click the{' '}
-                              <strong>Get Started</strong> button above and
-                              answer the questions based on your most recent
-                              discharge. When you’re asked if you completed a
-                              period of service in which your character of
-                              service was honorable or general under honorable
-                              conditions, select: “Yes, I completed a prior
-                              period of service, but I did not receive discharge
-                              paperwork from that period.”
-                            </p>
-                          </div>
-                        </div>
-                      </li>
-                      <li itemScope itemType="http://schema.org/Question">
-                        <button
-                          className="usa-button-unstyled usa-accordion-button"
-                          aria-controls="dbq5"
-                          itemProp="name"
-                          aria-expanded={!!accordionQuestionsState.q5}
-                          onClick={handleFAQToggle}
-                          name="q5"
-                        >
-                          What if I have a DD215 showing an upgraded discharge,
-                          but my DD214 still isn’t correct?
-                        </button>
-                        <div
-                          id="dbq5"
-                          className="usa-accordion-content"
-                          itemProp="acceptedAnswer"
-                          itemScope
-                          itemType="http://schema.org/Answer"
-                          aria-hidden={!accordionQuestionsState.q5}
-                        >
-                          <div itemProp="text">
-                            <p>
-                              When the Department of Defense (DoD) or the Coast
-                              Guard upgrades a Veteran’s discharge, it usually
-                              issues a DD215 showing corrections to the DD214.
-                              The DoD or the Coast Guard attaches the DD215 to
-                              the old DD214—which still shows the outdated
-                              discharge and related information. While the
-                              discharge on the DD215 is the correct discharge, a
-                              Veteran may still want a new DD214 that shows no
-                              record of their earlier characterization of
-                              discharge.
-                            </p>
-                            <p>
-                              If you have a DD215 and want an updated DD214,
-                              click the <strong>Get Started</strong> button
-                              above. On the next page, select: “I received a
-                              discharge upgrade or correction, but my upgrade
-                              came in the form of a DD215, and I want an updated
-                              DD214.” After you’ve answered all the questions,
-                              you’ll see instructions for how to request a new
-                              DD214.
-                            </p>
-                          </div>
-                        </div>
-                      </li>
-                    </ul>
-                  </div>
+                  <va-accordion uswds>
+                    <va-accordion-item
+                      header="Can I get VA benefits without a discharge upgrade?"
+                      uswds
+                    >
+                      <p>
+                        Even with a less than honorable discharge, you may be
+                        able to access some VA benefits through the Character of
+                        Discharge review process. When you apply for VA
+                        benefits, we’ll review your record to determine if your
+                        service was “honorable for VA purposes.” This review can
+                        take up to a year. Please provide us with documents
+                        supporting your case, similar to the evidence you’d send
+                        with an application to upgrade your discharge.
+                      </p>
+                      <p>
+                        You may want to consider finding someone to advocate on
+                        your behalf, depending on the complexity of your case. A
+                        lawyer or Veterans Service Organization (VSO) can
+                        collect and submit supporting documents for you.{' '}
+                        <va-link
+                          href="https://www.benefits.va.gov/vso/varo.asp"
+                          text="Find a VSO near you."
+                        />
+                      </p>
+                      <p>
+                        <strong>Note:</strong> You can ask for a VA Character of
+                        Discharge review while at the same time applying for a
+                        discharge upgrade from the Department of Defense (DoD)
+                        or the Coast Guard.
+                      </p>
+                      <p>
+                        If you need mental health services related to PTSD or
+                        other mental health problems linked to your service
+                        (including conditions related to an experience of
+                        military sexual trauma), you may qualify for VA health
+                        benefits right away, even without a VA Character of
+                        Discharge review or a discharge upgrade.
+                      </p>
+                      <p>Learn more about:</p>
+                      <ul>
+                        <li>
+                          <va-link
+                            href="/health-care/health-needs-conditions/military-sexual-trauma/"
+                            text="VA health benefits for Veterans who’ve experienced military sexual trauma"
+                          />
+                        </li>
+                        <li>
+                          <va-link
+                            href="/health-care/health-needs-conditions/mental-health/"
+                            text="VA health benefits for Veterans with mental health conditions"
+                          />
+                        </li>
+                        <li>
+                          <va-link
+                            href="/health-care/health-needs-conditions/mental-health/ptsd/"
+                            text="VA health benefits for Veterans with PTSD"
+                          />
+                        </li>
+                      </ul>
+                    </va-accordion-item>
+                    <va-accordion-item
+                      header="What if I already applied for an upgrade or correction and was denied?"
+                      uswds
+                    >
+                      <p>
+                        If your previous upgrade application was denied, you can
+                        apply again, but you may have to follow a different
+                        process. Click the <strong>Get Started</strong> button
+                        above. When you’re asked if you’ve applied before,
+                        select <strong>Yes</strong>. After you’ve answered all
+                        the questions, you’ll see application instructions
+                        specific to your situation.
+                      </p>
+                      <p>
+                        Applying again is most likely to be successful if your
+                        application is significantly different from when you
+                        last applied. For example, you may have additional
+                        evidence that wasn’t available to you when you last
+                        applied, or the Departent of Defense (DoD) may have
+                        issued new rules regarding discharges. DoD rules changed
+                        for discharges related to PTSD, TBI, and mental health
+                        in 2014, military sexual harassment and assault in 2017,
+                        and sexual orientation in 2011.
+                      </p>
+                    </va-accordion-item>
+                    <va-accordion-item
+                      header="What if I have discharges for more than one period of service?"
+                      uswds
+                    >
+                      <p>
+                        If the Department of Defense (DoD) or the Coast Guard
+                        determined you served honorably in one period of
+                        service, you may use that honorable characterization to
+                        establish eligibility for VA benefits, even if you later
+                        received a less than honorable discharge. You earned
+                        your benefits during the period in which you served
+                        honorably. Make sure you specifically mention your
+                        period of honorable service when applying for VA
+                        benefits.
+                      </p>
+                      <p>
+                        <strong>Note:</strong> The only exception is for
+                        service-connected disability compensation. You’re only
+                        eligible to earn disability compensation for
+                        disabilities you suffered during a period of honorable
+                        service. You can’t use an honorable discharge from one
+                        period of service to establish eligibility for a
+                        service-connected disability from a different period of
+                        service.
+                      </p>
+                    </va-accordion-item>
+                    <va-accordion-item
+                      header="What if I served honorably, but didn’t receive discharge paperwork?"
+                      uswds
+                    >
+                      <p>
+                        You’re eligible for VA benefits at the end of a period
+                        of honorable service, even if you didn’t receive a
+                        discharge in the form of a DD214. If you completed your
+                        original contract period without any disciplinary
+                        problems, you can use this period of service to
+                        establish your eligibility, even if you re-enlisted or
+                        extended your service and did not receive an “honorable”
+                        DD214 at the end of your second period of service. If
+                        you completed a period of honorable service that’s not
+                        reflected on a DD214, make sure you specifically mention
+                        this period of service when you apply for VA benefits.
+                        We may do a Character of Discharge review to confirm
+                        your eligibility.
+                      </p>
+                      <p>
+                        You can also apply to the Department of Defense (DoD) or
+                        the Coast Guard for a second DD214 only for that
+                        honorable period of service. Click the{' '}
+                        <strong>Get Started</strong> button above and answer the
+                        questions based on your most recent discharge. When
+                        you’re asked if you completed a period of service in
+                        which your character of service was honorable or general
+                        under honorable conditions, select: “Yes, I completed a
+                        prior period of service, but I did not receive discharge
+                        paperwork from that period.”
+                      </p>
+                    </va-accordion-item>
+                    <va-accordion-item
+                      header="What if I have a DD215 showing an upgraded discharge, but my DD214 still isn’t correct?"
+                      uswds
+                    >
+                      <p>
+                        When the Department of Defense (DoD) or the Coast Guard
+                        upgrades a Veteran’s discharge, it usually issues a
+                        DD215 showing corrections to the DD214. The DoD or the
+                        Coast Guard attaches the DD215 to the old DD214—which
+                        still shows the outdated discharge and related
+                        information. While the discharge on the DD215 is the
+                        correct discharge, a Veteran may still want a new DD214
+                        that shows no record of their earlier characterization
+                        of discharge.
+                      </p>
+                      <p>
+                        If you have a DD215 and want an updated DD214, click the{' '}
+                        <strong>Get Started</strong> button above. On the next
+                        page, select: “I received a discharge upgrade or
+                        correction, but my upgrade came in the form of a DD215,
+                        and I want an updated DD214.” After you’ve answered all
+                        the questions, you’ll see instructions for how to
+                        request a new DD214.
+                      </p>
+                    </va-accordion-item>
+                  </va-accordion>
                 </div>
               </div>
             </div>

--- a/src/applications/discharge-wizard/components/gpMinorComponents/AdditionalInstructions.jsx
+++ b/src/applications/discharge-wizard/components/gpMinorComponents/AdditionalInstructions.jsx
@@ -1,161 +1,116 @@
-// Dependencies
 import React from 'react';
 import PropTypes from 'prop-types';
-
-// Relative Imports
 import { board } from '../../helpers';
 
-const AdditionalInstructions = ({
-  formValues,
-  handleFAQToggle,
-  parentState,
-}) => {
+const AdditionalInstructions = ({ formValues }) => {
   const serviceBranch = formValues['1_branchOfService'];
 
   return (
     <section>
-      <div className="usa-accordion accordion-container">
-        {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
-        <ul className="usa-unstyled-list" role="list">
-          <li itemScope itemType="http://schema.org/Question">
-            <button
-              className="usa-button-unstyled usa-accordion-button"
-              aria-controls="dbq1"
-              itemProp="name"
-              name="q1"
-              aria-expanded={!!parentState?.q1}
-              onClick={handleFAQToggle}
+      <va-accordion uswds>
+        <va-accordion-item
+          header="What happens after I send in my application?"
+          uswds
+        >
+          <p>
+            The Board reviews nearly all applications within 18 months. You can
+            continue to submit supporting documentation until the Board has
+            reviewed your application.
+          </p>
+          <p>
+            If your application is successful, the Board will direct your
+            service personnel office to issue you either a DD215, which contains
+            updates to the DD214, or an entirely new DD214. If you get a new
+            DD214,{' '}
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://www.dpris.dod.mil/veteranaccess.html"
             >
-              What happens after I send in my application?
-            </button>
-            <div
-              id="dbq1"
-              className="usa-accordion-content"
-              itemProp="acceptedAnswer"
-              itemScope
-              itemType="http://schema.org/Answer"
-              aria-hidden={!parentState?.q1}
+              request a copy
+            </a>
+            .
+          </p>
+          <p>
+            If your appeal results in raising your discharge to honorable,
+            you’ll immediately be considered an eligible Veteran to VA, and you
+            can apply for VA benefits and services. For now, you may still apply
+            for VA eligibility by{' '}
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href="https://www.benefits.va.gov/BENEFITS/docs/COD_Factsheet.pdf"
             >
-              <div itemProp="text">
-                <p>
-                  The Board reviews nearly all applications within 18 months.
-                  You can continue to submit supporting documentation until the
-                  Board has reviewed your application.
-                </p>
-                <p>
-                  If your application is successful, the Board will direct your
-                  service personnel office to issue you either a DD215, which
-                  contains updates to the DD214, or an entirely new DD214. If
-                  you get a new DD214,{' '}
-                  <a
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href="https://www.dpris.dod.mil/veteranaccess.html"
-                  >
-                    request a copy
-                  </a>
-                  .
-                </p>
-                <p>
-                  If your appeal results in raising your discharge to honorable,
-                  you’ll immediately be considered an eligible Veteran to VA,
-                  and you can apply for VA benefits and services. For now, you
-                  may still apply for VA eligibility by{' '}
-                  <a
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href="https://www.benefits.va.gov/BENEFITS/docs/COD_Factsheet.pdf"
-                  >
-                    requesting a Character of Discharge review
-                  </a>
-                  .
-                </p>
-              </div>
-            </div>
-          </li>
-          <li itemScope itemType="http://schema.org/Question">
-            <button
-              className="usa-button-unstyled usa-accordion-button"
-              aria-controls="dbq2"
-              itemProp="name"
-              name="q2"
-              aria-expanded={!!parentState?.q2}
-              onClick={handleFAQToggle}
-            >
-              Can I get VA benefits without a discharge upgrade?
-            </button>
-            <div
-              id="dbq2"
-              className="usa-accordion-content"
-              itemProp="acceptedAnswer"
-              itemScope
-              itemType="http://schema.org/Answer"
-              aria-hidden={!parentState?.q2}
-            >
-              <div itemProp="text">
-                <p>
-                  Even with a less than honorable discharge, you may be able to
-                  access some VA benefits through the Character of Discharge
-                  review process. When you apply for VA benefits, we’ll review
-                  your record to determine if your service was “honorable for VA
-                  purposes.” This review can take up to a year. Please provide
-                  us with documents supporting your case, similar to the
-                  evidence you’d send with an application to upgrade your
-                  discharge.
-                </p>
-                <p>
-                  You may want to consider finding someone to advocate on your
-                  behalf, depending on the complexity of your case. A lawyer or
-                  Veterans Service Organization (VSO) can collect and submit
-                  supporting documents for you.{' '}
-                  <a href="https://www.benefits.va.gov/vso/varo.asp">
-                    Find a VSO near you.
-                  </a>
-                </p>
-                <p>
-                  <strong>Note:</strong> You can ask for a VA Character of
-                  Discharge review while at the same time applying for a
-                  discharge upgrade from the Department of Defense (DoD) or the
-                  Coast Guard.
-                </p>
-                <p>
-                  If you experienced sexual assault or harassment while in the
-                  military, or need mental health services related to PTSD or
-                  other mental health conditions linked to your service, you may
-                  qualify immediately for VA health benefits, even without a VA
-                  Character of Discharge review or a discharge upgrade.
-                </p>
-                <p>Learn more about:</p>
-                <ul>
-                  <li>
-                    <a href="/health-care/health-needs-conditions/military-sexual-trauma/">
-                      VA health benefits for Veterans who have experienced
-                      military sexual trauma
-                    </a>
-                  </li>
-                  <li>
-                    <a href="/health-care/health-needs-conditions/mental-health/">
-                      VA health benefits for Veterans with mental health
-                      conditions
-                    </a>
-                  </li>
-                  <li>
-                    <a href="/health-care/health-needs-conditions/mental-health/ptsd/">
-                      VA health benefits for Veterans with PTSD
-                    </a>
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </li>
-        </ul>
-      </div>
+              requesting a Character of Discharge review
+            </a>
+            .
+          </p>
+        </va-accordion-item>
+        <va-accordion-item
+          header="Can I get VA benefits without a discharge upgrade?"
+          uswds
+        >
+          <p>
+            Even with a less than honorable discharge, you may be able to access
+            some VA benefits through the Character of Discharge review process.
+            When you apply for VA benefits, we’ll review your record to
+            determine if your service was “honorable for VA purposes.” This
+            review can take up to a year. Please provide us with documents
+            supporting your case, similar to the evidence you’d send with an
+            application to upgrade your discharge.
+          </p>
+          <p>
+            You may want to consider finding someone to advocate on your behalf,
+            depending on the complexity of your case. A lawyer or Veterans
+            Service Organization (VSO) can collect and submit supporting
+            documents for you.{' '}
+            <va-link
+              href="https://www.benefits.va.gov/vso/varo.asp"
+              text="Find a VSO near you."
+            />
+          </p>
+          <p>
+            <strong>Note:</strong> You can ask for a VA Character of Discharge
+            review while at the same time applying for a discharge upgrade from
+            the Department of Defense (DoD) or the Coast Guard.
+          </p>
+          <p>
+            If you experienced sexual assault or harassment while in the
+            military, or need mental health services related to PTSD or other
+            mental health conditions linked to your service, you may qualify
+            immediately for VA health benefits, even without a VA Character of
+            Discharge review or a discharge upgrade.
+          </p>
+          <p>Learn more about:</p>
+          <ul>
+            <li>
+              <va-link
+                href="/health-care/health-needs-conditions/military-sexual-trauma/"
+                text="VA health benefits for Veterans who have experienced military sexual trauma"
+              />
+            </li>
+            <li>
+              <va-link
+                href="/health-care/health-needs-conditions/mental-health/"
+                text="VA health benefits for Veterans with mental health conditions"
+              />
+            </li>
+            <li>
+              <va-link
+                href="/health-care/health-needs-conditions/mental-health/ptsd/"
+                text="VA health benefits for Veterans with PTSD"
+              />
+            </li>
+          </ul>
+        </va-accordion-item>
+      </va-accordion>
       <h4>Additional Resources</h4>
       <hr />
       <ul className="additional-resources">
         <li>
           <a
             target="_blank"
+            rel="noopener noreferrer"
             href="/health-care/health-needs-conditions/military-sexual-trauma/"
           >
             VA health benefits for Veterans who experience military sexual
@@ -165,6 +120,7 @@ const AdditionalInstructions = ({
         <li>
           <a
             target="_blank"
+            rel="noopener noreferrer"
             href="/health-care/health-needs-conditions/mental-health/"
           >
             VA health benefits for Veterans with mental health conditions
@@ -173,6 +129,7 @@ const AdditionalInstructions = ({
         <li>
           <a
             target="_blank"
+            rel="noopener noreferrer"
             href="/health-care/health-needs-conditions/mental-health/ptsd/"
           >
             VA health benefits for Veterans with PTSD

--- a/src/applications/discharge-wizard/components/gpSteps/StepOne.jsx
+++ b/src/applications/discharge-wizard/components/gpSteps/StepOne.jsx
@@ -1,8 +1,5 @@
-// Dependencies
 import React from 'react';
 import PropTypes from 'prop-types';
-
-// Relative imports
 import AlertMessage from '../AlertMessage';
 import { board, formData } from '../../helpers';
 
@@ -155,50 +152,48 @@ const StepOne = ({ formValues }) => {
   );
 
   const form = formData(formValues);
+  const header = `Download and fill out DoD Form ${form.num}`;
+
   return (
-    <li className="list-group-item">
-      <div>
-        <h4>Download and fill out DoD Form {form.num}</h4>
-        <p>Important tips for completing Form {form.num}:</p>
-        {formValues['4_reason'] === '8' ? dd214Tips : nonDd2014Tips}
-        <a
-          target="_blank"
-          href={form.link}
-          rel="noopener noreferrer external"
-          className="usa-button-primary usa-button"
-        >
-          Download Form {form.num}
-        </a>
-        <AlertMessage
-          content={
-            <div>
-              <h4 className="usa-alert-heading">
-                Need help preparing your application?
-              </h4>
-              <p>
-                The process of preparing a discharge upgrade or correction
-                application can be a lot of work and can take a long time.
-                Although many Veterans are successful on their own, you may want
-                to consider finding someone to advocate for you in this process.
-                Try a Veterans Service Organization (VSO), search online for a
-                lawyer who may provide services for low or no cost, or ask other
-                Veterans for recommendations.{' '}
-                <a
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  href="https://www.benefits.va.gov/vso/varo.asp"
-                >
-                  Find a VSO near you
-                </a>
-                .
-              </p>
-            </div>
-          }
-          isVisible
-          status="warning"
-        />
-      </div>
-    </li>
+    <va-process-list-item header={header}>
+      <p>Important tips for completing Form {form.num}:</p>
+      {formValues['4_reason'] === '8' ? dd214Tips : nonDd2014Tips}
+      <va-link
+        class="vads-u-display--block vads-u-margin-bottom--1"
+        download
+        filetype="PDF"
+        href={form.link}
+        text={`Download Form ${form.num}`}
+      />
+      <AlertMessage
+        content={
+          <>
+            <h4 className="usa-alert-heading">
+              Need help preparing your application?
+            </h4>
+            <p>
+              The process of preparing a discharge upgrade or correction
+              application can be a lot of work and can take a long time.
+              Although many Veterans are successful on their own, you may want
+              to consider finding someone to advocate for you in this process.
+              Try a Veterans Service Organization (VSO), search online for a
+              lawyer who may provide services for low or no cost, or ask other
+              Veterans for recommendations.{' '}
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://www.benefits.va.gov/vso/varo.asp"
+              >
+                Find a VSO near you
+              </a>
+              .
+            </p>
+          </>
+        }
+        isVisible
+        status="warning"
+      />
+    </va-process-list-item>
   );
 };
 

--- a/src/applications/discharge-wizard/components/gpSteps/StepThree.jsx
+++ b/src/applications/discharge-wizard/components/gpSteps/StepThree.jsx
@@ -6,7 +6,7 @@ import moment from 'moment';
 // Relative imports
 import { board, branchOfService, venueAddress } from '../../helpers';
 
-const StepThree = ({ formValues, handlePrint }) => {
+const StepThree = ({ formValues }) => {
   const reasonCode = formValues['4_reason'];
   const noPrevApp = formValues['8_prevApplication'] === '2';
   const prevAppType = formValues['10_prevApplicationType'];
@@ -108,42 +108,42 @@ const StepThree = ({ formValues, handlePrint }) => {
     );
   }
 
+  const handlePrint = () => {
+    if (window.print) {
+      window.print();
+    }
+  };
+
   return (
-    <li className="list-group-item">
-      <div>
-        <h4>Mail your completed form and all supporting materials</h4>
+    <va-process-list-item header="Mail your completed form and all supporting materials">
+      <p>
+        There are a number of different boards that handle discharge upgrades
+        and corrections. Based on your answers on the previous page, you need to
+        apply to {boardExplanation}
+      </p>
+      {prevAppYear === '1' &&
+      ['BCNR', 'BCMR'].includes(board(formValues).abbr) ? (
         <p>
-          There are a number of different boards that handle discharge upgrades
-          and corrections. Based on your answers on the previous page, you need
-          to apply to {boardExplanation}
+          Your last application was made before the release of DoD guidance
+          related to discharges like yours. As a result, the Board may treat
+          your application as a new case. If possible, review the new policies
+          and state in your application how the change in policy is relevant to
+          your case.
         </p>
-        {prevAppYear === '1' &&
-        ['BCNR', 'BCMR'].includes(board(formValues).abbr) ? (
-          <p>
-            Your last application was made before the release of DoD guidance
-            related to discharges like yours. As a result, the Board may treat
-            your application as a new case. If possible, review the new policies
-            and state in your application how the change in policy is relevant
-            to your case.
-          </p>
-        ) : null}
-        <p>
-          Mail your completed form and all supporting documents to the{' '}
-          {boardToSubmit.abbr} at:
-        </p>
-        {venueAddress(formValues)}
-        {onlineSubmissionMsg}
-        <a href="#" onClick={handlePrint}>
-          Print this page
-        </a>
-      </div>
-    </li>
+      ) : null}
+      <p>
+        Mail your completed form and all supporting documents to the{' '}
+        {boardToSubmit.abbr} at:
+      </p>
+      {venueAddress(formValues)}
+      {onlineSubmissionMsg}
+      <va-button onClick={handlePrint} text="Print this page" />
+    </va-process-list-item>
   );
 };
 
 StepThree.propTypes = {
   formValues: PropTypes.object.isRequired,
-  handlePrint: PropTypes.func.isRequired,
 };
 
 export default StepThree;

--- a/src/applications/discharge-wizard/components/gpSteps/StepTwo.jsx
+++ b/src/applications/discharge-wizard/components/gpSteps/StepTwo.jsx
@@ -1,8 +1,5 @@
-// Dependencies
 import React from 'react';
 import PropTypes from 'prop-types';
-
-// Relative imports
 import { board } from '../../helpers';
 
 const renderMedicalRecordInfo = formValues => {
@@ -35,14 +32,13 @@ const renderMedicalRecordInfo = formValues => {
         <ul>
           <li>
             You can request your <strong>VA medical records</strong> by
-            submitting VA Form 10-5345 to your local VA Medical Center.{' '}
-            <a
+            submitting VA Form 10-5345 to your local VA Medical Center.
+            <br />
+            <va-link
               download
-              rel="noopener noreferrer"
-              href="https://www.va.gov/vaforms/medical/pdf/VHA%20Form%2010-5345%20Fill-revision.pdf"
-            >
-              Download VA Form 10-5345.
-            </a>
+              text="Download VA Form 10-5345"
+              href="https://www.va.gov/find-forms/about-form-10-5345/"
+            />
           </li>
           <li>{requestQuestion}</li>
           <li>
@@ -120,64 +116,60 @@ const StepOne = ({ formValues }) => {
   }
 
   return (
-    <li className="list-group-item">
-      <div>
-        <h4>Add supporting information</h4>
-        <p>
-          To improve your chances of success, also include as many of the below
-          documents as you can.
-        </p>
-        <ul>
-          <li>
-            <strong>Military Record</strong>: In most cases, your records will
-            be important to the Board’s decision. The Board may not have easy
-            access to your military records, especially if you served many years
-            ago, so we strongly recommend you submit any relevant documents
-            yourself.{' '}
-            {boardToSubmit.abbr !== 'DRB' ? (
-              <span>
-                Note that the {boardToSubmit.abbr} is required to help you
-                collect evidence if you can demonstrate you made a reasonable
-                attempt to get your records but you didn’t succeed.
-              </span>
-            ) : null}{' '}
-            {militaryRecordInfo}{' '}
-            {specificTypeInstruction && (
-              <p>
-                Remember, you should try to prove that {specificTypeInstruction}
-                . Submit any documents from this record that help support your
-                case for a discharge upgrade.
-              </p>
-            )}
-          </li>
-          {renderMedicalRecordInfo(formValues)}
-          <li>
-            <strong>“Buddy Statements” or Other References From Service</strong>
-            : On top of military records, you can attach statements from friends
-            or colleagues you knew while in the service, or other individuals
-            with direct knowledge of your time in the military. The content of
-            the letter is more important than who it comes from, as long as the
-            writer’s opinion is credible and they know you well. The writer
-            should state how they learned about the facts or opinions they’re
-            writing about. The letters may include statements about your
-            achievements in the military, positive relationships you formed in
-            the military, why your discharge may be unjust or incorrect, and
-            your good deeds during that time.
-          </li>
-          <li>
-            <strong>Testaments of Achievements Since Service</strong>: You may
-            decide to add information about what you have achieved in your life
-            since your discharge, particularly if your discharge involved any
-            issues related to drugs, alcohol, or bad behavior. This can be in
-            the form of a letter from an employer or community leader, evidence
-            of successful drug treatment, or copies of certificates and degrees.
-            The DoD will soon release more specific information about
-            achievements since service, but, for now, add any achievements you
-            would like to call out.
-          </li>
-        </ul>
-      </div>
-    </li>
+    <va-process-list-item header="Add supporting information">
+      <p>
+        To improve your chances of success, also include as many of the below
+        documents as you can.
+      </p>
+      <ul>
+        <li>
+          <strong>Military Record</strong>: In most cases, your records will be
+          important to the Board’s decision. The Board may not have easy access
+          to your military records, especially if you served many years ago, so
+          we strongly recommend you submit any relevant documents yourself.{' '}
+          {boardToSubmit.abbr !== 'DRB' ? (
+            <span>
+              Note that the {boardToSubmit.abbr} is required to help you collect
+              evidence if you can demonstrate you made a reasonable attempt to
+              get your records but you didn’t succeed.
+            </span>
+          ) : null}{' '}
+          {militaryRecordInfo}{' '}
+          {specificTypeInstruction && (
+            <p>
+              Remember, you should try to prove that {specificTypeInstruction}.
+              Submit any documents from this record that help support your case
+              for a discharge upgrade.
+            </p>
+          )}
+        </li>
+        {renderMedicalRecordInfo(formValues)}
+        <li>
+          <strong>“Buddy Statements” or Other References From Service</strong>:
+          On top of military records, you can attach statements from friends or
+          colleagues you knew while in the service, or other individuals with
+          direct knowledge of your time in the military. The content of the
+          letter is more important than who it comes from, as long as the
+          writer’s opinion is credible and they know you well. The writer should
+          state how they learned about the facts or opinions they’re writing
+          about. The letters may include statements about your achievements in
+          the military, positive relationships you formed in the military, why
+          your discharge may be unjust or incorrect, and your good deeds during
+          that time.
+        </li>
+        <li>
+          <strong>Testaments of Achievements Since Service</strong>: You may
+          decide to add information about what you have achieved in your life
+          since your discharge, particularly if your discharge involved any
+          issues related to drugs, alcohol, or bad behavior. This can be in the
+          form of a letter from an employer or community leader, evidence of
+          successful drug treatment, or copies of certificates and degrees. The
+          DoD will soon release more specific information about achievements
+          since service, but, for now, add any achievements you would like to
+          call out.
+        </li>
+      </ul>
+    </va-process-list-item>
   );
 };
 

--- a/src/applications/discharge-wizard/containers/GuidancePage.jsx
+++ b/src/applications/discharge-wizard/containers/GuidancePage.jsx
@@ -1,8 +1,7 @@
 // Dependencies
 import { connect } from 'react-redux';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import recordEvent from 'platform/monitoring/record-event';
 import localStorage from 'platform/utilities/storage/localStorage';
 
 // Relative imports
@@ -21,10 +20,6 @@ import { applyAirForcePortalLink } from '../helpers/selectors';
 
 export const GuidancePage = ({ formValues, showNewAirForcePortal, router }) => {
   const airForceAFRBAPortal = deriveIsAirForceAFRBAPortal(formValues);
-  const [accordionQuestionsState, setAccordionQuestionsState] = useState({
-    q1: false,
-    q2: false,
-  });
 
   useEffect(() => {
     // Redirect to the discharge wizard homepage if there isn't any form values in state.
@@ -43,23 +38,6 @@ export const GuidancePage = ({ formValues, showNewAirForcePortal, router }) => {
     [formValues],
   );
 
-  const handleFAQToggle = e => {
-    e.preventDefault();
-    recordEvent({ event: 'discharge-upgrade-faq-toggle' });
-    setAccordionQuestionsState({
-      ...accordionQuestionsState,
-      [e.target.name]: !accordionQuestionsState[e.target.name],
-    });
-  };
-
-  const handlePrint = e => {
-    e.preventDefault();
-    recordEvent({ event: 'discharge-upgrade-print' });
-    if (window.print) {
-      window.print();
-    }
-  };
-
   if (formValues?.questions?.length > 1) {
     return (
       <article className="dw-guidance">
@@ -74,22 +52,15 @@ export const GuidancePage = ({ formValues, showNewAirForcePortal, router }) => {
               <Warnings formValues={formValues} />
               <OptionalStep formValues={formValues} />
               <section>
-                <ul className="steps-list vertical-list-group more-bottom-cushion numbered">
+                <va-process-list uswds>
                   <StepOne formValues={formValues} />
                   <StepTwo formValues={formValues} />
-                  <StepThree
-                    formValues={formValues}
-                    handlePrint={handlePrint}
-                  />
-                </ul>
+                  <StepThree formValues={formValues} />
+                </va-process-list>
               </section>
             </>
           )}
-          <AdditionalInstructions
-            formValues={formValues}
-            handleFAQToggle={handleFAQToggle}
-            parentState={accordionQuestionsState}
-          />
+          <AdditionalInstructions formValues={formValues} />
         </div>
       </article>
     );

--- a/src/applications/discharge-wizard/containers/RequestDD214.jsx
+++ b/src/applications/discharge-wizard/containers/RequestDD214.jsx
@@ -41,9 +41,10 @@ const RequestDD214 = ({ router }) => {
             <div>
               <h4>
                 Download and fill out{' '}
-                <a href="https://www.esd.whs.mil/Portals/54/Documents/DD/forms/dd/dd0149.pdf">
-                  DoD Form 149
-                </a>
+                <va-link
+                  href="https://www.esd.whs.mil/Portals/54/Documents/DD/forms/dd/dd0149.pdf"
+                  text="DoD Form 149"
+                />
               </h4>
               <ul>
                 <li>

--- a/src/applications/discharge-wizard/sass/discharge-wizard.scss
+++ b/src/applications/discharge-wizard/sass/discharge-wizard.scss
@@ -9,6 +9,7 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
 
   .form-radio-buttons {
     position: relative;
+
     input {
       top: -15px;
     }
@@ -36,10 +37,6 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
     p {
       margin-top: 0;
     }
-  }
-
-  .accordion-container {
-    margin-bottom: 3em;
   }
 
   hr {
@@ -91,13 +88,6 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
     }
   }
 
-  .airForce-portal-link {
-    width: max-content;
-    i:hover {
-      color: $color-green-darker !important;
-    }
-  }
-
   .answers {
     border-bottom: 1px solid $color-gray-light;
   }
@@ -118,7 +108,7 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
   // Override styles for h2 semantic/ visual h4 headers(matches h4 visual styles)
   va-select::part(label) {
     font-family: "Bitter", "Georgia", "Cambria", "Times New Roman", "Times",
-    serif;
+      serif;
     font-size: 1.7rem;
     font-weight: bold;
   }

--- a/src/applications/discharge-wizard/tests/components/InstructionsPage.unit.spec.js
+++ b/src/applications/discharge-wizard/tests/components/InstructionsPage.unit.spec.js
@@ -10,7 +10,7 @@ describe('Discharge Wizard <InstructionsPage /> ', () => {
   it('should have the html elements', () => {
     const tree = mount(<InstructionsPage />);
     const html = tree.html();
-    expect(html).to.contain('Get started »');
+    expect(html).to.contain('Get started');
     expect(html).to.contain('How to Apply for a Discharge Upgrade');
     expect(tree.find('p[itemProp="description"]')).to.be.lengthOf(1);
     tree.unmount();

--- a/src/applications/discharge-wizard/tests/containers/GuidancePage.unit.spec.js
+++ b/src/applications/discharge-wizard/tests/containers/GuidancePage.unit.spec.js
@@ -74,19 +74,19 @@ describe('Discharge Wizard <GuidancePage />', () => {
         router={reactRouterStub}
       />,
     );
-    expect(tree.find('.usa-button-primary.usa-button')).to.have.lengthOf(1);
+    expect(tree.find('va-link[text*="Download Form"]')).to.have.lengthOf(1);
     tree.unmount();
   });
 
-  it('should have 1 button for the vet to print the', () => {
+  it('should have 1 button for the vet to print the page', () => {
     const tree = mount(
       <GuidancePage
         formValues={formValuesAllQuestionsListed}
         router={reactRouterStub}
       />,
     );
-    const content = tree.text();
-    expect(content).to.contain('Print this page');
+    const content = tree.find('va-button[text="Print this page"]');
+    expect(content).to.not.be.null;
     tree.unmount();
   });
 });

--- a/src/applications/discharge-wizard/tests/e2e/discharge-wizard.cypress.spec.js
+++ b/src/applications/discharge-wizard/tests/e2e/discharge-wizard.cypress.spec.js
@@ -19,7 +19,7 @@ describe('functionality of discharge wizard', () => {
     axeTestPage();
 
     // questions page | fill out form
-    cy.get('.main .usa-button-primary').click();
+    cy.get('.main .vads-c-action-link--green').click();
 
     cy.get('va-radio[name="1_branchOfService"] va-radio-option')
       .first()
@@ -57,12 +57,14 @@ describe('functionality of discharge wizard', () => {
     // a11y check after all elements are visible
     axeTestPage();
 
-    cy.get('.main .usa-button-primary').click();
+    cy.get('.main .vads-c-action-link--green').click();
 
     // a11y check on results page
     axeTestPage();
 
     // open Form download
-    cy.get('.main .usa-button-primary').click();
+    cy.get('.main va-link[download="true"]')
+      .first()
+      .click();
   });
 });

--- a/src/applications/resources-and-support/components/SearchBar.jsx
+++ b/src/applications/resources-and-support/components/SearchBar.jsx
@@ -187,7 +187,7 @@ function SearchBar({ onInputChange, previousValue, setSearchData, userInput }) {
               </div>
             </VaRadio>
           </div>
-          <p className="small-screen:vads-u-margin-top--2 medium-screen:vads-u-margin-top--1 vads-u-margin-bottom-0p5">
+          <p className="small-screen:vads-u-margin-top--2 medium-screen:vads-u-margin-top--1 vads-u-margin-bottom--0p5">
             Enter a keyword, phrase, or question
             {inputError && (
               <span


### PR DESCRIPTION
## Summary
Use all available v1 and v3 design system web components for Discharge Upgrade Wizard. There's a companion PR for this one that will remove the breadcrumbs prop for this app in content-build so we can fall back to using the web component in vets-website.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17252

## Testing done
Tested all pages manually.

## Screenshots

<details>
<summary>Breadcrumbs</summary>
<img width="446" alt="Screenshot 2024-03-05 at 10 40 25 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/299a7fe0-72a7-4476-92ca-f3428951abc2">
<img width="594" alt="Screenshot 2024-03-05 at 10 40 31 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/3fcc2b68-7848-4a14-abbd-e35d58c39a3d">

</details>

<details>
<summary>Action links</summary>

### Home page
<img width="863" alt="Screenshot 2024-03-05 at 10 52 50 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/6ccbb747-caea-4220-8d11-e4c946f85161">
<img width="483" alt="Screenshot 2024-03-05 at 10 52 57 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/385671e1-c4f6-49eb-84af-b02cb8edf540">

### Review page
<img width="189" alt="Screenshot 2024-03-05 at 2 48 30 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/0296404b-c81d-4695-a55d-3346013d9e3e">

</details>

<details>
<summary>Alert</summary>
<img width="726" alt="Screenshot 2024-03-05 at 11 05 03 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/4bc8d68e-70ca-401a-b592-628ef2d79067">
<img width="489" alt="Screenshot 2024-03-05 at 11 05 10 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/cd8e2924-fddc-464a-975e-6106ca1f9647">

</details>

<details>
<summary>Accordions</summary>

### Home page
<img width="467" alt="Screenshot 2024-03-05 at 2 43 35 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/77c51da1-38e5-48c8-8c96-8e5791ce25eb">
<img width="701" alt="Screenshot 2024-03-05 at 2 43 29 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/850268ec-51fc-4a19-a4e0-6a2b7a4d75a6">
<img width="711" alt="Screenshot 2024-03-05 at 2 43 25 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/f50b9b44-f228-43b9-943c-27a5a7fe4171">


### Results page
<img width="621" alt="Screenshot 2024-03-04 at 1 44 57 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/00960ff2-ba7b-48cf-9395-eb9134f0c32d">
<img width="655" alt="Screenshot 2024-03-04 at 1 45 01 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/1d26b52f-7f7b-40f8-93f9-74092ec66a38">
<img width="469" alt="Screenshot 2024-03-04 at 1 45 18 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/293a3aac-0874-4158-ad53-936143de7171">
</details>

## Acceptance criteria
 - [x] Links use V1
 - [x]  Action link is using the proper VADS class
  - [x] Accordion is using V3
  - [x] Process list is using V3
  - [x] Button /Download link is per guidance
  - [x] Breadcrumbs use v3 component
  - [x] other features display correctly
 - [x]  verify/review the E2E tests
  - [x] check desktop and mobile
 a11y review

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed