### PR TITLE
Update external service for downtime notifications for the EZR

### DIFF
--- a/src/applications/ezr/config/form.js
+++ b/src/applications/ezr/config/form.js
@@ -115,7 +115,7 @@ const formConfig = {
   },
   submissionError: SubmissionErrorAlert,
   downtime: {
-    dependencies: [externalServices.es],
+    dependencies: [externalServices['1010ezr']],
     message: DowntimeWarning,
   },
   introduction: IntroductionPage,

--- a/src/applications/ezr/containers/IntroductionPage.jsx
+++ b/src/applications/ezr/containers/IntroductionPage.jsx
@@ -40,7 +40,7 @@ const IntroductionPage = ({ fetchEnrollmentStatus, route }) => {
       <div className="ezr-intro schemaform-intro">
         <DowntimeNotification
           appTitle={content['form-title']}
-          dependencies={[externalServices.es]}
+          dependencies={[externalServices['1010ezr']]}
         >
           {isLoading ? (
             <va-loading-indicator message={content['load-enrollment-status']} />


### PR DESCRIPTION
## Summary
This PR updates the external service for the downtime notification component to account for additional pager duty services that have been implemented to separate the 1010EZ and 1010EZR applications. The current implementation has the apps utilizing the same service, but there are multiple use cases for allowing one application to be down while the other stays up. With them both on the same service, if we have an incident with one, we have to take them both down.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#78638

## Acceptance criteria

- EZR application utilizes the EZR-specific service

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution