### PR TITLE
MHV-55961: Medication image changes

### DIFF
--- a/src/applications/mhv/medications/components/PrescriptionDetails/VaPrescription.jsx
+++ b/src/applications/mhv/medications/components/PrescriptionDetails/VaPrescription.jsx
@@ -138,6 +138,7 @@ const VaPrescription = prescription => {
                 >
                   <h3
                     className="vads-u-margin-y--2 vads-u-font-size--lg vads-u-font-family--sans vads-u-margin-bottom--2"
+                    data-testid="rx-refill"
                     id={`h3-refill-${refillHistory.length - i - 1}`}
                   >
                     {i + 1 === refillHistory.length
@@ -181,6 +182,7 @@ const VaPrescription = prescription => {
                           1}`}
                         aria-labelledby="prescription-name"
                         className="vads-u-margin-top--1"
+                        data-testid="rx-image"
                         src={getImageUri(entry.cmopNdcNumber)}
                         alt={entry.prescriptionName}
                         width="350"

--- a/src/applications/mhv/medications/components/PrescriptionDetails/VaPrescription.jsx
+++ b/src/applications/mhv/medications/components/PrescriptionDetails/VaPrescription.jsx
@@ -138,10 +138,10 @@ const VaPrescription = prescription => {
                 >
                   <h3
                     className="vads-u-margin-y--2 vads-u-font-size--lg vads-u-font-family--sans vads-u-margin-bottom--2"
-                    data-testid="refill"
+                    id={`h3-refill-${refillHistory.length - i - 1}`}
                   >
                     {i + 1 === refillHistory.length
-                      ? 'First fill'
+                      ? 'Original fill'
                       : `Refill ${refillHistory.length - i - 1}`}
                   </h3>
                   <h4
@@ -172,25 +172,23 @@ const VaPrescription = prescription => {
                     className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-top--2 vads-u-margin--0"
                     data-testid="med-image"
                   >
-                    Image of the medication or supply
+                    Image
                   </h4>
                   <div className="no-print">
                     {entry.cmopNdcNumber ? (
-                      <va-additional-info
-                        trigger="Review image"
-                        data-testid="review-rx-image"
-                        uswds
-                      >
-                        <img
-                          src={getImageUri(entry.cmopNdcNumber)}
-                          alt={entry.prescriptionName}
-                          width="350"
-                          height="350"
-                        />
-                      </va-additional-info>
+                      <img
+                        aria-describedby={`prescription-name h3-refill-${i +
+                          1}`}
+                        aria-labelledby="prescription-name"
+                        className="vads-u-margin-top--1"
+                        src={getImageUri(entry.cmopNdcNumber)}
+                        alt={entry.prescriptionName}
+                        width="350"
+                        height="350"
+                      />
                     ) : (
                       <p className="vads-u-margin--0" data-testid="no-image">
-                        No image available
+                        Image not available
                       </p>
                     )}
                   </div>

--- a/src/applications/mhv/medications/tests/e2e/medications-refill-history-details-page..cypress.spec.js
+++ b/src/applications/mhv/medications/tests/e2e/medications-refill-history-details-page..cypress.spec.js
@@ -20,13 +20,12 @@ describe('Medications Refill History on Details Page', () => {
     detailsPage.verifyFirstRefillHeaderTextOnDetailsPage();
     detailsPage.verifyFillDateFieldOnDetailsPage();
     detailsPage.verifyShippedOnDateFieldOnDetailsPage();
-    detailsPage.verifyImageOfMedicationFieldOnDetailsPage();
+    detailsPage.verifyNoImageFieldMessageOnDetailsPage();
     detailsPage.verifyRxFilledByPharmacyDateOnDetailsPage(
       refillHistoryDetails.data.attributes.refillDate,
     );
     detailsPage.verifyRxShippedOnDateOnDetailsPage(
       refillHistoryDetails.data.attributes.dispensedDate,
     );
-    // No image available added as a separate test
   });
 });

--- a/src/applications/mhv/medications/tests/e2e/medications-rx-image-details-page.cypress.spec.js
+++ b/src/applications/mhv/medications/tests/e2e/medications-rx-image-details-page.cypress.spec.js
@@ -14,7 +14,7 @@ describe('Medications Details Review Image DropDown', () => {
     landingPage.visitLandingPageURL();
     listPage.clickGotoMedicationsLink();
     detailsPage.clickMedicationDetailsLink(rxTrackingDetails);
-    detailsPage.clickReviewImageDropDownOnDetailsPage();
+    // detailsPage.clickReviewImageDropDownOnDetailsPage();
     detailsPage.verifyMedicationImageVisibleOnDetailsPage();
     cy.injectAxe();
     cy.axeCheck('main');

--- a/src/applications/mhv/medications/tests/e2e/pages/MedicationsDetailsPage.js
+++ b/src/applications/mhv/medications/tests/e2e/pages/MedicationsDetailsPage.js
@@ -276,20 +276,13 @@ class MedicationsDetailsPage {
     );
   };
 
-  clickReviewImageDropDownOnDetailsPage = () => {
+  verifyMedicationImageVisibleOnDetailsPage = () => {
     cy.intercept(
       'GET',
       '/my_health/v1/prescriptions/get_prescription_image/00113002239',
       rxTracking,
     ).as('rxImage');
-    cy.get('[data-testid="review-rx-image"]').should('exist');
-    cy.get('[data-testid="review-rx-image"]').click({
-      waitForAnimations: true,
-    });
-  };
-
-  verifyMedicationImageVisibleOnDetailsPage = () => {
-    cy.get('[data-testid="review-rx-image"] > img').should('be.visible');
+    cy.get('[data-testid="rx-image"]').should('be.visible');
   };
 
   verifyRefillHistoryHeaderOnDetailsPage = () => {
@@ -300,7 +293,7 @@ class MedicationsDetailsPage {
   };
 
   verifyFirstRefillHeaderTextOnDetailsPage = () => {
-    cy.get('[data-testid="refill"]')
+    cy.get('[data-testid="rx-refill"]')
       .first()
       .should('contain', 'Refill 1');
   };
@@ -336,7 +329,7 @@ class MedicationsDetailsPage {
   };
 
   verifyNoImageFieldMessageOnDetailsPage = () => {
-    cy.get('[data-testid="no-image"]').should('contain', 'No image available');
+    cy.get('[data-testid="no-image"]').should('contain', 'Image not available');
   };
 
   verifyNonVaMedicationStatusOnDetailsPage = prescriptionDetails => {


### PR DESCRIPTION
## Summary

Minor changes to how we display images on Medication Details pags

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-55961

<img width="917" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/271e5aeb-81cb-4e4a-ac94-6e8852c70fac">

Sketch Link: [Medications – Figma](https://www.figma.com/file/UGHasFKuKENvKz8AgSmxtI/Medications?type=design&node-id=2172-28648&mode=design)

## Testing done

- Manual testing via Chrome DevTools Accessibility

## What areas of the site does it impact?

/my-health/medications/

## Screenshots

<img width="692" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/779ce312-8537-45cf-b2a8-3b9e41513d79">

<img width="645" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/4aebd2dd-4423-4e2d-bb9b-9ab3b51a4974">

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
