### PR TITLE
Feat/actions sha refs

### DIFF
--- a/.github/workflows/annotations/action.yml
+++ b/.github/workflows/annotations/action.yml
@@ -19,7 +19,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: yuzutech/annotations-action@v0.4.0
+    - uses: yuzutech/annotations-action@0e061a6e3ac848299310b6429b60d67cafd4e7f8
       with:
         repo-token: ${{ inputs.token }}
         title: ${{ inputs.check_title }}

--- a/.github/workflows/checks-action/action.yml
+++ b/.github/workflows/checks-action/action.yml
@@ -20,7 +20,7 @@ runs:
   steps:
     - name: Unit test results
       if: ${{ always() }}
-      uses: LouisBrunner/checks-action@v2.0.0
+      uses: LouisBrunner/checks-action@fc03edcdf8f3383c36691e17635efeddecf9e2ce
       with:
         token: ${{ inputs.token }}
         name: ${{ inputs.name }}

--- a/.github/workflows/configure-aws-credentials/action.yml
+++ b/.github/workflows/configure-aws-credentials/action.yml
@@ -35,7 +35,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: aws-actions/configure-aws-credentials@v4
+    - uses: aws-actions/configure-aws-credentials@587276aa2b7ab3e81491bc89886f7805ee29494c
       with:
         aws-access-key-id: ${{ inputs.aws_id }}
         aws-secret-access-key: ${{ inputs.aws_key }}

--- a/.github/workflows/configure-bigquery/action.yml
+++ b/.github/workflows/configure-bigquery/action.yml
@@ -11,11 +11,11 @@ runs:
         env_variable_name: BIGQUERY_SERVICE_CREDENTIALS
 
     - name: Authenticate with Google Cloud
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@d176447fc74bc94b2926da1eed97c57afbb553ea
       with:
         credentials_json: '${{ env.BIGQUERY_SERVICE_CREDENTIALS }}'
 
     - name: Setup Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@f431b4bff53ca90c8c0b6735fffe6aaae80e70c9
       with:
         project_id: vsp-analytics-and-insights

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
 
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS credentials
         uses: ./.github/workflows/configure-aws-credentials
@@ -162,7 +162,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
 
@@ -254,7 +254,7 @@ jobs:
         ci_node_index: [0,1,2,3,4,5,6,7,8,9]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
 
@@ -362,7 +362,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
 
@@ -410,7 +410,7 @@ jobs:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS credentials
         uses: ./.github/workflows/configure-aws-credentials
@@ -480,7 +480,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
 
@@ -510,7 +510,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
 
