### PR TITLE
Add updated file tracking component

### DIFF
--- a/src/applications/ivc-champva/10-10D/components/File/MissingFileOverview.jsx
+++ b/src/applications/ivc-champva/10-10D/components/File/MissingFileOverview.jsx
@@ -1,0 +1,344 @@
+import React, { useState } from 'react';
+import {
+  VaAlert,
+  VaCheckboxGroup,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
+import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import PropTypes from 'prop-types';
+import {
+  identifyMissingUploads,
+  getConditionalPages,
+} from '../../helpers/supportingDocsVerification';
+import MissingFileList from './MissingFileList';
+
+export const mailInfo = (
+  <>
+    Mail your files to:
+    <address className="vads-u-border-color--primary vads-u-border-left--4px vads-u-margin-left--3">
+      <p className="vads-u-padding-x--10px vads-u-margin-left--1">
+        VHA Office of Community Care
+        <br />
+        CHAMPVA Eligibility
+        <br />
+        P.O. Box 469028
+        <br />
+        Denver, CO 80246-9028
+        <br />
+        UnitedStates of America
+      </p>
+    </address>
+    Or fax your documents here:
+    <br />
+    VHA Office of Community Care CHAMPVA Eligibility, 303-331-7809
+  </>
+);
+
+export const optionalDescription =
+  'These files are not required to complete your application, but may prevent delays in your processing time.';
+export const requiredDescription =
+  'These files are required to complete your application';
+
+// Return a boolean if there are any missing uploads where 'required'
+// matches expectedVal. Optionally use dropUploaded if you want to ignore
+// required files that have already been uploaded.
+export function hasReq(data, expectedVal, dropUploaded = false) {
+  const wrapped = Array.isArray(data) ? data : [data];
+  return wrapped.some(el =>
+    el.missingUploads.some(
+      file =>
+        file.required === expectedVal && (dropUploaded ? !file.uploaded : true),
+    ),
+  );
+}
+
+// Helper function to manage object that tracks which files a user
+// has uploaded/still needs to upload
+export function checkFlags(pages, person, newListOfMissingFiles) {
+  const personUpdated = person; // shallow, updates reflect on actual form state
+  const wrapped = Array.isArray(pages)
+    ? pages
+    : Object.keys(pages).map(pg => pages[pg]); // On confirmation, "pages" is obj
+
+  // Update missingUploads to account for any changes in conditional pages
+  personUpdated.missingUploads = personUpdated?.missingUploads?.filter(el =>
+    wrapped.flatMap(pg => pg.path).includes(el.path),
+  );
+
+  if (
+    personUpdated?.missingUploads === undefined ||
+    personUpdated?.missingUploads?.length === 0
+  ) {
+    // Track missing files and store if they get subsequently uploaded
+    const filesObj = newListOfMissingFiles.map(file => {
+      return { ...file, uploaded: false };
+    });
+    personUpdated.missingUploads = filesObj;
+  } else {
+    /*
+    Update the object created previously if they have uploaded a file
+    since it was identified as missing.
+    This lets us show the "Success" message for a file that was previously
+    missing but has since been uploaded.
+    */
+    const missingUploads = [];
+    personUpdated.missingUploads.forEach(el => {
+      if (newListOfMissingFiles.flatMap(file => file.name).includes(el.name)) {
+        missingUploads.push({ ...el, uploaded: false });
+      } else {
+        missingUploads.push({ ...el, uploaded: true });
+      }
+    });
+
+    // Update with any conditionally shown uploads that weren't in last list
+    const fm = personUpdated.missingUploads.flatMap(el => el.name);
+    newListOfMissingFiles.forEach(
+      el =>
+        !fm.includes(el.name)
+          ? missingUploads.push({ ...el, uploaded: false })
+          : null,
+    );
+    personUpdated.missingUploads = missingUploads; // Shallow
+  }
+  return personUpdated;
+}
+
+export default function MissingFileOverview({
+  contentAfterButtons,
+  data,
+  goBack,
+  goForward,
+  setFormData,
+  disableLinks,
+  heading,
+  optionalWarningHeading,
+  requiredWarningHeading,
+  showMail,
+  showConsent,
+  allPages,
+}) {
+  const [error, setError] = useState(undefined);
+  const [isChecked, setIsChecked] = useState(
+    data?.consentToMailMissingRequiredFiles || false,
+  );
+  const navButtons = <FormNavButtons goBack={goBack} submitToContinue />;
+  const chapters = contentAfterButtons?.props?.formConfig?.chapters;
+  // Create single list of pages from multiple chapter objects
+  const pages =
+    allPages ||
+    Object.keys(chapters)
+      .map(ch => chapters?.[ch]?.pages)
+      .map(ch => Object.keys(ch).map(k => ch[k]))
+      .flat(1);
+
+  // eslint-disable-next-line no-unused-vars
+  const apps =
+    // Filter out any conditional pages that don't apply to this applicant
+    data.applicants.map(app => {
+      const tmpData = { ...data, applicants: [app] };
+      const conditionalPages = getConditionalPages(pages, tmpData, 0);
+
+      // data.applicants will reflect changes
+      return checkFlags(
+        conditionalPages,
+        app,
+        identifyMissingUploads(conditionalPages, app, false),
+      );
+    });
+
+  const applicantsWithMissingFiles = data.applicants
+    .map(applicant => {
+      const missing = identifyMissingUploads(
+        getConditionalPages(pages, { ...data, applicants: [applicant] }, 0),
+        applicant,
+        false,
+      );
+      if (missing.length !== 0) {
+        return {
+          name: applicant.applicantName,
+          missingUploads: missing,
+        };
+      }
+      return undefined;
+    })
+    .filter(el => el);
+
+  // Update sponsor to identify missing uploads
+  const sponsorMiss = {
+    name: data.veteransFullName,
+    missingUploads: checkFlags(
+      pages,
+      data,
+      identifyMissingUploads(getConditionalPages(pages, data), data, true),
+    ).missingUploads,
+  };
+
+  const requiredFilesStillMissing =
+    hasReq(sponsorMiss, true, showConsent) ||
+    hasReq(applicantsWithMissingFiles, true, showConsent);
+
+  const filesAreMissing =
+    requiredFilesStillMissing ||
+    hasReq(sponsorMiss, false, showConsent) ||
+    hasReq(apps, false, showConsent);
+
+  const onGroupChange = event => {
+    setIsChecked(event.detail.checked);
+    return requiredFilesStillMissing && !event.detail.checked
+      ? setError('This field is required')
+      : setError(undefined);
+  };
+
+  const onGoForward = args => {
+    args.preventDefault();
+    // Prevent user advancing if acknowledgement box is unchecked
+    if (showConsent === true && requiredFilesStillMissing && !isChecked) {
+      setError('This field is required');
+      return;
+    }
+    setFormData({
+      ...data,
+      consentToMailMissingRequiredFiles: isChecked,
+    });
+    goForward(args);
+  };
+
+  const defaultHeading = (
+    <>
+      {titleUI('Upload your supporting files')['ui:title']}
+      {filesAreMissing ? (
+        <>
+          <p>
+            <i>
+              Any required supporting files that are not uploaded will need to
+              be mailed in before your application is considered complete
+            </i>
+          </p>
+          <p>
+            If you choose not to upload your files, we’ll provide instructions
+            on how to send them to us by mail or fax.
+          </p>
+          <p>Uploading may result in a faster processing time.</p>
+        </>
+      ) : null}
+    </>
+  );
+
+  let displayHeading = defaultHeading;
+  if (requiredWarningHeading && requiredFilesStillMissing) {
+    displayHeading = requiredWarningHeading;
+  } else if (optionalWarningHeading && filesAreMissing) {
+    displayHeading = optionalWarningHeading;
+  } else if (heading && !requiredFilesStillMissing && !showConsent) {
+    displayHeading = heading;
+  }
+  return (
+    <form onSubmit={onGoForward}>
+      {displayHeading}
+
+      {filesAreMissing ? (
+        <>
+          {hasReq(sponsorMiss, true, showConsent) ? (
+            <MissingFileList
+              data={sponsorMiss}
+              nameKey="name"
+              title="Required"
+              subset="required"
+              description={requiredDescription}
+              disableLinks={disableLinks}
+            />
+          ) : null}
+
+          {hasReq(sponsorMiss, false, showConsent) ? (
+            <MissingFileList
+              data={sponsorMiss}
+              nameKey="name"
+              title="Optional"
+              subset="optional"
+              description={optionalDescription}
+              disableLinks={disableLinks}
+            />
+          ) : null}
+          {hasReq(apps, true, showConsent) ? (
+            <MissingFileList
+              data={apps}
+              nameKey="applicantName"
+              title="Required"
+              subset="required"
+              description={requiredDescription}
+              disableLinks={disableLinks}
+            />
+          ) : null}
+          {hasReq(apps, false, showConsent) ? (
+            <MissingFileList
+              data={apps}
+              nameKey="applicantName"
+              title="Optional"
+              subset="optional"
+              description={optionalDescription}
+              disableLinks={disableLinks}
+            />
+          ) : null}
+          {requiredFilesStillMissing && showMail ? (
+            <>
+              {mailInfo}
+              Your application will be considered complete upon submission
+            </>
+          ) : null}
+          {requiredFilesStillMissing && showConsent ? (
+            <>
+              <h3>Supporting files acknowledgement</h3>
+              <VaCheckboxGroup onVaChange={onGroupChange} error={error}>
+                {requiredFilesStillMissing ? (
+                  <>
+                    <va-checkbox
+                      hint={null}
+                      required
+                      label="I understand that my application is not complete until VA receives my remaining required file(s) in the mail or by fax."
+                      onBlur={function noRefCheck() {}}
+                      checked={isChecked}
+                      tile
+                      uswds
+                    />
+                  </>
+                ) : null}
+              </VaCheckboxGroup>
+            </>
+          ) : null}
+        </>
+      ) : null}
+      {goForward && !filesAreMissing ? (
+        <>
+          <VaAlert status="success" uswds>
+            <h2>All supporting files uploaded</h2>
+            <p>
+              You will not need to mail or fax in any files. Your application
+              will be considered complete upon submission
+            </p>
+          </VaAlert>
+          <p>
+            You will not need to take any further action after submission of
+            your application.
+          </p>
+        </>
+      ) : null}
+
+      {goForward ? navButtons : null}
+    </form>
+  );
+}
+
+MissingFileOverview.propTypes = {
+  allPages: PropTypes.any,
+  contentAfterButtons: PropTypes.object,
+  data: PropTypes.object,
+  disableLinks: PropTypes.bool,
+  goBack: PropTypes.func,
+  goForward: PropTypes.func,
+  heading: PropTypes.node,
+  optionalWarningHeading: PropTypes.node,
+  requiredWarningHeading: PropTypes.node,
+  setFormData: PropTypes.func,
+  showConsent: PropTypes.bool,
+  showMail: PropTypes.bool,
+};

--- a/src/applications/ivc-champva/10-10D/components/File/MissingFileOverview.jsx
+++ b/src/applications/ivc-champva/10-10D/components/File/MissingFileOverview.jsx
@@ -25,7 +25,7 @@ export const mailInfo = (
         <br />
         Denver, CO 80246-9028
         <br />
-        UnitedStates of America
+        United States of America
       </p>
     </address>
     Or fax your documents here:


### PR DESCRIPTION
## Summary
This PR adds a component for the supporting documents list page (being implemented in https://github.com/department-of-veterans-affairs/vets-website/pull/28312). It adds a new page component that will replace existing code in the confirmation page, as well as some helper functions to process data. No changes are made to the actual form with this PR, but these components will be used by future additions. This is an effort to keep PRs to a reasonable size.

- Adds new components for viewing lists of file uploads the user needs to provide along with consent checkbox
- Team: IVC-CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/77121

## Testing done

- Manual testing
- Ran `yarn test:coverage-app ivc-champva/10-10D` to verify existing tests run and pass
## Screenshots

NA

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
