### PR TITLE
MHV-55494 Remove-Status-And-The-Note-After-The-Status-From-Health-Conditions

### DIFF
--- a/src/applications/mhv/medical-records/containers/ConditionDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/ConditionDetails.jsx
@@ -56,7 +56,7 @@ const ConditionDetails = props => {
   );
   const { conditionId } = useParams();
   const dispatch = useDispatch();
-  const activeAlert = useAlerts();
+  const activeAlert = useAlerts(dispatch);
 
   useEffect(
     () => {

--- a/src/applications/mhv/medical-records/containers/ConditionDetails.jsx
+++ b/src/applications/mhv/medical-records/containers/ConditionDetails.jsx
@@ -56,14 +56,14 @@ const ConditionDetails = props => {
   );
   const { conditionId } = useParams();
   const dispatch = useDispatch();
-  const activeAlert = useAlerts(dispatch);
+  const activeAlert = useAlerts();
 
   useEffect(
     () => {
       dispatch(
         setBreadcrumbs([
           {
-            url: '/conditions',
+            url: '/my-health/medical-records/conditions',
             label: 'Conditions',
           },
         ]),
@@ -171,12 +171,6 @@ SNOMED Clinical term: ${record.name} \n`;
           </div>
           <div className="condition-details max-80">
             <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              Status of health condition
-            </h2>
-            <p data-dd-privacy="mask" data-testid="condition-status">
-              {record.active}
-            </p>
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
               Provider
             </h2>
             <p data-dd-privacy="mask" data-testid="condition-provider">
@@ -187,12 +181,6 @@ SNOMED Clinical term: ${record.name} \n`;
             </h2>
             <p data-dd-privacy="mask" data-testid="condition-location">
               {record.facility || 'There is no facility reported at this time'}
-            </p>
-            <h2 className="vads-u-font-size--base vads-u-font-family--sans">
-              SNOMED Clinical term
-            </h2>
-            <p data-dd-privacy="mask" data-testid="condition-snomed">
-              {record.name}
             </p>
             <h2 className="vads-u-margin-bottom--0">Provider notes</h2>
             <ItemList

--- a/src/applications/mhv/medical-records/reducers/conditions.js
+++ b/src/applications/mhv/medical-records/reducers/conditions.js
@@ -31,8 +31,6 @@ export const convertCondition = condition => {
       ? formatDateLong(condition.recordedDate)
       : EMPTY_FIELD,
     name: condition.code?.text || EMPTY_FIELD,
-    clinicalTerm: condition.code?.coding?.code || EMPTY_FIELD,
-    active: condition.clinicalStatus?.coding?.code || EMPTY_FIELD,
     provider: condition.asserter || EMPTY_FIELD,
     facility: condition.facility,
     comments: condition.note || EMPTY_FIELD,

--- a/src/applications/mhv/medical-records/tests/e2e/medical-records-view-conditions-details.cypress.spec.js
+++ b/src/applications/mhv/medical-records/tests/e2e/medical-records-view-conditions-details.cypress.spec.js
@@ -10,10 +10,8 @@ describe('Medical Records View Conditions', () => {
 
     ConditionsListPage.verifyConditionsPageTitle();
     ConditionsListPage.clickConditionsDetailsLink(0);
-    ConditionDetailsPage.verifyConditionStatus('abc123');
     ConditionDetailsPage.verifyProvider('Dr. John');
     ConditionDetailsPage.verifyLocation("chiropractor's office");
-    ConditionDetailsPage.verifySnomed('Back pain (SCT 161891005)');
     ConditionDetailsPage.verifyProviderNotes('A note');
     // Axe check
     cy.injectAxe();

--- a/src/applications/mhv/medical-records/tests/e2e/pages/ConditionDetailsPage.js
+++ b/src/applications/mhv/medical-records/tests/e2e/pages/ConditionDetailsPage.js
@@ -1,11 +1,6 @@
 // import defaultCondition from '../fixtures/Condition.json';
 
 class ConditionDetailsPage {
-  verifyConditionStatus = status => {
-    cy.get('[data-testid="condition-status"]').should('be.visible');
-    cy.get('[data-testid="condition-status"]').contains(status);
-  };
-
   verifyProvider = provider => {
     cy.get('[data-testid="condition-provider"]').should('be.visible');
     cy.get('[data-testid="condition-provider"]').contains(provider);
@@ -14,11 +9,6 @@ class ConditionDetailsPage {
   verifyLocation = location => {
     cy.get('[data-testid="condition-location"]').should('be.visible');
     cy.get('[data-testid="condition-location"]').contains(location);
-  };
-
-  verifySnomed = snomed => {
-    cy.get('[data-testid="condition-snomed"]').should('be.visible');
-    cy.get('[data-testid="condition-snomed"]').contains(snomed);
   };
 
   verifyProviderNotes = providerNotes => {


### PR DESCRIPTION
## Summary
"Status of health condition" and "SNOMED Clinical term" have been taken off the ConditionsDetail page.

## Related issue(s)
[MHV-55494](https://jira.devops.va.gov/browse/MHV-55494) - Remove status and the note after the status from Health Conditions

Remove status and the note after the status from Health Conditions.

From Amelia:  This is a minor change, so I didn't add it to the "for devs" page in Figma (but I certainly can if that would be helpful)
We are removing status and the note after the status from health conditions, as per request from the SMEs. These are now the only fields in health conditions details pages.

User Story: As a Medical Records User, I want to   * , so that I can    

GIVEN

WHEN

THEN

Feature Flag Y/N ? N

DataDog/Analytics Y/N ? N

Manual Testing Y/N ? Y

Automated Testing Y/N ? Y

Accessibility Testing Y/N ? N

UCD Validation Y/N N

 
Acceptance Criteria:

AC1  Status Field has been removed from Health Conditions

AC2 Notes after the status field has been removed from Health Conditions

AC3 Send Amelia screen shot for validation
AC4
AC5


Links to UCD:

Figma Link:

User Flow:

Mobile:

Desktop:

Other Design Notes:

## Testing done
Conducted UI testing to ensure the expected behavior. I updated existing unit test for new components.

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/8ae81081-2fc7-4d42-ae86-3b9711ad355e)


## What areas of the site does it impact?
The modification affects the conditionsDetail section of the Medical Records page.


## Acceptance criteria
AC1  Status Field has been removed from Health Conditions
AC2 Notes after the status field has been removed from Health Conditions
AC3 Send Amelia screen shot for validation
AC4
AC5

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
