### PR TITLE
Fixes copy for Primary emergency contact

### DIFF
--- a/src/applications/personalization/profile/components/personal-health-care-contacts/Contact.jsx
+++ b/src/applications/personalization/profile/components/personal-health-care-contacts/Contact.jsx
@@ -12,7 +12,7 @@ const CONTACT_TYPES = [
 ];
 
 const DESCRIPTIONS = {
-  [CONTACT_TYPES[0]]: 'The person we’ll contact first in an emergency.',
+  [CONTACT_TYPES[0]]: 'The person we’ll contact in an emergency.',
   [CONTACT_TYPES[1]]:
     'The person we’ll contact if your primary contact isn’t available.',
   [CONTACT_TYPES[2]]:


### PR DESCRIPTION
## Summary

- Simple copy change for the Primary emergency contact at `/profile/contacts`
  * Previously: "The person we’ll contact first in an emergency."
  * Now: "The person we’ll contact in an emergency."

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#72549

