### PR TITLE
Terms of Use - Staging Review (fixes)

### DIFF
--- a/src/applications/terms-of-use/components/TermsAcceptanceAction.jsx
+++ b/src/applications/terms-of-use/components/TermsAcceptanceAction.jsx
@@ -13,41 +13,39 @@ export default function TermsAcceptance({
 }) {
   const termsOfUseAuthorized = useSelector(termsOfUseEnabled);
   const className = isUnauthenticated ? 'hidden' : '';
+  const acceptBtnText =
+    isFullyAuthenticated && !isMiddleAuth ? 'Continue to accept' : 'Accept';
   return (
     <>
-      <h2 id="do-you-accept-of-terms-of-use" className={className}>
-        Do you accept these terms of use?
-      </h2>
-      {error.isError && (
-        <va-alert
-          status="error"
-          slim
-          visible
-          uswds
-          data-testid="error-non-modal"
-          class="vads-u-margin-y--1p5"
-        >
-          {error.message}
-        </va-alert>
-      )}
       {(isMiddleAuth || isFullyAuthenticated) &&
         termsOfUseAuthorized && (
           <>
+            <h2 id="do-you-accept-of-terms-of-use" className={className}>
+              Do you accept these terms of use?
+            </h2>
+            {error.isError && (
+              <va-alert
+                status="error"
+                slim
+                visible
+                uswds
+                data-testid="error-non-modal"
+                class="vads-u-margin-y--1p5"
+              >
+                {error.message}
+              </va-alert>
+            )}
             <va-button
               data-testid="accept"
-              text={`${
-                isFullyAuthenticated && !isMiddleAuth
-                  ? 'Continue to accept'
-                  : 'Accept'
-              }`}
+              text={acceptBtnText}
               onClick={() => handleTouClick('accept')}
-              ariaLabel="I accept the VA online services terms of use"
+              ariaLabel="Accept the VA online services terms of use"
             />
             <va-button
               data-testid="decline"
               text="Decline"
               secondary
-              ariaLabel="I decline the VA online services terms of use"
+              ariaLabel="Decline the VA online services terms of use"
               onClick={() => setShowDeclineModal(true)}
             />
           </>

--- a/src/applications/terms-of-use/containers/TermsOfUse.jsx
+++ b/src/applications/terms-of-use/containers/TermsOfUse.jsx
@@ -95,12 +95,10 @@ export default function TermsOfUse() {
       {isMiddleAuth &&
         !isFullyAuthenticated &&
         !isUnauthenticated && <style>{touStyles}</style>}
-      <section className="vads-l-grid-container vads-u-padding-y--5">
-        <div className="usa-content">
-          <h1 className="vads-u-padding-x--1 medium-screen:vads-u-padding-x--0">
-            VA online services terms of use
-          </h1>
-          <p className="va-introtext vads-u-padding-x--1 medium-screen:vads-u-padding-x--0">
+      <section className="usa-grid usa-grid-full">
+        <article className="usa-content vads-u-padding-x--1 medium-screen:vads-u-padding-x--0">
+          <h1>VA online services terms of use</h1>
+          <p className="va-introtext">
             {isUnauthenticated &&
               'We’ve recently updated our terms of use for VA.gov and other VA online services. Read the updated terms on this page. If you haven’t yet accepted these terms, you can sign in and accept them now.'}
             {isMiddleAuth &&
@@ -120,75 +118,73 @@ export default function TermsOfUse() {
               </a>
             </div>
           )}
-          <article>
-            <div>
-              <p>
-                Version: 1<br />
-                Last updated: {touUpdatedDate}
-              </p>
-            </div>
-            <h2 id="terms-of-use">Terms of use</h2>
-            <div>
-              <va-accordion bordered>
-                {touData.map(({ header, content }, i) => (
-                  <va-accordion-item
-                    header={header}
-                    level={3}
-                    key={header}
-                    part={`item-${i}`}
-                  >
-                    {content}
-                  </va-accordion-item>
-                ))}
-              </va-accordion>
-            </div>
-            <h2 id="getting-va-benefits-and-services">
-              Getting VA benefits and services if you don’t accept
-            </h2>
+          <div>
             <p>
-              Your decision to decline these terms won’t affect your eligibility
-              for VA health care and benefits in any way. You can still get VA
-              health care and benefits without using online services. If you
-              need help or have questions, <IdentityPhone /> We’re here 24/7.
+              Version: 1<br />
+              Last updated: {touUpdatedDate}
             </p>
-            <va-alert status="warning" visible>
-              <h3 slot="headline" id="what-happens-if-you-decline">
-                What will happen if you decline
-              </h3>
-              <p>
-                If you decline these terms, we’ll sign you out. You can still
-                get VA health care and benefits by phone, by mail, or in person.
-                But you won't be able to use some VA online services, including
-                these services:
-              </p>
-              <ul>
-                <li>VA.gov</li>
-                <li>My HealtheVet</li>
-                <li>My VA Health</li>
-                <li>VA Health and Benefits Mobile App</li>
-              </ul>
-              <p>
-                This means you won’t be able to do these types of things using
-                VA online services:
-              </p>
-              <ul>
-                <li>Apply for some benefits</li>
-                <li>Check your claim status</li>
-                <li>Send messages to your VA health care providers</li>
-                <li>Refill your prescriptions</li>
-                <li>Update your personal information</li>
-              </ul>
-            </va-alert>
-            <TermsAcceptance
-              error={error}
-              isMiddleAuth={isMiddleAuth}
-              handleTouClick={handleTouClick}
-              setShowDeclineModal={setShowDeclineModal}
-              isFullyAuthenticated={isFullyAuthenticated}
-              isUnauthenticated={isUnauthenticated}
-            />
-          </article>
-        </div>
+          </div>
+          <h2 id="terms-of-use">Terms of use</h2>
+          <div>
+            <va-accordion bordered>
+              {touData.map(({ header, content }, i) => (
+                <va-accordion-item
+                  header={header}
+                  level={3}
+                  key={header}
+                  part={`item-${i}`}
+                >
+                  {content}
+                </va-accordion-item>
+              ))}
+            </va-accordion>
+          </div>
+          <h2 id="getting-va-benefits-and-services">
+            Getting VA benefits and services if you don’t accept
+          </h2>
+          <p>
+            Your decision to decline these terms won’t affect your eligibility
+            for VA health care and benefits in any way. You can still get VA
+            health care and benefits without using online services. If you need
+            help or have questions, <IdentityPhone /> We’re here 24/7.
+          </p>
+          <va-alert status="warning" visible>
+            <h3 slot="headline" id="what-happens-if-you-decline">
+              What will happen if you decline
+            </h3>
+            <p>
+              If you decline these terms, we’ll sign you out. You can still get
+              VA health care and benefits by phone, by mail, or in person. But
+              you won't be able to use some VA online services, including these
+              services:
+            </p>
+            <ul>
+              <li>VA.gov</li>
+              <li>My HealtheVet</li>
+              <li>My VA Health</li>
+              <li>VA Health and Benefits Mobile App</li>
+            </ul>
+            <p>
+              This means you won’t be able to do these types of things using VA
+              online services:
+            </p>
+            <ul>
+              <li>Apply for some benefits</li>
+              <li>Check your claim status</li>
+              <li>Send messages to your VA health care providers</li>
+              <li>Refill your prescriptions</li>
+              <li>Update your personal information</li>
+            </ul>
+          </va-alert>
+          <TermsAcceptance
+            error={error}
+            isMiddleAuth={isMiddleAuth}
+            handleTouClick={handleTouClick}
+            setShowDeclineModal={setShowDeclineModal}
+            isFullyAuthenticated={isFullyAuthenticated}
+            isUnauthenticated={isUnauthenticated}
+          />
+        </article>
         <VaModal
           visible={showDeclineModal}
           clickToClose


### PR DESCRIPTION
## Summary
This PR includes the body of work that came from the Staging Review of Terms of Use. The PR fixes the following items

- [x] Fixes the margin/padding of the Terms of Use [issue #78953](department-of-veterans-affairs/va.gov-team#78953)
    - Changes `vads-l-grid-container vads-u-padding-y--5` to => `usa-grid usa-grid-full`
    - Changes the inner wrapper from a `div` to `article` tag (VA Design System `article` has x-padding built-in)
    - Remove `vads-u-padding-x--1 medium-screen:vads-u-padding-x--0` CSS class from `h1` and `p.va-introtext`
- [x] Remove the `aria-label` for the button [issue #78948](department-of-veterans-affairs/va.gov-team#78948)
- [x] Adds content for external anchor tags with `(opens in a new tab)` [issue #78949](department-of-veterans-affairs/va.gov-team#78949)
    - *This is for screen-reader users ONLY

## Related issue(s)

- closes department-of-veterans-affairs/va.gov-team#78953
- closes department-of-veterans-affairs/va.gov-team#78948
- closes department-of-veterans-affairs/va.gov-team#78949


## Testing done

- Unit tests + manual tests

## Screenshots
n/a - Unchanged

## What areas of the site does it impact?
Terms of use in staging & below environments

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
