### PR TITLE
[CST] - Added logic to hide the details tab

### DIFF
--- a/src/applications/claims-status/components/TabNav.jsx
+++ b/src/applications/claims-status/components/TabNav.jsx
@@ -18,12 +18,14 @@ export default function TabNav({ id }) {
           tabpath={`your-claims/${id}/files`}
           title="Files"
         />
-        <TabItem
-          shortcut={3}
-          tabpath={`your-claims/${id}/details`}
-          title="Details"
-        />
         <Toggler toggleName={Toggler.TOGGLE_NAMES.cstUseClaimDetailsV2}>
+          <Toggler.Disabled>
+            <TabItem
+              shortcut={3}
+              tabpath={`your-claims/${id}/details`}
+              title="Details"
+            />
+          </Toggler.Disabled>
           <Toggler.Enabled>
             <TabItem
               shortcut={4}

--- a/src/applications/claims-status/routes.jsx
+++ b/src/applications/claims-status/routes.jsx
@@ -45,11 +45,13 @@ const routes = (
       <IndexRedirect to="status" />
       <Route component={ClaimStatusPage} path="status" />,
       <Route component={FilesPage} path="files" />,
-      <Route component={DetailsPage} path="details" />,
       <Toggler toggleName={Toggler.TOGGLE_NAMES.cstUseClaimDetailsV2}>
         <Toggler.Enabled>
           <Route component={OverviewPage} path="overview" />,
         </Toggler.Enabled>
+        <Toggler.Disabled>
+          <Route component={DetailsPage} path="details" />,
+        </Toggler.Disabled>
       </Toggler>
       <Route component={AskVAPage} path="ask-va-to-decide" />,
       <Route

--- a/src/applications/claims-status/tests/components/ClaimDetailLayout.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimDetailLayout.unit.spec.jsx
@@ -117,7 +117,7 @@ describe('<ClaimDetailLayout>', () => {
     expect(within(tabList).getAllByRole('listitem').length).to.equal(3);
   });
 
-  it('should render 4 tabs when toggle true', () => {
+  it('should render 3 tabs when toggle true', () => {
     const claim = {
       attributes: {
         claimType: 'Compensation',
@@ -133,7 +133,7 @@ describe('<ClaimDetailLayout>', () => {
     );
 
     const tabList = $('.tabs', container);
-    expect(within(tabList).getAllByRole('listitem').length).to.equal(4);
+    expect(within(tabList).getAllByRole('listitem').length).to.equal(3);
   });
 
   it('should render normal info', () => {

--- a/src/applications/claims-status/tests/components/TabNav.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/TabNav.unit.spec.jsx
@@ -30,14 +30,14 @@ describe('<TabNav>', () => {
   });
 
   context('cstUseClaimDetailsV2 feature toggle true', () => {
-    it('should render four tabs', () => {
+    it('should render three tabs', () => {
       const screen = render(
         <Provider store={getStore(true)}>
           <TabNav id={1} />
         </Provider>,
       );
 
-      expect(screen.getAllByRole('listitem').length).to.equal(4);
+      expect(screen.getAllByRole('listitem').length).to.equal(3);
     });
   });
 });

--- a/src/applications/claims-status/tests/components/evss/ClaimDetailLayout.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/evss/ClaimDetailLayout.unit.spec.jsx
@@ -168,7 +168,7 @@ describe('<ClaimDetailLayoutEVSS>', () => {
     expect(within(tabList).getAllByRole('listitem').length).to.equal(3);
   });
 
-  it('should render 4 tabs when toggle true', () => {
+  it('should render 3 tabs when toggle true', () => {
     const claim = {
       attributes: {
         claimType: 'Compensation',
@@ -184,7 +184,7 @@ describe('<ClaimDetailLayoutEVSS>', () => {
     );
 
     const tabList = $('.tabs', container);
-    expect(within(tabList).getAllByRole('listitem').length).to.equal(4);
+    expect(within(tabList).getAllByRole('listitem').length).to.equal(3);
   });
 
   it('should render normal info', () => {


### PR DESCRIPTION
## Summary

- Added logic to hide the details tab. When toggle `cst_use_claim_details_v2` is enabled it doesnt show and when its disabled it shows
- Updated test logic around tabs

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#76993

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Toggle on - Details tab doesn't show  | N/A | ![Screenshot 2024-03-06 at 3 24 59 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/ab8242fd-03f3-490c-b970-b5acabc1b6e7) |
| Toggle off - Details tab shows | N/A | ![Screenshot 2024-03-06 at 6 51 06 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/256f67fe-fa69-4303-a52e-03eae195fd4f) |

## What areas of the site does it impact?

Claim Status Tool

## Acceptance criteria

- [x]  Remove Detail tab and its contents from the tab list for a claim
- [x] This is behind the feature flag cst_use_claim_details_v2
- [x] When feature flag cst_use_claim_details_v2 is disabled, the Details tab still shows

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
