### PR TITLE
[CST] Prepping for upgrade to react-router V6

### DIFF
--- a/src/applications/claims-status/claims-status-entry.jsx
+++ b/src/applications/claims-status/claims-status-entry.jsx
@@ -1,5 +1,5 @@
-import 'platform/polyfills';
-import startApp from 'platform/startup';
+import '@department-of-veterans-affairs/platform-polyfills';
+import startApp from '@department-of-veterans-affairs/platform-startup/index';
 
 import './sass/claims-status.scss';
 

--- a/src/applications/claims-status/components/ClaimDetailLayout.jsx
+++ b/src/applications/claims-status/components/ClaimDetailLayout.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import {
   buildDateFormatter,
   getClaimType,
+  isClaimOpen,
   isPopulatedClaim,
 } from '../utils/helpers';
 import { setFocus } from '../utils/page';
@@ -59,7 +60,7 @@ export default function ClaimDetailLayout(props) {
     const { claimDate, closeDate, contentions, status } =
       claim.attributes || {};
 
-    const isOpen = status !== 'COMPLETE' && closeDate === null;
+    const isOpen = isClaimOpen(status, closeDate);
     const formattedClaimDate = buildDateFormatter()(claimDate);
     const claimSubheader = `Received on ${formattedClaimDate}`;
 
@@ -94,7 +95,7 @@ export default function ClaimDetailLayout(props) {
 
     bodyContent = (
       <div className="claim-container">
-        <TabNav id={props.claim.id} />
+        <TabNav id={claim.id} />
         {tabs.map(tab => (
           <div key={tab} id={`tabPanel${tab}`} className="tab-panel">
             {currentTab === tab && (

--- a/src/applications/claims-status/components/ClaimStatusHeader.jsx
+++ b/src/applications/claims-status/components/ClaimStatusHeader.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { buildDateFormatter, isClaimOpen } from '../utils/helpers';
 
-const getLastUpdated = claim => {
+export const getLastUpdated = claim => {
   const updatedOn = buildDateFormatter()(
     claim.attributes.claimPhaseDates?.phaseChangeDate,
   );

--- a/src/applications/claims-status/components/FilesNeededOld.jsx
+++ b/src/applications/claims-status/components/FilesNeededOld.jsx
@@ -1,7 +1,8 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
-import { getTrackedItemId, truncateDescription } from '../utils/helpers';
+
+import { truncateDescription } from '../utils/helpers';
 import DueDateOld from './DueDateOld';
 
 function FilesNeededOld({ id, item }) {
@@ -19,7 +20,7 @@ function FilesNeededOld({ id, item }) {
           aria-label={`View Details for ${item.displayName}`}
           title={`View Details for ${item.displayName}`}
           className="usa-button usa-button-secondary view-details-button"
-          to={`your-claims/${id}/document-request/${getTrackedItemId(item)}`}
+          to={`your-claims/${id}/document-request/${item.id}`}
         >
           View Details
         </Link>

--- a/src/applications/claims-status/components/Notification.jsx
+++ b/src/applications/claims-status/components/Notification.jsx
@@ -20,7 +20,7 @@ export default function Notification({ body, title, type, onClose }) {
 }
 
 Notification.propTypes = {
-  body: PropTypes.string.isRequired,
+  body: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
   title: PropTypes.string.isRequired,
   type: PropTypes.string,
   onClose: PropTypes.func,

--- a/src/applications/claims-status/components/TabItem.jsx
+++ b/src/applications/claims-status/components/TabItem.jsx
@@ -1,43 +1,38 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { IndexLink, withRouter } from 'react-router';
 import PropTypes from 'prop-types';
 
-class TabItem extends React.Component {
-  componentDidMount() {
-    document.addEventListener('keydown', this.tabShortcut);
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener('keydown', this.tabShortcut);
-  }
-
-  // Grab the current URL, trim the leading '/', and return activeTabPath
-  trimCurrentUrl = () => this.props.location?.pathname.slice(1);
-
-  tabShortcut = evt => {
-    if (evt.altKey && evt.which === 48 + this.props.shortcut) {
-      this.props.router.push(this.props.tabpath);
+function TabItem({ id, location, router, shortcut, tabpath, title }) {
+  const tabShortcut = evt => {
+    if (evt.altKey && evt.which === 48 + shortcut) {
+      router.push(tabpath);
     }
   };
 
-  render() {
-    const { id, tabpath, title } = this.props;
-    const activeTab = this.trimCurrentUrl();
+  useEffect(() => {
+    document.addEventListener('keydown', tabShortcut);
 
-    return (
-      <li>
-        <IndexLink
-          id={`tab${id || title}`}
-          aria-current={activeTab === tabpath ? 'page' : null}
-          activeClassName="tab--current"
-          className="tab"
-          to={tabpath}
-        >
-          <span>{title}</span>
-        </IndexLink>
-      </li>
-    );
-  }
+    return () => {
+      document.removeEventListener('keydown', tabShortcut);
+    };
+  }, []);
+
+  // Grab the current URL, trim the leading '/', and return activeTabPath
+  const activeTab = location?.pathname.slice(1);
+
+  return (
+    <li>
+      <IndexLink
+        id={`tab${id || title}`}
+        aria-current={activeTab === tabpath ? 'page' : null}
+        activeClassName="tab--current"
+        className="tab"
+        to={tabpath}
+      >
+        <span>{title}</span>
+      </IndexLink>
+    </li>
+  );
 }
 
 TabItem.propTypes = {

--- a/src/applications/claims-status/components/TabNav.jsx
+++ b/src/applications/claims-status/components/TabNav.jsx
@@ -1,8 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { Toggler } from 'platform/utilities/feature-toggles';
+import { Toggler } from '~/platform/utilities/feature-toggles';
 import TabItem from './TabItem';
+
+const { cstUseClaimDetailsV2 } = Toggler.TOGGLE_NAMES;
 
 export default function TabNav({ id }) {
   return (
@@ -18,7 +20,7 @@ export default function TabNav({ id }) {
           tabpath={`your-claims/${id}/files`}
           title="Files"
         />
-        <Toggler toggleName={Toggler.TOGGLE_NAMES.cstUseClaimDetailsV2}>
+        <Toggler toggleName={cstUseClaimDetailsV2}>
           <Toggler.Disabled>
             <TabItem
               shortcut={3}
@@ -28,7 +30,7 @@ export default function TabNav({ id }) {
           </Toggler.Disabled>
           <Toggler.Enabled>
             <TabItem
-              shortcut={4}
+              shortcut={3}
               tabpath={`your-claims/${id}/overview`}
               title="Overview"
             />

--- a/src/applications/claims-status/components/appeals-v2/AppealsV2TabNav.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealsV2TabNav.jsx
@@ -3,27 +3,27 @@ import PropTypes from 'prop-types';
 
 import TabItem from '../TabItem';
 
-const AppealsV2TabNav = ({ appealId }) => (
-  <nav aria-label="Appeal">
-    <ul className="tabs">
-      <TabItem
-        shortcut={1}
-        id="v2status"
-        tabpath={`appeals/${appealId}/status`}
-        title="Status"
-      />
-      <TabItem
-        shortcut={2}
-        id="v2detail"
-        tabpath={`appeals/${appealId}/detail`}
-        title="Issues"
-      />
-    </ul>
-  </nav>
-);
+export default function AppealsV2TabNav({ appealId }) {
+  return (
+    <nav aria-label="Appeal">
+      <ul className="tabs">
+        <TabItem
+          shortcut={1}
+          id="v2status"
+          tabpath={`appeals/${appealId}/status`}
+          title="Status"
+        />
+        <TabItem
+          shortcut={2}
+          id="v2detail"
+          tabpath={`appeals/${appealId}/detail`}
+          title="Issues"
+        />
+      </ul>
+    </nav>
+  );
+}
 
 AppealsV2TabNav.propTypes = {
   appealId: PropTypes.string.isRequired,
 };
-
-export default AppealsV2TabNav;

--- a/src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx
@@ -88,9 +88,11 @@ class AdditionalEvidencePage extends React.Component {
     const filesPath = `your-claims/${this.props.params.id}/additional-evidence`;
     let content;
 
+    const { claim, lastPage } = this.props;
+
     const isOpen = isClaimOpen(
-      this.props.claim.attributes.status,
-      this.props.claim.attributes.closeDate,
+      claim.attributes.status,
+      claim.attributes.closeDate,
     );
 
     if (this.props.loading) {
@@ -120,39 +122,27 @@ class AdditionalEvidencePage extends React.Component {
           {isOpen ? (
             <>
               {this.props.filesNeeded.map(item => (
-                <FilesNeeded
-                  key={item.id}
-                  id={this.props.claim.id}
-                  item={item}
-                />
+                <FilesNeeded key={item.id} id={claim.id} item={item} />
               ))}
               {this.props.filesOptional.map(item => (
-                <FilesOptional
-                  key={item.id}
-                  id={this.props.claim.id}
-                  item={item}
-                />
+                <FilesOptional key={item.id} id={claim.id} item={item} />
               ))}
               <AddFilesForm
                 field={this.props.uploadField}
                 progress={this.props.progress}
                 uploading={this.props.uploading}
                 files={this.props.files}
-                backUrl={this.props.lastPage || filesPath}
+                backUrl={lastPage || filesPath}
                 onSubmit={() => {
                   // START lighthouse_migration
                   if (this.props.documentsUseLighthouse) {
                     this.props.submitFilesLighthouse(
-                      this.props.claim.id,
+                      claim.id,
                       null,
                       this.props.files,
                     );
                   } else {
-                    this.props.submitFiles(
-                      this.props.claim.id,
-                      null,
-                      this.props.files,
-                    );
+                    this.props.submitFiles(claim.id, null, this.props.files);
                   }
                   // END lighthouse_migration
                 }}

--- a/src/applications/claims-status/components/claim-files-tab/DocumentsFiled.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/DocumentsFiled.jsx
@@ -55,7 +55,7 @@ const getSortedItems = itemsFiled => {
   const items = generateDocsFiled(itemsFiled);
 
   return items.sort((item1, item2) => {
-    return moment(item2.date) > moment(item1.date);
+    return moment(item2.date) - moment(item1.date);
   });
 };
 

--- a/src/applications/claims-status/components/claim-files-tab/DocumentsFiled.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/DocumentsFiled.jsx
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
 import React, { useCallback, useState } from 'react';
 import { VaPagination } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import moment from 'moment';
-import { buildDateFormatter } from '../../utils/helpers';
+
 import { ITEMS_PER_PAGE } from '../../constants';
+import { buildDateFormatter } from '../../utils/helpers';
 
 const NEED_ITEMS_STATUS = 'NEEDED_FROM_';
 
@@ -54,7 +54,7 @@ const getSortedItems = itemsFiled => {
   const items = generateDocsFiled(itemsFiled);
 
   return items.sort((item1, item2) => {
-    return moment(item2.date) - moment(item1.date);
+    return item2.date > item1.date ? 1 : -1;
   });
 };
 

--- a/src/applications/claims-status/components/claim-files-tab/DocumentsFiled.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/DocumentsFiled.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useCallback, useState } from 'react';
 import { VaPagination } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import moment from 'moment';
 
 import { ITEMS_PER_PAGE } from '../../constants';
 import { buildDateFormatter } from '../../utils/helpers';
@@ -54,7 +55,7 @@ const getSortedItems = itemsFiled => {
   const items = generateDocsFiled(itemsFiled);
 
   return items.sort((item1, item2) => {
-    return item2.date > item1.date ? 1 : -1;
+    return moment(item2.date) > moment(item1.date);
   });
 };
 

--- a/src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx
@@ -1,7 +1,8 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
-import { getTrackedItemId, truncateDescription } from '../../utils/helpers';
+
+import { truncateDescription } from '../../utils/helpers';
 import DueDate from '../DueDate';
 
 function FilesNeeded({ id, item }) {
@@ -23,7 +24,7 @@ function FilesNeeded({ id, item }) {
           aria-label={`View details for ${item.displayName}`}
           title={`View details for ${item.displayName}`}
           className="vads-c-action-link--blue"
-          to={`your-claims/${id}/document-request/${getTrackedItemId(item)}`}
+          to={`your-claims/${id}/document-request/${item.id}`}
         >
           View details
         </Link>

--- a/src/applications/claims-status/components/claim-files-tab/FilesOptional.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/FilesOptional.jsx
@@ -1,7 +1,8 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
-import { getTrackedItemId, truncateDescription } from '../../utils/helpers';
+
+import { truncateDescription } from '../../utils/helpers';
 
 function FilesOptional({ id, item }) {
   return (
@@ -21,7 +22,7 @@ function FilesOptional({ id, item }) {
         <Link
           aria-label={`Add information for ${item.displayName}`}
           className="add-your-claims-link"
-          to={`your-claims/${id}/document-request/${getTrackedItemId(item)}`}
+          to={`your-claims/${id}/document-request/${item.id}`}
         >
           add it here.
         </Link>

--- a/src/applications/claims-status/components/claim-status-tab/ClosedClaimAlert.jsx
+++ b/src/applications/claims-status/components/claim-status-tab/ClosedClaimAlert.jsx
@@ -1,13 +1,12 @@
-import PropTypes from 'prop-types';
 import React from 'react';
-import moment from 'moment';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
-const formatDate = closedDate => moment(closedDate).format('MMMM D, YYYY');
+import { buildDateFormatter } from '../../utils/helpers';
 
 const headerText = closeDate => {
   return closeDate
-    ? `We closed your claim on ${formatDate(closeDate)}`
+    ? `We closed your claim on ${buildDateFormatter()(closeDate)}`
     : 'We closed your claim';
 };
 function ClosedClaimAlert({ closeDate, decisionLetterSent = false }) {

--- a/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
+++ b/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
@@ -2,12 +2,11 @@ import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import { VaPagination } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import moment from 'moment';
 
-import { buildDateFormatter, getTrackedItemId } from '../../utils/helpers';
 import { ITEMS_PER_PAGE } from '../../constants';
+import { buildDateFormatter } from '../../utils/helpers';
 
-const getOldestDocuentDate = item => {
+const getOldestDocumentDate = item => {
   const arrDocumentDates = item.documents.map(document => document.uploadDate);
   return arrDocumentDates.sort()[0]; // Tried to do Math.min() here and it was erroring out
 };
@@ -20,7 +19,7 @@ const getTrackedItemDateFromStatus = item => {
     case 'NO_LONGER_REQUIRED':
       return item.closedDate;
     case 'SUBMITTED_AWAITING_REVIEW':
-      return getOldestDocuentDate(item);
+      return getOldestDocumentDate(item);
     case 'INITIAL_REVIEW_COMPLETE':
     case 'ACCEPTED':
       return item.receivedDate;
@@ -65,11 +64,11 @@ const getSortedItems = claim => {
   const items = [...trackedItems, ...phaseItems];
 
   return items.sort((item1, item2) => {
-    return moment(item2.date) - moment(item1.date);
+    return item2.date > item1.date ? 1 : -1;
   });
 };
 
-function RecentActivity({ claim }) {
+export default function RecentActivity({ claim }) {
   const [currentPage, setCurrentPage] = useState(1);
   const items = getSortedItems(claim);
   const pageLength = items.length;
@@ -146,9 +145,7 @@ function RecentActivity({ claim }) {
                   <Link
                     aria-label={`Add information for ${item.displayName}`}
                     className="add-your-claims-link"
-                    to={`your-claims/${
-                      item.id
-                    }/document-request/${getTrackedItemId(item)}`}
+                    to={`your-claims/${claim.id}/document-request/${item.id}`}
                   >
                     add it here.
                   </Link>
@@ -174,5 +171,3 @@ function RecentActivity({ claim }) {
 RecentActivity.propTypes = {
   claim: PropTypes.object,
 };
-
-export default RecentActivity;

--- a/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
+++ b/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import { VaPagination } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import moment from 'moment';
 
 import { ITEMS_PER_PAGE } from '../../constants';
 import { buildDateFormatter } from '../../utils/helpers';
@@ -64,7 +65,7 @@ const getSortedItems = claim => {
   const items = [...trackedItems, ...phaseItems];
 
   return items.sort((item1, item2) => {
-    return item2.date > item1.date ? 1 : -1;
+    return moment(item2.date) - moment(item1.date);
   });
 };
 

--- a/src/applications/claims-status/containers/ClaimPage.jsx
+++ b/src/applications/claims-status/containers/ClaimPage.jsx
@@ -1,20 +1,18 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import PropTypes from 'prop-types';
 
 import { getClaim as getClaimAction } from '../actions';
 
-class ClaimPage extends React.Component {
-  componentDidMount() {
-    const { getClaim, params, router } = this.props;
-
+export function ClaimPage({ children, getClaim, params, router }) {
+  useEffect(() => {
     getClaim(params.id, router);
-  }
+  }, []);
 
-  render() {
-    return this.props.children;
-  }
+  // This doesn't need to be wrapped in a fragment, but the linter
+  // gets upset about us importing React if it's not like this
+  return <>{children}</>;
 }
 
 const mapDispatchToProps = {
@@ -34,5 +32,3 @@ ClaimPage.propTypes = {
   params: PropTypes.object,
   router: PropTypes.object,
 };
-
-export { ClaimPage };

--- a/src/applications/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/applications/claims-status/containers/DocumentRequestPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Scroll from 'react-scroll';
-import _ from 'lodash';
+import { merge } from 'lodash';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
@@ -29,14 +29,14 @@ import {
   setFieldsDirty,
   clearNotification,
 } from '../actions';
-import { scrubDescription } from '../utils/helpers';
-import { setPageFocus, setUpPage } from '../utils/page';
 // START lighthouse_migration
 import { benefitsDocumentsUseLighthouse } from '../selectors';
 // END lighthouse_migration
+import { scrubDescription } from '../utils/helpers';
+import { setPageFocus, setUpPage } from '../utils/page';
 
 const scrollToError = () => {
-  const options = _.merge({}, window.VetsGov.scroll, { offset: -25 });
+  const options = merge({}, window.VetsGov.scroll, { offset: -25 });
   scrollTo('uploadError', options);
 };
 const { Element } = Scroll;

--- a/src/applications/claims-status/containers/FilesPage.jsx
+++ b/src/applications/claims-status/containers/FilesPage.jsx
@@ -186,7 +186,7 @@ FilesPage.propTypes = {
   lastPage: PropTypes.string,
   loading: PropTypes.bool,
   message: PropTypes.shape({
-    body: PropTypes.string,
+    body: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
     title: PropTypes.string,
     type: PropTypes.string,
   }),

--- a/src/applications/claims-status/containers/StemClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/StemClaimStatusPage.jsx
@@ -1,22 +1,23 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { setUpPage } from '../utils/page';
+import PropTypes from 'prop-types';
 
+import { getStemClaims } from '../actions';
 import StemAskVAQuestions from '../components/StemAskVAQuestions';
 import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
 import ClaimsUnavailable from '../components/ClaimsUnavailable';
 import StemDeniedDetails from '../components/StemDeniedDetails';
-import { getStemClaims } from '../actions';
+import { setUpPage } from '../utils/page';
+
+const setTitle = () => {
+  document.title = 'Your Edith Nourse Rogers STEM Scholarship application';
+};
 
 class StemClaimStatusPage extends React.Component {
   componentDidMount() {
-    this.setTitle();
+    setTitle();
     setUpPage();
     this.props.getStemClaims();
-  }
-
-  setTitle() {
-    document.title = 'Your Edith Nourse Rogers STEM Scholarship application';
   }
 
   render() {
@@ -77,10 +78,10 @@ class StemClaimStatusPage extends React.Component {
   }
 }
 
-function mapStateToProps(state, props) {
+function mapStateToProps(state, ownProps) {
   const claimsState = state.disability.status;
   const claim = claimsState.claimsV2.stemClaims.filter(
-    stemClaim => stemClaim.id === props.params.id,
+    stemClaim => stemClaim.id === ownProps.params.id,
   )[0];
   return {
     loading: claimsState.claimsV2.stemClaimsLoading,
@@ -96,5 +97,11 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps,
 )(StemClaimStatusPage);
+
+StemClaimStatusPage.propTypes = {
+  claim: PropTypes.object,
+  getStemClaims: PropTypes.func,
+  loading: PropTypes.bool,
+};
 
 export { StemClaimStatusPage };

--- a/src/applications/claims-status/tests/components/ClaimStatusHeader.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimStatusHeader.unit.spec.jsx
@@ -4,16 +4,9 @@ import { expect } from 'chai';
 
 import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 
-import { buildDateFormatter } from '../../utils/helpers';
-import ClaimStatusHeader from '../../components/ClaimStatusHeader';
-
-const getLastUpdated = claim => {
-  const updatedOn = buildDateFormatter()(
-    claim.attributes.claimPhaseDates?.phaseChangeDate,
-  );
-
-  return `Last updated: ${updatedOn}`;
-};
+import ClaimStatusHeader, {
+  getLastUpdated,
+} from '../../components/ClaimStatusHeader';
 
 describe('<ClaimStatusHeader>', () => {
   it('should render a ClaimStatusHeader section for an In Progress claim', () => {

--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import moment from 'moment';
-import _ from 'lodash';
+import { find, get, startCase } from 'lodash';
 import * as Sentry from '@sentry/browser';
 import { Link } from 'react-router';
-import { Toggler } from 'platform/utilities/feature-toggles';
+
+import { Toggler } from '~/platform/utilities/feature-toggles';
 
 import Decision from '../components/appeals-v2/Decision';
 import { ITEMS_PER_PAGE } from '../constants';
@@ -243,9 +244,9 @@ export function addStatusToIssues(issues) {
  * @returns {object} One appeal object or undefined if not found in the array
  */
 export function isolateAppeal(state, id) {
-  return _.find(
+  return find(
     state.disability.status.claimsV2.appeals,
-    a => a.id === id || (_.get(a, 'attributes.appealIds') || []).includes(id),
+    a => a.id === id || (get(a, 'attributes.appealIds') || []).includes(id),
   );
 }
 
@@ -282,7 +283,7 @@ export function getStatusContents(appeal, name = {}) {
   const appealType = appeal.type;
   const statusType = status.type || status;
   const details = status.details || {};
-  const amaDocket = _.get(appeal, 'attributes.docket.type');
+  const amaDocket = get(appeal, 'attributes.docket.type');
   const aojDescription = getAojDescription(aoj);
 
   const contents = {};
@@ -580,7 +581,7 @@ export function getStatusContents(appeal, name = {}) {
       contents.title = 'The appeal was closed';
       contents.description = (
         <p>
-          VA records indicate that {_.startCase(_.toLower(nameString))} is
+          VA records indicate that {startCase(nameString.toLowerCase())} is
           deceased, so this appeal has been closed. If this information is
           incorrect, please contact your Veterans Service Organization or
           representative as soon as possible.
@@ -1462,7 +1463,7 @@ export function getNextEvents(appeal) {
       };
     }
     case STATUS_TYPES.pendingHearingScheduling: {
-      const eligibleToSwitch = _.get(
+      const eligibleToSwitch = get(
         appeal,
         'attributes.docket.eligibleToSwitch',
       );


### PR DESCRIPTION
## Summary
These are changes that I extracted out of a PR that will come after this one in an attempt to make the next PR smaller

Summary of changes:
* `src/applications/claims-status/claims-status-entry.jsx`
    * Updating platform imports to fix linting issues
* `src/applications/claims-status/components/ClaimDetailLayout.jsx`
    * Replacing logic for checking if claim is open with the `isClaimOpen` helper function
    * Updating an instance of `props.claim.id` to be `claim.id` since claim is already available directly in the current scope
* `src/applications/claims-status/components/ClaimStatusHeader.jsx`
    * Exporting `getLastUpdated` as it is being used in the spec for this component as well. This will allow changes to `getLastUpdated` to be propagated to the spec without any user intervention
* `src/applications/claims-status/components/FilesNeededOld.jsx` 
    * Replacing `getTrackedItemId(item)` with `item.id` as there is no longer a need for the helper as we are only using Lighthouse claims now
* `src/applications/claims-status/components/Notification.jsx` 
    * Updating the propType of the `body` prop to indicate that is can either be a string or an object
* `src/applications/claims-status/components/TabItem.jsx` 
    * Converting this component from a Class-based component to a functional one. This will allow it to use the hooks provided by later versions of `react-router-dom`
* `src/applications/claims-status/components/TabNav.jsx` 
    * Destructuring the `cstUseClaimDetailsV2` key off of the `Toggler.TOGGLE_NAMES` object to simplify the JSX a bit
    * Updating the shortcut for the overview tab to be 3 as it is acting as a replacement for the details and should be accessible via the same keyboard shortcut as the details tab
* `src/applications/claims-status/components/appeals-v2/AppealsV2TabNav.jsx`
    * Converting the component from an arrow function to a regular function so that we can move the `export default` code up to the declaration instead of having to do it separately
* `src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx` 
    * Destructuring the `claim` and `lastPage` keys off of `this.props` as `claim` is used in multiple places and `lastPage` will be used multiple times after later changes are introduced
* `src/applications/claims-status/components/claim-files-tab/DocumentsFiled.jsx` 
    * Reordering imports to align with convention established in other files
* `src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx`
    * Replacing `getTrackedItemId(item)` with `item.id` as there is no longer a need for the helper as we are only using Lighthouse claims now
* `src/applications/claims-status/components/claim-files-tab/FilesOptional.jsx`
    * Replacing `getTrackedItemId(item)` with `item.id` as there is no longer a need for the helper as we are only using Lighthouse claims now
* `src/applications/claims-status/components/claim-status-tab/ClosedClaimAlert.jsx`
    * Replacing an instance of the component using moment for date formatting with a call to the `buildDateFormatter` helper that provides the same functionality but with `date-fns` instead of `moment`
* `src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx`
    * Fixing a typo (missing m) in the `getOldestDocuentDate` function
    * Moving the `export default` to the function declaration
    * **Fixed a bug where `item.id` (the id of the tracked item) was being used as the id of the claim in the `to` prop of a `Link` component**
    * Replacing `getTrackedItemId(item)` with `item.id` as there is no longer a need for the helper as we are only using Lighthouse claims now
* `src/applications/claims-status/containers/ClaimPage.jsx`
    * Converting the component from a Class-based component to a functional one. This will allow hooks to be used
* `src/applications/claims-status/containers/DocumentRequestPage.jsx`
    * Replacing an instance of `_.merge` with `merge`  as importing `_` from lodash imports the entire lodash library whereas importing `merge` by itself only pulls in the code needed for the `merge` function
* `src/applications/claims-status/containers/FilesPage.jsx`
    * Updating the propTypes of the `message.body` prop to indicate that is can either be a string or an object
* `src/applications/claims-status/containers/StemClaimStatusPage.jsx` 
    * Moving `setTitle` out of the component because it does not rely on any of the classes internal state / variables (fixes a linter error as well)
    * Renaming `props` to `ownProps` in the `mapStateToProps` function to match the standard convention used elsewhere in the code
    * Adding propTypes for the component
* `src/applications/claims-status/tests/components/ClaimStatusHeader.unit.spec.jsx`
    * importing `getLastUpdated` from the component as it's not being exported. This will allow us to have changes to the original `getLastUpdated` function propagated to the spec automatically
* `src/applications/claims-status/utils/appeals-v2-helpers.jsx`
    * Replacing calls to `_.{some function}` from lodash with the individual modules. This will reduce the amount of code that gets pulled into our application 

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#50486

## Testing done
Tests still pass - no functional changes were made so this is as expected

## Screenshots
#### ClaimDetailLayout
<img width="500" alt="Screenshot 2024-03-27 at 12 06 47 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/4fa737ee-5030-481e-a61e-110e9c1999db">

#### TabItem
<img width="500" alt="Screenshot 2024-03-27 at 12 07 04 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/0823588a-2e30-47f5-a427-6ece81d00043">

#### AppealsV2TabNav
<img width="500" alt="Screenshot 2024-03-27 at 12 09 25 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/d56f1ec3-2d70-4bb5-8eb2-029578cfb742">

#### ClosedClaimAlert
<img width="500" alt="Screenshot 2024-03-27 at 12 08 13 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/5c42f51a-38a0-45a3-b2f3-30dde3c96420">

#### StemClaimStatusPage
<img width="277" alt="Screenshot 2024-03-27 at 12 08 52 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/dc36d3e2-1ab4-4984-9105-1b84df0e983d">

## What areas of the site does it impact?
Claim Status Tool

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
