### PR TITLE
Setup directline mock

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -448,6 +448,8 @@ module.exports = async (env = {}) => {
         'process.env.VIRTUAL_AGENT_BACKEND_URL': JSON.stringify(
           process.env.VIRTUAL_AGENT_BACKEND_URL || '',
         ),
+        'process.env.USE_LOCAL_DIRECTLINE':
+          process.env.USE_LOCAL_DIRECTLINE || false,
       }),
 
       new webpack.ProvidePlugin({

--- a/src/applications/virtual-agent/components/webchat/WebChat.jsx
+++ b/src/applications/virtual-agent/components/webchat/WebChat.jsx
@@ -105,12 +105,15 @@ const WebChat = ({
     }
   }
 
+  const directlineDomain = process.env.USE_LOCAL_DIRECTLINE
+    ? 'http://localhost:3002/v3/directline'
+    : 'https://northamerica.directline.botframework.com/v3/directline';
+
   directLine = useMemo(
     () =>
       createDirectLine({
         token: directLineToken,
-        domain:
-          'https://northamerica.directline.botframework.com/v3/directline',
+        domain: directlineDomain,
         conversationId,
         watermark: '',
       }),


### PR DESCRIPTION
This change works in tandem with https://github.com/department-of-veterans-affairs/va-virtual-agent/pull/1596 to allow users to test skills locally using a directline mock within the vets-website chatbot.