### PR TITLE
77121a add helpers for file listings

### DIFF
--- a/src/applications/ivc-champva/10-10D/components/File/MissingFileList.jsx
+++ b/src/applications/ivc-champva/10-10D/components/File/MissingFileList.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { Link } from 'react-router';
+import PropTypes from 'prop-types';
+import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { makeHumanReadable } from '../../helpers/utilities';
+
+// TODO: update makeHumanReadable() to improve file names
+
+/**
+ * Produce either a success message or a link to upload a file
+ * @param {object} file Object representing a missing file
+ * @param {string} entryName String of a person's name
+ * @param {number} index entry index number (used to target list-loop element)
+ * @returns JSX
+ */
+function alertOrLink(file, entryName, index) {
+  const t = `Upload ${entryName}'s ${makeHumanReadable(file.name)}`;
+  const href = file?.path
+    ? `${file?.path.replace(/:index/, index)}?fileReview=true`
+    : '';
+  return (
+    <>
+      {file.uploaded ? (
+        <VaAlert status="success" showIcon uswds>
+          <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
+            {`${entryName}'s `}
+            {makeHumanReadable(file.name)} uploaded
+          </p>
+        </VaAlert>
+      ) : (
+        <Link aria-label={t} to={href} className="vads-c-action-link--green">
+          {t}
+        </Link>
+      )}
+    </>
+  );
+}
+
+/**
+ * Produce an unordered list JSX component with a list of all missing files
+ * a user needs to upload.
+ * @param {object} param0 data: either an applicant obj or an entire formData obj
+ * nameKey: property name to access person's full name (e.g., 'applicantName')
+ * title: title text to display
+ * description: description text to display
+ * disableLinks: whether or not to show link to edit page
+ * @returns JSX
+ */
+export default function MissingFileList({
+  data,
+  nameKey,
+  title,
+  description,
+  disableLinks,
+}) {
+  // data: an array or a single object, must have 'missingUploads' on it
+  const wrapped = Array.isArray(data) ? data : [data];
+  if (
+    wrapped.length > 0 &&
+    wrapped
+      .flatMap(app => app.missingUploads)
+      .every(file => file.uploaded === true)
+  )
+    return <p>No missing uploads found</p>;
+
+  return (
+    <div>
+      <h4>{title || ''}</h4>
+      <p>{description || ''}</p>
+      {wrapped.map((entry, idx) => {
+        const entryName = `${entry[nameKey].first} ${entry[nameKey]?.middle ||
+          ''} ${entry[nameKey].last} ${entry[nameKey]?.suffix || ''}`;
+        return (
+          <div key={Object.keys(entry).join('') + idx}>
+            <strong>{entryName}</strong>
+            <ul>
+              {entry.missingUploads?.map((file, index) => (
+                <div key={file.name + file.uploaded + index}>
+                  <li>{makeHumanReadable(file.name)}</li>
+                  {!disableLinks ? alertOrLink(file, entryName, idx) : null}
+                </div>
+              ))}
+            </ul>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+MissingFileList.propTypes = {
+  data: PropTypes.array || PropTypes.object,
+  description: PropTypes.string,
+  disableLinks: PropTypes.bool,
+  nameKey: PropTypes.string,
+  title: PropTypes.string,
+};

--- a/src/applications/ivc-champva/10-10D/pages/SupportingDocumentsPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/SupportingDocumentsPage.jsx
@@ -1,0 +1,147 @@
+import React, { useState } from 'react';
+import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
+import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import PropTypes from 'prop-types';
+import {
+  identifyMissingUploads,
+  getConditionalPages,
+} from '../helpers/supportingDocsVerification';
+import MissingFileList from '../components/File/MissingFileList';
+
+/**
+ * TODO:
+ * - Implement way to tell if files are required or optional
+ *   - Add proper wording to top of page based on required status
+ * - Create follow-on page:
+ *   - Add checkbox acknowledging if any files have to be mailed in
+ */
+
+// TODO: find this wording elsewhere and collapse vars
+const optionalDescription =
+  'These files are not required to complete your application, but may prevent delays in your processing time.';
+// const requiredDescription =
+//  'These files are required to complete your application';
+
+export function checkFlags(pages, person, newListOfMissingFiles) {
+  // TODO: in here, add a flag that indicates if upload is required
+  const personUpdated = person; // shallow, updates reflect on actual form state
+
+  // Update missingUploads to account for any changes in conditional pages
+  personUpdated.missingUploads = personUpdated?.missingUploads?.filter(el =>
+    pages.flatMap(pg => pg.path).includes(el.path),
+  );
+
+  if (
+    personUpdated?.missingUploads === undefined ||
+    personUpdated?.missingUploads?.length === 0
+  ) {
+    // Track missing files and store if they get subsequently uploaded
+    const filesObj = newListOfMissingFiles.map(file => {
+      return { ...file, uploaded: false };
+    });
+    personUpdated.missingUploads = filesObj;
+  } else {
+    /*
+    Update the object created previously if they have uploaded a file
+    since it was identified as missing.
+    This lets us show the "Success" message for a file that was previously
+    missing but has since been uploaded.
+    */
+    const missingUploads = [];
+    personUpdated.missingUploads.forEach(el => {
+      if (newListOfMissingFiles.flatMap(file => file.name).includes(el.name)) {
+        missingUploads.push({ ...el, uploaded: false });
+      } else {
+        missingUploads.push({ ...el, uploaded: true });
+      }
+    });
+
+    // Update with any conditionally shown uploads that weren't in last list
+    const fm = personUpdated.missingUploads.flatMap(el => el.name);
+    newListOfMissingFiles.forEach(
+      el =>
+        !fm.includes(el.name)
+          ? missingUploads.push({ ...el, uploaded: false })
+          : null,
+    );
+    personUpdated.missingUploads = missingUploads; // Shallow
+  }
+  return personUpdated;
+}
+
+export default function SupportingDocumentsPage({
+  contentAfterButtons,
+  data,
+  goBack,
+  goForward,
+}) {
+  const navButtons = <FormNavButtons goBack={goBack} goForward={goForward} />;
+  const { chapters } = contentAfterButtons.props.formConfig;
+  // Create single list of pages from multiple chapter objects
+  const pages = Object.keys(chapters)
+    .map(ch => chapters?.[ch]?.pages)
+    .map(ch => Object.keys(ch).map(k => ch[k]))
+    .flat(1);
+
+  // eslint-disable-next-line no-unused-vars
+  const [apps, setApps] = useState(
+    // Filter out any conditional pages that don't apply to this applicant
+    data.applicants.map(app => {
+      const tmpData = { ...data, applicants: [app] };
+      const conditionalPages = getConditionalPages(pages, tmpData, 0);
+
+      // data.applicants will reflect changes
+      return checkFlags(
+        conditionalPages,
+        app,
+        identifyMissingUploads(conditionalPages, app, false),
+      );
+    }),
+  );
+
+  // Update sponsor to identify missing uploads (not in use currently)
+  // checkFlags(data, identifyMissingUploads(pages, data, true));
+
+  const filesAreMissing = apps
+    .flatMap(app => app.missingUploads)
+    .some(file => file.uploaded === false);
+
+  return (
+    <>
+      {/* TODO: conditional logic here based on required or optional */}
+      {titleUI('Upload your supporting files')['ui:title']}
+      {filesAreMissing ? (
+        <MissingFileList
+          data={apps}
+          nameKey="applicantName"
+          title="Optional"
+          description={optionalDescription}
+        />
+      ) : (
+        <>
+          <VaAlert status="success" uswds>
+            <h2>All supporting files uploaded</h2>
+            <p>
+              You will not need to mail or fax in any files. Your application
+              will be considered complete upon submission
+            </p>
+          </VaAlert>
+          <p>
+            You will not need to take any further action after submission of
+            your application.
+          </p>
+        </>
+      )}
+
+      {navButtons}
+    </>
+  );
+}
+
+SupportingDocumentsPage.propTypes = {
+  contentAfterButtons: PropTypes.object,
+  data: PropTypes.object,
+  goBack: PropTypes.func,
+  goForward: PropTypes.func,
+};


### PR DESCRIPTION
## Summary

This PR lays some groundwork for the supporting documents list page (being implemented in [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/28312)). It adds a new page component that will be used, as well as some helper functions to process data. No changes are made to the actual form with this PR, but these components will be used by future additions. This is an effort to keep PRs to a reasonable size.

- Adds new components for viewing lists of file uploads the user needs to provide
- Team: IVC-CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/77121

## Testing done

- Manual testing
- Ran `yarn test:coverage-app ivc-champva/10-10D` to verify existing tests run and pass

## Screenshots

NA, no interface changes actually occurred.

## What areas of the site does it impact?

This form only.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
