### PR TITLE
Breadcrumbs set uswds to false on virtual agent only

### DIFF
--- a/src/applications/virtual-agent/components/page/Disclaimer.jsx
+++ b/src/applications/virtual-agent/components/page/Disclaimer.jsx
@@ -4,7 +4,7 @@ import { CONTACTS } from '@department-of-veterans-affairs/component-library/cont
 export default function Disclaimer() {
   return (
     <>
-      <va-breadcrumbs label="Breadcrumb">
+      <va-breadcrumbs uswds="false" label="Breadcrumb">
         <a href="/">Home</a>
         <a href="/contact-us">Contact us</a>
         <a href="/contact-us/virtual-agent">VA chatbot</a>


### PR DESCRIPTION
Breadcrumbs v1 and v3 have some differences in how they are composed. Because of this, all instances where breadcrumb web components have not already been set with uswds="true" will be set to false for the time being.