### PR TITLE
Update downtime external service for Health Care Application

### DIFF
--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -136,7 +136,7 @@ const formConfig = {
     noAuth: 'Please sign in again to resume your application for health care.',
   },
   downtime: {
-    dependencies: [externalServices.es],
+    dependencies: [externalServices['1010ez']],
     message: DowntimeWarning,
   },
   transformForSubmit: transform,

--- a/src/applications/hca/containers/IntroductionPage.jsx
+++ b/src/applications/hca/containers/IntroductionPage.jsx
@@ -27,7 +27,7 @@ const IntroductionPage = ({ route }) => {
     <div className="schemaform-intro">
       <DowntimeNotification
         appTitle={content['form-title']}
-        dependencies={[externalServices.es]}
+        dependencies={[externalServices['1010ez']]}
       >
         {isLoadingApplicationStatus ? (
           <va-loading-indicator


### PR DESCRIPTION
## Summary
This PR updates the external service for the downtime notification component to account for additional pager duty services that have been implemented to separate the 1010EZ and 1010EZR applications. The current implementation has the apps utilizing the same service, but there are multiple use cases for allowing one application to be down while the other stays up. With them both on the same service, if we have an incident with one, we have to take them both down.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#78638

## Acceptance criteria

- Health care application utilizes the EZ-specific service

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution