### PR TITLE
 A little more testing for 21-0966

### DIFF
--- a/src/applications/simple-forms/21-0966/components/ITFStatusLoadingIndicatorPage.jsx
+++ b/src/applications/simple-forms/21-0966/components/ITFStatusLoadingIndicatorPage.jsx
@@ -2,12 +2,14 @@ import React, { useEffect } from 'react';
 import { waitForRenderThenFocus } from 'platform/utilities/ui';
 
 export default () => {
-  useEffect(() => {
+  const focus = () => {
     /* istanbul ignore next */
     if (!window.Cypress) {
       waitForRenderThenFocus('va-loading-indicator');
     }
-  }, []);
+  };
+
+  useEffect(focus, []);
 
   return (
     <div className="vads-u-margin-y--5">

--- a/src/applications/simple-forms/21-0966/tests/components/ITFStatusLoadingIndicatorPage.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0966/tests/components/ITFStatusLoadingIndicatorPage.unit.spec.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import ITFStatusLoadingIndicatorPage from '../../components/ITFStatusLoadingIndicatorPage';
+
+describe('ITFStatusLoadingIndicatorPage', () => {
+  afterEach(cleanup);
+
+  it('renders without crashing', () => {
+    render(<ITFStatusLoadingIndicatorPage />);
+  });
+});


### PR DESCRIPTION
## Summary
This is a small afterthought for [my previous PR](https://github.com/department-of-veterans-affairs/vets-website/pull/28802), adding a component test for 21-0966.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1161


## Screenshots
Now all rows are GREEN ✅ !

<img width="1722" alt="Screenshot 2024-03-27 at 11 35 05 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/10481391/1edde0e6-987f-42ab-88eb-0f918d61af7c">

