### PR TITLE
Update 10207 FileField to use VaCard and add confirmation modals

### DIFF
--- a/src/applications/simple-forms/20-10207/components/FileField.jsx
+++ b/src/applications/simple-forms/20-10207/components/FileField.jsx
@@ -7,7 +7,10 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState, useRef } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import {
+  VaCard,
+  VaModal,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import get from 'platform/utilities/data/get';
@@ -109,7 +112,7 @@ const FileField = props => {
   const attachmentIdRequired = schema.additionalItems.required
     ? schema.additionalItems.required.includes('attachmentId')
     : false;
-  const uswds = uiOptions.uswds || null;
+  const uswds = true;
 
   const content = {
     upload: uiOptions.buttonText || 'Upload',
@@ -437,10 +440,13 @@ const FileField = props => {
               errorSchema?.[index]?.__errors ||
               [file.errorMessage].filter(error => error);
             const hasErrors = errors.length > 0;
-            const itemClasses = classNames('va-growable-background', {
-              'schemaform-file-error usa-input-error':
-                hasErrors && !file.uploading,
-            });
+            const itemClasses = classNames(
+              'vads-u-margin-bottom--2 vads-u-padding--2',
+              {
+                'schemaform-file-error usa-input-error':
+                  hasErrors && !file.uploading,
+              },
+            );
             const itemSchema = schema.items[index];
             const attachmentIdSchema = {
               $id: `${idSchema.$id}_${index}_attachmentId`,
@@ -509,137 +515,141 @@ const FileField = props => {
             };
 
             return (
-              <li key={index} id={fileListId} className={itemClasses}>
-                {file.uploading && (
-                  <div className="schemaform-file-uploading">
-                    <strong
-                      id={fileNameId}
-                      className="dd-privacy-hidden"
-                      data-dd-action-name="file name"
-                    >
-                      {file.name}
-                    </strong>
-                    <br />
-                    {/* no USWDS v3 "activity progress bar" */}
-                    <va-progress-bar percent={progress} />
-                    <va-button
-                      secondary
-                      class="cancel-upload vads-u-width--auto"
-                      onClick={() => {
-                        cancelUpload(index);
-                      }}
-                      label={content.cancelLabel(file.name)}
-                      text={content.cancel}
-                      uswds={uswds}
-                    />
-                  </div>
-                )}
-                {description && <p>{description}</p>}
-                {!file.uploading && (
-                  <>
-                    <strong
-                      id={fileNameId}
-                      className="dd-privacy-hidden"
-                      data-dd-action-name="file name"
-                    >
-                      {file.name}
-                    </strong>
-                    {file?.size && <div> {displayFileSize(file.size)}</div>}
-                  </>
-                )}
-                {(showPasswordInput || showPasswordSuccess) && (
-                  <PasswordLabel />
-                )}
-                {showPasswordSuccess && <PasswordSuccess />}
-                {!hasErrors &&
-                  !showPasswordInput &&
-                  get('properties.attachmentId', itemSchema) && (
-                    <Tag className="schemaform-file-attachment review">
-                      <SchemaField
-                        name="attachmentId"
-                        required={attachmentIdRequired}
-                        schema={itemSchema.properties.attachmentId}
-                        uiSchema={getUiSchema(uiOptions.attachmentSchema)}
-                        errorSchema={attachmentIdErrors}
-                        idSchema={attachmentIdSchema}
-                        formData={formData[index].attachmentId}
-                        onChange={value => onAttachmentIdChange(index, value)}
-                        onBlur={onBlur}
-                        registry={indexedRegistry}
-                        disabled={props.disabled}
-                        readonly={props.readonly}
-                      />
-                    </Tag>
-                  )}
-                {!hasErrors &&
-                  !showPasswordInput &&
-                  uiOptions.attachmentName && (
-                    <Tag className="schemaform-file-attachment review">
-                      <SchemaField
-                        name="attachmentName"
-                        required
-                        schema={itemSchema.properties.name}
-                        uiSchema={getUiSchema(uiOptions.attachmentName)}
-                        errorSchema={attachmentNameErrors}
-                        idSchema={attachmentNameSchema}
-                        formData={formData[index].name}
-                        onChange={value => onAttachmentNameChange(index, value)}
-                        onBlur={onBlur}
-                        registry={indexedRegistry}
-                        disabled={props.disabled}
-                        readonly={props.readonly}
-                      />
-                    </Tag>
-                  )}
-                {!file.uploading &&
-                  hasErrors && (
-                    <span className="usa-input-error-message" role="alert">
-                      <span className="sr-only">Error</span> {errors[0]}
-                    </span>
-                  )}
-                {showPasswordInput && (
-                  <ShowPdfPassword
-                    file={file.file}
-                    index={index}
-                    onSubmitPassword={onSubmitPassword}
-                    passwordLabel={content.passwordLabel(file.name)}
-                    uswds={uswds}
-                  />
-                )}
-                {!formContext.reviewMode &&
-                  !isUploading && (
-                    <div className="vads-u-margin-top--2">
-                      {hasErrors &&
-                        enableShortWorkflow && (
-                          <va-button
-                            name={`retry_upload_${index}`}
-                            class="retry-upload vads-u-width--auto vads-u-margin-right--2"
-                            onClick={getRetryFunction(
-                              allowRetry,
-                              index,
-                              file.file,
-                            )}
-                            label={
-                              allowRetry
-                                ? content.tryAgainLabel(file.name)
-                                : content.newFile
-                            }
-                            text={retryButtonText}
-                            uswds={uswds}
-                          />
-                        )}
+              <li key={index} id={fileListId}>
+                <VaCard className={itemClasses}>
+                  {file.uploading && (
+                    <div className="schemaform-file-uploading">
+                      <strong
+                        id={fileNameId}
+                        className="dd-privacy-hidden"
+                        data-dd-action-name="file name"
+                      >
+                        {file.name}
+                      </strong>
+                      <br />
+                      {/* no USWDS v3 "activity progress bar" */}
+                      <va-progress-bar percent={progress} />
                       <va-button
                         secondary
-                        class="delete-upload vads-u-width--auto"
+                        class="cancel-upload vads-u-width--auto"
                         onClick={() => {
-                          openRemoveModal(index);
+                          cancelUpload(index);
                         }}
-                        label={content.deleteLabel(file.name)}
-                        text={deleteButtonText}
+                        label={content.cancelLabel(file.name)}
+                        text={content.cancel}
                         uswds={uswds}
                       />
                     </div>
                   )}
+                  {description && <p>{description}</p>}
+                  {!file.uploading && (
+                    <>
+                      <strong
+                        id={fileNameId}
+                        className="dd-privacy-hidden"
+                        data-dd-action-name="file name"
+                      >
+                        {file.name}
+                      </strong>
+                      {file?.size && <div> {displayFileSize(file.size)}</div>}
+                    </>
+                  )}
+                  {(showPasswordInput || showPasswordSuccess) && (
+                    <PasswordLabel />
+                  )}
+                  {showPasswordSuccess && <PasswordSuccess />}
+                  {!hasErrors &&
+                    !showPasswordInput &&
+                    get('properties.attachmentId', itemSchema) && (
+                      <Tag className="schemaform-file-attachment review">
+                        <SchemaField
+                          name="attachmentId"
+                          required={attachmentIdRequired}
+                          schema={itemSchema.properties.attachmentId}
+                          uiSchema={getUiSchema(uiOptions.attachmentSchema)}
+                          errorSchema={attachmentIdErrors}
+                          idSchema={attachmentIdSchema}
+                          formData={formData[index].attachmentId}
+                          onChange={value => onAttachmentIdChange(index, value)}
+                          onBlur={onBlur}
+                          registry={indexedRegistry}
+                          disabled={props.disabled}
+                          readonly={props.readonly}
+                        />
+                      </Tag>
+                    )}
+                  {!hasErrors &&
+                    !showPasswordInput &&
+                    uiOptions.attachmentName && (
+                      <Tag className="schemaform-file-attachment review">
+                        <SchemaField
+                          name="attachmentName"
+                          required
+                          schema={itemSchema.properties.name}
+                          uiSchema={getUiSchema(uiOptions.attachmentName)}
+                          errorSchema={attachmentNameErrors}
+                          idSchema={attachmentNameSchema}
+                          formData={formData[index].name}
+                          onChange={value =>
+                            onAttachmentNameChange(index, value)
+                          }
+                          onBlur={onBlur}
+                          registry={indexedRegistry}
+                          disabled={props.disabled}
+                          readonly={props.readonly}
+                        />
+                      </Tag>
+                    )}
+                  {!file.uploading &&
+                    hasErrors && (
+                      <span className="usa-input-error-message" role="alert">
+                        <span className="sr-only">Error</span> {errors[0]}
+                      </span>
+                    )}
+                  {showPasswordInput && (
+                    <ShowPdfPassword
+                      file={file.file}
+                      index={index}
+                      onSubmitPassword={onSubmitPassword}
+                      passwordLabel={content.passwordLabel(file.name)}
+                      uswds={uswds}
+                    />
+                  )}
+                  {!formContext.reviewMode &&
+                    !isUploading && (
+                      <div className="vads-u-margin-top--2">
+                        {hasErrors &&
+                          enableShortWorkflow && (
+                            <va-button
+                              name={`retry_upload_${index}`}
+                              class="retry-upload vads-u-width--auto vads-u-margin-right--2"
+                              onClick={getRetryFunction(
+                                allowRetry,
+                                index,
+                                file.file,
+                              )}
+                              label={
+                                allowRetry
+                                  ? content.tryAgainLabel(file.name)
+                                  : content.newFile
+                              }
+                              text={retryButtonText}
+                              uswds={uswds}
+                            />
+                          )}
+                        <va-button
+                          secondary
+                          class="delete-upload vads-u-width--auto"
+                          onClick={() => {
+                            openRemoveModal(index);
+                          }}
+                          label={content.deleteLabel(file.name)}
+                          text={deleteButtonText}
+                          uswds={uswds}
+                        />
+                      </div>
+                    )}
+                </VaCard>
               </li>
             );
           })}

--- a/src/applications/simple-forms/20-10207/pages/medicalTreatment.js
+++ b/src/applications/simple-forms/20-10207/pages/medicalTreatment.js
@@ -22,6 +22,7 @@ export default {
         keepInPageOnReview: true,
         customTitle: ' ',
         useDlWrap: true,
+        confirmRemove: true,
       },
       items: {
         'ui:options': {

--- a/src/applications/simple-forms/20-10207/pages/medicalTreatmentThirdPartyNonVeteran.js
+++ b/src/applications/simple-forms/20-10207/pages/medicalTreatmentThirdPartyNonVeteran.js
@@ -22,6 +22,7 @@ export default {
         keepInPageOnReview: true,
         customTitle: ' ',
         useDlWrap: true,
+        confirmRemove: true,
       },
       items: {
         'ui:options': {

--- a/src/applications/simple-forms/20-10207/pages/medicalTreatmentThirdPartyVeteran.js
+++ b/src/applications/simple-forms/20-10207/pages/medicalTreatmentThirdPartyVeteran.js
@@ -22,6 +22,7 @@ export default {
         keepInPageOnReview: true,
         customTitle: ' ',
         useDlWrap: true,
+        confirmRemove: true,
       },
       items: {
         'ui:options': {

--- a/src/applications/simple-forms/20-10207/tests/unit/components/FileField.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10207/tests/unit/components/FileField.unit.spec.jsx
@@ -389,7 +389,7 @@ describe('Schemaform <FileField>', () => {
     );
 
     // Prepend 'Error' for screenreader
-    expect($('.va-growable-background', container).textContent).to.contain(
+    expect($('.schemaform-file-error', container).textContent).to.contain(
       'Error Bad error',
     );
     expect($('span[role="alert"]', container)).to.exist;


### PR DESCRIPTION
## Summary

- Update 10207's file upload to use VaCard
- Update to show confirmation modals for facility remove

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#1149
department-of-veterans-affairs/va.gov-team-forms#1144
department-of-veterans-affairs/va.gov-team-forms#1143

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/1e48f693-445f-4dc4-bd21-0dc371f5f70d)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/a4db1f90-8a74-4958-9216-5e7177a5ba8d)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/3458aff0-70b2-4f11-8a96-041f7da26471)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/47520721-f033-46c5-9302-44824a7c4a4f)

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
