### PR TITLE
fix: update all mailingAddressYesNo components to use hint instead of description

### DIFF
--- a/src/applications/simple-forms/20-10207/pages/mailingAddressYesNo.js
+++ b/src/applications/simple-forms/20-10207/pages/mailingAddressYesNo.js
@@ -8,7 +8,7 @@ export default {
   uiSchema: {
     mailingAddressYesNo: yesNoUI({
       title: 'Do you have a current mailing address?',
-      description:
+      hint:
         'If we have a way to contact you, we’ll be able to process this request faster. But we don’t require a mailing address for this request.',
       labels: MAILING_ADDRESS_YES_NO_LABELS,
       labelHeaderLevel: '3',

--- a/src/applications/simple-forms/20-10207/pages/mailingAddressYesNoThirdPartyNonVeteran.js
+++ b/src/applications/simple-forms/20-10207/pages/mailingAddressYesNoThirdPartyNonVeteran.js
@@ -8,7 +8,7 @@ export default {
   uiSchema: {
     mailingAddressYesNo: yesNoUI({
       title: 'Does the Claimant have a current mailing address?',
-      description:
+      hint:
         'If we have a way to contact the Claimant, we’ll be able to process this request faster. But we don’t require a mailing address for this request.',
       labels: MAILING_ADDRESS_YES_NO_LABELS_3RD_PTY_NON_VET,
       labelHeaderLevel: '3',

--- a/src/applications/simple-forms/20-10207/pages/mailingAddressYesNoThirdPartyVeteran.js
+++ b/src/applications/simple-forms/20-10207/pages/mailingAddressYesNoThirdPartyVeteran.js
@@ -8,7 +8,7 @@ export default {
   uiSchema: {
     mailingAddressYesNo: yesNoUI({
       title: 'Does the Veteran have a current mailing address?',
-      description:
+      hint:
         'If we have a way to contact the Veteran, we’ll be able to process this request faster. But we don’t require a mailing address for this request.',
       labels: MAILING_ADDRESS_YES_NO_LABELS_3RD_PTY_VET,
       labelHeaderLevel: '3',


### PR DESCRIPTION
## Summary

- Updated all instances of the mailingAddressYesNo component to utilize `hint` instead of `description`.
- This was a bug where the mailing address boolean radio button components were not showing hint text between the title and the options.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/VA.gov-team-forms#1154


## Testing done

- Browser Testing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |![Screenshot 2024-03-22 at 3 30 35 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/05b86f1a-3c9e-40ff-9caf-147c7e504347)|![Screenshot 2024-03-22 at 3 34 24 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/0705971d-af58-4f23-a302-2935abb7e8ec)|
| Mobile  |![Screenshot 2024-03-22 at 3 30 26 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/a155f7fe-9c98-4074-a8e5-fa429b66ca3d)|![Screenshot 2024-03-22 at 3 34 10 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/edbadc6c-2266-4a4c-97cb-eaf79907bded)|
| Mobile  |![Screenshot 2024-03-22 at 3 30 20 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/467b7c54-d676-4628-836e-482cfd5d2f06)|![Screenshot 2024-03-22 at 3 33 49 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/4de08aa9-37a7-41b7-9a7c-de81b505f214)|
| Desktop |![Screenshot 2024-03-22 at 3 24 52 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/e938afd8-c33e-452d-abf4-75c78d77018a)|![Screenshot 2024-03-22 at 3 23 25 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/75dbba35-d5c0-464f-a7e5-03c3b0ae27e6)|
| Desktop |![Screenshot 2024-03-22 at 3 24 46 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/fe5ebfff-690f-43e9-b5ac-b09c89e1c241)|![Screenshot 2024-03-22 at 3 23 17 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/156573f5-3b3b-48ff-bd61-a6dd541e8d79)|
| Desktop |![Screenshot 2024-03-22 at 3 24 39 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/dae872c6-516d-463f-912d-5fac0f92aafe)|![Screenshot 2024-03-22 at 3 23 08 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/6524fff5-bc95-4919-8823-35f96b1ed00a)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
