### PR TITLE
Add 1010 Apps to Change Apps Build list

### DIFF
--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -9,6 +9,10 @@
       "slackGroup": "<@U0329KDCJ0Y> <@U031KTDNYEP>"
     },
     {
+      "rootFolder": "caregivers",
+      "slackGroup": "@1010-fe-dev"
+    },
+    {
       "rootFolder": "check-in",
       "slackGroup": "@check-in-fe"
     },
@@ -43,6 +47,10 @@
       "rootFolder": "gi",
       "slackGroup": "<@U0243BHR2RZ> <@U026MB3UE5S> <@U024FPCTE6M>",
       "continuousDeployment": false
+    },
+    {
+      "rootFolder": "hca",
+      "slackGroup": "@1010-fe-dev"
     },
     {
       "rootFolder": "health-care-supply-reordering",


### PR DESCRIPTION
## Summary
This PR has been created in an effort to get two of the 1010 apps isolated and added to the CD allow-list.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#76209

## Testing done

- Cross-app import check has been performed on both applications and has passed
- Header test has been performed on both applications and has passed

## Screenshots
 
- See additional commented posts below 

## Acceptance criteria

- Applications meet the criteria to be approved for isolation
