### PR TITLE
SC | Update to use USWDS v3 web components

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -199,6 +199,7 @@ const formConfig = {
           path: 'board-review-option',
           uiSchema: boardReview.uiSchema,
           schema: boardReview.schema,
+          scrollAndFocusTarget: focusRadioH3,
         },
         evidenceIntro: {
           title: 'Additional evidence',
@@ -220,6 +221,7 @@ const formConfig = {
           depends: needsHearingType,
           uiSchema: hearingType.uiSchema,
           schema: hearingType.schema,
+          scrollAndFocusTarget: focusRadioH3,
         },
       },
     },

--- a/src/applications/appeals/10182/sass/10182-nod.scss
+++ b/src/applications/appeals/10182/sass/10182-nod.scss
@@ -7,81 +7,6 @@
 @import "../../../../platform/forms/sass/m-form-confirmation";
 @import "../../shared/sass/appeals";
 
-.schemaform-intro {
-  padding: 0 0 2rem 0;
-
-  .process-step:last-child {
-    padding-bottom: 0;
-  }
-
-  .omb-info--container {
-    margin-top: 1em;
-  }
-}
-
-/* Contested issue cards (contested issue page & review/submit page)
- * This could go in the schemaform css, it's used in form 526 & HLR
- */
- .issues {
-
-  .widget-wrapper {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-
-    .widget-checkbox-wrap {
-      margin: 0;
-      width: 4rem;
-      min-width: 4rem;
-
-      label {
-        margin-top: 0;
-      }
-
-      [type="checkbox"] {
-        width: 1.8rem;
-        height: 1.8rem;
-        margin: 0;
-      }
-    }
-
-    .widget-content {
-      width: 100%;
-      margin-inline-start: 0; /* override user agent */
-      text-align: left;
-      margin: 0;
-    }
-    .widget-content.widget-edit {
-      margin-top: 0;
-      margin-right: 0;
-      display: flex;
-
-      .widget-content-wrap {
-        margin-top: 3rem;
-        margin-right: 0.5rem;
-        width: 100%;
-      }
-
-      .edit {
-        margin-top: 2rem;
-        /* position the edit button above the overlapping label */
-        position: relative;
-        z-index: 1;
-        align-self: center;
-      }
-    }
-    .edit-issue-link:visited {
-      color: inherit;
-    }
-  }
-
-  .checkbox-hidden {
-    .widget-content {
-      margin: 2rem 0 0 0;
-    }
-  }
-}
-
 ul.issues-summary,
 ul.issues,
 .usa-accordion-bordered ul li ul.issues {
@@ -105,10 +30,6 @@ ul.issues,
   .usa-input-error {
     margin-top: 0;
   }
-}
-
-.form-checkbox.usa-input-error {
-  margin-top: 0;
 }
 
 /* request extension NOD v2 */
@@ -154,10 +75,6 @@ article[data-location="add-issue"] {
 }
 
 /* Show issues list */
-.capitalize {
-  text-transform: capitalize;
-}
-
 form.rjsf > fieldset {
   margin-top: 0 !important;
 }
@@ -182,32 +99,4 @@ article[data-location$="/upload"] {
 #root_hearingTypePreference-label,
 #root_boardReviewOption-label {
   margin-bottom: 2rem;
-}
-
-article[data-location="review-and-submit"] {
-  /* hide when reviewing content. Shows when editing */
-  dt .hide-on-review, dd .hide-on-review {
-    display: none;
-  }
-  dt strong.opt-in-title {
-    font-weight: normal;
-  }
-  dd {
-    word-break: break-word;
-  }
-}
-
-/* Fix va-radio v3 input overlapping finish this request later link */
-.schemaform-save-container {
-  position: relative;
-  z-index: 1;
-}
-
-/* contestable issues widget - copy uswds v3 style */
-.widget-checkbox-wrap label:before {
-  box-shadow: rgb(27, 27, 27) 0px 0px 0px 2px;
-}
-
-.rjsf-object-field:empty {
-  display: none;
 }

