### PR TITLE
Update HCA dependent schema declaration

### DIFF
--- a/src/applications/hca/definitions/dependent.js
+++ b/src/applications/hca/definitions/dependent.js
@@ -1,3 +1,4 @@
+import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
 import fullNameUI from '~/platform/forms/definitions/fullName';
 import currentOrPastDateUI from '~/platform/forms-system/src/js/definitions/currentOrPastDate';
 import ssnUI from '~/platform/forms-system/src/js/definitions/ssn';
@@ -11,31 +12,31 @@ import {
   OtherIncomeDescription,
 } from '../components/FormDescriptions';
 
+const {
+  dependents: {
+    items: { properties: dependent },
+  },
+} = fullSchemaHca.properties;
+
 // define uiSchemas for each page in dependent flow
 export const dependentUISchema = {
   basic: {
     fullName: {
-      ...fullNameUI,
       first: {
+        ...fullNameUI.first,
         'ui:title': 'Dependent\u2019s first name',
-        'ui:errorMessages': {
-          required: 'Please enter a first name',
-        },
       },
       middle: {
+        ...fullNameUI.middle,
         'ui:title': 'Dependent\u2019s middle name',
       },
       last: {
+        ...fullNameUI.last,
         'ui:title': 'Dependent\u2019s last name',
-        'ui:errorMessages': {
-          required: 'Please enter a last name',
-        },
       },
       suffix: {
+        ...fullNameUI.suffix,
         'ui:title': 'Dependent\u2019s suffix',
-        'ui:options': {
-          widgetClassNames: 'form-select-medium',
-        },
       },
     },
     dependentRelation: {
@@ -133,83 +134,27 @@ export const dependentSchema = {
       'becameDependent',
     ],
     properties: {
-      fullName: {
-        type: 'object',
-        required: ['first', 'last'],
-        properties: {
-          first: {
-            type: 'string',
-            minLength: 1,
-            maxLength: 25,
-            pattern: '^.*\\S.*',
-          },
-          middle: {
-            type: 'string',
-            maxLength: 30,
-          },
-          last: {
-            type: 'string',
-            minLength: 2,
-            maxLength: 35,
-            pattern: '^.*\\S.*',
-          },
-          suffix: {
-            type: 'string',
-            enum: ['Jr.', 'Sr.', 'II', 'III', 'IV'],
-          },
-        },
-      },
-      dependentRelation: {
-        type: 'string',
-        enum: [
-          'Daughter',
-          'Son',
-          'Stepson',
-          'Stepdaughter',
-          'Father',
-          'Mother',
-          'Spouse',
-          'Other',
-        ],
-      },
-      socialSecurityNumber: {
-        type: 'string',
-        pattern: '^[0-9]{9}$',
-      },
-      dateOfBirth: {
-        type: 'string',
-        format: 'date',
-      },
-      becameDependent: {
-        type: 'string',
-        format: 'date',
-      },
+      fullName: dependent.fullName,
+      dependentRelation: dependent.dependentRelation,
+      socialSecurityNumber: dependent.socialSecurityNumber,
+      dateOfBirth: dependent.dateOfBirth,
+      becameDependent: dependent.becameDependent,
     },
   },
   education: {
     type: 'object',
     required: ['dependentEducationExpenses'],
     properties: {
-      attendedSchoolLastYear: {
-        type: 'boolean',
-      },
-      dependentEducationExpenses: {
-        type: 'number',
-        minimum: 0,
-        maximum: 9999999.99,
-      },
+      attendedSchoolLastYear: dependent.attendedSchoolLastYear,
+      dependentEducationExpenses: dependent.dependentEducationExpenses,
     },
   },
   additional: {
     type: 'object',
     required: ['disabledBefore18', 'cohabitedLastYear', 'view:dependentIncome'],
     properties: {
-      disabledBefore18: {
-        type: 'boolean',
-      },
-      cohabitedLastYear: {
-        type: 'boolean',
-      },
+      disabledBefore18: dependent.disabledBefore18,
+      cohabitedLastYear: dependent.cohabitedLastYear,
       'view:dependentIncome': {
         type: 'boolean',
       },
@@ -218,9 +163,7 @@ export const dependentSchema = {
   support: {
     type: 'object',
     properties: {
-      receivedSupportLastYear: {
-        type: 'boolean',
-      },
+      receivedSupportLastYear: dependent.receivedSupportLastYear,
     },
   },
   income: {
@@ -230,33 +173,21 @@ export const dependentSchema = {
         type: 'object',
         required: ['grossIncome'],
         properties: {
-          grossIncome: {
-            type: 'number',
-            minimum: 0,
-            maximum: 9999999.99,
-          },
+          grossIncome: dependent.grossIncome,
         },
       },
       'view:netIncome': {
         type: 'object',
         required: ['netIncome'],
         properties: {
-          netIncome: {
-            type: 'number',
-            minimum: 0,
-            maximum: 9999999.99,
-          },
+          netIncome: dependent.netIncome,
         },
       },
       'view:otherIncome': {
         type: 'object',
         required: ['otherIncome'],
         properties: {
-          otherIncome: {
-            type: 'number',
-            minimum: 0,
-            maximum: 9999999.99,
-          },
+          otherIncome: dependent.otherIncome,
         },
       },
     },


### PR DESCRIPTION
## Summary

This PR updates the form schema definition for the dependents section of the Health Care Application. Previously, the schema was declared directly in the app, instead of utilizing the dependent schema declaration from `vets-json-schema`. This update now has the definition use the values from the global HCA schema.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#70857

## Testing done

- Validated all fields render as intended with the update

## Acceptance criteria

- Dependents form schema utilizes full HCA schema, instead of being hardcoded into the app.

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution