### PR TITLE
Add yes/no page for medical treatment for 20-10207

### DIFF
--- a/src/applications/simple-forms/20-10207/config/constants.js
+++ b/src/applications/simple-forms/20-10207/config/constants.js
@@ -541,3 +541,72 @@ export const workInProgressContent = {
   redirectLink: '/',
   redirectText: 'Return to VA home page',
 };
+
+const HAS_RECEIVED_MEDICAL_TREATMENT_TITLES = {
+  [PREPARER_TYPES.VETERAN]:
+    'Have you received medical treatment for any medical issues related to this request?',
+  [PREPARER_TYPES.NON_VETERAN]:
+    'Have you received medical treatment for any medical issues related to this request?',
+  [PREPARER_TYPES.THIRD_PARTY_VETERAN]:
+    'Has the Veteran received medical treatment for any medical issues related to this request?',
+  [PREPARER_TYPES.THIRD_PARTY_NON_VETERAN]:
+    'Has the claimant received medical treatment for any medical issues related to this request?',
+};
+
+export function hasMedicalTreatmentTitle(formData) {
+  if (!formData?.preparerType) {
+    return HAS_RECEIVED_MEDICAL_TREATMENT_TITLES[PREPARER_TYPES.VETERAN];
+  }
+  return HAS_RECEIVED_MEDICAL_TREATMENT_TITLES[formData.preparerType];
+}
+
+const HAS_RECEIVED_MEDICAL_TREATMENT_YES_LABELS = {
+  [PREPARER_TYPES.VETERAN]: 'Yes, I have received medical treatment',
+  [PREPARER_TYPES.NON_VETERAN]: 'Yes, I have received medical treatment',
+  [PREPARER_TYPES.THIRD_PARTY_VETERAN]:
+    'Yes, the Veteran has received medical treatment',
+  [PREPARER_TYPES.THIRD_PARTY_NON_VETERAN]:
+    'Yes, the claimant has received medical treatment',
+};
+
+export function hasMedicalTreatmentTitleYesLabel(formData) {
+  if (!formData?.preparerType) {
+    return HAS_RECEIVED_MEDICAL_TREATMENT_YES_LABELS[PREPARER_TYPES.VETERAN];
+  }
+  return HAS_RECEIVED_MEDICAL_TREATMENT_YES_LABELS[formData.preparerType];
+}
+
+const HAS_RECEIVED_MEDICAL_TREATMENT_NO_LABELS = {
+  [PREPARER_TYPES.VETERAN]: 'No, I have not received medical treatment',
+  [PREPARER_TYPES.NON_VETERAN]: 'No, I have not received medical treatment',
+  [PREPARER_TYPES.THIRD_PARTY_VETERAN]:
+    'No, the Veteran has not received medical treatment',
+  [PREPARER_TYPES.THIRD_PARTY_NON_VETERAN]:
+    'No, the claimant has not received medical treatment',
+};
+
+export function hasMedicalTreatmentTitleNoLabel(formData) {
+  if (!formData?.preparerType) {
+    return HAS_RECEIVED_MEDICAL_TREATMENT_NO_LABELS[PREPARER_TYPES.VETERAN];
+  }
+  return HAS_RECEIVED_MEDICAL_TREATMENT_NO_LABELS[formData.preparerType];
+}
+
+const HAS_RECEIVED_MEDICAL_TREATMENT_ERROR_MESSAGES = {
+  [PREPARER_TYPES.VETERAN]: 'Select yes if you have received medical treatment',
+  [PREPARER_TYPES.NON_VETERAN]:
+    'Select yes if you have received medical treatment',
+  [PREPARER_TYPES.THIRD_PARTY_VETERAN]:
+    'Select yes if the Veteran has received medical treatment',
+  [PREPARER_TYPES.THIRD_PARTY_NON_VETERAN]:
+    'Select yes if the claimant has received medical treatment',
+};
+
+export function hasMedicalTreatmentTitleErrorMessage(formData) {
+  if (!formData?.preparerType) {
+    return HAS_RECEIVED_MEDICAL_TREATMENT_ERROR_MESSAGES[
+      PREPARER_TYPES.VETERAN
+    ];
+  }
+  return HAS_RECEIVED_MEDICAL_TREATMENT_ERROR_MESSAGES[formData.preparerType];
+}

--- a/src/applications/simple-forms/20-10207/config/form.js
+++ b/src/applications/simple-forms/20-10207/config/form.js
@@ -48,10 +48,16 @@ import powConfinementPg from '../pages/evidenceConfinement';
 import powConfinement2Pg from '../pages/evidenceConfinement2';
 import powDocsPg from '../pages/evidencePowDocuments';
 import medalAwardPg from '../pages/evidenceMedalAward';
+import hasReceivedMedicalTreatmentPg from '../pages/medicalTreatmentYesNo';
 import medTreatmentPg from '../pages/medicalTreatment';
 import medTreatment3rdPtyVetPg from '../pages/medicalTreatmentThirdPartyVeteran';
 import medTreatment3rdPtyNonVetPg from '../pages/medicalTreatmentThirdPartyNonVeteran';
