### PR TITLE
Add error scenarios

### DIFF
--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -483,13 +483,13 @@ class ApiInitializer {
   };
 
   initializeBtsssPost = {
-    withSuccess: () => {
-      cy.intercept(`/check_in/v0/travel_claims/`, { times: 1 }, req => {
+    withSuccess: (times = 1) => {
+      cy.intercept(`/check_in/v0/travel_claims/`, { times }, req => {
         req.reply(202, btsss.post.createMockSuccessResponse());
       }).as('btsssPostSuccess');
     },
-    withFailure: () => {
-      cy.intercept(`/check_in/v0/travel_claims/`, { times: 1 }, req => {
+    withFailure: (times = 1) => {
+      cy.intercept(`/check_in/v0/travel_claims/`, { times }, req => {
         req.reply(500, btsss.post.createMockFailedResponse());
       }).as('btsssPostFailure');
     },

--- a/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
+++ b/src/applications/check-in/api/local-mock-api/e2e/ApiInitializer.js
@@ -484,14 +484,14 @@ class ApiInitializer {
 
   initializeBtsssPost = {
     withSuccess: () => {
-      cy.intercept('POST', `/check_in/v0/travel_claims/`, req => {
+      cy.intercept(`/check_in/v0/travel_claims/`, { times: 1 }, req => {
         req.reply(202, btsss.post.createMockSuccessResponse());
-      });
+      }).as('btsssPostSuccess');
     },
     withFailure: () => {
-      cy.intercept('POST', `/check_in/v0/travel_claims/`, req => {
+      cy.intercept(`/check_in/v0/travel_claims/`, { times: 1 }, req => {
         req.reply(500, btsss.post.createMockFailedResponse());
-      });
+      }).as('btsssPostFailure');
     },
   };
 

--- a/src/applications/check-in/tests/e2e/pages/TravelPages.js
+++ b/src/applications/check-in/tests/e2e/pages/TravelPages.js
@@ -121,6 +121,12 @@ class TravelPages {
     });
   };
 
+  clickBackButton = () => {
+    cy.get('[data-testid="no-button"]').click({
+      waitForAnimations: true,
+    });
+  };
+
   clickAgreementLink = () => {
     cy.get(`[data-testid="travel-agreement-link"]`).click();
   };

--- a/src/applications/check-in/travel-claim/pages/error/index.jsx
+++ b/src/applications/check-in/travel-claim/pages/error/index.jsx
@@ -143,6 +143,7 @@ const Error = () => {
       // no-token
       // bad-token
       // session-error
+      // cant-retrieve-travel-claim-data
       header = t('something-went-wrong-on-our-end');
       alerts = [
         {
@@ -161,7 +162,7 @@ const Error = () => {
   }
 
   return (
-    <Wrapper pageTitle={header}>
+    <Wrapper pageTitle={header} testID="travel-error-page">
       {alerts.map((alert, index) => (
         <div key={`alert-${index}`} data-testid={error}>
           <va-alert

--- a/src/applications/check-in/travel-claim/tests/e2e/errors-already-filed.cypress.spec.js
+++ b/src/applications/check-in/travel-claim/tests/e2e/errors-already-filed.cypress.spec.js
@@ -11,12 +11,10 @@ describe('A Patient who has already filed for all eligile appointments', () => {
       initializeFeatureToggle,
       initializeSessionGet,
       initializeSessionPost,
-      initializeBtsssPost,
     } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
     initializeSessionGet.withSuccessfulNewSession();
     initializeSessionPost.withSuccess();
-    initializeBtsssPost.withSuccess();
   });
   it('should redirect to the correct error page after login', () => {
     ApiInitializer.initializeCheckInDataGetOH.withSuccess(

--- a/src/applications/check-in/travel-claim/tests/e2e/errors-already-filed.cypress.spec.js
+++ b/src/applications/check-in/travel-claim/tests/e2e/errors-already-filed.cypress.spec.js
@@ -1,0 +1,43 @@
+import '../../../tests/e2e/commands';
+
+import ApiInitializer from '../../../api/local-mock-api/e2e/ApiInitializer';
+import ValidateVeteran from '../../../tests/e2e/pages/ValidateVeteran';
+import sharedData from '../../../api/local-mock-api/mocks/v2/shared';
+import Error from './pages/Error';
+
+describe('A Patient who has already filed for all eligile appointments', () => {
+  beforeEach(() => {
+    const {
+      initializeFeatureToggle,
+      initializeSessionGet,
+      initializeSessionPost,
+      initializeBtsssPost,
+    } = ApiInitializer;
+    initializeFeatureToggle.withCurrentFeatures();
+    initializeSessionGet.withSuccessfulNewSession();
+    initializeSessionPost.withSuccess();
+    initializeBtsssPost.withSuccess();
+  });
+  it('should redirect to the correct error page after login', () => {
+    ApiInitializer.initializeCheckInDataGetOH.withSuccess(
+      sharedData.get.defaultUUID,
+    );
+    cy.visitTravelClaimWithUUID();
+    cy.window().then(win => {
+      // Set the value in local storage using win.localStorage.setItem()
+      win.localStorage.setItem(
+        'my.health.travel-claim.travel.pay.sent',
+        `{"530":"${new Date().toISOString()}"}`,
+      );
+    });
+    ValidateVeteran.validatePage.travelClaim();
+    cy.injectAxeThenAxeCheck();
+    ValidateVeteran.validateVeteran();
+    ValidateVeteran.attemptToGoToNextPage();
+
+    Error.validatePageLoaded();
+    Error.validateErrorAlert('already-filed-claim');
+    cy.injectAxeThenAxeCheck();
+    cy.createScreenshots('Travel-claim--error-already-filed-claim');
+  });
+});

--- a/src/applications/check-in/travel-claim/tests/e2e/errors-form-validation.cypress.spec.js
+++ b/src/applications/check-in/travel-claim/tests/e2e/errors-form-validation.cypress.spec.js
@@ -1,0 +1,131 @@
+import '../../../tests/e2e/commands';
+
+import ApiInitializer from '../../../api/local-mock-api/e2e/ApiInitializer';
+import ValidateVeteran from '../../../tests/e2e/pages/ValidateVeteran';
+import TravelIntro from './pages/TravelIntro';
+import TravelMileage from './pages/TravelMileage';
+import TravelPages from '../../../tests/e2e/pages/TravelPages';
+import sharedData from '../../../api/local-mock-api/mocks/v2/shared';
+import Error from './pages/Error';
+
+describe('Travel claim validation', () => {
+  beforeEach(() => {
+    const {
+      initializeFeatureToggle,
+      initializeSessionGet,
+      initializeSessionPost,
+      initializeCheckInDataGetOH,
+    } = ApiInitializer;
+    initializeFeatureToggle.withCurrentFeatures();
+    initializeSessionGet.withSuccessfulNewSession();
+    initializeSessionPost.withSuccess();
+    initializeCheckInDataGetOH.withSuccess(
+      sharedData.get.multiApptMultiFacilityUUID,
+    );
+    cy.visitTravelClaimWithUUID();
+    ValidateVeteran.validatePage.travelClaim();
+    cy.injectAxeThenAxeCheck();
+    ValidateVeteran.validateVeteran();
+    ValidateVeteran.attemptToGoToNextPage();
+
+    TravelIntro.validatePageLoaded();
+    cy.injectAxeThenAxeCheck();
+    TravelIntro.attemptToGoToNextPage();
+  });
+  describe('A patient that answers no to travel questions', () => {
+    it('should go to error page if answers no to travel vehicle', () => {
+      TravelMileage.validatePageLoaded();
+      cy.injectAxeThenAxeCheck();
+      TravelMileage.selectFacility('500');
+      TravelMileage.attemptToGoToNextPage();
+
+      TravelPages.validatePageWrapper('travel-claim-vehicle-page');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage('no');
+
+      Error.validatePageLoaded();
+      Error.validateErrorAlert('cant-file-claim-type');
+      cy.injectAxeThenAxeCheck();
+      cy.createScreenshots('Travel-claim--error-no-to-travel-vehicle');
+    });
+    it('should go to error page if answers no to travel address', () => {
+      TravelMileage.validatePageLoaded();
+      cy.injectAxeThenAxeCheck();
+      TravelMileage.selectFacility('500');
+      TravelMileage.attemptToGoToNextPage();
+
+      TravelPages.validatePageWrapper('travel-claim-vehicle-page');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage('yes');
+
+      TravelPages.validatePageWrapper('travel-claim-address-page');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage('no');
+
+      Error.validatePageLoaded();
+      Error.validateErrorAlert('cant-file-claim-type');
+      cy.injectAxeThenAxeCheck();
+      cy.createScreenshots('Travel-claim--error-no-to-travel-address');
+    });
+    it('should go to error page if answers no to travel address after coming back from the review page', () => {
+      TravelMileage.validatePageLoaded();
+      cy.injectAxeThenAxeCheck();
+      TravelMileage.selectFacility('500');
+      TravelMileage.attemptToGoToNextPage();
+
+      TravelPages.validatePageWrapper('travel-claim-vehicle-page');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage('yes');
+
+      TravelPages.validatePageWrapper('travel-claim-address-page');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage('yes');
+
+      TravelPages.validatePageWrapper('travel-claim-review-page');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.clickBackButton();
+
+      TravelPages.validatePageWrapper('travel-claim-address-page');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage('no');
+
+      Error.validatePageLoaded();
+      Error.validateErrorAlert('cant-file-claim-type');
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+  describe('A patient who does not click the checkbox for the travel agreement', () => {
+    it('should display an error on the page', () => {
+      TravelMileage.validatePageLoaded();
+      cy.injectAxeThenAxeCheck();
+      TravelMileage.selectFacility('500');
+      TravelMileage.attemptToGoToNextPage();
+
+      TravelPages.validatePageWrapper('travel-claim-vehicle-page');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage('yes');
+
+      TravelPages.validatePageWrapper('travel-claim-address-page');
+      cy.injectAxeThenAxeCheck();
+      TravelPages.attemptToGoToNextPage('yes');
+
+      TravelPages.validatePageWrapper('travel-claim-review-page');
+      TravelPages.attemptToGoToNextPage('yes');
+      TravelPages.checkForValidationError();
+      cy.injectAxeThenAxeCheck();
+      cy.createScreenshots(
+        'Travel-claim--error-travel-agreement-checkbox-validation',
+      );
+    });
+  });
+  describe('A patient who attempts to click continue from facility selection with check at least one facility', () => {
+    it('should display an error on the page', () => {
+      TravelMileage.validatePageLoaded();
+      cy.injectAxeThenAxeCheck();
+      TravelMileage.attemptToGoToNextPage();
+      TravelMileage.checkForValidationError();
+      cy.injectAxeThenAxeCheck();
+      cy.createScreenshots('Travel-claim--error-facility-selection-validation');
+    });
+  });
+});

--- a/src/applications/check-in/travel-claim/tests/e2e/errors-form-validation.cypress.spec.js
+++ b/src/applications/check-in/travel-claim/tests/e2e/errors-form-validation.cypress.spec.js
@@ -118,7 +118,7 @@ describe('Travel claim validation', () => {
       );
     });
   });
-  describe('A patient who attempts to click continue from facility selection with check at least one facility', () => {
+  describe('A patient who attempts to click continue from facility selection without checking at least one facility', () => {
     it('should display an error on the page', () => {
       TravelMileage.validatePageLoaded();
       cy.injectAxeThenAxeCheck();

--- a/src/applications/check-in/travel-claim/tests/e2e/errors-retrieving-data.cypress.spec.js
+++ b/src/applications/check-in/travel-claim/tests/e2e/errors-retrieving-data.cypress.spec.js
@@ -1,0 +1,32 @@
+import '../../../tests/e2e/commands';
+
+import ApiInitializer from '../../../api/local-mock-api/e2e/ApiInitializer';
+import ValidateVeteran from '../../../tests/e2e/pages/ValidateVeteran';
+import Error from './pages/Error';
+
+describe('A Patient who encounters an error retrieving check in data', () => {
+  beforeEach(() => {
+    const {
+      initializeFeatureToggle,
+      initializeSessionGet,
+      initializeSessionPost,
+      initializeCheckInDataGetOH,
+    } = ApiInitializer;
+    initializeFeatureToggle.withCurrentFeatures();
+    initializeSessionGet.withSuccessfulNewSession();
+    initializeSessionPost.withSuccess();
+    initializeCheckInDataGetOH.withFailure();
+  });
+  it('should redirect to the correct error page after login', () => {
+    cy.visitTravelClaimWithUUID();
+    ValidateVeteran.validatePage.travelClaim();
+    cy.injectAxeThenAxeCheck();
+    ValidateVeteran.validateVeteran();
+    ValidateVeteran.attemptToGoToNextPage();
+
+    Error.validatePageLoaded();
+    Error.validateErrorAlert();
+    cy.injectAxeThenAxeCheck();
+    cy.createScreenshots('Travel-claim--error-retrieving-data');
+  });
+});

--- a/src/applications/check-in/travel-claim/tests/e2e/errors-submitting-travel-claim.cypress.spec.js
+++ b/src/applications/check-in/travel-claim/tests/e2e/errors-submitting-travel-claim.cypress.spec.js
@@ -1,0 +1,114 @@
+import '../../../tests/e2e/commands';
+
+import ApiInitializer from '../../../api/local-mock-api/e2e/ApiInitializer';
+import ValidateVeteran from '../../../tests/e2e/pages/ValidateVeteran';
+import TravelIntro from './pages/TravelIntro';
+import TravelMileage from './pages/TravelMileage';
+import TravelPages from '../../../tests/e2e/pages/TravelPages';
+import sharedData from '../../../api/local-mock-api/mocks/v2/shared';
+import Error from './pages/Error';
+
+describe('A Patient that encounters an error when submitting for a travel claim', () => {
+  beforeEach(() => {
+    const {
+      initializeFeatureToggle,
+      initializeSessionGet,
+      initializeSessionPost,
+      initializeBtsssPost,
+    } = ApiInitializer;
+    initializeFeatureToggle.withCurrentFeatures();
+    initializeSessionGet.withSuccessfulNewSession();
+    initializeSessionPost.withSuccess();
+    initializeBtsssPost.withFailure();
+  });
+  it('should see the correct error page', () => {
+    ApiInitializer.initializeCheckInDataGetOH.withSuccess(
+      sharedData.get.defaultUUID,
+    );
+    cy.visitTravelClaimWithUUID();
+    ValidateVeteran.validatePage.travelClaim();
+    cy.injectAxeThenAxeCheck();
+    ValidateVeteran.validateVeteran();
+    ValidateVeteran.attemptToGoToNextPage();
+
+    TravelIntro.validatePageLoaded();
+    cy.injectAxeThenAxeCheck();
+    TravelIntro.attemptToGoToNextPage();
+
+    TravelMileage.validatePageLoaded();
+    cy.injectAxeThenAxeCheck();
+    TravelMileage.attemptToGoToNextPage();
+
+    TravelPages.validatePageWrapper('travel-claim-vehicle-page');
+    cy.injectAxeThenAxeCheck();
+    TravelPages.attemptToGoToNextPage();
+
+    TravelPages.validatePageWrapper('travel-claim-address-page');
+    cy.injectAxeThenAxeCheck();
+    TravelPages.attemptToGoToNextPage();
+
+    TravelPages.validatePageWrapper('travel-claim-review-page');
+    cy.injectAxeThenAxeCheck();
+    TravelPages.acceptTerms();
+    TravelPages.attemptToGoToNextPage();
+
+    Error.validatePageLoaded();
+    Error.validateErrorAlert('completing-travel-submission');
+    cy.injectAxeThenAxeCheck();
+    cy.createScreenshots('Travel-claim--error-completing-travel-submission');
+  });
+});
+
+describe('A Patient that encounters an error and a success when submitting multiple travel claims', () => {
+  beforeEach(() => {
+    const {
+      initializeFeatureToggle,
+      initializeSessionGet,
+      initializeSessionPost,
+      initializeBtsssPost,
+    } = ApiInitializer;
+    initializeFeatureToggle.withCurrentFeatures();
+    initializeSessionGet.withSuccessfulNewSession();
+    initializeSessionPost.withSuccess();
+    initializeBtsssPost.withSuccess();
+    initializeBtsssPost.withFailure();
+  });
+  it('should see the correct error page', () => {
+    ApiInitializer.initializeCheckInDataGetOH.withSuccess(
+      sharedData.get.multiApptMultiFacilityUUID,
+    );
+    cy.visitTravelClaimWithUUID();
+    ValidateVeteran.validatePage.travelClaim();
+    cy.injectAxeThenAxeCheck();
+    ValidateVeteran.validateVeteran();
+    ValidateVeteran.attemptToGoToNextPage();
+
+    TravelIntro.validatePageLoaded();
+    cy.injectAxeThenAxeCheck();
+    TravelIntro.attemptToGoToNextPage();
+
+    TravelMileage.validatePageLoaded();
+    cy.injectAxeThenAxeCheck();
+    TravelMileage.selectFacility('530');
+    TravelMileage.selectFacility('500');
+    TravelMileage.attemptToGoToNextPage();
+
+    TravelPages.validatePageWrapper('travel-claim-vehicle-page');
+    cy.injectAxeThenAxeCheck();
+    TravelPages.attemptToGoToNextPage();
+
+    TravelPages.validatePageWrapper('travel-claim-address-page');
+    cy.injectAxeThenAxeCheck();
+    TravelPages.attemptToGoToNextPage();
+
+    TravelPages.validatePageWrapper('travel-claim-review-page');
+    cy.injectAxeThenAxeCheck();
+    TravelPages.acceptTerms();
+    TravelPages.attemptToGoToNextPage();
+
+    Error.validatePageLoaded();
+    Error.validateErrorAlert('completing-travel-submission');
+    cy.injectAxeThenAxeCheck();
+    cy.createScreenshots('Travel-claim--error-completing-travel-submission');
+  });
+});

--- a/src/applications/check-in/travel-claim/tests/e2e/errors-submitting-travel-claim.cypress.spec.js
+++ b/src/applications/check-in/travel-claim/tests/e2e/errors-submitting-travel-claim.cypress.spec.js
@@ -14,17 +14,16 @@ describe('A Patient that encounters an error when submitting for a travel claim'
       initializeFeatureToggle,
       initializeSessionGet,
       initializeSessionPost,
+      initializeCheckInDataGetOH,
       initializeBtsssPost,
     } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
     initializeSessionGet.withSuccessfulNewSession();
     initializeSessionPost.withSuccess();
-    initializeBtsssPost.withFailure();
+    initializeCheckInDataGetOH.withSuccess(sharedData.get.defaultUUID);
+    initializeBtsssPost.withFailure(1);
   });
   it('should see the correct error page', () => {
-    ApiInitializer.initializeCheckInDataGetOH.withSuccess(
-      sharedData.get.defaultUUID,
-    );
     cy.visitTravelClaimWithUUID();
     ValidateVeteran.validatePage.travelClaim();
     cy.injectAxeThenAxeCheck();
@@ -65,18 +64,19 @@ describe('A Patient that encounters an error and a success when submitting multi
       initializeFeatureToggle,
       initializeSessionGet,
       initializeSessionPost,
+      initializeCheckInDataGetOH,
       initializeBtsssPost,
     } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
     initializeSessionGet.withSuccessfulNewSession();
     initializeSessionPost.withSuccess();
-    initializeBtsssPost.withSuccess();
-    initializeBtsssPost.withFailure();
-  });
-  it('should see the correct error page', () => {
-    ApiInitializer.initializeCheckInDataGetOH.withSuccess(
+    initializeCheckInDataGetOH.withSuccess(
       sharedData.get.multiApptMultiFacilityUUID,
     );
+    initializeBtsssPost.withSuccess(1);
+    initializeBtsssPost.withFailure(1);
+  });
+  it('should see the correct error page', () => {
     cy.visitTravelClaimWithUUID();
     ValidateVeteran.validatePage.travelClaim();
     cy.injectAxeThenAxeCheck();

--- a/src/applications/check-in/travel-claim/tests/e2e/errors-uuid.cypress.spec.js
+++ b/src/applications/check-in/travel-claim/tests/e2e/errors-uuid.cypress.spec.js
@@ -1,0 +1,19 @@
+import '../../../tests/e2e/commands';
+
+import ApiInitializer from '../../../api/local-mock-api/e2e/ApiInitializer';
+import Error from './pages/Error';
+
+describe('A patient that visits a url with a UUID that is not found', () => {
+  beforeEach(() => {
+    const { initializeFeatureToggle, initializeSessionGet } = ApiInitializer;
+    initializeFeatureToggle.withCurrentFeatures();
+    initializeSessionGet.withFailure(404);
+    cy.visitTravelClaimWithUUID();
+  });
+  it('should display the error page', () => {
+    Error.validatePageLoaded();
+    Error.validateErrorAlert('uuid-not-found');
+    cy.injectAxeThenAxeCheck();
+    cy.createScreenshots('Travel-claim--error-uuid-not-found');
+  });
+});

--- a/src/applications/check-in/travel-claim/tests/e2e/errors-validation.cypress.spec.js
+++ b/src/applications/check-in/travel-claim/tests/e2e/errors-validation.cypress.spec.js
@@ -1,0 +1,40 @@
+import '../../../tests/e2e/commands';
+
+import ApiInitializer from '../../../api/local-mock-api/e2e/ApiInitializer';
+import ValidateVeteran from '../../../tests/e2e/pages/ValidateVeteran';
+import sharedData from '../../../api/local-mock-api/mocks/v2/shared';
+import Error from './pages/Error';
+
+describe('A patient that attempts to log in with an incorrect last name and dob ', () => {
+  beforeEach(() => {
+    const {
+      initializeFeatureToggle,
+      initializeSessionGet,
+      initializeCheckInDataGetOH,
+    } = ApiInitializer;
+    initializeFeatureToggle.withCurrentFeatures();
+    initializeSessionGet.withSuccessfulNewSession();
+    initializeCheckInDataGetOH.withSuccess(sharedData.get.defaultUUID);
+    cy.visitTravelClaimWithUUID();
+    ValidateVeteran.validatePage.travelClaim();
+  });
+  it('should display the inline error message', () => {
+    ApiInitializer.initializeSessionPost.withValidation();
+    cy.injectAxeThenAxeCheck();
+    ValidateVeteran.validateVeteranIncorrect();
+    ValidateVeteran.attemptToGoToNextPage();
+    ValidateVeteran.validateErrorAlert();
+    cy.createScreenshots('Travel-claim--inline-validation-error');
+  });
+  it('should display the error page', () => {
+    ApiInitializer.initializeSessionPost.withValidationMaxAttempts();
+    cy.injectAxeThenAxeCheck();
+    ValidateVeteran.validateVeteranIncorrect();
+    ValidateVeteran.attemptToGoToNextPage();
+
+    Error.validatePageLoaded();
+    Error.validateErrorAlert('max-validation');
+    cy.injectAxeThenAxeCheck();
+    cy.createScreenshots('Travel-claim--max-validation-error');
+  });
+});

--- a/src/applications/check-in/travel-claim/tests/e2e/errors-validation.cypress.spec.js
+++ b/src/applications/check-in/travel-claim/tests/e2e/errors-validation.cypress.spec.js
@@ -2,19 +2,13 @@ import '../../../tests/e2e/commands';
 
 import ApiInitializer from '../../../api/local-mock-api/e2e/ApiInitializer';
 import ValidateVeteran from '../../../tests/e2e/pages/ValidateVeteran';
-import sharedData from '../../../api/local-mock-api/mocks/v2/shared';
 import Error from './pages/Error';
 
 describe('A patient that attempts to log in with an incorrect last name and dob ', () => {
   beforeEach(() => {
-    const {
-      initializeFeatureToggle,
-      initializeSessionGet,
-      initializeCheckInDataGetOH,
-    } = ApiInitializer;
+    const { initializeFeatureToggle, initializeSessionGet } = ApiInitializer;
     initializeFeatureToggle.withCurrentFeatures();
     initializeSessionGet.withSuccessfulNewSession();
-    initializeCheckInDataGetOH.withSuccess(sharedData.get.defaultUUID);
     cy.visitTravelClaimWithUUID();
     ValidateVeteran.validatePage.travelClaim();
   });

--- a/src/applications/check-in/travel-claim/tests/e2e/multiple-facility.cypress.spec.js
+++ b/src/applications/check-in/travel-claim/tests/e2e/multiple-facility.cypress.spec.js
@@ -19,7 +19,7 @@ describe('A patient with appointments at multiple facilities', () => {
     initializeFeatureToggle.withCurrentFeatures();
     initializeSessionGet.withSuccessfulNewSession();
     initializeSessionPost.withSuccess();
-    initializeBtsssPost.withSuccess();
+    initializeBtsssPost.withSuccess(2);
   });
   it('should successfully file a travel claim for a single facility', () => {
     ApiInitializer.initializeCheckInDataGetOH.withSuccess(

--- a/src/applications/check-in/travel-claim/tests/e2e/pages/Error.js
+++ b/src/applications/check-in/travel-claim/tests/e2e/pages/Error.js
@@ -1,0 +1,42 @@
+import Timeouts from 'platform/testing/e2e/timeouts';
+
+class Error {
+  validatePageLoaded = () => {
+    cy.get(`[data-testid="travel-error-page"]`).should('be.visible');
+    cy.get('h1', { timeout: Timeouts.slow }).should('be.visible');
+  };
+
+  validateErrorAlert = error => {
+    switch (error) {
+      case 'uuid-not-found':
+        cy.get('[data-testid="expired-link-alert"]').should('be.visible');
+        break;
+      case 'max-validation':
+        cy.get('[data-testid="no-matching-information-alert"]').should(
+          'be.visible',
+        );
+        break;
+      case 'cant-file-claim-type':
+        cy.get('[data-testid="cant-file-claim-type-alert"]').should(
+          'be.visible',
+        );
+        break;
+      case 'already-filed-claim':
+        cy.get('[data-testid="already-filed-claim-alert"]').should(
+          'be.visible',
+        );
+        break;
+      case 'completing-travel-submission':
+        cy.get('[data-testid="something-went-wrong-alert"]').should(
+          'be.visible',
+        );
+        break;
+      default:
+        cy.get('[data-testid="we-cant-file-a-claim-alert"]').should(
+          'be.visible',
+        );
+    }
+  };
+}
+
+export default new Error();

--- a/src/applications/check-in/travel-claim/tests/e2e/pages/TravelMileage.js
+++ b/src/applications/check-in/travel-claim/tests/e2e/pages/TravelMileage.js
@@ -34,6 +34,12 @@ class TravelMileage {
       expectedCount,
     );
   };
+
+  checkForValidationError = () => {
+    cy.get('va-checkbox')
+      .shadow()
+      .find('#checkbox-error-message');
+  };
 }
 
 export default new TravelMileage();


### PR DESCRIPTION
## Summary

- Adds tests for failure scenarios outlined in https://github.com/department-of-veterans-affairs/va.gov-team/issues/77876

## Related issue(s)

- [department-of-veterans-affairs/va.gov-team#77876](https://github.com/department-of-veterans-affairs/va.gov-team/issues/77876)

## Testing done

- Ran created cypress tests

## What areas of the site does it impact?

Check-in Travel claim app

## Acceptance criteria

-  [ ] the tests pass