### PR TITLE
Breadcrumbs v1 part three set uswds to false

### DIFF
--- a/src/applications/my-education-benefits/containers/App.jsx
+++ b/src/applications/my-education-benefits/containers/App.jsx
@@ -361,7 +361,7 @@ export const App = ({
 
   return (
     <>
-      <va-breadcrumbs>
+      <va-breadcrumbs uswds="false">
         <a href="/">Home</a>
         <a href="/education">Education and training</a>
         <a href="/education/apply-for-benefits-form-22-1990">

--- a/src/applications/representatives/components/common/Breadcrumbs.jsx
+++ b/src/applications/representatives/components/common/Breadcrumbs.jsx
@@ -47,7 +47,7 @@ const Breadcrumbs = ({ pathname }) => {
   });
 
   return (
-    <va-breadcrumbs home-veterans-affairs={false}>
+    <va-breadcrumbs uswds="false" home-veterans-affairs={false}>
       {breadcrumbs.map(({ link, label }) => (
         <li key={label}>
           <Link to={link}>{label}</Link>

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomHeader.jsx
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomHeader.jsx
@@ -77,7 +77,7 @@ const CustomHeader = ({ formData, formConfig, currentLocation }) => {
     // With this custom header, breadcrumbs should not appear on the form pages.
     // However we still want to show them on the introduction page and review page.
     // Static breadcrumbs from content-build cannot be used with this custom header
-    <va-breadcrumbs label="Breadcrumb">
+    <va-breadcrumbs uswds="false" label="Breadcrumb">
       <a href="/">Home</a>
       <a href="/authorization-to-disclose-alternate/">
         Authorize VA to release your information to a third-party source

--- a/src/applications/static-pages/manage-va-debt/MangeVADebtCTA.jsx
+++ b/src/applications/static-pages/manage-va-debt/MangeVADebtCTA.jsx
@@ -6,7 +6,7 @@ const fsrUrl = getAppUrl('request-debt-help-form-5655');
 
 const ManageVADebtCTA = () => (
   <>
-    <va-breadcrumbs>
+    <va-breadcrumbs uswds="false">
       <a href="/">Home</a>
       <a href="/manage-va-debt">Manage your VA debt</a>
     </va-breadcrumbs>


### PR DESCRIPTION
## Description
Breadcrumbs v1 and v3 have some differences in how they are composed. Because of this, all instances where breadcrumb web components have not already been set with `uswds="true"` will be set to false for the time being. 