### PR TITLE
10-7959f-1 Review and Confirmation pages

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -37,6 +37,7 @@ const formConfig = {
         'I confirm that the identifying information in this form is accurate and has been represented correctly.',
       messageAriaDescribedby:
         'I confirm that the identifying information in this form is accurate and has been represented correctly.',
+      fullNamePath: 'fullName',
     },
   },
   formId: '10-7959F-1',

--- a/src/applications/ivc-champva/10-7959f-1/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/ConfirmationPage.jsx
@@ -44,7 +44,8 @@ export class ConfirmationPage extends React.Component {
             <p>
               <strong>Who submitted this form</strong>
               <br />
-              <span>Test A. Tester</span>
+              {data.statementOfTruthSignature}
+              <br />
             </p>
           ) : null}
 
@@ -81,6 +82,7 @@ export class ConfirmationPage extends React.Component {
 ConfirmationPage.propTypes = {
   form: PropTypes.shape({
     data: PropTypes.shape({
+      statementOfTruthSignature: PropTypes.string,
       fullName: {
         first: PropTypes.string,
         middle: PropTypes.string,


### PR DESCRIPTION
## Summary
This is a small PR updating the Review and Confirmation pages with the name/name validation for SOT and who submitted info

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/74868

## Testing done
Unit tests ran to ensure all passing
Manual testing

## Screenshots
![Screenshot 2024-03-08 at 11 21 09 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/ae0ce5f9-23ee-4560-b2c2-392c31713d70)
![Screenshot 2024-03-08 at 11 20 59 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/1c58086b-a0d8-44f9-a28b-307b93bbbc2a)

## What areas of the site does it impact?
ivc-forms

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA