### PR TITLE
74399 ARF - Create app copy with name arp

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -219,7 +219,7 @@ src/applications/vaos @department-of-veterans-affairs/vfs-vaos-fe @department-of
 src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page  @department-of-veterans-affairs/vfs-vaos-fe @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 
 # Benefits Accredited Representative Facing (ARF)
-src/applications/representatives @department-of-veterans-affairs/benefits-accredited-rep-facing
+src/applications/accredited-representative-facing @department-of-veterans-affairs/benefits-accredited-rep-facing
 
 # Other
 

--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -110,6 +110,10 @@
     {
       "rootFolder": "representatives",
       "slackGroup": "@arfeng"
+    },
+    {
+      "rootFolder": "accredited-representative-portal",
+      "slackGroup": "@arfeng"
     }
   ]
 }

--- a/src/applications/accredited-representative-facing/actions/poaRequests.js
+++ b/src/applications/accredited-representative-facing/actions/poaRequests.js
@@ -1,0 +1,29 @@
+import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
+
+const settings = {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+};
+
+const handlePOARequest = async (veteranId, action) => {
+  try {
+    const resource = `/poa_requests/${veteranId}/${action}`;
+    const response = await apiRequest(resource, settings);
+
+    if (!response.ok) {
+      throw new Error(`Server responded with status: ${response.status}`);
+    }
+
+    return { status: 'success' };
+  } catch (error) {
+    const errorMessage = error.message || 'An unexpected error occurred.';
+    return { status: 'error', error: errorMessage };
+  }
+};
+
+export const acceptPOARequest = veteranId =>
+  handlePOARequest(veteranId, 'accept');
+export const declinePOARequest = veteranId =>
+  handlePOARequest(veteranId, 'decline');

--- a/src/applications/accredited-representative-facing/app-entry.jsx
+++ b/src/applications/accredited-representative-facing/app-entry.jsx
@@ -1,0 +1,13 @@
+import '@department-of-veterans-affairs/platform-polyfills';
+import startApp from '@department-of-veterans-affairs/platform-startup/index';
+
+import './sass/representative.scss';
+import routes from './routes';
+import reducer from './reducers';
+import manifest from './manifest.json';
+
+startApp({
+  url: manifest.rootUrl,
+  reducer,
+  routes,
+});

--- a/src/applications/accredited-representative-facing/components/POARequestsTable/POARequestsTable.jsx
+++ b/src/applications/accredited-representative-facing/components/POARequestsTable/POARequestsTable.jsx
@@ -1,0 +1,60 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { acceptPOARequest, declinePOARequest } from '../../actions/poaRequests';
+
+const isActionable = status => status === 'Pending';
+
+const POARequestsTable = ({ poaRequests }) => {
+  return (
+    <va-table data-testid="poa-requests-table" sort-column={1}>
+      <va-table-row slot="headers">
+        <span>Claimant</span>
+        <span>Submitted</span>
+        <span>Description</span>
+        <span>Status</span>
+        <span>Actions</span>
+      </va-table-row>
+      {poaRequests.map(({ id, name, date, description, status }) => (
+        <va-table-row key={id}>
+          <span data-testid={`${id}-claimant`}>{name}</span>
+          <span data-testid={`${id}-submitted`}>{date}</span>
+          <span data-testid={`${id}-description`}>{description}</span>
+          <span data-testid={`${id}-status`}>{status}</span>
+          <span>
+            {isActionable(status) && (
+              <>
+                <va-button
+                  data-testid={`${id}-accept-button`}
+                  secondary
+                  text="Accept"
+                  onClick={() => acceptPOARequest(id)}
+                />
+                <va-button
+                  data-testid={`${id}-decline-button`}
+                  secondary
+                  text="Decline"
+                  onClick={() => declinePOARequest(id)}
+                />
+              </>
+            )}
+          </span>
+        </va-table-row>
+      ))}
+    </va-table>
+  );
+};
+
+POARequestsTable.propTypes = {
+  poaRequests: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number,
+      name: PropTypes.string,
+      date: PropTypes.string,
+      description: PropTypes.string,
+      status: PropTypes.string,
+    }),
+  ).isRequired,
+};
+
+export default POARequestsTable;

