### PR TITLE
Fix API endpoints for document upload for 20-10207

### DIFF
--- a/src/applications/simple-forms/20-10207/config/submit-transformer.js
+++ b/src/applications/simple-forms/20-10207/config/submit-transformer.js
@@ -82,7 +82,7 @@ export default function transformForSubmit(formConfig, form) {
   ) {
     const { street, street2, city } = transformedData.veteranMailingAddress;
     transformedData.veteranMailingAddress.street = street.slice(0, 30);
-    transformedData.veteranMailingAddress.street2 = street2.slice(0, 5);
+    transformedData.veteranMailingAddress.street2 = street2?.slice(0, 5);
     transformedData.veteranMailingAddress.city = city.slice(0, 20);
   }
   if (
@@ -91,7 +91,7 @@ export default function transformForSubmit(formConfig, form) {
   ) {
     const { street, street2, city } = transformedData.nonVeteranMailingAddress;
     transformedData.nonVeteranMailingAddress.street = street.slice(0, 30);
-    transformedData.nonVeteranMailingAddress.street2 = street2.slice(0, 5);
+    transformedData.nonVeteranMailingAddress.street2 = street2?.slice(0, 5);
     transformedData.nonVeteranMailingAddress.city = city.slice(0, 20);
   }
 

--- a/src/applications/simple-forms/20-10207/pages/evidenceALS.js
+++ b/src/applications/simple-forms/20-10207/pages/evidenceALS.js
@@ -35,7 +35,7 @@ export default {
         },
         fileUploadUrl: `${
           environment.API_URL
-        }/simple_forms_api/v1/simple_forms/submit_als_documents`,
+        }/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
         fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
         createPayload,
         parseResponse,

--- a/src/applications/simple-forms/20-10207/pages/evidenceFinancialHardship.js
+++ b/src/applications/simple-forms/20-10207/pages/evidenceFinancialHardship.js
@@ -34,7 +34,7 @@ export default {
         },
         fileUploadUrl: `${
           environment.API_URL
-        }/simple_forms_api/v1/simple_forms/submit_financial_hardship_documents`,
+        }/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
         fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
         createPayload,
         parseResponse,

--- a/src/applications/simple-forms/20-10207/pages/evidenceMedalAward.js
+++ b/src/applications/simple-forms/20-10207/pages/evidenceMedalAward.js
@@ -35,7 +35,7 @@ export default {
         },
         fileUploadUrl: `${
           environment.API_URL
-        }/simple_forms_api/v1/simple_forms/submit_medal_award_documents`,
+        }/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
         fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
         createPayload,
         parseResponse,

--- a/src/applications/simple-forms/20-10207/pages/evidencePowDocuments.js
+++ b/src/applications/simple-forms/20-10207/pages/evidencePowDocuments.js
@@ -34,7 +34,7 @@ export default {
         },
         fileUploadUrl: `${
           environment.API_URL
-        }/simple_forms_api/v1/simple_forms/submit_pow_documents`,
+        }/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
         fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
         createPayload,
         parseResponse,

--- a/src/applications/simple-forms/20-10207/pages/evidenceTerminalIllness.js
+++ b/src/applications/simple-forms/20-10207/pages/evidenceTerminalIllness.js
@@ -34,7 +34,7 @@ export default {
         },
         fileUploadUrl: `${
           environment.API_URL
-        }/simple_forms_api/v1/simple_forms/submit_terminal_illness_documents`,
+        }/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
         fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
         createPayload,
         parseResponse,

--- a/src/applications/simple-forms/20-10207/pages/evidenceVSI.js
+++ b/src/applications/simple-forms/20-10207/pages/evidenceVSI.js
@@ -35,7 +35,7 @@ export default {
         },
         fileUploadUrl: `${
           environment.API_URL
-        }/simple_forms_api/v1/simple_forms/submit_vsi_documents`,
+        }/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
         fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
         createPayload,
         parseResponse,


### PR DESCRIPTION
## Summary

This PR updates the endpoints for document uploads for 20-10207. We want all document uploads to go through one endpoint--they don't really need to be disambiguated, as far as I understand it.

Related to https://github.com/department-of-veterans-affairs/vets-api/pull/15868

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/912