--- a/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
+++ b/src/applications/appeals/995/components/EvidencePrivateRecords.jsx
@@ -394,7 +394,6 @@ const EvidencePrivateRecords = ({
           error={showError('country')}
           uswds
         >
-          <option value=""> </option>
           {countries.map(country => (
             <option key={country.value} value={country.value}>
               {country.label}
@@ -449,7 +448,6 @@ const EvidencePrivateRecords = ({
             error={showError('state')}
             uswds
           >
-            <option value=""> </option>
             {hasStates.map(state => (
               <option key={state.value} value={state.value}>
                 {state.label}

--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -195,7 +195,7 @@ const formConfig = {
           path: EVIDENCE_VA_REQUEST,
           uiSchema: evidenceVaRecordsRequest.uiSchema,
           schema: evidenceVaRecordsRequest.schema,
-          scrollAndFocusTarget: focusAlertH3,
+          scrollAndFocusTarget: focusRadioH3,
         },
         evidenceVaRecords: {
           title: 'VA medical records',
@@ -250,7 +250,7 @@ const formConfig = {
           path: EVIDENCE_ADDITIONAL_PATH,
           uiSchema: evidenceWillUpload.uiSchema,
           schema: evidenceWillUpload.schema,
-          scrollAndFocusTarget: focusAlertH3,
+          scrollAndFocusTarget: focusRadioH3,
         },
         evidenceUpload: {
           title: 'Uploaded evidence',

--- a/src/applications/appeals/995/content/evidenceVaRecordsRequest.jsx
+++ b/src/applications/appeals/995/content/evidenceVaRecordsRequest.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 
-export const requestVaRecordsTitle = (
-  <h3 className="vads-u-margin-y--0 vads-u-display--inline">
-    Would you like us to request your VA medical records for you?
-  </h3>
-);
+export const requestVaRecordsTitle =
+  'Would you like us to request your VA medical records for you?';
 
 export const requestVaRecordsInfo = (
   <va-additional-info

--- a/src/applications/appeals/995/content/evidenceWillUpload.jsx
+++ b/src/applications/appeals/995/content/evidenceWillUpload.jsx
@@ -3,12 +3,6 @@ import React from 'react';
 export const evidenceWillUploadTitle =
   'Do you want to upload your records or other documents to support your claim?';
 
-export const evidenceWillUploadHeader = (
-  <h3 className="vads-u-margin-top--0 vads-u-display--inline">
-    {evidenceWillUploadTitle}
-  </h3>
-);
-
 export const evidenceWillUploadInfo = (
   <va-additional-info
     trigger="Types of supporting evidence"

--- a/src/applications/appeals/995/pages/evidenceVaRecordsRequest.js
+++ b/src/applications/appeals/995/pages/evidenceVaRecordsRequest.js
@@ -1,4 +1,9 @@
 import {
+  yesNoSchema,
+  yesNoUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+import {
   requestVaRecordsTitle,
   requestVaRecordsInfo,
 } from '../content/evidenceVaRecordsRequest';
@@ -7,32 +12,28 @@ import { EVIDENCE_VA, errorMessages } from '../constants';
 
 export default {
   uiSchema: {
-    'ui:title': ' ',
-    'ui:options': {
-      forceDivWrapper: true,
-    },
-    [EVIDENCE_VA]: {
-      'ui:title': requestVaRecordsTitle,
-      'ui:widget': 'yesNo',
-      'ui:errorMessages': {
+    [EVIDENCE_VA]: yesNoUI({
+      title: requestVaRecordsTitle,
+      enableAnalytics: true,
+      labelHeaderLevel: '3',
+      labels: {
+        Y: 'Yes',
+        N: 'No',
+      },
+      errorMessages: {
         required: errorMessages.requiredYesNo,
       },
-      'ui:options': {
-        hideOnReview: true,
-        enableAnalytics: true,
-      },
-    },
+    }),
+
     'view:vaEvidenceInfo': {
       'ui:description': requestVaRecordsInfo,
     },
   },
+
   schema: {
     type: 'object',
-    required: [EVIDENCE_VA],
     properties: {
-      [EVIDENCE_VA]: {
-        type: 'boolean',
-      },
+      [EVIDENCE_VA]: yesNoSchema,
       'view:vaEvidenceInfo': {
         type: 'object',
         properties: {},

--- a/src/applications/appeals/995/pages/evidenceVaRecordsRequest.js
+++ b/src/applications/appeals/995/pages/evidenceVaRecordsRequest.js
@@ -20,6 +20,7 @@ export default {
         Y: 'Yes',
         N: 'No',
       },
+      required: () => true,
       errorMessages: {
         required: errorMessages.requiredYesNo,
       },

--- a/src/applications/appeals/995/pages/evidenceWillUpload.js
+++ b/src/applications/appeals/995/pages/evidenceWillUpload.js
@@ -20,6 +20,7 @@ export default {
         Y: 'Yes',
         N: 'No',
       },
+      required: () => true,
       errorMessages: {
         required: errorMessages.requiredYesNo,
       },

--- a/src/applications/appeals/995/pages/evidenceWillUpload.js
+++ b/src/applications/appeals/995/pages/evidenceWillUpload.js
@@ -1,5 +1,10 @@
 import {
-  evidenceWillUploadHeader,
+  yesNoSchema,
+  yesNoUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+import {
+  evidenceWillUploadTitle,
   evidenceWillUploadInfo,
 } from '../content/evidenceWillUpload';
 
@@ -7,21 +12,20 @@ import { EVIDENCE_OTHER, errorMessages } from '../constants';
 
 export default {
   uiSchema: {
-    'ui:title': ' ',
-    'ui:options': {
-      forceDivWrapper: true,
-    },
-    [EVIDENCE_OTHER]: {
-      'ui:title': evidenceWillUploadHeader,
-      'ui:widget': 'yesNo',
-      'ui:errorMessages': {
+    [EVIDENCE_OTHER]: yesNoUI({
+      title: evidenceWillUploadTitle,
+      enableAnalytics: true,
+      labelHeaderLevel: '3',
+      labels: {
+        Y: 'Yes',
+        N: 'No',
+      },
+      errorMessages: {
         required: errorMessages.requiredYesNo,
       },
-      'ui:options': {
-        hideOnReview: true,
-        enableAnalytics: true,
-      },
-    },
+      uswds: true,
+    }),
+
     'view:otherEvidenceInfo': {
       'ui:description': evidenceWillUploadInfo,
     },
@@ -30,9 +34,7 @@ export default {
     type: 'object',
     required: [EVIDENCE_OTHER],
     properties: {
-      [EVIDENCE_OTHER]: {
-        type: 'boolean',
-      },
+      [EVIDENCE_OTHER]: yesNoSchema,
       'view:otherEvidenceInfo': {
         type: 'object',
         properties: {},

--- a/src/applications/appeals/995/sass/995-supplemental-claim.scss
+++ b/src/applications/appeals/995/sass/995-supplemental-claim.scss
@@ -5,26 +5,7 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "../../../../platform/forms/sass/m-form-confirmation";
-
-.schemaform-intro {
-  padding: 0 0 2rem 0;
-
-  .process-step:last-child {
-    padding-bottom: 0;
-  }
-
-  .omb-info--container {
-    margin-top: 1em;
-  }
-}
-
-/* Global */
-.nowrap {
-  white-space: nowrap;
-}
-
-/* Step 2 */
-/*** Contested issues block ***/
+@import "../../shared/sass/appeals";
 
 /* global definitions */
 // hide Required label (added to description)
@@ -34,73 +15,6 @@
 
 #root_additionalDocuments_add_label {
   margin-top: 0;
-}
-
-/* Contested issue cards (contested issue page & review/submit page)
- * This could go in the schemaform css, it's used in form 526 & HLR
- */
-.issues {
-
-  .widget-wrapper {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-
-    .widget-checkbox-wrap {
-      margin: 0;
-      width: 5rem;
-      min-width: 5rem;
-
-      label {
-        margin-top: 0;
-      }
-
-      [type="checkbox"] {
-        width: 1.8rem;
-        height: 1.8rem;
-        margin: 0;
-      }
-    }
-
-    .widget-content {
-      width: 100%;
-      margin-inline-start: 0; /* override user agent */
-      text-align: left;
-      margin: 0;
-    }
-    .widget-content.widget-edit {
-      margin-top: 0;
-      margin-right: 0;
-      display: flex;
-
-      .widget-content-wrap {
-        margin-top: 3rem;
-        margin-right: 0.5rem;
-        width: 100%;
-      }
-
-      .edit {
-        margin-top: 2rem;
-        /* position the edit button above the overlapping label */
-        position: relative;
-        z-index: 1;
-        align-self: center;
-      }
-    }
-    .edit-issue-link:visited {
-      color: inherit;
-    }
-  }
-
-  .checkbox-hidden {
-    .widget-content {
-      margin: 2rem 0 0 0;
-    }
-  }
-}
-
-.usa-accordion-content .issues .checkbox-hidden .widget-content {
-  margin-left: 0; /* remove card margin on review & submit page */
 }
 
 .usa-input-error #root_additionalIssues_0_decisionDate-label {
@@ -135,12 +49,6 @@ ul.issues,
 
 #root_form5103Acknowledged-label {
   display: none !important;
-}
-
-/* Hide home & mobile phone extension entry, per design */
-article[data-location="edit-mobile-phone"] .schemaform-field-template:not(.schemaform-first-field),
-article[data-location="edit-home-phone"] va-text-input[name="extension"] {
-  display: none;
 }
 
 article[data-location="issue-summary"] {

--- a/src/applications/appeals/995/tests/pages/evidenceVaRecordsRequest.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/evidenceVaRecordsRequest.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, waitFor, render } from '@testing-library/react';
 import sinon from 'sinon';
 
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
@@ -26,10 +26,10 @@ describe('Supplemental Claims VA evidence request page', () => {
       />,
     );
 
-    expect($$('input', container).length).to.eq(2);
+    expect($$('va-radio-option', container).length).to.eq(2);
   });
 
-  it('should not allow submit with radios unselected (required)', () => {
+  it('should not allow submit with radios unselected (required)', async () => {
     const onSubmit = sinon.spy();
     const { container } = render(
       <DefinitionTester
@@ -42,10 +42,15 @@ describe('Supplemental Claims VA evidence request page', () => {
       />,
     );
     fireEvent.submit($('form', container));
-    expect($('.usa-input-error', container).textContent).to.contain(
-      errorMessages.requiredYesNo,
-    );
-    expect(onSubmit.called).to.be.false;
+
+    await waitFor(() => {
+      const radios = $$('[error]', container);
+      expect(radios.length).to.equal(1);
+      expect(radios[0].getAttribute('error')).to.eq(
+        errorMessages.requiredYesNo,
+      );
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should allow submit with one radio selected', () => {
@@ -62,32 +67,7 @@ describe('Supplemental Claims VA evidence request page', () => {
     );
     fireEvent.submit($('form', container));
     expect(container.innerHTML).to.contain('value="Y" checked');
-    expect($('.usa-input-error', container)).to.not.exist;
+    expect($('[error]', container)).to.not.exist;
     expect(onSubmit.called).to.be.true;
-  });
-
-  it('should capture google analytics', () => {
-    global.window.dataLayer = [];
-    const { container } = render(
-      <DefinitionTester
-        definitions={{}}
-        schema={schema}
-        uiSchema={uiSchema}
-        data={{}}
-        formData={{}}
-        onSubmit={() => {}}
-      />,
-    );
-
-    fireEvent.click($('input[value="Y"]', container));
-
-    const event = global.window.dataLayer.slice(-1)[0];
-    expect(event).to.deep.equal({
-      event: 'int-radio-button-option-click',
-      'radio-button-label':
-        'Would you like us to request your VA medical records for you?',
-      'radio-button-optionLabel': 'Yes',
-      'radio-button-required': true,
-    });
   });
 });

--- a/src/applications/appeals/995/tests/pages/evidenceWillUpload.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/pages/evidenceWillUpload.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, waitFor, render } from '@testing-library/react';
 import sinon from 'sinon';
 
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
@@ -8,7 +8,6 @@ import { $, $$ } from 'platform/forms-system/src/js/utilities/ui';
 
 import formConfig from '../../config/form';
 import { errorMessages, EVIDENCE_OTHER } from '../../constants';
-import { evidenceWillUploadTitle } from '../../content/evidenceWillUpload';
 
 describe('Supplemental Claims evidence upload request page', () => {
   const {
@@ -27,10 +26,10 @@ describe('Supplemental Claims evidence upload request page', () => {
       />,
     );
 
-    expect($$('input', container).length).to.eq(2);
+    expect($$('va-radio-option', container).length).to.eq(2);
   });
 
-  it('should prevent submit with radios unselected (required)', () => {
+  it('should prevent submit with radios unselected (required)', async () => {
     const onSubmit = sinon.spy();
     const { container } = render(
       <DefinitionTester
@@ -43,10 +42,15 @@ describe('Supplemental Claims evidence upload request page', () => {
       />,
     );
     fireEvent.submit($('form', container));
-    expect($('.usa-input-error', container).textContent).to.contain(
-      errorMessages.requiredYesNo,
-    );
-    expect(onSubmit.called).to.be.false;
+
+    await waitFor(() => {
+      const radios = $$('[error]', container);
+      expect(radios.length).to.equal(1);
+      expect(radios[0].getAttribute('error')).to.eq(
+        errorMessages.requiredYesNo,
+      );
+      expect(onSubmit.called).to.be.false;
+    });
   });
 
   it('should allow submit with one radio selected', () => {
@@ -65,29 +69,5 @@ describe('Supplemental Claims evidence upload request page', () => {
     expect(container.innerHTML).to.contain('value="Y" checked');
     expect($('.usa-input-error', container)).to.not.exist;
     expect(onSubmit.called).to.be.true;
-  });
-
-  it('should capture google analytics', () => {
-    global.window.dataLayer = [];
-    const { container } = render(
-      <DefinitionTester
-        definitions={{}}
-        schema={schema}
-        uiSchema={uiSchema}
-        data={{}}
-        formData={{}}
-        onSubmit={() => {}}
-      />,
-    );
-
-    fireEvent.click($('input[value="Y"]', container));
-
-    const event = global.window.dataLayer.slice(-1)[0];
-    expect(event).to.deep.equal({
-      event: 'int-radio-button-option-click',
-      'radio-button-label': evidenceWillUploadTitle,
-      'radio-button-optionLabel': 'Yes',
-      'radio-button-required': true,
-    });
   });
 });

--- a/src/applications/appeals/995/utils/upload.js
+++ b/src/applications/appeals/995/utils/upload.js
@@ -1,7 +1,7 @@
 import environment from 'platform/utilities/environment';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
 import { focusElement } from 'platform/utilities/ui';
-
+import VaSelectField from 'platform/forms-system/src/js/web-component-fields/VaSelectField';
 import { EVIDENCE_UPLOAD_API } from '../constants';
 
 import {
@@ -45,17 +45,18 @@ export const fileUploadUi = content => {
         attachmentId: '',
       };
     },
-    attachmentSchema: ({ fileId }) => ({
+    attachmentSchema: (/* { fileId, index } */) => ({
       'ui:title': 'Document type',
       'ui:disabled': false,
-      'ui:widget': 'select',
+      'ui:webComponentField': VaSelectField,
       'ui:options': {
-        widgetProps: {
-          'aria-describedby': fileId,
-        },
+        // TO DO: not implemented - see vets-design-system-documentation #2587;
+        // Need to get file name from within element with ID of fileId
+        // 'message-aria-describedby': // ???
       },
     }),
     hideOnReview: true,
     attachmentName: false,
+    uswds: true,
   });
 };

--- a/src/applications/appeals/996/sass/0996-higher-level-review.scss
+++ b/src/applications/appeals/996/sass/0996-higher-level-review.scss
@@ -5,25 +5,8 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "../../../../platform/forms/sass/m-form-confirmation";
+@import "../../shared/sass/appeals";
 
-.schemaform-intro {
-  padding: 0 0 2rem 0;
-
-  .process-step:last-child {
-    padding-bottom: 0;
-  }
-
-  .omb-info--container {
-    margin-top: 1em;
-  }
-}
-
-/* Global */
-.nowrap {
-  white-space: nowrap;
-}
-
-fieldset.vads-u-margin-y--2,
 /* Wizard */
 .wizard-content-inner .fieldset-input:first-child {
   margin-top: 0 !important;
@@ -33,17 +16,6 @@ fieldset.vads-u-margin-y--2,
 .input-section,
 .row.form-progress-buttons {
   margin-bottom: 1em;
-}
-
-/* Step 1a */
-/* Veteran details block */
-.blue-bar-block {
-  border-left: 7px solid $color-primary;
-  padding-left: 1em;
-
-  p {
-    margin: 0.5em 0;
-  }
 }
 
 /* contact info page */
@@ -67,86 +39,8 @@ article[data-location="contact-information"] {
   display: none;
 }
 
-/* Contested issue cards (contested issue page & review/submit page)
- * This could go in the schemaform css, it's used in form 526 & HLR
- */
-.issues {
-  /* v2 cards */
-  .widget-wrapper {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-
-    .widget-checkbox-wrap {
-      margin: 0;
-      width: 4rem;
-      min-width: 4rem;
-
-      label {
-        margin-top: 0;
-      }
-
-      [type="checkbox"] {
-        width: 1.8rem;
-        height: 1.8rem;
-        margin: 0;
-      }
-    }
-
-    .widget-title {
-      margin: 0;
-      text-transform: capitalize;
-      /*
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      overflow: hidden;
-      width: calc(100% - 7rem);
-      */
-    }
-
-    .widget-content {
-      width: 100%;
-      margin-inline-start: 0; /* override user agent */
-      text-align: left;
-      margin: 0;
-    }
-    .widget-content.widget-edit {
-      margin-top: 0;
-      margin-right: 0;
-      display: flex;
-
-      .widget-content-wrap {
-        margin-top: 3rem;
-        margin-right: 0.5rem;
-        width: 100%;
-      }
-
-      .edit {
-        margin-top: 2rem;
-        /* position the edit button above the overlapping label */
-        position: relative;
-        z-index: 1;
-        align-self: center;
-      }
-    }
-    .edit-issue-link:visited {
-      color: inherit;
-    }
-  }
-
-  .checkbox-hidden {
-    .widget-content {
-      margin: 2rem 0 0 0;
-    }
-  }
-}
-
 .usa-input-error #root_additionalIssues_0_decisionDate-label {
   font-weight: bold;
-}
-
-.review-row > dd {
-  word-break: break-word;
 }
 
 ul.issues-summary,
@@ -217,33 +111,6 @@ article[data-location="add-issue"] {
   }
 }
 
-/* Area of disagreement */
-.area-of-disagreement-label {
-  margin-top: 0;
-
-  .usa-input-error-message {
-    display: none;
-  }
-}
-.area-of-disagreement-label[data-submitted="true"].usa-input-error {
-  .usa-input-error-message {
-    display: block;
-  }
-  .input-section {
-    margin-bottom: 0;
-  }
-}
-.area-of-disagreement-label:not(.usa-input-error) {
-  margin: 2rem 0;
-}
-label[for^="root_disagreementOptions"] {
-  margin-top: 3rem;
-}
-
-/* override formation to maintain margin between checkboxes */
-.usa-input-error label {
-  margin-top: 3rem;
-}
 #root_otherEntry-label {
   margin-top: 2rem;
 }
@@ -274,35 +141,6 @@ label > .opt-in-title {
 }
 
 /* page specific */
-
-article[data-location^="area-of-disagreement"],
-article[data-location="review-and-submit"] div[name="areaOfDisagreementFollowUp0ScrollElement"] + form {
-  .schemaform-block-header,
-  .schemaform-block-header + .usa-input-error {
-    margin-top: 0;
-    margin-bottom: 0;
-  }
-  .area-of-disagreement-label.usa-input-error ~ div {
-    /* add left red border to 2 associated divs */
-    border-left: 4px solid var(--color-secondary-dark);
-    position: relative;
-    right: 1.9rem;
-    padding-left: 1.9rem;
-
-    .vads-u-margin-y--2 {
-      margin-top: 0 !important;
-      margin-bottom: 0 !important;
-    }
-    #root_otherEntry-label {
-      margin-top: 0 !important;
-      padding-top: 2rem;
-    }
-    label[for="root_disagreementOptions_evaluation"] {
-      margin-bottom: 0;
-    }
-  }
-}
-
 article[data-location="informal-conference/representative-info"],
 article[data-location="informal-conference/representative-information"] {
   .schemaform-field-container {
@@ -312,9 +150,6 @@ article[data-location="informal-conference/representative-information"] {
 
 /* Step 4 Review Application */
 article[data-location="review-and-submit"] {
-  .normal-weight-in-review {
-    font-weight: normal;
-  }
   dl.review .widget-wrapper-v2.checkbox-hidden {
     margin-top: 1rem;
 
@@ -322,13 +157,6 @@ article[data-location="review-and-submit"] {
       width: 0;
       min-width: 0;
     }
-  }
-  dd {
-    word-break: break-word;
-  }
-  /* hide when reviewing content. Shows when editing */
-  dt .hide-on-review, dd .hide-on-review {
-    display: none;
   }
 }
 
@@ -356,6 +184,12 @@ article[data-location="review-and-submit"] {
         margin: 2rem 0 0 0;
       }
     }
+  }
+}
+
+article[data-location="review-and-submit"] {
+  dt strong.opt-in-title {
+    font-weight: normal;
   }
 }
 

--- a/src/applications/appeals/shared/sass/appeals.scss
+++ b/src/applications/appeals/shared/sass/appeals.scss
@@ -1,5 +1,96 @@
+/* Global */
+.nowrap {
+  white-space: nowrap;
+}
+
+.capitalize {
+  text-transform: capitalize;
+}
+
+fieldset.vads-u-margin-y--2 {
+  margin-top: 0 !important;
+}
+
+// .rjsf-object-field:empty {
+//   display: none;
+// }
+
 
 /* area of disagreement input error removes top margin */
 va-checkbox-group va-text-input[error]::part(label) {
   margin-top: 3rem;
+}
+
+/* Contested issue cards (contested issue page & review/submit page)
+ * This could go in the schemaform css, it's used in form 526 & HLR
+ */
+ .issues {
+
+  .widget-wrapper {
+    display: flex;
+    flex-direction: row;
+    align-items: flex-start;
+
+    .widget-checkbox-wrap {
+      margin: 0;
+      width: 5rem;
+      min-width: 5rem;
+
+      label {
+        margin-top: 0;
+      }
+
+      /* contestable issues widget - copy uswds v3 style */
+      label:before {
+        box-shadow: rgb(27, 27, 27) 0px 0px 0px 2px;
+      }
+
+      [type="checkbox"] {
+        width: 1.8rem;
+        height: 1.8rem;
+        margin: 0;
+      }
+    }
+
+    .widget-content {
+      width: 100%;
+      margin-inline-start: 0; /* override user agent */
+      text-align: left;
+      margin: 0;
+    }
+    .widget-content.widget-edit {
+      margin-top: 0;
+      margin-right: 0;
+      display: flex;
+
+      .widget-content-wrap {
+        margin-top: 3rem;
+        margin-right: 0.5rem;
+        width: 100%;
+      }
+
+      .edit {
+        margin-top: 2rem;
+        /* position the edit button above the overlapping label */
+        position: relative;
+        z-index: 1;
+        align-self: center;
+      }
+    }
+    .edit-issue-link:visited {
+      color: inherit;
+    }
+  }
+
+  .checkbox-hidden {
+    .widget-content {
+      margin: 2rem 0 0 0;
+    }
+  }
+}
+
+article[data-location="review-and-submit"] {
+  dd {
+    word-break: break-word;
+  }
 }

--- a/src/applications/appeals/shared/utils/focus.js
+++ b/src/applications/appeals/shared/utils/focus.js
@@ -1,6 +1,7 @@
 import {
   defaultFocusSelector,
   focusElement,
+  focusByOrder,
   scrollTo,
   waitForRenderThenFocus,
 } from 'platform/utilities/ui';
@@ -42,7 +43,7 @@ export const focusRadioH3 = () => {
     // va-radio content doesn't immediately render
     waitForRenderThenFocus('h3', radio.shadowRoot);
   } else {
-    focusElement(defaultFocusSelector);
+    focusByOrder(['#main h3', defaultFocusSelector]);
   }
 };
 

--- a/src/applications/appeals/testing/sass/appeals-testing.scss
+++ b/src/applications/appeals/testing/sass/appeals-testing.scss
@@ -59,6 +59,10 @@ article[data-location="review-then-submit2"] {
   .form-progress-buttons {
     display: none;
   }
+  /* hide when reviewing content. Shows when editing */
+  dt .hide-on-review, dd .hide-on-review {
+    display: none;
+  }
 }
 
 .issue-title {

--- a/src/platform/forms-system/src/js/web-component-patterns/yesNoPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/yesNoPattern.jsx
@@ -6,11 +6,15 @@ import YesNoField from '../web-component-fields/YesNoField';
  * ```js
  * hasHealthInsurance: yesNoUI('Do you have health insurance coverage?')
  * hasHealthInsurance: yesNoUI({
- *    title: 'Do you have health insurance coverage?'
- *    labels: {
- *      Y: 'Yes, I have health insurance',
- *      N: 'No, I do not have health insurance',
- *    },
+ *   title: 'Do you have health insurance coverage?'
+ *   labels: {
+ *     Y: 'Yes, I have health insurance',
+ *     N: 'No, I do not have health insurance',
+ *   },
+ *   required: () => true,
+ *   errorMessages: {
+ *     required: 'Make a selection',
+ *   },
  * })
  * ```
  *
@@ -21,6 +25,7 @@ import YesNoField from '../web-component-fields/YesNoField';
  *   description?: UISchemaOptions['ui:description'],
  *   labels?: {Y?: string, N?: string},
  *   tile?: boolean,
+ *   required?: UISchemaOptions['ui:required'],
  *   yesNoReverse?: boolean,
  *   hint?: string,
  *   errorMessages?: UISchemaOptions['ui:errorMessages'],
@@ -36,6 +41,7 @@ export const yesNoUI = options => {
     description,
     yesNoReverse,
     errorMessages,
+    required,
     ...uiOptions
   } = typeof options === 'object' ? options : { title: options };
 
@@ -45,6 +51,7 @@ export const yesNoUI = options => {
     'ui:widget': 'yesNo', // This is required for the review page to render the field properly
     'ui:webComponentField': YesNoField,
     'ui:errorMessages': errorMessages,
+    'ui:required': required,
     'ui:options': {
       labels: {
         Y: labels?.Y || 'Yes',


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Update Supplemental Claim to use USWDS v3 web components (WC). Specifically switching from using the React radio widget to the WC yes/no pattern. The pattern was missing a required property, so that was added. Also, cleaned up unused CSS and move shared CSS into the shared folder.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Using established pattern to switch from React widget to Web component
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#73828](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73828)

## Testing done

- _Describe what the old behavior was prior to the change_
  > VA evidence and Evidence upload yes/no questions were previously using the built-in form system React radio widget
- _Describe the steps required to verify your changes are working as expected_
  > Test in review instance or staging; those 2 pages now use a `va-radio` v3 WC
- _Describe the tests completed and the results_
  > Updated unit tests to work with WC; Cypress e2e tests detect and interact with the WC
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| VA evidence | <img width="598" alt="va-before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/dc716c95-d6f4-4341-8f73-1d9436f84d48"> | <img width="588" alt="va-after" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/f6570693-b721-46f4-aaf4-fe838f6b3184"> |
| Upload evidence | <img width="600" alt="upload-before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/c7787657-ba8d-4981-9121-c4d0ae7805cb"> | <img width="589" alt="upload-after" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/b1f3a06d-b21d-4eda-ae53-68d7e3a1319e"> |

## What areas of the site does it impact?

- Supplemental Claims
- Apps using `yesNoPattern`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
