### PR TITLE
Update intro page on 10-7959c form

### DIFF
--- a/src/applications/ivc-champva/10-7959C/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959C/containers/IntroductionPage.jsx
@@ -1,8 +1,12 @@
 import React from 'react';
+import { Link } from 'react-router';
+import { connect } from 'react-redux';
 
-import { focusElement } from 'platform/utilities/ui';
-import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
+import { focusElement } from '@department-of-veterans-affairs/platform-forms-system/ui';
+import FormTitle from '@department-of-veterans-affairs/platform-forms-system/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import GetFormHelp from '../../shared/components/GetFormHelp';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
@@ -10,84 +14,125 @@ class IntroductionPage extends React.Component {
   }
 
   render() {
-    const { route } = this.props;
+    const { route, loggedIn } = this.props;
     const { formConfig, pageList } = route;
 
     return (
       <article className="schemaform-intro">
         <FormTitle
-          title="10-7959C CHAMPVA Other Health Insurance Certification form"
-          subtitle="Equal to VA Form 10-7959C (10-7959C CHAMPVA Other Health Insurance Certification form)"
+          title="Apply for CHAMPVA Other Health Insurance Certification"
+          subTitle="Application for CHAMPVA Other Health Insurance Certification (VA Form 10-7959c)"
         />
-        <SaveInProgressIntro
-          headingLevel={2}
-          prefillEnabled={formConfig.prefillEnabled}
-          messages={formConfig.savedFormMessages}
-          pageList={pageList}
-          startText="Start the Application"
-        >
-          Please complete the 10-7959C form to apply for CHAMPVA other health
-          insurance certification.
-        </SaveInProgressIntro>
+
+        <p>
+          If you’re the spouse or child of a Veteran with disabilities or a
+          Veteran who has died, you may be able to get health insurance through
+          the Civilian Health and Medical Program of the Department of Veterans
+          Affairs (CHAMPVA). Apply online now.
+        </p>
+
+        {!loggedIn && (
+          <VaAlert status="info" visible uswds>
+            <h2>Have you applied for VA health care before?</h2>
+            <SaveInProgressIntro
+              buttonOnly
+              headingLevel={2}
+              prefillEnabled={formConfig.prefillEnabled}
+              messages={formConfig.savedFormMessages}
+              pageList={pageList}
+              unauthStartText="Sign in to check your application status"
+              hideUnauthedStartLink
+            />
+          </VaAlert>
+        )}
+
         <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
-          Follow the steps below to apply for CHAMPVA other health insurance
-          certification.
+          Follow the steps to get started
         </h2>
         <va-process-list uswds>
-          <va-process-list-item header="Prepare">
-            <h4>To fill out this application, you’ll need your:</h4>
+          <va-process-list-item header="Gather this information">
+            <p>
+              <b>Here’s what you’ll need to apply:</b>
+              Make sure you meet our eligibility requirements before you apply
+            </p>
             <ul>
-              <li>Social Security number (required)</li>
+              <li>
+                <b>Personal information about you</b> and anyone else you’re
+                applying for
+              </li>
             </ul>
             <p>
-              <strong>What if I need help filling out my application?</strong>{' '}
-              An accredited representative, like a Veterans Service Officer
-              (VSO), can help you fill out your claim.{' '}
-              <a href="/disability-benefits/apply/help/index.html">
-                Get help filing your claim
-              </a>
+              You may also need to submit supporting documents, like copies of
+              your Medicare or other health insurance cards
             </p>
           </va-process-list-item>
           <va-process-list-item header="Apply">
             <p>
-              Complete this CHAMPVA other health insurance certification form.
-            </p>
-            <p>
-              After submitting the form, you’ll get a confirmation message. You
-              can print this for your records.
+              We’ll take you through each step of the process. This application
+              should take about [XX] minutes.
             </p>
           </va-process-list-item>
-          <va-process-list-item header="VA Review">
+          <va-process-list-item header="After you apply">
             <p>
-              We process claims within a week. If more than a week has passed
-              since you submitted your application and you haven’t heard back,
-              please don’t apply again. Call us at.
-            </p>
-          </va-process-list-item>
-          <va-process-list-item header="Decision">
-            <p>
-              Once we’ve processed your claim, you’ll get a notice in the mail
-              with our decision.
+              We’ll contact you if we have questions or need more information.
             </p>
           </va-process-list-item>
         </va-process-list>
-        <SaveInProgressIntro
-          buttonOnly
-          headingLevel={2}
-          prefillEnabled={formConfig.prefillEnabled}
-          messages={formConfig.savedFormMessages}
-          pageList={pageList}
-          startText="Start the Application"
-        />
-        <p />
+
+        {!loggedIn && (
+          <VaAlert status="info" visible uswds>
+            <h2>Sign in now to save time and save your work in progress</h2>
+            <p>Here’s how signing in now helps you:</p>
+            <ul>
+              <li>
+                We can fill in some of your information for you to save you
+                time.
+              </li>
+              <li>
+                You can save your work in progress. You’ll have 60 days from
+                when you start or make updates to your application to come back
+                and finish it.
+              </li>
+            </ul>
+            <p>
+              <strong>Note:</strong> You can sign in after you start your
+              application. But you’ll lose any information you already filled
+              in.
+            </p>
+            <SaveInProgressIntro
+              buttonOnly
+              headingLevel={2}
+              prefillEnabled={formConfig.prefillEnabled}
+              messages={formConfig.savedFormMessages}
+              pageList={pageList}
+              startText="Start the Application"
+            />
+          </VaAlert>
+        )}
+        {loggedIn && (
+          <Link
+            to="/your-information/description"
+            className="auth-start-link vads-c-action-link--green"
+          >
+            Start your application
+          </Link>
+        )}
+        <br />
+
         <va-omb-info
           res-burden={10}
           omb-number="2900-0219"
           exp-date="10/31/2024"
         />
+
+        <GetFormHelp />
       </article>
     );
   }
 }
 
-export default IntroductionPage;
+const mapStateToProps = state => ({
+  loggedIn: state.user.login.currentlyLoggedIn,
+});
+
+export default connect(mapStateToProps)(IntroductionPage);

--- a/src/applications/ivc-champva/10-7959C/tests/containers/IntroductionPage.unit.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/containers/IntroductionPage.unit.spec.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+
+import formConfig from '../../config/form';
+import IntroductionPage from '../../containers/IntroductionPage';
+
+const props = {
+  route: {
+    path: 'introduction',
+    pageList: [],
+    formConfig,
+  },
+};
+
+const mockStore = {
+  getState: () => ({
+    user: {
+      login: {
+        currentlyLoggedIn: false,
+      },
+      profile: {
+        savedForms: [],
+        prefillsAvailable: [],
+        verified: false,
+        dob: '2000-01-01',
+        claims: {
+          appeals: false,
+        },
+      },
+    },
+    form: {
+      formId: formConfig.formId,
+      loadedStatus: 'success',
+      savedStatus: '',
+      loadedData: {
+        metadata: {},
+      },
+      data: {},
+    },
+    scheduledDowntime: {
+      globalDowntime: null,
+      isReady: true,
+      isPending: false,
+      serviceMap: { get() {} },
+      dismissedDowntimeWarnings: [],
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+describe('IntroductionPage', () => {
+  it('should render', () => {
+    const { container } = render(
+      <Provider store={mockStore}>
+        <IntroductionPage {...props} />
+      </Provider>,
+    );
+    expect(container).to.exist;
+  });
+});

--- a/src/applications/ivc-champva/shared/components/GetFormHelp.jsx
+++ b/src/applications/ivc-champva/shared/components/GetFormHelp.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+
+export default function GetFormHelp() {
+  return (
+    <>
+      <h2 className="vads-u-font-size--h3">Need help?</h2>
+      <hr className="vads-u-margin-y--0 vads-u-border-bottom--2px vads-u-border-top--0px vads-u-border-color--primary" />
+      <p className="help-talk">
+        <strong>If you have trouble using this online form,</strong> call us at{' '}
+        <va-telephone contact={CONTACTS.HELP_DESK} /> (
+        <va-telephone contact={CONTACTS['711']} tty />
+        ). We’re here 24/7.
+      </p>
+      <p className="help-talk">
+        <strong>
+          If you need help gathering your information or filling out this form,
+        </strong>{' '}
+        contact a local Veterans Service Organization (VSO).
+      </p>
+      <va-link
+        href="https://va.gov/vso/"
+        text="Find a local Veterans Service Organization"
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

This PR updates the introduction page content to be in line with latest mockups.

- Updated content and layout of intro page
- Added GetHelp component
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/78848

## Testing done

- Manual
- Unit

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![b](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/39a20ef4-8519-4e3d-8dfc-9a749871a110)|![a](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/81fa449b-79b9-4657-823d-161fe5a350cc)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
