### PR TITLE
78841e Applicant medicare flow (sub PR 3/X)

### DIFF
--- a/src/applications/ivc-champva/10-7959C/components/ApplicantMedicareAdvantagePage.jsx
+++ b/src/applications/ivc-champva/10-7959C/components/ApplicantMedicareAdvantagePage.jsx
@@ -1,0 +1,51 @@
+import { pageProps, reviewPageProps, yesNoOptions } from '../config/constants';
+
+import ApplicantRelationshipPage, {
+  ApplicantRelationshipReviewPage,
+  appRelBoilerplate,
+} from '../../shared/components/applicantLists/ApplicantRelationshipPage';
+
+const PROPERTY_NAMES = {
+  keyname: 'applicantMedicareAdvantage',
+  primary: 'hasAdvantage',
+  secondary: '_unused',
+};
+
+function generateOptions({ data, pagePerItemIndex }) {
+  const bp = appRelBoilerplate({ data, pagePerItemIndex });
+  const prompt = `Did ${
+    bp.useFirstPerson ? 'you' : `${bp.applicant}`
+  } choose the advantage plan for coverage?`;
+
+  return {
+    ...bp,
+    options: yesNoOptions,
+    relativeBeingVerb: `${bp.relative} ${bp.beingVerbPresent}`,
+    customTitle: `${
+      bp.useFirstPerson ? `Your` : `${bp.applicant}’s`
+    } Medicare coverage`,
+    customHint:
+      'You can find this information on the front of your Medicare card.',
+    description: prompt,
+  };
+}
+
+export function ApplicantMedicareAdvantagePage(props) {
+  const newProps = {
+    ...props,
+    ...PROPERTY_NAMES,
+    genOp: generateOptions,
+  };
+  return ApplicantRelationshipPage(newProps);
+}
+export function ApplicantMedicareAdvantageReviewPage(props) {
+  const newProps = {
+    ...props,
+    ...PROPERTY_NAMES,
+    genOp: generateOptions,
+  };
+  return ApplicantRelationshipReviewPage(newProps);
+}
+
+ApplicantMedicareAdvantagePage.propTypes = pageProps;
+ApplicantMedicareAdvantageReviewPage.propTypes = reviewPageProps;

--- a/src/applications/ivc-champva/10-7959C/components/ApplicantMedicarePharmacyPage.jsx
+++ b/src/applications/ivc-champva/10-7959C/components/ApplicantMedicarePharmacyPage.jsx
@@ -1,0 +1,51 @@
+import { pageProps, reviewPageProps, yesNoOptions } from '../config/constants';
+
+import ApplicantRelationshipPage, {
+  ApplicantRelationshipReviewPage,
+  appRelBoilerplate,
+} from '../../shared/components/applicantLists/ApplicantRelationshipPage';
+
+const PROPERTY_NAMES = {
+  keyname: 'applicantMedicarePharmacyBenefits',
+  primary: 'hasBenefits',
+  secondary: '_unused',
+};
+
+function generateOptions({ data, pagePerItemIndex }) {
+  const bp = appRelBoilerplate({ data, pagePerItemIndex });
+  const prompt = `Do ${
+    bp.useFirstPerson ? 'your' : `${bp.applicant}’s`
+  } Medicare Parts A & B provide pharmacy benefits?`;
+
+  return {
+    ...bp,
+    options: yesNoOptions,
+    relativeBeingVerb: `${bp.relative} ${bp.beingVerbPresent}`,
+    customTitle: `${
+      bp.useFirstPerson ? `Your` : `${bp.applicant}’s`
+    } Medicare pharmacy benefits`,
+    customHint:
+      'You can find this information on the front of your Medicare card.',
+    description: prompt,
+  };
+}
+
+export function ApplicantMedicarePharmacyPage(props) {
+  const newProps = {
+    ...props,
+    ...PROPERTY_NAMES,
+    genOp: generateOptions,
+  };
+  return ApplicantRelationshipPage(newProps);
+}
+export function ApplicantMedicarePharmacyReviewPage(props) {
+  const newProps = {
+    ...props,
+    ...PROPERTY_NAMES,
+    genOp: generateOptions,
+  };
+  return ApplicantRelationshipReviewPage(newProps);
+}
+
+ApplicantMedicarePharmacyPage.propTypes = pageProps;
+ApplicantMedicarePharmacyReviewPage.propTypes = reviewPageProps;


### PR DESCRIPTION
## Summary

This PR is the third of multiple that breaks up the code added in https://github.com/department-of-veterans-affairs/vets-website/pull/28928

- Added custom page setup for Medicare Advantage question screens
- Added custom page setup for Medicare pharmacy benefits question screens

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-website/pull/28928
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/78848

## Testing done

- Manual
- Unit

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
