### PR TITLE
fixed bug with duplicate key

### DIFF
--- a/src/applications/ivc-champva/10-10D/pages/ApplicantRelationshipPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantRelationshipPage.jsx
@@ -65,7 +65,10 @@ function generateOptions({ data, pagePerItemIndex }) {
     marriageOptions.push({ label: marriedDeceased, value: 'spouse' });
   } else {
     marriageOptions.push({ label: marriedLiving, value: 'spouse' });
-    marriageOptions.push({ label: marriedLivingDivorced, value: 'spouse' });
+    marriageOptions.push({
+      label: marriedLivingDivorced,
+      value: 'spouseSeparated',
+    });
   }
 
   // Create dynamic radio labels based on above phrasing


### PR DESCRIPTION
## Summary

Bug fix for two radio options with duplicate values.

- Rendering issue was caused because two keys used the "spouse" value
- Updated to remove duplicate key value and everything works as intended.
- Team: IVC CHAMPVA
- Flipper: NA

## Testing done

- Manual testing
- Verified unit tests run and pass

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
