### PR TITLE
Update validation for Toxic Exposure month/year date fields

### DIFF
--- a/src/applications/hca/tests/unit/utils/validation.unit.spec.js
+++ b/src/applications/hca/tests/unit/utils/validation.unit.spec.js
@@ -105,9 +105,10 @@ describe('hca `validateGulfWarDates` form validation', () => {
     spy = () => {},
     startDate = '1990-09-XX',
     endDate = '1991-01-XX',
+    fieldName = 'gulfWarEndDate',
   }) => ({
     errors: {
-      gulfWarEndDate: {
+      [fieldName]: {
         addError: spy,
       },
     },
@@ -139,6 +140,33 @@ describe('hca `validateGulfWarDates` form validation', () => {
       expect(spy.called).to.be.true;
     });
   });
+
+  context('when only a month is provided to the end date', () => {
+    const spy = sinon.spy();
+    const { errors, fieldData } = getData({
+      endDate: 'XXXX-09-XX',
+      spy,
+    });
+
+    it('should set error message ', () => {
+      validateGulfWarDates(errors, fieldData);
+      expect(spy.called).to.be.true;
+    });
+  });
+
+  context('when only a month is provided to the start date', () => {
+    const spy = sinon.spy();
+    const { errors, fieldData } = getData({
+      fieldName: 'gulfWarStartDate',
+      startDate: 'XXXX-09-XX',
+      spy,
+    });
+
+    it('should set error message ', () => {
+      validateGulfWarDates(errors, fieldData);
+      expect(spy.called).to.be.true;
+    });
+  });
 });
 
 describe('hca `validateExposureDates` form validation', () => {
@@ -146,9 +174,10 @@ describe('hca `validateExposureDates` form validation', () => {
     spy = () => {},
     startDate = '1990-09-XX',
     endDate = '1991-01-XX',
+    fieldName = 'toxicExposureEndDate',
   }) => ({
     errors: {
-      toxicExposureEndDate: {
+      [fieldName]: {
         addError: spy,
       },
     },
@@ -172,6 +201,33 @@ describe('hca `validateExposureDates` form validation', () => {
     const spy = sinon.spy();
     const { errors, fieldData } = getData({
       endDate: '1989-09-XX',
+      spy,
+    });
+
+    it('should set error message ', () => {
+      validateExposureDates(errors, fieldData);
+      expect(spy.called).to.be.true;
+    });
+  });
+
+  context('when only a month is provided to the end date', () => {
+    const spy = sinon.spy();
+    const { errors, fieldData } = getData({
+      endDate: 'XXXX-09-XX',
+      spy,
+    });
+
+    it('should set error message ', () => {
+      validateExposureDates(errors, fieldData);
+      expect(spy.called).to.be.true;
+    });
+  });
+
+  context('when only a month is provided to the start date', () => {
+    const spy = sinon.spy();
+    const { errors, fieldData } = getData({
+      fieldName: 'toxicExposureStartDate',
+      startDate: 'XXXX-09-XX',
       spy,
     });
 

--- a/src/applications/hca/utils/validation.js
+++ b/src/applications/hca/utils/validation.js
@@ -44,11 +44,21 @@ export function validateGulfWarDates(
 ) {
   const fromDate = convertToDateField(gulfWarStartDate);
   const toDate = convertToDateField(gulfWarEndDate);
+  const messages = {
+    range: 'Service end date must be after the service start date',
+    format: 'Enter a date that includes a month and year',
+  };
 
   if (!isValidDateRange(fromDate, toDate)) {
-    errors.gulfWarEndDate.addError(
-      'Service end date must be after the service start date',
-    );
+    errors.gulfWarEndDate.addError(messages.range);
+  }
+
+  if (fromDate.month.value && !fromDate.year.value) {
+    errors.gulfWarStartDate.addError(messages.format);
+  }
+
+  if (toDate.month.value && !toDate.year.value) {
+    errors.gulfWarEndDate.addError(messages.format);
   }
 }
 
@@ -58,11 +68,21 @@ export function validateExposureDates(
 ) {
   const fromDate = convertToDateField(toxicExposureStartDate);
   const toDate = convertToDateField(toxicExposureEndDate);
+  const messages = {
+    range: 'Exposure end date must be after the exposure start date',
+    format: 'Enter a date that includes a month and year',
+  };
 
   if (!isValidDateRange(fromDate, toDate)) {
-    errors.toxicExposureEndDate.addError(
-      'Exposure end date must be after the exposure start date',
-    );
+    errors.toxicExposureEndDate.addError(messages.range);
+  }
+
+  if (fromDate.month.value && !fromDate.year.value) {
+    errors.toxicExposureStartDate.addError(messages.format);
+  }
+
+  if (toDate.month && !toDate.year) {
+    errors.toxicExposureEndDate.addError(messages.format);
   }
 }
 


### PR DESCRIPTION
## Summary
This PR updates the validation for the Toxic Exposure date questions on the Health Care Application. Previously, Veterans were able to input only a month and not a year value for the date. The updated validation does not permit this behavior--thus if the Veteran inputs a month value, they need to also include a year value.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#77804

## Testing done

- Prior to the change, a month value could be submitted without providing a year value.
- After the change, if a month value is provided the input will error if no year value is input.

## Screenshots

![Screenshot 2024-03-07 at 11 50 59](https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/4eafa8fd-c5dd-4d1a-856f-f652709de3e8)

## Acceptance criteria

- Validation is properly firing for the desired use case

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution