### PR TITLE
VACMS-17252 Change download links back to regular anchor tags

### DIFF
--- a/src/applications/discharge-wizard/components/gpSteps/StepOne.jsx
+++ b/src/applications/discharge-wizard/components/gpSteps/StepOne.jsx
@@ -158,13 +158,14 @@ const StepOne = ({ formValues }) => {
     <va-process-list-item header={header}>
       <p>Important tips for completing Form {form.num}:</p>
       {formValues['4_reason'] === '8' ? dd214Tips : nonDd2014Tips}
-      <va-link
-        class="vads-u-display--block vads-u-margin-bottom--1"
+      {/* Intentionally not using <va-link> per Platform Analytics team */}
+      <a
+        className="vads-u-display--block vads-u-margin-bottom--1 step-1-download"
         download
-        filetype="PDF"
         href={form.link}
-        text={`Download Form ${form.num}`}
-      />
+      >
+        Download Form {form.num}
+      </a>
       <AlertMessage
         content={
           <>

--- a/src/applications/discharge-wizard/components/gpSteps/StepTwo.jsx
+++ b/src/applications/discharge-wizard/components/gpSteps/StepTwo.jsx
@@ -34,11 +34,13 @@ const renderMedicalRecordInfo = formValues => {
             You can request your <strong>VA medical records</strong> by
             submitting VA Form 10-5345 to your local VA Medical Center.
             <br />
-            <va-link
+            {/* Intentionally not using <va-link> per Platform Analytics team */}
+            <a
               download
-              text="Download VA Form 10-5345"
               href="https://www.va.gov/find-forms/about-form-10-5345/"
-            />
+            >
+              Download VA Form 10-5345
+            </a>
           </li>
           <li>{requestQuestion}</li>
           <li>

--- a/src/applications/discharge-wizard/tests/containers/GuidancePage.unit.spec.js
+++ b/src/applications/discharge-wizard/tests/containers/GuidancePage.unit.spec.js
@@ -74,7 +74,7 @@ describe('Discharge Wizard <GuidancePage />', () => {
         router={reactRouterStub}
       />,
     );
-    expect(tree.find('va-link[text*="Download Form"]')).to.have.lengthOf(1);
+    expect(tree.find('.step-1-download')).to.have.lengthOf(1);
     tree.unmount();
   });
 

--- a/src/applications/discharge-wizard/tests/e2e/discharge-wizard.cypress.spec.js
+++ b/src/applications/discharge-wizard/tests/e2e/discharge-wizard.cypress.spec.js
@@ -63,7 +63,7 @@ describe('functionality of discharge wizard', () => {
     axeTestPage();
 
     // open Form download
-    cy.get('.main va-link[download="true"]')
+    cy.get('.main .step-1-download')
       .first()
       .click();
   });


### PR DESCRIPTION
## Summary
We have been advised by the Platform Analytics team not to use `<va-link>` for `download` type links as the analytics sent over are duplicative. We also were told not to use custom events on them. This updates the 2 download links for Discharge Upgrade Wizard to follow those guidelines.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17252

## Testing done
Tested locally.
1.
<img width="326" alt="Screenshot 2024-03-12 at 10 21 16 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/47251568-35f6-48c1-bc63-db66e3b81fa9">
<img width="491" alt="Screenshot 2024-03-12 at 10 21 10 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/c7ac4373-b8f7-4f3f-969b-fada071e9dbb">
2.
<img width="383" alt="Screenshot 2024-03-12 at 10 21 06 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/43bd9122-9e20-4acf-9762-eac1eb7a9ab0">
<img width="581" alt="Screenshot 2024-03-12 at 10 20 58 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/b8fc1878-e795-4f2a-8281-314d0fd6ef85">
