### PR TITLE
Remove reference to va_online_scheduling_required_schedulable_param feature flag

### DIFF
--- a/src/applications/mhv/secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
+++ b/src/applications/mhv/secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
@@ -1731,10 +1731,6 @@
         "value": true
       },
       {
-        "name": "va_online_scheduling_required_schedulable_param",
-        "value": true
-      },
-      {
         "name": "vaOnlineSchedulingAfterVisitSummary",
         "value": false
       },


### PR DESCRIPTION
This PR removes the obsolete feature flag `va_online_scheduling_required_schedulable_param` and its references in this repo. This flag is currently enabled in [staging](https://staging-api.va.gov/v0/feature_toggles?cookie_id) and [production](https://api.va.gov/v0/feature_toggles).

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/63682. 

## Testing done

- Prior to this change, the feature flag is set to be true for e2e testing. 
- Ensure e2e tests continue to pass after the feature flag is removed.
- TBD: _Describe the tests completed and the results_

## Screenshots

N/A

## What areas of the site does it impact?

No other areas impacted.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