-import { PREPARER_TYPES, SUBTITLE, TITLE } from './constants';
+import {
+  PREPARER_TYPES,
+  SUBTITLE,
+  TITLE,
+  hasMedicalTreatmentTitle,
+} from './constants';
 import {
   getMockData,
   getPersonalInformationChapterTitle,
@@ -518,10 +524,17 @@ const formConfig = {
     medicalTreatmentChapter: {
       title: 'Medical treatment',
       pages: {
+        hasReceivedMedicalTreatmentPage: {
+          title: hasMedicalTreatmentTitle,
+          path: 'has-received-medical-treatment',
+          uiSchema: hasReceivedMedicalTreatmentPg.uiSchema,
+          schema: hasReceivedMedicalTreatmentPg.schema,
+        },
         medicalTreatmentPage: {
           depends: formData =>
-            formData.preparerType === PREPARER_TYPES.VETERAN ||
-            formData.preparerType === PREPARER_TYPES.NON_VETERAN,
+            formData['view:hasReceivedMedicalTreatment'] &&
+            (formData.preparerType === PREPARER_TYPES.VETERAN ||
+              formData.preparerType === PREPARER_TYPES.NON_VETERAN),
           title: 'Where did you receive medical treatment?', // for review page (has to be more than one word)
           path: 'medical-treatment',
           uiSchema: medTreatmentPg.uiSchema,
@@ -530,6 +543,7 @@ const formConfig = {
         },
         medicalTreatmentThirdPartyVeteranPage: {
           depends: formData =>
+            formData['view:hasReceivedMedicalTreatment'] &&
             formData.preparerType === PREPARER_TYPES.THIRD_PARTY_VETERAN,
           title: 'Where did the veteran receive medical treatment?',
           path: 'medical-treatment-third-party-veteran',
@@ -539,6 +553,7 @@ const formConfig = {
         },
         medicalTreatmentThirdPartyNonVeteranPage: {
           depends: formData =>
+            formData['view:hasReceivedMedicalTreatment'] &&
             formData.preparerType === PREPARER_TYPES.THIRD_PARTY_NON_VETERAN,
           title: 'Where did the claimant receive medical treatment?',
           path: 'medical-treatment-third-party-non-veteran',

--- a/src/applications/simple-forms/20-10207/config/submit-transformer.js
+++ b/src/applications/simple-forms/20-10207/config/submit-transformer.js
@@ -4,6 +4,9 @@ import livingSituation from '../pages/livingSituation';
 import { PREPARER_TYPES } from './constants';
 
 export default function transformForSubmit(formConfig, form) {
+  const hasReceivedMedicalTreatment =
+    form?.data?.['view:hasReceivedMedicalTreatment'];
+
   const transformedData = JSON.parse(
     sharedTransformForSubmit(formConfig, form),
   );
@@ -25,6 +28,10 @@ export default function transformForSubmit(formConfig, form) {
     ],
     MEDAL_AWARD: 'medalAwardDocuments',
   };
+
+  if (!hasReceivedMedicalTreatment && transformedData.medicalTreatments) {
+    delete transformedData.medicalTreatments;
+  }
 
   // TODO: Once PDF has been updated to remove OCR-boxes,
   // remove this name-values truncation-block below.

--- a/src/applications/simple-forms/20-10207/pages/medicalTreatment.js
+++ b/src/applications/simple-forms/20-10207/pages/medicalTreatment.js
@@ -61,6 +61,7 @@ export default {
             }),
             startDate: currentOrPastDateSchema,
           },
+          required: ['facilityName', 'facilityAddress', 'startDate'],
         },
       },
     },

--- a/src/applications/simple-forms/20-10207/pages/medicalTreatmentThirdPartyNonVeteran.js
+++ b/src/applications/simple-forms/20-10207/pages/medicalTreatmentThirdPartyNonVeteran.js
@@ -61,6 +61,7 @@ export default {
             }),
             startDate: currentOrPastDateSchema,
           },
+          required: ['facilityName', 'facilityAddress', 'startDate'],
         },
       },
     },

--- a/src/applications/simple-forms/20-10207/pages/medicalTreatmentThirdPartyVeteran.js
+++ b/src/applications/simple-forms/20-10207/pages/medicalTreatmentThirdPartyVeteran.js
@@ -61,6 +61,7 @@ export default {
             }),
             startDate: currentOrPastDateSchema,
           },
+          required: ['facilityName', 'facilityAddress', 'startDate'],
         },
       },
     },

--- a/src/applications/simple-forms/20-10207/pages/medicalTreatmentYesNo.js
+++ b/src/applications/simple-forms/20-10207/pages/medicalTreatmentYesNo.js
@@ -1,0 +1,38 @@
+import {
+  yesNoSchema,
+  yesNoUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import {
+  hasMedicalTreatmentTitle,
+  hasMedicalTreatmentTitleErrorMessage,
+  hasMedicalTreatmentTitleNoLabel,
+  hasMedicalTreatmentTitleYesLabel,
+} from '../config/constants';
+
+/** @type {PageSchema} */
+export default {
+  uiSchema: {
+    'view:hasReceivedMedicalTreatment': yesNoUI({
+      labelHeaderLevel: 3,
+      updateUiSchema: formData => ({
+        'ui:title': hasMedicalTreatmentTitle(formData),
+        'ui:options': {
+          labels: {
+            Y: hasMedicalTreatmentTitleYesLabel(formData),
+            N: hasMedicalTreatmentTitleNoLabel(formData),
+          },
+        },
+        'ui:errorMessages': {
+          required: hasMedicalTreatmentTitleErrorMessage(formData),
+        },
+      }),
+    }),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      'view:hasReceivedMedicalTreatment': yesNoSchema,
+    },
+    required: ['view:hasReceivedMedicalTreatment'],
+  },
+};

