### PR TITLE
No delete modal on upload cancel

### DIFF
--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -106,7 +106,6 @@ const FileField = props => {
   const attachmentIdRequired = schema.additionalItems.required
     ? schema.additionalItems.required.includes('attachmentId')
     : false;
-  const uswds = uiOptions.uswds || null;
 
   const content = {
     upload: uiOptions.buttonText || 'Upload',
@@ -418,7 +417,7 @@ const FileField = props => {
         onPrimaryButtonClick={() => closeRemoveModal({ remove: true })}
         onSecondaryButtonClick={closeRemoveModal}
         visible={showRemoveModal}
-        uswds={uswds}
+        uswds
       >
         <p>
           {removeIndex !== null
@@ -534,7 +533,7 @@ const FileField = props => {
                       }}
                       label={content.cancelLabel(file.name)}
                       text={content.cancel}
-                      uswds={uswds}
+                      uswds
                     />
                   </div>
                 )}
@@ -607,7 +606,6 @@ const FileField = props => {
                     index={index}
                     onSubmitPassword={onSubmitPassword}
                     passwordLabel={content.passwordLabel(file.name)}
-                    uswds={uswds}
                   />
                 )}
                 {!formContext.reviewMode &&
@@ -629,18 +627,26 @@ const FileField = props => {
                                 : content.newFile
                             }
                             text={retryButtonText}
-                            uswds={uswds}
+                            uswds
                           />
                         )}
                       <va-button
                         secondary
                         class="delete-upload vads-u-width--auto"
                         onClick={() => {
-                          openRemoveModal(index);
+                          if (hasVisibleError) {
+                            // Cancelling with error should not show the remove
+                            // file modal
+                            removeFile(index);
+                          } else {
+                            openRemoveModal(index);
+                          }
                         }}
-                        label={content.deleteLabel(file.name)}
+                        label={content[
+                          hasVisibleError ? 'cancelLabel' : 'deleteLabel'
+                        ](file.name)}
                         text={deleteButtonText}
-                        uswds={uswds}
+                        uswds
                       />
                     </div>
                   )}
@@ -656,6 +662,7 @@ const FileField = props => {
           {(maxItems === null || files.length < maxItems) &&
             // Prevent additional upload if any upload has error state
             checkUploadVisibility() && (
+              // eslint-disable-next-line jsx-a11y/label-has-associated-control
               <label
                 id={`${idSchema.$id}_add_label`}
                 htmlFor={idSchema.$id}
@@ -669,7 +676,7 @@ const FileField = props => {
                   onClick={() => fileInputRef?.current?.click()}
                   label={`${uploadText} ${titleString || ''}`}
                   text={uploadText}
-                  uswds={uswds}
+                  uswds
                 />
               </label>
             )}

--- a/src/platform/forms-system/src/js/utilities/file/ShowPdfPassword.jsx
+++ b/src/platform/forms-system/src/js/utilities/file/ShowPdfPassword.jsx
@@ -10,7 +10,6 @@ const ShowPdfPassword = ({
   onSubmitPassword,
   passwordLabel = null,
   testVal = '', // for testing
-  uswds,
 }) => {
   const [value, setValue] = useState(testVal);
   const [dirty, setDirty] = useState(false);
@@ -48,7 +47,7 @@ const ShowPdfPassword = ({
         onInput={({ target }) => setValue(target.value || '')}
         onBlur={() => setDirty(true)}
         messageAriaDescribedby={passwordLabel}
-        uswds={uswds}
+        uswds
       />
       <va-button
         className="vads-u-width--auto"
@@ -63,7 +62,7 @@ const ShowPdfPassword = ({
           }
         }}
         label={passwordLabel}
-        uswds={uswds}
+        uswds
       />
     </div>
   );
@@ -74,7 +73,6 @@ ShowPdfPassword.propTypes = {
   index: PropTypes.number,
   passwordLabel: PropTypes.string,
   testVal: PropTypes.string,
-  uswds: PropTypes.bool,
   onSubmitPassword: PropTypes.func,
 };
 

--- a/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
@@ -1297,6 +1297,7 @@ describe('Schemaform <FileField>', () => {
     });
 
     it('should render remove file button as cancel', () => {
+      const onChangeSpy = sinon.spy();
       const { container } = render(
         <FileField
           registry={mockRegistry}
@@ -1306,7 +1307,7 @@ describe('Schemaform <FileField>', () => {
           errorSchema={mockErrorSchemaWithError}
           formData={mockFormDataWithError}
           formContext={formContext}
-          onChange={f => f}
+          onChange={onChangeSpy}
           requiredSchema={requiredSchema}
           enableShortWorkflow
         />,
@@ -1315,6 +1316,11 @@ describe('Schemaform <FileField>', () => {
       // This button is specific to the file that has the error
       const cancelButton = $('.delete-upload', container);
       expect(cancelButton.getAttribute('text')).to.equal('Cancel');
+      fireEvent.click(cancelButton);
+      // clicking cancel should remove errored upload without showing delete
+      // modal
+      expect(onChangeSpy.called).to.be.true;
+      expect($('va-modal[visible="false"]', container)).to.exist;
     });
 
     it('should render delete button for successfully uploaded file', () => {

--- a/src/platform/forms-system/test/js/utilities/file.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/file.unit.spec.js
@@ -304,13 +304,6 @@ describe('ShowPdfPassword', () => {
 
     expect($('va-text-input', container)).to.exist;
     expect($('va-button', container)).to.exist;
-    expect($('va-text-input[uswds]', container)).to.not.exist;
-    expect($('va-button[uswds]', container)).to.not.exist;
-  });
-  it('should render uswds components', () => {
-    const props = getProps();
-    const { container } = render(<ShowPdfPassword {...props} uswds />);
-
     expect($('va-text-input[uswds]', container)).to.exist;
     expect($('va-button[uswds]', container)).to.exist;
   });


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > When the short workflow is enabled for uploads (on in prod), and an upload leads to an error (too small, too large, etc), an "Upload a new file" and "Cancel" button are visible. Currently, when the "Cancel" button is used, a delete confirmation modal opens asking the user to verify their choice (see screenshots). This extra step isn't necessary. In this PR, the cancel button immediately removes the file and shifts focus to the add another file button. Using the "Update a new file" button has always immediately removed the upload and opened the OS file selector.
  > 
  > Additionally, the form elements would use the `ui:options` to enable USWDS v3 components; this has been removed and USWDS v3 components are always visible.
- _(If bug, how to reproduce)_
  > Upload a too large or too small file
- _(What is the solution, why is this the solution)_
  > Preferred UX
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#76218](https://github.com/department-of-veterans-affairs/va.gov-team/issues/76218)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ----- | ---- |
| Cancel upload | ![cancel-before](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/8183d83a-64da-45b3-a221-4298d1de607a) | ![cancel-after](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/b868b096-995b-4165-b62d-62e0e6e83e50) |

## What areas of the site does it impact?

All forms using file uploads

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
