### PR TITLE
Fix toxic exposure date validation for Health Care Application

### DIFF
--- a/src/applications/hca/utils/validation.js
+++ b/src/applications/hca/utils/validation.js
@@ -2,8 +2,8 @@ import moment from 'moment';
 import {
   convertToDateField,
   validateCurrentOrPastDate,
-} from 'platform/forms-system/src/js/validation';
-import { isValidDateRange } from 'platform/forms/validations';
+} from '~/platform/forms-system/src/js/validation';
+import { isValidDateRange } from '~/platform/forms/validations';
 
 export function validateServiceDates(
   errors,
@@ -77,7 +77,7 @@ export function validateExposureDates(
     errors.toxicExposureStartDate.addError(messages.format);
   }
 
-  if (toDate.month && !toDate.year) {
+  if (toDate.month.value && !toDate.year.value) {
     errors.toxicExposureEndDate.addError(messages.format);
   }
 


### PR DESCRIPTION
## Summary
This PR updates the validation for toxic exposure dates to correctly validate the actual value. This is a bugfix where we aren't currently looking at the value when checking the form data.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#77804

## Testing done

- Prior to the change the `To` field for the exposure dates are not being checked
- After the change, we are checking the value for that field

## Acceptance criteria

 - Date fields are correctly validating

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution