### PR TITLE
[Rated Disabilities] - Update va-link to v3 component

### DIFF
--- a/src/applications/rated-disabilities/components/CombinedRating.jsx
+++ b/src/applications/rated-disabilities/components/CombinedRating.jsx
@@ -33,7 +33,6 @@ export default function CombinedRating({ combinedRating }) {
         href="/claim-or-appeal-status"
         onClick={clickHandler}
         text="Check the status of your claims, decision reviews, or appeals online"
-        uswds="false"
       />
     </va-summary-box>
   );


### PR DESCRIPTION
## Summary

Updated the va-link in CombinedRating.jsx to  use the v3 component. Found that a va-link using v1 was added after our audit of disability ratings and our initial pr to update all components to v3 didnt update this. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#76124

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| CombinedRating.jsx  | ![Screenshot 2024-03-25 at 12 10 20 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/d2c4ca52-17b2-4c71-a9b9-98ea443c901a) | ![Screenshot 2024-03-25 at 12 35 46 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/e1ebd2b8-85cd-426f-a579-a920609a1622) |

## What areas of the site does it impact?

Rated Disabilities

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
