### PR TITLE
Check in/79739/time to complete

### DIFF
--- a/src/applications/check-in/actions/travel-claim/index.js
+++ b/src/applications/check-in/actions/travel-claim/index.js
@@ -16,11 +16,11 @@ export const setFilteredAppointments = payload => {
   };
 };
 
-export const SET_FACILITY_TO_FILE = 'SET_FACILITY_TO_FILE';
+export const SET_FORM_DATA = 'SET_FORM_DATA';
 
-export const setFacilityToFile = facility => {
+export const setFormData = data => {
   return {
-    type: SET_FACILITY_TO_FILE,
-    payload: facility,
+    type: SET_FORM_DATA,
+    payload: data,
   };
 };

--- a/src/applications/check-in/actions/travel-claim/travel-claim.actions.unit.spec.js
+++ b/src/applications/check-in/actions/travel-claim/travel-claim.actions.unit.spec.js
@@ -5,8 +5,8 @@ import {
   RECEIVED_TRAVEL_DATA,
   setFilteredAppointments,
   SET_FILTERED_APPOINTMENTS,
-  SET_FACILITY_TO_FILE,
-  setFacilityToFile,
+  SET_FORM_DATA,
+  setFormData,
 } from './index';
 
 describe('travel-claim', () => {
@@ -56,13 +56,13 @@ describe('travel-claim', () => {
         expect(action.payload.eligibleToFile).to.be.an('array');
       });
     });
-    describe('setFacilityToFile', () => {
+    describe('setFormData', () => {
       it('should return correct action', () => {
-        const action = setFacilityToFile({});
-        expect(action.type).to.equal(SET_FACILITY_TO_FILE);
+        const action = setFormData({});
+        expect(action.type).to.equal(SET_FORM_DATA);
       });
       it('should return correct structure', () => {
-        const action = setFacilityToFile({
+        const action = setFormData({
           facilitiesToFile: [],
         });
         expect(action.payload).to.be.an('object');

--- a/src/applications/check-in/api/versions/v2.js
+++ b/src/applications/check-in/api/versions/v2.js
@@ -236,7 +236,7 @@ const v2 = {
       ...json,
     };
   },
-  postTravelPayClaims: async (claims, uuid) => {
+  postTravelPayClaims: async (claims, uuid, timeToComplete) => {
     const url = '/check_in/v0/travel_claims/';
     const headers = { 'Content-Type': 'application/json' };
 
@@ -245,6 +245,7 @@ const v2 = {
         travelClaims: {
           uuid,
           appointmentDate: claim.startTime,
+          timeToComplete,
           facilityType: 'oh',
         },
       };

--- a/src/applications/check-in/hooks/usePostTravelClaims.jsx
+++ b/src/applications/check-in/hooks/usePostTravelClaims.jsx
@@ -25,7 +25,7 @@ const usePostTravelClaims = props => {
   );
   const travelPaySent = getTravelPaySent(window);
   const now = new Date().getTime();
-  const timeToComplete = (now - startedTime) / 1000;
+  const timeToComplete = Math.round((now - startedTime) / 1000).toString();
   const faciltiesToPost = facilitiesToFile.filter(
     facility =>
       !(facility.stationNo in travelPaySent) ||

--- a/src/applications/check-in/hooks/usePostTravelClaims.jsx
+++ b/src/applications/check-in/hooks/usePostTravelClaims.jsx
@@ -16,7 +16,7 @@ const usePostTravelClaims = props => {
   const [travelPayClaimError, setTravelPayClaimError] = useState(false);
   const selectForm = useMemo(makeSelectForm, []);
   const { data } = useSelector(selectForm);
-  const { facilitiesToFile } = data;
+  const { facilitiesToFile, startedTime } = data;
   const selectCurrentContext = useMemo(makeSelectCurrentContext, []);
   const { token: uuid } = useSelector(selectCurrentContext);
   const { setTravelPaySent, getTravelPaySent } = useStorage(
@@ -24,7 +24,8 @@ const usePostTravelClaims = props => {
     true,
   );
   const travelPaySent = getTravelPaySent(window);
-
+  const now = new Date().getTime();
+  const timeToComplete = (now - startedTime) / 1000;
   const faciltiesToPost = facilitiesToFile.filter(
     facility =>
       !(facility.stationNo in travelPaySent) ||
@@ -58,7 +59,7 @@ const usePostTravelClaims = props => {
         return;
       }
       api.v2
-        .postTravelPayClaims(faciltiesToPost, uuid)
+        .postTravelPayClaims(faciltiesToPost, uuid, timeToComplete)
         .catch(() => {
           setTravelPayClaimError(true);
         })
@@ -77,6 +78,7 @@ const usePostTravelClaims = props => {
       travelPaySent,
       data,
       jumpToPage,
+      timeToComplete,
     ],
   );
 

--- a/src/applications/check-in/reducers/index.js
+++ b/src/applications/check-in/reducers/index.js
@@ -40,13 +40,13 @@ import {
 import {
   RECEIVED_TRAVEL_DATA,
   SET_FILTERED_APPOINTMENTS,
-  SET_FACILITY_TO_FILE,
+  SET_FORM_DATA,
 } from '../actions/travel-claim';
 
 import {
   receivedTravelDataHandler,
   setFilteredAppointmentsHandler,
-  setFacilityToFileHandler,
+  setFormDataHandler,
 } from './travel-claim';
 
 import { setAppHandler, setErrorHandler, setFormHandler } from './universal';
@@ -83,7 +83,7 @@ const handler = Object.freeze({
   [ADDITIONAL_CONTEXT]: additionalContextHandler,
   [RECEIVED_TRAVEL_DATA]: receivedTravelDataHandler,
   [SET_FILTERED_APPOINTMENTS]: setFilteredAppointmentsHandler,
-  [SET_FACILITY_TO_FILE]: setFacilityToFileHandler,
+  [SET_FORM_DATA]: setFormDataHandler,
 
   default: state => {
     return { ...state };

--- a/src/applications/check-in/reducers/travel-claim/index.js
+++ b/src/applications/check-in/reducers/travel-claim/index.js
@@ -14,7 +14,7 @@ const setFilteredAppointmentsHandler = (state, action) => {
   };
 };
 
-const setFacilityToFileHandler = (state, action) => {
+const setFormDataHandler = (state, action) => {
   const data = { ...state.form.data, ...action.payload };
   return {
     ...state,
@@ -25,5 +25,5 @@ const setFacilityToFileHandler = (state, action) => {
 export {
   receivedTravelDataHandler,
   setFilteredAppointmentsHandler,
-  setFacilityToFileHandler,
+  setFormDataHandler,
 };

--- a/src/applications/check-in/reducers/travel-claim/travel-claim.reducers.unit.spec.js
+++ b/src/applications/check-in/reducers/travel-claim/travel-claim.reducers.unit.spec.js
@@ -3,12 +3,12 @@ import { expect } from 'chai';
 import {
   receivedTravelDataHandler,
   setFilteredAppointmentsHandler,
-  setFacilityToFileHandler,
+  setFormDataHandler,
 } from './index';
 import {
   receivedTravelData,
   setFilteredAppointments,
-  setFacilityToFile,
+  setFormData,
 } from '../../actions/travel-claim';
 
 import appReducer from '../index';
@@ -108,15 +108,15 @@ describe('check in', () => {
         });
       });
     });
-    describe('setFacilityToFile', () => {
+    describe('setFormData', () => {
       it('should create basic structure', () => {
-        const action = setFacilityToFile(facilityToFile);
-        const state = setFacilityToFileHandler({ form: {} }, action);
+        const action = setFormData(facilityToFile);
+        const state = setFormDataHandler({ form: {} }, action);
         expect(state.form.data.facilitiesToFile).to.be.an('array');
       });
       it('should set the correct values', () => {
-        const action = setFacilityToFile(facilityToFile);
-        const state = setFacilityToFileHandler({ form: {} }, action);
+        const action = setFormData(facilityToFile);
+        const state = setFormDataHandler({ form: {} }, action);
         expect(state.form.data.facilitiesToFile[0].stationNo).to.equal('555');
         expect(state.form.data.facilitiesToFile[0].startTime).to.equal(
           '2021-08-19T13:56:31',
@@ -126,7 +126,7 @@ describe('check in', () => {
       });
       describe('reducer is called;', () => {
         it('finds the correct handler', () => {
-          const action = setFacilityToFile(facilityToFile);
+          const action = setFormData(facilityToFile);
           const state = appReducer.checkInData(undefined, action);
           expect(state.form.data.facilitiesToFile[0].stationNo).to.equal('555');
           expect(state.form.data.facilitiesToFile[0].startTime).to.equal(

--- a/src/applications/check-in/travel-claim/pages/travel-mileage/index.jsx
+++ b/src/applications/check-in/travel-claim/pages/travel-mileage/index.jsx
@@ -7,7 +7,7 @@ import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring
 
 import { useFormRouting } from '../../../hooks/useFormRouting';
 import { createAnalyticsSlug } from '../../../utils/analytics';
-import { setFacilityToFile } from '../../../actions/travel-claim';
+import { setFormData } from '../../../actions/travel-claim';
 import {
   hasMultipleFacilities,
   sortAppointmentsByStartTime,
@@ -78,7 +78,7 @@ const TravelMileage = props => {
             APP_NAMES.TRAVEL_CLAIM,
           ),
         });
-        dispatch(setFacilityToFile({ facilitiesToFile: selectedFacilities }));
+        dispatch(setFormData({ facilitiesToFile: selectedFacilities }));
         goToNextPage();
       } else {
         setError(true);

--- a/src/applications/check-in/travel-claim/pages/validate/index.jsx
+++ b/src/applications/check-in/travel-claim/pages/validate/index.jsx
@@ -5,6 +5,7 @@ import propTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 
 import { createSetSession } from '../../../actions/authentication';
+import { setFormData } from '../../../actions/travel-claim';
 
 import ValidateDisplay from '../../../components/pages/validate/ValidateDisplay';
 
@@ -31,7 +32,13 @@ const Validate = ({ router }) => {
     },
     [dispatch, setPermissions],
   );
-
+  const recordTimeAndGoToNextPage = useCallback(
+    () => {
+      dispatch(setFormData({ startedTime: new Date().getTime() }));
+      goToNextPage();
+    },
+    [dispatch, goToNextPage],
+  );
   const selectContext = useMemo(makeSelectCurrentContext, []);
   const { token } = useSelector(selectContext);
 
@@ -53,14 +60,22 @@ const Validate = ({ router }) => {
         setLastNameError,
         setIsLoading,
         setShowValidateError,
-        goToNextPage,
+        recordTimeAndGoToNextPage,
         token,
         setSession,
         APP_NAMES.TRAVEL_CLAIM,
         updateError,
       );
     },
-    [goToNextPage, lastName, dob, dobError, setSession, token, updateError],
+    [
+      recordTimeAndGoToNextPage,
+      lastName,
+      dob,
+      dobError,
+      setSession,
+      token,
+      updateError,
+    ],
   );
 
   const validateErrorMessage = t(


### PR DESCRIPTION
## Summary

This PR adds sending time to complete in seconds to vets-api for tracking in datadog. I went to create an action to record the start time in redux, but realized that facilitesToFile was already doing a generic form.data action. So I renamed that action to reflect how it works better. Then I utilized that to record the start time in form.data.

On travel POST, I grab the difference in start time and now and convert to seconds to pass to vets-api.


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#79739

## Testing done

Updates action/reducer tests

## What areas of the site does it impact?

Travel claim application for Oracle Health appointments

## Acceptance criteria

 - [ ] time to complete in seconds is sent to vets-api
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

