### PR TITLE
HLR & SC | Prevent lose information warning alert on sign in on start page

### DIFF
--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -8,6 +8,7 @@ import migrations from '../migrations';
 
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
+import SubTaskContainer from '../subtask/SubTaskContainer';
 
 import AddContestableIssue from '../components/AddContestableIssue';
 import PrimaryPhone from '../components/PrimaryPhone';
@@ -113,6 +114,16 @@ const formConfig = {
   // when true, initial focus on page to H3s by default, and enable page
   // scrollAndFocusTarget (selector string or function to scroll & focus)
   useCustomScrollAndFocus: true,
+
+  additionalRoutes: [
+    {
+      path: 'start',
+      component: SubTaskContainer,
+      pageKey: 'start',
+      depends: () => false,
+    },
+  ],
+
   chapters: {
     infoPages: {
       title: 'Veteran information',

--- a/src/applications/appeals/995/containers/App.jsx
+++ b/src/applications/appeals/995/containers/App.jsx
@@ -56,6 +56,10 @@ export const App = ({
   const subTaskBenefitType =
     formData?.benefitType || getStoredSubTask()?.benefitType;
 
+  const hasSupportedBenefitType = SUPPORTED_BENEFIT_TYPES_LIST.includes(
+    subTaskBenefitType,
+  );
+
   useEffect(
     () => {
       // Set user account & application id in Sentry so we can access their form
@@ -70,7 +74,7 @@ export const App = ({
 
   useEffect(
     () => {
-      if (SUPPORTED_BENEFIT_TYPES_LIST.includes(subTaskBenefitType)) {
+      if (hasSupportedBenefitType) {
         // form data is reset after logging in and from the save-in-progress data,
         // so get it from the session storage
         if (!formData.benefitType) {
@@ -115,6 +119,7 @@ export const App = ({
 
       setFormData,
       subTaskBenefitType,
+      hasSupportedBenefitType,
     ],
   );
 
@@ -153,7 +158,8 @@ export const App = ({
     service: DATA_DOG_SERVICE,
   });
 
-  if (!SUPPORTED_BENEFIT_TYPES_LIST.includes(subTaskBenefitType)) {
+  // Go to start page if we don't have an expected benefit type
+  if (!location.pathname.endsWith('/start') && !hasSupportedBenefitType) {
     router.push('/start');
     content = wrapInH1(
       <va-loading-indicator
@@ -163,6 +169,7 @@ export const App = ({
     );
   } else if (
     loggedIn &&
+    hasSupportedBenefitType &&
     ((contestableIssues.status || '') === '' ||
       contestableIssues.status === FETCH_CONTESTABLE_ISSUES_INIT)
   ) {

--- a/src/applications/appeals/995/containers/ITFWrapper.jsx
+++ b/src/applications/appeals/995/containers/ITFWrapper.jsx
@@ -166,7 +166,6 @@ const itfShape = {
 };
 
 ITFWrapper.propTypes = {
-  benefitType: PropTypes.string.isRequired,
   children: PropTypes.any.isRequired,
   loggedIn: PropTypes.bool.isRequired,
   pathname: PropTypes.string.isRequired,
@@ -174,6 +173,7 @@ ITFWrapper.propTypes = {
     push: PropTypes.func,
   }).isRequired,
   accountUuid: PropTypes.string,
+  benefitType: PropTypes.string,
   inProgressFormId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   itf: PropTypes.shape({
     fetchCallState: PropTypes.oneOf(requestStateEnum).isRequired,

--- a/src/applications/appeals/995/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/995/containers/IntroductionPage.jsx
@@ -47,6 +47,7 @@ class IntroductionPage extends React.Component {
       startText: 'Start your Claim',
       gaStartEventName: 'decision-reviews-va20-0995-start-form',
       useActionLinks: true,
+      pathname: '/introduction',
     };
 
     // Check LOA3 first, then check canApply (true when LOA3 & has SSN)

--- a/src/applications/appeals/995/routes.jsx
+++ b/src/applications/appeals/995/routes.jsx
@@ -1,16 +1,11 @@
 import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
 
 import App from './containers/App';
-import SubTaskContainer from './subtask/SubTaskContainer';
 import formConfig from './config/form';
 
 const onEnter = (nextState, replace) => replace('/introduction');
 
 const routes = [
-  {
-    path: '/start',
-    component: SubTaskContainer,
-  },
   {
     path: '/',
     component: App,

--- a/src/applications/appeals/995/subtask/SubTaskContainer.jsx
+++ b/src/applications/appeals/995/subtask/SubTaskContainer.jsx
@@ -4,15 +4,16 @@ import FormFooter from 'platform/forms/components/FormFooter';
 import SubTask from 'platform/forms/sub-task';
 
 import pages from './pages';
-import formConfig from '../config/form';
+
+import GetFormHelp from '../../shared/content/GetFormHelp';
 
 export const SubTaskContainer = () => {
   return (
     <article data-page="start" className="row">
-      <div className="usa-width-two-thirds medium-8 columns vads-u-margin-bottom--2">
+      <div className="vads-u-margin-bottom--2">
         <SubTask pages={pages} />
       </div>
-      <FormFooter formConfig={formConfig} />
+      <FormFooter formConfig={{ getHelp: GetFormHelp }} />
     </article>
   );
 };

--- a/src/applications/appeals/995/tests/995-subtask.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-subtask.cypress.spec.js
@@ -14,6 +14,10 @@ describe('995 subtask', () => {
     cy.location('pathname').should('eq', `${BASE_URL}/start`);
   });
 
+  const checkOpt = {
+    waitForAnimations: true,
+  };
+
   it('should show error when nothing selected - C30850', () => {
     cy.injectAxeThenAxeCheck();
 
@@ -31,7 +35,7 @@ describe('995 subtask', () => {
     cy.injectAxeThenAxeCheck();
 
     cy.get('h1').contains('File a Supplemental Claim');
-    cy.selectRadio('benefitType', 'compensation');
+    cy.get('va-radio-option[value="compensation"] label').click(checkOpt);
     cy.findByText(/continue/i, { selector: 'va-button' }).click();
 
     cy.location('pathname').should('eq', `${BASE_URL}/introduction`);
@@ -41,7 +45,7 @@ describe('995 subtask', () => {
     cy.injectAxeThenAxeCheck();
 
     cy.get('h1').contains('File a Supplemental Claim');
-    cy.selectRadio('benefitType', 'other');
+    cy.get('va-radio-option[value="other"] label').click(checkOpt);
     cy.findByText(/continue/i, { selector: 'va-button' }).click();
 
     cy.location('pathname').should('eq', `${BASE_URL}/start`);

--- a/src/applications/appeals/995/tests/containers/App.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/containers/App.unit.spec.jsx
@@ -23,12 +23,13 @@ const getData = ({
   verified = true,
   data = hasComp,
   accountUuid = '',
+  pathname = '/introduction',
   push = () => {},
 } = {}) => {
   setStoredSubTask({ benefitType: data?.benefitType || '' });
   return {
     props: {
-      location: { pathname: '/introduction', search: '' },
+      location: { pathname, search: '' },
       children: <h1>Intro</h1>,
       router: { push },
     },
@@ -135,6 +136,23 @@ describe('App', () => {
     expect(alert).to.exist;
     expect(alert.getAttribute('message')).to.contain('restart the app');
     expect(push.calledWith('/start')).to.be.true;
+  });
+
+  it('should not redirect to start for unsupported benefit types and already on the start page', () => {
+    const push = sinon.spy();
+    const { props, data } = getData({
+      push,
+      pathname: '/start',
+      data: { benefitType: 'other' },
+    });
+    const { container } = render(
+      <Provider store={mockStore(data)}>
+        <App {...props} />
+      </Provider>,
+    );
+
+    expect($('va-loading-indicator', container)).to.not.exist;
+    expect(push.notCalled).to.be.true;
   });
 
   it('should update benefit type in form data', async () => {

--- a/src/applications/appeals/995/tests/routes.unit.spec.js
+++ b/src/applications/appeals/995/tests/routes.unit.spec.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import routes from '../routes';
 
 describe('Form 995 routes', () => {
-  const { onEnter } = routes[1].indexRoute;
+  const { onEnter } = routes[0].indexRoute;
   it('should redirect from the root to /introduction', () => {
     const replace = sinon.spy();
     onEnter(null, replace);

--- a/src/applications/appeals/996/config/form.js
+++ b/src/applications/appeals/996/config/form.js
@@ -12,6 +12,7 @@ import submitForm from './submitForm';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import AddContestableIssue from '../components/AddContestableIssue';
+import WizardContainer from '../wizard/WizardContainer';
 
 // Pages
 import veteranInformation from '../pages/veteranInformation';
@@ -100,6 +101,15 @@ const formConfig = {
   // when true, initial focus on page to H3s by default, and enable page
   // scrollAndFocusTarget (selector string or function to scroll & focus)
   useCustomScrollAndFocus: true,
+
+  additionalRoutes: [
+    {
+      path: 'start',
+      component: WizardContainer,
+      pageKey: 'start',
+      depends: () => false,
+    },
+  ],
 
   chapters: {
     infoPages: {

--- a/src/applications/appeals/996/containers/Form0996App.jsx
+++ b/src/applications/appeals/996/containers/Form0996App.jsx
@@ -45,9 +45,11 @@ export const Form0996App = ({
   // https://github.com/department-of-veterans-affairs/va.gov-team/issues/33931
   const [isLoadingIssues, setIsLoadingIssues] = useState(false);
 
+  const isWizardComplete = getHlrWizardStatus() === WIZARD_STATUS_COMPLETE;
+
   useEffect(
     () => {
-      if (loggedIn && getHlrWizardStatus() === WIZARD_STATUS_COMPLETE) {
+      if (loggedIn && isWizardComplete) {
         const areaOfDisagreement = getSelected(formData);
         if (!isLoadingIssues && (contestableIssues?.status || '') === '') {
           // load benefit type contestable issues
@@ -126,7 +128,10 @@ export const Form0996App = ({
     </RoutedSavableApp>
   );
 
-  if (shouldShowWizard(formConfig.formId, savedForms)) {
+  if (
+    !location.pathname.endsWith('/start') &&
+    shouldShowWizard(formConfig.formId, savedForms)
+  ) {
     router.push('/start');
     content = (
       <h1 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
@@ -138,6 +143,7 @@ export const Form0996App = ({
     );
   } else if (
     loggedIn &&
+    isWizardComplete &&
     ((contestableIssues?.status || '') === '' ||
       contestableIssues?.status === FETCH_CONTESTABLE_ISSUES_INIT)
   ) {

--- a/src/applications/appeals/996/containers/IntroductionPage.jsx
+++ b/src/applications/appeals/996/containers/IntroductionPage.jsx
@@ -46,6 +46,7 @@ export const IntroductionPage = props => {
     gaStartEventName: 'decision-reviews-va20-0996-start-form',
     ariaDescribedby: 'main-content',
     useActionLinks: true,
+    pathname: '/introduction',
   };
 
   const restartWizard = () => {

--- a/src/applications/appeals/996/routes.jsx
+++ b/src/applications/appeals/996/routes.jsx
@@ -2,7 +2,6 @@ import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/
 import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 
 import Form0996App from './containers/Form0996App';
-import WizardContainer from './wizard/WizardContainer';
 import formConfig from './config/form';
 import { getHlrWizardStatus } from './wizard/utils';
 
@@ -14,10 +13,6 @@ const onEnter = (nextState, replace) =>
   );
 
 const routes = [
-  {
-    path: '/start',
-    component: WizardContainer,
-  },
   {
     path: '/',
     component: Form0996App,

--- a/src/applications/appeals/996/tests/containers/FormApp.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/containers/FormApp.unit.spec.jsx
@@ -36,11 +36,12 @@ const getData = ({
   savedForms = [],
   formData = { benefitType: 'compensation' },
   contestableIssues = { status: '' },
+  pathname = '/introduction',
   routerPush = () => {},
 } = {}) => ({
   props: {
     loggedIn,
-    location: { pathname: '/introduction', search: '' },
+    location: { pathname, search: '' },
     children: <h1>Intro</h1>,
     router: { push: routerPush },
   },
@@ -130,6 +131,24 @@ describe('Form0996App', () => {
     expect(loadingIndicator.getAttribute('message')).to.contain('restart');
     expect(routerPushSpy.called).to.be.true;
     expect(routerPushSpy.args[0][0]).to.eq('/start');
+  });
+
+  it('should not redirect to /start if already on the start page', () => {
+    removeHlrWizardStatus();
+    const routerPushSpy = sinon.spy();
+    const { props, data } = getData({
+      savedForms: savedHlr,
+      pathname: '/start',
+      routerPush: routerPushSpy,
+    });
+    const { container } = render(
+      <Provider store={mockStore(data)}>
+        <Form0996App {...props} />
+      </Provider>,
+    );
+
+    expect($('va-loading-indicator', container)).to.not.exist;
+    expect(routerPushSpy.notCalled).to.be.true;
   });
 
   it('should call API is logged in', async () => {

--- a/src/applications/appeals/996/tests/hlr-wizard.cypress.spec.js
+++ b/src/applications/appeals/996/tests/hlr-wizard.cypress.spec.js
@@ -69,7 +69,7 @@ describe('HLR wizard', () => {
   });
   // other claims flow
   it('should show other claims - C12066', () => {
-    cy.get('va-radio-option[value="other"]').click(checkOpt);
+    cy.get('va-radio-option[value="other"] label').click(checkOpt);
     cy.checkStorage(SAVED_CLAIM_TYPE, undefined);
     // #8622 set by public websites accordion anchor ID
     cy.get(`a[href*="${BENEFIT_OFFICES_URL}"]`).should('exist');
@@ -92,7 +92,7 @@ describe('HLR wizard', () => {
       .should('be.visible')
       .and('have.text', h1Text);
 
-    cy.get('va-radio-option[value="compensation"]').click(checkOpt);
+    cy.get('va-radio-option[value="compensation"] label').click(checkOpt);
     cy.checkStorage(SAVED_CLAIM_TYPE, 'compensation');
     cy.checkFormChange({
       label: 'For what type of claim are you requesting a Higher-Level Review?',

--- a/src/applications/appeals/996/tests/routes.unit.spec.js
+++ b/src/applications/appeals/996/tests/routes.unit.spec.js
@@ -2,19 +2,10 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { WIZARD_STATUS_COMPLETE } from 'platform/site-wide/wizard';
 import routes from '../routes';
-import { setHlrWizardStatus, removeHlrWizardStatus } from '../wizard/utils';
+import { setHlrWizardStatus } from '../wizard/utils';
 
 describe('Form 996 routes', () => {
-  const { onEnter } = routes[1].indexRoute;
-  afterEach(() => {
-    removeHlrWizardStatus();
-  });
-  it('should redirect from root to /start', () => {
-    const replace = sinon.spy();
-    removeHlrWizardStatus();
-    onEnter(null, replace);
-    expect(replace.calledWith('/start')).to.be.true;
-  });
+  const { onEnter } = routes[0].indexRoute;
   it('should redirect from the root to /introduction', () => {
     const replace = sinon.spy();
     setHlrWizardStatus(WIZARD_STATUS_COMPLETE);


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > While not signed in and on the HLR or Supplemental Claim start page, if you activate the "Sign in" button in the header, a warning modal would pop up stating that you'll lost any information you've filled in. This is very confusing as you're not signed in and you may not have made any changes.
- _(If bug, how to reproduce)_
  > - Don't sign in!
  > - Go to [SC start](https://staging.va.gov/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/start) or [HLR start page](https://staging.va.gov/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996/start)
  > - Activate the "Sign in" button in the header
  > - You'll see the warning alert about losing information
- _(What is the solution, why is this the solution)_
  > The start page was not added as an additional page to the form config. This PR makes those changes, and necessary updates to the form app to prevent continuous redirecting to the start page
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#79637](https://github.com/department-of-veterans-affairs/va.gov-team/issues/79637)

## Testing done

- _Describe what the old behavior was prior to the change_
  > See summary
- _Describe the steps required to verify your changes are working as expected_
  > See summary - only the sign in modal should display instead of the warning alert
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Start page  | <img width="1049" alt="alert warning appearing after sign in button is activated" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/54ecd664-8cd9-4b53-a808-e6e9846d9f45"> | <img width="880" alt="login modal showing after sign in button is activated" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/a249c52d-7d1b-474a-9176-655f4e2d6fc8"> |

## What areas of the site does it impact?

Higher-Level Review & Supplemental Claim

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
