### PR TITLE
[AVS] Fix header spacing

### DIFF
--- a/src/applications/avs/README.md
+++ b/src/applications/avs/README.md
@@ -2,7 +2,7 @@
 
 ## Quick start to get running locally
 
-fore you get started check [this page](https://depo-platform-documentation.scrollhelp.site/developer-docs/setting-up-your-local-frontend-environment) first to make sure you are setup to use the correct version of Node and Yarn.
+Before you get started check [this page](https://depo-platform-documentation.scrollhelp.site/developer-docs/setting-up-your-local-frontend-environment) first to make sure you are setup to use the correct version of Node and Yarn.
 
 - clone vets-website repo `git clone git@github.com:department-of-veterans-affairs/vets-website.git`
 - navigate to the AVS application `cd src/applications/avs`

--- a/src/applications/avs/README.md
+++ b/src/applications/avs/README.md
@@ -1,20 +1,24 @@
 # AVS application
 
 ## Quick start to get running locally
-Before you get started check [this page](https://depo-platform-documentation.scrollhelp.site/developer-docs/setting-up-your-local-frontend-environment) first to make sure you are setup to use the correct version of Node and Yarn.
-  - clone vets-website repo `git clone git@github.com:department-of-veterans-affairs/vets-website.git`
-  - navigate to the AVS application `cd src/applications/avs`
-  - run `yarn install`
-  - turn on local mocks `yarn --cwd $( git rev-parse --show-toplevel ) mock-api --responses src/applications/avs/api/mocks/index.js`
-  - start app `yarn --cwd $( git rev-parse --show-toplevel ) watch --env entry=avs`
-  - Run this in your browser console to simulate being logged in `localStorage.setItem('hasSession', true);`
-  - visit the app: `http://localhost:3001/my-health/medical-records/summaries-and-notes/visit-summary/9A7AF40B2BC2471EA116891839113252`
+
+fore you get started check [this page](https://depo-platform-documentation.scrollhelp.site/developer-docs/setting-up-your-local-frontend-environment) first to make sure you are setup to use the correct version of Node and Yarn.
+
+- clone vets-website repo `git clone git@github.com:department-of-veterans-affairs/vets-website.git`
+- navigate to the AVS application `cd src/applications/avs`
+- run `yarn install`
+- turn on local mocks `yarn --cwd $( git rev-parse --show-toplevel ) mock-api --responses src/applications/avs/api/mocks/index.js`
+- start app `yarn --cwd $( git rev-parse --show-toplevel ) watch --env entry=avs`
+- Run this in your browser console to simulate being logged in `localStorage.setItem('hasSession', true);`
+- visit the app: `http://localhost:3001/my-health/medical-records/summaries-and-notes/visit-summary/9A7AF40B2BC2471EA116891839113252`
 
 ## Running tests
+
 Unit tests for can be run using this command: `yarn test:unit --app-folder avs`. To get detailed errors, run this command with `--log-level=error`. To get coverage reports run this command `yarn test:unit --app-folder avs --coverage --coverage-html`. View the report at `/coverage/index.html`
 
 Cypress tests can be run with the GUI using this command: `yarn cy:open`. From there you can filter by `avs` to run just AVS end to end tests.
 
 Run Cypress from command line:
+
 - Run all `yarn cy:run --spec "src/applications/avs/**/**/*"`
 - Specify browser `-b electron`

--- a/src/applications/avs/components/BreadCrumb.jsx
+++ b/src/applications/avs/components/BreadCrumb.jsx
@@ -15,7 +15,7 @@ const BreadCrumb = () => {
   const { referrer } = document;
   if (referrer && isPastAppointmentLink(referrer)) {
     return (
-      <div className="avs-breadcrumb vads-u-padding-top--1p5 vads-u-padding-bottom--3">
+      <div className="avs-breadcrumb vads-u-padding-top--1p5 vads-u-padding-bottom--1">
         <a onClick={goBack} href={referrer}>
           Back to appointment details
         </a>

--- a/src/applications/avs/containers/Avs.jsx
+++ b/src/applications/avs/containers/Avs.jsx
@@ -97,7 +97,7 @@ const Avs = props => {
         serviceRequired={[backendServices.USER_PROFILE]}
       >
         <BreadCrumb />
-        <h1>After-visit summary</h1>
+        <h1 className="vads-u-padding-top--2">After-visit summary</h1>
         {avs.meta?.pageHeader && (
           <p>
             <AvsPageHeader text={avs.meta.pageHeader} />


### PR DESCRIPTION
## Summary

Fixes spacing above H1 when there is no breadcrumb

## Testing done

- local testing

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Without Breadcrumb  |   ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/101649/2e3556ca-42f0-4895-a469-c45cf7b29f5d)     |   ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/101649/a79ddf92-19f4-4f90-91be-20ed98ffcba5)    |
| With Breadcrumb (meant to be the same) |   ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/101649/c624c09b-3c1a-4102-b1b0-19ff9bde2eb4)  |    ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/101649/62268637-b744-4ffe-9141-538d2ef52958)   |

## What areas of the site does it impact?

- AVS application only  
