### PR TITLE
Replacement application URL changes

### DIFF
--- a/src/applications/pensions/21p527ez/README.md
+++ b/src/applications/pensions/21p527ez/README.md
@@ -1,155 +1,115 @@
 # Form: 21P-527EZ - Application for Veterans Pension
 
 ## Routes (URLs)
-### Base URLs
-[https://www.staging.va.gov/pension/application/527EZ](https://www.staging.va.gov/pension/application/527EZ)
 
-[https://www.va.gov/pension/application/527EZ](https://www.va.gov/pension/application/527EZ)
+### Base URLs
+
+[https://www.staging.va.gov/pension/apply-for-veteran-pension-form-21p-527ez](https://www.staging.va.gov/pension/apply-for-veteran-pension-form-21p-527ez)
+
+[https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez)
 
 Note: All of the following urls are listed with the `va.gov` base url
 
 ### Introduction
-[https://www.va.gov/pension/application/527EZ/introduction](https://www.va.gov/pension/application/527EZ/introduction)
+
+[https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/introduction](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/introduction)
 
 ### Chapters and Pages
+
 #### Applicant Information
+
 - Applicant Information
-[https://www.va.gov/pension/application/527EZ/applicant/information](https://www.va.gov/pension/application/527EZ/applicant/information)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/applicant/information](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/applicant/information)
 
 #### Military History
+
 - Service Periods
-[https://www.va.gov/pension/application/527EZ/military/history](https://www.va.gov/pension/application/527EZ/military/history)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/military/history](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/military/history)
 - General History
-[https://www.va.gov/pension/application/527EZ/military/general](https://www.va.gov/pension/application/527EZ/military/general)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/military/general](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/military/general)
 - Reserve and National Guard
-[https://www.va.gov/pension/application/527EZ/military/reserve-national-guard](https://www.va.gov/pension/application/527EZ/military/reserve-national-guard)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/military/reserve-national-guard](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/military/reserve-national-guard)
 - Pow Status & Severance Pay
-[https://www.va.gov/pension/application/527EZ/military/pow-severance](https://www.va.gov/pension/application/527EZ/military/pow-severance)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/military/pow-severance](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/military/pow-severance)
 
 #### Work History
+
 - Disability History
-[https://www.va.gov/pension/application/527EZ/disability/history](https://www.va.gov/pension/application/527EZ/disability/history)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/disability/history](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/disability/history)
 - Employment History
-[https://www.va.gov/pension/application/527EZ/employment/history](https://www.va.gov/pension/application/527EZ/employment/history)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/employment/history](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/employment/history)
 
 #### Household Information
+
 - Marriage History
-[https://www.va.gov/pension/application/527EZ/household/marriage-info](https://www.va.gov/pension/application/527EZ/household/marriage-info)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/household/marriage-info](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/household/marriage-info)
 - Current Marriage / 1st Marriage / 2nd Marriage / Etc.
-[https://www.va.gov/pension/application/527EZ/household/marriages/:index](https://www.va.gov/pension/application/527EZ/household/marriages/:index)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/household/marriages/:index](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/household/marriages/:index)
 - Spouse Information (Required if married)
-[https://www.va.gov/pension/application/527EZ/household/spouse-info](https://www.va.gov/pension/application/527EZ/household/spouse-info)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/household/spouse-info](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/household/spouse-info)
 - Spouse Marriage History (Required if spouse married more than once)
-[https://www.va.gov/pension/application/527EZ/household/spouse-marriages/:index](https://www.va.gov/pension/application/527EZ/household/spouse-marriages/:index)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/household/spouse-marriages/:index](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/household/spouse-marriages/:index)
 - Dependent Children
-[https://www.va.gov/pension/application/527EZ/household/dependents](https://www.va.gov/pension/application/527EZ/household/dependents)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/household/dependents](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/household/dependents)
 - Children Information (Required if dependents)
-[https://www.va.gov/pension/application/527EZ/household/dependents/children/information/:index](https://www.va.gov/pension/application/527EZ/household/dependents/children/information/:index)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/household/dependents/children/information/:index](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/household/dependents/children/information/:index)
 - Children Address (Required if dependents)
-[https://www.va.gov/pension/application/527EZ/household/dependents/children/address/:index](https://www.va.gov/pension/application/527EZ/household/dependents/children/address/:index)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/household/dependents/children/address/:index](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/household/dependents/children/address/:index)
 
 #### Financial Disclosure
+
 - Net Worth
-[https://www.va.gov/pension/application/527EZ/financial-disclosure/net-worth](https://www.va.gov/pension/application/527EZ/financial-disclosure/net-worth)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/net-worth](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/net-worth)
 - Monthly Income
-[https://www.va.gov/pension/application/527EZ/financial-disclosure/monthly-income](https://www.va.gov/pension/application/527EZ/financial-disclosure/monthly-income)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/monthly-income](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/monthly-income)
 - Expected Income
-[https://www.va.gov/pension/application/527EZ/financial-disclosure/expected-income](https://www.va.gov/pension/application/527EZ/financial-disclosure/expected-income)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/expected-income](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/expected-income)
 - Other Expenses
-[https://www.va.gov/pension/application/527EZ/financial-disclosure/other-expenses](https://www.va.gov/pension/application/527EZ/financial-disclosure/other-expenses)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/other-expenses](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/other-expenses)
 - Spouse Net Worth (Required if married)
-[https://www.va.gov/pension/application/527EZ/financial-disclosure/net-worth/spouse](https://www.va.gov/pension/application/527EZ/financial-disclosure/net-worth/spouse)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/net-worth/spouse](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/net-worth/spouse)
 - Spouse Monthly Income (Required if married)
-[https://www.va.gov/pension/application/527EZ/financial-disclosure/monthly-income/spouse](https://www.va.gov/pension/application/527EZ/financial-disclosure/monthly-income/spouse)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/monthly-income/spouse](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/monthly-income/spouse)
 - Spouse Expected Income (Required if married)
-[https://www.va.gov/pension/application/527EZ/financial-disclosure/expected-income/spouse](https://www.va.gov/pension/application/527EZ/financial-disclosure/expected-income/spouse)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/expected-income/spouse](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/expected-income/spouse)
 - Spouse Other Expenses (Required if married)
-[https://www.va.gov/pension/application/527EZ/financial-disclosure/other-expenses/spouse](https://www.va.gov/pension/application/527EZ/financial-disclosure/other-expenses/spouse)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/other-expenses/spouse](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/other-expenses/spouse)
 - Dependents Net Worth (Required if dependents)
-[https://www.va.gov/pension/application/527EZ/financial-disclosure/net-worth/dependents/:index](https://www.va.gov/pension/application/527EZ/financial-disclosure/net-worth/dependents/:index)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/net-worth/dependents/:index](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/net-worth/dependents/:index)
 - Dependents Monthly Income (Required if dependents)
-[https://www.va.gov/pension/application/527EZ/financial-disclosure/monthly-income/dependents/:index](https://www.va.gov/pension/application/527EZ/financial-disclosure/monthly-income/dependents/:index)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/monthly-income/dependents/:index](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/monthly-income/dependents/:index)
 - Dependents Expected Income (Required if dependents)
-[https://www.va.gov/pension/application/527EZ/financial-disclosure/expected-income/dependents/:index](https://www.va.gov/pension/application/527EZ/financial-disclosure/expected-income/dependents/:index)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/expected-income/dependents/:index](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/expected-income/dependents/:index)
 - Dependents Other Expenses (Required if dependents)
-[https://www.va.gov/pension/application/527EZ/financial-disclosure/other-expenses/dependents/:index](https://www.va.gov/pension/application/527EZ/financial-disclosure/other-expenses/dependents/:index)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/other-expenses/dependents/:index](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/financial-disclosure/other-expenses/dependents/:index)
 
 #### Additional Information
+
 - Direct Deposit
-[https://www.va.gov/pension/application/527EZ/additional-information/direct-deposit](https://www.va.gov/pension/application/527EZ/additional-information/direct-deposit)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/additional-information/direct-deposit](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/additional-information/direct-deposit)
 - Contact Information
-[https://www.va.gov/pension/application/527EZ/additional-information/contact](https://www.va.gov/pension/application/527EZ/additional-information/contact)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/additional-information/contact](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/additional-information/contact)
 - Aid and Attendance and Housebound benefits
-[https://www.va.gov/pension/application/527EZ/additional-information/aid-attendance](https://www.va.gov/pension/application/527EZ/additional-information/aid-attendance)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/additional-information/aid-attendance](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/additional-information/aid-attendance)
 - Document Upload
-[https://www.va.gov/pension/application/527EZ/documents](https://www.va.gov/pension/application/527EZ/documents)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/documents](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/documents)
 - Fully Developed Claim Program
-[https://www.va.gov/pension/application/527EZ/additional-information/fdc](https://www.va.gov/pension/application/527EZ/additional-information/fdc)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/additional-information/fdc](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/additional-information/fdc)
 
 #### Review and Submit
+
 - Review Application
-[https://www.va.gov/pension/application/527EZ/review-and-submit](https://www.va.gov/pension/application/527EZ/review-and-submit)
+  [https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/review-and-submit](https://www.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/review-and-submit)
 
 ## Context
 
-VA Form 21P-527EZ (Application for Veterans Pension) is intended for wartime Veterans who want to file a pension claim. 
+VA Form 21P-527EZ (Application for Veterans Pension) is intended for wartime Veterans who want to file a pension claim.
 
 This form, 21P-527EZ, should not be confused with VA Form 21P-527 (Income, Net Worth, and Employment Statement), which allows Veterans who have already filed a claim for pension benefits to add financial evidence to their existing claim. VA21-527 is paper-only.
 
 ### Async and Error Handling for Form Submission
 
 527EZ is submitted via a POST request to /v0/in_progress_forms/21P-527EZ.
-- `app/controllers/claims_base_controller.rb` 
-	- Enters submission flow via `ClaimsBaseController#create`
-		- Creates and validates an instance of the class, removing any copies of the form that had been previously saved by the user.
-	- Adds Sentry tags via `lib/pension_burial/tag_sentry.rb` 
-	- Creates a new instance of `SavedClaim::Pension` (`app/models/saved_claim/pension.rb`) via `V0::PensionClaimsController::ClaimsBaseController` (`app/controllers/v0/pension_claims_controller.rb`)
-		- argument: ClaimsBaseController::filteredParams :form
-		- formatted JSON string
-		- **schema validation appears to only check if keys :short_name and :form are present**
-	- If the claim fails to save, StatsD failure count is increased and a ValidationError is raised
-	- If claim is saved successfully:
-		- *async* Runs `SavedClaim#process_attachments!` which attempts to process any files and workflows that are present and send them to internal partners for processing via `CentralMail::SubmitSavedClaimJob#perform_async` (see below for details on `perform_async`)
-		- StatsD success count is increased and some claim data is logged, the saved form is cleared, and the success page is rendered
-- `app/sidekiq/central_mail/submit_saved_claim_job.rb`
-	- `CentralMail::SubmitSavedClaimJob#perform`
-		- argument: saved claim ID
-		- **async sidekick job**
-	- Adds Sentry tags via `lib/pension_burial/tag_sentry.rb` 
-	- Attempts to find the claim by ID
-		- No error handling if claim not found
-	- Creates a PDF of the claim using `.to_pdf`, which forwards to `PdfFill::Filler#fill_form` (`lib/pdf_fill/filler.rb`)
-		- Converts the data to a hash using `PdfFill::Forms` (`lib/pdf_fill/forms/va21p527ez.rb`)
-			- In some cases, has alternate handling if data is null
-			- Otherwise, no specific error handling
-		- Creates a file and filepath; adds additional extra docs in some cases (flow unclear)
-		- No error handling
-	- `CentralMail::SubmitSavedClaimJob#process_record` is run for the claim and each persistent attachment
-		- argument: claim object
-		- Creates a new `CentralMail::DatestampPdf` (`lib/central_mail/datestamp_pdf.rb`)
-			- No error handling in `#process_record` or `#perform` for errors in this step. DatestampPDF has some logging and error handling in its methods, with some errors being raised to the called method. Because this is occurring in the async method, I don't think these errors would be returned to the user. 
-	- `CentralMail::SubmitSavedClaimJob#create_request_body`
-		- Generates request metadata in `CentralMail::SubmitSavedClaimJob#generate_metadata`
-			- Mostly involves pulling data off the claim, but also reads data from the PDF files created in `#process_record`
-			- No specific error handling
-		- Runs `to_faraday_upload` for each created file
-			- No specific error handling
-	- Passes the created request body to `CentralMail::Service#upload` (`lib/central_mail/service.rb`)
-		- Adds additional Sentry tags via Raven
-		- Uploads the data
-			- Upload occurs in a `with_monitoring do` block
-		- Adds additional Sentry tags via Raven after request completes, and increases StatsD upload failure count if the request fails
-	- Logs the response if the claim type is VRE
-		- skipped in the pension flow
-	- Deletes all local copies of created files
-		- No specific error handling
-	- If the upload response is a success:
-		- Update the claim's central_mail_submission status to success if it has a central_mail_submission
-			- No specific error handling
-		- Send a confirmation email if the claim has the send_confirmation_email method **(unclear if pension does)**
-			- No specific error handling
-	- Else if the upload response fails:
-		- raise CentralMailResponseError
-	- *Error handling*: If any error occurs in the entirety of `CentralMail::SubmitSavedClaimJob#perform`:
-		- Update the claim's central_mail_submission status to failure if it has a central_mail_submission
-		- Re-raise the error to the calling method 
+
+- `app/controllers/claims_base_controller.rb` - Enters submission flow via `ClaimsBaseController#create` - Creates and validates an instance of the class, removing any copies of the form that had been previously saved by the user. - Adds Sentry tags via `lib/pension_burial/tag_sentry.rb` - Creates a new instance of `SavedClaim::Pension` (`app/models/saved_claim/pension.rb`) via `V0::PensionClaimsController::ClaimsBaseController` (`app/controllers/v0/pension_claims_controller.rb`) - argument: ClaimsBaseController::filteredParams :form - formatted JSON string - **schema validation appears to only check if keys :short_name and :form are present** - If the claim fails to save, StatsD failure count is increased and a ValidationError is raised - If claim is saved successfully: - _async_ Runs `SavedClaim#process_attachments!` which attempts to process any files and workflows that are present and send them to internal partners for processing via `CentralMail::SubmitSavedClaimJob#perform_async` (see below for details on `perform_async`) - StatsD success count is increased and some claim data is logged, the saved form is cleared, and the success page is rendered
+- `app/sidekiq/central_mail/submit_saved_claim_job.rb` - `CentralMail::SubmitSavedClaimJob#perform` - argument: saved claim ID - **async sidekick job** - Adds Sentry tags via `lib/pension_burial/tag_sentry.rb` - Attempts to find the claim by ID - No error handling if claim not found - Creates a PDF of the claim using `.to_pdf`, which forwards to `PdfFill::Filler#fill_form` (`lib/pdf_fill/filler.rb`) - Converts the data to a hash using `PdfFill::Forms` (`lib/pdf_fill/forms/va21p527ez.rb`) - In some cases, has alternate handling if data is null - Otherwise, no specific error handling - Creates a file and filepath; adds additional extra docs in some cases (flow unclear) - No error handling - `CentralMail::SubmitSavedClaimJob#process_record` is run for the claim and each persistent attachment - argument: claim object - Creates a new `CentralMail::DatestampPdf` (`lib/central_mail/datestamp_pdf.rb`) - No error handling in `#process_record` or `#perform` for errors in this step. DatestampPDF has some logging and error handling in its methods, with some errors being raised to the called method. Because this is occurring in the async method, I don't think these errors would be returned to the user. - `CentralMail::SubmitSavedClaimJob#create_request_body` - Generates request metadata in `CentralMail::SubmitSavedClaimJob#generate_metadata` - Mostly involves pulling data off the claim, but also reads data from the PDF files created in `#process_record` - No specific error handling - Runs `to_faraday_upload` for each created file - No specific error handling - Passes the created request body to `CentralMail::Service#upload` (`lib/central_mail/service.rb`) - Adds additional Sentry tags via Raven - Uploads the data - Upload occurs in a `with_monitoring do` block - Adds additional Sentry tags via Raven after request completes, and increases StatsD upload failure count if the request fails - Logs the response if the claim type is VRE - skipped in the pension flow - Deletes all local copies of created files - No specific error handling - If the upload response is a success: - Update the claim's central*mail_submission status to success if it has a central_mail_submission - No specific error handling - Send a confirmation email if the claim has the send_confirmation_email method **(unclear if pension does)** - No specific error handling - Else if the upload response fails: - raise CentralMailResponseError - \_Error handling*: If any error occurs in the entirety of `CentralMail::SubmitSavedClaimJob#perform`: - Update the claim's central_mail_submission status to failure if it has a central_mail_submission - Re-raise the error to the calling method

--- a/src/applications/pensions/manifest.json
+++ b/src/applications/pensions/manifest.json
@@ -2,6 +2,6 @@
   "appName": "21-527EZ pension benefits form",
   "entryFile": "./pensions-entry.jsx",
   "entryName": "pensions",
-  "rootUrl": "/pension/application/527EZ",
+  "rootUrl": "/pension/apply-for-veteran-pension-form-21p-527ez",
   "productId": "fb68f9f1-c8f0-4e81-9181-57c35dc84910"
 }

--- a/src/applications/pensions/tests/e2e/cypress.setup.js
+++ b/src/applications/pensions/tests/e2e/cypress.setup.js
@@ -4,7 +4,8 @@ import featuresEnabled from '../fixtures/mocks/featuresEnabled.json';
 import mockStatus from '../fixtures/mocks/profile-status.json';
 import mockVamc from '../fixtures/mocks/vamc-ehr.json';
 
-const TEST_URL = '/pension/application/527EZ/introduction';
+const TEST_URL =
+  '/pension/apply-for-veteran-pension-form-21p-527ez/introduction';
 const IN_PROGRESS_URL = '/v0/in_progress_forms/21P-527EZ';
 const PENSIONS_CLAIMS_URL = '/v0/pension_claims';
 const SUBMISSION_DATE = new Date().toISOString();

--- a/src/applications/pensions/tests/unit/PensionsApp.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/PensionsApp.unit.spec.jsx
@@ -12,7 +12,7 @@ const pensionLocation = {
   hash: '',
   action: 'POP',
   key: null,
-  basename: '/pension/application/527EZ',
+  basename: '/pension/apply-for-veteran-pension-form-21p-527ez',
   query: '{}',
 };
 

--- a/src/applications/static-pages/pension-how-do-i-apply-widget/components/App/index.js
+++ b/src/applications/static-pages/pension-how-do-i-apply-widget/components/App/index.js
@@ -32,7 +32,7 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
       <p>You can apply online right now.</p>
       <a
         className="vads-c-action-link--green"
-        href="/pension/application/527EZ/introduction"
+        href="/pension/apply-for-veteran-pension-form-21p-527ez/introduction"
       >
         Apply for Veteran Pension benefits
       </a>
@@ -141,7 +141,7 @@ export const App = ({ loggedIn, toggleLoginModal }) => {
             saved information when you fill out the PDF form.
           </p>
           <va-link
-            href="/pension/application/527EZ/introduction"
+            href="/pension/apply-for-veteran-pension-form-21p-527ez/introduction"
             text="Refer to your saved form"
           />
           <p>Then submit your completed form in 1 of these ways:</p>

--- a/src/applications/static-pages/pension-how-do-i-apply-widget/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/pension-how-do-i-apply-widget/components/App/index.unit.spec.js
@@ -73,7 +73,8 @@ describe('Pension Widget <App>', () => {
       </Provider>,
     );
 
-    const selector = 'va-link[href="/pension/application/527EZ/introduction"]';
+    const selector =
+      'va-link[href="/pension/apply-for-veteran-pension-form-21p-527ez/introduction"]';
     expect($(selector, container)).to.not.be.null;
   });
 

--- a/src/platform/landing-pages/header-footer-data.json
+++ b/src/platform/landing-pages/header-footer-data.json
@@ -423,7 +423,7 @@
                 {
                   "text": "File a claim online",
                   "href": "/disability/file-disability-claim-form-21-526ez/"
-                }    
+                }
               ]
             },
             "columnTwo": {
@@ -561,8 +561,7 @@
                   "href": "/careers-employment/veteran-owned-business-support"
                 },
                 {
-                  "href":
-                    "/careers-employment/vocational-rehabilitation/apply-vre-form-28-1900/",
+                  "href": "/careers-employment/vocational-rehabilitation/apply-vre-form-28-1900/",
                   "text": "Apply for VR&E benefits"
                 }
               ]
@@ -629,7 +628,7 @@
                 },
                 {
                   "text": "Apply now for a Veterans Pension",
-                  "href": "/pension/application/527EZ"
+                  "href": "/pension/apply-for-veteran-pension-form-21p-527ez"
                 }
               ]
             },


### PR DESCRIPTION
## Summary

Pensions team has been asked to change the root url of the site from:
pension/application/527EZ

to: 
pension/apply-for-veteran-pension-form-21p-527ez

## Testing done

-  Made the changes, tested locally.  
