### PR TITLE
update instances of formation color variables to css-library equivalents - proxy-rewrite

### DIFF
--- a/src/applications/proxy-rewrite/sass/_m-vet-nav-px.scss
+++ b/src/applications/proxy-rewrite/sass/_m-vet-nav-px.scss
@@ -24,7 +24,7 @@ body.va-pos-fixed {
 }
 
 #vetnav {
-  background-color: $color-primary-darkest;
+  background-color: var(--vads-color-primary-darker);
 
   // This value should be equal to the default y-position of the menu so that removing it
   // shouldn't affect anything. However, it's here to show how the height is offset by the
@@ -101,7 +101,7 @@ body.va-pos-fixed {
     padding: calc(10px + 2px);
     margin: 8px 16px;
     width: auto;
-    background-color: $color-gray-lightest;
+    background-color: var(--vads-color-base-lightest);
 
     &:hover {
       text-decoration: none;
@@ -130,7 +130,7 @@ body.va-pos-fixed {
   }
 
   path {
-    fill: $color-white;
+    fill: var(--vads-color-white);
   }
 
   @include media($medium-screen) {
@@ -156,8 +156,8 @@ body.va-pos-fixed {
     //border-bottom: 1px solid transparent;
 
     &:hover {
-      background-color: $color-primary;
-      border-bottom-color: $color-primary;
+      background-color: var(--vads-color-primary);
+      border-bottom-color: var(--vads-color-primary);
       transition: none;
     }
   }
@@ -166,13 +166,13 @@ body.va-pos-fixed {
 .vetnav-level1 {
   font-size: 16px;
   -webkit-font-smoothing: antialiased;
-  background-color: $color-primary-darker;
+  background-color: var(--vads-color-primary-dark);
   background-position: right 30px center;
   background-repeat: no-repeat;
   background-size: 13px auto;
   border-radius: 0;
   border-top: 3px solid transparent;
-  color: $color-white;
+  color: var(--vads-color-white);
   cursor: pointer;
   display: block;
   font-weight: bold;
@@ -193,10 +193,10 @@ body.va-pos-fixed {
 
   &[aria-expanded="true"] {
     @include media($medium-screen) {
-      color: $color-base;
-      background-color: $color-white;
+      color: var(--vads-color-base);
+      background-color: var(--vads-color-white);
       background-image: url(/img/arrow-up.svg);
-      border-top-color: $color-va-accent;
+      border-top-color: var(--vads-color-va-accent);
     }
   }
 
@@ -204,7 +204,7 @@ body.va-pos-fixed {
     background-image: url(/img/plus-white.svg);
 
     &:hover {
-      background-color: $color-primary;
+      background-color: var(--vads-color-primary);
     }
 
     @include media($medium-screen) {
@@ -233,7 +233,7 @@ body.va-pos-fixed {
 
 .vetnav-level2 {
   font-size: 16px;
-  background: $color-primary-darkest url(/img/arrow-right-white.svg) right 30px
+  background: var(--vads-color-primary-darker) url(/img/arrow-right-white.svg) right 30px
     center no-repeat;
   background-size: 14px auto;
   border-radius: 0;
@@ -251,7 +251,7 @@ body.va-pos-fixed {
     border-color: transparent;
     border-style: solid;
     border-width: 1px 0;
-    color: $color-link-default;
+    color: var(--vads-color-link);
     background-size: 10px auto;
     margin-left: 8px;
     padding: 8px 0 8px 16px;
@@ -261,17 +261,17 @@ body.va-pos-fixed {
     &:hover {
       background-color: transparent;
       border-bottom: 1px solid transparent;
-      box-shadow: -3px 0 $color-va-accent;
-      color: $color-primary;
+      box-shadow: -3px 0 var(--vads-color-va-accent);
+      color: var(--vads-color-primary);
       text-decoration: underline;
     }
 
     &[aria-expanded="true"] {
-      background-color: $color-gray-lightest;
-      border-bottom-color: $color-gray-warm-light;
-      border-top-color: $color-gray-warm-light;
-      box-shadow: -3px 0 $color-va-accent;
-      color: $color-gray-dark;
+      background-color: var(--vads-color-base-lightest);
+      border-bottom-color: var(--vads-color-gray-warm-light);
+      border-top-color: var(--vads-color-gray-warm-light);
+      box-shadow: -3px 0 var(--vads-color-va-accent);
+      color: var(--vads-color-base-darker);
       font-weight: bold;
       text-decoration: inherit;
       position: relative;
@@ -291,7 +291,7 @@ body.va-pos-fixed {
 }
 
 #vetnav .back-button {
-  background: $color-primary-darker url(/img/arrow-left-white.svg) right 30px
+  background: var(--vads-color-primary-dark) url(/img/arrow-left-white.svg) right 30px
     center no-repeat;
   background-position: left 1px center;
   background-size: 14px auto;
@@ -313,13 +313,13 @@ body.va-pos-fixed {
     font-size: 16px;
 
     background-image: none;
-    color: $color-white;
+    color: var(--vads-color-white);
     display: block;
     padding: 8px 16px;
     text-decoration: none;
 
     @include media($medium-screen) {
-      color: $color-link-default;
+      color: var(--vads-color-link);
 
       &:hover {
         background: transparent;
@@ -329,8 +329,8 @@ body.va-pos-fixed {
   }
 
   @include media($medium-screen) {
-    box-shadow: 0 5px 9px -5px $color-base;
-    background: $color-white;
+    box-shadow: 0 5px 9px -5px var(--vads-color-base);
+    background: var(--vads-color-white);
     padding-bottom: 16px;
     position: absolute;
   }
@@ -338,7 +338,7 @@ body.va-pos-fixed {
 
 .vetnav-panel--submenu {
   &:not([hidden]) {
-    background-color: $color-primary-darkest;
+    background-color: var(--vads-color-primary-darker);
     box-shadow: none;
     position: absolute;
     width: 100%;
@@ -347,8 +347,8 @@ body.va-pos-fixed {
     margin: 0;
 
     @include media($medium-screen) {
-      border-left: 1px solid $color-gray-warm-light;
-      background-color: $color-gray-lightest;
+      border-left: 1px solid var(--vads-color-gray-warm-light);
+      background-color: var(--vads-color-base-lightest);
       height: 100%;
       margin-left: 230px;
       left: 30px;
@@ -507,7 +507,7 @@ body.va-pos-fixed {
     }
 
     path {
-      fill: $color-white;
+      fill: var(--vads-color-white);
     }
 
     @include media($medium-screen) {
@@ -517,7 +517,7 @@ body.va-pos-fixed {
 
   .vetnav-panel {
     @include media($medium-screen) {
-      box-shadow: 0 5px 9px -3px $color-base;
+      box-shadow: 0 5px 9px -3px var(--vads-color-base);
     }
   }
 

--- a/src/applications/proxy-rewrite/sass/consolidated-patches.scss
+++ b/src/applications/proxy-rewrite/sass/consolidated-patches.scss
@@ -24,7 +24,7 @@ $teamsite-large-screen: 1008px;
 }
 
 .login .container h1 {
-  color: $color-black !important;
+  color: var(--vads-color-black) !important;
 }
 
 .usa-banner-content p {
@@ -67,7 +67,7 @@ header.merger {
 
       // HACK: override rules from benefits.va.gov
       .va-crisis-line-text {
-        color: $color-white;
+        color: var(--vads-color-white);
       }
     }
   }
@@ -191,16 +191,16 @@ footer.footer {
 }
 
 .footer-lastupdated {
-  background: $color-white;
-  color: $color-gray-dark;
+  background: var(--vads-color-white);
+  color: var(--vads-color-base-darker);
   font-size: 1em;
-  border: 2px solid $color-gray-light;
+  border: 2px solid var(--vads-color-base-light);
   padding: 5px 0;
 }
 
 .sign-in-nav {
   .sign-in-links {
-    color: $color-white;
+    color: var(--vads-color-white);
   }
 }
 

--- a/src/applications/proxy-rewrite/sass/style-consolidated.scss
+++ b/src/applications/proxy-rewrite/sass/style-consolidated.scss
@@ -108,7 +108,7 @@ $font-stack: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Roboto", "Arial"
 
 .consolidated {
   font-family: $font-stack;
-
+  @import '~@department-of-veterans-affairs/component-library/dist/main.css';
   @import "~@department-of-veterans-affairs/formation/sass/core";
   @import "~@department-of-veterans-affairs/formation/sass/modules/m-alert";
   @import "~@department-of-veterans-affairs/formation/sass/modules/m-table";
@@ -136,6 +136,7 @@ $font-stack: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Roboto", "Arial"
   @import "m-vet-nav-px";
   @import "../../../platform/site-wide/sass/shame";
   @import "consolidated-patches";
+
 }
 
 // A specificity issue snuck into teamsites that switched some divs to use Arial


### PR DESCRIPTION
## Summary

This PR updates the names of color variables in `/proxy-rewrite` from formation to their css-library equivalents in preparation for moving away from formation.

## Related issue(s)

[79489](https://github.com/department-of-veterans-affairs/va.gov-team/issues/79489)

## Testing done

local testing of build and app

## Screenshots

<img width="1371" alt="Screenshot 2024-03-28 at 1 21 50 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/8867779/4a91875d-4285-4a45-bc1c-edc40560c4ab">

<hr/>

<img width="1376" alt="Screenshot 2024-03-28 at 1 22 08 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/8867779/c1c8234c-0975-4921-a7de-2513645b0bf0">

<hr/> 

<img width="1378" alt="Screenshot 2024-03-28 at 1 22 21 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/8867779/6b8b581c-51ab-4669-9018-b31610765223">


## What areas of the site does it impact?

header / footer on teamsites

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
