### PR TITLE
Add new missing file mail-consent screen

### DIFF
--- a/src/applications/ivc-champva/10-10D/pages/MissingFileConsentPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/MissingFileConsentPage.jsx
@@ -1,0 +1,217 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import { focusElement } from 'platform/utilities/ui';
+import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import {
+  VaAlert,
+  VaCheckboxGroup,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import {
+  identifyMissingUploads,
+  getConditionalPages,
+} from '../helpers/supportingDocsVerification';
+import MissingFileList from '../components/File/MissingFileList';
+import { mailInfo } from '../containers/ConfirmationPage';
+import {
+  optionalDescription,
+  requiredDescription,
+} from './SupportingDocumentsPage';
+
+// Return a boolean if there are any missing uploads where 'required'
+// matches expectedVal
+export function hasReq(data, isSponsor, expectedVal) {
+  return isSponsor
+    ? data.missingUploads.some(file => file.required === expectedVal)
+    : data.some(el =>
+        el.missingUploads.some(file => file.required === expectedVal),
+      );
+}
+
+export function MissingFileConsentPage(props) {
+  const { data } = props;
+  const { form } = props.contentAfterButtons.props;
+  const { veteransFullName } = data;
+  const [error, setError] = useState(undefined);
+  const [isChecked, setIsChecked] = useState(
+    data.consentToMailMissingRequiredFiles || false,
+  );
+
+  const applicantsWithMissingFiles = data.applicants
+    .map(applicant => {
+      const missing = identifyMissingUploads(
+        getConditionalPages(
+          form.pages,
+          { ...data, applicants: [applicant] },
+          0,
+        ),
+        applicant,
+        false,
+      );
+      if (missing.length !== 0) {
+        return {
+          name: applicant.applicantName,
+          missingUploads: missing,
+        };
+      }
+      return undefined;
+    })
+    .filter(el => el);
+
+  const sponsorMissingFiles = {
+    name: veteransFullName,
+    missingUploads: identifyMissingUploads(
+      getConditionalPages(form.pages, data),
+      data,
+      true,
+    ),
+  };
+
+  const requiredFilesStillMissing =
+    hasReq(sponsorMissingFiles, true, true) ||
+    hasReq(applicantsWithMissingFiles, false, true);
+
+  // Get the right alert
+  const alert = requiredFilesStillMissing ? (
+    <VaAlert uswds status="warning">
+      <h2>You have not uploaded all required supporting documents</h2>
+      <p>{requiredDescription}</p>
+    </VaAlert>
+  ) : (
+    <VaAlert uswds status="warning">
+      <h2>You have not uploaded all optional supporting documents</h2>
+      <p>{optionalDescription}</p>
+    </VaAlert>
+  );
+
+  const onGroupChange = event => {
+    setIsChecked(event.detail.checked);
+    return requiredFilesStillMissing && !event.detail.checked
+      ? setError('This field is required')
+      : setError(undefined);
+  };
+
+  const onGoForward = args => {
+    args.preventDefault();
+    // Prevent user advancing if acknowledgement box is unchecked
+    if (requiredFilesStillMissing && !isChecked) {
+      setError('This field is required');
+      return;
+    }
+    props.setFormData({
+      ...data,
+      consentToMailMissingRequiredFiles: isChecked,
+    });
+    props.goForward(args);
+  };
+
+  const navButtons = <FormNavButtons goBack={props.goBack} submitToContinue />;
+
+  useEffect(() => {
+    focusElement('h2');
+    scrollToTop('topScrollElement');
+  }, []);
+
+  return (
+    <form onSubmit={onGoForward}>
+      <div className="print-only">
+        <img
+          src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
+          alt="VA logo"
+          width="300"
+        />
+        <h2>Application for CHAMPVA benefits</h2>
+      </div>
+      {alert}
+      {hasReq(sponsorMissingFiles, true, true) ? (
+        <MissingFileList
+          data={sponsorMissingFiles}
+          nameKey="name"
+          title="Required"
+          description={requiredDescription}
+          disableLinks
+          subset="required"
+        />
+      ) : null}
+      {hasReq(sponsorMissingFiles, true, false) ? (
+        <MissingFileList
+          data={sponsorMissingFiles}
+          nameKey="name"
+          title="Optional"
+          description={optionalDescription}
+          disableLinks
+          subset="optional"
+        />
+      ) : null}
+      {hasReq(applicantsWithMissingFiles, false, true) ? (
+        <MissingFileList
+          data={applicantsWithMissingFiles}
+          nameKey="name"
+          title="Required"
+          description={requiredDescription}
+          disableLinks
+          subset="required"
+        />
+      ) : null}
+      {hasReq(applicantsWithMissingFiles, false, false) ? (
+        <MissingFileList
+          data={applicantsWithMissingFiles}
+          nameKey="name"
+          title="Optional"
+          description={optionalDescription}
+          disableLinks
+          subset="optional"
+        />
+      ) : null}
+      {sponsorMissingFiles.missingUploads || applicantsWithMissingFiles ? (
+        <>
+          {mailInfo()}
+          Your application will be considered complete upon submission
+        </>
+      ) : null}
+
+      <h3>Supporting files acknowledgement</h3>
+      <VaCheckboxGroup onVaChange={onGroupChange} error={error}>
+        {requiredFilesStillMissing ? (
+          <>
+            <va-checkbox
+              hint={null}
+              required
+              label="I understand that my application is not complete until VA receives my remaining required file(s) in the mail or by fax."
+              onBlur={function noRefCheck() {}}
+              checked={isChecked}
+              tile
+              uswds
+            />
+          </>
+        ) : null}
+      </VaCheckboxGroup>
+      {navButtons}
+    </form>
+  );
+}
+
+MissingFileConsentPage.propTypes = {
+  contentAfterButtons: PropTypes.shape({ props: PropTypes.any }),
+  data: PropTypes.shape({
+    applicants: PropTypes.array,
+    consentToMailMissingRequiredFiles: PropTypes.string,
+    statementOfTruthSignature: PropTypes.string,
+    veteransFullName: {
+      first: PropTypes.string,
+      last: PropTypes.string,
+      middle: PropTypes.string,
+      suffix: PropTypes.string,
+    },
+  }),
+  formId: PropTypes.string,
+  goBack: PropTypes.func,
+  goForward: PropTypes.func,
+  name: PropTypes.string,
+  pages: PropTypes.object,
+  setFormData: PropTypes.func,
+  submission: PropTypes.shape({
+    response: PropTypes.shape({ confirmationNumber: PropTypes.string }),
+    timestamp: PropTypes.string,
+  }),
+};


### PR DESCRIPTION
## Summary
This PR lays some more groundwork for the supporting documents list page (being implemented in https://github.com/department-of-veterans-affairs/vets-website/pull/28312). It adds a new page component that will be used, as well as some helper functions to process data. No changes are made to the actual form with this PR, but these components will be used by future additions. This is an effort to keep PRs to a reasonable size.

- Adds new components for viewing lists of file uploads the user needs to provide along with consent checkbox
- Team: IVC-CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/77121

## Testing done

- Manual testing
- Ran `yarn test:coverage-app ivc-champva/10-10D` to verify existing tests run and pass
## Screenshots

NA

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
