### PR TITLE
VACMS-17188 Find Forms download link adjustment

### DIFF
--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -275,22 +275,15 @@ export const SearchResults = ({
             <a
               href={pdfUrl}
               className="vads-u-margin-top--2"
+              download
               rel="noreferrer noopener"
               target="_blank"
-              onClick={() => {
-                recordEvent(
-                  `Download VA form ${pdfSelected} ${pdfLabel}`,
-                  pdfUrl,
-                  'pdf',
-                );
-              }}
             >
               <i
                 aria-hidden="true"
                 className="fas fa-download fa-lg vads-u-margin-right--1"
                 role="presentation"
               />
-
               <span className="vads-u-text-decoration--underline">
                 Download VA Form {pdfSelected}
               </span>

--- a/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFModal.jsx
+++ b/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFModal.jsx
@@ -66,17 +66,10 @@ const DownloadPDFModal = ({ formNumber, removeNode, url }) => {
           <a
             href={pdfUrl}
             className="usa-button vads-u-margin-top--2"
+            download
             role="button"
             rel="noreferrer noopener"
-            onClick={() => {
-              recordEvent({
-                event: 'int-modal-click',
-                'modal-status': 'open',
-                'modal-title':
-                  'Download this PDF and open it in Acrobat Reader',
-                'modal-primaryButton-text': `Download VA Form ${pdfSelected}`,
-              });
-            }}
+            target="_blank"
           >
             Download VA Form {pdfSelected}
           </a>


### PR DESCRIPTION
## Summary
We have been advised by the Platform Analytics team not to use <va-link> for download type links as the analytics sent over are duplicative. We also were told not to use custom events on them. This updates the 2 download links for Discharge Upgrade Wizard to follow those guidelines.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17188

## Testing done
Tested locally.

## Screenshots
<img width="378" alt="Screenshot 2024-03-12 at 11 45 43 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/d9f35ee0-912c-4ce1-a6ea-d2fc5b9c0472">
<img width="453" alt="Screenshot 2024-03-12 at 11 45 34 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/2e07a83d-1950-4b85-9443-382cd2bc5c93">
<img width="265" alt="Screenshot 2024-03-12 at 11 45 29 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/53bb8225-1f39-46c9-b1c3-f204055be1db">