### PR TITLE
fixes generateReturnUrl fn

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -87,6 +87,7 @@ export const sanitizeCernerParams = path => {
 
 export const generateReturnURL = returnUrl => {
   return [
+    ``, // create account links don't have a authReturnUrl
     `${environment.BASE_URL}/?next=loginModal`,
     `${environment.BASE_URL}`,
   ].includes(returnUrl)

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -649,5 +649,8 @@ describe('Authentication Utilities', () => {
         nonHomepageRoute,
       );
     });
+    it('should return users to /my-va page when `authReturnUrl` is empty', () => {
+      expect(authUtilities.generateReturnURL('')).to.eql(myVARoute);
+    });
   });
 });


### PR DESCRIPTION
## Summary
There is a bug that exists that when attempting to Create an account on VA.gov. The looping issue occurs because the `window.location.replace` is called with an empty string in the `AuthApp` component. When the `window.location.replace` is called with an empty string the default behavior is to refresh the page which causes the loop to occur.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#78221

## Testing done
Unit testing + manual testing

## Screenshots
n/a

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
1. Open Sign in Modal > Click "Create an account" link
2. Sign up with an account > Redirect back to VA.gov (verify you arrive back at `/my-va`
