### PR TITLE
[CST] Refactoring the ClaimStatusHeader logic

### DIFF
--- a/src/applications/claims-status/components/ClaimStatusHeader.jsx
+++ b/src/applications/claims-status/components/ClaimStatusHeader.jsx
@@ -1,22 +1,19 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
+
+import { DATE_FORMATS } from '../constants';
 import { buildDateFormatter, isClaimOpen } from '../utils/helpers';
 
-const isClaimComplete = claim => claim.attributes.status === 'COMPLETE';
-
-const formatDate = date => buildDateFormatter('MMMM d, yyyy')(date);
-
 const getLastUpdated = claim => {
-  const updatedOn = formatDate(
+  const updatedOn = buildDateFormatter(DATE_FORMATS.LONG_DATE)(
     claim.attributes.claimPhaseDates?.phaseChangeDate,
   );
 
   return `Last updated: ${updatedOn}`;
 };
 
-function ClaimStatusHeader({ claim }) {
+export default function ClaimStatusHeader({ claim }) {
   const { closeDate, status } = claim.attributes;
-  const inProgress = !isClaimComplete(claim) ? 'In Progress' : null;
 
   const isOpen = isClaimOpen(status, closeDate);
 
@@ -24,11 +21,11 @@ function ClaimStatusHeader({ claim }) {
     <div className="claim-status-header-container">
       <h2 className="vads-u-margin-y--0">Claim status</h2>
       <p className="vads-u-margin-top--1 vads-u-margin-bottom--3 va-introtext">
-        Here’s the latest information on your claim.{' '}
+        Here’s the latest information on your claim.
       </p>
       {isOpen && (
-        <div className="vads-u-margin-top--0 vads-u-margin-bottom--4">
-          {inProgress && <span className="usa-label">{inProgress}</span>}
+        <div className="vads-u-margin-bottom--4">
+          <span className="usa-label">In Progress</span>
           <p className="vads-u-margin-top--1 vads-u-margin-bottom--0">
             {getLastUpdated(claim)}
           </p>
@@ -41,5 +38,3 @@ function ClaimStatusHeader({ claim }) {
 ClaimStatusHeader.propTypes = {
   claim: PropTypes.object,
 };
-
-export default ClaimStatusHeader;


### PR DESCRIPTION
## Summary
Updating the logic around the ClaimsStatusHeader component. Specifically:
- `isClaimComplete` is redundant since we have the `isClaimOpen` helper
- The `inProgress` variable is redundant since we only want to show the "In Progress" tag when the claim is open
- Refactored the way that date formatting is handled (No functional change)
- Removed an unneeded `{' '}` from the DOM and an unneeded `vads-u-margin--top-0` className

## Related issue(s)

## Testing done
Tests still pass

## Screenshots
### Open claim
<img width="500" alt="Screenshot 2024-03-26 at 1 55 31 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/ea19aaa9-541a-4637-b304-88e3fa118c50">

### Closed claim
<img width="500" alt="Screenshot 2024-03-26 at 1 55 18 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/c12593f2-dd6d-42e2-8c1e-5a99d1848cda">


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
