### PR TITLE
77125a add info screen to applicant info section

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -1,4 +1,5 @@
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import React from 'react';
 import {
   fullNameSchema,
   fullNameUI,
@@ -100,6 +101,7 @@ import FileViewField, {
 import { MissingFileConsentPage } from '../pages/MissingFileConsentPage';
 
 // Used to condense some repetitive schema boilerplate
+const maxApplicants = 3;
 const applicantListSchema = (requireds, propertyList) => {
   return {
     type: 'object',
@@ -107,7 +109,7 @@ const applicantListSchema = (requireds, propertyList) => {
       applicants: {
         type: 'array',
         minItems: 1,
-        maxItems: 25,
+        maxItems: maxApplicants,
         items: {
           type: 'object',
           required: requireds,
@@ -601,15 +603,24 @@ const formConfig = {
           arrayPath: 'applicants',
           title: 'Applicants',
           uiSchema: {
-            ...titleUI(
-              'Applicant name and date of birth',
-              'Please tell us the names of the applicants that you want to enroll in CHAMPVA. You can only add up to 3 applicants at a time. If you have more than 3 applicants then you will need to submit a separate form for each applicant.',
-            ),
+            ...titleUI('Applicant name and date of birth', () => (
+              <>
+                {`Enter your information and the information for any other 
+              applicants you want to enroll in CHAMPVA benefits.`}
+                <br />
+                <br />
+                {`You can add up to ${maxApplicants} applicants in a single application. If you 
+              need to add more than ${maxApplicants} applicants, you'll need to submit a 
+              separate application for them.`}
+              </>
+            )),
             applicants: {
               'ui:options': {
                 viewField: ApplicantField,
                 keepInPageOnReview: true,
                 useDlWrap: false,
+                itemName: 'Applicant',
+                addAnotherLabel: 'Add another applicant',
               },
               'ui:errorMessages': {
                 minItems: 'Must have at least one applicant listed.',

--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -603,10 +603,13 @@ const formConfig = {
           arrayPath: 'applicants',
           title: 'Applicants',
           uiSchema: {
-            ...titleUI('Applicant name and date of birth', () => (
+            ...titleUI('Applicant name and date of birth', ({ formData }) => (
               <>
-                {`Enter your information and the information for any other 
-              applicants you want to enroll in CHAMPVA benefits.`}
+                {`Enter ${
+                  formData.certifierRole === 'applicant'
+                    ? 'your information and the information for any other'
+                    : 'the information for any'
+                } applicants you want to enroll in CHAMPVA benefits.`}
                 <br />
                 <br />
                 {`You can add up to ${maxApplicants} applicants in a single application. If you 
@@ -620,7 +623,6 @@ const formConfig = {
                 keepInPageOnReview: true,
                 useDlWrap: false,
                 itemName: 'Applicant',
-                addAnotherLabel: 'Add another applicant',
               },
               'ui:errorMessages': {
                 minItems: 'Must have at least one applicant listed.',

--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -650,7 +650,7 @@ const formConfig = {
         page13a: {
           path: 'applicant-information/:index/start',
           arrayPath: 'applicants',
-          title: item => `${applicantWording(item)} name and date of birth`,
+          title: item => `${applicantWording(item)} information`,
           showPagePerItem: true,
           depends: () => !onReviewPage(),
           uiSchema: {
@@ -664,10 +664,7 @@ const formConfig = {
                     return {
                       title: context =>
                         titleUI(
-                          `${applicantWording(
-                            formData,
-                            context,
-                          )} name and date of birth`,
+                          `${applicantWording(formData, context)} information`,
                           `Next we'll ask more questions about ${applicantWording(
                             formData,
                             context,

--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -5,6 +5,8 @@ import {
   fullNameUI,
   ssnOrVaFileNumberSchema,
   ssnOrVaFileNumberUI,
+  ssnOrVaFileNumberNoHintSchema,
+  ssnOrVaFileNumberNoHintUI,
   addressSchema,
   addressUI,
   phoneSchema,
@@ -36,7 +38,12 @@ import IntroductionPage from '../containers/IntroductionPage';
 import ApplicantField from '../components/Applicant/ApplicantField';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import getNameKeyForSignature from '../helpers/signatureKeyName';
-import { getAgeInYears, isInRange, getParts } from '../helpers/utilities';
+import {
+  getAgeInYears,
+  isInRange,
+  getParts,
+  onReviewPage,
+} from '../helpers/utilities';
 import {
   sponsorWording,
   applicantWording,
@@ -640,6 +647,47 @@ const formConfig = {
             applicantDOB: dateOfBirthSchema,
           }),
         },
+        page13a: {
+          path: 'applicant-information/:index/start',
+          arrayPath: 'applicants',
+          title: item => `${applicantWording(item)} name and date of birth`,
+          showPagePerItem: true,
+          depends: () => !onReviewPage(),
+          uiSchema: {
+            applicants: {
+              'ui:options': {
+                viewField: ApplicantField,
+              },
+              items: {
+                'ui:options': {
+                  updateSchema: formData => {
+                    return {
+                      title: context =>
+                        titleUI(
+                          `${applicantWording(
+                            formData,
+                            context,
+                          )} name and date of birth`,
+                          `Next we'll ask more questions about ${applicantWording(
+                            formData,
+                            context,
+                            false,
+                            false,
+                          )}. This includes social security number, mailing address, 
+                          contact information, relationship to sponsor, and health 
+                          insurance information.`,
+                        )['ui:title'],
+                    };
+                  },
+                },
+              },
+            },
+          },
+          schema: applicantListSchema([], {
+            titleSchema,
+            'view:description': blankSchema,
+          }),
+        },
         page14: {
           path: 'applicant-information/:index/ssn-dob',
           arrayPath: 'applicants',
@@ -660,7 +708,7 @@ const formConfig = {
                   'ui:description':
                     'You must enter either a VA file number or Social Security number',
                 },
-                applicantSSN: ssnOrVaFileNumberUI(),
+                applicantSSN: ssnOrVaFileNumberNoHintUI(),
                 // Dynamic title (uses "your" if certifierRole is applicant and
                 // this is applicant[0])
                 'ui:options': {
@@ -682,7 +730,7 @@ const formConfig = {
           schema: applicantListSchema([], {
             titleSchema,
             'view:description': blankSchema,
-            applicantSSN: ssnOrVaFileNumberSchema,
+            applicantSSN: ssnOrVaFileNumberNoHintSchema,
           }),
         },
         page15: {

--- a/src/applications/ivc-champva/10-10D/helpers/utilities.js
+++ b/src/applications/ivc-champva/10-10D/helpers/utilities.js
@@ -39,3 +39,10 @@ export function makeHumanReadable(inputStr) {
     .map(word => word[0].toUpperCase() + word.substr(1).toLowerCase())
     .join(' ');
 }
+
+// Helper to detect if we're on review page when we don't have access
+// to form context. Necessary because list and loop pages don't seem
+// to respect 'hideOnReview' or 'keepInPageOnReview'
+export function onReviewPage() {
+  return window.location.href.includes('review-and-submit');
+}

--- a/src/applications/ivc-champva/10-10D/helpers/wordingCustomization.js
+++ b/src/applications/ivc-champva/10-10D/helpers/wordingCustomization.js
@@ -6,7 +6,12 @@ export function sponsorWording(formData) {
 
 // Produce a string that is either an applicant's name or
 // "your" depending on additional context provided.
-export function applicantWording(formData, context) {
+export function applicantWording(
+  formData,
+  context,
+  isPosessive = true,
+  cap = true,
+) {
   let retVal = '';
   if (context) {
     // If we have additional context that means we have to dig for applicant
@@ -16,12 +21,17 @@ export function applicantWording(formData, context) {
       formData?.applicants[idx]?.applicantName?.last
     }`;
 
-    retVal = idx === 0 && isApplicant ? 'Your ' : `${name}'s `;
+    const Y = cap ? 'Y' : 'y';
+
+    retVal =
+      idx === 0 && isApplicant
+        ? `${Y}ou${isPosessive ? 'r ' : ''}`
+        : `${name}${isPosessive ? '’s' : ''}`;
   } else {
     // No context means we're directly accessing an applicant object
     retVal = `${`${formData?.applicantName?.first || ''} ${
       formData?.applicantName?.last
-    }` || 'Applicant'}'s `;
+    }` || 'Applicant'}${isPosessive ? '’s' : ''}`;
   }
   return retVal;
 }

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantRelationshipPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantRelationshipPage.jsx
@@ -15,7 +15,7 @@ const keyname = 'applicantRelationshipToSponsor';
 function generateOptions({ data, pagePerItemIndex }) {
   const currentListItem = data?.applicants?.[pagePerItemIndex];
   const personTitle = 'Sponsor';
-  const applicant = applicantWording(currentListItem).slice(0, -3); // remove 's_
+  const applicant = applicantWording(currentListItem, undefined, false);
 
   // Determine what tense/person the phrasing should be in
   const useFirstPerson =
@@ -28,9 +28,12 @@ function generateOptions({ data, pagePerItemIndex }) {
       : `${data.sponsorIsDeceased ? 'I was' : 'I’m'}`
   }`}`;
 
-  const relativePossessive = `${`${
-    useFirstPerson ? 'your' : `${applicant}’s`
-  }`}`;
+  const relativePossessive = applicantWording(
+    currentListItem,
+    undefined,
+    true,
+    false,
+  );
 
   // Create dynamic radio labels based on above phrasing
   const options = [
@@ -209,7 +212,7 @@ export default function ApplicantRelationshipPage({
       {
         titleUI(
           `${
-            useFirstPerson ? `Your` : `${applicant}'s`
+            useFirstPerson ? `Your` : `${applicant}’s`
           } relationship to the ${personTitle}`,
         )['ui:title']
       }
@@ -218,7 +221,7 @@ export default function ApplicantRelationshipPage({
         <VaRadio
           class="vads-u-margin-y--2"
           label={`What's ${
-            useFirstPerson ? `your` : `${applicant}'s`
+            useFirstPerson ? `your` : `${applicant}’s`
           } relationship to the ${personTitle}?`}
           required
           error={checkError}

--- a/src/applications/ivc-champva/10-10D/tests/helpers/helpers.unit.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/helpers/helpers.unit.spec.js
@@ -12,7 +12,7 @@ describe('applicantWording helper', () => {
       applicantWording({
         applicantName: { first: 'firstname', last: 'lastname' },
       }),
-    ).to.equal("firstname lastname's ");
+    ).to.equal('firstname lastname’s');
   });
 });
 


### PR DESCRIPTION
## Summary

This PR adds an information screen at the start of the list and loop and refactors the `applicantWording` helper function as well as some other helpers to control page display.

- Team: IVC-CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/77125

## Testing done

- Manual testing
- Ran `yarn test:coverage-app ivc-champva/10-10D` to verify tests work
- Updated a unit test to match new output from `applicantWording`

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Personal | Third Person |
| ------- | ------ | ----- |
| Desktop |![Screenshot 2024-03-12 at 08 42 33](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/aab113a2-ecbc-4830-a632-9ca1caf7624e)|![Screenshot 2024-03-12 at 08 42 03](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/86689629-5761-49f1-86d8-a97628cec6d8)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA
