### PR TITLE
Remove stale actions from Health Care Application

### DIFF
--- a/src/applications/hca/reducers/enrollment-status.js
+++ b/src/applications/hca/reducers/enrollment-status.js
@@ -5,16 +5,12 @@ import {
 } from '../utils/constants';
 
 function hcaEnrollmentStatus(state = ENROLLMENT_STATUS_INIT_STATE, action) {
-  const { data = {}, response = {}, type } = action;
+  const { data = {}, type } = action;
   const {
     FETCH_ENROLLMENT_STATUS_STARTED,
     FETCH_ENROLLMENT_STATUS_SUCCEEDED,
     FETCH_ENROLLMENT_STATUS_FAILED,
     RESET_ENROLLMENT_STATUS,
-    FETCH_DISMISSED_HCA_NOTIFICATION_STARTED,
-    FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED,
-    FETCH_DISMISSED_HCA_NOTIFICATION_FAILED,
-    SET_DISMISSED_HCA_NOTIFICATION,
   } = ENROLLMENT_STATUS_ACTIONS;
 
   const actionMap = {
@@ -64,28 +60,6 @@ function hcaEnrollmentStatus(state = ENROLLMENT_STATUS_INIT_STATE, action) {
       };
     },
     [RESET_ENROLLMENT_STATUS]: () => ({ ...ENROLLMENT_STATUS_INIT_STATE }),
-    [FETCH_DISMISSED_HCA_NOTIFICATION_STARTED]: () => ({
-      ...state,
-      isLoadingDismissedNotification: true,
-    }),
-    [FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED]: () => {
-      const {
-        statusEffectiveAt: dismissedNotificationDate,
-      } = response.data.attributes;
-      return {
-        ...state,
-        dismissedNotificationDate,
-        isLoadingDismissedNotification: false,
-      };
-    },
-    [FETCH_DISMISSED_HCA_NOTIFICATION_FAILED]: () => ({
-      ...state,
-      isLoadingDismissedNotification: false,
-    }),
-    [SET_DISMISSED_HCA_NOTIFICATION]: () => ({
-      ...state,
-      dismissedNotificationDate: data,
-    }),
   };
 
   return actionMap[type] ? actionMap[type]() : state;

--- a/src/applications/hca/tests/unit/reducers/enrollment-status.unit.spec.js
+++ b/src/applications/hca/tests/unit/reducers/enrollment-status.unit.spec.js
@@ -26,7 +26,6 @@ describe('hca EnrollmentStatus reducer', () => {
       expect(reducedState.noESRRecordFound).to.be.false;
       expect(reducedState.hasServerError).to.be.false;
       expect(reducedState.isLoadingApplicationStatus).to.be.false;
-      expect(reducedState.isLoadingDismissedNotification).to.be.false;
     });
   });
 
@@ -44,7 +43,6 @@ describe('hca EnrollmentStatus reducer', () => {
       expect(reducedState.noESRRecordFound).to.be.false;
       expect(reducedState.hasServerError).to.be.false;
       expect(reducedState.isLoadingApplicationStatus).to.be.false;
-      expect(reducedState.isLoadingDismissedNotification).to.be.false;
     });
   });
 
@@ -219,67 +217,6 @@ describe('hca EnrollmentStatus reducer', () => {
       reducedState = reducer(state, action);
       expect(reducedState.hasServerError).to.be.false;
       expect(reducedState.isLoadingApplicationStatus).to.be.false;
-      expect(reducedState.isLoadingDismissedNotification).to.be.false;
-    });
-  });
-
-  describe('when `FETCH_DISMISSED_HCA_NOTIFICATION_STARTED` executes', () => {
-    const {
-      FETCH_DISMISSED_HCA_NOTIFICATION_STARTED,
-    } = ENROLLMENT_STATUS_ACTIONS;
-    it('should set `isLoadingDismissedNotification` to `true`', () => {
-      state = { isLoadingDismissedNotification: false };
-      action = {
-        type: FETCH_DISMISSED_HCA_NOTIFICATION_STARTED,
-      };
-      reducedState = reducer(state, action);
-      expect(reducedState.isLoadingDismissedNotification).to.be.true;
-    });
-  });
-
-  describe('when `FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED` executes', () => {
-    const {
-      FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED,
-    } = ENROLLMENT_STATUS_ACTIONS;
-    it('should set the state correctly', () => {
-      state = {
-        isLoadingDismissedNotification: true,
-        dismissedNotificationDate: null,
-      };
-      action = {
-        type: FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED,
-        response: {
-          data: {
-            attributes: {
-              subject: 'form_10_10ez',
-              status: 'pending_mt',
-              statusEffectiveAt: '2019-02-25T01:22:00.000Z',
-              readAt: '2019-02-26T21:20:50.151Z',
-            },
-          },
-        },
-      };
-      reducedState = reducer(state, action);
-      expect(reducedState.isLoadingDismissedNotification).to.be.false;
-      expect(reducedState.dismissedNotificationDate).to.equal(
-        '2019-02-25T01:22:00.000Z',
-      );
-    });
-  });
-
-  describe('when `FETCH_DISMISSED_HCA_NOTIFICATION_FAILED` executes', () => {
-    const {
-      FETCH_DISMISSED_HCA_NOTIFICATION_FAILED,
-    } = ENROLLMENT_STATUS_ACTIONS;
-    it('should set `isLoadingDismissedNotification` to `false`', () => {
-      state = {
-        isLoadingDismissedNotification: true,
-      };
-      action = {
-        type: FETCH_DISMISSED_HCA_NOTIFICATION_FAILED,
-      };
-      reducedState = reducer(state, action);
-      expect(reducedState.isLoadingDismissedNotification).to.be.false;
     });
   });
 });

--- a/src/applications/hca/tests/unit/utils/actions.unit.spec.js
+++ b/src/applications/hca/tests/unit/utils/actions.unit.spec.js
@@ -5,11 +5,9 @@ import {
   mockApiRequest,
   mockFetch,
   setFetchJSONResponse,
-} from 'platform/testing/unit/helpers';
+} from '~/platform/testing/unit/helpers';
 
 import {
-  getDismissedHCANotification,
-  setDismissedHCANotification,
   getEnrollmentStatus,
   resetEnrollmentStatus,
 } from '../../../utils/actions';
@@ -21,10 +19,6 @@ describe('hca actions', () => {
     FETCH_ENROLLMENT_STATUS_SUCCEEDED,
     FETCH_ENROLLMENT_STATUS_FAILED,
     RESET_ENROLLMENT_STATUS,
-    FETCH_DISMISSED_HCA_NOTIFICATION_STARTED,
-    FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED,
-    FETCH_DISMISSED_HCA_NOTIFICATION_FAILED,
-    SET_DISMISSED_HCA_NOTIFICATION,
   } = ENROLLMENT_STATUS_ACTIONS;
   let dispatch;
 
@@ -131,106 +125,6 @@ describe('hca actions', () => {
     it('should dispatch a reset enrollment status action', () => {
       resetEnrollmentStatus()(dispatch);
       expect(dispatch.firstCall.args[0].type).to.equal(RESET_ENROLLMENT_STATUS);
-    });
-  });
-
-  describe('when `getDismissedHCANotification` executes', () => {
-    beforeEach(() => {
-      dispatch = sinon.spy();
-    });
-
-    describe('when fetch operation succeeds', () => {
-      it('should dispatch a fetch succeeded action with data', () => {
-        const mockData = { data: 'data' };
-        mockApiRequest(mockData);
-        return getDismissedHCANotification()(dispatch).then(() => {
-          expect(dispatch.firstCall.args[0].type).to.equal(
-            FETCH_DISMISSED_HCA_NOTIFICATION_STARTED,
-          );
-          expect(dispatch.secondCall.args[0]).to.eql({
-            type: FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED,
-            response: mockData,
-          });
-        });
-      });
-    });
-
-    describe('when fetch operation fails', () => {
-      it('should dispatch a fetch failed action', () => {
-        const mockData = { data: 'data' };
-        mockApiRequest(mockData, false);
-        return getDismissedHCANotification()(dispatch).then(() => {
-          expect(dispatch.firstCall.args[0].type).to.equal(
-            FETCH_DISMISSED_HCA_NOTIFICATION_STARTED,
-          );
-          expect(dispatch.secondCall.args[0].type).to.equal(
-            FETCH_DISMISSED_HCA_NOTIFICATION_FAILED,
-          );
-        });
-      });
-    });
-  });
-
-  describe('when `setDismissedHCANotification` executes', () => {
-    const statusEffectiveAtDate = 1565025055759;
-    beforeEach(() => {
-      mockFetch();
-      setFetchJSONResponse(global.fetch.onFirstCall(), { status: 'OK' });
-      dispatch = sinon.spy();
-    });
-
-    describe('when an HCA notification is being dismissed for the first time', () => {
-      beforeEach(() => {
-        setDismissedHCANotification('status', statusEffectiveAtDate)(
-          dispatch,
-          () => ({
-            hcaEnrollmentStatus: {
-              dismissedNotificationDate: null,
-            },
-          }),
-        );
-      });
-
-      it('should dispatch a SET_DISMISSED_HCA_NOTIFICATION action with the effective date', () => {
-        expect(dispatch.firstCall.args[0]).to.eql({
-          type: SET_DISMISSED_HCA_NOTIFICATION,
-          data: statusEffectiveAtDate,
-        });
-      });
-
-      it('should call the correct POST endpoint', () => {
-        expect(global.fetch.firstCall.args[0]).to.contain(
-          '/v0/notifications/dismissed_statuses',
-        );
-        expect(global.fetch.firstCall.args[1].method).to.eql('POST');
-      });
-    });
-
-    describe('when an HCA notification has previously been dismissed', () => {
-      beforeEach(() => {
-        setDismissedHCANotification('status', statusEffectiveAtDate)(
-          dispatch,
-          () => ({
-            hcaEnrollmentStatus: {
-              dismissedNotificationDate: 1565025055758,
-            },
-          }),
-        );
-      });
-
-      it('should dispatch a SET_DISMISSED_HCA_NOTIFICATION action with the effective date', () => {
-        expect(dispatch.firstCall.args[0]).to.eql({
-          type: SET_DISMISSED_HCA_NOTIFICATION,
-          data: statusEffectiveAtDate,
-        });
-      });
-
-      it('should call the correct PUT endpoint if a notification is being dismissed for the second time', () => {
-        expect(global.fetch.firstCall.args[0]).to.contain(
-          '/notifications/dismissed_statuses/form_10_10ez',
-        );
-        expect(global.fetch.firstCall.args[1].method).to.eql('PUT');
-      });
     });
   });
 });

