### PR TITLE
[CST] - Update Files and Overview Tabs for closed status

### DIFF
--- a/src/applications/claims-status/components/ClaimTimeline.jsx
+++ b/src/applications/claims-status/components/ClaimTimeline.jsx
@@ -62,23 +62,7 @@ export default function ClaimTimeline({ currentPhaseBack, id, events, phase }) {
           current={userPhase}
           activity={activityByPhase}
           id={id}
-        >
-          {userPhase === 5 && (
-            <div>
-              <p>
-                We mailed you a decision letter. It should arrive within 10 days
-                after the date we decided your claim. It can sometimes take
-                longer.
-              </p>
-              <h5 className="vads-u-font-size--h4">Payments</h5>
-              <p>
-                If you are entitled to back payment (based on an effective
-                date), you can expect to receive payment within 1 month of your
-                claim’s decision date.
-              </p>
-            </div>
-          )}
-        </ClaimPhase>
+        />
       </ol>
     </>
   );

--- a/src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx
@@ -40,6 +40,7 @@ import {
   getTrackedItems,
   getFilesNeeded,
   getFilesOptional,
+  isClaimOpen,
 } from '../../utils/helpers';
 
 const scrollToError = () => {
@@ -101,7 +102,10 @@ class AdditionalEvidencePage extends React.Component {
     const filesPath = `your-claims/${this.props.params.id}/additional-evidence`;
     let content;
 
-    // TODO: Add logic for isOpen and then add that to the if statement here
+    const isOpen = isClaimOpen(
+      this.props.claim.attributes.status,
+      this.props.claim.attributes.closeDate,
+    );
 
     if (this.props.loading) {
       content = (
@@ -127,49 +131,58 @@ class AdditionalEvidencePage extends React.Component {
             </>
           )}
           <h3 className="vads-u-margin-bottom--3">Additional evidence</h3>
-          {this.props.filesNeeded.map(item => (
-            <FilesNeeded
-              key={getTrackedItemId(item)}
-              id={this.props.claim.id}
-              item={item}
-            />
-          ))}
-          {this.props.filesOptional.map(item => (
-            <FilesOptional
-              key={getTrackedItemId(item)}
-              id={this.props.claim.id}
-              item={item}
-            />
-          ))}
-          <AddFilesForm
-            field={this.props.uploadField}
-            progress={this.props.progress}
-            uploading={this.props.uploading}
-            files={this.props.files}
-            backUrl={this.props.lastPage || filesPath}
-            onSubmit={() => {
-              // START lighthouse_migration
-              if (this.props.documentsUseLighthouse) {
-                this.props.submitFilesLighthouse(
-                  this.props.claim.id,
-                  null,
-                  this.props.files,
-                );
-              } else {
-                this.props.submitFiles(
-                  this.props.claim.id,
-                  null,
-                  this.props.files,
-                );
-              }
-              // END lighthouse_migration
-            }}
-            onAddFile={this.props.addFile}
-            onRemoveFile={this.props.removeFile}
-            onFieldChange={this.props.updateField}
-            onCancel={this.props.cancelUpload}
-            onDirtyFields={this.props.setFieldsDirty}
-          />
+          {isOpen ? (
+            <>
+              {this.props.filesNeeded.map(item => (
+                <FilesNeeded
+                  key={getTrackedItemId(item)}
+                  id={this.props.claim.id}
+                  item={item}
+                />
+              ))}
+              {this.props.filesOptional.map(item => (
+                <FilesOptional
+                  key={getTrackedItemId(item)}
+                  id={this.props.claim.id}
+                  item={item}
+                />
+              ))}
+              <AddFilesForm
+                field={this.props.uploadField}
+                progress={this.props.progress}
+                uploading={this.props.uploading}
+                files={this.props.files}
+                backUrl={this.props.lastPage || filesPath}
+                onSubmit={() => {
+                  // START lighthouse_migration
+                  if (this.props.documentsUseLighthouse) {
+                    this.props.submitFilesLighthouse(
+                      this.props.claim.id,
+                      null,
+                      this.props.files,
+                    );
+                  } else {
+                    this.props.submitFiles(
+                      this.props.claim.id,
+                      null,
+                      this.props.files,
+                    );
+                  }
+                  // END lighthouse_migration
+                }}
+                onAddFile={this.props.addFile}
+                onRemoveFile={this.props.removeFile}
+                onFieldChange={this.props.updateField}
+                onCancel={this.props.cancelUpload}
+                onDirtyFields={this.props.setFieldsDirty}
+              />
+            </>
+          ) : (
+            <p className="vads-u-margin-top--0 vads-u-margin-bottom--4">
+              The claim is closed so you can no longer submit any additional
+              evidence.
+            </p>
+          )}
         </div>
       );
     }

--- a/src/applications/claims-status/components/claim-files-tab/ClaimFileHeader.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/ClaimFileHeader.jsx
@@ -1,15 +1,24 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
-function ClaimFileHeader() {
+function ClaimFileHeader({ isOpen }) {
+  const headerDescription = isClaimOpen => {
+    return isClaimOpen
+      ? 'If you need to add evidence, you can do that here. You can also see the files associated with this claim.'
+      : 'You can see the files associated with this claim.';
+  };
   return (
     <div className="claim-file-header-container">
       <h2 className="vads-u-margin-y--0">Claim files</h2>
       <p className="vads-u-margin-top--1 vads-u-margin-bottom--4 va-introtext">
-        If you need to add evidence, you can do that here. You can also see the
-        files associated with this claim.
+        {headerDescription(isOpen)}
       </p>
     </div>
   );
 }
+
+ClaimFileHeader.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+};
 
 export default ClaimFileHeader;

--- a/src/applications/claims-status/containers/FilesPage.jsx
+++ b/src/applications/claims-status/containers/FilesPage.jsx
@@ -139,7 +139,7 @@ class FilesPage extends React.Component {
             </div>
           </Toggler.Disabled>
           <Toggler.Enabled>
-            <ClaimFileHeader />
+            <ClaimFileHeader isOpen={isOpen} />
             <AdditionalEvidencePage />
             {showDecision && <AskVAToDecide id={params.id} />}
             <DocumentsFiled claim={claim} />

--- a/src/applications/claims-status/containers/OverviewPage.jsx
+++ b/src/applications/claims-status/containers/OverviewPage.jsx
@@ -5,13 +5,10 @@ import PropTypes from 'prop-types';
 import scrollToTop from '@department-of-veterans-affairs/platform-utilities/scrollToTop';
 
 import { clearNotification } from '../actions';
-import ClaimComplete from '../components/ClaimComplete';
 import ClaimDetailLayout from '../components/ClaimDetailLayout';
-import ClaimsDecision from '../components/ClaimsDecision';
 import ClaimTimeline from '../components/ClaimTimeline';
 import ClaimOverviewHeader from '../components/ClaimOverviewHeader';
 import { DATE_FORMATS } from '../constants';
-import { showClaimLettersFeature } from '../selectors';
 import {
   buildDateFormatter,
   getClaimType,
@@ -19,7 +16,6 @@ import {
   getStatusMap,
   getTrackedItemDate,
   getUserPhase,
-  isClaimOpen,
   setDocumentTitle,
 } from '../utils/helpers';
 import { setUpPage, isTab, setFocus } from '../utils/page';
@@ -186,40 +182,22 @@ class OverviewPage extends React.Component {
   }
 
   getPageContent() {
-    const { claim, showClaimLettersLink } = this.props;
+    const { claim } = this.props;
 
     // claim can be null
     const attributes = (claim && claim.attributes) || {};
 
-    const {
-      claimPhaseDates,
-      closeDate,
-      decisionLetterSent,
-      status,
-    } = attributes;
-
-    const isOpen = isClaimOpen(status, closeDate);
+    const { claimPhaseDates } = attributes;
 
     return (
-      <div>
+      <div className="overview-container">
         <ClaimOverviewHeader />
-        {decisionLetterSent && !isOpen ? (
-          <ClaimsDecision
-            completedDate={closeDate}
-            showClaimLettersLink={showClaimLettersLink}
-          />
-        ) : null}
-        {!decisionLetterSent && !isOpen ? (
-          <ClaimComplete completedDate={closeDate} />
-        ) : null}
-        {status && isOpen ? (
-          <ClaimTimeline
-            id={claim.id}
-            phase={getPhaseFromStatus(claimPhaseDates.latestPhaseType)}
-            currentPhaseBack={claimPhaseDates.currentPhaseBack}
-            events={generateEventTimeline(claim)}
-          />
-        ) : null}
+        <ClaimTimeline
+          id={claim.id}
+          phase={getPhaseFromStatus(claimPhaseDates.latestPhaseType)}
+          currentPhaseBack={claimPhaseDates.currentPhaseBack}
+          events={generateEventTimeline(claim)}
+        />
       </div>
     );
   }
@@ -269,7 +247,6 @@ function mapStateToProps(state) {
     claim: claimsState.claimDetail.detail,
     message: claimsState.notifications.message,
     lastPage: claimsState.routing.lastPage,
-    showClaimLettersLink: showClaimLettersFeature(state),
     synced: claimsState.claimSync.synced,
   };
 }

--- a/src/applications/claims-status/containers/OverviewPage.jsx
+++ b/src/applications/claims-status/containers/OverviewPage.jsx
@@ -26,7 +26,7 @@ const formatDate = buildDateFormatter(DATE_FORMATS.LONG_DATE);
 const STATUSES = getStatusMap();
 
 const getPhaseFromStatus = latestStatus =>
-  [...STATUSES.keys()].indexOf(latestStatus) + 1;
+  [...STATUSES.keys()].indexOf(latestStatus.toUpperCase()) + 1;
 
 const isEventOrPrimaryPhase = event => {
   if (event.type === 'phase_entered') {
@@ -183,7 +183,6 @@ class OverviewPage extends React.Component {
 
   getPageContent() {
     const { claim } = this.props;
-
     // claim can be null
     const attributes = (claim && claim.attributes) || {};
 

--- a/src/applications/claims-status/tests/components/OverviewPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/OverviewPage.unit.spec.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
-import sinon from 'sinon';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
@@ -32,29 +30,28 @@ describe('<OverviewPage>', () => {
         decisionLetterSent: false,
         status: 'COMPLETE',
         supportingDocuments: [],
+        trackedItems: [],
       },
     };
 
-    it('should not render a need files from you alert, claim decision alert, or timeline', () => {
-      const { container, queryByText } = render(
+    it('should render empty content when loading', () => {
+      const { container } = render(
         <Provider store={store}>
           <OverviewPage
             claim={claim}
             params={params}
             clearNotification={() => {}}
+            loading
           />
         </Provider>,
       );
-      const overviewPage = $('#tabPanelFiles', container);
-      expect(overviewPage).to.exist;
-      expect(queryByText('View Details')).not.to.exist;
-      expect(queryByText('You can download your decision letter online now.'))
-        .not.to.exist;
-      expect($('.claim-timeline', container)).not.to.exist;
+      const overviewSection = $('.overview-container', container);
+      expect(overviewSection).to.not.exist;
+      expect($('va-loading-indicator', container)).to.exist;
     });
 
-    it('should render overview header and claim complete alert', () => {
-      const { container, getByText, queryByText } = render(
+    it('should render overview header and timeline', () => {
+      const { container, getByText } = render(
         <Provider store={store}>
           <OverviewPage
             claim={claim}
@@ -66,11 +63,11 @@ describe('<OverviewPage>', () => {
       const overviewPage = $('#tabPanelFiles', container);
       expect(overviewPage).to.exist;
       getByText('Overview of the claim process');
-      expect(queryByText('We decided your claim on January 10, 2023')).to.exist;
+      expect($('.claim-timeline', container)).to.exist;
     });
   });
 
-  context('when decisionLetterSent is true', () => {
+  context('when claim is open', () => {
     const claim = {
       id: '1',
       attributes: {
@@ -91,25 +88,20 @@ describe('<OverviewPage>', () => {
       },
     };
 
-    it('should not render a need files from you alert, claim decision alert, or complete alert', () => {
-      const { container, queryByText } = render(
+    it('should render empty content when loading', () => {
+      const { container } = render(
         <Provider store={store}>
           <OverviewPage
             claim={claim}
             params={params}
             clearNotification={() => {}}
+            loading
           />
         </Provider>,
       );
-
-      const overviewPage = $('#tabPanelFiles', container);
-      expect(overviewPage).to.exist;
-      expect(queryByText('View Details')).not.to.exist;
-      expect(queryByText('We decided your claim')).not.to.exist;
-      expect(queryByText('You can download your decision letter online now.'))
-        .not.to.exist;
-      expect(queryByText('We decided your claim on January 10, 2023')).not.to
-        .exist;
+      const overviewSection = $('.overview-container', container);
+      expect(overviewSection).to.not.exist;
+      expect($('va-loading-indicator', container)).to.exist;
     });
 
     it('should render overview header and timeline', () => {
@@ -127,124 +119,5 @@ describe('<OverviewPage>', () => {
       getByText('Overview of the claim process');
       expect($('.claim-timeline', container)).to.exist;
     });
-  });
-
-  context('when documentsNeeded is false', () => {
-    const claim = {
-      id: '1',
-      attributes: {
-        claimDate: '2023-01-01',
-        claimPhaseDates: {
-          currentPhaseBack: false,
-          phaseChangeDate: '2023-02-08',
-          latestPhaseType: 'INITIAL_REVIEW',
-          previousPhases: {
-            phase1CompleteDate: '2023-02-08',
-          },
-        },
-        closeDate: null,
-        decisionLetterSent: false,
-        status: 'INITIAL_REVIEW',
-        supportingDocuments: [],
-        trackedItems: [],
-      },
-    };
-
-    it('should render page with no alerts and a timeline', () => {
-      const { container, getByText, queryByText } = render(
-        <Provider store={store}>
-          <OverviewPage
-            claim={claim}
-            params={params}
-            clearNotification={() => {}}
-          />
-        </Provider>,
-      );
-
-      const overviewPage = $('#tabPanelFiles', container);
-      expect(overviewPage).to.exist;
-      getByText('Overview of the claim process');
-      expect(queryByText('View Details')).not.to.exist;
-      expect(queryByText('We decided your claim')).not.to.exist;
-      expect(queryByText('You can download your decision letter online now.'))
-        .not.to.exist;
-      expect($('.claim-timeline', container)).to.exist;
-    });
-  });
-
-  it('should render empty content when loading', () => {
-    const claim = {};
-
-    const tree = SkinDeep.shallowRender(
-      <OverviewPage loading claim={claim} params={params} />,
-    );
-    expect(tree.props.children).to.be.null;
-  });
-
-  it('should render notification', () => {
-    const claim = {};
-
-    const tree = SkinDeep.shallowRender(
-      <OverviewPage
-        loading
-        params={params}
-        message={{ title: 'Test', body: 'Body' }}
-        claim={claim}
-      />,
-    );
-    expect(tree.props.message).not.to.be.null;
-  });
-
-  it('should clear alert', () => {
-    const claim = {
-      attributes: {
-        claimDate: '2023-01-01',
-        closeDate: '2023-10-10',
-      },
-    };
-    const clearNotification = sinon.spy();
-    const message = {
-      title: 'Test',
-      body: 'Test',
-    };
-
-    const tree = SkinDeep.shallowRender(
-      <OverviewPage
-        params={params}
-        clearNotification={clearNotification}
-        message={message}
-        claim={claim}
-      />,
-    );
-    expect(clearNotification.called).to.be.false;
-    tree.subTree('ClaimDetailLayout').props.clearNotification();
-    expect(clearNotification.called).to.be.true;
-  });
-
-  it('should clear notification when leaving', () => {
-    const claim = {
-      id: '1',
-      attributes: {
-        claimDate: '2023-01-01',
-        closeDate: '2023-10-10',
-      },
-    };
-    const clearNotification = sinon.spy();
-    const message = {
-      title: 'Test',
-      body: 'Test',
-    };
-
-    const tree = SkinDeep.shallowRender(
-      <OverviewPage
-        params={params}
-        clearNotification={clearNotification}
-        message={message}
-        claim={claim}
-      />,
-    );
-    expect(clearNotification.called).to.be.false;
-    tree.getMountedInstance().componentWillUnmount();
-    expect(clearNotification.called).to.be.true;
   });
 });

--- a/src/applications/claims-status/tests/components/claim-files-tab/AdditionalEvidencePage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab/AdditionalEvidencePage.unit.spec.jsx
@@ -14,13 +14,6 @@ import * as AddFilesForm from '../../../components/claim-files-tab/AddFilesForm'
 
 const getRouter = () => ({ push: sinon.spy() });
 
-const params = { id: 1 };
-
-const claim = {
-  id: 1,
-  attributes: {},
-};
-
 const fileFormProps = {
   addFile: () => {},
   cancelUpload: () => {},
@@ -45,285 +38,350 @@ describe('<AdditionalEvidencePage>', () => {
   afterEach(() => {
     stub.restore();
   });
-  it('should render loading div', () => {
-    const tree = SkinDeep.shallowRender(
-      <AdditionalEvidencePage params={params} loading />,
-    );
-    expect(tree.everySubTree('va-loading-indicator')).not.to.be.empty;
-  });
 
-  it('should render upload error alert', () => {
-    const message = {
-      title: 'test',
-      body: 'test',
-      type: 'error',
+  context('when claim is open', () => {
+    const params = { id: 1 };
+
+    const claim = {
+      id: 1,
+      attributes: {
+        status: 'EVIDENCE_GATHERING_REVIEW_DECISION',
+        closeDate: null,
+      },
     };
 
-    const tree = SkinDeep.shallowRender(
-      <AdditionalEvidencePage
-        params={params}
-        claim={claim}
-        message={message}
-        filesNeeded={[]}
-        filesOptional={[]}
-      />,
-    );
-    expect(tree.subTree('Notification')).not.to.be.false;
-  });
+    it('should render loading div', () => {
+      const tree = SkinDeep.shallowRender(
+        <AdditionalEvidencePage params={params} claim={claim} loading />,
+      );
+      expect(tree.everySubTree('va-loading-indicator')).not.to.be.empty;
+    });
 
-  it('should clear upload error when leaving', () => {
-    const message = {
-      title: 'test',
-      body: 'test',
-      type: 'error',
-    };
-    const clearAdditionalEvidenceNotification = sinon.spy();
+    it('should render upload error alert', () => {
+      const message = {
+        title: 'test',
+        body: 'test',
+        type: 'error',
+      };
 
-    const tree = SkinDeep.shallowRender(
-      <AdditionalEvidencePage
-        params={params}
-        claim={claim}
-        clearAdditionalEvidenceNotification={
-          clearAdditionalEvidenceNotification
-        }
-        message={message}
-        filesNeeded={[]}
-        filesOptional={[]}
-      />,
-    );
-    expect(tree.subTree('Notification')).not.to.be.false;
-    tree.getMountedInstance().componentWillUnmount();
-    expect(clearAdditionalEvidenceNotification.called).to.be.true;
-  });
+      const tree = SkinDeep.shallowRender(
+        <AdditionalEvidencePage
+          params={params}
+          claim={claim}
+          message={message}
+          filesNeeded={[]}
+          filesOptional={[]}
+        />,
+      );
+      expect(tree.subTree('Notification')).not.to.be.false;
+    });
 
-  it('should not clear notification after completed upload', () => {
-    const message = {
-      title: 'test',
-      body: 'test',
-      type: 'error',
-    };
-    const clearAdditionalEvidenceNotification = sinon.spy();
+    it('should clear upload error when leaving', () => {
+      const message = {
+        title: 'test',
+        body: 'test',
+        type: 'error',
+      };
+      const clearAdditionalEvidenceNotification = sinon.spy();
 
-    const tree = SkinDeep.shallowRender(
-      <AdditionalEvidencePage
-        params={params}
-        claim={claim}
-        uploadComplete
-        clearAdditionalEvidenceNotification={
-          clearAdditionalEvidenceNotification
-        }
-        message={message}
-        filesNeeded={[]}
-        filesOptional={[]}
-      />,
-    );
-    expect(tree.subTree('Notification')).not.to.be.false;
-    tree.getMountedInstance().componentWillUnmount();
-    expect(clearAdditionalEvidenceNotification.called).to.be.false;
-  });
+      const tree = SkinDeep.shallowRender(
+        <AdditionalEvidencePage
+          params={params}
+          claim={claim}
+          clearAdditionalEvidenceNotification={
+            clearAdditionalEvidenceNotification
+          }
+          message={message}
+          filesNeeded={[]}
+          filesOptional={[]}
+        />,
+      );
+      expect(tree.subTree('Notification')).not.to.be.false;
+      tree.getMountedInstance().componentWillUnmount();
+      expect(clearAdditionalEvidenceNotification.called).to.be.true;
+    });
 
-  it('should handle submit files', () => {
-    stub.restore();
-    const files = [];
-    const onSubmit = sinon.spy();
-    const tree = SkinDeep.shallowRender(
-      <AdditionalEvidencePage
-        params={params}
-        claim={claim}
-        files={files}
-        submitFiles={onSubmit}
-        filesNeeded={[]}
-        filesOptional={[]}
-        {...fileFormProps}
-      />,
-    );
-    tree.subTree('AddFilesForm').props.onSubmit();
-    expect(onSubmit.calledWith(1, null, files)).to.be.true;
-  });
+    it('should not clear notification after completed upload', () => {
+      const message = {
+        title: 'test',
+        body: 'test',
+        type: 'error',
+      };
+      const clearAdditionalEvidenceNotification = sinon.spy();
 
-  it('should reset uploads and set title on mount', () => {
-    const resetUploads = sinon.spy();
-    const mainDiv = document.createElement('div');
-    mainDiv.classList.add('va-nav-breadcrumbs');
-    document.body.appendChild(mainDiv);
-    ReactTestUtils.renderIntoDocument(
-      <Provider store={uploadStore}>
+      const tree = SkinDeep.shallowRender(
+        <AdditionalEvidencePage
+          params={params}
+          claim={claim}
+          uploadComplete
+          clearAdditionalEvidenceNotification={
+            clearAdditionalEvidenceNotification
+          }
+          message={message}
+          filesNeeded={[]}
+          filesOptional={[]}
+        />,
+      );
+      expect(tree.subTree('Notification')).not.to.be.false;
+      tree.getMountedInstance().componentWillUnmount();
+      expect(clearAdditionalEvidenceNotification.called).to.be.false;
+    });
+
+    it('should handle submit files', () => {
+      stub.restore();
+      const files = [];
+      const onSubmit = sinon.spy();
+      const tree = SkinDeep.shallowRender(
+        <AdditionalEvidencePage
+          params={params}
+          claim={claim}
+          files={files}
+          submitFiles={onSubmit}
+          filesNeeded={[]}
+          filesOptional={[]}
+          {...fileFormProps}
+        />,
+      );
+      tree.subTree('AddFilesForm').props.onSubmit();
+      expect(onSubmit.calledWith(1, null, files)).to.be.true;
+    });
+
+    it('should reset uploads and set title on mount', () => {
+      const resetUploads = sinon.spy();
+      const mainDiv = document.createElement('div');
+      mainDiv.classList.add('va-nav-breadcrumbs');
+      document.body.appendChild(mainDiv);
+      ReactTestUtils.renderIntoDocument(
+        <Provider store={uploadStore}>
+          <AdditionalEvidencePage
+            params={params}
+            claim={claim}
+            files={[]}
+            uploadField={{ value: null, dirty: false }}
+            resetUploads={resetUploads}
+            filesNeeded={[]}
+            filesOptional={[]}
+          />
+        </Provider>,
+      );
+
+      expect(document.title).to.equal('Additional Evidence');
+      expect(resetUploads.called).to.be.true;
+    });
+
+    it('should set details and go to files page if complete', () => {
+      const getClaimEVSS = sinon.spy();
+      const resetUploads = sinon.spy();
+      const router = getRouter();
+
+      const tree = SkinDeep.shallowRender(
         <AdditionalEvidencePage
           params={params}
           claim={claim}
           files={[]}
+          uploadComplete
           uploadField={{ value: null, dirty: false }}
+          router={router}
+          getClaimEVSS={getClaimEVSS}
           resetUploads={resetUploads}
           filesNeeded={[]}
           filesOptional={[]}
-        />
-      </Provider>,
-    );
+        />,
+      );
 
-    expect(document.title).to.equal('Additional Evidence');
-    expect(resetUploads.called).to.be.true;
+      tree
+        .getMountedInstance()
+        .UNSAFE_componentWillReceiveProps({ uploadComplete: true });
+      expect(getClaimEVSS.calledWith(1)).to.be.true;
+      expect(router.push.calledWith('your-claims/1/files')).to.be.true;
+    });
+
+    // START lighthouse_migration
+    context('cst_use_lighthouse feature toggle', () => {
+      const props = {
+        claim,
+        files: [],
+        params,
+        resetUploads: () => {},
+        router: getRouter(),
+        uploadField: { value: null, dirty: false },
+        filesNeeded: [],
+        filesOptional: [],
+      };
+
+      it('calls getClaimLighthouse when enabled, doesnt show va-alerts', () => {
+        // Reset sinon spies / set up props
+        props.getClaimEVSS = sinon.spy();
+        props.getClaimLighthouse = sinon.spy();
+        props.useLighthouse = true;
+        props.filesNeeded = [];
+        props.filesOptional = [];
+
+        const { rerender, container } = render(
+          <AdditionalEvidencePage {...props} />,
+        );
+
+        // We want to trigger the 'UNSAFE_componentWillReceiveProps' method
+        // which requires rerendering
+        rerender(<AdditionalEvidencePage {...props} uploadComplete />);
+
+        expect(props.getClaimEVSS.called).to.be.false;
+        expect(props.getClaimLighthouse.called).to.be.true;
+        expect($('.primary-alert', container)).not.to.exist;
+        expect($('.optional-alert', container)).not.to.exist;
+      });
+
+      it('calls getClaimLighthouse when enabled, shows va-alerts', () => {
+        // Reset sinon spies / set up props
+        props.getClaimEVSS = sinon.spy();
+        props.getClaimLighthouse = sinon.spy();
+        props.useLighthouse = true;
+        props.filesNeeded = [
+          {
+            id: 1,
+            status: 'NEEDED_FROM_YOU',
+            displayName: 'Test',
+            description: 'Test',
+            suspenseDate: '2024-02-01',
+          },
+        ];
+        props.filesOptional = [
+          {
+            id: 2,
+            status: 'NEEDED_FROM_OTHERS',
+            displayName: 'Test',
+            description: 'Test',
+          },
+        ];
+
+        const { rerender, container } = render(
+          <AdditionalEvidencePage {...props} {...fileFormProps} />,
+        );
+
+        // We want to trigger the 'UNSAFE_componentWillReceiveProps' method
+        // which requires rerendering
+        rerender(<AdditionalEvidencePage {...props} uploadComplete />);
+
+        expect(props.getClaimEVSS.called).to.be.false;
+        expect(props.getClaimLighthouse.called).to.be.true;
+        // expect($('va-alert', container)).to.exist;
+        expect($('.primary-alert', container)).to.exist;
+        expect($('.optional-alert', container)).to.exist;
+      });
+
+      it('calls getClaimEVSS when disabled, doesnt show va-alerts', () => {
+        // Reset sinon spies / set up props
+        props.getClaimEVSS = sinon.spy();
+        props.getClaimLighthouse = sinon.spy();
+        props.useLighthouse = false;
+        props.filesNeeded = [];
+        props.filesOptional = [];
+
+        const { rerender, container } = render(
+          <AdditionalEvidencePage {...props} {...fileFormProps} />,
+        );
+
+        // We want to trigger the 'UNSAFE_componentWillReceiveProps' method
+        // which requires rerendering
+        rerender(<AdditionalEvidencePage {...props} uploadComplete />);
+
+        expect(props.getClaimEVSS.called).to.be.true;
+        expect(props.getClaimLighthouse.called).to.be.false;
+        expect($('.primary-alert', container)).not.to.exist;
+        expect($('.optional-alert', container)).not.to.exist;
+      });
+
+      it('calls getClaimEVSS when disabled, shows va-alerts', () => {
+        // Reset sinon spies / set up props
+        props.getClaimEVSS = sinon.spy();
+        props.getClaimLighthouse = sinon.spy();
+        props.useLighthouse = false;
+        props.filesNeeded = [
+          {
+            id: 1,
+            status: 'NEEDED',
+            type: 'still_need_from_you_list',
+            displayName: 'Test',
+            description: 'Test',
+            suspenseDate: '2024-02-01',
+          },
+        ];
+        props.filesOptional = [
+          {
+            id: 2,
+            status: 'NEEDED',
+            type: 'still_need_from_others_list',
+            displayName: 'Test',
+            description: 'Test',
+          },
+        ];
+
+        const { rerender, container } = render(
+          <AdditionalEvidencePage {...props} {...fileFormProps} />,
+        );
+
+        // We want to trigger the 'UNSAFE_componentWillReceiveProps' method
+        // which requires rerendering
+        rerender(<AdditionalEvidencePage {...props} uploadComplete />);
+
+        expect(props.getClaimEVSS.called).to.be.true;
+        expect(props.getClaimLighthouse.called).to.be.false;
+        expect($('.primary-alert', container)).to.exist;
+        expect($('.optional-alert', container)).to.exist;
+      });
+    });
+    // END lighthouse_migration
   });
 
-  it('should set details and go to files page if complete', () => {
-    const getClaimEVSS = sinon.spy();
-    const resetUploads = sinon.spy();
-    const router = getRouter();
+  context('when claim is closed', () => {
+    const params = { id: 1 };
 
-    const tree = SkinDeep.shallowRender(
-      <AdditionalEvidencePage
-        params={params}
-        claim={claim}
-        files={[]}
-        uploadComplete
-        uploadField={{ value: null, dirty: false }}
-        router={router}
-        getClaimEVSS={getClaimEVSS}
-        resetUploads={resetUploads}
-        filesNeeded={[]}
-        filesOptional={[]}
-      />,
-    );
-
-    tree
-      .getMountedInstance()
-      .UNSAFE_componentWillReceiveProps({ uploadComplete: true });
-    expect(getClaimEVSS.calledWith(1)).to.be.true;
-    expect(router.push.calledWith('your-claims/1/files')).to.be.true;
-  });
-
-  // START lighthouse_migration
-  context('cst_use_lighthouse feature toggle', () => {
-    const props = {
-      claim,
-      files: [],
-      params,
-      resetUploads: () => {},
-      router: getRouter(),
-      uploadField: { value: null, dirty: false },
-      filesNeeded: [],
-      filesOptional: [],
+    const claim = {
+      id: 1,
+      attributes: {
+        status: 'COMPLETE',
+        closeDate: '01-01-2024',
+      },
     };
 
-    it('calls getClaimLighthouse when enabled, doesnt show va-alerts', () => {
-      // Reset sinon spies / set up props
-      props.getClaimEVSS = sinon.spy();
-      props.getClaimLighthouse = sinon.spy();
-      props.useLighthouse = true;
-      props.filesNeeded = [];
-      props.filesOptional = [];
+    const resetUploads = sinon.spy();
 
-      const { rerender, container } = render(
-        <AdditionalEvidencePage {...props} />,
+    it('should render loading div', () => {
+      const { container } = render(
+        <AdditionalEvidencePage
+          params={params}
+          claim={claim}
+          resetUploads={resetUploads}
+          uploadComplete
+          loading
+        />,
       );
-
-      // We want to trigger the 'UNSAFE_componentWillReceiveProps' method
-      // which requires rerendering
-      rerender(<AdditionalEvidencePage {...props} uploadComplete />);
-
-      expect(props.getClaimEVSS.called).to.be.false;
-      expect(props.getClaimLighthouse.called).to.be.true;
-      expect($('.primary-alert', container)).not.to.exist;
-      expect($('.optional-alert', container)).not.to.exist;
+      const additionalEvidenceSection = $(
+        '.additional-evidence-container',
+        container,
+      );
+      expect(additionalEvidenceSection).to.not.exist;
+      expect($('va-loading-indicator', container)).to.exist;
     });
 
-    it('calls getClaimLighthouse when enabled, shows va-alerts', () => {
-      // Reset sinon spies / set up props
-      props.getClaimEVSS = sinon.spy();
-      props.getClaimLighthouse = sinon.spy();
-      props.useLighthouse = true;
-      props.filesNeeded = [
-        {
-          id: 1,
-          status: 'NEEDED_FROM_YOU',
-          displayName: 'Test',
-          description: 'Test',
-          suspenseDate: '2024-02-01',
-        },
-      ];
-      props.filesOptional = [
-        {
-          id: 2,
-          status: 'NEEDED_FROM_OTHERS',
-          displayName: 'Test',
-          description: 'Test',
-        },
-      ];
-
-      const { rerender, container } = render(
-        <AdditionalEvidencePage {...props} {...fileFormProps} />,
+    it('should render closed message', () => {
+      const { container, getByText } = render(
+        <AdditionalEvidencePage
+          params={params}
+          claim={claim}
+          resetUploads={resetUploads}
+          uploadComplete
+        />,
       );
-
-      // We want to trigger the 'UNSAFE_componentWillReceiveProps' method
-      // which requires rerendering
-      rerender(<AdditionalEvidencePage {...props} uploadComplete />);
-
-      expect(props.getClaimEVSS.called).to.be.false;
-      expect(props.getClaimLighthouse.called).to.be.true;
-      // expect($('va-alert', container)).to.exist;
-      expect($('.primary-alert', container)).to.exist;
-      expect($('.optional-alert', container)).to.exist;
-    });
-
-    it('calls getClaimEVSS when disabled, doesnt show va-alerts', () => {
-      // Reset sinon spies / set up props
-      props.getClaimEVSS = sinon.spy();
-      props.getClaimLighthouse = sinon.spy();
-      props.useLighthouse = false;
-      props.filesNeeded = [];
-      props.filesOptional = [];
-
-      const { rerender, container } = render(
-        <AdditionalEvidencePage {...props} {...fileFormProps} />,
+      const additionalEvidenceSection = $(
+        '.additional-evidence-container',
+        container,
       );
+      expect(additionalEvidenceSection).to.exist;
 
-      // We want to trigger the 'UNSAFE_componentWillReceiveProps' method
-      // which requires rerendering
-      rerender(<AdditionalEvidencePage {...props} uploadComplete />);
-
-      expect(props.getClaimEVSS.called).to.be.true;
-      expect(props.getClaimLighthouse.called).to.be.false;
-      expect($('.primary-alert', container)).not.to.exist;
-      expect($('.optional-alert', container)).not.to.exist;
-    });
-
-    it('calls getClaimEVSS when disabled, shows va-alerts', () => {
-      // Reset sinon spies / set up props
-      props.getClaimEVSS = sinon.spy();
-      props.getClaimLighthouse = sinon.spy();
-      props.useLighthouse = false;
-      props.filesNeeded = [
-        {
-          id: 1,
-          status: 'NEEDED',
-          type: 'still_need_from_you_list',
-          displayName: 'Test',
-          description: 'Test',
-          suspenseDate: '2024-02-01',
-        },
-      ];
-      props.filesOptional = [
-        {
-          id: 2,
-          status: 'NEEDED',
-          type: 'still_need_from_others_list',
-          displayName: 'Test',
-          description: 'Test',
-        },
-      ];
-
-      const { rerender, container } = render(
-        <AdditionalEvidencePage {...props} {...fileFormProps} />,
-      );
-
-      // We want to trigger the 'UNSAFE_componentWillReceiveProps' method
-      // which requires rerendering
-      rerender(<AdditionalEvidencePage {...props} uploadComplete />);
-
-      expect(props.getClaimEVSS.called).to.be.true;
-      expect(props.getClaimLighthouse.called).to.be.false;
-      expect($('.primary-alert', container)).to.exist;
-      expect($('.optional-alert', container)).to.exist;
+      const text =
+        'The claim is closed so you can no longer submit any additional evidence.';
+      expect(getByText(text)).to.exist;
     });
   });
-  // END lighthouse_migration
 });

--- a/src/applications/claims-status/tests/components/claim-files-tab/ClaimFileHeader.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab/ClaimFileHeader.unit.spec.jsx
@@ -6,8 +6,24 @@ import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import ClaimFileHeader from '../../../components/claim-files-tab/ClaimFileHeader';
 
 describe('<ClaimFileHeader>', () => {
-  it('should render a ClaimFileHeader section', () => {
-    const { container } = render(<ClaimFileHeader />);
-    expect($('.claim-file-header-container', container)).to.exist;
+  context('when isOpen is true', () => {
+    it('should render a ClaimFileHeader section with is open text', () => {
+      const { container, getByText } = render(<ClaimFileHeader isOpen />);
+      const text =
+        'If you need to add evidence, you can do that here. You can also see the files associated with this claim.';
+      expect($('.claim-file-header-container', container)).to.exist;
+      expect(getByText(text)).to.exist;
+    });
+  });
+
+  context('when isOpen is false', () => {
+    it('should render a ClaimFileHeader section with is closed text', () => {
+      const { container, getByText } = render(
+        <ClaimFileHeader isOpen={false} />,
+      );
+      const text = 'You can see the files associated with this claim.';
+      expect($('.claim-file-header-container', container)).to.exist;
+      expect(getByText(text)).to.exist;
+    });
   });
 });


### PR DESCRIPTION
## Summary

Updated ClaimTimeline.jsx and removed the payment section from the closed phase as we dont want to show this anymore, this info now appears on the status tab. Also we never showed this when the toggle was off since the timeline was hidden when a claim was closed.

Updated AdditionalEvidencePage.jsx and added logic for when the claim is open vs closed. When closed we show a closed message.

Updated ClaimFileHeader.jsx and added `isOpen` prop that is true when a claim status isn't closed. Used this prop to add logic to to change the file header text when the claim was closed.

Updated FilesPage.jsx to add the isOpen prop to the ClaimFileHeader.jsx

Updated OverviewPage.jsx
- Removed ClaimComplete.jsx
- Removed ClaimsDecision.jsx
- Added `.toUpperCase()` to `getPhaseFromStatus()` to account for bad mockdata that has statuses with `Complete` instead of `COMPLETE`
- Removed prop showClaimLettersLink since it is no longer needed

Updated tests for the following:
- src/applications/claims-status/tests/components/OverviewPage.unit.spec.jsx
- src/applications/claims-status/tests/components/claim-files-tab/AdditionalEvidencePage.unit.spec.jsx
- src/applications/claims-status/tests/components/claim-files-tab/ClaimFileHeader.unit.spec.jsx

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#77293

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Files Tab  | ![Screenshot 2024-03-07 at 10 25 58 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/03f54cf3-47ba-44a0-9a24-16f2814691c7) | ![Screenshot 2024-03-08 at 9 01 50 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/0f975c04-8172-4cb3-af51-d6089577d39b) |
| Overview Tab - previous view didnt show timeline when claim closed | ![Screenshot 2024-02-28 at 12 37 20 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/be829ed6-806c-4ed0-87b2-8455f0eefa7b) | ![Screenshot 2024-03-08 at 10 19 33 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/2021d4df-1919-47cb-aaa6-85d93abb57a7) |
| Overview Tab - timeline showing on closed claim  | ![Screenshot 2024-03-08 at 8 49 42 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/c7189867-b3e5-4187-b85d-190244a28f3b) | ![Screenshot 2024-03-08 at 10 19 33 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/3c3e2b0c-6373-4f33-bb9e-d5fa02a7f76a) |

## What areas of the site does it impact?

Claim Status Tool

## Acceptance criteria

Files Tab

- [x]  Add logic for Files tab when claim is closed then we show ClaimFileHeader, AdditionalEvidencePage
- [x]  Add logic to ClaimFileHeader so that the description text is different when a claim is closed
- [x]  Add logic to AdditionalEvidencePage so that when claim is closed we show 'closed text'
- [x]  Documents filed shows when claim is closed
- [x]  Design Check

Overview Tab

- [x]  The "Claims Decision" component is removed from this tab
- [x]  The "Claim Complete" component is removed from this tab
- [x]  The "Next Steps" section is removed from this tab
- [x]  The Overview tab shows the timeline when the claim is closed
- [x]  The timeline 

doesnt show the "Claims Decision" component under phase 5 when the v2 toggle is enabled

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
