### PR TITLE
VYE-258

### DIFF
--- a/src/applications/verify-your-enrollment/components/EnrollmentVerificationBreadcrumbs.jsx
+++ b/src/applications/verify-your-enrollment/components/EnrollmentVerificationBreadcrumbs.jsx
@@ -14,7 +14,7 @@ export default function EnrollmentVerificationBreadcrumbs() {
       Education and training
     </a>,
     <a href={BASE_URL} key="enrollment-verification-page">
-      GI Bill® enrollment verifications
+      Montgomery GI Bill® Enrollment Verifications
     </a>,
   ];
 
@@ -27,7 +27,7 @@ export default function EnrollmentVerificationBreadcrumbs() {
   if ([BENEFITS_PROFILE_URL_SEGMENT].includes(page)) {
     breadcrumbs.push(
       <a href={BENEFITS_PROFILE_URL} key="BenefitsProfilePage">
-        Benefits profile
+        Your Benefits Profile
       </a>,
     );
   }

--- a/src/applications/verify-your-enrollment/tests/components/EnrollmentVerificationBreadcrumbs.unit.spec.js
+++ b/src/applications/verify-your-enrollment/tests/components/EnrollmentVerificationBreadcrumbs.unit.spec.js
@@ -35,9 +35,9 @@ describe('<EnrollmentVerificationBreadcrumbs>', () => {
     expect(breadcrumbs.at(0).text()).to.equal('Home');
     expect(breadcrumbs.at(1).text()).to.equal('Education and training');
     expect(breadcrumbs.at(2).text()).to.equal(
-      'GI Bill® enrollment verifications',
+      'Montgomery GI Bill® Enrollment Verifications',
     );
-    expect(breadcrumbs.at(3).text()).to.equal('Benefits profile');
+    expect(breadcrumbs.at(3).text()).to.equal('Your Benefits Profile');
 
     wrapper.unmount();
 
@@ -45,7 +45,7 @@ describe('<EnrollmentVerificationBreadcrumbs>', () => {
     delete window.location;
     window.location = location;
   });
-  it('does not include "Benefits profile" breadcrumb for other pages', () => {
+  it('does not include "Your Benefits profile" breadcrumb for other pages', () => {
     global.window = Object.create(window);
     Object.defineProperty(window, 'location', {
       value: {


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
- - This PR is to simply update the breadcrumb links in the Verify Your Enrollment application to match the current H1 tag.
- _(If bug, how to reproduce)_NA
- _(What is the solution, why is this the solution)_
- - Prior to this PR, the breadcrumb did not match exactly to the H1 of the current page. It does now.
- _(Which team do you work for, does your team own the maintenance of this component?)_
- - I work for GOVCIO we are the code owners of this change
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
- Using environment variable to keep the VYE app in staging while in development

## Related issue(s)

Jira ticket -> https://jira.devops.va.gov/browse/VYE-258

- Here is the Jira description for those that can not access Jira
As:
a VYE frontend developer
I need:
to update the breadcrumb on the Montgomery GI Bill enrollment verification page and the Your Benefits Profile page to match the h1 header of that page
So that:
the breadcrumb is in compliance
Considerations:
N/A
Acceptance Criteria:
Enter the acceptance criteria that will be used to test the user story.
Update breadcrumb for the Montgomery GI Bill enrollment verification page
Update breadcrumb for the Your Benefits Profile page
Testing Considerations:
Since this is a text change only, testing will be conducted visually on local machine and confirmed once in staging.
Other Considerations:
N/A
## Testing done

- _Describe what the old behavior was prior to the change_ NA
- _Describe the steps required to verify your changes are working as expected_
- - go to the VYE app in staging [http://localhost:3001/education/verify-your-enrollment](https://staging.va.gov/education/verify-your-enrollment/) and verify the breadcrumb is the same as the H1 for that page
- _Describe the tests completed and the results_
- - Unit test updated, visual test on local machine
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_NA

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

Before
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/88905347/11b8a77e-05a2-4be6-a6ca-5576b967e938)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/88905347/2c230c46-ea1e-4f9d-a6dd-c9ee186a9d7b)

After
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/88905347/701533b1-e9ad-409c-a0f3-c6816986f4f8)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/88905347/911233e9-e2a1-45b1-adb3-3db6282f81d0)



## What areas of the site does it impact?
-- This only impacts the Verify Your Enrollment app

## Acceptance criteria
-- Breadcrumbs match the current page's H1

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