--- a/src/applications/accredited-representative-facing/components/POARequestsWidget/POARequestsWidget.jsx
+++ b/src/applications/accredited-representative-facing/components/POARequestsWidget/POARequestsWidget.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router';
+
+const POARequestsWidget = ({ poaRequests }) => (
+  <div className="vads-u-background-color--white vads-u-padding--2p5 rounded-corners">
+    <Link
+      className="view-all-link vads-u-margin-bottom--neg4"
+      data-testid="view-all-poa-requests-link"
+      to="/poa-requests"
+    >
+      View all
+    </Link>
+    <va-table sort-column={1} table-title="POA requests">
+      <va-table-row slot="headers">
+        <span>Claimant</span>
+        <span>Submitted</span>
+        <span>Accept/ decline</span>
+      </va-table-row>
+      {poaRequests.map(request => {
+        return (
+          <va-table-row key={request.id}>
+            <span>
+              <Link to={`/poa-requests/${request.id}`}>{request.name}</Link>
+            </span>
+            <span>{request.date}</span>
+            <span />
+          </va-table-row>
+        );
+      })}
+    </va-table>
+  </div>
+);
+
+POARequestsWidget.propTypes = {
+  poaRequests: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string,
+      id: PropTypes.number,
+      date: PropTypes.string,
+    }),
+  ).isRequired,
+};
+
+export default POARequestsWidget;

--- a/src/applications/accredited-representative-facing/components/Sidenav.jsx
+++ b/src/applications/accredited-representative-facing/components/Sidenav.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Link } from 'react-router';
+
+const Sidenav = () => {
+  return (
+    <nav className="va-sidebarnav vads-u-width--full">
+      <div>
+        <div className="left-side-nav-title">
+          <h4>Navigation</h4>
+        </div>
+        <ul className="usa-sidenav-list">
+          <li>
+            <Link to="/dashboard">Dashboard</Link>
+          </li>
+          <li>
+            <Link to="/poa-requests">POA requests</Link>
+          </li>
+          <li>
+            <Link to="/permissions">Permissions</Link>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  );
+};
+
+export default Sidenav;

--- a/src/applications/accredited-representative-facing/components/common/Breadcrumbs.jsx
+++ b/src/applications/accredited-representative-facing/components/common/Breadcrumbs.jsx
@@ -1,0 +1,64 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Link } from 'react-router';
+import upperFirst from 'lodash/upperFirst';
+import lowerCase from 'lodash/lowerCase';
+
+const acronymMapping = {
+  poa: 'POA',
+  va: 'VA',
+};
+
+const formatSegment = segment => {
+  const words = segment.split('-');
+
+  const acronymsFixed = words.map(word => {
+    if (acronymMapping[word]) {
+      return acronymMapping[word];
+    }
+    return lowerCase(word);
+  });
+  return upperFirst(acronymsFixed.join(' '));
+};
+
+const Breadcrumbs = ({ pathname }) => {
+  const pathSegments = pathname.split('/').filter(Boolean);
+  let pathAccumulator = '';
+  const breadcrumbs = pathSegments.map((segment, index) => {
+    if (!index) {
+      return {
+        link: '/',
+        label: 'Home',
+      };
+    }
+
+    if (index === pathSegments.length - 1) {
+      return {
+        link: null,
+        label: formatSegment(segment),
+      };
+    }
+
+    pathAccumulator += `/${segment}`;
+    return {
+      link: pathAccumulator,
+      label: formatSegment(segment),
+    };
+  });
+
+  return (
+    <va-breadcrumbs uswds="false" home-veterans-affairs={false}>
+      {breadcrumbs.map(({ link, label }) => (
+        <li key={label}>
+          <Link to={link}>{label}</Link>
+        </li>
+      ))}
+    </va-breadcrumbs>
+  );
+};
+
+Breadcrumbs.propTypes = {
+  pathname: PropTypes.string.isRequired,
+};
+
+export default Breadcrumbs;

--- a/src/applications/accredited-representative-facing/constants/index.js
+++ b/src/applications/accredited-representative-facing/constants/index.js
@@ -1,0 +1,15 @@
+import * as SIS from './sis';
+import * as USIP from './usip';
+
+export const SIGN_IN_URL = (function getSignInUrl() {
+  const url = new URL(USIP.PATH, USIP.BASE_URL);
+  url.searchParams.set(USIP.QUERY_PARAMS.application, USIP.APPLICATIONS.ARP);
+  url.searchParams.set(USIP.QUERY_PARAMS.OAuth, true);
+  return url;
+})();
+
+export const SIGN_OUT_URL = (function getSignOutUrl() {
+  const url = new URL(SIS.getLogoutUrl());
+  url.searchParams.set(SIS.QUERY_PARAM_KEYS.CLIENT_ID, SIS.CLIENT_IDS.ARP);
+  return url;
+})();

