### PR TITLE
Streamline E2E Test CI runs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -316,7 +316,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [fetch-allow-lists, tests-prep]
-    if: ${{ always() && needs.tests-prep.outputs.unit-tests-to-stress-test != '[]' && github.ref != 'refs/heads/main' }}
+    if: ${{ always() && needs.tests-prep.outputs.unit-tests-to-stress-test != '[]' && github.ref != 'refs/heads/main' && needs.fetch-allow-lists.result == 'success' && needs.tests-prep.result == 'success' }}
 
     env:
       TESTS_TO_VERIFY: ${{ needs.tests-prep.outputs.unit-tests-to-stress-test }}
@@ -578,7 +578,6 @@ jobs:
       needs.tests-prep.result == 'success'
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge
-      # options: -u 1001:1001 -v /usr/local/share:/share
 
     strategy:
       fail-fast: false
@@ -587,8 +586,6 @@ jobs:
         ci_node_index: ${{ fromJson(needs.tests-prep.outputs.ci_node_index) }}
 
     env:
-      # CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
-      # NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
       CI_NODE_INDEX: ${{ needs.tests-prep.outputs.ci_node_index }}
 
     steps:
@@ -689,7 +686,6 @@ jobs:
       github.ref != 'refs/heads/main'
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
-      # options: -u 1001:1001 -v /usr/local/share:/share
 
     strategy:
       fail-fast: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -570,7 +570,7 @@ jobs:
 
   cypress-tests:
     name: Cypress E2E Tests
-    runs-on: self-hosted
+    runs-on: ubuntu-16-cores-latest
     timeout-minutes: 60
     needs: [build, tests-prep]
     if: |
@@ -578,7 +578,7 @@ jobs:
       needs.tests-prep.result == 'success'
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge
-      options: -u 1001:1001 -v /usr/local/share:/share
+      # options: -u 1001:1001 -v /usr/local/share:/share
 
     strategy:
       fail-fast: false
@@ -587,8 +587,8 @@ jobs:
         ci_node_index: ${{ fromJson(needs.tests-prep.outputs.ci_node_index) }}
 
     env:
-      CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
-      NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
+      # CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
+      # NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
       CI_NODE_INDEX: ${{ needs.tests-prep.outputs.ci_node_index }}
 
     steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -679,7 +679,7 @@ jobs:
 
   stress-test-cypress-tests:
     name: E2E Test Stability Review
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     needs: [build, tests-prep]
     if: |
@@ -689,7 +689,7 @@ jobs:
       github.ref != 'refs/heads/main'
     container:
       image: public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98
-      options: -u 1001:1001 -v /usr/local/share:/share
+      # options: -u 1001:1001 -v /usr/local/share:/share
 
     strategy:
       fail-fast: false
@@ -698,8 +698,6 @@ jobs:
         ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
     env:
-      CHROMEDRIVER_FILEPATH: /share/chrome_driver/chromedriver
-      NODE_EXTRA_CA_CERTS: /share/ca-certificates/VA-Internal-S2-RCA1-v1.cer.crt
       CI_NODE_INDEX: ${{ needs.tests-prep.outputs.ci_node_index }}
 
     steps:

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -9,7 +9,7 @@ const appUrl = process.env.APP_URLS.split(',')[0];
 // If it has been selected, it is run in its own container in the last parallel container.
 let divider;
 let longestTestIsPresent = false;
-const longestTest = /all-claims.cypress.spec.js/g;
+const longestTest = /long-ptsd.cypress.spec.js/g;
 const lastStep = numContainers - 1;
 
 if (tests.some(test => test.match(longestTest))) {

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -4,7 +4,6 @@ let tests = JSON.parse(process.env.TESTS);
 const step = Number(process.env.STEP);
 const numContainers = Number(process.env.NUM_CONTAINERS);
 const appUrl = process.env.APP_URLS.split(',')[0];
-const isStressTest = process.env.IS_STRESS_TEST;
 
 // The following logic checks if the longest-running test has been selected.
 // If it has been selected, it is run in its own container in the last parallel container.
@@ -28,20 +27,17 @@ const batch = tests
   .join(',');
 
 let status = null;
-const runTestsInLoopUpTo = isStressTest ? 25 : 1;
 
-for (let i = 0; i < runTestsInLoopUpTo; i += 1) {
-  if (longestTestIsPresent && step === lastStep) {
-    status = runCommandSync(
-      `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.js" --spec 'src/applications/**/all-claims.cypress.spec.js' --env app_url=${appUrl}`,
-    );
-  } else if (batch !== '') {
-    status = runCommandSync(
-      `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.js" --spec '${batch}' --env app_url=${appUrl}`,
-    );
-  } else {
-    process.exit(0);
-  }
+if (longestTestIsPresent && step === lastStep) {
+  status = runCommandSync(
+    `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.js" --spec 'src/applications/**/all-claims.cypress.spec.js' --env app_url=${appUrl}`,
+  );
+} else if (batch !== '') {
+  status = runCommandSync(
+    `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.js" --spec '${batch}' --env app_url=${appUrl}`,
+  );
+} else {
+  process.exit(0);
 }
 
 process.exit(status);

--- a/script/github-actions/run-cypress-tests.js
+++ b/script/github-actions/run-cypress-tests.js
@@ -9,13 +9,14 @@ const appUrl = process.env.APP_URLS.split(',')[0];
 // If it has been selected, it is run in its own container in the last parallel container.
 let divider;
 let longestTestIsPresent = false;
-const longestTest = /long-ptsd.cypress.spec.js/g;
+const longestTestFilename = `long-ptsd.cypress.spec.js`;
+const longestTestPattern = new RegExp(longestTestFilename, 'g');
 const lastStep = numContainers - 1;
 
-if (tests.some(test => test.match(longestTest))) {
+if (tests.some(test => test.match(longestTestPattern))) {
   longestTestIsPresent = true;
   divider = Math.ceil(tests.length / (numContainers - 1));
-  tests = tests.filter(test => !test.match(longestTest));
+  tests = tests.filter(test => !test.match(longestTestPattern));
 } else {
   divider = Math.ceil(tests.length / numContainers);
 }
@@ -30,7 +31,7 @@ let status = null;
 
 if (longestTestIsPresent && step === lastStep) {
   status = runCommandSync(
-    `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.js" --spec 'src/applications/**/all-claims.cypress.spec.js' --env app_url=${appUrl}`,
+    `CYPRESS_EVERY_NTH_FRAME=1 yarn cy:run --browser chrome --headless --reporter cypress-multi-reporters --reporter-options "configFile=config/cypress-reporters.js" --spec 'src/applications/**/${longestTestFilename}' --env app_url=${appUrl}`,
   );
 } else if (batch !== '') {
   status = runCommandSync(

--- a/src/applications/disability-benefits/all-claims/subtask/pages/unable-to-file-bdd.jsx
+++ b/src/applications/disability-benefits/all-claims/subtask/pages/unable-to-file-bdd.jsx
@@ -12,7 +12,7 @@ import pageNames from './pageNames';
 
 const content = {
   linkText:
-    'Learnn more about why you’re not eligible for disability benefits right now',
+    'Learn more about why you’re not eligible for disability benefits right now',
 };
 
 const UnableToFileBDDPage = ({ data = {} }) => {

--- a/src/applications/disability-benefits/all-claims/subtask/pages/unable-to-file-bdd.jsx
+++ b/src/applications/disability-benefits/all-claims/subtask/pages/unable-to-file-bdd.jsx
@@ -12,7 +12,7 @@ import pageNames from './pageNames';
 
 const content = {
   linkText:
-    'Learn more about why you’re not eligible for disability benefits right now',
+    'Learnn more about why you’re not eligible for disability benefits right now',
 };
 
 const UnableToFileBDDPage = ({ data = {} }) => {


### PR DESCRIPTION
## Summary

- Takes down e2e tests to roughly 13 minutes total runtime.

## Related issue(s)

https://app.zenhub.com/workspaces/reliability-team-633b069d2920b776613c93d8/issues/gh/department-of-veterans-affairs/va.gov-team/74532

## Testing done

- Ran all e2e tests to ensure speed increased and nothing was broken.
- Forced E2E Stress Test to run to ensure that it worked successfully.

