### PR TITLE
update instances of formation color variables to css-library equivalents - post-911-gib-status

### DIFF
--- a/src/applications/post-911-gib-status/sass/post-911-gib-status.scss
+++ b/src/applications/post-911-gib-status/sass/post-911-gib-status.scss
@@ -8,14 +8,14 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
   margin-bottom: 5em;
 
   h3 {
-    border-bottom: 1px solid $color-gray-light;
+    border-bottom: 1px solid var(--vads-color-base-light);
     margin: 1em 0 .5em 0;
     padding: 0 0 .25em 0;
   }
 
   hr {
     border-style: solid;
-    border-color: $color-gray-light;
+    border-color: var(--vads-color-base-light);
     border-width: 1px 0 0 0;
     margin-top: 1em;
     margin-bottom: 1em;
@@ -60,7 +60,7 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
   }
 
   .print-status {
-    background-color: $color-white;
+    background-color: var(--vads-color-white);
     position: fixed;
     top: 0;
     left: 0;
@@ -87,7 +87,7 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
 
     @media print {
       font: $font-serif;
-      color: $color-gray-dark;
+      color: var(--vads-color-base-darker);
       padding: 0;
       a {
         text-decoration: none;
@@ -111,7 +111,7 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
   hr {
     margin-top: 0;
     margin-bottom: 0;
-    border-color: $color-primary;
+    border-color: var(--vads-color-primary);
   }
 
   .gi-phone-nowrap {


### PR DESCRIPTION
## Summary
This PR updates the names of color variables in`/post-911-gib-status` from formation to their css-library equivalents in preparation for moving away from formation.

## Related issue(s)

[79489](https://github.com/department-of-veterans-affairs/va.gov-team/issues/79489)

## Testing done

local testing of build

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
