### PR TITLE
Fix session GET logic to skip validation on a good read.full session

### DIFF
--- a/src/applications/check-in/travel-claim/pages/landing/index.jsx
+++ b/src/applications/check-in/travel-claim/pages/landing/index.jsx
@@ -82,7 +82,7 @@ const Landing = props => {
                 setSession(token, session.permissions);
                 if (session.permissions === SCOPES.READ_FULL) {
                   // redirect if already full access
-                  jumpToPage(URLS.INTRODUCTION);
+                  jumpToPage(URLS.LOADING);
                 } else {
                   // TODO: dispatch to redux
                   jumpToPage(URLS.VERIFY);

--- a/src/applications/check-in/travel-claim/tests/e2e/trave-claim.returning-user.cypress.spec.js
+++ b/src/applications/check-in/travel-claim/tests/e2e/trave-claim.returning-user.cypress.spec.js
@@ -20,6 +20,5 @@ describe('A patent who returns to the app with a valid session ', () => {
     cy.visitTravelClaimWithUUID();
     TravelIntro.validatePageLoaded();
     cy.injectAxeThenAxeCheck();
-    cy.createScreenshots('Travel-claim--Returning-user--Intro');
   });
 });

--- a/src/applications/check-in/travel-claim/tests/e2e/trave-claim.returning-user.cypress.spec.js
+++ b/src/applications/check-in/travel-claim/tests/e2e/trave-claim.returning-user.cypress.spec.js
@@ -1,0 +1,25 @@
+import '../../../tests/e2e/commands';
+
+import ApiInitializer from '../../../api/local-mock-api/e2e/ApiInitializer';
+import TravelIntro from './pages/TravelIntro';
+
+describe('A patent who returns to the app with a valid session ', () => {
+  beforeEach(() => {
+    const {
+      initializeFeatureToggle,
+      initializeSessionGet,
+      initializeCheckInDataGetOH,
+      initializeCheckInDataPost,
+    } = ApiInitializer;
+    initializeFeatureToggle.withCurrentFeatures();
+    initializeSessionGet.withSuccessfulReturningSession();
+    initializeCheckInDataGetOH.withSuccess();
+    initializeCheckInDataPost.withSuccess();
+  });
+  it('should be redirected to the travel intro screen with data loaded', () => {
+    cy.visitTravelClaimWithUUID();
+    TravelIntro.validatePageLoaded();
+    cy.injectAxeThenAxeCheck();
+    cy.createScreenshots('Travel-claim--Returning-user--Intro');
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes the logic to go to the loading page on successful read.full response

## Related issue(s)

- [department-of-veterans-affairs/va.gov-team#78753](https://github.com/department-of-veterans-affairs/va.gov-team/issues/78753)

## Testing done

- Cypress

## What areas of the site does it impact?

Check in -> Travel Claim

## Acceptance criteria

- [ ] it skips validation with a good read.full session

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
