### PR TITLE
78841e Applicant medicare flow (sub PR 2/X)

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
@@ -1,0 +1,274 @@
+import VaTextInputField from 'platform/forms-system/src/js/web-component-fields/VaTextInputField';
+import {
+  titleUI,
+  titleSchema,
+  currentOrPastDateUI,
+  currentOrPastDateSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { applicantListSchema } from '../config/constants';
+import { applicantWording } from '../../shared/utilities';
+import ApplicantField from '../../shared/components/applicantLists/ApplicantField';
+
+export const blankSchema = { type: 'object', properties: {} };
+
+// Used with a custom page
+export const applicantHasMedicareABSchema = {
+  uiSchema: {
+    applicants: { items: {} },
+  },
+  schema: applicantListSchema([], {
+    applicantMedicareStatus: {
+      type: 'object',
+      properties: {
+        enrollment: { type: 'string' },
+        otherEnrollment: { type: 'string' },
+      },
+    },
+  }),
+};
+
+export const applicantMedicareABContextSchema = {
+  uiSchema: {
+    applicants: { items: {} },
+  },
+  schema: applicantListSchema([], {
+    applicantMedicareStatusContinued: {
+      type: 'object',
+      properties: {
+        medicareContext: { type: 'string' },
+        otherMedicareContext: { type: 'string' },
+      },
+    },
+  }),
+};
+
+export const applicantMedicarePartACarrierSchema = {
+  uiSchema: {
+    applicants: {
+      'ui:options': {
+        viewField: ApplicantField,
+      },
+      items: {
+        applicantMedicarePartACarrier: {
+          'ui:title': 'Carrier’s name',
+          'ui:webComponentField': VaTextInputField,
+        },
+        'ui:options': {
+          updateSchema: formData => {
+            return {
+              title: context =>
+                titleUI(
+                  `${applicantWording(
+                    formData,
+                    context,
+                  )} Medicare Part A carrier`,
+                )['ui:title'],
+            };
+          },
+        },
+      },
+    },
+  },
+  schema: applicantListSchema(['applicantMedicarePartACarrier'], {
+    titleSchema,
+    applicantMedicarePartACarrier: { type: 'string' },
+  }),
+};
+
+export const applicantMedicarePartAEffectiveDateSchema = {
+  uiSchema: {
+    applicants: {
+      'ui:options': {
+        viewField: ApplicantField,
+      },
+      items: {
+        applicantMedicarePartAEffectiveDate: currentOrPastDateUI(
+          'Medicare Part A effective date',
+        ),
+        'ui:options': {
+          updateSchema: formData => {
+            return {
+              title: context =>
+                titleUI(
+                  `${applicantWording(formData, context)} coverage information`,
+                )['ui:title'],
+            };
+          },
+        },
+      },
+    },
+  },
+  schema: applicantListSchema(['applicantMedicarePartAEffectiveDate'], {
+    titleSchema,
+    applicantMedicarePartAEffectiveDate: currentOrPastDateSchema,
+  }),
+};
+
+export const applicantMedicarePartBCarrierSchema = {
+  uiSchema: {
+    applicants: {
+      'ui:options': {
+        viewField: ApplicantField,
+      },
+      items: {
+        applicantMedicarePartBCarrier: {
+          'ui:title': 'Carrier’s name',
+          'ui:webComponentField': VaTextInputField,
+        },
+        'ui:options': {
+          updateSchema: formData => {
+            return {
+              title: context =>
+                titleUI(
+                  `${applicantWording(
+                    formData,
+                    context,
+                  )} Medicare Part B carrier`,
+                )['ui:title'],
+            };
+          },
+        },
+      },
+    },
+  },
+  schema: applicantListSchema(['applicantMedicarePartBCarrier'], {
+    titleSchema,
+    applicantMedicarePartBCarrier: { type: 'string' },
+  }),
+};
+
+export const applicantMedicarePartBEffectiveDateSchema = {
+  uiSchema: {
+    applicants: {
+      'ui:options': {
+        viewField: ApplicantField,
+      },
+      items: {
+        applicantMedicarePartBEffectiveDate: currentOrPastDateUI(
+          'Medicare Part B effective date',
+        ),
+        'ui:options': {
+          updateSchema: formData => {
+            return {
+              title: context =>
+                titleUI(
+                  `${applicantWording(formData, context)} coverage information`,
+                )['ui:title'],
+            };
+          },
+        },
+      },
+    },
+  },
+  schema: applicantListSchema(['applicantMedicarePartBEffectiveDate'], {
+    titleSchema,
+    applicantMedicarePartBEffectiveDate: currentOrPastDateSchema,
+  }),
+};
+
+export const applicantMedicarePharmacySchema = {
+  uiSchema: {
+    applicants: { items: {} },
+  },
+  schema: applicantListSchema([], {
+    applicantMedicarePharmacyBenefits: {
+      type: 'object',
+      properties: {
+        hasBenefits: { type: 'string' },
+        _unused: { type: 'string' },
+      },
+    },
+  }),
+};
+
+export const applicantMedicareAdvantageSchema = {
+  uiSchema: {
+    applicants: { items: {} },
+  },
+  schema: applicantListSchema([], {
+    applicantMedicareAdvantage: {
+      type: 'object',
+      properties: {
+        hasAdvantage: { type: 'string' },
+        _unused: { type: 'string' },
+      },
+    },
+  }),
+};
+
+export const applicantHasMedicareDSchema = {
+  uiSchema: {
+    applicants: { items: {} },
+  },
+  schema: applicantListSchema([], {
+    applicantMedicareStatusD: {
+      type: 'object',
+      properties: {
+        enrollment: { type: 'string' },
+        _unused: { type: 'string' },
+      },
+    },
+  }),
+};
+
+export const applicantMedicarePartDCarrierSchema = {
+  uiSchema: {
+    applicants: {
+      'ui:options': {
+        viewField: ApplicantField,
+      },
+      items: {
+        applicantMedicarePartDCarrier: {
+          'ui:title': 'Carrier’s name',
+          'ui:webComponentField': VaTextInputField,
+        },
+        'ui:options': {
+          updateSchema: formData => {
+            return {
+              title: context =>
+                titleUI(
+                  `${applicantWording(
+                    formData,
+                    context,
+                  )} Medicare Part D carrier`,
+                )['ui:title'],
+            };
+          },
+        },
+      },
+    },
+  },
+  schema: applicantListSchema(['applicantMedicarePartDCarrier'], {
+    titleSchema,
+    applicantMedicarePartDCarrier: { type: 'string' },
+  }),
+};
+
+export const applicantMedicarePartDEffectiveDateSchema = {
+  uiSchema: {
+    applicants: {
+      'ui:options': {
+        viewField: ApplicantField,
+      },
+      items: {
+        applicantMedicarePartDEffectiveDate: currentOrPastDateUI(
+          'Medicare Part D effective date',
+        ),
+        'ui:options': {
+          updateSchema: formData => {
+            return {
+              title: context =>
+                titleUI(
+                  `${applicantWording(formData, context)} coverage information`,
+                )['ui:title'],
+            };
+          },
+        },
+      },
+    },
+  },
+  schema: applicantListSchema(['applicantMedicarePartDEffectiveDate'], {
+    titleSchema,
+    applicantMedicarePartDEffectiveDate: currentOrPastDateSchema,
+  }),
+};


### PR DESCRIPTION
## Summary

This PR is the second of multiple that breaks up the code added in https://github.com/department-of-veterans-affairs/vets-website/pull/28928

- Added `medicareInformation.js`, which holds all uiSchema/schemas for the upcoming Medicare form fields

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-website/pull/28928
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/78848

## Testing done

- Manual
- Unit

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA