### PR TITLE
fix axe issue on review page for applicant cards (IVC form 10-10d)

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -593,8 +593,9 @@ const formConfig = {
               'ui:options': {
                 viewField: ApplicantField,
                 keepInPageOnReview: true,
-                useDlWrap: false,
+                useDlWrap: true,
                 itemName: 'Applicant',
+                customTitle: ' ', // prevent <dl> around the schemaform-field-container
                 confirmRemove: true,
               },
               'ui:errorMessages': {


### PR DESCRIPTION
## Summary

This PR fixes an Axe accessibility error that was flagged by the automatic detection system. Applicant list and loop cards were rendering with an extra `<dl>` tag, which was causing the resulting list to be mis-ordered.

To fix, I set `useDlWrap: true` and set `customTitle: ' '` in the `ui:options` of the applicant list and loop.

- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- NA

## Testing done

- Manual
- Unit

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![Screenshot 2024-04-04 at 16 47 55](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/05d901aa-7b4c-479b-bf9f-2d4be867c134)|![Screenshot 2024-04-04 at 16 50 16](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/bab61982-04a2-4023-945c-46a3398aed98)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA