### PR TITLE
Update submit URLs to use new backend IVC module

### DIFF
--- a/src/applications/ivc-champva/10-10D/components/File/upload.js
+++ b/src/applications/ivc-champva/10-10D/components/File/upload.js
@@ -8,7 +8,7 @@ import { fileTypes, maxSize, minSize } from '../../config/attachments';
 
 const uploadUrl = `${
   environment.API_URL
-}/simple_forms_api/v1/simple_forms/submit_supporting_documents`;
+}/ivc_champva/v1/forms/submit_supporting_documents`;
 
 function createPayload(file, _formId, password) {
   const payload = new FormData();

--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -125,7 +125,7 @@ const formConfig = {
   urlPrefix: '/',
   transformForSubmit,
   showReviewErrors: !environment.isProduction(),
-  submitUrl: `${environment.API_URL}/simple_forms_api/v1/simple_forms`,
+  submitUrl: `${environment.API_URL}/ivc_champva/v1/forms`,
   // submit: () =>
   // Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
   trackingPrefix: '10-10D-',


### PR DESCRIPTION
## Summary

This PR updates the submit URLs used by IVC CHAMPVA form 1010d away from simple_forms and over to the new ivc_champva module.

- Updated 1010d submit endpoint in form config
- Updated file upload component endpoint
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-api/pull/16091

## Testing done

- Manual testing
- Unit

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