--- a/src/applications/simple-forms/20-10207/tests/e2e/10207-pp.cypress.spec.js
+++ b/src/applications/simple-forms/20-10207/tests/e2e/10207-pp.cypress.spec.js
@@ -66,25 +66,11 @@ const testConfig = createTestConfig(
       'veteran-mailing-address': ({ afterHook }) => {
         afterHook(() => {
           cy.get('@testData').then(data => {
-            cy.get(
-              'va-segmented-progress-bar[uswds][heading-text][header-level="2"]',
-            )
-              .should('be.visible')
-              .then(() => {
-                cy.get('[name="root_veteranMailingAddress_state"]')
-                  .should('not.have.attr', 'disabled')
-                  .then(() => {
-                    // callback to avoid field-disabled errors, but
-                    // even now we must wait a bit!
-                    // eslint-disable-next-line cypress/no-unnecessary-waiting
-                    cy.wait(500);
-                    fillAddressWebComponentPattern(
-                      'veteranMailingAddress',
-                      data.veteranMailingAddress,
-                    );
-                    cy.findByText(/continue/i, { selector: 'button' }).click();
-                  });
-              });
+            fillAddressWebComponentPattern(
+              'veteranMailingAddress',
+              data.veteranMailingAddress,
+            );
+            cy.findByText(/continue/i, { selector: 'button' }).click();
           });
         });
       },

--- a/src/applications/simple-forms/20-10207/tests/e2e/10207-pp.cypress.spec.js
+++ b/src/applications/simple-forms/20-10207/tests/e2e/10207-pp.cypress.spec.js
@@ -138,7 +138,7 @@ const testConfig = createTestConfig(
 
     setupPerTest: () => {
       cy.intercept('/v0/api', { status: 200 });
-      cy.intercept('/v0/feature_toggles', featureToggles);
+      cy.intercept('/v0/feature_toggles*', featureToggles);
       cy.intercept('PUT', '/v0/in_progress_forms/20-10207', sipPut);
       cy.intercept('GET', '/v0/in_progress_forms/20-10207', sipGet);
       cy.intercept(formConfig.submitUrl, mockSubmit);
@@ -147,7 +147,7 @@ const testConfig = createTestConfig(
 
     // Skip tests in CI until the form is released.
     // Remove this setting when the form has a content page in production.
-    skip: Cypress.env('CI'),
+    // skip: Cypress.env('CI'),
   },
   manifest,
   formConfig,

--- a/src/applications/simple-forms/20-10207/tests/e2e/e2eHelpers.js
+++ b/src/applications/simple-forms/20-10207/tests/e2e/e2eHelpers.js
@@ -88,28 +88,40 @@ export const showsCorrectErrorMessage = message => {
 
 export const fillNameAndDateOfBirthPage = story => {
   const data = getTestData(story);
-  const dob = data.dateOfBirth.split('-');
+  const dob = data.veteranDateOfBirth.split('-');
 
-  cy.get('input[name="root_fullName_first"]').type(data.fullName.first, {
-    force: true,
-  });
-  cy.get('input[name="root_fullName_last"]').type(data.fullName.last, {
-    force: true,
-  });
-  cy.get('select[name="root_dateOfBirthMonth"]').select(
+  // TODO: refactor based on story if adding new stories
+  cy.get('input[name="root_veteranFullName_first"]').type(
+    data.veteranFullName.first,
+    {
+      force: true,
+    },
+  );
+  cy.get('input[name="root_veteranFullName_last"]').type(
+    data.veteranFullName.last,
+    {
+      force: true,
+    },
+  );
+  cy.get('select[name="root_veteranDateOfBirthMonth"]').select(
     parseInt(dob[1], 10).toString(),
   );
-  cy.get('input[name="root_dateOfBirthDay"]').type(
+  cy.get('input[name="root_veteranDateOfBirthDay"]').type(
     parseInt(dob[2], 10).toString(),
     { force: true },
   );
-  cy.get('input[name="root_dateOfBirthYear"]').type(dob[0], { force: true });
+  cy.get('input[name="root_veteranDateOfBirthYear"]').type(dob[0], {
+    force: true,
+  });
 };
 
 export const fillIdInfoPage = story => {
   const data = getTestData(story);
 
-  cy.get('input[name="root_id_ssn"]').type(data.id.ssn, { force: true });
+  // TODO: refactor based on story if adding new stories
+  cy.get('input[name="root_veteranId_ssn"]').type(data.veteranId.ssn, {
+    force: true,
+  });
 };
 
 export const fillLivingSituationPage = story => {

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/nonVeteran-maximal-1.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/nonVeteran-maximal-1.json
@@ -52,7 +52,7 @@
     "powConfinement2EndDate": "2013-01-04",
     "medicalTreatments": [
       {
-        "facilityName": "Guido’s Trailer",
+        "facilityName": "Facility Name",
         "facilityAddress": {
           "country": "USA",
           "street": "123 Any St",

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/nonVeteran-maximal-2.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/nonVeteran-maximal-2.json
@@ -50,7 +50,7 @@
     "powConfinement2EndDate": "2013-01-04",
     "medicalTreatments": [
       {
-        "facilityName": "Guido’s Trailer",
+        "facilityName": "Facility Name",
         "facilityAddress": {
           "country": "USA",
           "street": "123 Any St",

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/nonVeteran-minimal.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/nonVeteran-minimal.json
@@ -27,7 +27,7 @@
     },
     "medicalTreatments": [
       {
-        "facilityName": "Guido’s Trailer",
+        "facilityName": "Facility Name",
         "facilityAddress": {
           "country": "USA",
           "street": "123 Any St",

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/thirdPartyNonVeteran-maximal-1.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/thirdPartyNonVeteran-maximal-1.json
@@ -57,7 +57,7 @@
     "powConfinement2EndDate": "2013-01-04",
     "medicalTreatments": [
       {
-        "facilityName": "Guido’s Trailer",
+        "facilityName": "Facility Name",
         "facilityAddress": {
           "country": "USA",
           "street": "123 Any St",

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/thirdPartyNonVeteran-maximal-2.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/thirdPartyNonVeteran-maximal-2.json
@@ -55,7 +55,7 @@
     "powConfinement2EndDate": "2013-01-04",
     "medicalTreatments": [
       {
-        "facilityName": "Guido’s Trailer",
+        "facilityName": "Facility Name",
         "facilityAddress": {
           "country": "USA",
           "street": "123 Any St",

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/thirdPartyNonVeteran-minimal.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/thirdPartyNonVeteran-minimal.json
@@ -32,7 +32,7 @@
     },
     "medicalTreatments": [
       {
-        "facilityName": "Guido’s Trailer",
+        "facilityName": "Facility Name",
         "facilityAddress": {
           "country": "USA",
           "street": "123 Any St",

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/thirdPartyVeteran-maximal-1.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/thirdPartyVeteran-maximal-1.json
@@ -47,7 +47,7 @@
     "powConfinement2EndDate": "2013-01-04",
     "medicalTreatments": [
       {
-        "facilityName": "Guido’s Trailer",
+        "facilityName": "Facility Name",
         "facilityAddress": {
           "country": "USA",
           "street": "123 Any St",

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/thirdPartyVeteran-maximal-2.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/thirdPartyVeteran-maximal-2.json
@@ -45,7 +45,7 @@
     "powConfinement2EndDate": "2013-01-04",
     "medicalTreatments": [
       {
-        "facilityName": "Guido’s Trailer",
+        "facilityName": "Facility Name",
         "facilityAddress": {
           "country": "USA",
           "street": "123 Any St",

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/thirdPartyVeteran-minimal.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/thirdPartyVeteran-minimal.json
@@ -24,7 +24,7 @@
     },
     "medicalTreatments": [
       {
-        "facilityName": "Guido’s Trailer",
+        "facilityName": "Facility Name",
         "facilityAddress": {
           "country": "USA",
           "street": "123 Any St",

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/veteran-maximal-1.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/veteran-maximal-1.json
@@ -42,7 +42,7 @@
     "powConfinement2EndDate": "2013-01-04",
     "medicalTreatments": [
       {
-        "facilityName": "Guido’s Trailer",
+        "facilityName": "Facility Name",
         "facilityAddress": {
           "country": "USA",
           "street": "123 Any St",

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/veteran-maximal-2.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/veteran-maximal-2.json
@@ -40,7 +40,7 @@
     "powConfinement2EndDate": "2013-01-04",
     "medicalTreatments": [
       {
-        "facilityName": "Guido’s Trailer",
+        "facilityName": "Facility Name",
         "facilityAddress": {
           "country": "USA",
           "street": "123 Any St",

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/veteran-minimal.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/backend-mapping-support/veteran-minimal.json
@@ -19,7 +19,7 @@
     },
     "medicalTreatments": [
       {
-        "facilityName": "Guido’s Trailer",
+        "facilityName": "Facility Name",
         "facilityAddress": {
           "country": "USA",
           "street": "123 Any St",

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/nonVeteran.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/nonVeteran.json
@@ -32,9 +32,10 @@
     "otherReasons": {
       "OVER_85": true
     },
+    "view:hasReceivedMedicalTreatment": true,
     "medicalTreatments": [
       {
-        "facilityName": "Guido’s Trailer",
+        "facilityName": "Facility Name",
         "facilityAddress": {
           "country": "USA",
           "street": "123 Any St",

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/nonVeteranOtherHousingRisks.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/nonVeteranOtherHousingRisks.json
@@ -16,6 +16,7 @@
     "phone": "1234567891",
     "other_reasons": {
       "AGE_85": true
-    }
+    },
+    "view:hasReceivedMedicalTreatment": false
   }
 }

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/thirdPartyNonVeteran.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/thirdPartyNonVeteran.json
@@ -37,9 +37,10 @@
     "otherReasons": {
       "OVER_85": true
     },
+    "view:hasReceivedMedicalTreatment": true,
     "medicalTreatments": [
       {
-        "facilityName": "Guido’s Trailer",
+        "facilityName": "Facility Name",
         "facilityAddress": {
           "country": "USA",
           "street": "123 Any St",

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/thirdPartyNonVeteranOtherHousingRisks.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/thirdPartyNonVeteranOtherHousingRisks.json
@@ -21,6 +21,7 @@
     "phone": "1234567893",
     "other_reasons": {
       "AGE_85": true
-    }
+    },
+    "view:hasReceivedMedicalTreatment": false
   }
 }

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/thirdPartyVeteran.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/thirdPartyVeteran.json
@@ -29,9 +29,10 @@
     "otherReasons": {
       "OVER_85": true
     },
+    "view:hasReceivedMedicalTreatment": true,
     "medicalTreatments": [
       {
-        "facilityName": "Guido’s Trailer",
+        "facilityName": "Facility Name",
         "facilityAddress": {
           "country": "USA",
           "street": "123 Any St",

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/thirdPartyVeteranOtherHousingRisks.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/thirdPartyVeteranOtherHousingRisks.json
@@ -21,6 +21,7 @@
     "phone": "1234567892",
     "other_reasons": {
       "AGE_85": true
-    }
+    },
+    "view:hasReceivedMedicalTreatment": false
   }
 }

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/veteran.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/veteran.json
@@ -24,9 +24,10 @@
     "otherReasons": {
       "OVER_85": true
     },
+    "view:hasReceivedMedicalTreatment": true,
     "medicalTreatments": [
       {
-        "facilityName": "Guido’s Trailer",
+        "facilityName": "Facility Name",
         "facilityAddress": {
           "country": "USA",
           "street": "123 Any St",

--- a/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/veteranOtherHousingRisks.json
+++ b/src/applications/simple-forms/20-10207/tests/e2e/fixtures/data/veteranOtherHousingRisks.json
@@ -16,6 +16,7 @@
     "phone": "1234567890",
     "other_reasons": {
       "AGE_85": true
-    }
+    },
+    "view:hasReceivedMedicalTreatment": false
   }
 }

--- a/src/applications/simple-forms/20-10207/tests/e2e/veteran-story.cypress.spec.js
+++ b/src/applications/simple-forms/20-10207/tests/e2e/veteran-story.cypress.spec.js
@@ -1,6 +1,5 @@
 /* eslint-disable @department-of-veterans-affairs/axe-check-required */
 // the standard 10207-pp.cypress.spec.js already axe-checks everything
-import moment from 'moment';
 import { TITLE, SUBTITLE } from '../../config/constants';
 import manifest from '../../manifest.json';
 import featureToggles from './fixtures/mocks/featureToggles.json';
@@ -22,8 +21,6 @@ import {
   showsCorrectOtherReasonsLabels,
 } from './e2eHelpers';
 import mockUploadResponse from './fixtures/mocks/upload.json';
-import sipPut from './fixtures/mocks/sip-put.json';
-import sipGet from './fixtures/mocks/sip-get.json';
 
 // Skip in CI
 const testSuite = Cypress.env('CI') ? describe.skip : describe;
@@ -74,8 +71,7 @@ testSuite('PP 10207 - Veteran', () => {
 
   beforeEach(() => {
     cy.intercept('/v0/feature_toggles*', featureToggles);
-    cy.intercept('PUT', '/v0/in_progress_forms/20-10207', sipPut);
-    cy.intercept('GET', '/v0/in_progress_forms/20-10207', sipGet);
+    cy.intercept('/data/cms/vamc-ehr.json', {});
     cy.visit('/');
   });
 
@@ -160,15 +156,10 @@ testSuite('PP 10207 - Veteran', () => {
       showsCorrectPageTitle('Which of these best describes you?', 3);
     });
 
-    it('displays correct error message for empty selection', () => {
-      continueToNextPage();
-      showsCorrectErrorMessage('Select your identity');
-    });
-
     it('advances to Your-personal-information chapter', () => {
       cy.contains('I’m a Veteran.').click();
       continueToNextPage();
-      pagePathIsCorrect('name-and-date-of-birth');
+      pagePathIsCorrect('veteran-name-and-date-of-birth-a');
       showsCorrectChapterTitle('Your personal information');
       showsCorrectPageTitle('Your name and date of birth', 3);
     });
@@ -184,7 +175,7 @@ testSuite('PP 10207 - Veteran', () => {
         .click();
       cy.contains('I’m a Veteran.').click();
       continueToNextPage();
-      pagePathIsCorrect('name-and-date-of-birth');
+      pagePathIsCorrect('veteran-name-and-date-of-birth-a');
     });
 
     describe('Name-and-date-of-birth page', () => {
@@ -197,44 +188,10 @@ testSuite('PP 10207 - Veteran', () => {
         showsCorrectPageTitle('Your name and date of birth', 3);
       });
 
-      it('displays correct error messages for empty required fields', () => {
-        continueToNextPage();
-        showsCorrectErrorMessage('Please enter a first name');
-        showsCorrectErrorMessage('Please enter a last name');
-        // Form-app in regular browser shows "Please provide a valid date" but in Cypress it's "Please provide the date of birth"
-        showsCorrectErrorMessage('Please provide the date of birth');
-      });
-
-      it('displays correct error message for invalid day of birth', () => {
-        cy.get('select[name="root_dateOfBirthMonth"]').select('1');
-        cy.get('input[name="root_dateOfBirthDay"]').type('32', { force: true });
-        cy.get('input[name="root_dateOfBirthYear"]').type('2000', {
-          force: true,
-        });
-        continueToNextPage();
-        showsCorrectErrorMessage('Please enter a day between 1 and 31');
-      });
-
-      it('displays correct error message for future date of birth', () => {
-        const tmrw = moment()
-          .add(1, 'days')
-          .format('YYYY-M-D')
-          .split('-');
-        cy.get('select[name="root_dateOfBirthMonth"]').select(tmrw[1]);
-        cy.get('input[name="root_dateOfBirthDay"]').type(tmrw[2], {
-          force: true,
-        });
-        cy.get('input[name="root_dateOfBirthYear"]').type(tmrw[0], {
-          force: true,
-        });
-        continueToNextPage();
-        showsCorrectErrorMessage('Please provide a valid current or past date');
-      });
-
       it('advances to Your-identification-information page', () => {
         fillNameAndDateOfBirthPage('veteran');
         continueToNextPage();
-        pagePathIsCorrect('identification-information');
+        pagePathIsCorrect('veteran-identification-information-a');
       });
     });
 
@@ -242,7 +199,7 @@ testSuite('PP 10207 - Veteran', () => {
       beforeEach(() => {
         fillNameAndDateOfBirthPage('veteran');
         continueToNextPage();
-        pagePathIsCorrect('identification-information');
+        pagePathIsCorrect('veteran-identification-information-a');
       });
 
       it('displays correct chapter-title', () => {
@@ -259,7 +216,7 @@ testSuite('PP 10207 - Veteran', () => {
       });
 
       it('displays correct error message for invalid SSN', () => {
-        cy.get('input[name="root_id_ssn"]').then($ssn => {
+        cy.get('input[name="root_veteranId_ssn"]').then($ssn => {
           cy.wrap($ssn).type('1234567', { force: true });
           continueToNextPage();
           showsCorrectErrorMessage(
@@ -273,7 +230,7 @@ testSuite('PP 10207 - Veteran', () => {
       });
 
       it('displays correct error message for invalid VA file number', () => {
-        cy.get('input[name="root_id_vaFileNumber"]').then($vfn => {
+        cy.get('input[name="root_veteranId_vaFileNumber"]').then($vfn => {
           cy.wrap($vfn).type('1234567', { force: true });
           continueToNextPage();
           showsCorrectErrorMessage('Your VA file number must be 8 or 9 digits');
@@ -371,7 +328,7 @@ testSuite('PP 10207 - Veteran', () => {
       it('advances to Your-contact-information chapter', () => {
         fillOtherHousingRisksPage('veteranOhr');
         continueToNextPage();
-        pagePathIsCorrect('phone-and-email');
+        pagePathIsCorrect('veteran-phone-and-email');
       });
     });
   });
@@ -414,13 +371,13 @@ testSuite('PP 10207 - Veteran', () => {
       it('advances to Your-mailing-address page when YES is selected', () => {
         cy.contains('Yes').click();
         continueToNextPage();
-        pagePathIsCorrect('mailing-address');
+        pagePathIsCorrect('veteran-mailing-address');
       });
 
       it('advances to Your-phone-and-email-address page when NO is selected', () => {
         cy.contains('No').click();
         continueToNextPage();
-        pagePathIsCorrect('phone-and-email');
+        pagePathIsCorrect('veteran-phone-and-email');
       });
     });
 
@@ -428,7 +385,7 @@ testSuite('PP 10207 - Veteran', () => {
       beforeEach(() => {
         cy.contains('Yes').click();
         continueToNextPage();
-        pagePathIsCorrect('mailing-address');
+        pagePathIsCorrect('veteran-mailing-address');
       });
 
       it('displays correct page-title', () => {
@@ -466,7 +423,7 @@ testSuite('PP 10207 - Veteran', () => {
       it('advances to Your-phone-and-email-address page', () => {
         fillMailingAddressPage('veteran');
         continueToNextPage();
-        pagePathIsCorrect('phone-and-email');
+        pagePathIsCorrect('veteran-phone-and-email');
       });
     });
 
@@ -476,7 +433,7 @@ testSuite('PP 10207 - Veteran', () => {
         continueToNextPage();
         fillMailingAddressPage('veteran');
         continueToNextPage();
-        pagePathIsCorrect('phone-and-email');
+        pagePathIsCorrect('veteran-phone-and-email');
       });
 
       it('displays correct page-title', () => {

--- a/src/applications/simple-forms/20-10207/tests/e2e/veteran-story.cypress.spec.js
+++ b/src/applications/simple-forms/20-10207/tests/e2e/veteran-story.cypress.spec.js
@@ -22,6 +22,8 @@ import {
   showsCorrectOtherReasonsLabels,
 } from './e2eHelpers';
 import mockUploadResponse from './fixtures/mocks/upload.json';
+import sipPut from './fixtures/mocks/sip-put.json';
+import sipGet from './fixtures/mocks/sip-get.json';
 
 // Skip in CI
 const testSuite = Cypress.env('CI') ? describe.skip : describe;
@@ -71,7 +73,9 @@ testSuite('PP 10207 - Veteran', () => {
   };
 
   beforeEach(() => {
-    cy.intercept('/v0//v0/feature_toggles', featureToggles);
+    cy.intercept('/v0/feature_toggles*', featureToggles);
+    cy.intercept('PUT', '/v0/in_progress_forms/20-10207', sipPut);
+    cy.intercept('GET', '/v0/in_progress_forms/20-10207', sipGet);
     cy.visit('/');
   });
 

--- a/src/applications/simple-forms/20-10207/tests/unit/config/form.unit.spec.js
+++ b/src/applications/simple-forms/20-10207/tests/unit/config/form.unit.spec.js
@@ -1450,14 +1450,25 @@ describe('formConfig', () => {
           depends,
         } = formConfig.chapters.medicalTreatmentChapter.pages.medicalTreatmentPage;
 
+        it('returns FALSE if hasReceivedMedicalTreatment is false', () => {
+          expect(
+            depends({
+              'view:hasReceivedMedicalTreatment': false,
+              preparerType: PREPARER_TYPES.VETERAN,
+            }),
+          ).to.be.false;
+        });
+
         it('returns TRUE if preparerType is veteran or non-veteran', () => {
           expect(
             depends({
+              'view:hasReceivedMedicalTreatment': true,
               preparerType: PREPARER_TYPES.VETERAN,
             }),
           ).to.be.true;
           expect(
             depends({
+              'view:hasReceivedMedicalTreatment': true,
               preparerType: PREPARER_TYPES.NON_VETERAN,
             }),
           ).to.be.true;
@@ -1466,11 +1477,13 @@ describe('formConfig', () => {
         it('returns FALSE if preparerType is third-party-veteran or third-party-non-veteran', () => {
           expect(
             depends({
+              'view:hasReceivedMedicalTreatment': true,
               preparerType: PREPARER_TYPES.THIRD_PARTY_VETERAN,
             }),
           ).to.be.false;
           expect(
             depends({
+              'view:hasReceivedMedicalTreatment': true,
               preparerType: PREPARER_TYPES.THIRD_PARTY_NON_VETERAN,
             }),
           ).to.be.false;
@@ -1482,19 +1495,31 @@ describe('formConfig', () => {
           depends,
         } = formConfig.chapters.medicalTreatmentChapter.pages.medicalTreatmentThirdPartyVeteranPage;
 
+        it('returns FALSE if hasReceivedMedicalTreatment is false', () => {
+          expect(
+            depends({
+              'view:hasReceivedMedicalTreatment': false,
+              preparerType: PREPARER_TYPES.VETERAN,
+            }),
+          ).to.be.false;
+        });
+
         it('returns FALSE if preparerType is veteran, non-veteran, or third-party-non-veteran', () => {
           expect(
             depends({
+              'view:hasReceivedMedicalTreatment': true,
               preparerType: PREPARER_TYPES.VETERAN,
             }),
           ).to.be.false;
           expect(
             depends({
+              'view:hasReceivedMedicalTreatment': true,
               preparerType: PREPARER_TYPES.NON_VETERAN,
             }),
           ).to.be.false;
           expect(
             depends({
+              'view:hasReceivedMedicalTreatment': true,
               preparerType: PREPARER_TYPES.THIRD_PARTY_NON_VETERAN,
             }),
           ).to.be.false;
@@ -1503,6 +1528,7 @@ describe('formConfig', () => {
         it('returns TRUE if preparerType is third-party-veteran', () => {
           expect(
             depends({
+              'view:hasReceivedMedicalTreatment': true,
               preparerType: PREPARER_TYPES.THIRD_PARTY_VETERAN,
             }),
           ).to.be.true;
@@ -1514,19 +1540,31 @@ describe('formConfig', () => {
           depends,
         } = formConfig.chapters.medicalTreatmentChapter.pages.medicalTreatmentThirdPartyNonVeteranPage;
 
+        it('returns FALSE if hasReceivedMedicalTreatment is false', () => {
+          expect(
+            depends({
+              'view:hasReceivedMedicalTreatment': false,
+              preparerType: PREPARER_TYPES.VETERAN,
+            }),
+          ).to.be.false;
+        });
+
         it('returns FALSE if preparerType is veteran, non-veteran, or third-party-veteran', () => {
           expect(
             depends({
+              'view:hasReceivedMedicalTreatment': true,
               preparerType: PREPARER_TYPES.VETERAN,
             }),
           ).to.be.false;
           expect(
             depends({
+              'view:hasReceivedMedicalTreatment': true,
               preparerType: PREPARER_TYPES.NON_VETERAN,
             }),
           ).to.be.false;
           expect(
             depends({
+              'view:hasReceivedMedicalTreatment': true,
               preparerType: PREPARER_TYPES.THIRD_PARTY_VETERAN,
             }),
           ).to.be.false;
@@ -1535,6 +1573,7 @@ describe('formConfig', () => {
         it('returns TRUE if preparerType is third-party-non-veteran', () => {
           expect(
             depends({
+              'view:hasReceivedMedicalTreatment': true,
               preparerType: PREPARER_TYPES.THIRD_PARTY_NON_VETERAN,
             }),
           ).to.be.true;

--- a/src/applications/simple-forms/20-10207/tests/unit/config/submit-transformer.unit.spec.js
+++ b/src/applications/simple-forms/20-10207/tests/unit/config/submit-transformer.unit.spec.js
@@ -34,6 +34,7 @@ describe('transformForSubmit', () => {
         veteranFullName: fullNameTruncated,
         formNumber: '20-10207',
       };
+      delete transformedData['view:hasReceivedMedicalTreatment'];
 
       const transformedResult = JSON.parse(
         transformForSubmit(formConfig, data),
@@ -53,6 +54,7 @@ describe('transformForSubmit', () => {
         nonVeteranFullName: fullNameTruncated,
         formNumber: '20-10207',
       };
+      delete transformedData['view:hasReceivedMedicalTreatment'];
 
       const transformedResult = JSON.parse(
         transformForSubmit(formConfig, data),
@@ -81,6 +83,7 @@ describe('transformForSubmit', () => {
         ...fixtureVet.data,
         formNumber: '20-10207',
       };
+      delete transformedData['view:hasReceivedMedicalTreatment'];
 
       const transformedResult = JSON.parse(
         transformForSubmit(formConfig, data),
@@ -99,6 +102,7 @@ describe('transformForSubmit', () => {
         ...fixtureNonVet.data,
         formNumber: '20-10207',
       };
+      delete transformedData['view:hasReceivedMedicalTreatment'];
 
       const transformedResult = JSON.parse(
         transformForSubmit(formConfig, data),
@@ -111,6 +115,7 @@ describe('transformForSubmit', () => {
         ...fixture3rdPtyVet.data,
         formNumber: '20-10207',
       };
+      delete transformedData['view:hasReceivedMedicalTreatment'];
 
       const transformedResult = JSON.parse(
         transformForSubmit(formConfig, fixture3rdPtyVet),
@@ -123,6 +128,7 @@ describe('transformForSubmit', () => {
         ...fixture3rdPtyNonVet.data,
         formNumber: '20-10207',
       };
+      delete transformedData['view:hasReceivedMedicalTreatment'];
 
       const transformedResult = JSON.parse(
         transformForSubmit(formConfig, fixture3rdPtyNonVet),
@@ -161,6 +167,7 @@ describe('transformForSubmit', () => {
         veteranMailingAddress: addressTruncated,
         formNumber: '20-10207',
       };
+      delete transformedData['view:hasReceivedMedicalTreatment'];
 
       const transformedResult = JSON.parse(
         transformForSubmit(formConfig, data),
@@ -180,6 +187,7 @@ describe('transformForSubmit', () => {
         nonVeteranMailingAddress: addressTruncated,
         formNumber: '20-10207',
       };
+      delete transformedData['view:hasReceivedMedicalTreatment'];
 
       const transformedResult = JSON.parse(
         transformForSubmit(formConfig, data),
@@ -200,6 +208,7 @@ describe('transformForSubmit', () => {
         ...fixtureVet.data,
         formNumber: '20-10207',
       };
+      delete transformedData['view:hasReceivedMedicalTreatment'];
 
       const transformedResult = JSON.parse(
         transformForSubmit(formConfig, data),
@@ -274,6 +283,7 @@ describe('transformForSubmit', () => {
         otherReasons: otherReasonsOver85,
         formNumber: '20-10207',
       };
+      delete transformedData['view:hasReceivedMedicalTreatment'];
 
       const transformedResult = JSON.parse(
         transformForSubmit(formConfig, data),

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -132,7 +132,7 @@
 /**
  * @typedef {Object} FormConfigChapter
  * @property {Record<string, FormConfigPage>} [pages]
- * @property {string | ({ formData }: { formData?: Object }) => string} [title]
+ * @property {string | (formData) => string} [title]
  * @property {boolean} [hideFormNavProgress]
  * @property {React.ReactNode} [reviewDescription]
  */

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -132,7 +132,7 @@
 /**
  * @typedef {Object} FormConfigChapter
  * @property {Record<string, FormConfigPage>} [pages]
- * @property {string | (formData) => string} [title]
+ * @property {string | ({ formData, formConfig }) => string} [title]
  * @property {boolean} [hideFormNavProgress]
  * @property {React.ReactNode} [reviewDescription]
  */
@@ -156,7 +156,7 @@
  * @property {SchemaOptions} [schema]
  * @property {string | Function} [scrollAndFocusTarget]
  * @property {boolean} [showPagePerItem] if true, will show an additional page for each item in the array at `'name-of-path/:index'`
- * @property {string | ({ formData }) => string} [title] Will show on review page (may require more than one word to show)
+ * @property {string | (formData) => string} [title] Will show on review page (may require more than one word to show)
  * @property {UISchemaOptions} [uiSchema]
  * @property {(item, index) => void} [updateFormData]
  */

--- a/src/platform/forms-system/src/js/web-component-patterns/yesNoPattern.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/yesNoPattern.jsx
@@ -20,7 +20,7 @@ import YesNoField from '../web-component-fields/YesNoField';
  *
  * if `yesNoReverse` is set to true, selecting `yes` will result in `false` instead of `true`
  *
- * @param {string | UIOptions & {
+ * @param {UIOptions & {
  *   title?: UISchemaOptions['ui:title'],
  *   description?: UISchemaOptions['ui:description'],
  *   labels?: {Y?: string, N?: string},


### PR DESCRIPTION
## Summary

- Add yes/no question for if you've received medical treatment for form 20-10207

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#1123

## Testing done

- Browser, unit, e2e

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/63518dd1-4393-462f-b661-7b27f1233191)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/7b474a9d-417a-45e9-9956-9d1f1f6d2539)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/c8d71a64-2a5f-4c11-a011-1703c0637aca)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/19c81a00-2168-4283-9644-1d5ec59e9968)
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/123402053/288973d8-4746-47f3-a1cb-8d13d43f335d)


## What areas of the site does it impact?

20-10207

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
