### PR TITLE
Update appointments links to send users directly into the app

### DIFF
--- a/src/applications/mhv-landing-page/utilities/data/index.js
+++ b/src/applications/mhv-landing-page/utilities/data/index.js
@@ -53,8 +53,8 @@ const resolveLandingPageLinks = (
   // Appointments section points to VAOS on va.gov
   const appointmentLinks = [
     {
-      href: '/my-health/appointments',
-      text: 'Schedule and manage appointments',
+      href: '/my-health/appointments/schedule/type-of-care',
+      text: 'Schedule a new appointment',
       toggle: null,
     },
     {


### PR DESCRIPTION
The first link still should be 'Schedule a new appointment'

The first link is navigating to /my-health/appointments/schedule/type-of-care

Before:
<img width="525" alt="Screenshot 2024-03-27 at 12 25 22 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/7745936/f562cde2-6623-49a2-8491-c902e1b43dbb">
 
After:
<img width="520" alt="Screenshot 2024-03-27 at 12 24 59 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/7745936/4253d927-8551-43a7-b3b5-8eff5c81d81b">

## Related issue(s)

[Related PR](https://github.com/department-of-veterans-affairs/va.gov-team/issues/77185#69895)

## What areas of the site does it impact?

My HealtheVet Landing Page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
