### PR TITLE
Move "last year" date calculation to constants

### DIFF
--- a/src/applications/hca/components/FormDescriptions/index.jsx
+++ b/src/applications/hca/components/FormDescriptions/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { APP_URLS } from '../../utils/constants';
+import { APP_URLS, LAST_YEAR } from '../../utils/constants';
 
 /** CHAPTER 1: Veteran Information */
 export const BirthInfoDescription = (
@@ -231,62 +231,54 @@ export const OtherToxicExposureDescription = (
 );
 
 /** CHAPTER 4: Household Information */
-export const DeductibleExpensesDescription = () => {
-  const date = new Date();
-  return (
-    <legend className="schemaform-block-title">
-      Deductible expenses from {date.getFullYear() - 1}
-      <span className="sr-only">.</span>
-      <div className="vads-u-color--base vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal vads-u-line-height--6 vads-u-margin-y--2">
-        These deductible expenses will lower the amount of money we count as
-        your income.
-      </div>
-    </legend>
-  );
-};
+export const DeductibleExpensesDescription = () => (
+  <legend className="schemaform-block-title">
+    Deductible expenses from {LAST_YEAR}
+    <span className="sr-only">.</span>
+    <div className="vads-u-color--base vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal vads-u-line-height--6 vads-u-margin-y--2">
+      These deductible expenses will lower the amount of money we count as your
+      income.
+    </div>
+  </legend>
+);
 
-export const DependentDescription = () => {
-  const date = new Date();
-  return (
-    <va-additional-info
-      trigger="Who we consider a dependent"
-      class="vads-u-margin-top--2 vads-u-margin-bottom--3"
-      uswds
-    >
-      <div>
-        <p className="vads-u-margin-top--0">
-          <strong>Here’s who we consider to be a dependent:</strong>
-        </p>
-        <ul>
-          <li>A spouse (we recognize same-sex and common law marriages)</li>
-          <li>
-            An unmarried child (including adopted children or stepchildren)
-          </li>
-        </ul>
-        <p>
-          <strong>
-            If your dependent is an unmarried child, one of these descriptions
-            must be true:
-          </strong>
-        </p>
-        <ul className="vads-u-margin-bottom--0">
-          <li>
-            They’re under 18 years old, <strong>or</strong>
-          </li>
-          <li>
-            They’re between the ages of 18 and 23 years old and were enrolled as
-            a full-time or part-time student in high school, college, or
-            vocational school in {date.getFullYear() - 1}, <strong>or</strong>
-          </li>
-          <li>
-            They’re living with a permanent disability that happened before they
-            turned 18 years old
-          </li>
-        </ul>
-      </div>
-    </va-additional-info>
-  );
-};
+export const DependentDescription = () => (
+  <va-additional-info
+    trigger="Who we consider a dependent"
+    class="vads-u-margin-top--2 vads-u-margin-bottom--3"
+    uswds
+  >
+    <div>
+      <p className="vads-u-margin-top--0">
+        <strong>Here’s who we consider to be a dependent:</strong>
+      </p>
+      <ul>
+        <li>A spouse (we recognize same-sex and common law marriages)</li>
+        <li>An unmarried child (including adopted children or stepchildren)</li>
+      </ul>
+      <p>
+        <strong>
+          If your dependent is an unmarried child, one of these descriptions
+          must be true:
+        </strong>
+      </p>
+      <ul className="vads-u-margin-bottom--0">
+        <li>
+          They’re under 18 years old, <strong>or</strong>
+        </li>
+        <li>
+          They’re between the ages of 18 and 23 years old and were enrolled as a
+          full-time or part-time student in high school, college, or vocational
+          school in {LAST_YEAR}, <strong>or</strong>
+        </li>
+        <li>
+          They’re living with a permanent disability that happened before they
+          turned 18 years old
+        </li>
+      </ul>
+    </div>
+  </va-additional-info>
+);
 
 export const DependentSupportDescription = (
   <va-additional-info
@@ -486,23 +478,20 @@ export const SpouseAdditionalInformationTitle = (
   </>
 );
 
-export const SpouseAdditionalInformationDescription = () => {
-  const date = new Date();
-  return (
-    <va-additional-info
-      trigger="Why we ask for this information"
-      class="vads-u-margin-top--1 vads-u-margin-bottom--4"
-      uswds
-    >
-      <div>
-        <p className="vads-u-margin-top--0">
-          This information helps us determine if your spouse was your dependent
-          in {date.getFullYear() - 1}.
-        </p>
-      </div>
-    </va-additional-info>
-  );
-};
+export const SpouseAdditionalInformationDescription = () => (
+  <va-additional-info
+    trigger="Why we ask for this information"
+    class="vads-u-margin-top--1 vads-u-margin-bottom--4"
+    uswds
+  >
+    <div>
+      <p className="vads-u-margin-top--0">
+        This information helps us determine if your spouse was your dependent in{' '}
+        {LAST_YEAR}.
+      </p>
+    </div>
+  </va-additional-info>
+);
 
 export const SpouseFinancialSupportDescription = (
   <va-additional-info

--- a/src/applications/hca/components/FormPages/DependentInformation.jsx
+++ b/src/applications/hca/components/FormPages/DependentInformation.jsx
@@ -2,8 +2,8 @@ import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { focusElement } from 'platform/utilities/ui';
-import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import { focusElement } from '~/platform/utilities/ui';
+import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
 import DependentListLoopForm from '../FormFields/DependentListLoopForm';
 
 import useAfterRenderEffect from '../../hooks/useAfterRenderEffect';
@@ -19,10 +19,8 @@ import {
   DEPENDENT_VIEW_FIELDS,
   SESSION_ITEM_NAME,
   SHARED_PATHS,
+  LAST_YEAR,
 } from '../../utils/constants';
-
-const date = new Date();
-const lastYear = date.getFullYear() - 1;
 
 // declare shared data & route attrs from the form
 const { dependents: DEPENDENT_PATHS } = SHARED_PATHS;
@@ -49,7 +47,7 @@ const SUB_PAGES = [
   },
   {
     id: 'income',
-    title: `%s\u2019s annual income from ${lastYear}`,
+    title: `%s\u2019s annual income from ${LAST_YEAR}`,
     depends: { key: 'view:dependentIncome', value: true },
   },
 ];

--- a/src/applications/hca/components/FormPages/FinancialOnboarding.jsx
+++ b/src/applications/hca/components/FormPages/FinancialOnboarding.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
 import EnhancedEligibilityDescription from '../FormDescriptions/EnhancedEligibilityDescription';
+import { LAST_YEAR } from '../../utils/constants';
 
 const HouseholdFinancialOnboarding = props => {
   const {
@@ -10,15 +11,13 @@ const HouseholdFinancialOnboarding = props => {
     contentBeforeButtons,
     contentAfterButtons,
   } = props;
-  const date = new Date();
-  const lastYear = date.getFullYear() - 1;
 
   return (
     <>
       <p>
         Next we’ll ask about your household financial information from{' '}
-        {lastYear}. We’ll ask about income and expenses for you, your spouse (if
-        you’re married), and any dependents you may have.
+        {LAST_YEAR}. We’ll ask about income and expenses for you, your spouse
+        (if you’re married), and any dependents you may have.
       </p>
 
       <h3 data-testid="hca-custom-page-title">

--- a/src/applications/hca/config/chapters/householdInformation/deductibleExpenses.js
+++ b/src/applications/hca/config/chapters/householdInformation/deductibleExpenses.js
@@ -1,7 +1,8 @@
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
-import currencyUI from 'platform/forms-system/src/js/definitions/currency';
+import currencyUI from '~/platform/forms-system/src/js/definitions/currency';
 
 import { validateCurrency } from '../../../utils/validation';
+import { LAST_YEAR } from '../../../utils/constants';
 import {
   DeductibleExpensesDescription,
   EducationalExpensesDescription,
@@ -14,9 +15,6 @@ const {
   deductibleMedicalExpenses,
 } = fullSchemaHca.properties;
 
-const date = new Date();
-const lastYear = date.getFullYear() - 1;
-
 export default {
   uiSchema: {
     'ui:title': DeductibleExpensesDescription,
@@ -25,7 +23,7 @@ export default {
       'ui:description': MedicalExpensesDescription,
       deductibleMedicalExpenses: {
         ...currencyUI(
-          `Enter the amount you or your spouse (if you’re married) paid in non-reimbursable medical expenses in ${lastYear}`,
+          `Enter the amount you or your spouse (if you’re married) paid in non-reimbursable medical expenses in ${LAST_YEAR}`,
         ),
         'ui:validations': [validateCurrency],
       },
@@ -35,7 +33,7 @@ export default {
       'ui:description': EducationalExpensesDescription,
       deductibleEducationExpenses: {
         ...currencyUI(
-          `Enter the amount you paid for your own college or vocational education in ${lastYear}`,
+          `Enter the amount you paid for your own college or vocational education in ${LAST_YEAR}`,
         ),
         'ui:validations': [validateCurrency],
       },
@@ -47,7 +45,7 @@ export default {
         'Funeral and burial expenses are any payments made by you, like prepaid expenses.',
       deductibleFuneralExpenses: {
         ...currencyUI(
-          `Enter the amount you paid in funeral or burial expenses in ${lastYear}`,
+          `Enter the amount you paid in funeral or burial expenses in ${LAST_YEAR}`,
         ),
         'ui:validations': [validateCurrency],
       },

--- a/src/applications/hca/config/chapters/householdInformation/spouseAdditionalInformation.js
+++ b/src/applications/hca/config/chapters/householdInformation/spouseAdditionalInformation.js
@@ -1,19 +1,18 @@
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
+import { LAST_YEAR } from '../../../utils/constants';
 import {
   SpouseAdditionalInformationDescription,
   SpouseAdditionalInformationTitle,
 } from '../../../components/FormDescriptions';
 
 const { cohabitedLastYear, sameAddress } = fullSchemaHca.properties;
-const date = new Date();
 
 export default {
   uiSchema: {
     'ui:title': SpouseAdditionalInformationTitle,
     'ui:description': SpouseAdditionalInformationDescription,
     cohabitedLastYear: {
-      'ui:title': `Did you live with your spouse for all or part of ${date.getFullYear() -
-        1}?`,
+      'ui:title': `Did you live with your spouse for all or part of ${LAST_YEAR}?`,
       'ui:widget': 'yesNo',
     },
     sameAddress: {

--- a/src/applications/hca/config/chapters/householdInformation/spouseAnnualIncome.js
+++ b/src/applications/hca/config/chapters/householdInformation/spouseAnnualIncome.js
@@ -1,7 +1,8 @@
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
-import currencyUI from 'platform/forms-system/src/js/definitions/currency';
+import currencyUI from '~/platform/forms-system/src/js/definitions/currency';
 
 import { validateCurrency } from '../../../utils/validation';
+import { LAST_YEAR } from '../../../utils/constants';
 import {
   GrossIncomeDescription,
   OtherIncomeDescription,
@@ -13,18 +14,15 @@ const {
   spouseOtherIncome,
 } = fullSchemaHca.properties;
 
-const date = new Date();
-const lastYear = date.getFullYear() - 1;
-
 export default {
   uiSchema: {
-    'ui:title': `Spouse\u2019s annual income from ${lastYear}`,
+    'ui:title': `Spouse\u2019s annual income from ${LAST_YEAR}`,
     'view:spouseGrossIncome': {
       'ui:title': 'Gross income from work',
       'ui:description': GrossIncomeDescription,
       spouseGrossIncome: {
         ...currencyUI(
-          `Enter your spouse\u2019s gross annual income from ${lastYear}`,
+          `Enter your spouse\u2019s gross annual income from ${LAST_YEAR}`,
         ),
         'ui:validations': [validateCurrency],
       },
@@ -35,7 +33,7 @@ export default {
         'Net income is income after any taxes and other deductions are subtracted.',
       spouseNetIncome: {
         ...currencyUI(
-          `Enter your spouse\u2019s net annual income from a farm, ranch, property or business from ${lastYear}`,
+          `Enter your spouse\u2019s net annual income from a farm, ranch, property or business from ${LAST_YEAR}`,
         ),
         'ui:validations': [validateCurrency],
       },
@@ -45,7 +43,7 @@ export default {
       'ui:description': OtherIncomeDescription,
       spouseOtherIncome: {
         ...currencyUI(
-          `Enter your spouse\u2019s other annual income from ${lastYear}`,
+          `Enter your spouse\u2019s other annual income from ${LAST_YEAR}`,
         ),
         'ui:validations': [validateCurrency],
       },

--- a/src/applications/hca/config/chapters/householdInformation/spouseFinancialSupport.js
+++ b/src/applications/hca/config/chapters/householdInformation/spouseFinancialSupport.js
@@ -1,15 +1,14 @@
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
+import { LAST_YEAR } from '../../../utils/constants';
 import { SpouseFinancialSupportDescription } from '../../../components/FormDescriptions';
 
 const { provideSupportLastYear } = fullSchemaHca.properties;
-const date = new Date();
 
 export default {
   uiSchema: {
     'ui:title': 'Spouse\u2019s financial support',
     provideSupportLastYear: {
-      'ui:title': `Did you provide financial support to your spouse in ${date.getFullYear() -
-        1} even though you didn\u2019t live together?`,
+      'ui:title': `Did you provide financial support to your spouse in ${LAST_YEAR} even though you didn\u2019t live together?`,
       'ui:description': SpouseFinancialSupportDescription,
       'ui:widget': 'yesNo',
     },

--- a/src/applications/hca/config/chapters/householdInformation/veteranAnnualIncome.js
+++ b/src/applications/hca/config/chapters/householdInformation/veteranAnnualIncome.js
@@ -1,7 +1,8 @@
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
-import currencyUI from 'platform/forms-system/src/js/definitions/currency';
+import currencyUI from '~/platform/forms-system/src/js/definitions/currency';
 
 import { validateCurrency } from '../../../utils/validation';
+import { LAST_YEAR } from '../../../utils/constants';
 import {
   GrossIncomeDescription,
   OtherIncomeDescription,
@@ -13,17 +14,14 @@ const {
   veteranOtherIncome,
 } = fullSchemaHca.properties;
 
-const date = new Date();
-const lastYear = date.getFullYear() - 1;
-
 export default {
   uiSchema: {
-    'ui:title': `Your annual income from ${lastYear}`,
+    'ui:title': `Your annual income from ${LAST_YEAR}`,
     'view:veteranGrossIncome': {
       'ui:title': 'Gross income from work',
       'ui:description': GrossIncomeDescription,
       veteranGrossIncome: {
-        ...currencyUI(`Enter your gross annual income from ${lastYear}`),
+        ...currencyUI(`Enter your gross annual income from ${LAST_YEAR}`),
         'ui:validations': [validateCurrency],
       },
     },
@@ -33,7 +31,7 @@ export default {
         'Net income is income after any taxes and other deductions are subtracted.',
       veteranNetIncome: {
         ...currencyUI(
-          `Enter your net annual income from a farm, property, or business from ${lastYear}`,
+          `Enter your net annual income from a farm, property, or business from ${LAST_YEAR}`,
         ),
         'ui:validations': [validateCurrency],
       },
@@ -42,7 +40,7 @@ export default {
       'ui:title': 'Other income',
       'ui:description': OtherIncomeDescription,
       veteranOtherIncome: {
-        ...currencyUI(`Enter your other annual income from ${lastYear}`),
+        ...currencyUI(`Enter your other annual income from ${LAST_YEAR}`),
         'ui:validations': [validateCurrency],
       },
     },

--- a/src/applications/hca/definitions/dependent.js
+++ b/src/applications/hca/definitions/dependent.js
@@ -1,17 +1,15 @@
-import fullNameUI from 'platform/forms/definitions/fullName';
-import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
-import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
-import currencyUI from 'platform/forms-system/src/js/definitions/currency';
+import fullNameUI from '~/platform/forms/definitions/fullName';
+import currentOrPastDateUI from '~/platform/forms-system/src/js/definitions/currentOrPastDate';
+import ssnUI from '~/platform/forms-system/src/js/definitions/ssn';
+import currencyUI from '~/platform/forms-system/src/js/definitions/currency';
 
 import { validateCurrency, validateDependentDate } from '../utils/validation';
+import { LAST_YEAR } from '../utils/constants';
 import {
   DependentSupportDescription,
   GrossIncomeDescription,
   OtherIncomeDescription,
 } from '../components/FormDescriptions';
-
-const date = new Date();
-const lastYear = date.getFullYear() - 1;
 
 // define uiSchemas for each page in dependent flow
 export const dependentUISchema = {
@@ -55,7 +53,7 @@ export const dependentUISchema = {
   },
   education: {
     attendedSchoolLastYear: {
-      'ui:title': `If your dependent is between 18 and 23 years old, were they enrolled as a full-time or part-time student in ${lastYear}?`,
+      'ui:title': `If your dependent is between 18 and 23 years old, were they enrolled as a full-time or part-time student in ${LAST_YEAR}?`,
       'ui:widget': 'yesNo',
     },
     dependentEducationExpenses: {
@@ -72,17 +70,17 @@ export const dependentUISchema = {
       'ui:widget': 'yesNo',
     },
     cohabitedLastYear: {
-      'ui:title': `Did your dependent live with you in ${lastYear}?`,
+      'ui:title': `Did your dependent live with you in ${LAST_YEAR}?`,
       'ui:widget': 'yesNo',
     },
     'view:dependentIncome': {
-      'ui:title': `Did your dependent earn income in ${lastYear}?`,
+      'ui:title': `Did your dependent earn income in ${LAST_YEAR}?`,
       'ui:widget': 'yesNo',
     },
   },
   support: {
     receivedSupportLastYear: {
-      'ui:title': `If your dependent didn\u2019t live with you in ${lastYear}, did you provide financial support?`,
+      'ui:title': `If your dependent didn\u2019t live with you in ${LAST_YEAR}, did you provide financial support?`,
       'ui:description': DependentSupportDescription,
       'ui:widget': 'yesNo',
     },
@@ -93,7 +91,7 @@ export const dependentUISchema = {
       'ui:description': GrossIncomeDescription,
       grossIncome: {
         ...currencyUI(
-          `Enter your dependent\u2019s gross annual income from ${lastYear}`,
+          `Enter your dependent\u2019s gross annual income from ${LAST_YEAR}`,
         ),
         'ui:validations': [validateCurrency],
       },
@@ -104,7 +102,7 @@ export const dependentUISchema = {
         'Net income is income after any taxes and other deductions are subtracted.',
       netIncome: {
         ...currencyUI(
-          `Enter your dependent\u2019s net annual income from a farm, ranch, property or business from ${lastYear}`,
+          `Enter your dependent\u2019s net annual income from a farm, ranch, property or business from ${LAST_YEAR}`,
         ),
         'ui:validations': [validateCurrency],
         'ui:required': () => true,
@@ -115,7 +113,7 @@ export const dependentUISchema = {
       'ui:description': OtherIncomeDescription,
       otherIncome: {
         ...currencyUI(
-          `Enter your dependent\u2019s other annual income from ${lastYear}`,
+          `Enter your dependent\u2019s other annual income from ${LAST_YEAR}`,
         ),
         'ui:validations': [validateCurrency],
         'ui:required': () => true,

--- a/src/applications/hca/utils/constants.js
+++ b/src/applications/hca/utils/constants.js
@@ -119,6 +119,9 @@ export const HCA_NULL_STATUSES = new Set([
 // declare the minimum percentage value to be considered high disability
 export const HIGH_DISABILITY_MINIMUM = 50;
 
+// declare previous year for form questions and content
+export const LAST_YEAR = new Date().getFullYear() - 1;
+
 // declare a valid response for the enrollment status endpoint
 export const MOCK_ENROLLMENT_RESPONSE = {
   applicationDate: '2019-04-24T00:00:00.000-06:00',


### PR DESCRIPTION
## Summary
This PR takes the "last year" date calculation that is repeated in many form text labels and additional info content and moves the value to a constant. The move is to avoid unnecessary repetition of the date calculation.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#70857

## Acceptance criteria

- Year value is accessible from the declared constants file

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution