### PR TITLE
Fixes some tests in `check-in`, maybe 😬 

### DIFF
--- a/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentListItem.unit.spec.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentListItem.unit.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 
 import AppointmentListItem from '../AppointmentListItem';
 
@@ -35,6 +36,12 @@ const mockRouter = {
 };
 
 describe('AppointmentListItem', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('pre-check-in and day-of', () => {
     describe('In person appointment context', () => {
       it('Renders appointment details', () => {

--- a/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentMessage.unit.spec.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentMessage.unit.spec.jsx
@@ -6,12 +6,17 @@ import AppointmentMessage from '../AppointmentMessage';
 
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 import { ELIGIBILITY } from '../../../utils/appointment/eligibility';
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 
 describe('check-in', () => {
-  afterEach(() => {
-    MockDate.reset();
+  beforeEach(() => {
+    setupI18n();
   });
 
+  afterEach(() => {
+    teardownI18n();
+    MockDate.reset();
+  });
   describe('AppointmentMessage', () => {
     it('should render the bad status message for appointments with INELIGIBLE_BAD_STATUS status', () => {
       const action = render(

--- a/src/applications/check-in/components/layout/tests/Footer.unit.spec.jsx
+++ b/src/applications/check-in/components/layout/tests/Footer.unit.spec.jsx
@@ -2,10 +2,17 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
 
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 import Footer from '../Footer';
 
 describe('check-in', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('Footer', () => {
     it('Renders day-of check-in footer', () => {
       const component = render(

--- a/src/applications/check-in/components/layout/tests/Wrapper.unit.spec.jsx
+++ b/src/applications/check-in/components/layout/tests/Wrapper.unit.spec.jsx
@@ -6,11 +6,18 @@ import { render } from '@testing-library/react';
 import { createServiceMap } from '@department-of-veterans-affairs/platform-monitoring';
 import { I18nextProvider } from 'react-i18next';
 import { addDays, subDays, format } from 'date-fns';
-import i18n from '../../../utils/i18n/i18n';
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 import Wrapper from '../Wrapper';
 
 describe('Wrapper component', () => {
+  let i18n;
+  beforeEach(() => {
+    i18n = setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   it('renders the passed in page title and child', () => {
     const { getByText, getByTestId } = render(
       <CheckInProvider store={{ app: 'PreCheckIn' }}>

--- a/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
@@ -9,8 +9,15 @@ import {
   singleAppointment,
 } from '../../../tests/unit/mocks/mock-appointments';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 
 describe('check-in experience', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('shared components', () => {
     const initAppointments = [...multipleAppointments, ...singleAppointment];
     const now = format(new Date(), "yyyy-LL-dd'T'HH:mm:ss");

--- a/src/applications/check-in/components/pages/ConfirmablePage/ConfirmablePage.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/ConfirmablePage/ConfirmablePage.unit.spec.jsx
@@ -4,9 +4,16 @@ import { expect } from 'chai';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
 import ConfirmablePage from './index';
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 
 describe('pre-check-in experience', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('shared components', () => {
     describe('ConfirmablePage', () => {
       it('renders custom header', () => {

--- a/src/applications/check-in/components/pages/TravelPage/TravelPage.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/TravelPage/TravelPage.unit.spec.jsx
@@ -4,9 +4,16 @@ import { expect } from 'chai';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
 import TravelPage from './index';
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 
 describe('Check-in experience', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('shared components', () => {
     describe('TravelPage', () => {
       it('renders custom header, eyebrow, body, and helptext', () => {

--- a/src/applications/check-in/components/pages/demographics/DemographicsDisplay.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/demographics/DemographicsDisplay.unit.spec.jsx
@@ -2,10 +2,17 @@ import React from 'react';
 import { expect } from 'chai';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 import DemographicsDisplay from './DemographicsDisplay';
 
 describe('pre-check-in experience', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('shared components', () => {
     describe('DemographicsDisplay', () => {
       it('renders with default values', () => {

--- a/src/applications/check-in/components/pages/emergencyContact/EmergencyContactDisplay.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/emergencyContact/EmergencyContactDisplay.unit.spec.jsx
@@ -2,10 +2,17 @@ import React from 'react';
 import { expect } from 'chai';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 import EmergencyContactDisplay from './EmergencyContactDisplay';
 
 describe('pre-check-in experience', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('shared components', () => {
     describe('EmergencyContactDisplay', () => {
       it('renders with default values', () => {

--- a/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/nextOfKin/NextOfKinDisplay.unit.spec.jsx
@@ -2,10 +2,17 @@ import React from 'react';
 import { expect } from 'chai';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 import NextOfKinDisplay from './NextOfKinDisplay';
 
 describe('pre-check-in experience', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('shared components', () => {
     describe('NextOfKinDisplay', () => {
       it('renders with default values', () => {

--- a/src/applications/check-in/components/pages/validate/ValidateDisplay.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/validate/ValidateDisplay.unit.spec.jsx
@@ -3,10 +3,17 @@ import React from 'react';
 import { expect } from 'chai';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 import ValidateDisplay from './ValidateDisplay';
 
 describe('check-in experience', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('shared components', () => {
     describe('ValidateDisplay', () => {
       it('renders with default values', () => {

--- a/src/applications/check-in/components/tests/AddressBlock.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/AddressBlock.unit.spec.jsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
+import { setupI18n, teardownI18n } from '../../utils/i18n/i18n';
 
 import AddressBlock from '../AddressBlock';
 
 describe('check-in', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('AddressBlock', () => {
     const fullAddress = {
       street1: 'line 1',

--- a/src/applications/check-in/components/tests/AppointmentBlock.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/AppointmentBlock.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
 import { format as formatDate } from 'date-fns';
+import { setupI18n, teardownI18n } from '../../utils/i18n/i18n';
 import CheckInProvider from '../../tests/unit/utils/CheckInProvider';
 
 import AppointmentBlock from '../AppointmentBlock';
@@ -28,7 +29,14 @@ const appointments = [
     kind: 'clinic',
   },
 ];
+
 describe('AppointmentBlock', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('pre-check-in context', () => {
     describe('In person appointment context', () => {
       it('Renders appointment day for multiple appointments', () => {

--- a/src/applications/check-in/components/tests/BackButton.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/BackButton.unit.spec.jsx
@@ -2,10 +2,17 @@ import React from 'react';
 import { expect } from 'chai';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
+import { setupI18n, teardownI18n } from '../../utils/i18n/i18n';
 import CheckInProvider from '../../tests/unit/utils/CheckInProvider';
 import BackButton from '../BackButton';
 
 describe('check-in', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('BackButton', () => {
     const store = {
       formPages: [

--- a/src/applications/check-in/components/tests/ExternalLink.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/ExternalLink.unit.spec.jsx
@@ -2,9 +2,16 @@ import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
 import ExternalLink from '../ExternalLink';
+import { setupI18n, teardownI18n } from '../../utils/i18n/i18n';
 import CheckInProvider from '../../tests/unit/utils/CheckInProvider';
 
 describe('check-in', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('ExternalLink component - en', () => {
     it('renders link component - en', () => {
       const screen = render(

--- a/src/applications/check-in/components/tests/HelpBlock.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/HelpBlock.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
 
+import { setupI18n, teardownI18n } from '../../utils/i18n/i18n';
 import CheckInProvider from '../../tests/unit/utils/CheckInProvider';
 import HelpBlock from '../HelpBlock';
 
@@ -14,6 +15,12 @@ describe('<HelpBlock />', () => {
     },
   };
 
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   it('renders correctly without the travel block when travel prop is false or undefined', () => {
     const component = render(
       <CheckInProvider

--- a/src/applications/check-in/components/tests/LanguagePicker.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/LanguagePicker.unit.spec.jsx
@@ -2,17 +2,21 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render, fireEvent } from '@testing-library/react';
-import i18next from 'i18next';
-import i18n from '../../utils/i18n/i18n';
 import CheckInProvider from '../../tests/unit/utils/CheckInProvider';
+import { setupI18n, teardownI18n } from '../../utils/i18n/i18n';
 
 import LanguagePicker from '../LanguagePicker';
 
 describe('check-in', () => {
+  let i18n;
+  beforeEach(() => {
+    i18n = setupI18n();
+  });
+
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('LanguagePicker', () => {
-    afterEach(() => {
-      i18next.changeLanguage('en');
-    });
     it('Renders', () => {
       const screen = render(
         <CheckInProvider>

--- a/src/applications/check-in/components/tests/MixedLanguageDisclaimer.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/MixedLanguageDisclaimer.unit.spec.jsx
@@ -2,12 +2,19 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
-import i18next from 'i18next';
+import { setupI18n, teardownI18n } from '../../utils/i18n/i18n';
 import CheckInProvider from '../../tests/unit/utils/CheckInProvider';
 
 import MixedLanguageDisclaimer from '../MixedLanguageDisclaimer';
 
 describe('Mixed Language Disclaimer', () => {
+  let i18n;
+  beforeEach(() => {
+    i18n = setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   const initState = {
     features: {
       check_in_experience_translation_disclaimer_spanish_enabled: true,
@@ -15,10 +22,10 @@ describe('Mixed Language Disclaimer', () => {
     },
   };
   afterEach(() => {
-    i18next.changeLanguage('en');
+    i18n.changeLanguage('en');
   });
   it('does not render when the language is set to english', () => {
-    i18next.changeLanguage('en');
+    i18n.changeLanguage('en');
     const screen = render(
       <CheckInProvider store={initState}>
         <MixedLanguageDisclaimer />
@@ -27,7 +34,7 @@ describe('Mixed Language Disclaimer', () => {
     expect(screen.queryByTestId('mixed-language-disclaimer')).to.be.null;
   });
   it('renders when the language is set to spanish', () => {
-    i18next.changeLanguage('es');
+    i18n.changeLanguage('es');
     const screen = render(
       <CheckInProvider store={initState}>
         <MixedLanguageDisclaimer />
@@ -36,7 +43,7 @@ describe('Mixed Language Disclaimer', () => {
     expect(screen.queryByTestId('mixed-language-disclaimer')).to.exist;
   });
   it('renders when the language is set to tagalog', () => {
-    i18next.changeLanguage('tl');
+    i18n.changeLanguage('tl');
     const screen = render(
       <CheckInProvider store={initState}>
         <MixedLanguageDisclaimer />

--- a/src/applications/check-in/components/tests/PreCheckinAccordionBlock.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/PreCheckinAccordionBlock.unit.spec.jsx
@@ -2,15 +2,22 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
-import i18next from 'i18next';
+import { setupI18n, teardownI18n } from '../../utils/i18n/i18n';
 import CheckInProvider from '../../tests/unit/utils/CheckInProvider';
 
 import PreCheckInAccordionBlock from '../PreCheckInAccordionBlock';
 
 describe('check-in', () => {
+  let i18n;
+  beforeEach(() => {
+    i18n = setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('PreCheckInAccordionBlock', () => {
     afterEach(() => {
-      i18next.changeLanguage('en');
+      i18n.changeLanguage('en');
     });
     const appointments = [
       {

--- a/src/applications/check-in/components/tests/PreCheckinConfirmation.test.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/PreCheckinConfirmation.test.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
+import { setupI18n, teardownI18n } from '../../utils/i18n/i18n';
 import CheckInProvider from '../../tests/unit/utils/CheckInProvider';
 import {
   singleAppointment,
@@ -30,6 +31,13 @@ describe('pre-check-in', () => {
   const mockRouter = {
     currentPage: '/health-care/appointment-pre-check-in',
   };
+
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
 
   describe('Confirmation page', () => {
     describe('appointment without friendly name', () => {

--- a/src/applications/check-in/components/tests/TravelEligibilityAddtionalInfo.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/TravelEligibilityAddtionalInfo.unit.spec.jsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
+import { setupI18n, teardownI18n } from '../../utils/i18n/i18n';
 import CheckInProvider from '../../tests/unit/utils/CheckInProvider';
 import TravelEligibilityAddtionalInfo from '../TravelEligibilityAdditionalInfo';
 
 describe('Check-in shared components', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('TravelEligibilityAddtionalInfo', () => {
     it('Renders', () => {
       const screen = render(

--- a/src/applications/check-in/day-of/app-entry.jsx
+++ b/src/applications/check-in/day-of/app-entry.jsx
@@ -7,7 +7,9 @@ import createRoutesWithStore from './routes';
 import reducer from '../reducers';
 import manifest from './manifest.json';
 
-import '../utils/i18n/i18n';
+import { setupI18n } from '../utils/i18n/i18n';
+
+setupI18n();
 
 startApp({
   url: manifest.rootUrl,

--- a/src/applications/check-in/day-of/pages/CheckIn/tests/CheckIn.test.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/tests/CheckIn.test.unit.spec.jsx
@@ -3,10 +3,17 @@ import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
 
+import { setupI18n, teardownI18n } from '../../../../utils/i18n/i18n';
 import CheckIn from '../index';
 import CheckInProvider from '../../../../tests/unit/utils/CheckInProvider';
 
 describe('check-in', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('CheckIn component', () => {
     it('refresh appointments button exists', () => {
       const screen = render(

--- a/src/applications/check-in/day-of/pages/CheckIn/tests/DisplayMultipleAppointments.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/CheckIn/tests/DisplayMultipleAppointments.unit.spec.jsx
@@ -3,10 +3,17 @@ import { expect } from 'chai';
 import format from 'date-fns/format';
 import { render } from '@testing-library/react';
 
+import { setupI18n, teardownI18n } from '../../../../utils/i18n/i18n';
 import CheckInProvider from '../../../../tests/unit/utils/CheckInProvider';
 import DisplayMultipleAppointments from '../DisplayMultipleAppointments';
 
 describe('check-in', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('DisplayMultipleAppointments component', () => {
     it('shows appointment details progress', () => {
       const token = 'token-123';

--- a/src/applications/check-in/day-of/pages/Confirmation/tests/CheckInConfirmation.test.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/tests/CheckInConfirmation.test.unit.spec.jsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import { setupI18n, teardownI18n } from '../../../../utils/i18n/i18n';
 import CheckInProvider from '../../../../tests/unit/utils/CheckInProvider';
 import CheckInConfirmation from '../CheckInConfirmation';
 
@@ -14,6 +15,12 @@ import * as useUpdateErrorModule from '../../../../hooks/useUpdateError';
 import * as useFormRoutingModule from '../../../../hooks/useFormRouting';
 
 describe('check in', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('CheckInConfirmation', () => {
     const appointments = [
       {

--- a/src/applications/check-in/day-of/pages/Confirmation/tests/TravelPayAlert.test.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/tests/TravelPayAlert.test.unit.spec.jsx
@@ -2,10 +2,17 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
 
+import { setupI18n, teardownI18n } from '../../../../utils/i18n/i18n';
 import CheckInProvider from '../../../../tests/unit/utils/CheckInProvider';
 import TravelPayAlert from '../TravelPayAlert';
 
 describe('check in', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('TravelPayAlert', () => {
     it('renders a eligible message', () => {
       const component = render(

--- a/src/applications/check-in/day-of/pages/tests/Demographics.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/tests/Demographics.unit.spec.jsx
@@ -4,9 +4,18 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import Demographics from '../Demographics';
 
 describe('check in', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+
+  afterEach(() => {
+    teardownI18n();
+  });
+
   describe('Demographics', () => {
     const veteranData = {
       demographics: {

--- a/src/applications/check-in/day-of/pages/tests/EmergencyContact.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/tests/EmergencyContact.unit.spec.jsx
@@ -3,10 +3,17 @@ import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 import EmergencyContact from '../EmergencyContact';
 
 describe('check in', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('EmergencyContact', () => {
     const veteranData = {
       demographics: {

--- a/src/applications/check-in/day-of/pages/tests/Error.test.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/tests/Error.test.unit.spec.jsx
@@ -3,9 +3,16 @@ import { expect } from 'chai';
 import { render } from '@testing-library/react';
 
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import Error from '../Error';
 
 describe('check-in', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('Error component', () => {
     it('renders without the phone number', () => {
       const component = render(

--- a/src/applications/check-in/day-of/pages/tests/NextOfKin.unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/tests/NextOfKin.unit.spec.jsx
@@ -3,10 +3,17 @@ import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 import NextOfKin from '../NextOfKin';
 
 describe('check in', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('Next of Kin', () => {
     const veteranData = {
       demographics: {

--- a/src/applications/check-in/day-of/pages/tests/SeeStaff-unit.spec.jsx
+++ b/src/applications/check-in/day-of/pages/tests/SeeStaff-unit.spec.jsx
@@ -2,11 +2,18 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
 
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 
 import SeeStaff from '../SeeStaff';
 
 describe('check in', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('SeeStaff', () => {
     it('has a header', () => {
       const component = render(

--- a/src/applications/check-in/hooks/tests/useSendTravelPayClaim/useSendTravelPayClaim.unit.spec.jsx
+++ b/src/applications/check-in/hooks/tests/useSendTravelPayClaim/useSendTravelPayClaim.unit.spec.jsx
@@ -35,6 +35,7 @@ describe('check-in', () => {
               'travel-question': 'yes',
               'travel-address': 'yes',
               'travel-mileage': 'yes',
+              'travel-review': 'yes',
               'travel-vehicle': 'yes',
             },
             pages: [],
@@ -53,7 +54,7 @@ describe('check-in', () => {
     afterEach(() => {
       sandbox.restore();
     });
-    it.skip('Loads test component with hook', () => {
+    it('Loads test component with hook', () => {
       const screen = render(
         <Provider store={store}>
           <TestComponent />

--- a/src/applications/check-in/pre-check-in/app-entry.jsx
+++ b/src/applications/check-in/pre-check-in/app-entry.jsx
@@ -8,8 +8,10 @@ import createRoutesWithStore from './routes';
 import reducer from '../reducers';
 import manifest from './manifest.json';
 
-import '../utils/i18n/i18n';
+import { setupI18n } from '../utils/i18n/i18n';
 import '../utils/defineWebComponents';
+
+setupI18n();
 
 startApp({
   url: manifest.rootUrl,

--- a/src/applications/check-in/pre-check-in/pages/Confirmation/tests/Confirmation.test.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Confirmation/tests/Confirmation.test.unit.spec.jsx
@@ -4,13 +4,20 @@ import { expect } from 'chai';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { I18nextProvider } from 'react-i18next';
-import i18n from '../../../../utils/i18n/i18n';
+import { setupI18n, teardownI18n } from '../../../../utils/i18n/i18n';
 import Confirmation from '../index';
 import { singleAppointment } from '../../../../tests/unit/mocks/mock-appointments';
 import { scheduledDowntimeState } from '../../../../tests/unit/utils/initState';
 import PreCheckinConfirmation from '../../../../components/PreCheckinConfirmation';
 
 describe('pre-check-in', () => {
+  let i18n;
+  beforeEach(() => {
+    i18n = setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('Confirmation page', () => {
     describe('redux store without friendly name', () => {
       const initState = {

--- a/src/applications/check-in/pre-check-in/pages/Demographics/tests/Demographics.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Demographics/tests/Demographics.unit.spec.jsx
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import { multipleAppointments } from '../../../../tests/unit/mocks/mock-appointments';
+import { setupI18n, teardownI18n } from '../../../../utils/i18n/i18n';
 import CheckInProvider from '../../../../tests/unit/utils/CheckInProvider';
 import Demographics from '../index';
 
@@ -49,6 +50,12 @@ const veteranData = {
 };
 
 describe('pre-check-in', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('Demographics sub message', () => {
     it('renders the sub-message for an in-person appointment', () => {
       const component = render(

--- a/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/tests/Error.unit.spec.jsx
@@ -6,11 +6,18 @@ import { render } from '@testing-library/react';
 import { within } from '@testing-library/dom';
 import MockDate from 'mockdate';
 
+import { setupI18n, teardownI18n } from '../../../../utils/i18n/i18n';
 import CheckInProvider from '../../../../tests/unit/utils/CheckInProvider';
 import { singleAppointment } from '../../../../tests/unit/mocks/mock-appointments';
 import Error from '../index';
 
 describe('check-in', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('Pre-check-in Error page', () => {
     afterEach(() => {
       MockDate.reset();

--- a/src/applications/check-in/tests/unit/utils/CheckInProvider.jsx
+++ b/src/applications/check-in/tests/unit/utils/CheckInProvider.jsx
@@ -2,12 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
 import { I18nextProvider } from 'react-i18next';
-
 import { createStore } from './initState';
-import i18n from '../../../utils/i18n/i18n';
 import { createMockRouter } from '../mocks/router';
 
-const CheckInProvider = ({ children, store = {}, router = {} }) => {
+const CheckInProvider = ({ i18n, children, store = {}, router = {} }) => {
   const initStore = createStore(store);
   const defaultRouter = {
     params: {
@@ -27,6 +25,7 @@ const CheckInProvider = ({ children, store = {}, router = {} }) => {
 };
 
 CheckInProvider.propTypes = {
+  i18n: PropTypes.object.isRequired,
   children: PropTypes.node,
   router: PropTypes.object,
   store: PropTypes.object,

--- a/src/applications/check-in/travel-claim/app-entry.jsx
+++ b/src/applications/check-in/travel-claim/app-entry.jsx
@@ -7,7 +7,9 @@ import createRoutesWithStore from './routes';
 import reducer from '../reducers';
 import manifest from './manifest.json';
 
-import '../utils/i18n/i18n';
+import { setupI18n } from '../utils/i18n/i18n';
+
+setupI18n();
 
 startApp({
   url: manifest.rootUrl,

--- a/src/applications/check-in/travel-claim/pages/complete/Complete.unit.spec.jsx
+++ b/src/applications/check-in/travel-claim/pages/complete/Complete.unit.spec.jsx
@@ -5,6 +5,7 @@ import { render } from '@testing-library/react';
 import MockDate from 'mockdate';
 import sinon from 'sinon';
 import Complete from './index';
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 import * as usePostTravelClaimsModule from '../../../hooks/usePostTravelClaims';
 import * as useUpdateErrorModule from '../../../hooks/useUpdateError';
@@ -12,6 +13,12 @@ import * as useStorageModule from '../../../hooks/useStorage';
 import { api } from '../../../api';
 
 describe('Check-in experience', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('travel-claim components', () => {
     describe('Complete', () => {
       const sandbox = sinon.createSandbox();

--- a/src/applications/check-in/travel-claim/pages/error/Error.unit.spec.jsx
+++ b/src/applications/check-in/travel-claim/pages/error/Error.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
 
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 import Error from './index';
 
@@ -12,6 +13,12 @@ const appointments = [
 ];
 
 describe('check-in', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('travel-claim', () => {
     describe('Error component', () => {
       it('renders the correct error on max-validation', () => {

--- a/src/applications/check-in/travel-claim/pages/travel-intro/travelIntro.unit.spec.js
+++ b/src/applications/check-in/travel-claim/pages/travel-intro/travelIntro.unit.spec.js
@@ -2,10 +2,17 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 import TravelIntro from '.';
 
 describe('travel-claim', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   const store = {
     formPages: ['travel-info', 'travel-mileage'],
   };

--- a/src/applications/check-in/travel-claim/pages/travel-mileage/travelMileage.unit.spec.js
+++ b/src/applications/check-in/travel-claim/pages/travel-mileage/travelMileage.unit.spec.js
@@ -2,10 +2,17 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 import TravelMileage from '.';
 
 describe('travel-mileage', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('Mileage page', () => {
     it('displays single facility context', () => {
       const store = {

--- a/src/applications/check-in/utils/i18n/i18n.js
+++ b/src/applications/check-in/utils/i18n/i18n.js
@@ -3,6 +3,7 @@ import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { format as formatDate, isDate } from 'date-fns';
 import { enUS as en, es } from 'date-fns/locale';
+import { get } from 'lodash';
 import enTranslation from '../../locales/en/translation.json';
 import esTranslation from '../../locales/es/translation.json';
 import tlTranslation from '../../locales/tl/translation.json';
@@ -18,68 +19,81 @@ const setPageLanguage = language => {
 
 const locales = { en, es };
 
+/**
+ * Interpolators for date formatting.
+ */
+export const dateFormatInterpolators = {
+  long: (value, _format, lng, locale) => {
+    return lng.startsWith('es')
+      ? formatDate(value, "dd 'de' MMMM 'de' yyy", { locale })
+      : formatDate(value, 'MMMM dd, yyyy', { locale });
+  },
+  longAtTime: (value, _format, _lng, locale) => {
+    let dateString = formatDate(value, 'PPPppp', { locale });
+    // Remove date suffixes. (1st/2nd/etc.)
+    dateString = dateString.replace(/([0-9]{1,2})([a-z]{2})(, )/, '$1$3');
+    // Adjust am/pm formatting.
+    dateString = dateString.replace(/:[0-9]{2} AM .*$/, ' a.m.');
+    dateString = dateString.replace(/:[0-9]{2} PM .*$/, ' p.m.');
+    return dateString;
+  },
+  mdY: (value, _format, lng, _locale) => {
+    return lng.startsWith('es')
+      ? formatDate(value, 'dd/M/Y')
+      : formatDate(value, 'MM/dd/Y');
+  },
+  time: (value, _format, _lng, locale) => {
+    return formatDate(value, 'h:mm aaaa', { locale });
+  },
+  day: (value, _format, _lng, locale) => {
+    return formatDate(value, 'iiii', { locale });
+  },
+  monthDay: (value, _format, _lng, locale) => {
+    return formatDate(value, "MMMM' 'dd", { locale });
+  },
+  dayOfWeek: (value, _format, _lng, locale) => {
+    return formatDate(value, 'eeee', { locale });
+  },
+  default: (value, format, _lng, locale) => {
+    return formatDate(value, format, { locale });
+  },
+};
+
+const i18nOptions = {
+  detection: {
+    order: ['localStorage', 'sessionStorage', 'navigator'],
+    lookupLocalStorage: 'checkin-i18nextLng',
+    lookupSessionStorage: 'checkin-i18nextLng',
+  },
+  fallbackLng: 'en',
+  debug: false,
+  interpolation: {
+    escapeValue: false,
+    format: (value, format, lng) => {
+      if (isDate(value)) {
+        const locale = locales[lng];
+        const interpolator = get(
+          dateFormatInterpolators,
+          format,
+          dateFormatInterpolators.default,
+        );
+        return interpolator(value, format, lng, locale);
+      }
+      return value;
+    },
+  },
+  resources: {
+    en: { translation: enTranslation },
+    es: { translation: esTranslation },
+    tl: { translation: tlTranslation },
+  },
+};
+
 export const setupI18n = () => {
   i18n
     .use(initReactI18next)
     .use(LanguageDetector)
-    .init({
-      detection: {
-        order: ['localStorage', 'sessionStorage', 'navigator'],
-        lookupLocalStorage: 'checkin-i18nextLng',
-        lookupSessionStorage: 'checkin-i18nextLng',
-      },
-      fallbackLng: 'en',
-      debug: false,
-      interpolation: {
-        escapeValue: false,
-        format: (value, format, lng) => {
-          if (isDate(value)) {
-            const locale = locales[lng];
-            if (format === 'long') {
-              return lng.startsWith('es')
-                ? formatDate(value, "dd 'de' MMMM 'de' yyy", { locale })
-                : formatDate(value, 'MMMM dd, yyyy', { locale });
-            }
-            if (format === 'longAtTime') {
-              let dateString = formatDate(value, 'PPPppp', { locale });
-              // Remove date suffixes. (1st/2nd/etc.)
-              dateString = dateString.replace(
-                /([0-9]{1,2})([a-z]{2})(, )/,
-                '$1$3',
-              );
-              // Adjust am/pm formatting.
-              dateString = dateString.replace(/:[0-9]{2} AM .*$/, ' a.m.');
-              dateString = dateString.replace(/:[0-9]{2} PM .*$/, ' p.m.');
-              return dateString;
-            }
-            if (format === 'mdY') {
-              return lng.startsWith('es')
-                ? formatDate(value, 'dd/M/Y')
-                : formatDate(value, 'MM/dd/Y');
-            }
-            if (format === 'time') {
-              return formatDate(value, 'h:mm aaaa', { locale });
-            }
-            if (format === 'day') {
-              return formatDate(value, 'iiii', { locale });
-            }
-            if (format === 'monthDay') {
-              return formatDate(value, "MMMM' 'dd", { locale });
-            }
-            if (format === 'dayOfWeek') {
-              return formatDate(value, 'eeee', { locale });
-            }
-            return formatDate(value, format, { locale });
-          }
-          return value;
-        },
-      },
-      resources: {
-        en: { translation: enTranslation },
-        es: { translation: esTranslation },
-        tl: { translation: tlTranslation },
-      },
-    });
+    .init(i18nOptions);
 
   // This is necessary for DS components to use our language preference on initial page load.
   i18n.on('languageChanged', language => {
@@ -96,5 +110,4 @@ setupI18n();
  */
 export const teardownI18n = () => {
   i18n.off('languageChanged', setPageLanguage);
-  // i18n.reset();
 };

--- a/src/applications/check-in/utils/i18n/i18n.js
+++ b/src/applications/check-in/utils/i18n/i18n.js
@@ -89,6 +89,8 @@ export const setupI18n = () => {
   return i18n;
 };
 
+setupI18n();
+
 /**
  * Cleans up i18n setup to avoid interference between tests.
  */

--- a/src/applications/check-in/utils/i18n/i18n.js
+++ b/src/applications/check-in/utils/i18n/i18n.js
@@ -18,73 +18,81 @@ const setPageLanguage = language => {
 
 const locales = { en, es };
 
-i18n
-  .use(initReactI18next)
-  .use(LanguageDetector)
-  .init({
-    detection: {
-      order: ['localStorage', 'sessionStorage', 'navigator'],
-      lookupLocalStorage: 'checkin-i18nextLng',
-      lookupSessionStorage: 'checkin-i18nextLng',
-    },
-    fallbackLng: 'en',
-    debug: false,
-    interpolation: {
-      escapeValue: false,
-      format: (value, format, lng) => {
-        if (isDate(value)) {
-          const locale = locales[lng];
-          if (format === 'long') {
-            return lng.startsWith('es')
-              ? formatDate(value, "dd 'de' MMMM 'de' yyy", { locale })
-              : formatDate(value, 'MMMM dd, yyyy', { locale });
-          }
-          if (format === 'longAtTime') {
-            let dateString = formatDate(value, 'PPPppp', { locale });
-            // Remove date suffixes. (1st/2nd/etc.)
-            dateString = dateString.replace(
-              /([0-9]{1,2})([a-z]{2})(, )/,
-              '$1$3',
-            );
-            // Adjust am/pm formatting.
-            dateString = dateString.replace(/:[0-9]{2} AM .*$/, ' a.m.');
-            dateString = dateString.replace(/:[0-9]{2} PM .*$/, ' p.m.');
-            return dateString;
-          }
-          if (format === 'mdY') {
-            return lng.startsWith('es')
-              ? formatDate(value, 'dd/M/Y')
-              : formatDate(value, 'MM/dd/Y');
-          }
-          if (format === 'time') {
-            return formatDate(value, 'h:mm aaaa', { locale });
-          }
-          if (format === 'day') {
-            return formatDate(value, 'iiii', { locale });
-          }
-          if (format === 'monthDay') {
-            return formatDate(value, "MMMM' 'dd", { locale });
-          }
-          if (format === 'dayOfWeek') {
-            return formatDate(value, 'eeee', { locale });
-          }
-          return formatDate(value, format, { locale });
-        }
-        return value;
+export const setupI18n = () => {
+  i18n
+    .use(initReactI18next)
+    .use(LanguageDetector)
+    .init({
+      detection: {
+        order: ['localStorage', 'sessionStorage', 'navigator'],
+        lookupLocalStorage: 'checkin-i18nextLng',
+        lookupSessionStorage: 'checkin-i18nextLng',
       },
-    },
-    resources: {
-      en: { translation: enTranslation },
-      es: { translation: esTranslation },
-      tl: { translation: tlTranslation },
-    },
+      fallbackLng: 'en',
+      debug: false,
+      interpolation: {
+        escapeValue: false,
+        format: (value, format, lng) => {
+          if (isDate(value)) {
+            const locale = locales[lng];
+            if (format === 'long') {
+              return lng.startsWith('es')
+                ? formatDate(value, "dd 'de' MMMM 'de' yyy", { locale })
+                : formatDate(value, 'MMMM dd, yyyy', { locale });
+            }
+            if (format === 'longAtTime') {
+              let dateString = formatDate(value, 'PPPppp', { locale });
+              // Remove date suffixes. (1st/2nd/etc.)
+              dateString = dateString.replace(
+                /([0-9]{1,2})([a-z]{2})(, )/,
+                '$1$3',
+              );
+              // Adjust am/pm formatting.
+              dateString = dateString.replace(/:[0-9]{2} AM .*$/, ' a.m.');
+              dateString = dateString.replace(/:[0-9]{2} PM .*$/, ' p.m.');
+              return dateString;
+            }
+            if (format === 'mdY') {
+              return lng.startsWith('es')
+                ? formatDate(value, 'dd/M/Y')
+                : formatDate(value, 'MM/dd/Y');
+            }
+            if (format === 'time') {
+              return formatDate(value, 'h:mm aaaa', { locale });
+            }
+            if (format === 'day') {
+              return formatDate(value, 'iiii', { locale });
+            }
+            if (format === 'monthDay') {
+              return formatDate(value, "MMMM' 'dd", { locale });
+            }
+            if (format === 'dayOfWeek') {
+              return formatDate(value, 'eeee', { locale });
+            }
+            return formatDate(value, format, { locale });
+          }
+          return value;
+        },
+      },
+      resources: {
+        en: { translation: enTranslation },
+        es: { translation: esTranslation },
+        tl: { translation: tlTranslation },
+      },
+    });
+
+  // This is necessary for DS components to use our language preference on initial page load.
+  i18n.on('languageChanged', language => {
+    setPageLanguage(language);
   });
 
-// This is necessary for DS components to use our language preference on initial page load.
-setPageLanguage(i18n.language);
+  return i18n;
+};
 
-i18n.on('languageChanged', language => {
-  setPageLanguage(language);
-});
-
-export default i18n;
+/**
+ * Cleans up i18n setup to avoid interference between tests.
+ */
+export const teardownI18n = () => {
+  i18n.off('languageChanged', setPageLanguage);
+  // i18n.reset();
+};

--- a/src/applications/check-in/utils/i18n/i18n.unit.spec.js
+++ b/src/applications/check-in/utils/i18n/i18n.unit.spec.js
@@ -1,0 +1,44 @@
+import { enUS as en, es } from 'date-fns/locale';
+import { expect } from 'chai';
+import { dateFormatInterpolators } from './i18n';
+
+const locales = { en, es };
+
+// Generate tests for date formatting interpolators
+describe('Date formatting interpolators', () => {
+  const expectedDates = {
+    en: {
+      long: 'March 12, 2024',
+      longAtTime: 'March 12, 2024 at 10:38 a.m.',
+      mdY: '03/12/2024',
+      time: '10:38 a.m.',
+      day: 'Tuesday',
+      monthDay: 'March 12',
+      dayOfWeek: 'Tuesday',
+    },
+    es: {
+      long: '12 de marzo de 2024',
+      longAtTime: '12 de marzo de 2024 a las 10:38:00 GMT-4',
+      mdY: '12/3/2024',
+      time: '10:38 a.m.',
+      day: 'martes',
+      monthDay: 'marzo 12',
+      dayOfWeek: 'martes',
+    },
+  };
+  ['en', 'es'].forEach(lng => {
+    Object.entries(dateFormatInterpolators).forEach(
+      ([format, interpolator]) => {
+        if (format === 'default') {
+          return;
+        }
+        it(`should format a date with the ${format} interpolator in ${lng}`, () => {
+          const date = new Date('2024-03-12T10:38:00');
+          const locale = locales[lng];
+          const result = interpolator(date, format, lng, locale);
+          expect(result).to.equal(expectedDates[lng][format]);
+        });
+      },
+    );
+  });
+});

--- a/src/applications/check-in/utils/i18n/i18n.unit.spec.js
+++ b/src/applications/check-in/utils/i18n/i18n.unit.spec.js
@@ -1,12 +1,14 @@
 import { enUS as en, es } from 'date-fns/locale';
+import { format as formatDate, zonedTimeToUtc } from 'date-fns-tz';
 import { expect } from 'chai';
 import { dateFormatInterpolators } from './i18n';
 
 const locales = { en, es };
+const languageCodes = Object.keys(locales);
 
 // Generate tests for date formatting interpolators
 describe('Date formatting interpolators', () => {
-  const expectedDates = {
+  const expectedDateStrings = {
     en: {
       long: 'March 12, 2024',
       longAtTime: 'March 12, 2024 at 10:38 a.m.',
@@ -18,7 +20,7 @@ describe('Date formatting interpolators', () => {
     },
     es: {
       long: '12 de marzo de 2024',
-      longAtTime: '12 de marzo de 2024 a las 10:38:00 GMT-4',
+      longAtTime: '12 de marzo de 2024 a las 10:38:00 ',
       mdY: '12/3/2024',
       time: '10:38 a.m.',
       day: 'martes',
@@ -26,17 +28,30 @@ describe('Date formatting interpolators', () => {
       dayOfWeek: 'martes',
     },
   };
-  ['en', 'es'].forEach(lng => {
+  languageCodes.forEach(lng => {
     Object.entries(dateFormatInterpolators).forEach(
       ([format, interpolator]) => {
         if (format === 'default') {
           return;
         }
-        it(`should format a date with the ${format} interpolator in ${lng}`, () => {
-          const date = new Date('2024-03-12T10:38:00');
+        let expected = expectedDateStrings[lng][format];
+        it(`should format a date with the "${format}" format in "${lng}"`, () => {
+          const now = new Date();
+          // March 12, 2024 at 10:38:00 AM EDT
+          const dateString = '2024-03-12T10:38:00.000';
+          const correctedDateString = `${dateString}${formatDate(
+            now,
+            'XXX',
+            process.env.TZ,
+          )}`;
+          const date = new Date(correctedDateString);
+          const utcDate = zonedTimeToUtc(date, process.env.TZ);
           const locale = locales[lng];
-          const result = interpolator(date, format, lng, locale);
-          expect(result).to.equal(expectedDates[lng][format]);
+          const actual = interpolator(utcDate, format, lng, locale);
+          if (format === 'longAtTime' && lng === 'es') {
+            expected = `${expected}${formatDate(now, 'O', process.env.TZ)}`;
+          }
+          expect(actual).to.equal(expected);
         });
       },
     );


### PR DESCRIPTION
## Summary

This reënables a previously skipped test and modifies how some `check-in` tests that confirmed translations worked; they relied on global state effects from imports, and this wraps the relevant code in a function so it can be executed, and also adds a teardown function.

**TL;DR**:
- Shifted `check-in` `i18n` initialization code into a function so that we could execute it directly before tests in addition to having it run as a side effect before all tests.
- Refactored above function because CodeClimate complained that it was too long and hard to understand.
- Added unit tests for date formatters that I refactored out of the above function because it's scary lol.

**Note**: Our code _still_ initializes `i18next` in the global execution context as well, or else translation would break; this PR effectively just re-initializes right before our tests as a defensive measure.

## Related issue(s)

-  department-of-veterans-affairs/va.gov-team#77029

## Testing done

- I ran all unit tests locally; some failed, but none in `check-in`'s area. I should've run them before to verify that the same ones failed 😞 
- I rebuilt pre-check-in, check-in, and travel-claims and went through them in English, Spanish, and partially in Tagalog to confirm that there were no unexpected changes.
- I ran various unit test commands (e.g. running certain tests pairwise) that had failed locally before my changes and verified they passed.
- I ran all check-in tests collectively locally in pseudorandom order and verified that none failed.
- I ran all check-in tests _individually_ locally and verified that none failed.

## Test Commands

The following commands can be run on `main` and then on this PR branch. On `main` they should fail. On this PR branch, they should succeed.

```bash
# Runs `appeals` and `check-in` unit tests in pseudorandom order.
failures=0;
for i in {1..10}; do
  files=$(find src/applications -type f \( -path '*applications/check-in*' -o -path '*applications/appeals*' \) -name '*.unit.spec.*' | shuf);
  if ! yarn test:unit $files; then
    ((failures++)); 
    echo "failed";
  else
    echo "passed";
  fi;
done;
echo "Failed $failures times out of 10."
```

```bash
# Runs a `check-in` test that does not import `i18n.js`.
yarn test:unit src/applications/check-in/components/tests/AddressBlock.unit.spec.jsx
```

```bash
# Runs a `check-in` test that imports `i18n.js` followed by an `appeals` test
# that initializes `i18next` via a different route.
# Note that running this command with the files listed in reverse order will pass
# on `main` because of the order of initialization.
yarn test:unit \
  ./src/applications/check-in/day-of/pages/tests/Demographics.unit.spec.jsx \
  ./src/applications/appeals/shared/tests/pages/areaOfDisagreement.unit.spec.jsx
```

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

Anything, I'm new here.