### PR TITLE
update instances of formation color variables to css-library equivalents - ask-va

### DIFF
--- a/src/applications/ask-va/sass/ask-va-too.scss
+++ b/src/applications/ask-va/sass/ask-va-too.scss
@@ -118,7 +118,7 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
 }
 
 .remove-attachment-button-wrapper {
-  color: $color-red-dark;
+  color: var(--vads-color-secondary-dark);
 }
 
 .header-breadcrumbs {
@@ -141,7 +141,7 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
     width: 18px;
     text-align: center;
     margin-right: 8px;
-    color: $color-link-default;
+    color: var(--vads-color-link);
   }
 
   .clearfix {
@@ -152,11 +152,11 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
 
   .search-controls-container {
     padding: 24px 16px 0 12px;
-    border: solid thin $color-gray-lightest;
-    background: $color-gray-lightest;
+    border: solid thin var(--vads-color-base-lightest);
+    background: var(--vads-color-base-lightest);
 
     select:disabled {
-      background: $color-gray-lightest;
+      background: var(--vads-color-base-lightest);
     }
 
     #facility-search-controls {
@@ -236,7 +236,7 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
       .use-my-location-link {
         text-decoration: none;
         background-color: transparent;
-        color: $color-link-default;
+        color: var(--vads-color-link);
         font-weight: normal;
         padding: 0;
         margin: 0;
@@ -274,7 +274,7 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
     position: absolute;
     float: right;
     background-color: rgb(255, 255, 255);
-    color: $color-black;
+    color: var(--vads-color-black);
     font-family: "Font Awesome 5 Free";
     max-width: 2rem;
     left: 68%;


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

This PR updates the names of color variables in `/ask-va` from formation to their css-library equivalents in preparation for moving away from formation.

## Related issue(s)

[79489](https://github.com/department-of-veterans-affairs/va.gov-team/issues/79489)

## Testing done

local testing of build

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
