### PR TITLE
#79492: Mask PHI data in DataDog RUM dashboard

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/AtlasLocation.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/AtlasLocation.jsx
@@ -15,7 +15,10 @@ export default function AtlasLocation({ appointment, isPast }) {
   return (
     <div>
       <FacilityAddress facility={facility} showDirectionsLink />
-      <h3 className="vaos-appts__block-label vads-u-margin-top--2">
+      <h3
+        className="vaos-appts__block-label vads-u-margin-top--2"
+        data-dd-privacy="mask"
+      >
         Appointment code: {appointment.videoData.atlasConfirmationCode}
       </h3>
       {!isPast && (

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VAInstructions.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/VAInstructions.jsx
@@ -20,7 +20,7 @@ export default function VAInstructions({ appointment }) {
         <h2 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0">
           You shared these details about your concern
         </h2>
-        <div>{appointment.comment}</div>
+        <div data-dd-privacy="mask">{appointment.comment}</div>
       </div>
     </div>
   );

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -209,7 +209,7 @@ export default function RequestedAppointmentDetailsPage() {
           </li>
         ))}
       </ul>
-      <div className="vaos-u-word-break--break-word">
+      <div className="vaos-u-word-break--break-word" data-dd-privacy="mask">
         <h2 className="vads-u-margin-top--2 vaos-appts__block-label">
           You shared these details about your concern
         </h2>
@@ -222,12 +222,15 @@ export default function RequestedAppointmentDetailsPage() {
         <h3 className="vads-u-font-family--sans vads-u-display--inline vads-u-font-size--base">
           Email:{' '}
         </h3>
-        <span>{getPatientTelecom(appointment, 'email')}</span>
+        <span data-dd-privacy="mask">
+          {getPatientTelecom(appointment, 'email')}
+        </span>
         <br />
         <h3 className="vads-u-font-family--sans vads-u-display--inline vads-u-font-size--base">
           Phone number:{' '}
         </h3>
         <VaTelephone
+          data-dd-privacy="mask"
           notClickable
           contact={getPatientTelecom(appointment, 'phone')}
           data-testid="patient-telephone"

--- a/src/applications/vaos/covid-19-vaccine/components/ReviewPage.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/ReviewPage.jsx
@@ -100,10 +100,11 @@ export default function ReviewPage({ changeCrumb }) {
         <div className="vads-l-row vads-u-justify-content--space-between">
           <div className="vads-u-flex--1 vads-u-padding-right--1">
             <h3 className="vaos-appts__block-label">Your contact details</h3>
-            <div>
+            <div data-dd-privacy="mask">
               {data.email}
               <br />
               <VaTelephone
+                data-dd-privacy="mask"
                 notClickable
                 contact={data.phoneNumber}
                 data-testid="patient-telephone"

--- a/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationDirectScheduleInfoV2.jsx
+++ b/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationDirectScheduleInfoV2.jsx
@@ -101,7 +101,7 @@ export default function ConfirmationDirectScheduleInfoV2({
           <h3 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-bottom--0">
             Your reason for your visit
           </h3>
-          <div>
+          <div data-dd-privacy="mask">
             {
               PURPOSE_TEXT_V2.find(
                 purpose => purpose.id === data.reasonForAppointment,

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/CommunityCareSection/CommunityCareSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/CommunityCareSection/CommunityCareSection.jsx
@@ -21,6 +21,7 @@ export default function CommunityCareSection({ data, facility, vaCityState }) {
       <hr aria-hidden="true" className="vads-u-margin-y--2" />
       <ReasonForAppointmentSection data={data} />
       <hr
+        data-dd-privacy="mask"
         aria-hidden="true"
         className={classNames('vads-u-margin-y--2', {
           'vads-u-display--none':

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/ContactDetailSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/ContactDetailSection.jsx
@@ -52,10 +52,11 @@ function getContent({ data, flowType, formData }) {
     return (
       <>
         <h3 className="vaos-appts__block-label">Your contact details</h3>
-        <span>
+        <span data-dd-privacy="mask">
           {data.email}
           <br />
           <VaTelephone
+            data-dd-privacy="mask"
             notClickable
             contact={data.phoneNumber}
             data-testid="patient-telephone"
@@ -76,12 +77,13 @@ function getContent({ data, flowType, formData }) {
       <h2 className="vads-u-font-size--h3 vaos-appts__block-label">
         Your contact information
       </h2>
-      <span>
+      <span data-dd-privacy="mask">
         <strong>Email: </strong>
         {data.email}
         <br />
         <strong>Phone number: </strong>
         <VaTelephone
+          data-dd-privacy="mask"
           notClickable
           contact={data.phoneNumber}
           data-testid="patient-telephone"
@@ -109,7 +111,10 @@ export default function ContactDetailSection({ data }) {
     <>
       <div className="vads-l-grid-container vads-u-padding--0">
         <div className="vads-l-row vads-u-justify-content--space-between">
-          <div className="vads-u-flex--1 vads-u-padding-right--1">
+          <div
+            className="vads-u-flex--1 vads-u-padding-right--1"
+            data-dd-privacy="mask"
+          >
             {getContent({ data, flowType, formData })}
           </div>
           <div>

--- a/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/ReasonForAppointmentSection.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/ReviewRequestInfo/ReasonForAppointmentSection.jsx
@@ -36,7 +36,10 @@ export default function ReasonForAppointmentSection({ data }) {
         <div className="vads-l-row vads-u-justify-content--space-between">
           <div className="vads-u-flex--1 vads-u-padding-right--1">
             {FLOW_TYPES.DIRECT === flowType && (
-              <h2 className="vads-u-font-size--h3 vaos-appts__block-label">
+              <h2
+                className="vads-u-font-size--h3 vaos-appts__block-label"
+                data-dd-privacy="mask"
+              >
                 {PURPOSE_TEXT_V2.find(
                   purpose => purpose.id === reasonForAppointment,
                 )?.short || 'Additional details'}
@@ -49,7 +52,7 @@ export default function ReasonForAppointmentSection({ data }) {
                 </h2>
                 {reasonForAppointment && (
                   <>
-                    <span>
+                    <span data-dd-privacy="mask">
                       {
                         PURPOSE_TEXT_V2.find(
                           purpose => purpose.id === reasonForAppointment,
@@ -61,7 +64,10 @@ export default function ReasonForAppointmentSection({ data }) {
                 )}
               </>
             )}
-            <span className="vaos-u-word-break--break-word">
+            <span
+              className="vaos-u-word-break--break-word"
+              data-dd-privacy="mask"
+            >
               {reasonAdditionalInfo}
             </span>
           </div>


### PR DESCRIPTION
## Summary
Masks PHI data in DataDog RUM dashboard.
## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#79492

## Testing done
Tested flows locally and confirmed that PHI data is masked in DD RUM dashboard.
**Link to sample session replay**: https://vagov.ddog-gov.com/rum/replay/sessions/4b003b31-0719-4446-85c4-861710032abb?applicationId=fa7a1075-965f-484d-b812-6f10f4572694&highlightedEventId=AgAAAY6bmReQpfyHWgAAAAAAAAAYAAAAAEFZNmJtVERPQUFCYU42SzI1TUdnSXdBRQAAACQAAAAAMDE4ZTliOTktMzI0OS00YjQ5LWI1MzktNGM4ODBiMmM2NTZm&ts=1712007485328&from=1712007485067