### PR TITLE
MHV-56706 Moved the redirection into a useEffect and slightly changed logic

### DIFF
--- a/src/applications/mhv/medical-records/containers/App.jsx
+++ b/src/applications/mhv/medical-records/containers/App.jsx
@@ -191,6 +191,24 @@ const App = ({ children }) => {
     [current],
   );
 
+  useEffect(
+    () => {
+      // If the user is not whitelisted or feature flag is disabled, redirect them.
+      if (featureTogglesLoading === false && appEnabled !== true) {
+        window.location.replace('/health-care/get-medical-records');
+      }
+    },
+    [featureTogglesLoading, appEnabled],
+  );
+
+  const isMissingRequiredService = (loggedIn, services) => {
+    if (loggedIn && !services.includes(backendServices.MEDICAL_RECORDS)) {
+      window.location.replace('/health-care/get-medical-records');
+      return true;
+    }
+    return false;
+  };
+
   if (featureTogglesLoading) {
     return (
       <div className="vads-l-grid-container">
@@ -203,19 +221,10 @@ const App = ({ children }) => {
     );
   }
 
-  // If the user is not whitelisted or feature flag is disabled, redirect them.
-  if (!appEnabled) {
-    window.location.replace('/health-care/get-medical-records');
+  if (appEnabled !== true) {
+    // If the user is not whitelisted or feature flag is disabled, return nothing.
     return <></>;
   }
-
-  const isMissingRequiredService = (loggedIn, services) => {
-    if (loggedIn && !services.includes(backendServices.MEDICAL_RECORDS)) {
-      window.location.replace('/health-care/get-medical-records');
-      return true;
-    }
-    return false;
-  };
 
   return (
     <RequiredLoginView


### PR DESCRIPTION
## Summary

Modified redirect logic slightly, and moved the redirect into a `useEffect`.

## Related issue(s)

### [MHV-56706](https://jira.devops.va.gov/browse/MHV-56706) - User is occasionally redirected to /health-care/get-medical-records ###

> To reproduce:
> 
> 1. Log into Staging and browse to MR landing page
> 1. Wait 5 minutes
> 1. Refresh the page. You will be redirected to /health-care/get-medical-records
> 
> Checking the network logs reveals that the feature-toggles call has returned a 403 due to an expired token.

## Testing done

- There is already testing in place to check for redirection

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
