### PR TITLE
Set USWDS to false on process list and breadcrumbs

### DIFF
--- a/src/applications/_mock-form/containers/IntroductionPage.jsx
+++ b/src/applications/_mock-form/containers/IntroductionPage.jsx
@@ -49,7 +49,7 @@ class IntroductionPage extends React.Component {
         <h2 className="vads-u-font-size--h3 vads-u-margin-top--0">
           Follow the steps below to apply for Mock form.
         </h2>
-        <va-process-list>
+        <va-process-list uswds="false">
           <li>
             <h3>Prepare</h3>
             <h4>To fill out this application, you’ll need your:</h4>

--- a/src/applications/ask-va/components/BreadCrumbs.jsx
+++ b/src/applications/ask-va/components/BreadCrumbs.jsx
@@ -17,7 +17,7 @@ const BreadCrumbs = ({ currentLocation }) => {
   const breadcrumbLinks = breadcrumbsDictionary[adjustedLocation];
 
   return (
-    <va-breadcrumbs label="Breadcrumbs">
+    <va-breadcrumbs uswds="false" label="Breadcrumbs">
       {breadcrumbLinks.map(link => (
         <a href={link.href} key={link.key}>
           {link.title}

--- a/src/applications/burial-poc-v6/pages/BurialIntroduction.jsx
+++ b/src/applications/burial-poc-v6/pages/BurialIntroduction.jsx
@@ -14,7 +14,7 @@ export default function BurialIntroduction(props) {
           <h2 className="vads-u-font-size--h4">
             Follow the steps below to apply for burial benefits.
           </h2>
-          <va-process-list>
+          <va-process-list uswds="false">
             <li>
               <div>
                 <h3>Prepare</h3>

--- a/src/applications/burials-v2/components/IntroductionPage.jsx
+++ b/src/applications/burials-v2/components/IntroductionPage.jsx
@@ -26,7 +26,7 @@ class IntroductionPage extends React.Component {
         <h2 className="vads-u-font-size--h4">
           Follow the steps below to apply for burial benefits.
         </h2>
-        <va-process-list>
+        <va-process-list uswds="false">
           <li>
             <h3>Prepare</h3>
             <a

--- a/src/applications/debt-letters/components/DebtDetails.jsx
+++ b/src/applications/debt-letters/components/DebtDetails.jsx
@@ -57,7 +57,7 @@ const DebtDetails = ({ selectedDebt, debts }) => {
 
   return (
     <div className="vads-u-display--flex vads-u-flex-direction--column">
-      <VaBreadcrumbs label="Breadcrumb">
+      <VaBreadcrumbs uswds="false" label="Breadcrumb">
         <a href="/">Home</a>
         <a href="/manage-va-debt">Manage your VA debt</a>
         <a href="/manage-va-debt/your-debt">Your VA debt</a>

--- a/src/applications/debt-letters/components/DebtLettersDownload.jsx
+++ b/src/applications/debt-letters/components/DebtLettersDownload.jsx
@@ -24,7 +24,7 @@ const DebtLettersDownload = ({
   return (
     <div className="vads-l-row large-screen:vads-u-margin-x--neg2p5">
       <div className="vads-u-font-family--sans">
-        <VaBreadcrumbs label="Breadcrumb">
+        <VaBreadcrumbs uswds="false" label="Breadcrumb">
           <a href="/">Home</a>
           <a href="/manage-va-debt">Manage your VA debt</a>
           <a href="/manage-va-debt/your-debt">Your debt</a>

--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -112,7 +112,7 @@ const DebtLettersSummary = ({ isError, isVBMSError, debts, debtLinks }) => {
 
   return (
     <>
-      <VaBreadcrumbs label="Breadcrumb">
+      <VaBreadcrumbs uswds="false" label="Breadcrumb">
         <a href="/">Home</a>
         <a href="/manage-va-debt">Manage your VA debt</a>
         <a href="/manage-va-debt/your-debt">Your VA debt</a>

--- a/src/applications/disability-benefits/2346/containers/App.jsx
+++ b/src/applications/disability-benefits/2346/containers/App.jsx
@@ -65,7 +65,7 @@ class App extends Component {
       <>
         {!featureToggles.loading && (
           <div className="large-screen:vads-u-padding-left--0 vads-u-padding-left--2">
-            <VaBreadcrumbs label="Breadcrumb">
+            <VaBreadcrumbs uswds="false" label="Breadcrumb">
               <a href="/">Home</a>
               {/* this will get updated when this route is added */}
               <a href="/health-care">Health care</a>

--- a/src/applications/education-letters/components/Layout.jsx
+++ b/src/applications/education-letters/components/Layout.jsx
@@ -10,7 +10,7 @@ const Layout = ({ children, clsName = '', breadCrumbs = {} }) => {
 
   return (
     <>
-      <va-breadcrumbs>
+      <va-breadcrumbs uswds="false">
         <a href="/">Home</a>
         <a href="/education/">Education and training</a>
         {renderBreadCrumbs()}

--- a/src/applications/enrollment-verification/components/EnrollmentVerificationBreadcrumbs.jsx
+++ b/src/applications/enrollment-verification/components/EnrollmentVerificationBreadcrumbs.jsx
@@ -52,5 +52,5 @@ export default function EnrollmentVerificationBreadcrumbs() {
     );
   }
 
-  return <va-breadcrumbs>{breadcrumbs}</va-breadcrumbs>;
+  return <va-breadcrumbs uswds="false">{breadcrumbs}</va-breadcrumbs>;
 }

--- a/src/applications/fry-dea/containers/FryDeaApp.jsx
+++ b/src/applications/fry-dea/containers/FryDeaApp.jsx
@@ -60,7 +60,7 @@ function FryDeaApp({
 
   return (
     <>
-      <va-breadcrumbs>
+      <va-breadcrumbs uswds="false">
         <a href="/">Home</a>
         <a href="/education">Education and training</a>
         <a href="/fry-dea">

--- a/src/applications/fry-dea/containers/IntroductionPage.jsx
+++ b/src/applications/fry-dea/containers/IntroductionPage.jsx
@@ -52,7 +52,7 @@ class IntroductionPage extends React.Component {
           Follow these steps to get started
         </h2>
 
-        <va-process-list>
+        <va-process-list uswds="false">
           <li>
             <h3 className="vads-u-font-size--h4">Check your eligibility</h3>
             <p>

--- a/src/applications/gi/components/GiBillBreadcrumbs.jsx
+++ b/src/applications/gi/components/GiBillBreadcrumbs.jsx
@@ -47,7 +47,7 @@ const GiBillBreadcrumbs = () => {
     );
   }
 
-  return <VaBreadcrumbs>{crumbs}</VaBreadcrumbs>;
+  return <VaBreadcrumbs uswds="false">{crumbs}</VaBreadcrumbs>;
 };
 
 export default GiBillBreadcrumbs;

--- a/src/applications/health-care-supply-reordering/containers/App.jsx
+++ b/src/applications/health-care-supply-reordering/containers/App.jsx
@@ -63,7 +63,7 @@ class App extends Component {
     return (
       <>
         {!featureToggles.loading && (
-          <va-breadcrumbs class="va-nav-breadcrumbs">
+          <va-breadcrumbs uswds="false" class="va-nav-breadcrumbs">
             <a href="/">Home</a>
             {/* this will get updated when this route is added */}
             <a href="/health-care">Health care</a>

--- a/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
@@ -32,7 +32,7 @@ class IntroductionPage extends React.Component {
         <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
           Follow the steps below to apply for CHAMPVA benefits.
         </h2>
-        <va-process-list>
+        <va-process-list uswds="false">
           <li>
             <h3>Prepare</h3>
             <h4>To fill out this application, you’ll need your:</h4>

--- a/src/applications/medical-copays/components/AlertView.jsx
+++ b/src/applications/medical-copays/components/AlertView.jsx
@@ -37,7 +37,7 @@ const AlertView = ({ pathname, alertType, error, cdpToggle, hasDebts }) => {
 
   return (
     <>
-      <VaBreadcrumbs label="Breadcrumb">
+      <VaBreadcrumbs uswds="false" label="Breadcrumb">
         <a href="/">Home</a>
         <a href="/health-care">Health care</a>
         <a href="/health-care/pay-copay-bill">Pay your VA copay bill</a>

--- a/src/applications/medical-copays/containers/DetailPage.jsx
+++ b/src/applications/medical-copays/containers/DetailPage.jsx
@@ -45,7 +45,10 @@ const DetailPage = ({ match }) => {
 
   return (
     <>
-      <va-breadcrumbs className="vads-u-font-family--sans no-wrap">
+      <va-breadcrumbs
+        uswds="false"
+        className="vads-u-font-family--sans no-wrap"
+      >
         <a href="/">Home</a>
         <a href="/health-care">Health care</a>
         <a href="/health-care/pay-copay-bill">Pay your VA copay bill</a>

--- a/src/applications/medical-copays/containers/HTMLStatementPage.jsx
+++ b/src/applications/medical-copays/containers/HTMLStatementPage.jsx
@@ -32,7 +32,10 @@ const HTMLStatementPage = ({ match }) => {
   return (
     <>
       <article>
-        <va-breadcrumbs className="vads-u-font-family--sans no-wrap">
+        <va-breadcrumbs
+          uswds="false"
+          className="vads-u-font-family--sans no-wrap"
+        >
           <a href="/">Home</a>
           <a href="/health-care">Health care</a>
           <a href="/health-care/pay-copay-bill">Pay your VA copay bill</a>

--- a/src/applications/medical-copays/containers/OverviewPage.jsx
+++ b/src/applications/medical-copays/containers/OverviewPage.jsx
@@ -59,7 +59,7 @@ const OverviewPage = () => {
   return (
     <>
       <div className="vads-u-font-family--sans no-wrap">
-        <VaBreadcrumbs label="Breadcrumb">
+        <VaBreadcrumbs uswds="false" label="Breadcrumb">
           <a href="/">Home</a>
           <a href="/health-care">Health care</a>
           <a href="/health-care/pay-copay-bill">Pay your VA copay bill</a>

--- a/src/applications/mhv/secure-messaging/components/shared/SmBreadcrumbs.jsx
+++ b/src/applications/mhv/secure-messaging/components/shared/SmBreadcrumbs.jsx
@@ -133,7 +133,11 @@ const SmBreadcrumbs = () => {
         !crumbs?.label ? 'breadcrumbs--hidden' : ''
       }`}
     >
-      <va-breadcrumbs label="Breadcrumb" home-veterans-affairs={false}>
+      <va-breadcrumbs
+        uswds="false"
+        label="Breadcrumb"
+        home-veterans-affairs={false}
+      >
         {crumbs && (
           <ul className={breadcrumbSize()}>
             <li>

--- a/src/applications/my-education-benefits/components/IntroductionProcessListV2.jsx
+++ b/src/applications/my-education-benefits/components/IntroductionProcessListV2.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 function IntroductionProcessListV2() {
   return (
-    <va-process-list>
+    <va-process-list uswds="false">
       <li>
         <h3>Check your eligibility</h3>
         <p>Make sure you meet our eligibility requirements before you apply.</p>

--- a/src/applications/my-education-benefits/containers/App.jsx
+++ b/src/applications/my-education-benefits/containers/App.jsx
@@ -361,7 +361,7 @@ export const App = ({
 
   return (
     <>
-      <va-breadcrumbs>
+      <va-breadcrumbs uswds="false">
         <a href="/">Home</a>
         <a href="/education">Education and training</a>
         <a href="/education/apply-for-benefits-form-22-1990">

--- a/src/applications/representatives/components/common/Breadcrumbs.jsx
+++ b/src/applications/representatives/components/common/Breadcrumbs.jsx
@@ -47,7 +47,7 @@ const Breadcrumbs = ({ pathname }) => {
   });
 
   return (
-    <va-breadcrumbs home-veterans-affairs={false}>
+    <va-breadcrumbs uswds="false" home-veterans-affairs={false}>
       {breadcrumbs.map(({ link, label }) => (
         <li key={label}>
           <Link to={link}>{label}</Link>

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomHeader.jsx
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomHeader.jsx
@@ -77,7 +77,7 @@ const CustomHeader = ({ formData, formConfig, currentLocation }) => {
     // With this custom header, breadcrumbs should not appear on the form pages.
     // However we still want to show them on the introduction page and review page.
     // Static breadcrumbs from content-build cannot be used with this custom header
-    <va-breadcrumbs label="Breadcrumb">
+    <va-breadcrumbs uswds="false" label="Breadcrumb">
       <a href="/">Home</a>
       <a href="/authorization-to-disclose-alternate/">
         Authorize VA to release your information to a third-party source

--- a/src/applications/static-pages/manage-va-debt/MangeVADebtCTA.jsx
+++ b/src/applications/static-pages/manage-va-debt/MangeVADebtCTA.jsx
@@ -6,7 +6,7 @@ const fsrUrl = getAppUrl('request-debt-help-form-5655');
 
 const ManageVADebtCTA = () => (
   <>
-    <va-breadcrumbs>
+    <va-breadcrumbs uswds="false">
       <a href="/">Home</a>
       <a href="/manage-va-debt">Manage your VA debt</a>
     </va-breadcrumbs>

--- a/src/applications/toe/containers/ToeApp.jsx
+++ b/src/applications/toe/containers/ToeApp.jsx
@@ -125,7 +125,7 @@ function ToeApp({
 
   return (
     <>
-      <va-breadcrumbs>
+      <va-breadcrumbs uswds="false">
         <a href="/">Home</a>
         <a href="/education">Education and training</a>
         <a href="/education/survivor-dependent-benefits/transferred-benefits/">

--- a/src/applications/travel-pay/containers/IntroductionPage.jsx
+++ b/src/applications/travel-pay/containers/IntroductionPage.jsx
@@ -33,7 +33,7 @@ class IntroductionPage extends React.Component {
         <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
           Follow the steps below to apply for beneficiary travel claim.
         </h2>
-        <va-process-list>
+        <va-process-list uswds="false">
           <li>
             <h3>Prepare</h3>
             <h4>To fill out this application, you’ll need your:</h4>

--- a/src/applications/verify-your-enrollment/components/EnrollmentVerificationBreadcrumbs.jsx
+++ b/src/applications/verify-your-enrollment/components/EnrollmentVerificationBreadcrumbs.jsx
@@ -31,5 +31,5 @@ export default function EnrollmentVerificationBreadcrumbs() {
       </a>,
     );
   }
-  return <va-breadcrumbs>{breadcrumbs}</va-breadcrumbs>;
+  return <va-breadcrumbs uswds="false">{breadcrumbs}</va-breadcrumbs>;
 }

--- a/src/applications/virtual-agent/components/page/Disclaimer.jsx
+++ b/src/applications/virtual-agent/components/page/Disclaimer.jsx
@@ -4,7 +4,7 @@ import { CONTACTS } from '@department-of-veterans-affairs/component-library/cont
 export default function Disclaimer() {
   return (
     <>
-      <va-breadcrumbs label="Breadcrumb">
+      <va-breadcrumbs uswds="false" label="Breadcrumb">
         <a href="/">Home</a>
         <a href="/contact-us">Contact us</a>
         <a href="/contact-us/virtual-agent">VA chatbot</a>


### PR DESCRIPTION
## Summary

Design system team is setting the default version for web components to V3. Because the `va-process-list` and `va-breadcrumbs` is not forward compatible, we are setting current v1 instances of `va-process-list` and `va-breadcrumbs`  to `uswds="false"` to prevent the update. No changes will occur because of this update. 

## Related issue(s)
Partial [Formation Deprecation - set uswds prop to true on all components #2405](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2405)

## Testing done

- Tested locally to make sure update caused no change.

## What areas of the site does it impact?

Update is to ensure no change happens during web component update.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

