### PR TITLE
#78481: Implement DataDog RUM

### DIFF
--- a/src/applications/vaos/components/EnrolledRoute.jsx
+++ b/src/applications/vaos/components/EnrolledRoute.jsx
@@ -7,11 +7,13 @@ import backendServices from 'platform/user/profile/constants/backendServices';
 import { RequiredLoginView } from 'platform/user/authorization/components/RequiredLoginView';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import NoRegistrationMessage from './NoRegistrationMessage';
+import { useDatadogRum } from '../utils/useDatadogRum';
 
 export default function EnrolledRoute({ component: RouteComponent, ...rest }) {
   const user = useSelector(selectUser);
   const sites = useSelector(selectPatientFacilities);
   const hasRegisteredSystems = sites?.length > 0;
+  useDatadogRum();
   return (
     <RequiredLoginView
       serviceRequired={[

--- a/src/applications/vaos/utils/useDatadogRum.js
+++ b/src/applications/vaos/utils/useDatadogRum.js
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+import { datadogRum } from '@datadog/browser-rum';
+
+import environment from 'platform/utilities/environment';
+import { useSelector } from 'react-redux';
+import { selectFeatureDatadogRum } from '../redux/selectors';
+
+const initializeDatadogRum = () => {
+  if (
+    // Prevent RUM from running on local/CI environments.
+    environment.BASE_URL.indexOf('localhost') < 0 &&
+    // Prevent re-initializing the SDK.
+    !window.DD_RUM?.getInitConfiguration()
+  ) {
+    datadogRum.init({
+      applicationId: '8880279e-5c40-4f82-90f9-9a3cdb6d461b',
+      clientToken: 'pub4705a09a8da66995fa85908096f42321',
+      site: 'ddog-gov.com',
+      service: 'va.gov-appointments',
+      env: environment.vspEnvironment(),
+      sampleRate: 100,
+      sessionReplaySampleRate: 100,
+      trackInteractions: true,
+      trackFrustrations: true,
+      trackResources: true,
+      trackLongTasks: true,
+      defaultPrivacyLevel: 'mask-user-input',
+    });
+  }
+};
+
+const useDatadogRum = () => {
+  const featureDatadogRum = useSelector(state =>
+    selectFeatureDatadogRum(state),
+  );
+
+  useEffect(
+    () => {
+      if (featureDatadogRum) {
+        initializeDatadogRum();
+      } else {
+        delete window.DD_RUM;
+      }
+    },
+    [featureDatadogRum],
+  );
+};
+
+export { useDatadogRum };

--- a/src/applications/vaos/utils/useDatadogRum.js
+++ b/src/applications/vaos/utils/useDatadogRum.js
@@ -10,7 +10,8 @@ const initializeDatadogRum = () => {
     // Prevent RUM from running on local/CI environments.
     environment.BASE_URL.indexOf('localhost') < 0 &&
     // Prevent re-initializing the SDK.
-    !window.DD_RUM?.getInitConfiguration()
+    !window.DD_RUM?.getInitConfiguration() &&
+    !window.Mocha
   ) {
     datadogRum.init({
       applicationId: '8880279e-5c40-4f82-90f9-9a3cdb6d461b',
@@ -18,7 +19,7 @@ const initializeDatadogRum = () => {
       site: 'ddog-gov.com',
       service: 'va.gov-appointments',
       env: environment.vspEnvironment(),
-      sampleRate: 100,
+      sessionSampleRate: 100,
       sessionReplaySampleRate: 100,
       trackInteractions: true,
       trackFrustrations: true,
@@ -26,6 +27,7 @@ const initializeDatadogRum = () => {
       trackLongTasks: true,
       defaultPrivacyLevel: 'mask-user-input',
     });
+    datadogRum.startSessionReplayRecording();
   }
 };
 


### PR DESCRIPTION
## Summary
Implement DataDog RUM



## Related issue(s)

- https://app.zenhub.com/workspaces/appointments-team-603fdef281af6500110a1691/issues/gh/department-of-veterans-affairs/va.gov-team/78481

## Testing done
Tested UI with `va_online_scheduling_datadog_RUM`. feature flag turned on.

Data RUM api calls and logs

<img width="1468" alt="Screenshot 2024-03-15 at 11 44 56 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/47654119/f4229b9f-796c-4e52-9b61-7a0de087ae92">

<img width="1482" alt="Screenshot 2024-03-15 at 11 45 55 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/47654119/160eaea1-f24f-4ae2-b23b-a755a54e838d">

Tested UI with `va_online_scheduling_datadog_RUM`. feature flag turned off.

No data RUM api calls

<img width="1480" alt="Screenshot 2024-03-15 at 11 47 36 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/47654119/ab4fbe31-7c4d-4d91-8301-0cad3d86373f">








## Acceptance criteria
- [x] file coverage for Branches, functions, lines and statements is 100%