@@ -561,7 +561,7 @@ jobs:
       app_list: ${{ env.APPLICATION_LIST }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -608,7 +608,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS Credentials
         uses: ./.github/workflows/configure-aws-credentials
@@ -666,7 +666,7 @@ jobs:
 
       - name: Checkout vets-website
         if: needs.tests-prep.outputs.cypress-tests != '[]'
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS credentials
         if: needs.tests-prep.outputs.cypress-tests != '[]'
@@ -785,7 +785,7 @@ jobs:
     steps:
       - name: Checkout vets-website
         if: needs.tests-prep.outputs.cypress-tests-to-stress-test != '[]'
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS credentials
         if: needs.tests-prep.outputs.cypress-tests-to-stress-test != '[]'
@@ -866,7 +866,7 @@ jobs:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS credentials
         uses: ./.github/workflows/configure-aws-credentials
@@ -986,7 +986,7 @@ jobs:
               echo "IS_MASTER_BUILD=false" >> $GITHUB_ENV
           fi
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       # ----------------
       # | Notify Slack |
@@ -1117,7 +1117,7 @@ jobs:
               echo "IS_MASTER_BUILD=false" >> $GITHUB_ENV
           fi
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       # ------------------------
       # | Upload BigQuery Data |
@@ -1209,7 +1209,7 @@ jobs:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -1326,7 +1326,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Notify Slack about Cypress test failures
         if: ${{ github.ref == 'refs/heads/main' && needs.cypress-tests.result == 'failure' }}
@@ -1449,7 +1449,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Notify Slack about Cypress test failures
         if: ${{ github.ref == 'refs/heads/main' && needs.cypress-tests.result == 'failure' }}
@@ -1579,7 +1579,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
 
@@ -1707,7 +1707,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Download build artifact
         uses: ./.github/workflows/download-artifact
@@ -1819,7 +1819,7 @@ jobs:
       IS_ISOLATED_APP_BUILD: ${{ needs.build.outputs.entry_names != '' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
 
@@ -1892,7 +1892,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
 

--- a/.github/workflows/daily-cross-app-import-report.yml
+++ b/.github/workflows/daily-cross-app-import-report.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -35,7 +35,7 @@ jobs:
           aws_region: us-gov-west-1
 
       - name: Get AWS IAM role
-        uses: ./.github/workflows/inject-secrets@latest
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
           env_variable_name: AWS_FRONTEND_NONPROD_ROLE

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -47,7 +47,7 @@ jobs:
         uses: andymckay/cancel-action@0.2
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
 
@@ -80,7 +80,7 @@ jobs:
     needs: set-env
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -103,7 +103,7 @@ jobs:
     needs: set-env
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Notify Slack
         uses: ./.github/workflows/slack-notify
@@ -142,7 +142,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           ref: ${{ needs.set-env.outputs.COMMIT_SHA }}
 
@@ -238,7 +238,7 @@ jobs:
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
@@ -287,7 +287,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS credentials (1)
         uses: ./.github/workflows/configure-aws-credentials
@@ -326,7 +326,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Notify Slack
         uses: ./.github/workflows/slack-notify
@@ -345,7 +345,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Notify Slack
         if: ${{ env.DSVA_SCHEDULE_ENABLED == 'true' }}

--- a/.github/workflows/daily-lighthouse-scan.yml
+++ b/.github/workflows/daily-lighthouse-scan.yml
@@ -15,7 +15,7 @@ jobs:
       registries: ${{ steps.set-matrix.outputs.registries }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           repository: department-of-veterans-affairs/content-build
           ref: refs/heads/main
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -64,7 +64,7 @@ jobs:
           aws_region: us-gov-west-1
 
       - name: Get va-vsp-bot token
-        uses: ./.github/workflows/inject-secrets@latest
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
@@ -73,7 +73,7 @@ jobs:
         uses: ./.github/workflows/configure-bigquery
 
       - name: Get role from Parameter Store
-        uses: ./.github/workflows/inject-secrets@latest
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
           env_variable_name: AWS_FRONTEND_NONPROD_ROLE
@@ -106,7 +106,7 @@ jobs:
         run: yarn generate-app-list
 
       - name: Checkout Testing Tools Team Dashboard Data repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           repository: department-of-veterans-affairs/qa-standards-dashboard-data
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
@@ -148,7 +148,7 @@ jobs:
     needs: [lighthouse]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
       - name: Notify Slack
         uses: ./.github/workflows/slack-notify
         continue-on-error: true

--- a/.github/workflows/daily-product-scan.yml
+++ b/.github/workflows/daily-product-scan.yml
@@ -9,7 +9,7 @@ jobs:
     name: Daily Product Scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -29,26 +29,26 @@ jobs:
           aws_region: us-gov-west-1
 
       - name: Get va-vsp-bot token
-        uses: ./.github/workflows/inject-secrets@latest
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
       - name: Checkout product directory repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           repository: department-of-veterans-affairs/product-directory
           token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}
           path: product-directory
 
       - name: Set GitHub Product Directory Id
-        uses: ./.github/workflows/inject-secrets@latest
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /dsva-vagov/testing-team/product-directory/PRODUCT_DIRECTORY_APP_ID
           env_variable_name: PRODUCT_DIRECTORY_APP_ID
 
       - name: Set GitHub Product Directory Private Key
-        uses: ./.github/workflows/inject-secrets@latest
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /dsva-vagov/testing-team/product-directory/PRODUCT_DIRECTORY_PRIVATE_KEY
           env_variable_name: PRODUCT_DIRECTORY_PRIVATE_KEY

--- a/.github/workflows/download-artifact/action.yml
+++ b/.github/workflows/download-artifact/action.yml
@@ -23,7 +23,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/.github/workflows/e2e-allow-list-cleanup.yml
+++ b/.github/workflows/e2e-allow-list-cleanup.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -95,7 +95,7 @@ jobs:
     needs: [fetch-allow-lists]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS credentials
         uses: ./.github/workflows/configure-aws-credentials

--- a/.github/workflows/e2e-injection-test.yml
+++ b/.github/workflows/e2e-injection-test.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Notify Slack - \#status-vets-website
         uses: ./.github/workflows/slack-notify

--- a/.github/workflows/e2e-stress-test.yml
+++ b/.github/workflows/e2e-stress-test.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
 
@@ -79,7 +79,7 @@ jobs:
       app_list: ${{ env.APPLICATION_LIST }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS credentials
         uses: ./.github/workflows/configure-aws-credentials
@@ -168,7 +168,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
 
@@ -253,7 +253,7 @@ jobs:
 
       - name: Checkout vets-website
         if: needs.cypress-tests-prep.outputs.tests != '[]'
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Download production build artifact
         if: needs.cypress-tests-prep.outputs.tests != '[]'
@@ -333,7 +333,7 @@ jobs:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS credentials
         uses: ./.github/workflows/configure-aws-credentials

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
           ref: ${{ needs.set-commit-sha.outputs.COMMIT_SHA }}
@@ -76,7 +76,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           ref: ${{ needs.set-commit-sha.outputs.COMMIT_SHA }}
 
@@ -130,7 +130,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
           ref: ${{ needs.set-commit-sha.outputs.COMMIT_SHA }}
@@ -184,7 +184,7 @@ jobs:
           aws_region: us-gov-west-1
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           ref: ${{ needs.set-commit-sha.outputs.COMMIT_SHA }}
 
@@ -270,7 +270,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           ref: ${{ needs.set-commit-sha.outputs.COMMIT_SHA }}
 
@@ -322,7 +322,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           ref: ${{ needs.set-commit-sha.outputs.COMMIT_SHA }}
 
@@ -430,7 +430,7 @@ jobs:
 
   #   steps:
   #     - name: Checkout
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
   #       with:
   #         ref: ${{ needs.set-commit-sha.outputs.COMMIT_SHA }}
 
@@ -497,7 +497,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           ref: ${{ needs.set-commit-sha.outputs.COMMIT_SHA }}
 

--- a/.github/workflows/evaluate-workflow-failures.yml
+++ b/.github/workflows/evaluate-workflow-failures.yml
@@ -12,7 +12,7 @@ jobs:
     name: Steps Evaluation
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS credentials
         uses: ./.github/workflows/configure-aws-credentials

--- a/.github/workflows/init-data-repo/action.yml
+++ b/.github/workflows/init-data-repo/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Checkout Testing Tools Team Dashboard Data repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
       with:
         repository: department-of-veterans-affairs/qa-standards-dashboard-data
         token: ${{ env.VA_VSP_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/manual-deploy-dev-staging.yml
+++ b/.github/workflows/manual-deploy-dev-staging.yml
@@ -62,7 +62,7 @@ jobs:
       
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           ref: ${{ github.event.inputs.commit_sha }}
 
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS credentials (1)
         uses: ./.github/workflows/configure-aws-credentials
@@ -159,7 +159,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Notify Slack
         uses: ./.github/workflows/slack-notify

--- a/.github/workflows/publish-test-results/action.yml
+++ b/.github/workflows/publish-test-results/action.yml
@@ -22,7 +22,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: mikepenz/action-junit-report@v2.8.4
+    - uses: mikepenz/action-junit-report@9379f0ccddcab154835d4e2487555ee79614fe95
       with:
         check_name: ${{ inputs.check_name }}
         github_token: ${{ inputs.token }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS credentials
         uses: ./.github/workflows/configure-aws-credentials
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -83,7 +83,7 @@ jobs:
     if: ${{ github.event.pull_request.draft == false }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Get Node version
         id: get-node-version
@@ -139,7 +139,7 @@ jobs:
     if: ${{ github.event.pull_request.draft == false }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Get Node version
         id: get-node-version
@@ -196,7 +196,7 @@ jobs:
     if: ${{ github.event.pull_request.draft == false }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Get Node version
         id: get-node-version
@@ -252,7 +252,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Get Node version
         id: get-node-version

--- a/.github/workflows/review-instance-metrics.yml
+++ b/.github/workflows/review-instance-metrics.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS credentials
         uses: ./.github/workflows/configure-aws-credentials
@@ -20,7 +20,7 @@ jobs:
           aws_region: us-gov-west-1
 
       - name: Get va-vsp-bot token
-        uses: ./.github/workflows/inject-secrets@latest
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /devops/VA_VSP_BOT_GITHUB_TOKEN
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/workflows/configure-bigquery
 
       - name: Get AWS IAM role
-        uses: ./.github/workflows/inject-secrets@latest
+        uses: department-of-veterans-affairs/action-inject-ssm-secrets@latest
         with:
           ssm_parameter: /frontend-team/github-actions/parameters/AWS_FRONTEND_NONPROD_ROLE
           env_variable_name: AWS_FRONTEND_NONPROD_ROLE

--- a/.github/workflows/slack-notify/action.yml
+++ b/.github/workflows/slack-notify/action.yml
@@ -33,7 +33,7 @@ runs:
         env_variable_name: SLACK_BOT_TOKEN
 
     - name: Notify Slack
-      uses: slackapi/slack-github-action@v1.17.0
+      uses: slackapi/slack-github-action@d4473740bfcff61a77fb1beca1f0f0dbd4ce967a
       env:
         SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
       with:

--- a/.github/workflows/unit-test-stress-test.yml
+++ b/.github/workflows/unit-test-stress-test.yml
@@ -13,7 +13,7 @@ jobs:
       app_list: ${{ env.APPLICATION_LIST }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Install dependencies
         uses: ./.github/workflows/install
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS credentials
         uses: ./.github/workflows/configure-aws-credentials
@@ -130,7 +130,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
         with:
           fetch-depth: 0
 
@@ -185,7 +185,7 @@ jobs:
       APPLICATION_LIST: ${{ needs.testing-reports-prep.outputs.app_list }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS credentials
         uses: ./.github/workflows/configure-aws-credentials

--- a/.github/workflows/upload-artifact/action.yml
+++ b/.github/workflows/upload-artifact/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ef09cdac3e2d3e60d8ccadda691f4f1cec5035cb
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}


### PR DESCRIPTION
## Summary

- Changes actions to use direct references to specific commits instead of versions that pull new commits without warning. This allows us to ensure we are always using stable versions of these actions and update them deliberately instead of accidentally.


## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/75224

## Testing done

- Ran CI with no errors. CI uses every action that was updated.

