### PR TITLE
[CST] - Update va-select to only show one select option

### DIFF
--- a/src/applications/claims-status/components/AddFilesFormOld.jsx
+++ b/src/applications/claims-status/components/AddFilesFormOld.jsx
@@ -276,9 +276,6 @@ class AddFilesFormOld extends React.Component {
                     this.handleDocTypeChange(e.detail.value, index)
                   }
                 >
-                  {/* <option disabled value="">
-                    Select a description
-                  </option> */}
                   {DOC_TYPES.map(doc => (
                     <option key={doc.value} value={doc.value}>
                       {doc.label}

--- a/src/applications/claims-status/components/AddFilesFormOld.jsx
+++ b/src/applications/claims-status/components/AddFilesFormOld.jsx
@@ -276,9 +276,9 @@ class AddFilesFormOld extends React.Component {
                     this.handleDocTypeChange(e.detail.value, index)
                   }
                 >
-                  <option disabled value="">
+                  {/* <option disabled value="">
                     Select a description
-                  </option>
+                  </option> */}
                   {DOC_TYPES.map(doc => (
                     <option key={doc.value} value={doc.value}>
                       {doc.label}

--- a/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
@@ -249,9 +249,9 @@ class AddFilesForm extends React.Component {
                     this.handleDocTypeChange(e.detail.value, index)
                   }
                 >
-                  <option disabled value="">
+                  {/* <option disabled value="">
                     Select a description
-                  </option>
+                  </option> */}
                   {DOC_TYPES.map(doc => (
                     <option key={doc.value} value={doc.value}>
                       {doc.label}

--- a/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
@@ -249,9 +249,6 @@ class AddFilesForm extends React.Component {
                     this.handleDocTypeChange(e.detail.value, index)
                   }
                 >
-                  {/* <option disabled value="">
-                    Select a description
-                  </option> */}
                   {DOC_TYPES.map(doc => (
                     <option key={doc.value} value={doc.value}>
                       {doc.label}


### PR DESCRIPTION
## Summary

Updated va-select to only show one select option for AddFilesForm and AddFilesFormOld

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#80016

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
 | | ![Screenshot 2024-04-04 at 10 58 25 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/4494a11f-5d6f-4ada-9ecc-4b4fe6a33fc6) | ![Screenshot 2024-04-04 at 12 47 39 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/9cb53584-6ec3-42ae-b2c3-35b3f5ca3928) |

## What areas of the site does it impact?

Claim Status Tool

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
