### PR TITLE
Revert "Bump SC RUM session rate to 100% (#28637)"

### DIFF
--- a/src/applications/appeals/995/containers/App.jsx
+++ b/src/applications/appeals/995/containers/App.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import * as Sentry from '@sentry/browser';
 import PropTypes from 'prop-types';
-// import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { isLoggedIn } from 'platform/user/selectors';
@@ -146,8 +146,8 @@ export const App = ({
     formId: 'sc', // becomes "scBrowserMonitoringEnabled" feature flag
     version: '1.0.0',
     // record 100% of staging sessions, but only 10% of production
-    sessionReplaySampleRate: 100, // temp to 100%; end on 3/22/2024
-    //  environment.vspEnvironment() === 'staging' ? 100 : 10,
+    sessionReplaySampleRate:
+      environment.vspEnvironment() === 'staging' ? 100 : 10,
     applicationId: DATA_DOG_ID,
     clientToken: DATA_DOG_TOKEN,
     service: DATA_DOG_SERVICE,


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > This reverts commit fb454c0bebdb75fd762923a87d1475de8e71e56f (#28637)
  > We are restoring the `sessionReplaySampleRate` of Supplemental Claim from 100% back down to 10% in production. See the related issue for more details.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#76516](https://github.com/department-of-veterans-affairs/va.gov-team/issues/76516)

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

Supplemental Claims in DataDog - reestore to 10% of RUM sessions available

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
