### PR TITLE
fix: update to use sass variable instead of css variable

### DIFF
--- a/src/applications/personalization/profile/sass/profile.scss
+++ b/src/applications/personalization/profile/sass/profile.scss
@@ -98,18 +98,18 @@
     position: relative;
     display: list-item;
     text-align: -webkit-match-parent;
-    border-left: units(1) solid var(--color-gray-light);
+    border-left: units(1) solid $color-gray-light;
     margin: 0px !important;
     padding: 0 0 3.2rem 3.2rem;
 
     &:last-child {
       border-left: none;
-      padding-left: calc(3.1rem + 8px);
+      padding-left: calc(3.1rem + 9px);
       padding-bottom: 0;
     }
 
     &:before {
-      color: var(--color-white);
+      color: $color-white;
       content: counter(listCounter);
       float: left;
       font-size: 2.08rem;
@@ -119,8 +119,8 @@
       top: -0.4rem;
       margin-left: -5.6rem;
       display: block;
-      border: 4px solid var(--color-white);
-      background: var(--color-primary);
+      border: 4px solid $color-white;
+      background: $color-primary;
       border-radius: 4rem;
       position: relative;
       box-sizing: border-box !important;
@@ -131,7 +131,7 @@
   .item-complete::before {
     content: "\f00c";
     font-family: "Font Awesome 5 Free";
-    background: var(--color-green);
+    background: $color-green;
   }
 
   .item-heading {


### PR DESCRIPTION
## Summary

- Looks like some of the css variables were removed from the design system and so we need to hotfix so that the condtional process list uses the saas variable instead ☹️ 
- updates saas with those variables

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/79043

## Testing done

- Verified styling locally.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile - loa1  | ![Screenshot 2024-03-22 at 10 55 08 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/ca708ef6-e292-4c02-8ca2-24161d42046f) | ![Screenshot 2024-03-22 at 10 55 28 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/d732c81d-5ac7-4745-ac97-a8d8d0a0c74c) |
| Mobile - loa3 | ![Screenshot 2024-03-22 at 10 54 48 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/d22ed1c3-4a74-4619-8dc3-cc094e308067) | ![Screenshot 2024-03-22 at 10 54 09 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/3680d2c5-3bf4-47c8-bbaf-34ec4b980526) |
| Desktop - loa3 | ![Screenshot 2024-03-22 at 10 54 37 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/05bfc882-1697-4bba-a58b-50185b88d60b) | ![Screenshot 2024-03-22 at 10 54 21 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/b9681530-3228-46f4-a577-0655d28f8008) |

## What areas of the site does it impact?

Profile -> Account Security

## Acceptance criteria

- [x] Styling fixed

### Quality Assurance & Testing

- [x] Screenshot of the developed feature is added