### PR TITLE
Add aria-label link attr to link to google maps

### DIFF
--- a/src/applications/representative-search/components/results/SearchResult.jsx
+++ b/src/applications/representative-search/components/results/SearchResult.jsx
@@ -139,6 +139,7 @@ const SearchResult = ({
                   tabIndex="0"
                   target="_blank"
                   rel="noreferrer"
+                  aria-label={`${address} (opens in a new tab)`}
                 >
                   {addressLine1}{' '}
                   {addressLine2 ? (

--- a/src/applications/representative-search/tests/components/SearchResult.unit.spec.jsx
+++ b/src/applications/representative-search/tests/components/SearchResult.unit.spec.jsx
@@ -81,6 +81,27 @@ describe('SearchResults', () => {
 
     wrapper.unmount();
   });
+  it('sets the aria-label on the address link', () => {
+    const wrapper = shallow(
+      <SearchResult
+        addressLine1="123 test place"
+        city="Columbus"
+        stateCode="CA"
+        zipCode="43210"
+      />,
+    );
+
+    const expectedAriaLabel =
+      '123 test place, Columbus, CA, 43210 (opens in new tab)';
+    const addressLink = wrapper.find('.address-link');
+
+    expect(
+      addressLink.prop('aria-label'),
+      'Aria label is set correctly',
+    ).to.equal(expectedAriaLabel);
+
+    wrapper.unmount();
+  });
 
   it('displays the "Thanks for reporting outdated information." message when reports are present', () => {
     const { queryByText } = render(

--- a/src/applications/representative-search/tests/components/SearchResult.unit.spec.jsx
+++ b/src/applications/representative-search/tests/components/SearchResult.unit.spec.jsx
@@ -92,9 +92,10 @@ describe('SearchResults', () => {
     );
 
     const expectedAriaLabel =
-      '123 test place, Columbus, CA, 43210 (opens in new tab)';
-    const addressLink = wrapper.find('.address-link');
+      '123 test place Columbus, CA 43210 (opens in a new tab)';
+    const addressLink = wrapper.find('.address-link a');
 
+    expect(addressLink.exists(), 'Address link exists').to.be.true;
     expect(
       addressLink.prop('aria-label'),
       'Aria label is set correctly',


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/77117

## Summary
Add an aria-label indicating that the address link will open in a new tab, eg. `300 S State St Chicago, IL 60604 (opens in a new tab),

## Related issue(s)

## Testing done
New test address

## Screenshots

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
