### PR TITLE
[VA-IIR 440] add search filters to summary text above results

### DIFF
--- a/src/applications/yellow-ribbon/constants/index.js
+++ b/src/applications/yellow-ribbon/constants/index.js
@@ -1,6 +1,10 @@
+export const CONTRIBUTION_AMOUNT_SUMMARY_TEXT =
+  '"Schools that provide maximum funding"';
 export const FETCH_RESULTS = 'yellow-ribbon/FETCH_RESULTS';
 export const FETCH_RESULTS_FAILURE = 'yellow-ribbon/FETCH_RESULTS_FAILURE';
 export const FETCH_RESULTS_SUCCESS = 'yellow-ribbon/FETCH_RESULTS_SUCCESS';
+export const NUMBER_OF_STUDENTS_SUMMARY_TEXT =
+  '"Schools that provide funding to all eligible students"';
 export const TOGGLE_SHOW_MOBILE_FORM = 'yellow-ribbon/TOGGLE_SHOW_MOBILE_FORM';
 export const TOGGLE_TOOL_TIP = 'yellow-ribbon/TOGGLE_TOOL_TIP';
 export const TOOL_TIP_LABEL = 'Tips to improve search results';

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
@@ -14,7 +14,12 @@ import { focusElement } from 'platform/utilities/ui';
 import SearchResult from '../../components/SearchResult';
 import { fetchResultsThunk, toggleSearchResultsToolTip } from '../../actions';
 import { getYellowRibbonAppState } from '../../helpers/selectors';
-import { TOOL_TIP_CONTENT, TOOL_TIP_LABEL } from '../../constants';
+import {
+  CONTRIBUTION_AMOUNT_SUMMARY_TEXT,
+  NUMBER_OF_STUDENTS_SUMMARY_TEXT,
+  TOOL_TIP_CONTENT,
+  TOOL_TIP_LABEL,
+} from '../../constants';
 import { getCurrentAcademicYear, titleCase } from '../../helpers';
 
 export class SearchResults extends Component {
@@ -65,23 +70,41 @@ export class SearchResults extends Component {
   };
 
   deriveAdditionalParamsString = () => {
-    const { name, stateOrTerritory, city } = this.getSearchParams();
-    const formattedName = name ? titleCase(name) : '';
-    const formattedCity = city ? titleCase(city) : '';
-    const additionalSearchParams = [];
+    const {
+      name,
+      stateOrTerritory,
+      city,
+      contributionAmount,
+      numberOfStudents,
+    } = this.getSearchParams();
 
-    if (formattedName)
-      additionalSearchParams.push(
-        <strong key="name">"{formattedName}"</strong>,
-      );
-    if (formattedCity)
-      additionalSearchParams.push(
-        <strong key="city">"{formattedCity}"</strong>,
-      );
-    if (stateOrTerritory)
-      additionalSearchParams.push(
-        <strong key="state">"{stateOrTerritory}"</strong>,
-      );
+    const searchParams = [
+      { key: 'name', value: name, transform: val => titleCase(val) },
+      { key: 'city', value: city, transform: val => titleCase(val) },
+      { key: 'stateOrTerritory', value: stateOrTerritory },
+      {
+        key: 'contributionAmount',
+        value: contributionAmount,
+        text: CONTRIBUTION_AMOUNT_SUMMARY_TEXT,
+      },
+      {
+        key: 'numberOfStudents',
+        value: numberOfStudents,
+        text: NUMBER_OF_STUDENTS_SUMMARY_TEXT,
+      },
+    ];
+
+    const additionalSearchParams = searchParams.reduce(
+      (acc, { key, value, transform, text }) => {
+        if (value) {
+          const formattedValue = transform ? transform(value) : value;
+          const displayText = text || `"${formattedValue}"`;
+          acc.push(<strong key={key}>{displayText}</strong>);
+        }
+        return acc;
+      },
+      [],
+    );
 
     // Combine elements with commas
     const additionalParamsJsx = additionalSearchParams.reduce(
@@ -94,7 +117,7 @@ export class SearchResults extends Component {
     );
 
     if (additionalParamsJsx.length > 0) {
-      return <>: {additionalParamsJsx}</>; // Return JSX fragment
+      return <>: {additionalParamsJsx}</>;
     }
 
     return null;


### PR DESCRIPTION
## Summary

- The following code adds the two search checkbox filters to the summary above the [Yellow Ribbon Search tool's](https://www.va.gov/education/yellow-ribbon-participating-schools/) results.
- I work for the VA-IIR (a.k.a., "Iterate, Innovate, and Run") contractor team under Oddball (primary) and Ad Hoc.

## Related issue(s)

- Closes [VA-IIR 440](https://github.com/department-of-veterans-affairs/va-iir/issues/440)

## Testing done

- Conducted local tests, which passed, and viewed expected behavior.

## Screenshots

| Before | After |
| ------ | ------ |
![Yellow Ribbon without search filters in results summary](https://github.com/department-of-veterans-affairs/vets-website/assets/146031450/07f101c8-16c0-4137-9d11-eba29b96d991 "Before") | ![Yellow Ribbon with search filters in results summary](https://github.com/department-of-veterans-affairs/vets-website/assets/146031450/eb74670c-297c-4ef8-9005-b36a8cc308b6 "After")

## Acceptance criteria

- [x] Add search filter text to the summary above the YR Program results.

### Quality Assurance & Testing

- [x] Screenshot of the developed feature is added

