### PR TITLE
MHV-55652 Added more safety checks for Notes references

### DIFF
--- a/src/applications/mhv/medical-records/reducers/careSummariesAndNotes.js
+++ b/src/applications/mhv/medical-records/reducers/careSummariesAndNotes.js
@@ -15,49 +15,65 @@ const initialState = {
   careSummariesAndNotesDetails: undefined,
 };
 
-const extractName = record => {
-  return (
-    record.content?.[0]?.attachment?.title ||
-    (isArrayAndHasItems(record.type?.coding)
-      ? record.type.coding[0].display
-      : null)
-  );
+export const getTitle = record => {
+  const contentItem = record.content?.find(item => item.attachment);
+  if (contentItem?.attachment?.title) {
+    return contentItem.attachment.title;
+  }
+  if (isArrayAndHasItems(record.type?.coding)) {
+    const codingItem = record.type.coding.find(item => item.display);
+    return codingItem?.display ?? null;
+  }
+  return null;
 };
 
-const extractType = record => {
-  return isArrayAndHasItems(record.type?.coding)
-    ? record.type.coding[0].code
-    : null;
+export const getType = record => {
+  if (isArrayAndHasItems(record.type?.coding)) {
+    const codingItem = record.type?.coding.find(item => item.code);
+    return codingItem?.code ?? null;
+  }
+  return null;
 };
 
-const extractAuthenticator = record => {
-  return extractContainedResource(record, record.authenticator?.reference)
-    ?.name?.[0]?.text;
-};
-
-const extractAuthor = record => {
-  return extractContainedResource(
+export const extractAuthenticator = record => {
+  const authenticator = extractContainedResource(
     record,
-    isArrayAndHasItems(record.author) && record.author[0].reference,
-  )?.name?.[0]?.text;
-};
-
-const extractLocation = record => {
-  return (
-    record.content?.period?.location ||
-    (isArrayAndHasItems(record.contained) &&
-      record.contained.find(item => item.resourceType === 'Location')?.name)
+    record.authenticator?.reference,
   );
+  const name = authenticator?.name?.find(item => item.text);
+  return name?.text ?? null;
 };
 
-const extractNote = record => {
-  if (
-    isArrayAndHasItems(record.content) &&
-    typeof record.content[0].attachment?.data === 'string'
-  ) {
-    return Buffer.from(record.content[0].attachment.data, 'base64')
-      .toString('utf-8')
-      .replace(/\r\n|\r/g, '\n'); // Standardize line endings
+export const extractAuthor = record => {
+  if (isArrayAndHasItems(record.author)) {
+    const authorRef = record.author.find(item => item.reference);
+    const author = extractContainedResource(record, authorRef?.reference);
+    const name = author?.name?.find(item => item.text);
+    return name?.text ?? null;
+  }
+  return null;
+};
+
+export const extractLocation = record => {
+  if (isArrayAndHasItems(record?.context?.related)) {
+    const reference = record.context?.related?.find(item => item.reference)
+      ?.reference;
+    if (reference) {
+      const resource = extractContainedResource(record, reference);
+      return resource?.name ?? null;
+    }
+  }
+  return null;
+};
+
+export const getNote = record => {
+  if (isArrayAndHasItems(record.content)) {
+    const contentItem = record.content.find(item => item.attachment);
+    if (contentItem && typeof contentItem.attachment?.data === 'string') {
+      return Buffer.from(contentItem.attachment.data, 'base64')
+        .toString('utf-8')
+        .replace(/\r\n|\r/g, '\n'); // Standardize line endings
+    }
   }
   return null;
 };
@@ -65,29 +81,37 @@ const extractNote = record => {
 export const getDateSigned = record => {
   if (isArrayAndHasItems(record.authenticator?.extension)) {
     const ext = record.authenticator.extension.find(e => e.valueDateTime);
-    return ext ? formatDateLong(ext.valueDateTime) : null;
+    if (ext) {
+      const formattedDate = formatDateLong(ext.valueDateTime);
+      return formattedDate !== 'Invalid date' ? formattedDate : null;
+    }
   }
   return null;
 };
 
+export const getAttending = noteSummary => {
+  return (
+    noteSummary
+      ?.split('ATTENDING:')[1]
+      ?.split('\n')[0]
+      ?.trim() || null
+  );
+};
+
 const convertAdmissionAndDischargeDetails = record => {
-  const summary = extractNote(record) || EMPTY_FIELD;
+  const summary = getNote(record);
 
   return {
     id: record.id,
-    name: extractName(record),
-    type: extractType(record),
+    name: getTitle(record),
+    type: getType(record),
     admissionDate: record.context?.period?.start
-      ? formatDateLong(record.context?.period?.start)
+      ? formatDateLong(record.context.period.start)
       : EMPTY_FIELD,
     dischargeDate: record.context?.period?.end
-      ? formatDateLong(record.context?.period?.end)
+      ? formatDateLong(record.context.period.end)
       : EMPTY_FIELD,
-    admittedBy:
-      summary
-        .split('ATTENDING:')[1]
-        ?.split('\n')[0]
-        ?.trim() || EMPTY_FIELD,
+    admittedBy: getAttending(summary) || EMPTY_FIELD,
     dischargedBy: extractAuthor(record) || EMPTY_FIELD,
     location: extractLocation(record) || EMPTY_FIELD,
     summary: summary || EMPTY_FIELD,
@@ -96,15 +120,15 @@ const convertAdmissionAndDischargeDetails = record => {
 
 const convertProgressNote = record => {
   return {
-    id: record.id,
-    name: extractName(record),
-    type: extractType(record),
+    id: record.id || null,
+    name: getTitle(record) || EMPTY_FIELD,
+    type: getType(record),
     date: record.date ? formatDateLong(record.date) : EMPTY_FIELD,
     dateSigned: getDateSigned(record) || EMPTY_FIELD,
     signedBy: extractAuthor(record) || EMPTY_FIELD,
     coSignedBy: extractAuthenticator(record) || EMPTY_FIELD,
     location: extractLocation(record) || EMPTY_FIELD,
-    note: extractNote(record) || EMPTY_FIELD,
+    note: getNote(record) || EMPTY_FIELD,
   };
 };
 
@@ -138,7 +162,7 @@ const notesAndSummariesConverterMap = {
 };
 
 /**
- * @param {Object} record - A FHIR DiagnosticReport or DocumentReference object
+ * @param {Object} record - A FHIR DocumentReference object
  * @returns the appropriate frontend object for display
  */
 export const convertCareSummariesAndNotesRecord = record => {

--- a/src/applications/mhv/medical-records/tests/reducers/careSummariesAndNotes.unit.spec.js
+++ b/src/applications/mhv/medical-records/tests/reducers/careSummariesAndNotes.unit.spec.js
@@ -1,13 +1,336 @@
 import { expect } from 'chai';
 import {
-  getRecordType,
+  careSummariesAndNotesReducer,
   convertCareSummariesAndNotesRecord,
+  extractAuthenticator,
+  extractAuthor,
+  extractLocation,
+  getAttending,
   getDateSigned,
+  getNote,
+  getRecordType,
+  getTitle,
+  getType,
 } from '../../reducers/careSummariesAndNotes';
 import { noteTypes } from '../../util/constants';
 import dischargeSummary from '../fixtures/dischargeSummary.json';
 import progressNote from '../fixtures/physicianProcedureNote.json';
 import consultResultNote from '../fixtures/consultResultNote.json';
+import { Actions } from '../../util/actionTypes';
+
+describe('getTitle', () => {
+  context('local title is present', () => {
+    const record = {
+      content: [
+        { ignore: 'the wrong object' },
+        { attachment: { title: 'NOTE TITLE' } },
+      ],
+    };
+
+    it('should return the title', () => {
+      expect(getTitle(record)).to.equal('NOTE TITLE');
+    });
+  });
+
+  context('local title is absent', () => {
+    const record = {
+      type: {
+        coding: [
+          { ignore: 'the wrong object' },
+          { display: 'Consultation Note' },
+        ],
+      },
+    };
+
+    it('should return the title', () => {
+      expect(getTitle(record)).to.equal('Consultation Note');
+    });
+
+    it('should return null if the "coding" array contains no code', () => {
+      const badRec = { type: { coding: [{ ignore: 'the wrong object' }] } };
+      expect(getTitle(badRec)).to.be.null;
+    });
+
+    it('should return null if the "coding" array is empty', () => {
+      const badRec = { type: { coding: [] } };
+      expect(getTitle(badRec)).to.be.null;
+    });
+
+    it('should return null if the "type" object contains no coding', () => {
+      const badRec = { type: { ignore: 'the wrong object' } };
+      expect(getTitle(badRec)).to.be.null;
+    });
+  });
+});
+
+describe('getType', () => {
+  const record = {
+    type: {
+      coding: [{ ignore: 'the wrong object' }, { code: '11488-4' }],
+    },
+  };
+
+  it('should return the type', () => {
+    expect(getType(record)).to.equal('11488-4');
+  });
+
+  it('should return null if the "coding" array contains no code', () => {
+    const badRec = { type: { coding: [{ ignore: 'the wrong object' }] } };
+    expect(getType(badRec)).to.be.null;
+  });
+
+  it('should return null if the "coding" array is empty', () => {
+    const badRec = { type: { coding: [] } };
+    expect(getType(badRec)).to.be.null;
+  });
+
+  it('should return null if the "type" object contains no coding', () => {
+    const badRec = { type: { ignore: 'the wrong object' } };
+    expect(getType(badRec)).to.be.null;
+  });
+});
+
+describe('extractAuthenticator', () => {
+  const record = {
+    contained: [
+      {
+        id: 'Provider-1',
+        name: [{ ignore: 'the wrong object' }, { text: 'SMITH,JOHN' }],
+      },
+    ],
+    authenticator: { reference: '#Provider-1' },
+  };
+
+  it('should return the authenticator', () => {
+    expect(extractAuthenticator(record)).to.equal('SMITH,JOHN');
+  });
+
+  it('should return null if no "name" item contains a "text" field', () => {
+    const badRec = {
+      contained: [{ id: 'Provider-0', name: [{ ignore: 'the wrong object' }] }],
+      authenticator: { reference: '#Provider-1' },
+    };
+    expect(extractAuthenticator(badRec)).to.be.null;
+  });
+
+  it('should return null if "name" is empty', () => {
+    const badRec = {
+      contained: [{ id: 'Provider-0', name: [] }],
+      authenticator: { reference: '#Provider-1' },
+    };
+    expect(extractAuthenticator(badRec)).to.be.null;
+  });
+
+  it('should return null if the authenticator is not found', () => {
+    const badRec = {
+      contained: [{ id: 'Provider-0', name: [{ text: 'SMITH,JOHN' }] }],
+      authenticator: { reference: '#NotFound-0' },
+    };
+    expect(extractAuthenticator(badRec)).to.be.null;
+  });
+
+  it('should return null if the authenticator has no reference', () => {
+    const badRec = {
+      contained: [{ id: 'Provider-0', name: [{ text: 'SMITH,JOHN' }] }],
+      authenticator: { ignore: 'the wrong object' },
+    };
+    expect(extractAuthenticator(badRec)).to.be.null;
+  });
+});
+
+describe('extractAuthor', () => {
+  const record = {
+    contained: [
+      {
+        id: 'Author-0',
+        name: [{ ignore: 'the wrong object' }, { text: 'SMITH,JANE' }],
+      },
+    ],
+    author: [{ ignore: 'the wrong object' }, { reference: '#Author-0' }],
+  };
+
+  it('should return the author', () => {
+    expect(extractAuthor(record)).to.equal('SMITH,JANE');
+  });
+
+  it('should return null if no "name" item contains a "text" field', () => {
+    const badRec = {
+      contained: [{ id: 'Author-0', name: [{ ignore: 'the wrong object' }] }],
+      author: [{ reference: '#Author-0' }],
+    };
+    expect(extractAuthor(badRec)).to.be.null;
+  });
+
+  it('should return null if "name" is empty', () => {
+    const badRec = {
+      contained: [{ id: 'Author-0', name: [] }],
+      author: [{ reference: '#Author-0' }],
+    };
+    expect(extractAuthor(badRec)).to.be.null;
+  });
+
+  it('should return null if the author is not found', () => {
+    const badRec = {
+      contained: [{ id: 'Author-0', name: [{ text: 'SMITH,JANE' }] }],
+      author: [{ reference: '#NotFound-0' }],
+    };
+    expect(extractAuthor(badRec)).to.be.null;
+  });
+
+  it('should return null if the "author" array has no reference', () => {
+    const badRec = {
+      contained: [{ id: 'Author-0', name: [{ text: 'SMITH,JANE' }] }],
+      author: [{ ignore: 'the wrong object' }],
+    };
+    expect(extractAuthor(badRec)).to.be.null;
+  });
+
+  it('should return null if the "author" array is empty', () => {
+    const badRec = {
+      contained: [{ id: 'Author-0', name: [{ text: 'SMITH,JANE' }] }],
+      author: [],
+    };
+    expect(extractAuthor(badRec)).to.be.null;
+  });
+});
+
+describe('extractLocation', () => {
+  const record = {
+    contained: [
+      {
+        id: 'Location-0',
+        name: 'DAYTON',
+        resourceType: 'Location',
+      },
+    ],
+    context: {
+      related: [{ ignore: 'the wrong object' }, { reference: '#Location-0' }],
+    },
+  };
+
+  it('should return the location', () => {
+    expect(extractLocation(record)).to.equal('DAYTON');
+  });
+
+  it('should return null if "related" is not an array', () => {
+    const badRec = {
+      ...record,
+      context: { related: { reference: '#Location-0' } },
+    };
+    expect(extractLocation(badRec)).to.be.null;
+  });
+
+  it('should return null if "name" is not part of the contained location', () => {
+    const badRec = {
+      ...record,
+      contained: [{ id: 'Location-0' }],
+    };
+    expect(extractLocation(badRec)).to.be.null;
+  });
+
+  it('should return null if "context" is not found', () => {
+    const badRec = { ...record, context: null };
+    expect(extractLocation(badRec)).to.be.null;
+  });
+
+  it('should return null if the referenced item is not found', () => {
+    const badRec = {
+      ...record,
+      context: { related: [{ reference: '#NotFound-0' }] },
+    };
+    expect(extractLocation(badRec)).to.be.null;
+  });
+
+  it('should return null if no "related" items contain a "reference"', () => {
+    const badRec = {
+      ...record,
+      context: { related: [{ unrelated: 'unrelated' }] },
+    };
+    expect(extractLocation(badRec)).to.be.null;
+  });
+});
+
+describe('getNote', () => {
+  it('should return the decoded note, ignoring other content records', () => {
+    const record = {
+      content: [
+        { ignore: 'the wrong object' },
+        { attachment: { data: 'dGVzdA==' } },
+        { ignore: 'the wrong object' },
+      ],
+    };
+    expect(getNote(record)).to.equal('test');
+  });
+
+  it('should return null if the field is not a string', () => {
+    const record = { content: [{ attachment: { data: 12345 } }] };
+    expect(getNote(record)).to.be.null;
+  });
+
+  it('should return null if "content" is not an array', () => {
+    const record = { content: { attachment: { data: 'dGVzdA==' } } };
+    expect(getNote(record)).to.be.null;
+  });
+
+  it('should return null if no attachment is present', () => {
+    const record = { content: [{ ignore: 'the wrong object' }] };
+    expect(getNote(record)).to.be.null;
+  });
+});
+
+describe('getDateSigned', () => {
+  it('returns formatted date when extension array has an item with valueDateTime', () => {
+    const mockRecord = {
+      authenticator: {
+        extension: [
+          { ignore: 'the wrong object' },
+          { valueDateTime: '2024-02-07T15:41:47-05:00' },
+          { ignore: 'the wrong object' },
+        ],
+      },
+    };
+    const result = getDateSigned(mockRecord);
+    expect(result).to.equal('February 7, 2024');
+  });
+
+  it('returns null when the date is invalid', () => {
+    const mockRecord = {
+      authenticator: { extension: [{ valueDateTime: 'bad date' }] },
+    };
+    const result = getDateSigned(mockRecord);
+    expect(result).to.be.null;
+  });
+
+  it('returns null when extension array is present but empty', () => {
+    const mockRecord = { authenticator: { extension: [] } };
+    const result = getDateSigned(mockRecord);
+    expect(result).to.be.null;
+  });
+
+  it('returns null when "extension" is not an array', () => {
+    const mockRecord = { authenticator: { extension: { ignore: 'object' } } };
+    const result = getDateSigned(mockRecord);
+    expect(result).to.be.null;
+  });
+
+  it('returns null when extension array lacks a valueDateTime', () => {
+    const mockRecord = {
+      authenticator: {
+        extension: [{ notValueDateTime: 'some value' }],
+      },
+    };
+    const result = getDateSigned(mockRecord);
+    expect(result).to.be.null;
+  });
+
+  it('returns null when record does not have authenticator.extension array', () => {
+    const mockRecord = {
+      authenticator: {},
+    };
+    const result = getDateSigned(mockRecord);
+    expect(result).to.be.null;
+  });
+});
 
 describe('getRecordType', () => {
   const buildRecord = loinc => {
@@ -21,6 +344,25 @@ describe('getRecordType', () => {
     expect(getRecordType(dsNote)).to.equal(noteTypes.DISCHARGE_SUMMARY);
     expect(getRecordType(pnNote)).to.equal(noteTypes.PHYSICIAN_PROCEDURE_NOTE);
     expect(getRecordType(crNote)).to.equal(noteTypes.CONSULT_RESULT);
+  });
+});
+
+describe('getAttending', () => {
+  it('should return the attending', () => {
+    const summary =
+      'DICTATED BY: SMITH, ALICE    ATTENDING: SMITH, BOB         \nURGENCY: routine';
+    expect(getAttending(summary)).to.equal('SMITH, BOB');
+  });
+
+  it('should return null if there is no attending', () => {
+    const summary = 'DICTATED BY: SMITH, ALICE             \nURGENCY: routine';
+    expect(getAttending(summary)).to.be.null;
+  });
+
+  it('should return null if attending is listed with no entry', () => {
+    const summary =
+      'DICTATED BY: SMITH, ALICE    ATTENDING:          \nURGENCY: routine';
+    expect(getAttending(summary)).to.be.null;
   });
 });
 
@@ -50,42 +392,43 @@ describe('convertCareSummariesAndNotesRecord', () => {
   });
 });
 
-describe('getDateSigned', () => {
-  it('returns formatted date when extension array has an item with valueDateTime', () => {
-    const mockRecord = {
-      authenticator: {
-        extension: [{ valueDateTime: '2024-02-07T15:41:47-05:00' }],
-      },
+describe('careSummariesAndNotesReducer', () => {
+  it('creates a list', () => {
+    const response = {
+      entry: [
+        { resource: { type: { coding: [{ code: '18842-5' }] } } },
+        { resource: { type: { coding: [{ code: '11506-3' }] } } },
+        { resource: { type: { coding: [{ code: '11488-4' }] } } },
+      ],
+      resourceType: 'Bundle',
     };
-    const result = getDateSigned(mockRecord);
-    expect(result).to.equal('February 7, 2024');
+    const newState = careSummariesAndNotesReducer(
+      {},
+      { type: Actions.CareSummariesAndNotes.GET_LIST, response },
+    );
+    expect(newState.careSummariesAndNotesList.length).to.equal(3);
   });
 
-  it('returns null when extension array is present but empty', () => {
-    const mockRecord = {
-      authenticator: {
-        extension: [],
-      },
+  it('creates an empty list if "entry" is empty', () => {
+    const response = {
+      entry: [],
+      resourceType: 'Bundle',
     };
-    const result = getDateSigned(mockRecord);
-    expect(result).to.be.null;
+    const newState = careSummariesAndNotesReducer(
+      {},
+      { type: Actions.CareSummariesAndNotes.GET_LIST, response },
+    );
+    expect(newState).to.deep.equal({ careSummariesAndNotesList: [] });
   });
 
-  it("returns null when extension array's first item lacks valueDateTime", () => {
-    const mockRecord = {
-      authenticator: {
-        extension: [{ notValueDateTime: 'some value' }],
-      },
+  it('creates an empty list if "entry" is not present', () => {
+    const response = {
+      resourceType: 'Bundle',
     };
-    const result = getDateSigned(mockRecord);
-    expect(result).to.be.null;
-  });
-
-  it('returns null when record does not have authenticator.extension array', () => {
-    const mockRecord = {
-      authenticator: {},
-    };
-    const result = getDateSigned(mockRecord);
-    expect(result).to.be.null;
+    const newState = careSummariesAndNotesReducer(
+      {},
+      { type: Actions.CareSummariesAndNotes.GET_LIST, response },
+    );
+    expect(newState).to.deep.equal({ careSummariesAndNotesList: [] });
   });
 });


### PR DESCRIPTION
## Summary

- Fixed a bunch of unsafe references in Care Summaries & Notes reducer (e.g. grabbing [0] out of an array without verifying that it's the correct item)

## Related issue(s)

### [MHV-55652](https://jira.devops.va.gov/browse/MHV-55652) - Add more notes safety ###

> Add more reference-safety and tests for notes to help forestall any future frontend errors due to unexpected data.

## Testing done

- Added a ton of unit tests to check a wide variety of possible data scenarios.
 
## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
