### PR TITLE
Arf/77596/data router demo

### DIFF
--- a/src/applications/representatives/App.jsx
+++ b/src/applications/representatives/App.jsx
@@ -1,0 +1,442 @@
+import * as React from 'react';
+import {
+  Await,
+  createBrowserRouter,
+  defer,
+  Form,
+  Link,
+  Outlet,
+  RouterProvider,
+  useAsyncError,
+  useAsyncValue,
+  useFetcher,
+  useFetchers,
+  useLoaderData,
+  useNavigation,
+  useParams,
+  useRevalidator,
+  useRouteError,
+} from 'react-router-dom-v5-compat';
+
+import manifest from './manifest.json';
+
+const TODOS_KEY = 'todos';
+
+const uuid = () =>
+  Math.random()
+    .toString(36)
+    .substr(2, 9);
+
+function saveTodos(todos) {
+  return localStorage.setItem(TODOS_KEY, JSON.stringify(todos));
+}
+
+function initializeTodos() {
+  const todos = new Array(10)
+    .fill(null)
+    .reduce(
+      (acc, _, index) =>
+        Object.assign(acc, { [uuid()]: `Seeded Todo #${index + 1}` }),
+      {},
+    );
+  saveTodos(todos);
+  return todos;
+}
+
+function getTodos() {
+  let todos = null;
+  try {
+    todos = JSON.parse(localStorage.getItem(TODOS_KEY));
+  } catch (e) {
+    // Empty block statement
+  }
+  if (!todos) {
+    todos = initializeTodos();
+  }
+  return todos;
+}
+
+function addTodo(todo) {
+  const newTodos = { ...getTodos() };
+  newTodos[uuid()] = todo;
+  saveTodos(newTodos);
+}
+
+function deleteTodo(id) {
+  const newTodos = { ...getTodos() };
+  delete newTodos[id];
+  saveTodos(newTodos);
+}
+
+// function resetTodos() {
+//   localStorage.removeItem(TODOS_KEY);
+//   initializeTodos();
+// }
+
+function sleep(n) {
+  return new Promise(r => setTimeout(r, n));
+}
+
+function Fallback() {
+  return <p>Performing initial data load</p>;
+}
+
+// Layout
+function Layout() {
+  const navigation = useNavigation();
+  const revalidator = useRevalidator();
+  const fetchers = useFetchers();
+  const fetcherInProgress = fetchers.some(f =>
+    ['loading', 'submitting'].includes(f.state),
+  );
+
+  return (
+    <>
+      <h1>Data Router Example</h1>
+
+      <p>
+        This example demonstrates some of the core features of React Router
+        including nested &lt;Route&gt;s, &lt;Outlet&gt;s, &lt;Link&gt;s, and
+        using a "*" route (aka "splat route") to render a "not found" page when
+        someone visits an unrecognized URL.
+      </p>
+
+      <nav>
+        <ul>
+          <li>
+            <Link to="/">Home</Link>
+          </li>
+          <li>
+            <Link to="/todos">Todos</Link>
+          </li>
+          <li>
+            <Link to="/deferred">Deferred</Link>
+          </li>
+          <li>
+            <Link to="/404">404 Link</Link>
+          </li>
+          <li>
+            <button onClick={() => revalidator.revalidate()}>
+              Revalidate Data
+            </button>
+          </li>
+        </ul>
+      </nav>
+      <div style={{ position: 'fixed', top: 0, right: 0 }}>
+        {navigation.state !== 'idle' && <p>Navigation in progress...</p>}
+        {revalidator.state !== 'idle' && <p>Revalidation in progress...</p>}
+        {fetcherInProgress && <p>Fetcher in progress...</p>}
+      </div>
+      <p>
+        Click on over to <Link to="/todos">/todos</Link> and check out these
+        data loading APIs!
+      </p>
+      <p>
+        Or, checkout <Link to="/deferred">/deferred</Link> to see how to
+        separate critical and lazily loaded data in your loaders.
+      </p>
+      <p>
+        We've introduced some fake async-aspects of routing here, so Keep an eye
+        on the top-right hand corner to see when we're actively navigating.
+      </p>
+      <hr />
+      <Outlet />
+    </>
+  );
+}
+
+// Home
+async function homeLoader() {
+  await sleep();
+  return {
+    date: new Date().toISOString(),
+  };
+}
+
+function Home() {
+  const data = useLoaderData();
+  return (
+    <>
+      <h2>Home</h2>
+      <p>Date from loader: {data.date}</p>
+    </>
+  );
+}
+
+// Todos
+async function todosAction({ request }) {
+  await sleep();
+
+  const formData = await request.formData();
+
+  // Deletion via fetcher
+  if (formData.get('action') === 'delete') {
+    const id = formData.get('todoId');
+    if (typeof id === 'string') {
+      deleteTodo(id);
+      return { ok: true };
+    }
+  }
+
+  // Addition via <Form>
+  const todo = formData.get('todo');
+  if (typeof todo === 'string') {
+    addTodo(todo);
+  }
+
+  return new Response(null, {
+    status: 302,
+    headers: { Location: '/todos' },
+  });
+}
+
+async function todosLoader() {
+  await sleep();
+  return getTodos();
+}
+
+function TodosList() {
+  const todos = useLoaderData();
+  const navigation = useNavigation();
+  const formRef = React.useRef(null);
+
+  // If we add and then we delete - this will keep isAdding=true until the
+  // fetcher completes it's revalidation
+  const [isAdding, setIsAdding] = React.useState(false);
+  React.useEffect(
+    () => {
+      if (navigation.formData?.get('action') === 'add') {
+        setIsAdding(true);
+      } else if (navigation.state === 'idle') {
+        setIsAdding(false);
+        formRef.current?.reset();
+      }
+    },
+    [navigation],
+  );
+
+  return (
+    <>
+      <h2>Todos</h2>
+      <p>
+        This todo app uses a &lt;Form&gt; to submit new todos and a
+        &lt;fetcher.form&gt; to delete todos. Click on a todo item to navigate
+        to the /todos/:id route.
+      </p>
+      <ul>
+        <li>
+          <Link to="/todos/junk">
+            Click this link to force an error in the loader
+          </Link>
+        </li>
+        {Object.entries(todos).map(([id, todo]) => (
+          <li key={id}>
+            <TodoItem id={id} todo={todo} />
+          </li>
+        ))}
+      </ul>
+      <Form method="post" ref={formRef}>
+        <input type="hidden" name="action" value="add" />
+        <input name="todo" />
+        <button type="submit" disabled={isAdding}>
+          {isAdding ? 'Adding...' : 'Add'}
+        </button>
+      </Form>
+      <Outlet />
+    </>
+  );
+}
+
+function TodosBoundary() {
+  const error = useRouteError();
+  return (
+    <>
+      <h2>Error 💥</h2>
+      <p>{error.message}</p>
+    </>
+  );
+}
+
+function TodoItem({ id, todo }) {
+  const fetcher = useFetcher();
+
+  const isDeleting = fetcher.formData != null;
+  return (
+    <>
+      <Link to={`/todos/${id}`}>{todo}</Link>
+      &nbsp;
+      <fetcher.Form method="post" style={{ display: 'inline' }}>
+        <input type="hidden" name="action" value="delete" />
+        <button type="submit" name="todoId" value={id} disabled={isDeleting}>
+          {isDeleting ? 'Deleting...' : 'Delete'}
+        </button>
+      </fetcher.Form>
+    </>
+  );
+}
+
+// Todo
+async function todoLoader({ params }) {
+  await sleep();
+  const todos = getTodos();
+  if (!params.id) {
+    throw new Error('Expected params.id');
+  }
+  const todo = todos[params.id];
+  if (!todo) {
+    throw new Error(`Uh oh, I couldn't find a todo with id "${params.id}"`);
+  }
+  return todo;
+}
+
+function Todo() {
+  const params = useParams();
+  const todo = useLoaderData();
+  return (
+    <>
+      <h2>Nested Todo Route:</h2>
+      <p>id: {params.id}</p>
+      <p>todo: {todo}</p>
+    </>
+  );
+}
+
+const rand = () => Math.round(Math.random() * 100);
+const resolve = (d, ms) =>
+  new Promise(r => setTimeout(() => r(`${d} - ${rand()}`), ms));
+const reject = (d, ms) => {
+  let _d = d;
+  return new Promise((_, r) =>
+    setTimeout(() => {
+      if (_d instanceof Error) {
+        _d.message += ` - ${rand()}`;
+      } else {
+        _d += ` - ${rand()}`;
+      }
+      r(_d);
+    }, ms),
+  );
+};
+
+async function deferredLoader() {
+  return defer({
+    critical1: await resolve('Critical 1', 250),
+    critical2: await resolve('Critical 2', 500),
+    lazyResolved: Promise.resolve(`Lazy Data immediately resolved - ${rand()}`),
+    lazy1: resolve('Lazy 1', 1000),
+    lazy2: resolve('Lazy 2', 1500),
+    lazy3: resolve('Lazy 3', 2000),
+    lazyError: reject(new Error('Kaboom!'), 2500),
+  });
+}
+
+function DeferredPage() {
+  const data = useLoaderData();
+  return (
+    <div>
+      {/* Critical data renders immediately */}
+      <p>{data.critical1}</p>
+      <p>{data.critical2}</p>
+
+      {/* Pre-resolved deferred data never triggers the fallback */}
+      <React.Suspense fallback={<p>should not see me!</p>}>
+        <Await resolve={data.lazyResolved}>
+          <RenderAwaitedData />
+        </Await>
+      </React.Suspense>
+
+      {/* Deferred data can be rendered using a component + the useAsyncValue() hook */}
+      <React.Suspense fallback={<p>loading 1...</p>}>
+        <Await resolve={data.lazy1}>
+          <RenderAwaitedData />
+        </Await>
+      </React.Suspense>
+
+      <React.Suspense fallback={<p>loading 2...</p>}>
+        <Await resolve={data.lazy2}>
+          <RenderAwaitedData />
+        </Await>
+      </React.Suspense>
+
+      {/* Or you can bypass the hook and use a render function */}
+      <React.Suspense fallback={<p>loading 3...</p>}>
+        <Await resolve={data.lazy3}>{_data => <p>{_data}</p>}</Await>
+      </React.Suspense>
+
+      {/* Deferred rejections render using the useAsyncError hook */}
+      <React.Suspense fallback={<p>loading (error)...</p>}>
+        <Await resolve={data.lazyError} errorElement={<RenderAwaitedError />}>
+          <RenderAwaitedData />
+        </Await>
+      </React.Suspense>
+    </div>
+  );
+}
+
+function RenderAwaitedData() {
+  const data = useAsyncValue();
+  return <p>{data}</p>;
+}
+
+function RenderAwaitedError() {
+  const error = useAsyncError();
+  return (
+    <p style={{ color: 'red' }}>
+      Error (errorElement)!
+      <br />
+      {error.message} {error.stack}
+    </p>
+  );
+}
+
+const routes = [
+  {
+    path: '/',
+    Component: Layout,
+    children: [
+      {
+        index: true,
+        loader: homeLoader,
+        Component: Home,
+      },
+      {
+        path: 'todos',
+        action: todosAction,
+        loader: todosLoader,
+        Component: TodosList,
+        ErrorBoundary: TodosBoundary,
+        children: [
+          {
+            path: ':id',
+            loader: todoLoader,
+            Component: Todo,
+          },
+        ],
+      },
+      {
+        path: 'deferred',
+        loader: deferredLoader,
+        Component: DeferredPage,
+      },
+    ],
+  },
+];
+
+const router = createBrowserRouter(routes, {
+  basename: manifest.rootUrl,
+});
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => router.dispose());
+}
+
+export default function App() {
+  return (
+    <RouterProvider
+      router={router}
+      fallbackElement={<Fallback />}
+      // eslint-disable-next-line camelcase
+      future={{ v7_startTransition: true }}
+    />
+  );
+}

--- a/src/applications/representatives/app-entry.jsx
+++ b/src/applications/representatives/app-entry.jsx
@@ -1,13 +1,12 @@
+import * as React from 'react';
 import '@department-of-veterans-affairs/platform-polyfills';
-import startApp from '@department-of-veterans-affairs/platform-startup/index';
+import startReactApp from '@department-of-veterans-affairs/platform-startup/react';
 
 import './sass/representatives.scss';
-import routes from './routes';
-import reducer from './reducers';
-import manifest from './manifest.json';
+import App from './App';
 
-startApp({
-  url: manifest.rootUrl,
-  reducer,
-  routes,
-});
+startReactApp(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3932,6 +3932,11 @@
   resolved "https://registry.yarnpkg.com/@react-leaflet/core/-/core-1.1.1.tgz#827fd05bb542cf874116176d8ef48d5b12163f81"
   integrity sha512-7PGLWa9MZ5x/cWy8EH2VzI4T8q5WpuHbixzCDXqixP/WyqwIrg5NDUPgYuFnB4IEIZF+6nA265mYzswFo/h1Pw==
 
+"@remix-run/router@1.15.3":
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.15.3.tgz#d2509048d69dbb72d5389a14945339f1430b2d3c"
+  integrity sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==
+
 "@sentry/browser@^6.13.2":
   version "6.13.2"
   resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.13.2.tgz#8b731ecf8c3cdd92a4b6893a26f975fd5844056d"
@@ -11168,7 +11173,7 @@ history@^4.9.0:
     tiny-warning "^1.0.0"
     value-equal "^1.0.1"
 
-history@^5.2.0, history@^5.3.0:
+history@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/history/-/history-5.3.0.tgz#1548abaa245ba47992f063a0783db91ef201c73b"
   integrity sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==
@@ -16889,12 +16894,12 @@ react-remove-scroll@^2.5.2:
     use-sidecar "^1.1.2"
 
 react-router-dom-v5-compat@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.3.0.tgz#a6b1bf18a42e3c1b902711931c4b496920740815"
-  integrity sha512-lfnfDEAdfXf92VQQ692+aMFj9JKb73GZ7EbiQJeJT4sK+KUGvua3FGN2H8n2H5zSMaY1cvrihGiaI373cvv7OQ==
+  version "6.22.3"
+  resolved "https://registry.yarnpkg.com/react-router-dom-v5-compat/-/react-router-dom-v5-compat-6.22.3.tgz#4889b46d060492a58c401700c987bddcc8b915f4"
+  integrity sha512-icbyLKEUdMqWjehsRrQv0g/N4C33KFC2ZmnOBF7vvy1hudYSJWY4VTOjy3ey2YY+r3WtcdEH72M7IIGVHAkEtw==
   dependencies:
     history "^5.3.0"
-    react-router "6.3.0"
+    react-router "6.22.3"
 
 react-router-dom@^5.3.0:
   version "5.3.0"
@@ -16944,12 +16949,12 @@ react-router@5.2.1:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-router@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
-  integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==
+react-router@6.22.3:
+  version "6.22.3"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.22.3.tgz#9d9142f35e08be08c736a2082db5f0c9540a885e"
+  integrity sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==
   dependencies:
-    history "^5.2.0"
+    "@remix-run/router" "1.15.3"
 
 react-scroll@^1.8.4:
   version "1.8.4"
@@ -17310,7 +17315,12 @@ regenerator-runtime@^0.11.0:
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
 
-regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.9:
+regenerator-runtime@^0.13.4:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
+regenerator-runtime@^0.13.9:
   version "0.13.9"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
   integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==


### PR DESCRIPTION
The [deferred data guide](https://reactrouter.com/en/main/guides/deferred#the-solution) says:
> React Router takes advantage of React 18's Suspense for data fetching...

But I straightforwardly ported React Router's data router example that demonstrates a [`DeferredPage`](https://github.com/remix-run/react-router/blob/a04ae6b90127ae583be08432c52b951e53f6a3c7/examples/data-router/src/app.tsx#L342) to my app that has `react@17.0.2` and `react-router-dom-v5-compat@6.22.3` and the behavior looks basically correct. Am I not actually seeing the full "deferred data" behavior when I am on React 17? Or is the mention of React 18 in that guide slightly off instead?