### PR TITLE
ci(cypress): Use ECR for Cypress Image

### DIFF
--- a/.github/workflows/configure-aws-credentials/action.yml
+++ b/.github/workflows/configure-aws-credentials/action.yml
@@ -33,3 +33,4 @@ runs:
         role-to-assume: ${{ inputs.role }}
         role-session-name: ${{ inputs.session_name }}
         role-duration-seconds: ${{ inputs.role_duration }}
+        output-credentials: true

--- a/.github/workflows/configure-aws-credentials/action.yml
+++ b/.github/workflows/configure-aws-credentials/action.yml
@@ -21,6 +21,14 @@ inputs:
     description: Role Duration in Seconds
     required: true
 
+outputs:
+  ecr_user: 
+    description: Output of AWS stored ECR username credential
+    value: ${{ steps.login-ecr.outputs.docker_username_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
+  ecr_password:
+    description: Output of AWS stored ECR password credential 
+    value: ${{ steps.login-ecr.outputs.docker_password_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
+
 runs:
   using: composite
   steps:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -581,13 +581,22 @@ jobs:
       - name: Checkout vets-website
         uses: actions/checkout@v4
     
-      - name: Configure AWS credentials
-        id: configure-aws
-        uses: ./.github/workflows/configure-aws-credentials
+      # - name: Configure AWS credentials
+      #   id: configure-aws
+      #   uses: ./.github/workflows/configure-aws-credentials
+      #   with:
+      #     aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      #     aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      #     aws_region: us-gov-west-1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: us-gov-west-1
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-gov-west-1
+          mask-aws-account-id: true
+          output-credentials: true
 
       - name: Login to Amazon ECR
         id: login-ecr

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -574,8 +574,8 @@ jobs:
     timeout-minutes: 10
     needs: [build] 
     outputs:
-      ecr_user: ${{ steps.configure-aws.outputs.ecr_user }}
-      ecr_password: ${{ steps.configure-aws.outputs.ecr_password }}
+      ecr_user: ${{ steps.login-ecr.outputs.ecr_user }}
+      ecr_password: ${{ steps.login-ecr.outputs.ecr_password }}
         
     steps:
       - name: Checkout vets-website

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -577,7 +577,10 @@ jobs:
       needs.build.result == 'success' &&
       needs.tests-prep.result == 'success'
     container:
-      image: public.ecr.aws/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge
+      image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge
+      credentials:
+        username: AWS
+        password: ${{ steps.login-ecr.outputs.ecr-password }}
 
     strategy:
       fail-fast: false
@@ -612,6 +615,10 @@ jobs:
           aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-gov-west-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
 
       - name: Download production build artifact
         if: needs.tests-prep.outputs.cypress-tests != '[]'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -579,8 +579,8 @@ jobs:
     container:
       image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge
       credentials:
-        username: ${{ steps.login-ecr.outputs.docker_username_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
-        password: ${{ steps.login-ecr.outputs.docker_password_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
+        username: ${{ job.steps.login-ecr.outputs.docker_username_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
+        password: ${{ job.steps.login-ecr.outputs.docker_password_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -578,17 +578,6 @@ jobs:
       ecr_password: ${{ steps.login-ecr.outputs.docker_password_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
         
     steps:
-      - name: Checkout vets-website
-        uses: actions/checkout@v4
-    
-      # - name: Configure AWS credentials
-      #   id: configure-aws
-      #   uses: ./.github/workflows/configure-aws-credentials
-      #   with:
-      #     aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     aws_region: us-gov-west-1
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -568,19 +568,44 @@ jobs:
         run: yarn generate-app-list
         working-directory: qa-standards-dashboard-data
 
+  fetch-ecr-credentials:
+    name: Fetch ECR Credentials
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [build] 
+    outputs:
+      ecr_user: ${{ steps.login-ecr.outputs.docker_username_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
+      ecr_password: ${{ steps.login-ecr.outputs.docker_password_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
+        
+    steps:
+      - name: Checkout vets-website
+        uses: actions/checkout@v4
+    
+      - name: Configure AWS credentials
+        if: needs.tests-prep.outputs.cypress-tests != '[]'
+        uses: ./.github/workflows/configure-aws-credentials
+        with:
+          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_region: us-gov-west-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2    
+
   cypress-tests:
     name: Cypress E2E Tests
     runs-on: ubuntu-16-cores-latest
     timeout-minutes: 60
-    needs: [build, tests-prep]
+    needs: [build, tests-prep, fetch-ecr-credentials]
     if: |
       needs.build.result == 'success' &&
       needs.tests-prep.result == 'success'
     container:
       image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge
       credentials:
-        username: ${{ job.steps.login-ecr.outputs.docker_username_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
-        password: ${{ job.steps.login-ecr.outputs.docker_password_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
+        username: ${{ needs.fetch-ecr-credentials.ecr_user }}
+        password: ${{ needs.fetch-ecr-credentials.ecr_password }}
 
     strategy:
       fail-fast: false
@@ -615,10 +640,6 @@ jobs:
           aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-gov-west-1
-
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Download production build artifact
         if: needs.tests-prep.outputs.cypress-tests != '[]'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -579,7 +579,7 @@ jobs:
     container:
       image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge
       credentials:
-        username: AWS
+        username: ${{ steps.login-ecr.outputs.docker_username_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
         password: ${{ steps.login-ecr.outputs.docker_password_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
 
     strategy:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -618,7 +618,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Download production build artifact
         if: needs.tests-prep.outputs.cypress-tests != '[]'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -582,7 +582,6 @@ jobs:
         uses: actions/checkout@v4
     
       - name: Configure AWS credentials
-        if: needs.tests-prep.outputs.cypress-tests != '[]'
         uses: ./.github/workflows/configure-aws-credentials
         with:
           aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -580,7 +580,7 @@ jobs:
       image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge
       credentials:
         username: AWS
-        password: ${{ steps.login-ecr.outputs.ecr-password }}
+        password: ${{ steps.login-ecr.outputs.docker_password_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -574,14 +574,15 @@ jobs:
     timeout-minutes: 10
     needs: [build] 
     outputs:
-      ecr_user: ${{ steps.login-ecr.outputs.docker_username_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
-      ecr_password: ${{ steps.login-ecr.outputs.docker_password_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
+      ecr_user: ${{ steps.configure-aws.outputs.ecr_user }}
+      ecr_password: ${{ steps.configure-aws.outputs.ecr_password }}
         
     steps:
       - name: Checkout vets-website
         uses: actions/checkout@v4
     
       - name: Configure AWS credentials
+        id: configure-aws
         uses: ./.github/workflows/configure-aws-credentials
         with:
           aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -573,10 +573,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [build] 
-    outputs:
-      ecr_user: ${{ steps.login-ecr.outputs.docker_username_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
-      ecr_password: ${{ steps.login-ecr.outputs.docker_password_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
-        
+
     steps:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -590,7 +587,13 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2    
+        with:
+          mask-password: false
 
+    outputs:
+      ecr_user: ${{ steps.login-ecr.outputs.docker_username_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
+      ecr_password: ${{ steps.login-ecr.outputs.docker_password_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
+      
   cypress-tests:
     name: Cypress E2E Tests
     runs-on: ubuntu-16-cores-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -604,8 +604,8 @@ jobs:
     container:
       image: 008577686731.dkr.ecr.us-gov-west-1.amazonaws.com/dsva/cypress-io/cypress/browsers:node16.16.0-chrome107-ff107-edge
       credentials:
-        username: ${{ needs.fetch-ecr-credentials.ecr_user }}
-        password: ${{ needs.fetch-ecr-credentials.ecr_password }}
+        username: ${{ needs.fetch-ecr-credentials.outputs.ecr_user }}
+        password: ${{ needs.fetch-ecr-credentials.outputs.ecr_password }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -574,8 +574,8 @@ jobs:
     timeout-minutes: 10
     needs: [build] 
     outputs:
-      ecr_user: ${{ steps.login-ecr.outputs.ecr_user }}
-      ecr_password: ${{ steps.login-ecr.outputs.ecr_password }}
+      ecr_user: ${{ steps.login-ecr.outputs.docker_username_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
+      ecr_password: ${{ steps.login-ecr.outputs.docker_password_008577686731_dkr_ecr_us_gov_west_1_amazonaws_com }}
         
     steps:
       - name: Checkout vets-website


### PR DESCRIPTION
- Use ECR for Cypress Image
- Running multiple versions of Cypress. I only updated the 16.16 image reference
- `public.ecr.aws/cypress-io/cypress/browsers:node16.13.2-chrome100-ff98` is still being used elsewhere. why?