### PR TITLE
Render saved page content

### DIFF
--- a/src/platform/site-wide/wc-loader.js
+++ b/src/platform/site-wide/wc-loader.js
@@ -5,6 +5,11 @@ import {
   defineCustomElements,
 } from '@department-of-veterans-affairs/component-library';
 
-applyPolyfills().then(() => {
-  defineCustomElements();
-});
+// Don't initialize web components on saved pages because this causes the
+// content to become hidden. It does end up breaking the styling, but this is
+// better than not being able to see the internal content
+if (window.location?.protocol !== 'file:') {
+  applyPolyfills().then(() => {
+    defineCustomElements();
+  });
+}

--- a/src/platform/startup/react.js
+++ b/src/platform/startup/react.js
@@ -45,6 +45,14 @@ export default function startReactApp(
     return;
   }
 
+  // Don't over-write content within the react-root if this is a saved page
+  // loaded directly into a browser - this allows Veteran's to save pages and
+  // view them later. Otherwise, calling render will clear out the content &
+  // render a header & footer with no content
+  if (window.location?.protocol === 'file:') {
+    return;
+  }
+
   if (document.readyState !== 'loading') {
     ReactDOM.render(component, root);
   } else {

--- a/src/platform/startup/tests/react.unit.spec.js
+++ b/src/platform/startup/tests/react.unit.spec.js
@@ -47,4 +47,22 @@ describe('startReactApp', () => {
     startReactApp(FakeWidget, document.getElementById('another-widget-root'));
     expect(renderStub.called).to.be.false;
   });
+
+  it('should not render the component if the window location indicates loading in a locally saved file', () => {
+    // Method from https://stackoverflow.com/a/54021633
+    global.window = Object.create(window);
+    Object.defineProperty(window, 'location', {
+      value: { protocol: 'file:' },
+      writable: true,
+    });
+
+    startReactApp(FakeWidget, document.getElementById('widget-root'));
+    expect(renderStub.called).to.be.false;
+
+    // restore
+    Object.defineProperty(window, 'location', {
+      value: { protocol: 'http:' },
+      writable: false,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > When a web page is saved from VA.gov (Command ⌘ + S or Control Ctrl + S), the page saves an HTML and folder with associated files. When you open the HTML page, it renders the VA.gov header & footer, but no content. Not showing any content makes the saved page not work as expected.
  > This PR adds code to skip rendering and initializing web component by detecting the `window.location.protocol` of `file:`, which is set when an HTML page is rendered in the browser from a local drive. The React render is bypassed because it would otherwise overwrite the saved page content and only render the header & footer (see screenshot). The web component initialization is bypasses because initialization causes the content inside the web component to become hidden. Bypassing web component initialization results in the web component and its content being rendered without any styling. This is not ideal, but better than hiding the content entirely (see screenshots)
  >
  > Note: there is a **potential for this code change to break the entire website**, so we need a thorough review and check of it working in the review instance & staging environments before it gets deployed into production
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Veterans are saving form confirmation pages, and possibly other pages within the site; this allows them to view the content of the saved page
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#76675](https://github.com/department-of-veterans-affairs/va.gov-team/issues/76675)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before |
| ------- |  ----- |
| [Example page](https://staging.va.gov/decision-reviews/submitted-appeal/)  | <img width="717" alt="Board Appeal - before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/ff3410b7-c4e5-4e97-a813-c4d629aa11d4"> |
| Saved page loaded - current behavior (shows only header & footer) | <img width="698" alt="Board Appeal - current" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/0f918462-8f76-4c42-bfbb-25841d79783d"> |
| Save page loaded - new behavior (web components visible, but unstyled) | <img width="777" alt="Board Appeal - after" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/ac3086da-8495-4eee-8e41-b88c2a60922f"> |

## What areas of the site does it impact?

Entire website!

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
