### PR TITLE
Fix: implement logic to ensure there are unit tests to run before run…

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -255,7 +255,7 @@ jobs:
           NUM_CONTAINERS: 10
       
       - name: Archive unit test results
-        if: ${{ always() }}
+        if: ${{ always() && env.NO_APPS_TO_RUN == false }}
         uses: ./.github/workflows/upload-artifact
         with:
           name: unit-test-report-${{ matrix.ci_node_index }}
@@ -264,13 +264,14 @@ jobs:
       # - name: Generate coverage report by app
       #   run: node script/app-coverage-report.js > test-results/coverage_report-${{ matrix.ci_node_index }}.txt
       - name: Rename Coverage Summary file
+        if: ${{ env.NO_APPS_TO_RUN == false }}
         run: |
           cd coverage
           mv coverage-summary.json coverage-summary-${{ matrix.ci_node_index }}.json
         
       - name: Upload Coverage Report Artifact
         uses: ./.github/workflows/upload-artifact
-        if: ${{ always() }}
+        if: ${{ always() && env.NO_APPS_TO_RUN == false }}
         with:
           name: unit-test-coverage-${{ matrix.ci_node_index }}
           # path: test-results/coverage_report-${{ matrix.ci_node_index }}.txt

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -255,7 +255,7 @@ jobs:
           NUM_CONTAINERS: 10
       
       - name: Archive unit test results
-        if: ${{ always() && env.NO_APPS_TO_RUN == false }}
+        if: ${{ always() && env.NO_APPS_TO_RUN == 'false' }}
         uses: ./.github/workflows/upload-artifact
         with:
           name: unit-test-report-${{ matrix.ci_node_index }}
@@ -264,14 +264,14 @@ jobs:
       # - name: Generate coverage report by app
       #   run: node script/app-coverage-report.js > test-results/coverage_report-${{ matrix.ci_node_index }}.txt
       - name: Rename Coverage Summary file
-        if: ${{ env.NO_APPS_TO_RUN == false }}
+        if: ${{ env.NO_APPS_TO_RUN == 'false' }}
         run: |
           cd coverage
           mv coverage-summary.json coverage-summary-${{ matrix.ci_node_index }}.json
         
       - name: Upload Coverage Report Artifact
         uses: ./.github/workflows/upload-artifact
-        if: ${{ always() && env.NO_APPS_TO_RUN == false }}
+        if: ${{ always() && env.NO_APPS_TO_RUN == 'false' }}
         with:
           name: unit-test-coverage-${{ matrix.ci_node_index }}
           # path: test-results/coverage_report-${{ matrix.ci_node_index }}.txt


### PR DESCRIPTION
## Summary

- Fixes an error that could happen if the number of applications on va.gov was a multiple of 9, where due to rounding the last container would be empty and error out. Checks to ensure there are tests to run before trying to run them or generate reports.

