### PR TITLE
#78115: Add a new feature flag for Datadog RUM

### DIFF
--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -102,5 +102,9 @@ export const selectFeatureStartSchedulingLink = state =>
 
 export const selectFeaturePhysicalLocation = state =>
   toggleValues(state).vaOnlineSchedulingPhysicalLocation;
+
 export const selectFeatureBookingExclusion = state =>
   toggleValues(state).vaOnlineSchedulingBookingExclusion;
+
+export const selectFeatureDatadogRum = state =>
+  toggleValues(state).vaOnlineSchedulingDatadogRum;

--- a/src/applications/vaos/utils/featureFlags.js
+++ b/src/applications/vaos/utils/featureFlags.js
@@ -28,6 +28,7 @@ module.exports = [
   { name: 'vaOnlineSchedulingAfterVisitSummary', value: true },
   { name: 'vaOnlineSchedulingStartSchedulingLink', value: true },
   { name: 'vaOnlineSchedulingPhysicalLocation', value: true },
+  { name: 'vaOnlineSchedulingDatadogRum', value: true },
   { name: 'selectFeaturePocTypeOfCare', value: true },
   { name: 'edu_section_103', value: true },
   { name: 'vaViewDependentsAccess', value: false },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -223,6 +223,7 @@
   "vaOnlineSchedulingStartSchedulingLink": "va_online_scheduling_start_scheduling_link",
   "vaOnlineSchedulingBookingExclusion": "va_online_scheduling_booking_exclusion\t",
   "vaOnlineSchedulingPhysicalLocation": "va_online_scheduling_physical_location",
+  "vaOnlineSchedulingDatadogRum": "va_online_scheduling_datadog_RUM",
   "vaViewDependentsAccess": "va_view_dependents_access",
   "virtualAgentShowFloatingChatbot": "virtual_agent_show_floating_chatbot",
   "virtualAgentEnableParamErrorDetection": "virtual_agent_enable_param_error_detection",


### PR DESCRIPTION
Ticket summary:
Added va_online_scheduling_descriptive_back_link feature toggle
vets-api changes: https://github.com/department-of-veterans-affairs/vets-api/pull/15921

ticket link: https://app.zenhub.com/workspaces/appointments-team-603fdef281af6500110a1691/issues/gh/department-of-veterans-affairs/va.gov-team/78115