--- a/src/applications/accredited-representative-facing/constants/sis.js
+++ b/src/applications/accredited-representative-facing/constants/sis.js
@@ -1,0 +1,8 @@
+export {
+  CLIENT_IDS,
+  OAUTH_KEYS as QUERY_PARAM_KEYS,
+} from '~/platform/utilities/oauth/constants';
+
+export {
+  logoutUrlSiS as getLogoutUrl,
+} from '~/platform/utilities/oauth/utilities';

--- a/src/applications/accredited-representative-facing/constants/usip.js
+++ b/src/applications/accredited-representative-facing/constants/usip.js
@@ -1,0 +1,12 @@
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+
+// To keep isolated application status, this is hardcoded rather than cross-app
+// imported from `login/manifest.json`.
+// https://depo-platform-documentation.scrollhelp.site/developer-docs/how-to-add-your-application-to-the-allow-list
+export const PATH = '/sign-in';
+export const { BASE_URL } = environment;
+
+export {
+  AUTH_PARAMS as QUERY_PARAMS,
+  EXTERNAL_APPS as APPLICATIONS,
+} from 'platform/user/authentication/constants';

--- a/src/applications/accredited-representative-facing/containers/App.jsx
+++ b/src/applications/accredited-representative-facing/containers/App.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import { VaLoadingIndicator } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles/useFeatureToggle';
+
+function App({ children }) {
+  const {
+    useToggleValue,
+    useToggleLoadingValue,
+    TOGGLE_NAMES,
+  } = useFeatureToggle();
+
+  const appEnabled = useToggleValue(
+    TOGGLE_NAMES.accreditedRepresentativePortalFrontend,
+  );
+
+  const toggleIsLoading = useToggleLoadingValue();
+
+  if (toggleIsLoading) {
+    return (
+      <div className="vads-u-margin-x--3">
+        <VaLoadingIndicator />
+      </div>
+    );
+  }
+
+  if (!appEnabled && environment.isProduction()) {
+    return document.location.replace('/');
+  }
+
+  return children;
+}
+
+App.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+function mapStateToProps({ user }) {
+  return { user };
+}
+
+export default connect(mapStateToProps)(App);

--- a/src/applications/accredited-representative-facing/containers/Dashboard.jsx
+++ b/src/applications/accredited-representative-facing/containers/Dashboard.jsx
@@ -1,0 +1,39 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import POARequestsWidget from '../components/POARequestsWidget/POARequestsWidget';
+import { mockPOARequests } from '../mocks/mockPOARequests';
+
+const Dashboard = () => {
+  return (
+    <>
+      <h1>Accredited Representative Portal</h1>
+      <div className="placeholder-container">
+        <div className="dash-container">
+          <div className="vads-u-display--flex">
+            <article className="vads-l-col--11 vads-u-background-color--gray-lightest vads-u-padding--4 rounded-corners">
+              <div>
+                <div className="nav dash-box vads-u-background-color--white vads-u-margin-bottom--2 vads-l-col--12 rounded-corners" />
+              </div>
+              <div className="vads-u-display--flex vads-u-flex-direction--row">
+                <div className="vads-l-col--9">
+                  <POARequestsWidget poaRequests={mockPOARequests} />
+                </div>
+                <div className="vads-l-col--3 vads-u-padding-left--2">
+                  <div className="primary dash-box vads-u-background-color--white vads-u-margin-bottom--2 rounded-corners" />
+                  <div className="etc dash-box vads-u-background-color--white rounded-corners" />
+                </div>
+              </div>
+            </article>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+Dashboard.propTypes = {
+  poaPermissions: PropTypes.bool,
+};
+
+export default Dashboard;

--- a/src/applications/accredited-representative-facing/containers/LandingPage.jsx
+++ b/src/applications/accredited-representative-facing/containers/LandingPage.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Link } from 'react-router';
+
+import { SIGN_IN_URL } from '../constants';
+
+const LandingPage = () => {
+  return (
+    <div className="homepage-hero__wrapper homepage-hero__look-and-feel">
+      <div className="vads-l-grid-container vads-u-padding-x--0 homepage-hero">
+        <div className="vads-l-row">
+          <div className="vads-l-col--12 medium-screen:vads-l-col--6">
+            <div
+              className="vads-u-padding-left--2 vads-u-padding-right--3 vads-u-padding-top--5
+            vads-u-padding-bottom--3
+            small-desktop-screen:vads-u-padding-bottom--8"
+            >
+              <h1 className="homepage-hero__welcome-headline vads-u-color--white vads-u-margin-top--0 vads-u-margin-bottom--2 vads-u-padding-y--1 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-font-size--lg vads-u-font-family--serif">
+                Welcome to the Accredited Representative Portal
+              </h1>
+              <h2 className="vads-u-color--white vads-u-margin-top--3 vads-u-font-size--xl small-desktop-screen:vads-u-font-size--2xl">
+                Manage power of attorney requests
+              </h2>
+              <p className="vads-u-color--white vads-u-padding-right--5">
+                A system to help you get power of attorney and then support
+                Veterans by acting on their behalf.
+              </p>
+              <Link to="/dashboard" className="vads-c-action-link--white">
+                Until sign in is added use this to see dashboard
+              </Link>
+            </div>
+          </div>
+          <div className="vads-l-col--12 medium-screen:vads-l-col--6 homepage-hero__container">
+            <div className="vads-u-display--flex vads-u-width--full vads-u-align-items--center vars-u-justify-content--center">
+              <div className="va-flex vads-u-flex-direction--column vads-u-align-items--flex-start vads-u-background-color--white vads-u-margin-top--6 vads-u-margin-bottom--6 vads-u-padding-x--3 vads-u-padding-y--2 vads-u-width--full homepage-hero__create-account">
+                <h2 className="vads-u-font-size--md vads-u-line-height--5 vads-u-color--gray vads-u-margin-top--0 vads-u-padding-right--2 vads-u-font-family--sans vads-u-font-weight--normal">
+                  Create an account to start managing power of attorney.
+                </h2>
+                <a className="usa-button usa-button-primary" href={SIGN_IN_URL}>
+                  Sign in or create an account
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LandingPage;

--- a/src/applications/accredited-representative-facing/containers/POARequests.jsx
+++ b/src/applications/accredited-representative-facing/containers/POARequests.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import POARequestsTable from '../components/POARequestsTable/POARequestsTable';
+import { mockPOARequests } from '../mocks/mockPOARequests';
+
+const POARequests = () => {
+  return (
+    <>
+      <h1>Power of attorney requests</h1>
+      <POARequestsTable poaRequests={mockPOARequests} />
+    </>
+  );
+};
+
+export default POARequests;

--- a/src/applications/accredited-representative-facing/containers/PermissionsPage.jsx
+++ b/src/applications/accredited-representative-facing/containers/PermissionsPage.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const PermissionsPage = () => {
+  return (
+    <>
+      <h1>Permissions</h1>
+      <va-button
+        onClick={function noRefCheck() {}}
+        text="Add"
+        secondary
+        data-testid="permissions-add-button"
+      />
+      <va-button
+        onClick={function noRefCheck() {}}
+        text="Upload CSV"
+        secondary
+        data-testid="permissions-upload-csv-button"
+      />
+      <div className="placeholder-container">
+        <div className="vads-u-background-color--gray-lightest vads-u-margin-bottom--2 vads-u-height--viewport" />
+      </div>
+    </>
+  );
+};
+
+export default PermissionsPage;

--- a/src/applications/accredited-representative-facing/containers/SignedInViewLayout.jsx
+++ b/src/applications/accredited-representative-facing/containers/SignedInViewLayout.jsx
@@ -1,0 +1,58 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Sidenav from '../components/Sidenav';
+import Breadcrumbs from '../components/common/Breadcrumbs';
+
+const SignedInViewLayout = ({ children, poaPermissions = true }) => {
+  let content = null;
+
+  const { pathname } = document.location;
+
+  // If the VSO does not have permission to be Power of Attorney ( this will eventually be pulled from Redux state)
+  if (!poaPermissions) {
+    content = (
+      <va-alert status="info" visible>
+        <h2 slot="headline">You are missing some permissions</h2>
+        <div>
+          <p className="vads-u-margin-y--0">
+            In order to access the features of the Accredited Representative
+            Portal you need to have certain permissions, such as being
+            registered with the VA to accept Power of Attorney for a Veteran.
+          </p>
+        </div>
+      </va-alert>
+    );
+  }
+
+  if (poaPermissions) {
+    content = (
+      <div className="vads-l-row vads-u-margin-x--neg2p5">
+        <div className="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--4 large-screen:vads-l-col--3">
+          <Sidenav />
+        </div>
+        <div className="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--8 large-screen:vads-l-col--9">
+          {children}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="vads-u-margin-bottom--3">
+        <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
+          <Breadcrumbs pathname={pathname} />
+          {content}
+        </div>
+      </div>
+    </>
+  );
+};
+
+SignedInViewLayout.propTypes = {
+  children: PropTypes.node.isRequired,
+  poaPermissions: PropTypes.bool,
+};
+
+export default SignedInViewLayout;

--- a/src/applications/accredited-representative-facing/manifest.json
+++ b/src/applications/accredited-representative-facing/manifest.json
@@ -1,0 +1,7 @@
+{
+  "appName": "Accredited Representative Portal",
+  "entryFile": "./app-entry.jsx",
+  "entryName": "representative",
+  "rootUrl": "/representative",
+  "productId": "89100c00-5b5f-46fd-bd98-d3b35f220958"
+}

--- a/src/applications/accredited-representative-facing/mocks/mockPOARequests.js
+++ b/src/applications/accredited-representative-facing/mocks/mockPOARequests.js
@@ -1,0 +1,23 @@
+export const mockPOARequests = [
+  {
+    id: 200,
+    name: 'Johnathon Smith',
+    date: 'Jan 24, 2024 11:00 a.m.',
+    description: 'This is a description of the claimant',
+    status: 'Pending',
+  },
+  {
+    id: 400,
+    name: 'Madaline Rouge',
+    date: 'Jan 25, 2024 10:00 a.m.',
+    description: 'This is a different description of different claimant',
+    status: 'Accepted',
+  },
+  {
+    id: 500,
+    name: 'Arnold Ford',
+    date: 'Jan 26, 2024 11:00 p.m.',
+    description: 'This is another description of a claimant',
+    status: 'Pending',
+  },
+];

--- a/src/applications/accredited-representative-facing/reducers/index.js
+++ b/src/applications/accredited-representative-facing/reducers/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/src/applications/accredited-representative-facing/routes.jsx
+++ b/src/applications/accredited-representative-facing/routes.jsx
@@ -1,0 +1,41 @@
+import App from './containers/App';
+import Dashboard from './containers/Dashboard';
+import LandingPage from './containers/LandingPage';
+import POARequests from './containers/POARequests';
+import PermissionsPage from './containers/PermissionsPage';
+import SignedInViewLayout from './containers/SignedInViewLayout';
+
+const routes = [
+  {
+    component: App,
+    childRoutes: [
+      {
+        path: '/',
+        component: LandingPage,
+      },
+      {
+        component: SignedInViewLayout,
+        childRoutes: [
+          {
+            path: '/dashboard',
+            component: Dashboard,
+          },
+          {
+            path: '/poa-requests',
+            component: POARequests,
+          },
+          {
+            path: '/permissions',
+            component: PermissionsPage,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    path: '/permissions',
+    component: PermissionsPage,
+  },
+];
+
+export default routes;

--- a/src/applications/accredited-representative-facing/sass/representative.scss
+++ b/src/applications/accredited-representative-facing/sass/representative.scss
@@ -1,0 +1,39 @@
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+
+
+.dash-container {
+  max-width: 1024px;
+  margin: 32px auto;
+
+  .nav {
+    height: 48px;
+  }
+}
+
+.placeholder-container {
+  .primary {
+    height: 96px;
+  }
+  .etc {
+    height: 96px;
+  }
+}
+
+.homepage-hero {
+  &__look-and-feel {
+    background: linear-gradient(
+      to left,
+      $color-primary-alt 10%,
+      $color-primary-alt-dark 40%,
+      $color-primary-alt-darkest
+    );
+  }
+}
+
+.rounded-corners {
+  border-radius: 10px;
+}
+
+.view-all-link {
+  float: right;
+}

--- a/src/applications/accredited-representative-facing/tests/components/common/Breadcrumbs.unit.spec.js
+++ b/src/applications/accredited-representative-facing/tests/components/common/Breadcrumbs.unit.spec.js
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import React from 'react';
+
+import Breadcrumbs from '../../../components/common/Breadcrumbs';
+
+describe('breadcrumbs', () => {
+  it('creates breadcrumbs for the dashboard', () => {
+    const { getByText } = render(
+      <Breadcrumbs pathname="/representative/dashboard" />,
+    );
+    expect(getByText('Home')).to.exist;
+    expect(getByText('Dashboard')).to.exist;
+  });
+
+  it('creates breadcrumbs for the permissions page', () => {
+    const { getByText } = render(
+      <Breadcrumbs pathname="/representative/permissions" />,
+    );
+    expect(getByText('Home')).to.exist;
+    expect(getByText('Permissions')).to.exist;
+  });
+
+  it('creates breadcrumbs for the POA Requests page', () => {
+    const { getByText } = render(
+      <Breadcrumbs pathname="/representative/poa-requests" />,
+    );
+    expect(getByText('Home')).to.exist;
+    expect(getByText('POA requests')).to.exist;
+  });
+
+  it('creates breadcrumbs for the home page by default', () => {
+    const { getByText } = render(<Breadcrumbs pathname="representative" />);
+    expect(getByText('Home')).to.exist;
+  });
+});

--- a/src/applications/accredited-representative-facing/tests/containers/Dashboard.unit.spec.js
+++ b/src/applications/accredited-representative-facing/tests/containers/Dashboard.unit.spec.js
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import React from 'react';
+
+import Dashboard from '../../containers/Dashboard';
+
+describe('Dashboard', () => {
+  it('renders', () => {
+    render(<Dashboard poaPermissions />);
+  });
+
+  it('renders header', () => {
+    const { getByText } = render(<Dashboard poaPermissions />);
+    expect(getByText('Accredited Representative Portal')).to.exist;
+  });
+
+  it('renders content when has POA permissions', () => {
+    const { container } = render(<Dashboard />);
+    expect(container.querySelector('.placeholder-container')).to.exist;
+  });
+
+  describe('Pending POA requests', () => {
+    it('renders table headers', () => {
+      const { getByText } = render(<Dashboard poaPermissions />);
+      expect(getByText('Claimant')).to.exist;
+      expect(getByText('Submitted')).to.exist;
+      expect(getByText('Accept/ decline')).to.exist;
+    });
+
+    it('renders view all link', () => {
+      const { getByTestId } = render(<Dashboard />);
+      expect(getByTestId('view-all-poa-requests-link')).to.contain.text(
+        'View all',
+      );
+    });
+  });
+});

--- a/src/applications/accredited-representative-facing/tests/containers/LandingPage.unit.spec.js
+++ b/src/applications/accredited-representative-facing/tests/containers/LandingPage.unit.spec.js
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import React from 'react';
+
+import LandingPage from '../../containers/LandingPage';
+
+describe('Landing Page', () => {
+  it('renders', () => {
+    render(<LandingPage />);
+  });
+
+  it('should render welcome headline', () => {
+    const { getByText } = render(<LandingPage />);
+    expect(getByText('Welcome to the Accredited Representative Portal')).to
+      .exist;
+  });
+
+  it('should render subheading', () => {
+    const { getByText } = render(<LandingPage />);
+    expect(getByText('Manage power of attorney requests')).to.exist;
+  });
+
+  it('should render description', () => {
+    const { getByText } = render(<LandingPage />);
+    expect(
+      getByText(
+        'A system to help you get power of attorney and then support Veterans by acting on their behalf.',
+      ),
+    ).to.exist;
+  });
+
+  it('should render link to dashboard', () => {
+    const { getByText } = render(<LandingPage />);
+    expect(getByText('Until sign in is added use this to see dashboard')).to
+      .exist;
+  });
+});

--- a/src/applications/accredited-representative-facing/tests/containers/POARequests.unit.spec.js
+++ b/src/applications/accredited-representative-facing/tests/containers/POARequests.unit.spec.js
@@ -1,0 +1,56 @@
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import React from 'react';
+
+import POARequests from '../../containers/POARequests';
+import { mockPOARequests } from '../../mocks/mockPOARequests';
+
+describe('POARequests page', () => {
+  it('renders', () => {
+    render(<POARequests />);
+  });
+
+  it('renders header', () => {
+    const { getByText } = render(<POARequests />);
+    expect(getByText('Power of attorney requests')).to.exist;
+  });
+
+  it('renders content when has POA permissions', () => {
+    const { getByText } = render(<POARequests />);
+    expect(getByText('Power of attorney requests')).to.exist;
+  });
+
+  describe('POA requests table', () => {
+    it('renders table headers', () => {
+      const { getByTestId, getByText } = render(<POARequests />);
+      expect(getByTestId('poa-requests-table')).to.exist;
+      expect(getByText('Claimant')).to.exist;
+      expect(getByText('Submitted')).to.exist;
+      expect(getByText('Description')).to.exist;
+      expect(getByText('Status')).to.exist;
+      expect(getByText('Actions')).to.exist;
+    });
+
+    it('renders table with mockPOARequests', () => {
+      const { getByTestId } = render(<POARequests poaPermissions />);
+      mockPOARequests.forEach(poaRequest => {
+        expect(getByTestId(`${poaRequest.id}-claimant`)).to.contain.text(
+          poaRequest.name,
+        );
+        expect(getByTestId(`${poaRequest.id}-submitted`)).to.contain.text(
+          poaRequest.date,
+        );
+        expect(getByTestId(`${poaRequest.id}-description`)).to.contain.text(
+          poaRequest.description,
+        );
+        expect(getByTestId(`${poaRequest.id}-status`)).to.contain.text(
+          poaRequest.status,
+        );
+        if (poaRequest.status === 'Pending') {
+          expect(getByTestId(`${poaRequest.id}-accept-button`)).to.exist;
+          expect(getByTestId(`${poaRequest.id}-decline-button`)).to.exist;
+        }
+      });
+    });
+  });
+});

--- a/src/applications/accredited-representative-facing/tests/containers/Permissions.unit.spec.js
+++ b/src/applications/accredited-representative-facing/tests/containers/Permissions.unit.spec.js
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import React from 'react';
+
+import PermissionsPage from '../../containers/PermissionsPage.jsx';
+
+describe('Permissions page', () => {
+  it('renders', () => {
+    const container = render(<PermissionsPage />);
+
+    expect(container.getByRole('heading', { name: 'Permissions' })).to.exist;
+
+    expect(container.getByTestId('permissions-add-button')).to.exist;
+    expect(container.getByTestId('permissions-upload-csv-button')).to.exist;
+  });
+});

--- a/src/applications/accredited-representative-facing/tests/e2e/accessibility.cypress.spec.js
+++ b/src/applications/accredited-representative-facing/tests/e2e/accessibility.cypress.spec.js
@@ -1,0 +1,29 @@
+describe('Accessibility', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/v0/feature_toggles*', {
+      data: {
+        features: [
+          { name: 'accredited_representative_portal_frontend', value: true },
+        ],
+      },
+    });
+  });
+
+  it('has accessible landing page', () => {
+    cy.visit('/representative');
+    cy.injectAxe();
+    cy.axeCheck();
+  });
+
+  it('has accessible dashboard', () => {
+    cy.visit('/representative/dashboard');
+    cy.injectAxe();
+    cy.axeCheck();
+  });
+
+  it('has accessible POA requests page', () => {
+    cy.visit('/representative/poa-requests');
+    cy.injectAxe();
+    cy.axeCheck();
+  });
+});

--- a/src/applications/accredited-representative-facing/tests/e2e/accredited-representative-portal.cypress.spec.js
+++ b/src/applications/accredited-representative-facing/tests/e2e/accredited-representative-portal.cypress.spec.js
@@ -1,0 +1,80 @@
+const togglePortal = value => {
+  beforeEach(() => {
+    cy.intercept('GET', '/v0/feature_toggles*', {
+      data: {
+        features: [
+          { name: 'accredited_representative_portal_frontend', value },
+        ],
+      },
+    });
+  });
+};
+
+describe('Accredited Representative Portal', () => {
+  describe('feature toggling in production', () => {
+    // During CI, the environment is production, so we can test our global
+    // feature toggling behavior there. But when running this test locally, the
+    // environment is localhost, so we can't test our global feature toggling
+    // behavior there without doing some more complex test setup.
+    before(function skipOutsideCI() {
+      if (!Cypress.env('CI')) {
+        this.skip();
+      }
+    });
+
+    describe('when feature is toggled off', () => {
+      togglePortal(false);
+
+      it('does redirect to root', () => {
+        cy.visit('/representative');
+        cy.injectAxe();
+        cy.axeCheck();
+
+        cy.location('pathname').should('equal', '/');
+      });
+    });
+  });
+
+  // In CI, the feature toggle applies so we need to toggle it on to test
+  // behavior past the guard. On localhost, the feature toggle doesn't apply so
+  // toggling the feature on is redundant.
+  togglePortal(true);
+
+  it('does not redirect to root', () => {
+    cy.visit('/representative');
+    cy.injectAxe();
+    cy.axeCheck();
+
+    cy.location('pathname').should('equal', '/representative/');
+  });
+
+  it('allows navigation from landing page to unified sign-in page', () => {
+    cy.visit('/representative');
+    cy.injectAxe();
+    cy.axeCheck();
+
+    cy.contains('Sign in or create an account').click();
+    cy.url().should('include', '/sign-in/?application=arp&oauth=true');
+  });
+
+  it('allows navigation from landing page to dashboard to poa requests', () => {
+    cy.visit('/representative');
+    cy.injectAxe();
+    cy.axeCheck();
+
+    cy.contains('Welcome to the Accredited Representative Portal');
+    cy.contains('Until sign in is added use this to see dashboard').click();
+
+    cy.url().should('include', '/representative/dashboard');
+    cy.axeCheck();
+
+    cy.contains('Accredited Representative Portal');
+    cy.contains('View all').click();
+
+    cy.url().should('include', '/representative/poa-requests');
+    cy.axeCheck();
+
+    cy.contains('Power of attorney requests');
+    cy.get('[data-testid=poa-requests-table]').should('exist');
+  });
+});

--- a/src/platform/user/authentication/constants.js
+++ b/src/platform/user/authentication/constants.js
@@ -111,7 +111,7 @@ export const EXTERNAL_REDIRECTS = {
   [EXTERNAL_APPS.EBENEFITS]: `${eAuthURL}/ebenefits`,
   [EXTERNAL_APPS.VA_FLAGSHIP_MOBILE]: '',
   [EXTERNAL_APPS.VA_OCC_MOBILE]: `${eAuthURL}/MAP/users/v2/landing`,
-  [EXTERNAL_APPS.ARP]: `${environment.BASE_URL}/representatives`,
+  [EXTERNAL_APPS.ARP]: `${environment.BASE_URL}/representative`,
 };
 
 export const GA = {


### PR DESCRIPTION
## Summary
- Purpose
  - This is a follow on PR to [74399 ARF - Rename to arp and representative](https://github.com/department-of-veterans-affairs/vets-website/pull/28477). This creates a copy of the application with an updated manifest.
  - There are a number of places we are using `reps` or `representatives` such as the Github vets-website directory name, in our manifest, etc
  - As a team we decided the subdomain should be representative.va.gov (6 to 2 with 2 beings reps.va.gov) and as such uses of `reps` or `representatives` (plural) should be renamed to `rep` or `representative`
  - It was decided as a team that `rep` can be used in instances in which brevity is important
  - In addition, the portal within this subdomain now has a name - Accredited Representative Portal. As such, there are cases where `representatives` should actually be changed to `accredited-representative-portal` 
- Changes that have been made to the platform:
  - Created a copy of the /representatives app and renamed it to /accredited-representative-portal
  - Updated the manifest appName in the copy to Accredited Representative Portal
  - Updated the path to /representative across the copy
  - Updated CODEOWNERS and auth constants to point at the new /accredited-representative-portal app
  - Add the accredited-representative-portal app to changed-apps-build (but didn't remove the representatives app yet)
`Accredited Representative Portal`
- Team: Benefits Accredited Representative Facing Team

## Related issue

[#74399 Rename to representative / accredited-representative-portal](https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/74399)

## Related PRs
- vets-api toggle update: [74399 ARF - Rename arp feature toggle #15876](https://github.com/department-of-veterans-affairs/vets-api/pull/15876)
## Testing done

- Steps required to verify the changes are working as expected: Manually click through all functionality of the application including -
  - Landing page Link links to Dashboard
  - Dashboard POA Requests Widget has data and can be sorted
  - Dashboard Sidenav links to POA Requests page
  - POA Requests Sidenav links to Dashboard
  - Dashboard `View all` links to POA Requests page
  - POA Requests Table has data and can be sorted
  - Clicking Accept/Decline results in currently erroring but correctly pointing API calls in the console
  - POA Requests Sidenav links to Permissions Page
  - Home Breadcrumb navigates back to Landing Page

## Screenshots
- No visual UI changes

## What areas of the site does it impact?
- Only impacts the application /representatives and related config and feature toggle files

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
