### PR TITLE
DR | Add set-focus to loading indicator

### DIFF
--- a/src/applications/appeals/995/containers/App.jsx
+++ b/src/applications/appeals/995/containers/App.jsx
@@ -154,7 +154,10 @@ export const App = ({
   if (!SUPPORTED_BENEFIT_TYPES_LIST.includes(subTaskBenefitType)) {
     router.push('/start');
     content = wrapInH1(
-      <va-loading-indicator message="Please wait while we restart the application for you." />,
+      <va-loading-indicator
+        set-focus
+        message="Please wait while we restart the application for you."
+      />,
     );
   } else if (
     loggedIn &&

--- a/src/applications/appeals/995/containers/ITFWrapper.jsx
+++ b/src/applications/appeals/995/containers/ITFWrapper.jsx
@@ -16,7 +16,7 @@ import {
 const fetchWaitingStates = [requestStates.notCalled, requestStates.pending];
 
 const showLoading = (message, label) => (
-  <va-loading-indicator message={message} label={label} />
+  <va-loading-indicator set-focus message={message} label={label} />
 );
 
 const ITFWrapper = ({

--- a/src/applications/appeals/996/containers/Form0996App.jsx
+++ b/src/applications/appeals/996/containers/Form0996App.jsx
@@ -130,7 +130,10 @@ export const Form0996App = ({
     router.push('/start');
     content = (
       <h1 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
-        <va-loading-indicator message="Please wait while we restart the application for you." />
+        <va-loading-indicator
+          set-focus
+          message="Please wait while we restart the application for you."
+        />
       </h1>
     );
   } else if (


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > While the Intent to File is being loaded, the focus shifts to the footer H2. The `va-loading-indicator` that was used was missing the `set-focus` property. So this PR adds it.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > `set-focus` is a property of the loading indicator, and since our form manages focus on the ITF alert page, we don't have to worry about loss of focus.
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews  
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#43923](https://github.com/department-of-veterans-affairs/va.gov-team/issues/43923)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
 > Manual testing with network throttled to keep loading indicator visible (see screenshot)
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|  |  |
| ------- | ----- |
| Before | <img width="500" alt="intent to file loading with focus outline on the first footer h2" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/e1bfed18-3d6a-4825-b7a5-74180b425df5"> |
| After | <img width="500" alt="intent to file loading indicator with focus" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/f94855fc-b6ee-4264-a000-5cd5c65394bf"> |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
