### PR TITLE
[VA-IIR 393] Add Search Criteria to Results Summary

### DIFF
--- a/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
@@ -68,8 +68,8 @@ export class SearchResults extends Component {
     const { name, stateOrTerritory, city } = this.getSearchParams();
     const formattedName = name ? titleCase(name) : '';
     const formattedCity = city ? titleCase(city) : '';
-
     const additionalSearchParams = [];
+
     if (formattedName)
       additionalSearchParams.push(
         <strong key="name">"{formattedName}"</strong>,

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
@@ -15,7 +15,7 @@ import SearchResult from '../../components/SearchResult';
 import { fetchResultsThunk, toggleSearchResultsToolTip } from '../../actions';
 import { getYellowRibbonAppState } from '../../helpers/selectors';
 import { TOOL_TIP_CONTENT, TOOL_TIP_LABEL } from '../../constants';
-import { getCurrentAcademicYear } from '../../helpers';
+import { getCurrentAcademicYear, titleCase } from '../../helpers';
 
 export class SearchResults extends Component {
   static propTypes = {
@@ -50,19 +50,67 @@ export class SearchResults extends Component {
     }
   }
 
+  getSearchParams = (searchString = window.location.search) => {
+    // Derive the current name params.
+    const queryParams = new URLSearchParams(searchString);
+
+    // Derive and return the state values from our query params.
+    return {
+      name: queryParams.get('name') || '',
+      stateOrTerritory: queryParams.get('state') || '',
+      city: queryParams.get('city') || '',
+      contributionAmount: queryParams.get('contributionAmount') || '',
+      numberOfStudents: queryParams.get('numberOfStudents') || '',
+    };
+  };
+
+  deriveAdditionalParamsString = () => {
+    const { name, stateOrTerritory, city } = this.getSearchParams();
+    const formattedName = name ? titleCase(name) : '';
+    const formattedCity = city ? titleCase(city) : '';
+
+    const additionalSearchParams = [];
+    if (formattedName)
+      additionalSearchParams.push(
+        <strong key="name">"{formattedName}"</strong>,
+      );
+    if (formattedCity)
+      additionalSearchParams.push(
+        <strong key="city">"{formattedCity}"</strong>,
+      );
+    if (stateOrTerritory)
+      additionalSearchParams.push(
+        <strong key="state">"{stateOrTerritory}"</strong>,
+      );
+
+    // Combine elements with commas
+    const additionalParamsJsx = additionalSearchParams.reduce(
+      (prev, curr, index) => [
+        ...prev,
+        index > 0 ? ', ' : '', // Add comma separator if not the first element
+        curr,
+      ],
+      [],
+    );
+
+    if (additionalParamsJsx.length > 0) {
+      return <>: {additionalParamsJsx}</>; // Return JSX fragment
+    }
+
+    return null;
+  };
+
   onPageSelect = page => {
     // eslint-disable-next-line react/prop-types
     const { fetchResults, perPage } = this.props;
 
-    // Derive the current name params.
-    const queryParams = new URLSearchParams(window.location.search);
-
-    // Derive the state values from our query params.
-    const city = queryParams.get('city') || '';
-    const contributionAmount = queryParams.get('contributionAmount') || '';
-    const name = queryParams.get('name') || '';
-    const numberOfStudents = queryParams.get('numberOfStudents') || '';
-    const state = queryParams.get('state') || '';
+    const {
+      city,
+      contributionAmount,
+      name,
+      numberOfStudents,
+      stateOrTerritory,
+    } = this.getSearchParams();
 
     // Refetch results.
     fetchResults({
@@ -73,7 +121,7 @@ export class SearchResults extends Component {
       numberOfStudents,
       page,
       perPage,
-      state,
+      state: stateOrTerritory,
     });
 
     // Scroll to top.
@@ -106,15 +154,13 @@ export class SearchResults extends Component {
   };
 
   recordEventOnSearchResultClick = (school = {}) => () => {
-    // Derive the current name params.
-    const queryParams = new URLSearchParams(window.location.search);
-
-    // Derive the state values from our query params.
-    const searchQuery = queryParams.get('name') || '';
-    const city = queryParams.get('city') || '';
-    const contributionAmount = queryParams.get('contributionAmount') || '';
-    const numberOfStudents = queryParams.get('numberOfStudents') || '';
-    const stateOrTerritory = queryParams.get('state') || '';
+    const {
+      name,
+      city,
+      contributionAmount,
+      numberOfStudents,
+      stateOrTerritory,
+    } = this.getSearchParams();
 
     const { page, perPage, totalResults } = this.props;
 
@@ -131,7 +177,7 @@ export class SearchResults extends Component {
       'search-selection': 'Yellow Ribbon',
       'search-result-chosen-page-url': school?.insturl || undefined,
       'search-result-chosen-title': school?.nameOfInstitution,
-      'search-query': searchQuery,
+      'search-query': name,
       'search-results-total-count': totalResults,
       'search-results-total-pages': Math.ceil(totalResults / perPage),
       'search-result-position': school?.positionInResults,
@@ -208,6 +254,7 @@ export class SearchResults extends Component {
     const resultsStartNumber = deriveResultsStartNumber();
     const resultsEndNumber = deriveResultsEndNumber();
     const academicYear = getCurrentAcademicYear();
+    const additionalParamsString = this.deriveAdditionalParamsString();
 
     return (
       <>
@@ -222,7 +269,8 @@ export class SearchResults extends Component {
             <span aria-hidden="true">&ndash;</span>
             <span>
               {resultsEndNumber} of {totalResults} schools for academic year{' '}
-              {academicYear}.
+              {academicYear}
+              {additionalParamsString}.
             </span>
           </span>
         </h2>

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.unit.spec.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.unit.spec.jsx
@@ -102,4 +102,22 @@ describe('Yellow Ribbon container <SearchResults>', () => {
     expect(tree.find('VaPagination')).to.have.lengthOf(1);
     tree.unmount();
   });
+
+  it('correctly extracts search params from a given search string', () => {
+    const tree = shallow(<SearchResults />);
+    const searchResultsInstance = tree.instance();
+    const mockSearchString =
+      '?city=berkeley&name=university+of+california&state=CA';
+    const expectedParams = {
+      name: 'university of california',
+      stateOrTerritory: 'CA',
+      city: 'berkeley',
+      contributionAmount: '',
+      numberOfStudents: '',
+    };
+    const result = searchResultsInstance.getSearchParams(mockSearchString);
+
+    expect(result).to.deep.equal(expectedParams);
+    tree.unmount();
+  });
 });


### PR DESCRIPTION
## Summary

- The following code adds name, city, and state or territory search criteria to the summary above the [Yellow Ribbon Search tool's](https://www.va.gov/education/yellow-ribbon-participating-schools/) results.
- I work for the VA-IIR (a.k.a., "Iterate, Innovate, and Run") contractor team under Oddball (primary) and Ad Hoc.

## Related issue(s)

- Closes [VA-IIR 393](https://github.com/department-of-veterans-affairs/va-iir/issues/393)

## Testing done

- Tests have been updated with a new test.
- Conducted local test and viewed expected behavior.

## Screenshots

| Before | After |
| ------ | ------ |
![Yellow Ribbon without search criteria in results summary](https://github.com/department-of-veterans-affairs/vets-website/assets/146031450/eb94829a-ae11-43d6-b061-583589306500 "Before") | ![Yellow Ribbon with search criteria in results summary](https://github.com/department-of-veterans-affairs/vets-website/assets/146031450/f2b07e35-4a90-4359-80ec-c6f8a7e889c3 "After")

## Acceptance criteria

- [x] Change verbiage above YR Program results to include comma separated, bold list of name, state or territory, and city if used in search.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] Screenshot of the developed feature is added

