### PR TITLE
MHV-55160 Download-All-Records-TXT-And-PDF-Focus-States

### DIFF
--- a/src/applications/mhv-medical-records/sass/medical-records.scss
+++ b/src/applications/mhv-medical-records/sass/medical-records.scss
@@ -21,7 +21,7 @@
   text-decoration: underline;
   border: none;
   border-radius: 0px;
-  transition-duration: 0.3s;
+  transition-duration: 0.0s;
   padding: 0px;
   width: fit-content;
 }

--- a/src/applications/mhv/medical-records/sass/medical-records.scss
+++ b/src/applications/mhv/medical-records/sass/medical-records.scss
@@ -21,7 +21,7 @@
   text-decoration: underline;
   border: none;
   border-radius: 0px;
-  transition-duration: 0.3s;
+  transition-duration: 0.0s;
   padding: 0px;
   width: fit-content;
 }


### PR DESCRIPTION
## Summary
In the `medecal-record.scss` file, I modified the `transition-duration` from 0.3 to 0.0 to allow the focus border to appear instantly.

## Related issue(s)

[MHV-55160](https://jira.devops.va.gov/browse/MHV-55160) - Download all records TXT and PDF-Focus states are slowly flashing and easing in

Description:

Download all records TXT and PDF-Focus states are slowly flashing and easing in

Acceptance Criteria:

Interactive components (the TXT and PDF) gain keyboard focus and the focus states do not flash or ease-in. It must be a solid state on focus.

Steps to Reproduce:

Log in

Navigate to Medical records

Navigate Download all records (my-health/medical-records/download-all)

Use the keyboard tab

Tab to the TXT and PDF download elements

Watch the focus state ease in.

Expected Behavior:

When the elements receive focus, it should be instant and have the focus border instantly.

Accessibility Specialist: Bobby Bailey

 

Feature Flag Y/N ? N

Manual Testing Y/N ?  

Automated Testing Y/N ? 

Accessibility Testing Y/N ? Y

UCD Validation Y/N

 

Acceptance Criteria:

AC1  When the elements receive focus, it should be instant and have the focus border instantly

AC2  

AC3 

AC4

 

Links to UCD:

Sketch Link:

Other Design Notes
## Testing done
Conducted UI testing to ensure the expected behavior. I updated existing unit test for new components.

## Screenshots
In the case of this bug, there will be no screenshot present because it is not capable of capturing the glitch.

## What areas of the site does it impact?

The modification affects the download-all section of the Medical Records page.

## Acceptance criteria
When the elements receive focus, it should be instant and have the focus border instantly.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user