### PR TITLE
Remove VA & upload evidence yes/no from review page

### DIFF
--- a/src/applications/appeals/995/pages/evidenceVaRecordsRequest.js
+++ b/src/applications/appeals/995/pages/evidenceVaRecordsRequest.js
@@ -24,6 +24,7 @@ export default {
       errorMessages: {
         required: errorMessages.requiredYesNo,
       },
+      hideOnReview: true,
     }),
 
     'view:vaEvidenceInfo': {

--- a/src/applications/appeals/995/pages/evidenceWillUpload.js
+++ b/src/applications/appeals/995/pages/evidenceWillUpload.js
@@ -25,6 +25,7 @@ export default {
         required: errorMessages.requiredYesNo,
       },
       uswds: true,
+      hideOnReview: true,
     }),
 
     'view:otherEvidenceInfo': {


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > After upgrading the VA evidence and upload evidence yes/no radios to use V3, the ui option to hide the question on the review & submit page was accidentally omitted. This PR restores those options.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Review
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#73828](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73828)

## Testing done

- _Describe what the old behavior was prior to the change_
  > See screenshot - 2 additional yes/no questions included in the evidence accordion
- _Describe the steps required to verify your changes are working as expected_
  > Add back the missing `hideOnReview` option
- _Describe the tests completed and the results_
  > Manual testing; we don't have tests for the review & submit page
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Review & submit  | <img width="629" alt="review & submit page showing notice of evidence needed, request VA medical records and upload new and relevant evidence - the last two shouldn't be visible" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/8247c27e-72ed-4bde-b68c-1cb689b8ebf9"> | <img width="633" alt="review & submit page showing notice of evidence needed and evidence summary - request VA medical records and upload new and relevant evidence are not seen; this is expected" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/55d49fb9-0c28-41da-92e6-6adec84ee295"> |

## What areas of the site does it impact?

Supplemental Claim

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
