### PR TITLE
78841e Applicant medicare flow (sub PR 4/X)

### DIFF
--- a/src/applications/ivc-champva/10-7959C/components/ApplicantMedicareStatusContinuedPage.jsx
+++ b/src/applications/ivc-champva/10-7959C/components/ApplicantMedicareStatusContinuedPage.jsx
@@ -1,0 +1,70 @@
+import { pageProps, reviewPageProps } from '../config/constants';
+
+import ApplicantRelationshipPage, {
+  ApplicantRelationshipReviewPage,
+  appRelBoilerplate,
+} from '../../shared/components/applicantLists/ApplicantRelationshipPage';
+
+const PROPERTY_NAMES = {
+  keyname: 'applicantMedicareStatusContinued',
+  primary: 'medicareContext',
+  secondary: 'otherMedicareContext',
+};
+
+function generateOptions({ data, pagePerItemIndex }) {
+  const bp = appRelBoilerplate({ data, pagePerItemIndex });
+  const haveOrHas = bp.relative === 'I' ? 'have' : 'has';
+  const prompt = `Which of these best describes ${
+    bp.useFirstPerson ? 'you' : `${bp.applicant}`
+  }?`;
+  const options = [
+    {
+      label: `${bp.relative} ${bp.beingVerbPresent} not eligible for Medicare`,
+      value: 'ineligible',
+    },
+    {
+      label: `${
+        bp.relative
+      } ${haveOrHas} Medicare but no updates to add at this time`,
+      value: 'enrolledNoUpdates',
+    },
+    {
+      label: `No, ${bp.relative} ${
+        bp.beingVerbPresent
+      } eligible for Medicare but ${haveOrHas} not signed up for it yet`,
+      value: 'eligibleNotEnrolled',
+    },
+  ];
+
+  return {
+    ...bp,
+    options,
+    relativeBeingVerb: `${bp.relative} ${bp.beingVerbPresent}`,
+    customTitle: `${
+      bp.useFirstPerson ? `Your` : `${bp.applicant}'s`
+    } Medicare status`,
+    description: prompt,
+  };
+}
+
+// Using the widely customizable ApplicantRelationshipPage
+// as it now functions like a generic radioUI + other text field:
+export function ApplicantMedicareStatusContinuedPage(props) {
+  const newProps = {
+    ...props,
+    ...PROPERTY_NAMES,
+    genOp: generateOptions,
+  };
+  return ApplicantRelationshipPage(newProps);
+}
+export function ApplicantMedicareStatusContinuedReviewPage(props) {
+  const newProps = {
+    ...props,
+    ...PROPERTY_NAMES,
+    genOp: generateOptions,
+  };
+  return ApplicantRelationshipReviewPage(newProps);
+}
+
+ApplicantMedicareStatusContinuedReviewPage.propTypes = reviewPageProps;
+ApplicantMedicareStatusContinuedPage.propTypes = pageProps;


### PR DESCRIPTION
## Summary

This PR is the fourth of multiple that breaks up the code in https://github.com/department-of-veterans-affairs/vets-website/pull/28928

- Added custom page setup for Medicare status question screens
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-website/pull/28928
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/78848

## Testing done

- Manual
- Unit

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA