### PR TITLE
10-7959f-1 Refactor to match Figma for last pages

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -1,3 +1,5 @@
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+
 import {
   ssnOrVaFileNumberSchema,
   ssnOrVaFileNumberNoHintUI,
@@ -24,9 +26,9 @@ import ConfirmationPage from '../containers/ConfirmationPage';
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
-  // submitUrl: '/v0/api',
-  submit: () =>
-    Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
+  submitUrl: `${environment.API_URL}/simple_forms_api/v1/simple_forms`,
+  // submit: () =>
+  //   Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
   trackingPrefix: '10-7959f-1-FMP-',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
@@ -83,6 +85,11 @@ const formConfig = {
             },
           },
         },
+      },
+    },
+    identificationInformation: {
+      title: 'Identification Information',
+      pages: {
         page2: {
           path: 'veteran-information/ssn',
           title: 'Veteran SSN and VA file number',
@@ -102,6 +109,11 @@ const formConfig = {
             },
           },
         },
+      },
+    },
+    physicalAddress: {
+      title: 'Physical Address',
+      pages: {
         page3: {
           path: 'physical-address',
           title: 'Physical Address',
@@ -160,11 +172,19 @@ const formConfig = {
             },
           },
         },
+      },
+    },
+    contactInformation: {
+      title: 'Contact Information',
+      pages: {
         page5: {
           path: 'contact-info',
           title: "Veteran's contact information",
           uiSchema: {
-            ...titleUI("Veteran's contact information"),
+            ...titleUI(
+              'Phone and email address',
+              'Please include this information so that we can contact you with questions or updates',
+            ),
             phoneNumber: phoneUI(),
             emailAddress: emailUI(),
           },

--- a/src/applications/ivc-champva/10-7959f-1/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/ConfirmationPage.jsx
@@ -48,7 +48,13 @@ export class ConfirmationPage extends React.Component {
               <br />
             </p>
           ) : null}
-
+          {data.statementOfTruthSignature ? (
+            <span className="veterans-full-name">
+              <strong>Confirmation number</strong>
+              <br />
+              {form.submission?.response?.confirmationNumber || ''}
+            </span>
+          ) : null}
           {isValid(submitDate) ? (
             <p>
               <strong>Date submitted</strong>
@@ -74,6 +80,11 @@ export class ConfirmationPage extends React.Component {
           conditions that we'll cover. Then you can file FMP claims for care
           related to the covered conditions.{' '}
         </p>
+        <div>
+          <a className="vads-c-action-link--green" href="https://www.va.gov/">
+            Go back to VA.gov
+          </a>
+        </div>
       </div>
     );
   }
@@ -91,6 +102,7 @@ ConfirmationPage.propTypes = {
       },
     }),
     formId: PropTypes.string,
+    response: PropTypes.shape({ confirmationNumber: PropTypes.string }),
     submission: PropTypes.shape({
       timestamp: PropTypes.string,
     }),


### PR DESCRIPTION
## Summary
This PR is to refactor the confirmation, review, and contact pages on the form to match the Figma designs. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/77793

## Testing done
Ran unit tests to ensure they pass
Did manual testing

## Screenshots
<img width="675" alt="Screenshot 2024-03-20 at 2 46 44 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/
<img width="757" alt="Screenshot 2024-03-20 at 2 48 10 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/0b1283c0-77f3-4963-b88b-df0eee89fbf6">
20195737/9590c30e-48f5-4238
<img width="741" alt="Screenshot 2024-03-20 at 2 47 02 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/62b9bfe8-16b1-4095-a240-d945479dbe2c">
-8bf0-c36dda788c46">

## What areas of the site does it impact?
ivc/champva

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA
