### PR TITLE
[1060] fix: update all required checkBoxUI components to properly require input

### DIFF
--- a/src/applications/simple-forms/20-10207/pages/livingSituation.js
+++ b/src/applications/simple-forms/20-10207/pages/livingSituation.js
@@ -16,7 +16,6 @@ export default {
       errorMessages: {
         required: 'Select the appropriate living situation',
       },
-      // TODO: Determine how custom-validations work here.
     }),
     'ui:validations': [validateLivingSituation],
   },
@@ -25,5 +24,6 @@ export default {
     properties: {
       livingSituation: checkboxGroupSchema(Object.keys(LIVING_SITUATIONS)),
     },
+    required: ['livingSituation'],
   },
 };

--- a/src/applications/simple-forms/20-10207/pages/livingSituationThirdPartyNonVeteran.js
+++ b/src/applications/simple-forms/20-10207/pages/livingSituationThirdPartyNonVeteran.js
@@ -27,5 +27,6 @@ export default {
         Object.keys(LIVING_SITUATIONS_3RD_PTY_NON_VET),
       ),
     },
+    required: ['livingSituation'],
   },
 };

--- a/src/applications/simple-forms/20-10207/pages/livingSituationThirdPartyVeteran.js
+++ b/src/applications/simple-forms/20-10207/pages/livingSituationThirdPartyVeteran.js
@@ -27,5 +27,6 @@ export default {
         Object.keys(LIVING_SITUATIONS_3RD_PTY_VET),
       ),
     },
+    required: ['livingSituation'],
   },
 };

--- a/src/applications/simple-forms/20-10207/pages/otherReasons.js
+++ b/src/applications/simple-forms/20-10207/pages/otherReasons.js
@@ -23,5 +23,6 @@ export default {
     properties: {
       otherReasons: checkboxGroupSchema(Object.keys(OTHER_REASONS)),
     },
+    required: ['otherReasons'],
   },
 };

--- a/src/applications/simple-forms/20-10207/pages/otherReasonsThirdPartyNonVeteran.js
+++ b/src/applications/simple-forms/20-10207/pages/otherReasonsThirdPartyNonVeteran.js
@@ -25,5 +25,6 @@ export default {
         Object.keys(OTHER_REASONS_3RD_PTY_NON_VET),
       ),
     },
+    required: ['otherReasons'],
   },
 };

--- a/src/applications/simple-forms/20-10207/pages/otherReasonsThirdPartyVeteran.js
+++ b/src/applications/simple-forms/20-10207/pages/otherReasonsThirdPartyVeteran.js
@@ -23,5 +23,6 @@ export default {
     properties: {
       otherReasons: checkboxGroupSchema(Object.keys(OTHER_REASONS_3RD_PTY_VET)),
     },
+    required: ['otherReasons'],
   },
 };


### PR DESCRIPTION
## Summary

- _Updated all checkBoxUI component configurations to correctly require input_
- _Navigating to any of the following routes and refreshing the page would make cause the (* Required) warning message disappear_
  - [living-situation-third-party-veteran](http://localhost:3001/supporting-forms-for-claims/request-priority-processing-form-20-10207/living-situation-third-party-veteran)
  - [living-situation-third-party-non-veteran](http://localhost:3001/supporting-forms-for-claims/request-priority-processing-form-20-10207/living-situation-third-party-non-veteran)
  - [other-reasons-third-party-veteran](http://localhost:3001/supporting-forms-for-claims/request-priority-processing-form-20-10207/other-reasons-third-party-veteran)
  - [other-reasons-third-party-non-veteran](http://localhost:3001/supporting-forms-for-claims/request-priority-processing-form-20-10207/other-reasons-third-party-non-veteran)


## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/VA.gov-team-forms/issues/1060

## Testing done

- _Browser testing_
## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile |![Screenshot 2024-03-28 at 3 06 25 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/3fa660b3-0c80-4e9a-952d-8c6998544830)|![Screenshot 2024-03-28 at 3 06 40 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/13545543-1f26-4391-9098-81b92e22f3a9)|
| Mobile |![Screenshot 2024-03-28 at 3 08 46 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/974cd62b-ed83-4d6d-b763-d26d7d1bcaa4)|![Screenshot 2024-03-28 at 3 08 59 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/e1205820-2366-4edd-85ed-242d7e512b0b)|
| Mobile |![Screenshot 2024-03-28 at 3 10 47 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/fc8b3eaa-5cc6-4e9d-a1f2-2508d2712384)|![Screenshot 2024-03-28 at 3 10 56 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/5f7d62aa-f93d-40ef-96ef-1be139d263d8)|
| Mobile |![Screenshot 2024-03-28 at 3 15 40 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/10ded40e-e7cc-43bf-9849-a6cdf878b50e)|![Screenshot 2024-03-28 at 3 15 51 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/161746194/f070f7a5-2650-4ee8-bd9e-29fa3e0075dd)|






## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
