### PR TITLE
Add EZR to app isolation allow-list

### DIFF
--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -39,6 +39,11 @@
       "continuousDeployment": false
     },
     {
+      "rootFolder": "ezr",
+      "slackGroup": "@1010-fe-dev",
+      "continuousDeployment": false
+    },
+    {
       "rootFolder": "fry-dea",
       "slackGroup": "<@U0243BHR2RZ> <@U026MB3UE5S> <@U024FPCTE6M>",
       "continuousDeployment": false


### PR DESCRIPTION
## Summary
This PR has been created in an effort to get the 10-10EZR apps isolated and added to the allow-list. For reference, Continuous Deployment is being set to `false`, as this application requires authentication to access and we do not want the automated prod deployments without being able to do any testing in staging first.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#76209

## Testing done

- Cross-app import check has been performed and has passed
- Header test has been performed and has passed

## Screenshots
 
- See additional commented posts below 

## Acceptance criteria

- Application meets the criteria to be approved for isolation
