### PR TITLE
Breadcrumbs hotfix

### DIFF
--- a/src/applications/personalization/profile/components/ProfileBreadcrumbs.jsx
+++ b/src/applications/personalization/profile/components/ProfileBreadcrumbs.jsx
@@ -45,7 +45,11 @@ export const ProfileBreadcrumbs = ({ className }) => {
   );
 
   return (
-    <div className={className}>
+    <div
+      className={className}
+      data-breadcrumbs-json={JSON.stringify(breadcrumbs)}
+      data-testid="profile-breadcrumbs-wrapper"
+    >
       <VaBreadcrumbs
         uswds
         breadcrumbList={breadcrumbs}

--- a/src/applications/personalization/profile/components/ProfileBreadcrumbs.jsx
+++ b/src/applications/personalization/profile/components/ProfileBreadcrumbs.jsx
@@ -48,7 +48,7 @@ export const ProfileBreadcrumbs = ({ className }) => {
     <div className={className}>
       <VaBreadcrumbs
         uswds
-        breadcrumb-list={JSON.stringify(breadcrumbs)}
+        breadcrumbList={breadcrumbs}
         onRouteChange={handleRouteChange}
       />
     </div>

--- a/src/applications/personalization/profile/tests/components/ProfileBreadcrumbs.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/ProfileBreadcrumbs.unit.spec.jsx
@@ -20,9 +20,7 @@ const setup = path => {
   );
 
   const breadcrumbList = JSON.parse(
-    view.container
-      .querySelector('va-breadcrumbs')
-      .getAttribute('breadcrumb-list'),
+    view.getByTestId('profile-breadcrumbs-wrapper').dataset.breadcrumbsJson,
   );
 
   return { breadcrumbList };

--- a/src/applications/personalization/profile/tests/e2e/profile-breadcrumbs.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-breadcrumbs.cypress.spec.js
@@ -1,0 +1,44 @@
+import serviceHistory from '@@profile/tests/fixtures/service-history-success.json';
+import fullName from '@@profile/tests/fixtures/full-name-success.json';
+import disabilityRating from '@@profile/tests/fixtures/disability-rating-success.json';
+import error500 from '@@profile/tests/fixtures/500.json';
+
+import { mockUser } from '../fixtures/users/user';
+import { PROFILE_PATHS, PROFILE_PATHS_WITH_NAMES } from '../../constants';
+import { generateFeatureToggles } from '../../mocks/endpoints/feature-toggles';
+
+describe('Profile Breadcrumbs', () => {
+  beforeEach(() => {
+    cy.login(mockUser);
+    cy.intercept('/v0/profile/service_history', serviceHistory);
+    cy.intercept('/v0/profile/full_name', fullName);
+    cy.intercept('/v0/profile/personal_information', error500);
+    cy.intercept('/v0/mhv_account', error500);
+    cy.intercept(
+      '/v0/disability_compensation_form/rating_info',
+      disabilityRating,
+    );
+  });
+
+  PROFILE_PATHS_WITH_NAMES.forEach(({ path, name }) => {
+    // skip the edit path
+    if (path === PROFILE_PATHS.EDIT) {
+      return;
+    }
+    it('render the active page name in the breadcrumbs', () => {
+      cy.intercept(
+        'GET',
+        '/v0/feature_toggles*',
+        generateFeatureToggles({ profileContacts: true }),
+      );
+      cy.visit(`${path}/`);
+      cy.get('va-breadcrumbs')
+        .shadow()
+        .findByText(name)
+        .should('exist');
+
+      cy.url().should('eq', `${Cypress.config('baseUrl')}${path}/`);
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes breadcrumbs not being dynamic
- Adds e2e tests around this to prevent regression
- Updates unit tests with some real janky ways to test that the array is being created correctly. I don't really like this, but if the breadcrumbList is not stringified then its _impossible_ to unit tests I guess. (at least I couldn't figure out a way to do it)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/78611

## Testing done

- Unit tests fixed
- E2E test added

## Screenshots

No real screenshots, but you can reproduce it by navigating between pages in the profile and seeing that the breadcrumb doesn't change on `main` and that the fix works now in this branch.

## What areas of the site does it impact?

Profile

## Acceptance criteria

- [x] Breadcrumbs fixed

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
