### PR TITLE
[Bugfix] Personal health care contacts: toggle nav link

### DIFF
--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -50,8 +50,14 @@ const ProfileWrapper = ({
 
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
   const profileContactsToggle = useToggleValue(TOGGLE_NAMES.profileContacts);
+  const profileShowDirectDepositSingleFormToggle = useToggleValue(
+    TOGGLE_NAMES.profileShowDirectDepositSingleForm,
+  );
 
-  const routesForNav = getRoutesForNav(profileContactsToggle);
+  const routesForNav = getRoutesForNav({
+    profileContacts: profileContactsToggle,
+    profileShowDirectDepositSingleForm: profileShowDirectDepositSingleFormToggle,
+  });
 
   const layout = useMemo(
     () => {

--- a/src/applications/personalization/profile/routesForNav.js
+++ b/src/applications/personalization/profile/routesForNav.js
@@ -79,7 +79,7 @@ export const getRoutesForNav = (
 ) => {
   return routesForNav.reduce((acc, route) => {
     // don't include the contacts route if the profileContacts flag is false
-    if (!profileContacts && route.path === PROFILE_PATHS.CONTACTS) {
+    if (!profileContacts && route.name === PROFILE_PATH_NAMES.CONTACTS) {
       return acc;
     }
 

--- a/src/applications/personalization/profile/routesForNav.js
+++ b/src/applications/personalization/profile/routesForNav.js
@@ -79,7 +79,7 @@ export const getRoutesForNav = (
 ) => {
   return routesForNav.reduce((acc, route) => {
     // don't include the contacts route if the profileContacts flag is false
-    if (!profileContacts && route.name === PROFILE_PATH_NAMES.CONTACTS) {
+    if (!profileContacts && route.path === PROFILE_PATHS.CONTACTS) {
       return acc;
     }
 

--- a/src/applications/personalization/profile/tests/e2e/personal-health-care-contacts/contacts.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-health-care-contacts/contacts.cypress.spec.js
@@ -25,6 +25,22 @@ describe('Personal health care contacts -- feature enabled', () => {
     cy.intercept('GET', '/v0/feature_toggles*', featureToggles);
   });
 
+  it('links from the hub page', () => {
+    cy.intercept('GET', '/v0/profile/contacts', contacts);
+    cy.login(loa3User72);
+    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+    cy.get('a[href$="/profile/contacts"]').should('exist');
+    cy.injectAxeThenAxeCheck();
+  });
+
+  it('links from the nav', () => {
+    cy.intercept('GET', '/v0/profile/contacts', contacts);
+    cy.login(loa3User72);
+    cy.visit(PROFILE_PATHS.CONTACTS);
+    cy.get('a[href$="/profile/contacts"]').should('exist');
+    cy.injectAxeThenAxeCheck();
+  });
+
   it("displays a Veteran's Next of kin and Emergency contacts", () => {
     cy.intercept('GET', '/v0/profile/contacts', contacts);
     cy.login(loa3User72);

--- a/src/applications/personalization/profile/tests/routes.unit.spec.js
+++ b/src/applications/personalization/profile/tests/routes.unit.spec.js
@@ -15,6 +15,24 @@ describe('getRoutes', () => {
       expect(hasDirectDepositRoute).to.be.true;
     });
   });
+
+  it('enables contacts route when true', () => {
+    const phccRoute = routesForNav.find(
+      route => route.name === PROFILE_PATH_NAMES.CONTACTS,
+    );
+    expect(phccRoute).to.exist;
+    const routes = getRoutes({ profileContacts: true });
+    expect(routes).to.include(phccRoute);
+  });
+
+  it('disables contacts route when false', () => {
+    const phccRoute = routesForNav.find(
+      route => route.name === PROFILE_PATH_NAMES.CONTACTS,
+    );
+    expect(phccRoute).to.exist;
+    const routes = getRoutes({ profileContacts: false });
+    expect(routes).to.not.include(phccRoute);
+  });
 });
 
 describe('getRoutesForNav', () => {


### PR DESCRIPTION
## Summary

- There was a regression that prevented the Profile sub nav from displaying a feature toggled link.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#79265
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#62159

## Testing done

- Describe what the old behavior was prior to the change: When visiting a page within `/profile`, the Personal health care contacts link was not displayed when the `profile_contacts` feature toggle was enabled.
- Describe the steps required to verify your changes are working as expected.: The Personal health care contacts link is displayed in the Profile sub nav when the `profile_contacts` feature toggle is enabled.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |    ![Screenshot 2024-03-27 at 09-45-33 Personal Health Care Contacts Veterans Affairs](https://github.com/department-of-veterans-affairs/vets-website/assets/1299034/bc2290da-70a2-4a3a-a13f-8a7d25509310)    |   ![Screenshot 2024-03-27 at 09-46-27 Personal Health Care Contacts Veterans Affairs](https://github.com/department-of-veterans-affairs/vets-website/assets/1299034/28b9704e-4dfc-4a89-bf57-83cac26c1f55)    |
| Desktop |     ![Screenshot 2024-03-27 at 09-44-11 Personal Health Care Contacts Veterans Affairs](https://github.com/department-of-veterans-affairs/vets-website/assets/1299034/f708e15f-eeb7-435e-aa8a-1a3645239a8b)   |   ![Screenshot 2024-03-27 at 09-36-22 Personal Health Care Contacts Veterans Affairs](https://github.com/department-of-veterans-affairs/vets-website/assets/1299034/baa3ff19-fb87-47e6-b684-553dbd5d4bbb)    |


## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
