### PR TITLE
MHV-55428: Meds Downtime notification

### DIFF
--- a/src/applications/mhv/medications/containers/App.jsx
+++ b/src/applications/mhv/medications/containers/App.jsx
@@ -1,18 +1,22 @@
-import React from 'react';
+import React, { useMemo, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import { RequiredLoginView } from '@department-of-veterans-affairs/platform-user/RequiredLoginView';
 import { selectUser } from '@department-of-veterans-affairs/platform-user/selectors';
 import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
+import { renderMHVDowntime } from '@department-of-veterans-affairs/mhv/exports';
 import {
   DowntimeNotification,
   externalServices,
+  externalServiceStatus,
 } from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
+import { getScheduledDowntime } from 'platform/monitoring/DowntimeNotification/actions';
 import { useDatadogRum } from '../../shared/hooks/useDatadogRum';
 import { medicationsUrls } from '../util/constants';
 
 const App = ({ children }) => {
+  const dispatch = useDispatch();
   const user = useSelector(selectUser);
   const { featureTogglesLoading, appEnabled } = useSelector(
     state => {
@@ -24,6 +28,31 @@ const App = ({ children }) => {
     },
     state => state.featureToggles,
   );
+
+  const scheduledDowntimes = useSelector(
+    state => state.scheduledDowntime?.serviceMap || [],
+  );
+
+  const mhvMedsDown = useMemo(
+    () => {
+      if (scheduledDowntimes.size > 0) {
+        return (
+          scheduledDowntimes?.get(externalServices.mhvMeds)?.status ||
+          scheduledDowntimes?.get(externalServices.mhvPlatform)?.status
+        );
+      }
+      return 'downtime status: ok';
+    },
+    [scheduledDowntimes],
+  );
+
+  useEffect(
+    () => {
+      dispatch(getScheduledDowntime());
+    },
+    [dispatch],
+  );
+
   const datadogRumConfig = {
     applicationId: '2b875bc2-034a-445b-868c-d43bec8928d1',
     clientToken: 'pubb9b9c833770797060110a821283a0892',
@@ -64,12 +93,21 @@ const App = ({ children }) => {
       user={user}
       serviceRequired={[backendServices.USER_PROFILE]}
     >
-      <DowntimeNotification
-        appTitle="Medications"
-        dependencies={[externalServices.mhvPlatform, externalServices.mhvMeds]}
-      >
-        {children}
-      </DowntimeNotification>
+      {mhvMedsDown === externalServiceStatus.down ? (
+        <>
+          <h1 className="vads-u-padding-top--4">Medications</h1>
+          <DowntimeNotification
+            appTitle="Medications"
+            dependencies={[
+              externalServices.mhvPlatform,
+              externalServices.mhvMeds,
+            ]}
+            render={renderMHVDowntime}
+          />
+        </>
+      ) : (
+        children
+      )}
     </RequiredLoginView>
   );
 };

--- a/src/applications/mhv/medications/containers/App.jsx
+++ b/src/applications/mhv/medications/containers/App.jsx
@@ -38,10 +38,11 @@ const App = ({ children }) => {
       if (scheduledDowntimes.size > 0) {
         return (
           scheduledDowntimes?.get(externalServices.mhvMeds)?.status ||
-          scheduledDowntimes?.get(externalServices.mhvPlatform)?.status
+          scheduledDowntimes?.get(externalServices.mhvPlatform)?.status ||
+          externalServiceStatus.ok
         );
       }
-      return 'downtime status: ok';
+      return externalServiceStatus.ok;
     },
     [scheduledDowntimes],
   );
@@ -93,7 +94,7 @@ const App = ({ children }) => {
       user={user}
       serviceRequired={[backendServices.USER_PROFILE]}
     >
-      {mhvMedsDown === externalServiceStatus.down ? (
+      {mhvMedsDown !== externalServiceStatus.ok ? (
         <>
           <h1 className="vads-u-padding-top--4">Medications</h1>
           <DowntimeNotification

--- a/src/applications/mhv/medications/containers/App.jsx
+++ b/src/applications/mhv/medications/containers/App.jsx
@@ -1,22 +1,20 @@
-import React, { useMemo, useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
 import { RequiredLoginView } from '@department-of-veterans-affairs/platform-user/RequiredLoginView';
 import { selectUser } from '@department-of-veterans-affairs/platform-user/selectors';
 import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
-import { renderMHVDowntime } from '@department-of-veterans-affairs/mhv/exports';
 import {
   DowntimeNotification,
   externalServices,
   externalServiceStatus,
 } from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
-import { getScheduledDowntime } from 'platform/monitoring/DowntimeNotification/actions';
+import { MHVDowntime } from '@department-of-veterans-affairs/mhv/exports';
 import { useDatadogRum } from '../../shared/hooks/useDatadogRum';
 import { medicationsUrls } from '../util/constants';
 
 const App = ({ children }) => {
-  const dispatch = useDispatch();
   const user = useSelector(selectUser);
   const { featureTogglesLoading, appEnabled } = useSelector(
     state => {
@@ -27,31 +25,6 @@ const App = ({ children }) => {
       };
     },
     state => state.featureToggles,
-  );
-
-  const scheduledDowntimes = useSelector(
-    state => state.scheduledDowntime?.serviceMap || [],
-  );
-
-  const mhvMedsDown = useMemo(
-    () => {
-      if (scheduledDowntimes.size > 0) {
-        return (
-          scheduledDowntimes?.get(externalServices.mhvMeds)?.status ||
-          scheduledDowntimes?.get(externalServices.mhvPlatform)?.status ||
-          externalServiceStatus.ok
-        );
-      }
-      return externalServiceStatus.ok;
-    },
-    [scheduledDowntimes],
-  );
-
-  useEffect(
-    () => {
-      dispatch(getScheduledDowntime());
-    },
-    [dispatch],
   );
 
   const datadogRumConfig = {
@@ -94,21 +67,24 @@ const App = ({ children }) => {
       user={user}
       serviceRequired={[backendServices.USER_PROFILE]}
     >
-      {mhvMedsDown !== externalServiceStatus.ok ? (
-        <>
-          <h1 className="vads-u-padding-top--4">Medications</h1>
-          <DowntimeNotification
-            appTitle="Medications"
-            dependencies={[
-              externalServices.mhvPlatform,
-              externalServices.mhvMeds,
-            ]}
-            render={renderMHVDowntime}
-          />
-        </>
-      ) : (
-        children
-      )}
+      <DowntimeNotification
+        appTitle="Medications"
+        dependencies={[externalServices.mhvPlatform, externalServices.mhvMeds]}
+        render={(downtimeProps, downtimeChildren) => (
+          <>
+            {downtimeProps.status === externalServiceStatus.down && (
+              <h1 className="vads-u-margin-top--4">Medications</h1>
+            )}
+            {downtimeProps.status ===
+              externalServiceStatus.downtimeApproaching && (
+              <div className="vads-u-margin-top--4" />
+            )}
+            <MHVDowntime {...downtimeProps}>{downtimeChildren}</MHVDowntime>
+          </>
+        )}
+      >
+        {children}
+      </DowntimeNotification>
     </RequiredLoginView>
   );
 };

--- a/src/applications/mhv/medications/tests/containers/App.unit.spec.jsx
+++ b/src/applications/mhv/medications/tests/containers/App.unit.spec.jsx
@@ -157,13 +157,13 @@ describe('Medications <App>', () => {
       },
     );
     expect(
-      screen.getByText('This tool is down for maintenance', {
-        selector: 'h3',
+      screen.getByText('Maintenance on My HealtheVet', {
+        selector: 'h2',
         exact: true,
       }),
     );
     expect(
-      screen.getByText('We’re making some updates to this tool', {
+      screen.getByText('We’re working on Medications right now', {
         exact: false,
       }),
     );
@@ -200,13 +200,13 @@ describe('Medications <App>', () => {
       },
     );
     expect(
-      screen.getByText('This tool is down for maintenance', {
-        selector: 'h3',
+      screen.getByText('Maintenance on My HealtheVet', {
+        selector: 'h2',
         exact: true,
       }),
     );
     expect(
-      screen.getByText('We’re making some updates to this tool', {
+      screen.getByText('We’re working on Medications right now', {
         exact: false,
       }),
     );
@@ -243,13 +243,13 @@ describe('Medications <App>', () => {
       },
     );
     expect(
-      screen.getByText('This tool is down for maintenance', {
-        selector: 'h3',
-        exact: true,
+      screen.getByText('Maintenance on My HealtheVet', {
+        selector: 'h2',
+        exact: false,
       }),
     );
     expect(
-      screen.getByText('We’re making some updates to this tool', {
+      screen.getByText('We’re working on Medications right now', {
         exact: false,
       }),
     );

--- a/src/platform/mhv/downtime/mocks/api/maintenance-windows/index.js
+++ b/src/platform/mhv/downtime/mocks/api/maintenance-windows/index.js
@@ -33,6 +33,16 @@ const responses = {
           description: '',
         },
       },
+      {
+        id: '002',
+        type: 'maintenance_windows',
+        attributes: {
+          externalService: 'mhv_meds',
+          startTime: soonStartTime.toISOString(),
+          endTime: soonEndTime.toISOString(),
+          description: '',
+        },
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary

Updated Downtime notification styling for Medications

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-55428

<img width="957" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/65ab0c09-60a2-47f7-90f3-20ddb300cb74">

## Testing done

- Manual testing with mocked data (`yarn mock-api --responses src/platform/mhv/downtime/mocks/api`)
- Unit tests updated

<img width="1715" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/2278ddf1-4eef-46c2-b5be-6d3d67536b3c">

## What areas of the site does it impact?

/my-health/medications/

## Acceptance criteria

AC1: Styling is complete for the system is down for maintenance message

## Screenshots

<img width="1727" alt="Screenshot 2024-03-18 at 5 35 29 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/3af82e69-4a73-4993-9cbd-6b0569c341ea">

<img width="1723" alt="Screenshot 2024-03-18 at 5 34 37 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/1cd3f35a-cf79-4436-a8d8-617e0c1124f0">

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
