### PR TITLE
Update external services list for downtime notifications

### DIFF
--- a/src/platform/monitoring/DowntimeNotification/config/externalServices.js
+++ b/src/platform/monitoring/DowntimeNotification/config/externalServices.js
@@ -15,6 +15,8 @@ export default {
   // Enrollment System (HCA submissions)
   es: 'es',
   evss: 'evss',
+  '1010ez': '1010ez',
+  '1010ezr': '1010ezr',
   // global downtime, for scheduled downtime on apps that don't have specific dependencies documented
   global: 'global',
   // Intake, conversion, and mail handling services (central mail)

--- a/src/platform/monitoring/external-services/config.js
+++ b/src/platform/monitoring/external-services/config.js
@@ -10,6 +10,8 @@ export const EXTERNAL_SERVICES = {
   es: 'es',
   evss: 'evss',
   global: 'global',
+  '1010ez': '1010ez',
+  '1010ezr': '1010ezr',
   // Intake, conversion, and mail handling services (central mail)
   icmhs: 'icmhs',
   // ID.me, identity provider


### PR DESCRIPTION
## Summary
This PR updates the external services list to account for additional pager duty services that have been implemented to separate the 1010EZ and 1010EZR applications. The current implementation has the apps utilizing the same service, but there are multiple use cases for allowing one application to be down while the other stays up. With them both on the same service, if we have an incident with one, we have to take them both down.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#78638

## Acceptance criteria

- Additional services are available for the downtime notification component.

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution