### PR TITLE
MHV-56043 Rethrow caught errors

### DIFF
--- a/src/applications/mhv/medical-records/actions/allergies.js
+++ b/src/applications/mhv/medical-records/actions/allergies.js
@@ -18,6 +18,7 @@ export const getAllergiesList = (isCurrent = false) => async dispatch => {
     });
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
+    throw error;
   }
 };
 
@@ -33,6 +34,7 @@ export const getAllergyDetails = (id, allergyList) => async dispatch => {
     );
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
+    throw error;
   }
 };
 

--- a/src/applications/mhv/medical-records/actions/blueButtonReport.js
+++ b/src/applications/mhv/medical-records/actions/blueButtonReport.js
@@ -29,5 +29,6 @@ export const getBlueButtonReportData = () => async dispatch => {
     dispatch({ type: Actions.Vitals.GET_LIST, response: response.vitals });
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
+    throw error;
   }
 };

--- a/src/applications/mhv/medical-records/actions/conditions.js
+++ b/src/applications/mhv/medical-records/actions/conditions.js
@@ -18,6 +18,7 @@ export const getConditionsList = (isCurrent = false) => async dispatch => {
     });
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
+    throw error;
   }
 };
 
@@ -36,6 +37,7 @@ export const getConditionDetails = (
     );
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
+    throw error;
   }
 };
 

--- a/src/applications/mhv/medical-records/actions/labsAndTests.js
+++ b/src/applications/mhv/medical-records/actions/labsAndTests.js
@@ -17,6 +17,7 @@ export const getLabsAndTestsList = (isCurrent = false) => async dispatch => {
     });
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
+    throw error;
   }
 };
 
@@ -26,6 +27,7 @@ export const getlabsAndTestsDetails = labId => async dispatch => {
     dispatch({ type: Actions.LabsAndTests.GET, response });
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
+    throw error;
   }
 };
 

--- a/src/applications/mhv/medical-records/actions/sharing.js
+++ b/src/applications/mhv/medical-records/actions/sharing.js
@@ -5,11 +5,12 @@ export const fetchSharingStatus = () => async dispatch => {
   try {
     const response = await getSharingStatus();
     dispatch({ type: Actions.Sharing.STATUS, response });
-  } catch (e) {
+  } catch (error) {
     dispatch({
       type: Actions.Sharing.STATUS_ERROR,
-      response: { type: 'fetch', error: e },
+      response: { type: 'fetch', error },
     });
+    throw error;
   }
 };
 
@@ -20,11 +21,12 @@ export const updateSharingStatus = optIn => async dispatch => {
       type: Actions.Sharing.UPDATE,
       response: { ...response, optIn },
     });
-  } catch (e) {
+  } catch (error) {
     dispatch({
       type: Actions.Sharing.STATUS_ERROR,
-      response: { type: optIn ? 'optin' : 'optout', error: e },
+      response: { type: optIn ? 'optin' : 'optout', error },
     });
+    throw error;
   }
 };
 

--- a/src/applications/mhv/medical-records/actions/vaccines.js
+++ b/src/applications/mhv/medical-records/actions/vaccines.js
@@ -19,6 +19,7 @@ export const getVaccinesList = (isCurrent = false) => async dispatch => {
     });
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
+    throw error;
   }
 };
 
@@ -34,6 +35,7 @@ export const getVaccineDetails = (vaccineId, vaccineList) => async dispatch => {
     );
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
+    throw error;
   }
 };
 

--- a/src/applications/mhv/medical-records/actions/vitals.js
+++ b/src/applications/mhv/medical-records/actions/vitals.js
@@ -18,6 +18,7 @@ export const getVitals = (isCurrent = false) => async dispatch => {
     });
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
+    throw error;
   }
 };
 
@@ -29,6 +30,7 @@ export const getVitalDetails = (vitalType, vitalList) => async dispatch => {
     dispatch({ type: Actions.Vitals.GET, vitalType });
   } catch (error) {
     dispatch(addAlert(Constants.ALERT_TYPE_ERROR, error));
+    throw error;
   }
 };
 

--- a/src/applications/mhv/medical-records/tests/actions/allergies.unit.spec.js
+++ b/src/applications/mhv/medical-records/tests/actions/allergies.unit.spec.js
@@ -29,9 +29,13 @@ describe('Get allergies action', () => {
     const mockData = allergies;
     mockApiRequest(mockData, false);
     const dispatch = sinon.spy();
-    return getAllergiesList()(dispatch).then(() => {
-      expect(typeof dispatch.secondCall.args[0]).to.equal('function');
-    });
+    return getAllergiesList()(dispatch)
+      .then(() => {
+        throw new Error('Expected getAllergiesList() to throw an error.');
+      })
+      .catch(() => {
+        expect(typeof dispatch.secondCall.args[0]).to.equal('function');
+      });
   });
 });
 
@@ -44,6 +48,7 @@ describe('Get allergy details action', () => {
       expect(dispatch.firstCall.args[0].type).to.equal(Actions.Allergies.GET);
     });
   });
+
   it('should dispatch a get details action and pull from the list argument', () => {
     const dispatch = sinon.spy();
     return getAllergyDetails('1', [{ id: '1' }])(dispatch).then(() => {
@@ -52,13 +57,18 @@ describe('Get allergy details action', () => {
       );
     });
   });
+
   it('should dispatch an add alert action', () => {
     const mockData = allergy;
     mockApiRequest(mockData, false);
     const dispatch = sinon.spy();
-    return getAllergyDetails()(dispatch).then(() => {
-      expect(typeof dispatch.firstCall.args[0]).to.equal('function');
-    });
+    return getAllergyDetails()(dispatch)
+      .then(() => {
+        throw new Error('Expected getAllergyDetails() to throw an error.');
+      })
+      .catch(() => {
+        expect(typeof dispatch.firstCall.args[0]).to.equal('function');
+      });
   });
 });
 

--- a/src/applications/mhv/medical-records/tests/actions/sharing.unit.spec.js
+++ b/src/applications/mhv/medical-records/tests/actions/sharing.unit.spec.js
@@ -17,15 +17,20 @@ describe('Fetch sharing status action', () => {
       expect(dispatch.firstCall.args[0].type).to.equal(Actions.Sharing.STATUS);
     });
   });
+
   it('should dispatch an error action', () => {
     const mockData = { test: 'test' };
     mockApiRequest(mockData, false);
     const dispatch = sinon.spy();
-    return fetchSharingStatus()(dispatch).then(() => {
-      expect(dispatch.firstCall.args[0].type).to.equal(
-        Actions.Sharing.STATUS_ERROR,
-      );
-    });
+    return fetchSharingStatus()(dispatch)
+      .then(() => {
+        throw new Error('Expected fetchSharingStatus() to throw an error.');
+      })
+      .catch(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(
+          Actions.Sharing.STATUS_ERROR,
+        );
+      });
   });
 });
 
@@ -38,25 +43,35 @@ describe('Update sharing status action', () => {
       expect(dispatch.firstCall.args[0].type).to.equal(Actions.Sharing.UPDATE);
     });
   });
+
   it('should dispatch an error action and revert to opt in', () => {
     const mockData = { test: 'test' };
     mockApiRequest(mockData, false);
     const dispatch = sinon.spy();
-    return updateSharingStatus(false)(dispatch).then(() => {
-      expect(dispatch.firstCall.args[0].type).to.equal(
-        Actions.Sharing.STATUS_ERROR,
-      );
-    });
+    return updateSharingStatus(false)(dispatch)
+      .then(() => {
+        throw new Error('Expected updateSharingStatus() to throw an error.');
+      })
+      .catch(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(
+          Actions.Sharing.STATUS_ERROR,
+        );
+      });
   });
+
   it('should dispatch an error action and revert to opt out', () => {
     const mockData = { test: 'test' };
     mockApiRequest(mockData, false);
     const dispatch = sinon.spy();
-    return updateSharingStatus(true)(dispatch).then(() => {
-      expect(dispatch.firstCall.args[0].type).to.equal(
-        Actions.Sharing.STATUS_ERROR,
-      );
-    });
+    return updateSharingStatus(true)(dispatch)
+      .then(() => {
+        throw new Error('Expected updateSharingStatus() to throw an error.');
+      })
+      .catch(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(
+          Actions.Sharing.STATUS_ERROR,
+        );
+      });
   });
 });
 

--- a/src/applications/mhv/medical-records/tests/actions/vitals.unit.spec.js
+++ b/src/applications/mhv/medical-records/tests/actions/vitals.unit.spec.js
@@ -29,9 +29,13 @@ describe('Get vitals action', () => {
     const mockData = vitals;
     mockApiRequest(mockData, false);
     const dispatch = sinon.spy();
-    return getVitals()(dispatch).then(() => {
-      expect(typeof dispatch.secondCall.args[0]).to.equal('function');
-    });
+    return getVitals()(dispatch)
+      .then(() => {
+        throw new Error('Expected getVitals() to throw an error.');
+      })
+      .catch(() => {
+        expect(typeof dispatch.secondCall.args[0]).to.equal('function');
+      });
   });
 });
 


### PR DESCRIPTION
## Summary

- We were previously eating caught errors after logging them in Redux. Now re-throwing them.

## Related issue(s)

### [MHV-56043](https://jira.devops.va.gov/browse/MHV-56043) - Make sure to re-throw caught errors in React actions ###

> Currently for must action creator functions, we are catching errors, logging them in Redux, and then doing nothing else. Make sure to re-throw errors so they are logged in the console and sent to Datadog.

## Testing done

- Added test checks for thrown errors

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
