### PR TITLE
[CST] [DDL] [Frontend] Updated the doctypes for 5103 notices in the DDL

### DIFF
--- a/src/applications/claims-status/components/ClaimLetterListItem.jsx
+++ b/src/applications/claims-status/components/ClaimLetterListItem.jsx
@@ -14,8 +14,9 @@ const formatDate = buildDateFormatter(DATE_FORMATS.LONG_DATE);
 
 const docTypeToDescription = {
   27: 'Board Of Appeals Decision Letter',
-  65: '5103 Notice',
-  68: '5103 Notice',
+  704: '5103 Notice',
+  706: '5103 Notice',
+  858: '5103 Notice',
   184: 'Notification Letter',
 };
 


### PR DESCRIPTION
## Summary

- Our team discovered that the doctypes for 5103 Notices were different than we thought they were. We also discovered an additional 5103 notice document and have added that into the doctypes language map. We originally thought the doctypes were `65` & `68`, but our PM discovered they are actually `704`, `706`, and `858`.

## Related issue(s)

- [Add 5103 letter(s) to DDL](https://github.com/department-of-veterans-affairs/va.gov-team/issues/72464)
- [Updated the doctypes for 5103 notices in the DDL](https://github.com/department-of-veterans-affairs/vets-api/pull/15820)
