### PR TITLE
remove old route and feature flag to toggle between the two

### DIFF
--- a/src/applications/toe/actions.js
+++ b/src/applications/toe/actions.js
@@ -34,9 +34,6 @@ export const UPDATE_SPONSORS = 'UPDATE_SPONSORS';
 export const FETCH_DIRECT_DEPOSIT = 'FETCH_DIRECT_DEPOSIT';
 export const FETCH_DIRECT_DEPOSIT_SUCCESS = 'FETCH_DIRECT_DEPOSIT_SUCCESS';
 export const FETCH_DIRECT_DEPOSIT_FAILED = 'FETCH_DIRECT_DEPOSIT_FAILED';
-export const DIRECT_DEPOSIT_ENDPOINT = `${
-  environment.API_URL
-}/v0/profile/ch33_bank_accounts`;
 export const LIGHTHOUSE_DIRECT_DEPOSIT_ENDPOINT = `${
   environment.API_URL
 }/v0/profile/direct_deposits`;
@@ -65,14 +62,10 @@ export function fetchPersonalInformation() {
   };
 }
 
-export function fetchDirectDeposit(toeLightHouseDgiDirectDeposit) {
-  const ddEndpoint = toeLightHouseDgiDirectDeposit
-    ? LIGHTHOUSE_DIRECT_DEPOSIT_ENDPOINT
-    : DIRECT_DEPOSIT_ENDPOINT;
-
+export function fetchDirectDeposit() {
   return async dispatch => {
     dispatch({ type: FETCH_DIRECT_DEPOSIT });
-    return apiRequest(ddEndpoint)
+    return apiRequest(LIGHTHOUSE_DIRECT_DEPOSIT_ENDPOINT)
       .then(response => {
         dispatch({
           type: FETCH_DIRECT_DEPOSIT_SUCCESS,

--- a/src/applications/toe/containers/ToeApp.jsx
+++ b/src/applications/toe/containers/ToeApp.jsx
@@ -27,7 +27,6 @@ function ToeApp({
   showMebEnhancements,
   showMebEnhancements06,
   showMebEnhancements08,
-  toeLightHouseDgiDirectDeposit,
 }) {
   const [fetchedUserInfo, setFetchedUserInfo] = useState(false);
   const [fetchedDirectDeposit, setFetchedDirectDeposit] = useState(false);
@@ -107,21 +106,8 @@ function ToeApp({
           showMebEnhancements08,
         });
       }
-      if (
-        toeLightHouseDgiDirectDeposit !== formData.toeLightHouseDgiDirectDeposit
-      ) {
-        setFormData({
-          ...formData,
-          toeLightHouseDgiDirectDeposit,
-        });
-      }
     },
-    [
-      formData,
-      setFormData,
-      showMebEnhancements08,
-      toeLightHouseDgiDirectDeposit,
-    ],
+    [formData, setFormData, showMebEnhancements08],
   );
 
   useEffect(
@@ -131,7 +117,7 @@ function ToeApp({
       }
       if (!fetchedDirectDeposit) {
         setFetchedDirectDeposit(true);
-        getDirectDeposit(toeLightHouseDgiDirectDeposit);
+        getDirectDeposit();
       }
     },
     [fetchedDirectDeposit, getDirectDeposit, user?.login?.currentlyLoggedIn],
@@ -170,7 +156,6 @@ ToeApp.propTypes = {
   sponsors: SPONSORS_TYPE,
   sponsorsInitial: SPONSORS_TYPE,
   sponsorsSavedState: SPONSORS_TYPE,
-  toeLightHouseDgiDirectDeposit: PropTypes.bool,
   user: PropTypes.object,
 };
 

--- a/src/applications/toe/reducers.js
+++ b/src/applications/toe/reducers.js
@@ -27,22 +27,17 @@ const initialState = {
   },
 };
 
-const handleDirectDepositApi = (action, state) => {
+const handleDirectDepositApi = action => {
   if (!action?.response?.data?.attributes) {
     return {};
   }
 
-  const toeLightHouseDgiDirectDeposit =
-    state?.featureToggles?.toeLightHouseDgiDirectDeposit;
-  const accountNumber = toeLightHouseDgiDirectDeposit
-    ? action?.response?.data?.attributes?.paymentAccount?.accountNumber
-    : action?.response?.data?.attributes?.accountNumber;
-  const originalRoutingNumber = toeLightHouseDgiDirectDeposit
-    ? action?.response?.data?.attributes?.paymentAccount?.routingNumber
-    : action?.response?.data?.attributes?.financialInstitutionRoutingNumber;
-  const routingNumber = toeLightHouseDgiDirectDeposit
-    ? action?.response?.data?.attributes?.paymentAccount?.routingNumber
-    : action?.response?.data?.attributes?.financialInstitutionRoutingNumber;
+  const accountNumber =
+    action?.response?.data?.attributes?.paymentAccount?.accountNumber;
+  const originalRoutingNumber =
+    action?.response?.data?.attributes?.paymentAccount?.routingNumber;
+  const routingNumber =
+    action?.response?.data?.attributes?.paymentAccount?.routingNumber;
 
   return {
     ...action?.response?.data?.attributes,
@@ -135,7 +130,7 @@ export default {
         return {
           ...state,
           fetchDirectDepositInProgress: false,
-          bankInformation: handleDirectDepositApi(action, state),
+          bankInformation: handleDirectDepositApi(action),
         };
       default:
         return state;

--- a/src/applications/toe/selectors.js
+++ b/src/applications/toe/selectors.js
@@ -25,8 +25,5 @@ export const getAppData = state => ({
     state.featureToggles.showMeb1990EMaintenanceAlert,
   showMebEnhancements06: state.featureToggles.showMebEnhancements06,
   showMebEnhancements08: state.featureToggles.showMebEnhancements08,
-  toeLightHouseDgiDirectDeposit: !!toggleValues(state)[
-    FEATURE_FLAG_NAMES.toeLightHouseDgiDirectDeposit
-  ],
   user: state.user || {},
 });


### PR DESCRIPTION
## Summary

- Once new route is confirmed to be working the old one can be removed.  This PR will remove the references to the old route and feature flag used to control which route is called.

## Related issue(s)

https://github.com/department-of-veterans-affairs/vets-website/pull/28940
