### PR TITLE
Increase code coverage: post-911-gib-status

### DIFF
--- a/src/applications/post-911-gib-status/tests/actions/post-911-gib-status.unit.spec.js
+++ b/src/applications/post-911-gib-status/tests/actions/post-911-gib-status.unit.spec.js
@@ -4,7 +4,7 @@ import {
   mockFetch,
   setFetchJSONFailure,
   setFetchJSONResponse,
-} from 'platform/testing/unit/helpers';
+} from '@department-of-veterans-affairs/platform-testing/helpers';
 import {
   getEnrollmentData,
   getServiceAvailability,
@@ -134,7 +134,7 @@ describe('getEnrollmentData', () => {
   });
 
   it('dispatches GET_ENROLLMENT_DATA_FAILURE on unexpected error without code', done => {
-    setFetchJSONFailure(global.fetch.onCall(0), Promise.reject({}));
+    setFetchJSONFailure(global.fetch.onCall(0), Promise.reject(new Error()));
     const thunk = getEnrollmentData();
     const dispatch = sinon.spy();
     thunk(dispatch)

--- a/src/applications/post-911-gib-status/tests/actions/post-911-gib-status.unit.spec.js
+++ b/src/applications/post-911-gib-status/tests/actions/post-911-gib-status.unit.spec.js
@@ -10,9 +10,11 @@ import {
   getServiceAvailability,
 } from '../../actions/post-911-gib-status';
 import {
+  BACKEND_AUTHENTICATION_ERROR,
   BACKEND_SERVICE_ERROR,
   GET_ENROLLMENT_DATA_FAILURE,
   GET_ENROLLMENT_DATA_SUCCESS,
+  NO_CHAPTER33_RECORD_AVAILABLE,
   SET_SERVICE_AVAILABILITY,
   SERVICE_AVAILABILITY_STATES,
   SET_SERVICE_UPTIME_REMAINING,
@@ -167,6 +169,48 @@ describe('getEnrollmentData', () => {
       .then(() => {
         const action = dispatch.firstCall.args[0];
         expect(action.type).to.equal(BACKEND_SERVICE_ERROR);
+      })
+      .then(done, done);
+  });
+
+  it('dispatches BACKEND_AUTHENTICATION_ERROR on 403 error code', done => {
+    setFetchJSONFailure(global.fetch.onCall(0), {
+      errors: [{ status: '403' }],
+    });
+    const thunk = getEnrollmentData();
+    const dispatch = sinon.spy();
+    thunk(dispatch)
+      .then(() => {
+        const action = dispatch.firstCall.args[0];
+        expect(action.type).to.equal(BACKEND_AUTHENTICATION_ERROR);
+      })
+      .then(done, done);
+  });
+
+  it('dispatches BACKEND_AUTHENTICATION_ERROR on 404 error code', done => {
+    setFetchJSONFailure(global.fetch.onCall(0), {
+      errors: [{ status: '404' }],
+    });
+    const thunk = getEnrollmentData();
+    const dispatch = sinon.spy();
+    thunk(dispatch)
+      .then(() => {
+        const action = dispatch.firstCall.args[0];
+        expect(action.type).to.equal(NO_CHAPTER33_RECORD_AVAILABLE);
+      })
+      .then(done, done);
+  });
+
+  it('dispatches GET_ENROLLMENT_DATA_FAILURE when no error codes are received', done => {
+    setFetchJSONFailure(global.fetch.onCall(0), {
+      errors: [], // no errors received
+    });
+    const thunk = getEnrollmentData();
+    const dispatch = sinon.spy();
+    thunk(dispatch)
+      .then(() => {
+        const action = dispatch.firstCall.args[0];
+        expect(action.type).to.equal(GET_ENROLLMENT_DATA_FAILURE);
       })
       .then(done, done);
   });


### PR DESCRIPTION
## Summary

- Adds 3 tests to bring coverage from 88% to 100% for this file: `vets-website/src/applications/post-911-gib-status/actions/post-911-gib-status.js`.
- I work for VA IIR.

## Related issue(s)

Team IIR's ticket: https://app.zenhub.com/workspaces/va-iir-6508c0bd79e64e0fb5855caf/issues/gh/department-of-veterans-affairs/va-iir/487

## Testing done

From `vets-website` do `yarn test:coverage-app post-911-gib-status`. The console indicate passing tests, and none failing. A browser window is launched with a coverage report. Click on the "actions" link and you will see a readout of the file in question.

- Added a test to cover 403 response.
- Added a test to cover 404 response.
- Added a test to cover situation where an error is returned with no error status codes.


## Screenshots

<img width="882" alt="Screenshot 2024-04-03 at 9 54 49 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/1807967/0d2dc892-9fa5-49b6-9e99-c3e2ba9b6d7a">

## What areas of the site does it impact?

No other areas are affected.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user