### PR TITLE
Remove Caregivers cross-app import from mock forms

### DIFF
--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockCheckboxAndTextInput.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockCheckboxAndTextInput.js
@@ -6,9 +6,9 @@ import {
   ssnSchema,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { ssnUI } from 'applications/caregivers/definitions/UIDefinitions/sharedUI';
 import VaTextInputField from 'platform/forms-system/src/js/web-component-fields/VaTextInputField';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
+import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 
 /** @type {PageSchema} */
 export default {
@@ -28,13 +28,7 @@ export default {
         required: 'Checkbox required error',
       },
     },
-    rjsfCheckSsn: {
-      ...ssnUI('Social security number'),
-      'ui:title': 'Social security number',
-      'ui:errorMessages': {
-        required: 'Please enter a Social Security number',
-      },
-    },
+    rjsfCheckSsn: ssnUI('Social security number'),
     rjsfCheckboxWithBackground: {
       'ui:title': '',
       'ui:description': (

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockCheckboxAndTextInput.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockCheckboxAndTextInput.js
@@ -1,44 +1,16 @@
 import React from 'react';
 import {
-  inlineTitleSchema,
-  inlineTitleUI,
-  ssnUI as newSsnUI,
+  ssnUI,
   ssnSchema,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import VaTextInputField from 'platform/forms-system/src/js/web-component-fields/VaTextInputField';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
-import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    ...titleUI('RJSF / Widget'),
-    rjsfCheckSimpleTextInput: {
-      'ui:title': 'text input',
-    },
-    rjsfCheckRequiredCheckbox: {
-      'ui:title': 'required checkbox',
-      'ui:widget': 'checkbox',
-      'ui:options': {
-        hideLabelText: true,
-      },
-      'ui:errorMessages': {
-        enum: 'Please select a checkbox',
-        required: 'Checkbox required error',
-      },
-    },
-    rjsfCheckSsn: ssnUI('Social security number'),
-    rjsfCheckboxWithBackground: {
-      'ui:title': '',
-      'ui:description': (
-        <div className="vads-u-background-color--gray-light-alt">
-          <input type="checkbox" id="checkbox1" />
-          <label htmlFor="checkbox1">checkbox with background</label>
-        </div>
-      ),
-    },
-    'view:wcV3Title': inlineTitleUI('web component v3'),
+    ...titleUI('web component v3'),
     wcV3CheckSimpleText: {
       'ui:title': 'text input',
       'ui:webComponentField': VaTextInputField,
@@ -52,7 +24,7 @@ export default {
         required: 'Checkbox required error',
       },
     },
-    wcV3CheckSsn: newSsnUI('Social Security number'),
+    wcV3CheckSsn: ssnUI('Social Security number'),
     wcV3CheckboxWithBackground: {
       'ui:title': '',
       'ui:description': (
@@ -65,21 +37,6 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      rjsfCheckSimpleTextInput: {
-        type: 'string',
-      },
-      rjsfCheckRequiredCheckbox: {
-        type: 'boolean',
-        enum: [true],
-      },
-      rjsfCheckSsn: {
-        type: 'string',
-      },
-      rjsfCheckboxWithBackground: {
-        type: 'object',
-        properties: {},
-      },
-      'view:wcV3Title': inlineTitleSchema,
       wcV3CheckSimpleText: {
         type: 'string',
       },
@@ -94,9 +51,6 @@ export default {
       },
     },
     required: [
-      'rjsfCheckSimpleTextInput',
-      'rjsfCheckRequiredCheckbox',
-      'rjsfCheckSsn',
       'wcV3CheckSimpleText',
       'wcV3CheckRequiredCheckbox',
       'wcV3CheckSsn',

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockTextInputSsn.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockTextInputSsn.js
@@ -5,16 +5,13 @@ import {
   inlineTitleUI,
   inlineTitleSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { ssnUI } from 'applications/caregivers/definitions/UIDefinitions/sharedUI';
+import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
     ...titleUI('RJSF'),
-    ssn: {
-      ...ssnUI(),
-      'ui:title': 'Social security number',
-    },
+    ssn: ssnUI('Social security number'),
     vaFileNumber: {
       'ui:title': 'VA file number',
       'ui:errorMessages': {

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockTextInputSsn.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockTextInputSsn.js
@@ -5,13 +5,11 @@ import {
   inlineTitleUI,
   inlineTitleSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
     ...titleUI('RJSF'),
-    ssn: ssnUI('Social security number'),
     vaFileNumber: {
       'ui:title': 'VA file number',
       'ui:errorMessages': {
@@ -24,16 +22,13 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      ssn: {
-        $ref: '#/definitions/ssn',
-      },
       vaFileNumber: {
         $ref: '#/definitions/vaFileNumber',
       },
       'view:wcv3Title': inlineTitleSchema,
       wcv3SsnNew: ssnOrVaFileNumberSchema,
     },
-    required: ['ssn', 'wcv3SsnNew'],
+    required: ['wcv3SsnNew'],
   },
   initialData: {},
 };

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockTextInputSsn.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockTextInputSsn.js
@@ -2,30 +2,17 @@ import {
   ssnOrVaFileNumberUI,
   ssnOrVaFileNumberSchema,
   titleUI,
-  inlineTitleUI,
-  inlineTitleSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    ...titleUI('RJSF'),
-    vaFileNumber: {
-      'ui:title': 'VA file number',
-      'ui:errorMessages': {
-        pattern: 'Your VA file number must be 8 or 9 digits',
-      },
-    },
-    'view:wcv3Title': inlineTitleUI('Web component v3'),
+    ...titleUI('Web component v3'),
     wcv3SsnNew: ssnOrVaFileNumberUI(),
   },
   schema: {
     type: 'object',
     properties: {
-      vaFileNumber: {
-        $ref: '#/definitions/vaFileNumber',
-      },
-      'view:wcv3Title': inlineTitleSchema,
       wcv3SsnNew: ssnOrVaFileNumberSchema,
     },
     required: ['wcv3SsnNew'],

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockTextInputWidgets1.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockTextInputWidgets1.js
@@ -1,8 +1,6 @@
-import {
-  emailUI as emailOldUI,
-  ssnUI,
-} from 'applications/caregivers/definitions/UIDefinitions/sharedUI';
 import phoneOldUI from 'platform/forms-system/src/js/definitions/phone';
+import emailOldUI from 'platform/forms-system/src/js/definitions/email';
+import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 import {
   ssnUI as ssnNewUI,
   ssnSchema as ssnNewSchema,
@@ -19,15 +17,9 @@ import {
 export default {
   uiSchema: {
     ...titleUI('RJSF'),
-    emailOld: {
-      ...emailOldUI(),
-      'ui:title': 'TextWidget - emailUI',
-    },
+    emailOld: emailOldUI('TextWidget - emailUI'),
     phoneOld: phoneOldUI('TextWidget - phoneUI'),
-    ssnOld: {
-      ...ssnUI(),
-      'ui:title': 'TextWidget - ssnUI',
-    },
+    ssnOld: ssnUI('TextWidget - ssnUI'),
     'view:wcv3Title': inlineTitleUI('Web component v3'),
     wcv3TextEmailNew: emailUI({
       description:

--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockTextInputWidgets1.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockTextInputWidgets1.js
@@ -1,52 +1,30 @@
-import phoneOldUI from 'platform/forms-system/src/js/definitions/phone';
-import emailOldUI from 'platform/forms-system/src/js/definitions/email';
-import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 import {
-  ssnUI as ssnNewUI,
-  ssnSchema as ssnNewSchema,
+  ssnUI,
+  ssnSchema,
   titleUI,
   emailUI,
   emailSchema,
   phoneSchema,
   phoneUI,
-  inlineTitleUI,
-  inlineTitleSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 /** @type {PageSchema} */
 export default {
   uiSchema: {
-    ...titleUI('RJSF'),
-    emailOld: emailOldUI('TextWidget - emailUI'),
-    phoneOld: phoneOldUI('TextWidget - phoneUI'),
-    ssnOld: ssnUI('TextWidget - ssnUI'),
-    'view:wcv3Title': inlineTitleUI('Web component v3'),
+    ...titleUI('Web component v3'),
     wcv3TextEmailNew: emailUI({
       description:
         'By providing an email address, I agree to receive electronic correspondence from VA regarding my application',
     }),
     wcv3TextPhoneNew: phoneUI(),
-    wcv3TextSsnNew: ssnNewUI(),
+    wcv3TextSsnNew: ssnUI(),
   },
   schema: {
     type: 'object',
     properties: {
-      emailOld: {
-        type: 'string',
-        pattern: '^\\S+@\\S+$',
-      },
-      phoneOld: {
-        type: 'string',
-        minLength: 10,
-      },
-      ssnOld: {
-        type: 'string',
-        pattern: '^[0-9]{9}$',
-      },
-      'view:wcv3Title': inlineTitleSchema,
       wcv3TextEmailNew: emailSchema,
       wcv3TextPhoneNew: phoneSchema,
-      wcv3TextSsnNew: ssnNewSchema,
+      wcv3TextSsnNew: ssnSchema,
     },
     required: ['wcv3TextEmailNew'],
   },

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockCheckboxAndTextInput.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockCheckboxAndTextInput.unit.spec.jsx
@@ -1,7 +1,5 @@
 import {
-  testNumberOfErrorsOnSubmit,
   testNumberOfErrorsOnSubmitForWebComponents,
-  testNumberOfFields,
   testNumberOfWebComponentFields,
 } from '../../../shared/tests/pages/pageTests.spec';
 import formConfig from '../../config/form';
@@ -28,23 +26,5 @@ testNumberOfErrorsOnSubmitForWebComponents(
   schema,
   uiSchema,
   expectedNumberOfWebComponentErrors,
-  pageTitle,
-);
-
-const expectedNumberOfFields = 4;
-testNumberOfFields(
-  formConfig,
-  schema,
-  uiSchema,
-  expectedNumberOfFields,
-  pageTitle,
-);
-
-const expectedNumberOfErrors = 3;
-testNumberOfErrorsOnSubmit(
-  formConfig,
-  schema,
-  uiSchema,
-  expectedNumberOfErrors,
   pageTitle,
 );

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockTextInputSsn.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockTextInputSsn.unit.spec.jsx
@@ -28,7 +28,7 @@ testNumberOfErrorsOnSubmitForWebComponents(
   pageTitle,
 );
 
-const expectedNumberOfFields = 2;
+const expectedNumberOfFields = 1;
 testNumberOfFields(
   formConfig,
   schema,
@@ -37,7 +37,7 @@ testNumberOfFields(
   pageTitle,
 );
 
-const expectedNumberOfErrors = 1;
+const expectedNumberOfErrors = 0;
 testNumberOfErrorsOnSubmit(
   formConfig,
   schema,

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockTextInputSsn.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockTextInputSsn.unit.spec.jsx
@@ -1,7 +1,5 @@
 import {
-  testNumberOfErrorsOnSubmit,
   testNumberOfErrorsOnSubmitForWebComponents,
-  testNumberOfFields,
   testNumberOfWebComponentFields,
 } from '../../../shared/tests/pages/pageTests.spec';
 import formConfig from '../../config/form';
@@ -25,23 +23,5 @@ testNumberOfErrorsOnSubmitForWebComponents(
   schema,
   uiSchema,
   expectedNumberOfWebComponentErrors,
-  pageTitle,
-);
-
-const expectedNumberOfFields = 1;
-testNumberOfFields(
-  formConfig,
-  schema,
-  uiSchema,
-  expectedNumberOfFields,
-  pageTitle,
-);
-
-const expectedNumberOfErrors = 0;
-testNumberOfErrorsOnSubmit(
-  formConfig,
-  schema,
-  uiSchema,
-  expectedNumberOfErrors,
   pageTitle,
 );

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockTextInputWidgets1.unit.spec.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/pages/mockTextInputWidgets1.unit.spec.jsx
@@ -1,7 +1,5 @@
 import {
-  testNumberOfErrorsOnSubmit,
   testNumberOfErrorsOnSubmitForWebComponents,
-  testNumberOfFields,
   testNumberOfWebComponentFields,
 } from '../../../shared/tests/pages/pageTests.spec';
 import formConfig from '../../config/form';
@@ -28,23 +26,5 @@ testNumberOfErrorsOnSubmitForWebComponents(
   schema,
   uiSchema,
   expectedNumberOfWebComponentErrors,
-  pageTitle,
-);
-
-const expectedNumberOfFields = 3;
-testNumberOfFields(
-  formConfig,
-  schema,
-  uiSchema,
-  expectedNumberOfFields,
-  pageTitle,
-);
-
-const expectedNumberOfErrors = 0;
-testNumberOfErrorsOnSubmit(
-  formConfig,
-  schema,
-  uiSchema,
-  expectedNumberOfErrors,
   pageTitle,
 );


### PR DESCRIPTION
## Summary
The 1010 team is looking to move it's applications to the CD pipeline. In order to do so, we cannot have any cross-app imports with our applications. This PR converts an imported component to its own local file to remove the cross-app import.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#76209

## Acceptance criteria

- Form description successfully renders using local component
- Caregivers app contains no cross-app imports

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution