### PR TITLE
My VA + Profile: remove role from Nametag component

### DIFF
--- a/src/applications/personalization/components/NameTag.jsx
+++ b/src/applications/personalization/components/NameTag.jsx
@@ -189,7 +189,6 @@ const NameTag = ({
       aria-label={ariaLabel}
       className={classes.wrapper}
       data-testid="name-tag"
-      role="banner"
     >
       <div className={classes.innerWrapper}>
         <div className={classes.serviceBadge}>


### PR DESCRIPTION
## Summary

- remove `role="banner"` from Nametag component, as this role should be reserved for the global header

originally, it was recommended to update this to `role="region"` but this is redundant since `<section>` already has an implicit role of region

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/76585

## Testing done

- locally, visually, dev tools
- all unit and e2e tests still pass

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?
My VA and Profile

## Acceptance criteria
- [x] component is updated

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
