### PR TITLE
[985] fix: add flag to bypass middle name label conversion

### DIFF
--- a/src/applications/simple-forms/20-10207/helpers.js
+++ b/src/applications/simple-forms/20-10207/helpers.js
@@ -26,8 +26,8 @@ export function getPersonalInformationChapterTitle(formData) {
   return `${preparerString} personal information`;
 }
 
-export function getFullNameLabels(label) {
-  if (label === 'middle name') {
+export function getFullNameLabels(label, skipMiddleCheck = false) {
+  if (label === 'middle name' && !skipMiddleCheck) {
     return 'Middle initial';
   }
 

--- a/src/applications/simple-forms/20-10207/pages/nonVeteranNameAndDateOfBirth.js
+++ b/src/applications/simple-forms/20-10207/pages/nonVeteranNameAndDateOfBirth.js
@@ -18,7 +18,9 @@ export default {
       ({ formData }) => getNameAndDobPageTitle(formData),
       ({ formData }) => getNameAndDobPageDescription(formData),
     ),
-    nonVeteranFullName: fullNameNoSuffixUI(label => getFullNameLabels(label)),
+    nonVeteranFullName: fullNameNoSuffixUI(label =>
+      getFullNameLabels(label, true),
+    ),
     nonVeteranDateOfBirth: dateOfBirthUI({ required: true }),
   },
   schema: {

--- a/src/applications/simple-forms/20-10207/pages/veteranNameAndDateofBirth.js
+++ b/src/applications/simple-forms/20-10207/pages/veteranNameAndDateofBirth.js
@@ -18,7 +18,9 @@ export default {
       ({ formData }) => getNameAndDobPageTitle(formData),
       ({ formData }) => getNameAndDobPageDescription(formData),
     ),
-    veteranFullName: fullNameNoSuffixUI(label => getFullNameLabels(label)),
+    veteranFullName: fullNameNoSuffixUI(label =>
+      getFullNameLabels(label, true),
+    ),
     veteranDateOfBirth: dateOfBirthUI({ required: true }),
   },
   schema: {

--- a/src/applications/simple-forms/20-10207/pages/veteranNameAndDateofBirthB.js
+++ b/src/applications/simple-forms/20-10207/pages/veteranNameAndDateofBirthB.js
@@ -14,7 +14,9 @@ export default {
       'Veteran’s name and date of birth',
       'Please provide the Veteran’s information.',
     ),
-    veteranFullName: fullNameNoSuffixUI(label => getFullNameLabels(label)),
+    veteranFullName: fullNameNoSuffixUI(label =>
+      getFullNameLabels(label, true),
+    ),
     veteranDateOfBirth: dateOfBirthUI({ required: true }),
   },
   schema: {


### PR DESCRIPTION
## Summary

- _Added a flag to the getFullNameLabels helper function to bypass middle name label conversion_
- _To reproduce this bug, navigate to any of the following routes and the `Middle initial` field should be `Middle name`_
  - http://localhost:3001/supporting-forms-for-claims/request-priority-processing-form-20-10207/veteran-name-and-date-of-birth-a
  - http://localhost:3001/supporting-forms-for-claims/request-priority-processing-form-20-10207/veteran-name-and-date-of-birth-b
  - http://localhost:3001/supporting-forms-for-claims/request-priority-processing-form-20-10207/non-veteran-name-and-date-of-birth

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/VA.gov-team-forms/issues/985

## Testing done

- _Tested in browser_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |![Screenshot 2024-03-26 at 9 33 29 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/7d528537-6333-4b28-bc3f-43cf5a02f28a)|![Screenshot 2024-03-26 at 9 34 53 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/8f5d3d4f-5d34-40dd-b972-aed810e5b40f)|
| Mobile |![Screenshot 2024-03-26 at 9 33 12 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/b1f6386a-ecae-43bd-a408-9c64396c384f)|![Screenshot 2024-03-26 at 9 34 43 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/a4b76e17-2f13-49c9-8991-b9e1ff240784)|
| Mobile |![Screenshot 2024-03-26 at 9 32 46 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/dcae2193-1892-4b10-b0f3-e7e82aa9f6a2)|![Screenshot 2024-03-26 at 9 34 27 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/127a5678-bfc6-4882-b6ca-5d82c763e45d)|
| Desktop |![Screenshot 2024-03-26 at 9 15 55 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/b0f8abe3-9c0a-423e-a0b7-4a4aee219ff8)|![Screenshot 2024-03-26 at 9 16 34 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/0c97997e-c8d2-4593-8f3c-0bd7a03b66bb)|
| Desktop |![Screenshot 2024-03-26 at 9 14 56 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/ef2ec7f5-ad1f-4ee6-8422-9c5df7daf3ae)|![Screenshot 2024-03-26 at 9 15 33 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/7f921c3a-4dc5-4e16-81a9-c24f6fb954a9)|
| Desktop |![Screenshot 2024-03-26 at 9 13 08 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/c0066a38-5f5a-475a-94b0-b58380ee718e)|![Screenshot 2024-03-26 at 9 13 23 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/cb72c95e-0a4a-4e54-9355-0899cfeb2878)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
