### PR TITLE
[CST] - Update the Upload Status Modal on AddFilesForm

### DIFF
--- a/src/applications/claims-status/components/AddFilesFormOld.jsx
+++ b/src/applications/claims-status/components/AddFilesFormOld.jsx
@@ -310,7 +310,6 @@ class AddFilesFormOld extends React.Component {
         </div>
         <div>
           <VaButton
-            submit
             text="Submit Files for Review"
             class="submit-files-button"
             onClick={this.submit}

--- a/src/applications/claims-status/components/AddFilesFormOld.jsx
+++ b/src/applications/claims-status/components/AddFilesFormOld.jsx
@@ -71,6 +71,7 @@ class AddFilesFormOld extends React.Component {
       errorMessage: null,
       checked: false,
       errorMessageCheckbox: null,
+      canShowUploadModal: false,
     };
   }
 
@@ -166,6 +167,8 @@ class AddFilesFormOld extends React.Component {
           : 'Please confirm these documents apply to this claim only',
       });
 
+      this.setState({ canShowUploadModal: true });
+
       if (this.state.checked) {
         this.props.onSubmit();
         return;
@@ -177,6 +180,9 @@ class AddFilesFormOld extends React.Component {
   };
 
   render() {
+    const showUploadModal =
+      this.props.uploading && this.state.canShowUploadModal;
+
     return (
       <>
         <va-additional-info
@@ -315,9 +321,8 @@ class AddFilesFormOld extends React.Component {
         </div>
         <VaModal
           id="upload-status"
-          onCloseEvent={() => true}
-          visible={Boolean(this.props.uploading)}
-          uswds="false"
+          onCloseEvent={() => this.setState({ canShowUploadModal: false })}
+          visible={showUploadModal}
         >
           <UploadStatus
             progress={this.props.progress}

--- a/src/applications/claims-status/components/AddFilesFormOld.jsx
+++ b/src/applications/claims-status/components/AddFilesFormOld.jsx
@@ -9,6 +9,7 @@ import {
   VaSelect,
   VaTextInput,
   VaCheckbox,
+  VaButton,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import {
@@ -308,8 +309,8 @@ class AddFilesFormOld extends React.Component {
           <a href="/disability/how-to-file-claim">How to File a Claim</a> page.
         </div>
         <div>
-          <va-button
-            primary
+          <VaButton
+            submit
             text="Submit Files for Review"
             class="submit-files-button"
             onClick={this.submit}

--- a/src/applications/claims-status/components/AddFilesFormOld.jsx
+++ b/src/applications/claims-status/components/AddFilesFormOld.jsx
@@ -313,7 +313,6 @@ class AddFilesFormOld extends React.Component {
             text="Submit Files for Review"
             class="submit-files-button"
             onClick={this.submit}
-            uswds
           />
           <Link to={this.props.backUrl} className="claims-files-cancel">
             Cancel

--- a/src/applications/claims-status/components/UploadStatus.jsx
+++ b/src/applications/claims-status/components/UploadStatus.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function UploadStatus({ files, progress, onCancel }) {
+export default function UploadStatus({ files, onCancel, progress }) {
   const handleClick = evt => {
     evt.preventDefault();
     onCancel();

--- a/src/applications/claims-status/components/UploadStatus.jsx
+++ b/src/applications/claims-status/components/UploadStatus.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function UploadStatus({ files, onCancel, progress }) {
+export default function UploadStatus({ files, progress, onCancel }) {
   const handleClick = evt => {
     evt.preventDefault();
     onCancel();

--- a/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
@@ -72,6 +72,7 @@ class AddFilesForm extends React.Component {
       errorMessage: null,
       checked: false,
       errorMessageCheckbox: null,
+      canShowUploadModal: false,
     };
   }
 
@@ -167,6 +168,8 @@ class AddFilesForm extends React.Component {
           : 'Please confirm these documents apply to this claim only',
       });
 
+      this.setState({ canShowUploadModal: true });
+
       if (this.state.checked) {
         this.props.onSubmit();
         return;
@@ -178,6 +181,9 @@ class AddFilesForm extends React.Component {
   };
 
   render() {
+    const showUploadModal =
+      this.props.uploading && this.state.canShowUploadModal;
+
     return (
       <>
         <div className="add-files-form">
@@ -308,9 +314,8 @@ class AddFilesForm extends React.Component {
         </va-additional-info>
         <VaModal
           id="upload-status"
-          onCloseEvent={() => true}
-          visible={Boolean(this.props.uploading)}
-          uswds="false"
+          onCloseEvent={() => this.setState({ canShowUploadModal: false })}
+          visible={showUploadModal}
         >
           <UploadStatus
             progress={this.props.progress}

--- a/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
@@ -8,6 +8,7 @@ import {
   VaSelect,
   VaTextInput,
   VaCheckbox,
+  VaButton,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import {
@@ -169,7 +170,6 @@ class AddFilesForm extends React.Component {
       });
 
       this.setState({ canShowUploadModal: true });
-
       if (this.state.checked) {
         this.props.onSubmit();
         return;
@@ -298,7 +298,7 @@ class AddFilesForm extends React.Component {
             this.setState({ checked: event.detail.checked });
           }}
         />
-        <va-button
+        <VaButton
           id="submit"
           submit
           uswds

--- a/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
@@ -300,8 +300,6 @@ class AddFilesForm extends React.Component {
         />
         <VaButton
           id="submit"
-          submit
-          uswds
           text="Submit files for review"
           onClick={this.submit}
         />

--- a/src/applications/claims-status/tests/components/AddFilesFormOld.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AddFilesFormOld.unit.spec.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
+import { fireEvent } from '@testing-library/dom';
+import { render } from '@testing-library/react';
+import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
+
 import sinon from 'sinon';
 
 import {
@@ -145,6 +149,61 @@ describe('<AddFilesFormOld>', () => {
     tree.getMountedInstance().submit();
     expect(onSubmit.called).to.be.false;
     expect(onDirtyFields.called).to.be.true;
+  });
+
+  it('should add a valid file and submit', async () => {
+    const fileFormProps = {
+      field: { value: '', dirty: false },
+      files: [],
+      onSubmit: () => {},
+      onAddFile: () => {},
+      onRemoveFile: () => {},
+      onFieldChange: () => {},
+      onCancel: () => {},
+      removeFile: () => {},
+      onDirtyFields: () => {},
+    };
+    const onSubmit = sinon.spy();
+    const onDirtyFields = sinon.spy();
+
+    const { container, rerender } = render(
+      <AddFilesFormOld
+        {...fileFormProps}
+        onSubmit={onSubmit}
+        onDirtyFields={onDirtyFields}
+      />,
+    );
+
+    // Check the checkbox
+    $('va-checkbox', container).__events.vaChange({
+      detail: { checked: true },
+    });
+
+    // Rerender component with new props and submit the file upload
+    const file = {
+      file: new File(['hello'], 'hello.jpg', {
+        name: 'hello.jpg',
+        type: fileTypeSignatures.jpg.mime,
+        size: 9999,
+      }),
+      docType: { value: 'L029', dirty: true },
+      password: { value: '', dirty: false },
+      isEncrypted: false,
+    };
+
+    rerender(
+      <AddFilesFormOld
+        {...fileFormProps}
+        files={[file]}
+        onSubmit={onSubmit}
+        onDirtyFields={onDirtyFields}
+        uploading
+      />,
+    );
+
+    fireEvent.click($('.submit-files-button', container));
+    expect(onSubmit.called).to.be.true;
+    expect($('#upload-status', container).visible).to.be.true;
   });
 
   it('should not add an invalid file type', () => {

--- a/src/applications/claims-status/tests/components/AddFilesFormOld.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AddFilesFormOld.unit.spec.jsx
@@ -35,6 +35,7 @@ describe('<AddFilesFormOld>', () => {
     const onFieldChange = sinon.spy();
     const onCancel = sinon.spy();
     const onDirtyFields = sinon.spy();
+    const uploading = false;
 
     const tree = SkinDeep.shallowRender(
       <AddFilesFormOld
@@ -46,6 +47,7 @@ describe('<AddFilesFormOld>', () => {
         onFieldChange={onFieldChange}
         onCancel={onCancel}
         onDirtyFields={onDirtyFields}
+        uploading={uploading}
       />,
     );
 
@@ -56,34 +58,6 @@ describe('<AddFilesFormOld>', () => {
 
     // VaModal has an id of `upload-status` so we can use that as the selector here
     expect(tree.everySubTree('#upload-status')[0].props.visible).to.be.false;
-  });
-
-  it('should show uploading modal', () => {
-    const files = [];
-    const field = { value: '', dirty: false };
-    const onSubmit = sinon.spy();
-    const onAddFile = sinon.spy();
-    const onRemoveFile = sinon.spy();
-    const onFieldChange = sinon.spy();
-    const onCancel = sinon.spy();
-    const onDirtyFields = sinon.spy();
-
-    const tree = SkinDeep.shallowRender(
-      <AddFilesFormOld
-        uploading
-        files={files}
-        field={field}
-        onSubmit={onSubmit}
-        onAddFile={onAddFile}
-        onRemoveFile={onRemoveFile}
-        onFieldChange={onFieldChange}
-        onCancel={onCancel}
-        onDirtyFields={onDirtyFields}
-      />,
-    );
-
-    // VaModal has an id of `upload-status` so we can use that as the selector here
-    expect(tree.everySubTree('#upload-status')[0].props.visible).to.be.true;
   });
 
   it('should include mail info additional info', () => {

--- a/src/applications/claims-status/tests/components/AddFilesFormOld.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AddFilesFormOld.unit.spec.jsx
@@ -162,6 +162,7 @@ describe('<AddFilesFormOld>', () => {
       onCancel: () => {},
       removeFile: () => {},
       onDirtyFields: () => {},
+      uploading: false,
     };
     const onSubmit = sinon.spy();
     const onDirtyFields = sinon.spy();

--- a/src/applications/claims-status/tests/components/claim-files-tab/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab/AddFilesForm.unit.spec.jsx
@@ -59,7 +59,7 @@ describe('<AddFilesForm>', () => {
 
     it('uploading modal should not be visible', () => {
       const { container } = render(
-        <AddFilesForm uploading {...fileFormProps} />,
+        <AddFilesForm {...fileFormProps} uploading />,
       );
       expect($('#upload-status', container).visible).to.be.false;
     });

--- a/src/applications/claims-status/tests/components/claim-files-tab/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab/AddFilesForm.unit.spec.jsx
@@ -6,6 +6,8 @@ import { fireEvent } from '@testing-library/dom';
 import { render } from '@testing-library/react';
 import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import { createStore } from 'redux';
+import userEvent from '@testing-library/user-event';
+
 
 import sinon from 'sinon';
 
@@ -131,6 +133,53 @@ describe('<AddFilesForm>', () => {
       fireEvent.click($('#submit', container));
       expect(onSubmit.called).to.be.false;
       expect(onDirtyFields.called).to.be.true;
+    });
+
+    it.only('should add a valid file and submit', async () => {
+      const onSubmit = sinon.spy();
+      const onDirtyFields = sinon.spy();
+
+      const { container, rerender } = render(
+        <Provider store={store}>
+          <AddFilesForm
+            {...fileFormProps}
+            onSubmit={onSubmit}
+            onDirtyFields={onDirtyFields}
+          />
+          ,
+        </Provider>,
+      );
+
+      const file = new File(['hello'], 'hello.jpg', {
+        name: 'hello.jpg',
+        type: fileTypeSignatures.jpg.mime,
+        size: 9999,
+      });
+
+      const input = $('va-file-input', container);
+      expect(input).to.exist;
+      userEvent.upload(input, file);
+
+      $('va-checkbox', container).__events.vaChange({
+        detail: { checked: true },
+      });
+      fireEvent.click($('#submit', container));
+
+      rerender(
+        <Provider store={store}>
+          <AddFilesForm
+            {...fileFormProps}
+            onSubmit={onSubmit}
+            onDirtyFields={onDirtyFields}
+            uploading
+          />
+          ,
+        </Provider>,
+      );
+
+      console.log($('#upload-status', container));
+
+      expect(onSubmit.called).to.be.true;
     });
   });
 

--- a/src/applications/claims-status/tests/components/claim-files-tab/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab/AddFilesForm.unit.spec.jsx
@@ -124,17 +124,7 @@ describe('<AddFilesForm>', () => {
           onDirtyFields={onDirtyFields}
         />,
       );
-      // Create a file and add it to the vafileinput
-      const files = [
-        {
-          name: 'hello.jpg',
-          type: fileTypeSignatures.jpg.mime,
-          size: 9999,
-        },
-      ];
-      $('va-file-input', container).__events.vaChange({
-        detail: { files },
-      });
+
       // Check the checkbox
       $('va-checkbox', container).__events.vaChange({
         detail: { checked: true },


### PR DESCRIPTION
## Summary

Added changes to AddFilesForm.jsx and AddFilesFormOld.jsx 
- Added a new state called `canShowUploadModal` that is set to false when a user selects the close icon button on the va modal. When a user submits the  files to upload `canShowUploadModal` is set to true.
- changed va-button to VaButton 
- removed uswds prop from the VaButton since that is now defaulted to true

For AddFilesFormOld.jsx updated the VaButton to no longer have primary since that isnt a prop anymore.

For AddFilesFormOld.jsx updated the VaButton to no longer have submit since we are not submitting a form and its not needed.


Updated tests for  AddFilesForm and AddFilesFormOld to account for the new logic around the upload status modal.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#77046

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

`Submitting form with cst_use_claim_details_v2 enabled:`
https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/3dea7400-febb-47d9-bad8-2d82878179de

`Submitting form with cst_use_claim_details_v2 disabled:`
https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/a9da2fa8-1540-4f6a-b945-15e00ece1525

## What areas of the site does it impact?

Claim Status Tool 

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
