### PR TITLE
added back button to contact info page

### DIFF
--- a/src/applications/check-in/components/pages/demographics/DemographicsDisplay.jsx
+++ b/src/applications/check-in/components/pages/demographics/DemographicsDisplay.jsx
@@ -53,6 +53,7 @@ export default function DemographicsDisplay({
         noAction={noAction}
         pageType="demographic-information"
         router={router}
+        withBackButton
       />
     </>
   );

--- a/src/applications/check-in/day-of/pages/Demographics.jsx
+++ b/src/applications/check-in/day-of/pages/Demographics.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { useFormRouting } from '../../hooks/useFormRouting';
 import { seeStaffMessageUpdated } from '../../actions/day-of';
 import { recordAnswer } from '../../actions/universal';
+import BackButton from '../../components/BackButton';
 import DemographicsDisplay from '../../components/pages/demographics/DemographicsDisplay';
 import { makeSelectVeteranData } from '../../selectors';
 import { useStorage } from '../../hooks/useStorage';
@@ -17,7 +18,12 @@ const Demographics = props => {
   const { t } = useTranslation();
   const { demographics } = useSelector(selectVeteranData);
   const { router } = props;
-  const { goToNextPage, jumpToPage } = useFormRouting(router);
+  const {
+    goToNextPage,
+    jumpToPage,
+    goToPreviousPage,
+    getPreviousPageFromRouter,
+  } = useFormRouting(router);
   const { setShouldSendDemographicsFlags } = useStorage(APP_NAMES.CHECK_IN);
 
   const updateSeeStaffMessage = useCallback(
@@ -57,6 +63,11 @@ const Demographics = props => {
 
   return (
     <>
+      <BackButton
+        router={router}
+        action={goToPreviousPage}
+        prevUrl={getPreviousPageFromRouter()}
+      />
       <DemographicsDisplay
         demographics={demographics}
         yesAction={yesClick}


### PR DESCRIPTION
## Summary

This PR adds the back link to the contact information page in day-of check-in. Since this page is no longer the first page, it now needs a back button. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#78803


## Testing done

- Visual

## Screenshots

![localhost_3001_health-care_appointment-check-in_contact-information](https://github.com/department-of-veterans-affairs/vets-website/assets/13967174/287af422-d248-4531-9cd6-fb071c32f341)

## What areas of the site does it impact?

Day-of check-in application 

## Acceptance criteria
 - [ ] There is a back link on the contact information page
 - [ ] clicking it takes you back to the arrived page
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

