### PR TITLE
Updated feature toggle references

### DIFF
--- a/src/applications/representative-search/containers/App.jsx
+++ b/src/applications/representative-search/containers/App.jsx
@@ -16,7 +16,9 @@ function App({ children }) {
     TOGGLE_NAMES,
   } = useFeatureToggle();
 
-  const appEnabled = useToggleValue(TOGGLE_NAMES.findARepresentativeEnabled);
+  const appEnabled = useToggleValue(
+    TOGGLE_NAMES.findARepresentativeEnableFrontend,
+  );
 
   const togglesLoading = useToggleLoadingValue();
 

--- a/src/applications/representative-search/mocks/feature-toggles/index.js
+++ b/src/applications/representative-search/mocks/feature-toggles/index.js
@@ -1,5 +1,5 @@
 const generateFeatureToggles = (toggles = {}) => {
-  const { findARepresentativeEnabled = false } = toggles;
+  const { findARepresentativeEnableFrontend = false } = toggles;
 
   return {
     data: {
@@ -7,7 +7,7 @@ const generateFeatureToggles = (toggles = {}) => {
       features: [
         {
           name: 'find_a_representative',
-          value: findARepresentativeEnabled,
+          value: findARepresentativeEnableFrontend,
         },
       ],
     },

--- a/src/applications/representative-search/tests/e2e/accessibility.cypress.spec.js
+++ b/src/applications/representative-search/tests/e2e/accessibility.cypress.spec.js
@@ -7,7 +7,9 @@ describe('Accessibility', () => {
     cy.viewport(1200, 700);
     cy.intercept('GET', '/v0/feature_toggles*', {
       data: {
-        features: [{ name: 'find_a_representative_enabled', value: true }],
+        features: [
+          { name: 'find_a_representative_enable_frontend', value: true },
+        ],
       },
     });
     cy.intercept('GET', '/v0/maintenance_windows', []);

--- a/src/applications/representative-search/tests/e2e/geolocation.cypress.spec.js
+++ b/src/applications/representative-search/tests/e2e/geolocation.cypress.spec.js
@@ -20,7 +20,9 @@ describe('User geolocation', () => {
     cy.intercept('GET', '/geocoding/**/*', mockLaLocation).as('caLocation');
     cy.intercept('GET', '/v0/feature_toggles*', {
       data: {
-        features: [{ name: 'find_a_representative_enabled', value: true }],
+        features: [
+          { name: 'find_a_representative_enable_frontend', value: true },
+        ],
       },
     });
     cy.visit('/get-help-from-accredited-representative/find-rep/');

--- a/src/applications/representative-search/tests/e2e/mobile.cypress.spec.js
+++ b/src/applications/representative-search/tests/e2e/mobile.cypress.spec.js
@@ -17,7 +17,9 @@ describe('Mobile', () => {
   beforeEach(() => {
     cy.intercept('GET', '/v0/feature_toggles*', {
       data: {
-        features: [{ name: 'find_a_representative_enabled', value: true }],
+        features: [
+          { name: 'find_a_representative_enable_frontend', value: true },
+        ],
       },
     });
     cy.intercept('GET', '/v0/maintenance_windows', []);

--- a/src/applications/representative-search/tests/e2e/representativeSearch.cypress.spec.js
+++ b/src/applications/representative-search/tests/e2e/representativeSearch.cypress.spec.js
@@ -30,7 +30,9 @@ describe('Representative Search', () => {
   beforeEach(() => {
     cy.intercept('GET', '/v0/feature_toggles*', {
       data: {
-        features: [{ name: 'find_a_representative_enabled', value: true }],
+        features: [
+          { name: 'find_a_representative_enable_frontend', value: true },
+        ],
       },
     });
     cy.intercept('GET', '/v0/maintenance_windows', []);

--- a/src/applications/representative-search/tests/e2e/serverErrors.cypress.spec.js
+++ b/src/applications/representative-search/tests/e2e/serverErrors.cypress.spec.js
@@ -4,7 +4,9 @@ describe('Find a Representative error handling', () => {
   beforeEach(() => {
     cy.intercept('GET', '/v0/feature_toggles*', {
       data: {
-        features: [{ name: 'find_a_representative_enabled', value: true }],
+        features: [
+          { name: 'find_a_representative_enable_frontend', value: true },
+        ],
       },
     });
     cy.intercept('GET', '/v0/maintenance_windows', []);


### PR DESCRIPTION
## Summary

Updated frontend toggles for Find a Representative:

`find_a_representative_enabled` => `find_a_representative_enable_frontend`
`findARepresentativeEnabled` => `findARepresentativeEnableFrontend`

This follows a decision to split up our front/backend into two different toggles. 

## Related issues
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/77825