### PR TITLE
arf.77373 add ARP getPOARequestsByCode call to ARP

### DIFF
--- a/src/applications/accredited-representative-portal/actions/poaRequests.js
+++ b/src/applications/accredited-representative-portal/actions/poaRequests.js
@@ -7,9 +7,9 @@ const settings = {
   },
 };
 
-const handlePOARequest = async (veteranId, action) => {
+const handlePOARequest = async (poaId, action) => {
   try {
-    const resource = `/poa_requests/${veteranId}/${action}`;
+    const resource = `/power_of_attorney_requests/${poaId}/${action}`;
     const response = await apiRequest(resource, settings);
 
     if (!response.ok) {
@@ -23,7 +23,5 @@ const handlePOARequest = async (veteranId, action) => {
   }
 };
 
-export const acceptPOARequest = veteranId =>
-  handlePOARequest(veteranId, 'accept');
-export const declinePOARequest = veteranId =>
-  handlePOARequest(veteranId, 'decline');
+export const acceptPOARequest = poaId => handlePOARequest(poaId, 'accept');
+export const declinePOARequest = poaId => handlePOARequest(poaId, 'decline');

--- a/src/applications/accredited-representative-portal/actions/poaRequests.js
+++ b/src/applications/accredited-representative-portal/actions/poaRequests.js
@@ -9,5 +9,14 @@ const handlePOARequest = async (poaId, action) => {
   }
 };
 
+export const getPOARequestsByCode = async poaCode => {
+  try {
+    const resource = `/accredited_representative_portal/v0/power_of_attorney_requests?poaCode=${poaCode}`;
+    return await apiRequest(resource);
+  } catch (error) {
+    return error;
+  }
+};
+
 export const acceptPOARequest = poaId => handlePOARequest(poaId, 'accept');
 export const declinePOARequest = poaId => handlePOARequest(poaId, 'decline');

--- a/src/applications/accredited-representative-portal/actions/poaRequests.js
+++ b/src/applications/accredited-representative-portal/actions/poaRequests.js
@@ -1,25 +1,11 @@
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 
-const settings = {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-  },
-};
-
 const handlePOARequest = async (poaId, action) => {
   try {
-    const resource = `/power_of_attorney_requests/${poaId}/${action}`;
-    const response = await apiRequest(resource, settings);
-
-    if (!response.ok) {
-      throw new Error(`Server responded with status: ${response.status}`);
-    }
-
-    return { status: 'success' };
+    const resource = `/accredited_representative_portal/v0/power_of_attorney_requests/${poaId}/${action}`;
+    return await apiRequest(resource, { method: 'POST' });
   } catch (error) {
-    const errorMessage = error.message || 'An unexpected error occurred.';
-    return { status: 'error', error: errorMessage };
+    return error;
   }
 };
 

--- a/src/applications/accredited-representative-portal/tests/actions/poaRequests.unit.spec.js
+++ b/src/applications/accredited-representative-portal/tests/actions/poaRequests.unit.spec.js
@@ -14,9 +14,12 @@ afterEach(() => {
 describe('POA Request Handling', () => {
   it('handles acceptPOARequest successfully', async () => {
     server.use(
-      rest.post('/poa_requests/:veteranId/accept', (req, res, ctx) => {
-        return res(ctx.json({ status: 'success' }));
-      }),
+      rest.post(
+        '/power_of_attorney_requests/:poaId/accept',
+        (req, res, ctx) => {
+          return res(ctx.json({ status: 'success' }));
+        },
+      ),
     );
 
     const response = await acceptPOARequest('12345');
@@ -25,9 +28,12 @@ describe('POA Request Handling', () => {
 
   it('handles declinePOARequest successfully', async () => {
     server.use(
-      rest.post('/poa_requests/:veteranId/decline', (req, res, ctx) => {
-        return res(ctx.json({ status: 'success' }));
-      }),
+      rest.post(
+        '/power_of_attorney_requests/:poaId/decline',
+        (req, res, ctx) => {
+          return res(ctx.json({ status: 'success' }));
+        },
+      ),
     );
 
     const response = await declinePOARequest('12345');
@@ -36,9 +42,12 @@ describe('POA Request Handling', () => {
 
   it('returns an error status when the server responds with an error for accept', async () => {
     server.use(
-      rest.post('/poa_requests/:veteranId/accept', (req, res, ctx) => {
-        return res(ctx.status(500));
-      }),
+      rest.post(
+        '/power_of_attorney_requests/:poaId/accept',
+        (req, res, ctx) => {
+          return res(ctx.status(500));
+        },
+      ),
     );
 
     const response = await acceptPOARequest('12345');
@@ -50,9 +59,12 @@ describe('POA Request Handling', () => {
 
   it('returns an error status when the server responds with an error for decline', async () => {
     server.use(
-      rest.post('/poa_requests/:veteranId/decline', (req, res, ctx) => {
-        return res(ctx.status(500));
-      }),
+      rest.post(
+        '/power_of_attorney_requests/:poaId/decline',
+        (req, res, ctx) => {
+          return res(ctx.status(500));
+        },
+      ),
     );
 
     const response = await declinePOARequest('12345');
@@ -64,7 +76,7 @@ describe('POA Request Handling', () => {
 
   it('handles network errors gracefully for accept', async () => {
     server.use(
-      rest.post('/poa_requests/:veteranId/accept', (req, res) => {
+      rest.post('/power_of_attorney_requests/:poaId/accept', (req, res) => {
         return res.networkError('Failed to connect');
       }),
     );
@@ -78,7 +90,7 @@ describe('POA Request Handling', () => {
 
   it('handles network errors gracefully for decline', async () => {
     server.use(
-      rest.post('/poa_requests/:veteranId/decline', (req, res) => {
+      rest.post('/power_of_attorney_requests/:poaId/decline', (req, res) => {
         return res.networkError('Failed to connect');
       }),
     );

--- a/src/applications/accredited-representative-portal/tests/actions/poaRequests.unit.spec.js
+++ b/src/applications/accredited-representative-portal/tests/actions/poaRequests.unit.spec.js
@@ -1,0 +1,92 @@
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { expect } from 'chai';
+import { acceptPOARequest, declinePOARequest } from '../../actions/poaRequests';
+
+const server = setupServer();
+
+beforeEach(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+  server.close();
+});
+
+describe('POA Request Handling', () => {
+  it('handles acceptPOARequest successfully', async () => {
+    server.use(
+      rest.post('/poa_requests/:veteranId/accept', (req, res, ctx) => {
+        return res(ctx.json({ status: 'success' }));
+      }),
+    );
+
+    const response = await acceptPOARequest('12345');
+    expect(response).to.eq({ status: 'success' });
+  });
+
+  it('handles declinePOARequest successfully', async () => {
+    server.use(
+      rest.post('/poa_requests/:veteranId/decline', (req, res, ctx) => {
+        return res(ctx.json({ status: 'success' }));
+      }),
+    );
+
+    const response = await declinePOARequest('12345');
+    expect(response).to.eq({ status: 'success' });
+  });
+
+  it('returns an error status when the server responds with an error for accept', async () => {
+    server.use(
+      rest.post('/poa_requests/:veteranId/accept', (req, res, ctx) => {
+        return res(ctx.status(500));
+      }),
+    );
+
+    const response = await acceptPOARequest('12345');
+    expect(response).to.eq({
+      status: 'error',
+      error: 'Server responded with status: 500',
+    });
+  });
+
+  it('returns an error status when the server responds with an error for decline', async () => {
+    server.use(
+      rest.post('/poa_requests/:veteranId/decline', (req, res, ctx) => {
+        return res(ctx.status(500));
+      }),
+    );
+
+    const response = await declinePOARequest('12345');
+    expect(response).to.eq({
+      status: 'error',
+      error: 'Server responded with status: 500',
+    });
+  });
+
+  it('handles network errors gracefully for accept', async () => {
+    server.use(
+      rest.post('/poa_requests/:veteranId/accept', (req, res) => {
+        return res.networkError('Failed to connect');
+      }),
+    );
+
+    const response = await acceptPOARequest('12345');
+    expect(response).to.eq({
+      status: 'error',
+      error: 'An unexpected error occurred.',
+    });
+  });
+
+  it('handles network errors gracefully for decline', async () => {
+    server.use(
+      rest.post('/poa_requests/:veteranId/decline', (req, res) => {
+        return res.networkError('Failed to connect');
+      }),
+    );
+
+    const response = await declinePOARequest('12345');
+    expect(response).to.eq({
+      status: 'error',
+      error: 'An unexpected error occurred.',
+    });
+  });
+});

--- a/src/applications/accredited-representative-portal/tests/actions/poaRequests.unit.spec.js
+++ b/src/applications/accredited-representative-portal/tests/actions/poaRequests.unit.spec.js
@@ -1,7 +1,11 @@
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { expect } from 'chai';
-import { acceptPOARequest, declinePOARequest } from '../../actions/poaRequests';
+import {
+  acceptPOARequest,
+  declinePOARequest,
+  getPOARequestsByCode,
+} from '../../actions/poaRequests';
 import environment from '~/platform/utilities/environment';
 
 const prefix = `${environment.API_URL}/v0/accredited_representative_portal`;
@@ -98,6 +102,53 @@ describe('POA Request Handling', () => {
     );
 
     const response = await declinePOARequest('12345');
+    expect(response.status).to.equal(503);
+    expect(response.statusText).to.equal('Service Unavailable');
+  });
+});
+
+describe('POA Requests Retrieval', () => {
+  it('retrieves POA requests successfully', async () => {
+    const testPoaCode = 'AB123';
+    server.use(
+      rest.get(`${prefix}/v0/power_of_attorney_requests`, (req, res, ctx) => {
+        const queryPoaCode = req.url.searchParams.get('poaCode');
+        if (queryPoaCode === testPoaCode) {
+          return res(
+            ctx.json([{ id: '1', status: 'pending', poaCode: testPoaCode }]),
+            ctx.status(200),
+          );
+        }
+        return res(ctx.status(404));
+      }),
+    );
+
+    const response = await getPOARequestsByCode(testPoaCode);
+    expect(response).to.deep.equal([
+      { id: '1', status: 'pending', poaCode: testPoaCode },
+    ]);
+  });
+
+  it('returns an error status when the server responds with an error', async () => {
+    server.use(
+      rest.get(`${prefix}/v0/power_of_attorney_requests`, (_, res, ctx) => {
+        return res(ctx.status(500));
+      }),
+    );
+
+    const response = await getPOARequestsByCode('AB123');
+    expect(response.status).to.equal(500);
+    expect(response.statusText).to.equal('Internal Server Error');
+  });
+
+  it('handles network errors gracefully', async () => {
+    server.use(
+      rest.get(`${prefix}/v0/power_of_attorney_requests`, (_, res, ctx) => {
+        return res(ctx.status(503));
+      }),
+    );
+
+    const response = await getPOARequestsByCode('AB123');
     expect(response.status).to.equal(503);
     expect(response.statusText).to.equal('Service Unavailable');
   });

--- a/src/applications/ask-va/containers/ProfilePage.jsx
+++ b/src/applications/ask-va/containers/ProfilePage.jsx
@@ -17,7 +17,7 @@ const ProfileTest = ({ loggedIn }) => {
 
   const getData = async () => {
     const PROFILE_DATA = `${environment.API_URL}/ask_va_api/v0/static_data`;
-
+    // example
     const response = await apiRequest(PROFILE_DATA)
       .then(res => {
         return res;

--- a/src/applications/claims-status/actions/index.js
+++ b/src/applications/claims-status/actions/index.js
@@ -411,6 +411,7 @@ export function submitRequest(id) {
     }
 
     makeAuthRequest(
+      // example
       `/v0/evss_claims/${id}/request_decision`,
       { method: 'POST' },
       dispatch,

--- a/src/applications/claims-status/tests/actions.unit.spec.js
+++ b/src/applications/claims-status/tests/actions.unit.spec.js
@@ -469,6 +469,7 @@ describe('Actions', () => {
       const ID = 5;
       server.use(
         rest.post(
+          // example
           `https://dev-api.va.gov/v0/evss_claims/${ID}/request_decision`,
           (req, res, ctx) =>
             res(

--- a/src/applications/terms-of-use/containers/TermsOfUse.jsx
+++ b/src/applications/terms-of-use/containers/TermsOfUse.jsx
@@ -36,6 +36,7 @@ export default function TermsOfUse() {
   useEffect(
     () => {
       if (!termsCodeExists) {
+        // example
         apiRequest('/terms_of_use_agreements/v1/latest').catch(response => {
           const [{ code, title }] = response.errors;
           if (code === '401' || title?.includes('Not authorized')) {

--- a/src/applications/terms-of-use/tests/TermsOfUse.unit.spec.jsx
+++ b/src/applications/terms-of-use/tests/TermsOfUse.unit.spec.jsx
@@ -161,6 +161,7 @@ describe('TermsOfUse', () => {
         (_, res, ctx) => res(ctx.status(200)),
       ),
       rest.post(
+        // example
         `https://dev-api.va.gov/v0/terms_of_use_agreements/v1/decline`,
         (req, res, ctx) => {
           expect(req.url.searchParams.get('terms_code')).to.eql(termsCode);


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
Zenhub issue description:
#### Problem Statement
- We don't currently have a GET call to retrieve the POA Requests from a mock backend
- This is what should populate the POA Requests in the POA Requests Widget and the POA Requests Table

#### Implementation Details
- This should align with the POST calls that Accept or Deny a POA Requests utilizing the built-in VA API function

### Acceptance Criteria
- [ ] A GET call exists that retrieves mock JSON
- [ ] The POARequestsWidget and POARequestsTable are not populated by this GET request


## Related issue(s)
https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/77374

## Testing done
See unit test

## What areas of the site does it impact?
Accredited Representative Portal