--- a/src/applications/hca/utils/actions.js
+++ b/src/applications/hca/utils/actions.js
@@ -15,10 +15,6 @@ const {
   FETCH_ENROLLMENT_STATUS_FAILED,
   FETCH_ENROLLMENT_STATUS_SUCCEEDED,
   RESET_ENROLLMENT_STATUS,
-  FETCH_DISMISSED_HCA_NOTIFICATION_STARTED,
-  FETCH_DISMISSED_HCA_NOTIFICATION_FAILED,
-  FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED,
-  SET_DISMISSED_HCA_NOTIFICATION,
 } = ENROLLMENT_STATUS_ACTIONS;
 
 /**
@@ -162,64 +158,5 @@ export function getEnrollmentStatus(formData) {
 export function resetEnrollmentStatus() {
   return dispatch => {
     dispatch({ type: RESET_ENROLLMENT_STATUS });
-  };
-}
-
-/**
- * Action to fetch dismissed enrollment status notifications
- * @returns {Promise} - resolves to calling the reducer to set the correct state variables
- * for enrollment status
- */
-export function getDismissedHCANotification() {
-  return dispatch => {
-    dispatch({ type: FETCH_DISMISSED_HCA_NOTIFICATION_STARTED });
-    const url = `/notifications/dismissed_statuses/form_10_10ez`;
-    return apiRequest(url)
-      .then(response =>
-        dispatch({
-          type: FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED,
-          response,
-        }),
-      )
-      .catch(({ errors }) =>
-        dispatch({ type: FETCH_DISMISSED_HCA_NOTIFICATION_FAILED, errors }),
-      );
-  };
-}
-
-/**
- * Action to set dismissed enrollment status notifications
- * @param {String} status - current enrollment status value
- * @param {Number} statusEffectiveAt - timestamp for effective date
- * @returns {Promise} - resolves to calling the reducer to set the correct state variables
- * for enrollment status
- */
-export function setDismissedHCANotification(status, statusEffectiveAt) {
-  return (dispatch, getState) => {
-    const { dismissedNotificationDate } = selectEnrollmentStatus(getState());
-    const hasPreviouslyDismissedNotification = !!dismissedNotificationDate;
-    dispatch({
-      type: SET_DISMISSED_HCA_NOTIFICATION,
-      data: statusEffectiveAt,
-    });
-    if (hasPreviouslyDismissedNotification) {
-      return apiRequest('/notifications/dismissed_statuses/form_10_10ez', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          status,
-          statusEffectiveAt,
-        }),
-      });
-    }
-    return apiRequest('/notifications/dismissed_statuses', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        subject: 'form_10_10ez',
-        status,
-        statusEffectiveAt,
-      }),
-    });
   };
 }

--- a/src/applications/hca/utils/constants.js
+++ b/src/applications/hca/utils/constants.js
@@ -42,17 +42,10 @@ export const DISCHARGE_TYPE_LABELS = {
 
 // declare action statuses for fetching enrollment status
 export const ENROLLMENT_STATUS_ACTIONS = {
-  FETCH_DISMISSED_HCA_NOTIFICATION_STARTED:
-    'FETCH_DISMISSED_HCA_NOTIFICATION_STARTED',
-  FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED:
-    'FETCH_DISMISSED_HCA_NOTIFICATION_SUCCEEDED',
-  FETCH_DISMISSED_HCA_NOTIFICATION_FAILED:
-    'FETCH_DISMISSED_HCA_NOTIFICATION_FAILED',
   FETCH_ENROLLMENT_STATUS_STARTED: 'FETCH_ENROLLMENT_STATUS_STARTED',
   FETCH_ENROLLMENT_STATUS_SUCCEEDED: 'FETCH_ENROLLMENT_STATUS_SUCCEEDED',
   FETCH_ENROLLMENT_STATUS_FAILED: 'FETCH_ENROLLMENT_STATUS_FAILED',
   RESET_ENROLLMENT_STATUS: 'RESET_ENROLLMENT_STATUS',
-  SET_DISMISSED_HCA_NOTIFICATION: 'SET_DISMISSED_HCA_NOTIFICATION',
 };
 
 // declare initial state fetching enrollment status
@@ -62,10 +55,8 @@ export const ENROLLMENT_STATUS_INIT_STATE = {
   preferredFacility: null,
   enrollmentStatus: null,
   enrollmentStatusEffectiveDate: null,
-  dismissedNotificationDate: null,
   hasServerError: false,
   isLoadingApplicationStatus: false,
-  isLoadingDismissedNotification: false,
   isUserInMVI: false,
   loginRequired: false,
   noESRRecordFound: false,


### PR DESCRIPTION
## Summary
This PR removes unused/stale actions and associated state values from the Health Care Application.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#76129

## Testing done

- Updated all unit tests where values were referenced

## Acceptance criteria

 - Unused actions are removed from the application to reduce bloating

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution