### PR TITLE
Removed unused Yellow Ribbon feature toggle

### DIFF
--- a/src/applications/yellow-ribbon/helpers/selectors.js
+++ b/src/applications/yellow-ribbon/helpers/selectors.js
@@ -1,8 +1,1 @@
-// import the toggleValues helper
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-
 export const getYellowRibbonAppState = state => state.yellowRibbonReducer;
-
-export const selectShowYellowRibbonEnhancements = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.yellowRibbonEnhancements];

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -231,6 +231,5 @@
   "virtualAgentUpgradeWebchat14158": "virtual_agent_upgrade_webchat_14_15_8",
   "virtualAgentEnableMsftPvaTesting": "virtual_agent_enable_msft_pva_testing",
   "virtualAgentEnableNluPvaTesting": "virtual_agent_enable_nlu_pva_testing",
-  "yellowRibbonEnhancements": "yellow_ribbon_mvp_enhancement",
   "yellowRibbonAutomatedDateOnSchoolSearch": "yellow_ribbon_automated_date_on_school_search"
 }

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -231,7 +231,6 @@
   "virtualAgentUpgradeWebchat14158": "virtual_agent_upgrade_webchat_14_15_8",
   "virtualAgentEnableMsftPvaTesting": "virtual_agent_enable_msft_pva_testing",
   "virtualAgentEnableNluPvaTesting": "virtual_agent_enable_nlu_pva_testing",
-  "yellowRibbonDegreeFilter": "yellow_ribbon_degree_filter",
   "yellowRibbonEnhancements": "yellow_ribbon_mvp_enhancement",
   "yellowRibbonAutomatedDateOnSchoolSearch": "yellow_ribbon_automated_date_on_school_search"
 }


### PR DESCRIPTION
## Summary

- Removed an unused flipper toggle
- Not a bug
- Team IIR, we are the current owners

## Related issue(s)

https://github.com/department-of-veterans-affairs/va-iir/issues/465
https://github.com/department-of-veterans-affairs/va-iir/issues/242

## Testing done

- Prior to this change, one unused feature toggle was available for use
- No steps to verify correct operation other than confirming this one line removal
- Testing consisted of a code search to confirm that this toggle is unused

## Screenshots

No screenshots, UI unaffected

## What areas of the site does it impact?

Nothing beyond flipper

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

None