### PR TITLE
bump css-library version

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
     "@datadog/browser-logs": "^5.8.0",
     "@datadog/browser-rum": "^4.49.0",
     "@department-of-veterans-affairs/component-library": "^38.0.2",
-    "@department-of-veterans-affairs/css-library": "^0.3.0",
+    "@department-of-veterans-affairs/css-library": "^0.5.1",
     "@department-of-veterans-affairs/formation": "^10.1.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",
     "@department-of-veterans-affairs/va-forms-system-core": "1.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2875,13 +2875,6 @@
     react-focus-on "^3.5.1"
     react-transition-group "^1.0.0"
 
-"@department-of-veterans-affairs/css-library@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/css-library/-/css-library-0.3.0.tgz#87801abdfcace36605ed69574e777b10048304e0"
-  integrity sha512-Id7g3TmfWquzJtmFVVUIAKdF01XK29BOKcxKCMzsVBxlBm1FRqN99HtuQVVA32pJFwp5c3rRJnG4jTE4ZZKoOQ==
-  dependencies:
-    "@divriots/style-dictionary-to-figma" "^0.4.0"
-
 "@department-of-veterans-affairs/css-library@^0.5.1":
   version "0.5.1"
   resolved "https://registry.npmjs.org/@department-of-veterans-affairs/css-library/-/css-library-0.5.1.tgz#0e9790eed8fc8c0ce09894469034a17dab048b47"


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

This PR bumps the version of `css-library` in the repo in preparation for updating sass color variables to those found in `css-library` rather than those in formation.

## Related issue(s)

[78822](https://github.com/department-of-veterans-affairs/va.gov-team/issues/78822)

## Testing done

local testing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
