### PR TITLE
78843 Update urls per product guidance

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -187,7 +187,7 @@ const formConfig = {
       pages: {
         page1: {
           // initialData: mockData.data,
-          path: 'your-information/description',
+          path: 'signer',
           title: 'Which of these best describes you?',
           uiSchema: {
             ...titleUI('Your information'),
@@ -215,7 +215,7 @@ const formConfig = {
           },
         },
         page2: {
-          path: 'certification/name',
+          path: 'signer-information',
           title: 'Certification',
           depends: formData => get('certifierRole', formData) === 'other',
           uiSchema: {
@@ -232,7 +232,7 @@ const formConfig = {
           },
         },
         page3: {
-          path: 'certification/address',
+          path: 'signer-mailing-address',
           title: 'Certification',
           depends: formData => get('certifierRole', formData) === 'other',
           uiSchema: {
@@ -254,7 +254,7 @@ const formConfig = {
           },
         },
         page4: {
-          path: 'certification/phone',
+          path: 'signer-contact-information',
           title: 'Certification',
           depends: formData => get('certifierRole', formData) === 'other',
           uiSchema: {
@@ -276,7 +276,7 @@ const formConfig = {
           },
         },
         page5: {
-          path: 'certification/relationship',
+          path: 'signer-relationship',
           title: 'Certification',
           depends: formData => get('certifierRole', formData) === 'other',
           uiSchema: {
@@ -368,14 +368,14 @@ const formConfig = {
       title: 'Sponsor information',
       pages: {
         page6: {
-          path: 'sponsor-information/name-dob',
+          path: 'sponsor-information',
           title: formData =>
             `${sponsorWording(formData)} name and date of birth`,
           uiSchema: sponsorNameDobConfig.uiSchema,
           schema: sponsorNameDobConfig.schema,
         },
         page7: {
-          path: 'sponsor-information/ssn',
+          path: 'sponsor-identification-information',
           title: formData =>
             `${sponsorWording(formData)} identification information`,
           uiSchema: {
@@ -395,7 +395,7 @@ const formConfig = {
           },
         },
         page8: {
-          path: 'sponsor-information/status',
+          path: 'sponsor-status',
           title: 'Sponsor status',
           depends: formData => get('certifierRole', formData) !== 'sponsor',
           uiSchema: {
@@ -421,7 +421,7 @@ const formConfig = {
           },
         },
         page9: {
-          path: 'sponsor-information/status-date',
+          path: 'sponsor-status-date',
           title: 'Sponsor status (continued)',
           depends: formData =>
             get('certifierRole', formData) !== 'sponsor' &&
@@ -450,7 +450,7 @@ const formConfig = {
           },
         },
         page9a: {
-          path: 'sponsor-information/status-documents',
+          path: 'sponsor-status-file',
           title: 'Sponsor casualty report',
           depends: formData =>
             get('sponsorIsDeceased', formData) &&
@@ -470,7 +470,7 @@ const formConfig = {
           },
         },
         page10b1: {
-          path: 'sponsor-information/address',
+          path: 'sponsor-mailing-address',
           title: formData => `${sponsorWording(formData)} mailing address`,
           depends: formData => !get('sponsorIsDeceased', formData),
           uiSchema: {
@@ -499,7 +499,7 @@ const formConfig = {
           },
         },
         page11: {
-          path: 'sponsor-information/phone',
+          path: 'sponsor-contact-information',
           title: formData => `${sponsorWording(formData)} contact information`,
           depends: formData => !get('sponsorIsDeceased', formData),
           uiSchema: {
@@ -532,7 +532,7 @@ const formConfig = {
           },
         },
         page12: {
-          path: 'sponsor-information/disability',
+          path: 'sponsor-disability-file',
           title: 'Sponsor disability rating',
           CustomPage: FileFieldCustom,
           CustomPageReview: null,
@@ -549,7 +549,7 @@ const formConfig = {
           },
         },
         page12a: {
-          path: 'sponsor-information/discharge-papers',
+          path: 'sponsor-discharge-file',
           title: 'Sponsor discharge papers',
           CustomPage: FileFieldCustom,
           CustomPageReview: null,
@@ -614,7 +614,7 @@ const formConfig = {
           }),
         },
         page13a: {
-          path: 'applicant-information/:index/start',
+          path: 'applicant-information-intro/:index',
           arrayPath: 'applicants',
           title: item => `${applicantWording(item)} information`,
           showPagePerItem: true,
@@ -652,7 +652,7 @@ const formConfig = {
           }),
         },
         page14: {
-          path: 'applicant-information/:index/ssn',
+          path: 'applicant-identification-information/:index',
           arrayPath: 'applicants',
           title: item => `${applicantWording(item)} identification information`,
           showPagePerItem: true,
@@ -692,7 +692,7 @@ const formConfig = {
           }),
         },
         page15a: {
-          path: 'applicant-information/:index/pre-address',
+          path: 'applicant-mailing-same/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           keepInPageOnReview: false,
@@ -710,7 +710,7 @@ const formConfig = {
           schema: applicantListSchema([], {}),
         },
         page15: {
-          path: 'applicant-information/:index/address',
+          path: 'applicant-mailing-address/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item =>
@@ -755,7 +755,7 @@ const formConfig = {
           }),
         },
         page16: {
-          path: 'applicant-information/:index/email-phone',
+          path: 'applicant-contact-information/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} contact information`,
@@ -790,7 +790,7 @@ const formConfig = {
           }),
         },
         page17: {
-          path: 'applicant-information/:index/gender',
+          path: 'applicant-gender/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} gender`,
@@ -821,7 +821,7 @@ const formConfig = {
           }),
         },
         page18: {
-          path: 'applicant-information/:index/relationship',
+          path: 'applicant-sponsor-relationship/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} relationship to sponsor`,
@@ -843,7 +843,7 @@ const formConfig = {
           },
         },
         page18c: {
-          path: 'applicant-information/:index/child-info',
+          path: 'applicant-child-relationship/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item =>
@@ -878,7 +878,7 @@ const formConfig = {
           }),
         },
         page18a: {
-          path: 'applicant-information/:index/child-documents',
+          path: 'applicant-child-file/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} birth certificate`,
@@ -902,7 +902,7 @@ const formConfig = {
           }),
         },
         page18d: {
-          path: 'applicant-information/:index/adoption-documents',
+          path: 'applicant-child-adoption-file/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} adoption documents`,
@@ -932,7 +932,7 @@ const formConfig = {
           }),
         },
         page18e: {
-          path: 'applicant-information/:index/via-marriage-documents',
+          path: 'applicant-child-marriage-file/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item =>
@@ -963,7 +963,7 @@ const formConfig = {
           }),
         },
         page18b1: {
-          path: 'applicant-information/:index/school-age',
+          path: 'applicant-child-age/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} status`,
@@ -1006,7 +1006,7 @@ const formConfig = {
           }),
         },
         page18b: {
-          path: 'applicant-information/:index/school-documents',
+          path: 'applicant-child-school-file/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} school documents`,
@@ -1038,7 +1038,7 @@ const formConfig = {
           }),
         },
         page18b2: {
-          path: 'applicant-information/:index/helpless-child',
+          path: 'applicant-child-helpless/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} helpless child documents`,
@@ -1065,7 +1065,7 @@ const formConfig = {
           }),
         },
         page18f1: {
-          path: 'applicant-information/:index/marriage-details',
+          path: 'applicant-marriage/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} marriage documents`,
@@ -1099,7 +1099,7 @@ const formConfig = {
         },
         // If applicant has second marriage, is it ongoing?
         page18f2: {
-          path: 'applicant-information/:index/remarriage-viable',
+          path: 'applicant-remarriage/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} remarriage status`,
@@ -1109,7 +1109,7 @@ const formConfig = {
         },
         // Marriage dates (sponsor living or dead) when applicant did not remarry
         page18f3: {
-          path: 'applicant-information/:index/marriage-dates',
+          path: 'applicant-marriage-date/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} marriage dates`,
@@ -1119,7 +1119,7 @@ const formConfig = {
         },
         // Applicant remarried after sponsor died
         page18f4: {
-          path: 'applicant-information/:index/remarried-dates',
+          path: 'applicant-remarriage-date/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} marriage dates`,
@@ -1129,7 +1129,7 @@ const formConfig = {
         },
         // Applicant remarried after sponsor died but separated from 2nd spouse
         page18f5: {
-          path: 'applicant-information/:index/remarried-separated-dates',
+          path: 'applicant-remarriage-separation-date/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} marriage dates`,
@@ -1148,7 +1148,7 @@ const formConfig = {
           schema: marriageDatesSchema.separatedSchema,
         },
         page18f: {
-          path: 'applicant-information/:index/spouse',
+          path: 'applicant-marriage-file/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} marriage documents`,
@@ -1185,7 +1185,7 @@ const formConfig = {
           }),
         },
         page18f7: {
-          path: 'applicant-information/:index/second-marriage',
+          path: 'applicant-remarriage-file/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} second marriage documents`,
@@ -1217,7 +1217,7 @@ const formConfig = {
         // If applicant remarried after 55 but the second marriage is not viable,
         // upload a certificate proving the marriage dissolved
         page18f8: {
-          path: 'applicant-information/:index/second-marriage-dissolved',
+          path: 'applicant-remarriage-separation-file/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item =>
@@ -1249,7 +1249,7 @@ const formConfig = {
           }),
         },
         page19: {
-          path: 'applicant-information/:index/medicare-status',
+          path: 'applicant-medicare/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} Medicare status`,
@@ -1271,7 +1271,7 @@ const formConfig = {
           },
         },
         page20: {
-          path: 'applicant-information/:index/medicare-status-continued',
+          path: 'applicant-medicare-continued/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item =>
@@ -1303,7 +1303,7 @@ const formConfig = {
           },
         },
         page20a: {
-          path: 'applicant-information/:index/medicare-ab-upload',
+          path: 'applicant-medicare-ab-file/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} medicare card (parts A/B)`,
@@ -1329,7 +1329,7 @@ const formConfig = {
           }),
         },
         page20b: {
-          path: 'applicant-information/:index/medicare-d-upload',
+          path: 'applicant-medicare-d-file/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} medicare card (part D)`,
@@ -1361,7 +1361,7 @@ const formConfig = {
         // If the user is ineligible for Medicare and over 65 years,
         // require them to upload proof of ineligibility
         page20c: {
-          path: 'applicant-information/:index/over-65-ineligible',
+          path: 'applicant-medicare-ineligible/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item =>
@@ -1389,7 +1389,7 @@ const formConfig = {
           }),
         },
         page21: {
-          path: 'applicant-information/:index/ohi',
+          path: 'applicant-other-insurance-status/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} other health insurance`,
@@ -1405,7 +1405,7 @@ const formConfig = {
           },
         },
         page21a: {
-          path: 'applicant-information/:index/ohi-upload',
+          path: 'applicant-other-insurance-file/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} other health insurance`,
@@ -1428,7 +1428,7 @@ const formConfig = {
           }),
         },
         page22: {
-          path: 'applicant-information/:index/10-7959c-upload',
+          path: 'applicant-other-insurance-10-7959c-file/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} 10-7959c upload`,
@@ -1473,7 +1473,7 @@ const formConfig = {
           schema: blankSchema,
         },
         page24: {
-          path: 'consent-to-mail',
+          path: 'consent-mail',
           title: 'Upload your supporting files',
           depends: formData => {
             try {

--- a/src/applications/ivc-champva/10-10D/manifest.json
+++ b/src/applications/ivc-champva/10-10D/manifest.json
@@ -2,6 +2,6 @@
   "appName": "10-10d Application for CHAMPVA benefits",
   "entryFile": "./app-entry.jsx",
   "entryName": "10-10D",
-  "rootUrl": "/ivc-champva/10-10D",
+  "rootUrl": "/health-care/champva/apply-form-10-10d",
   "productId": "c485d6da-8094-433d-9cd3-3d31e7813650"
 }


### PR DESCRIPTION
## Summary

- Updates all URLs in form 10-10d to match new guidance from product

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/78843
- https://github.com/department-of-veterans-affairs/content-build/pull/1998

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA