### PR TITLE
Check in/78662/remove type of care

### DIFF
--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentListItem.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentListItem.jsx
@@ -28,9 +28,7 @@ const AppointmentListItem = props => {
 
   const detailsAriaLabel = () => {
     const modality = appointment.kind === 'phone' ? t('phone') : t('in-person');
-    const type = appointment.clinicStopCodeName
-      ? `${appointment.clinicStopCodeName} ${t('appointment')}`
-      : t('VA-appointment');
+    const type = t('VA-appointment');
     const provider = appointment.doctorName
       ? `${t('with')} ${appointment.doctorName}`
       : '';
@@ -84,9 +82,7 @@ const AppointmentListItem = props => {
           data-testid="appointment-type-and-provider"
           className="vads-u-font-weight--bold"
         >
-          {appointment.clinicStopCodeName
-            ? appointment.clinicStopCodeName
-            : t('VA-appointment')}
+          {t('VA-appointment')}
           {appointment.doctorName
             ? ` ${t('with')} ${appointment.doctorName}`
             : ''}

--- a/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentListItem.unit.spec.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentListItem.unit.spec.jsx
@@ -59,7 +59,7 @@ describe('AppointmentListItem', () => {
         );
         expect(
           screen.getByTestId('appointment-type-and-provider'),
-        ).to.have.text('Primary care with Dr. Green');
+        ).to.have.text('VA Appointment with Dr. Green');
         expect(
           screen.getByTestId('appointment-kind-and-location'),
         ).to.have.text('In person at LOMA LINDA VA CLINIC Clinic: TEST CLINIC');
@@ -92,7 +92,7 @@ describe('AppointmentListItem', () => {
       });
     });
     describe('Phone appointment context', () => {
-      it('Renders appointment details with no stopCodeName or provider', () => {
+      it('Renders appointment details with no provider', () => {
         const screen = render(
           <CheckInProvider router={mockRouter}>
             <AppointmentListItem

--- a/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
@@ -184,7 +184,7 @@ describe('check-in experience', () => {
         });
       });
       describe('All appointments - data exists', () => {
-        it('renders stopcode if exists', () => {
+        it('does not render stopcode if exists', () => {
           const { getByTestId } = render(
             <CheckInProvider
               store={preCheckInStore}
@@ -195,7 +195,7 @@ describe('check-in experience', () => {
           );
           expect(
             getByTestId('appointment-details--appointment-value'),
-          ).to.have.text('stop code test');
+          ).to.have.text('VA Appointment');
         });
         it('renders doctor name if exists', () => {
           const { getByTestId } = render(

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -138,9 +138,7 @@ const AppointmentDetails = props => {
               <div data-testid="appointment-details--what">
                 <h2 className="vads-u-font-size--sm">{t('what')}</h2>
                 <div data-testid="appointment-details--appointment-value">
-                  {appointment.clinicStopCodeName
-                    ? appointment.clinicStopCodeName
-                    : t('VA-appointment')}
+                  {t('VA-appointment')}
                 </div>
               </div>
               {appointment.doctorName && (


### PR DESCRIPTION
## Summary

Removed use of stopCodeName and setting all type of care to `VA Appointment`

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#78662

## Testing done

 - Updates unit tests

## What areas of the site does it impact?

Day of check-in and pre-check-in

## Acceptance criteria

 - [ ] stopCodeName is not displayed in day -of or pre-check-in
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

