### PR TITLE
VACMS-17304 Add Spanish toggle for new disability page

### DIFF
--- a/src/applications/static-pages/i18Select/tests/getNonActiveLinkUrls.unit.spec.js
+++ b/src/applications/static-pages/i18Select/tests/getNonActiveLinkUrls.unit.spec.js
@@ -9,7 +9,7 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(esp|tag)/i.test(url)).to.equal(true);
     });
 
-    expect(result.length).to.equal(23);
+    expect(result.length).to.equal(24);
   });
 
   it('should not return any "-esp" suffixed links when "es" is the active language code', () => {
@@ -19,7 +19,7 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(esp)/i.test(url)).to.equal(false);
     });
 
-    expect(result.length).to.equal(23);
+    expect(result.length).to.equal(24);
   });
 
   it('should not return any "-tag" suffixed links when "tl" is the active language code', () => {
@@ -29,6 +29,6 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(tag)/i.test(url)).to.equal(false);
     });
 
-    expect(result.length).to.equal(34);
+    expect(result.length).to.equal(36);
   });
 });

--- a/src/applications/static-pages/i18Select/utilities/urls.js
+++ b/src/applications/static-pages/i18Select/utilities/urls.js
@@ -80,4 +80,8 @@ export default {
     en: '/education/eligibility/',
     es: '/education/eligibility-esp/',
   },
+  dependencyIndemnity: {
+    en: '/disability/dependency-indemnity-compensation/',
+    es: '/disability/dependency-indemnity-compensation-esp/',
+  },
 };


### PR DESCRIPTION
## Summary
Add Spanish toggle to the `Survivor and dependent compensation (DIC)` page.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17304

## Testing done
Tested `/disability/dependency-indemnity-compensation/` and `/disability/dependency-indemnity-compensation-esp` locally.

## Screenshots
<img width="700" alt="Screenshot 2024-03-21 at 11 40 40 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/bdd76c97-ce54-4d2d-a16c-66c6f241ca9b">
<img width="700" alt="Screenshot 2024-03-21 at 11 40 48 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/1cf2616e-d8e1-45b3-bb5c-c4f0dd9bf8e8">