### PR TITLE
Use uniform modal language for direct deposit cancel editing modal

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/BankInfo.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/BankInfo.jsx
@@ -4,8 +4,6 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 
-import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-
 import {
   editCNPPaymentInformationToggled,
   saveCNPPaymentInformation as saveCNPPaymentInformationAction,
@@ -47,6 +45,7 @@ import NotEligible from './alerts/NotEligible';
 import { BANK_INFO_UPDATED_ALERT_SETTINGS } from '../../constants';
 import { ProfileInfoCard } from '../ProfileInfoCard';
 import { EduMigrationDowntimeAlert } from './alerts/EduMigrationDowntimeAlert';
+import ConfirmCancelModal from '~/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmCancelModal';
 
 export const BankInfo = ({
   isLOA3,
@@ -62,6 +61,7 @@ export const BankInfo = ({
   setFormIsDirty,
   setViewingPayments,
   showSuccessMessage,
+  benefitTypeLong,
 }) => {
   const formPrefix = type;
   const editBankInfoButton = useRef();
@@ -172,9 +172,6 @@ export const BankInfo = ({
   };
 
   const benefitTypeShort = typeIsCNP ? 'disability' : 'education';
-  const benefitTypeLong = typeIsCNP
-    ? 'disability compensation and pension'
-    : 'education';
 
   // When direct deposit is already set up we will show the current bank info
   const bankInfoContent = (
@@ -393,29 +390,17 @@ export const BankInfo = ({
 
   return (
     <>
-      <VaModal
-        modalTitle="Are you sure?"
-        status="warning"
-        visible={showConfirmCancelModal}
-        onCloseEvent={() => {
+      <ConfirmCancelModal
+        isVisible={showConfirmCancelModal}
+        onHide={() => {
           setShowConfirmCancelModal(false);
         }}
-        primaryButtonText="Continue Editing"
-        onPrimaryButtonClick={() => {
-          setShowConfirmCancelModal(false);
-        }}
-        secondaryButtonText="Cancel"
-        onSecondaryButtonClick={() => {
+        closeModal={() => {
           setShowConfirmCancelModal(false);
           toggleEditState();
         }}
-        uswds
-      >
-        <p>
-          You haven’t finished editing and saving the changes to your direct
-          deposit information. If you cancel now, we won’t save your changes.
-        </p>
-      </VaModal>
+        activeSection={`${benefitTypeLong} direct deposit information`}
+      />
 
       <ProfileInfoCard
         className="vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
@@ -429,6 +414,7 @@ export const BankInfo = ({
 };
 
 BankInfo.propTypes = {
+  benefitTypeLong: PropTypes.string.isRequired,
   directDepositServerError: PropTypes.bool.isRequired,
   isDirectDepositSetUp: PropTypes.bool.isRequired,
   isEligibleToSetUpDirectDeposit: PropTypes.bool.isRequired,
@@ -457,6 +443,9 @@ export const mapStateToProps = (state, ownProps) => {
   const typeIsCNP = ownProps.type === benefitTypes.CNP;
 
   return {
+    benefitTypeLong: typeIsCNP
+      ? 'disability compensation and pension'
+      : 'education',
     typeIsCNP,
     isLOA3: isLOA3Selector(state),
     directDepositAccountInfo: typeIsCNP

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/update-flow.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/update-flow.cypress.spec.js
@@ -77,6 +77,10 @@ describe('Direct Deposit', () => {
     cy.visit(PROFILE_PATHS.DIRECT_DEPOSIT);
     cy.injectAxe();
   });
+  afterEach(() => {
+    cy.injectAxeThenAxeCheck();
+    cy.visit(PROFILE_PATHS.CONTACT_INFORMATION);
+  });
   describe('for CNP', () => {
     it('should allow bank info updates, and show error', () => {
       cy.axeCheck();
@@ -129,6 +133,64 @@ describe('Direct Deposit', () => {
       saveSuccessAlertRemoved();
       cy.axeCheck();
     });
+
+    it('should allow a user to cancel unsaved changes and be shown a confirmation modal', () => {
+      cy.axeCheck();
+      cy.findByRole('button', {
+        name: /edit.*disability.*bank information/i,
+      }).click({
+        // using force: true since there are times when the click does not
+        // register and the bank info form does not open
+        force: true,
+      });
+      cy.get('#disability-compensation-and-pension-benefits').should(
+        'be.focused',
+      );
+      fillInBankInfoForm('CNP');
+      exitBankInfoForm('CNP');
+      cy.get('va-modal').should('exist');
+      cy.get('va-modal').contains(/are you sure/i);
+      cy.get('va-modal').contains(
+        /disability compensation and pension direct deposit information/i,
+      );
+      cy.get('va-modal')
+        .contains(/cancel/i)
+        .click();
+      cy.get('va-modal').should('not.exist');
+      cy.findByRole('button', {
+        name: /edit.*disability.*bank information/i,
+      }).should('exist');
+      cy.axeCheck();
+    });
+
+    it('should allow a user to cancel unsaved changes and be shown a confirmation modal, but decide to continue editing and not discard unsaved changes', () => {
+      cy.axeCheck();
+      cy.findByRole('button', {
+        name: /edit.*disability.*bank information/i,
+      }).click({
+        // using force: true since there are times when the click does not
+        // register and the bank info form does not open
+        force: true,
+      });
+      cy.get('#disability-compensation-and-pension-benefits').should(
+        'be.focused',
+      );
+      fillInBankInfoForm('CNP');
+      exitBankInfoForm('CNP');
+      cy.get('va-modal').should('exist');
+      cy.get('va-modal').contains(/are you sure/i);
+      cy.get('va-modal').contains(
+        /disability compensation and pension direct deposit information/i,
+      );
+      cy.get('va-modal')
+        .contains(/back to editing/i)
+        .click();
+      cy.get('va-modal').should('not.exist');
+      cy.findByRole('button', {
+        name: /save/i,
+      }).should('exist');
+      cy.axeCheck();
+    });
   });
   describe('for EDU', () => {
     it('should allow bank info updates, show WIP warning modals, show "update successful" banners, etc.', () => {
@@ -170,6 +232,56 @@ describe('Direct Deposit', () => {
       }).should('exist');
       saveSuccessAlertShown();
       saveSuccessAlertRemoved();
+      cy.axeCheck();
+    });
+
+    it('should allow a user to cancel unsaved changes and be shown a confirmation modal', () => {
+      cy.axeCheck();
+      cy.findByRole('button', {
+        name: /edit.*education.*bank information/i,
+      }).click({
+        // using force: true since there are times when the click does not
+        // register and the bank info form does not open
+        force: true,
+      });
+      cy.get('#education-benefits').should('be.focused');
+      fillInBankInfoForm('EDU');
+      exitBankInfoForm('EDU');
+      cy.get('va-modal').should('exist');
+      cy.get('va-modal').contains(/are you sure/i);
+      cy.get('va-modal').contains(/education direct deposit information/i);
+      cy.get('va-modal')
+        .contains(/cancel/i)
+        .click();
+      cy.get('va-modal').should('not.exist');
+      cy.findByRole('button', {
+        name: /edit.*education.*bank information/i,
+      }).should('exist');
+      cy.axeCheck();
+    });
+
+    it('should allow a user to cancel unsaved changes and be shown a confirmation modal, but decide to continue editing and not discard unsaved changes', () => {
+      cy.axeCheck();
+      cy.findByRole('button', {
+        name: /edit.*education.*bank information/i,
+      }).click({
+        // using force: true since there are times when the click does not
+        // register and the bank info form does not open
+        force: true,
+      });
+      cy.get('#education-benefits').should('be.focused');
+      fillInBankInfoForm('EDU');
+      exitBankInfoForm('EDU');
+      cy.get('va-modal').should('exist');
+      cy.get('va-modal').contains(/are you sure/i);
+      cy.get('va-modal').contains(/education direct deposit information/i);
+      cy.get('va-modal')
+        .contains(/back to editing/i)
+        .click();
+      cy.get('va-modal').should('not.exist');
+      cy.findByRole('button', {
+        name: /save/i,
+      }).should('exist');
       cy.axeCheck();
     });
   });


### PR DESCRIPTION
## Summary

- There was a unique modal that was in place for the Direct Deposit page that would show when a user attempted to cancel editing a form with unsaved changes. This PR uses a standardized modal that is shared with the other profile pages.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/62464

## Testing done

- Updated e2e tests for the direct deposit page and added tests for the edit cancel modal for both CNP and EDU page.
- There is a bit of repeated code in the tests right now, but I'm not super worried about DRYing it up, because we are literally about to rip out the 2 forms and combine into a singular form, and at that time we will be reworking all these E2E tests... oh joy.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | ![Screenshot 2024-03-11 at 1 24 12 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/05222157-4b54-4dfb-a18b-a76edeedcb26) | ![Screenshot 2024-03-11 at 1 58 03 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/d5cffa0b-6c89-4404-8aaa-92486aa124f4) |
| Mobile | ![Screenshot 2024-03-11 at 3 19 49 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/8c49ef2a-a5c9-469d-9e3a-9c7b9e21f9fb) | ![Screenshot 2024-03-11 at 3 19 10 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/db19c697-114b-4943-ba98-b07b1099cecd) |




## What areas of the site does it impact?
Profile -> Direct Deposit

## Acceptance criteria
- [x] Modal has same content and layout as contact info modal / uses same core component

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
