### PR TITLE
DR | Add upload file size & file name reference to file document type select

### DIFF
--- a/src/applications/appeals/995/tests/pages/evidenceUpload.unit.spec.js
+++ b/src/applications/appeals/995/tests/pages/evidenceUpload.unit.spec.js
@@ -89,5 +89,8 @@ describe('Additional evidence upload', () => {
     expect(content).to.contain('test.pdf');
     expect(content).to.contain('98KB');
     expect(select).to.exist;
+    expect(select.getAttribute('message-aria-describedby')).to.eq(
+      'Choose a document type for test.pdf',
+    );
   });
 });

--- a/src/applications/appeals/995/tests/pages/evidenceUpload.unit.spec.js
+++ b/src/applications/appeals/995/tests/pages/evidenceUpload.unit.spec.js
@@ -70,6 +70,7 @@ describe('Additional evidence upload', () => {
             additionalDocuments: [
               {
                 name: 'test.pdf',
+                size: 100000,
                 confirmationCode: 'testing',
                 attachmentId: 'L049',
               },
@@ -81,7 +82,12 @@ describe('Additional evidence upload', () => {
     );
 
     fireEvent.submit($('form', container));
-    expect($$('.usa-input-error-message', container).length).to.equal(0);
+    const content = container.textContent;
+    const select = $('va-select[value="L049"]', container);
+    expect($('.usa-input-error-message', container)).to.not.exist;
     expect(onSubmit.called).to.be.true;
+    expect(content).to.contain('test.pdf');
+    expect(content).to.contain('98KB');
+    expect(select).to.exist;
   });
 });

--- a/src/applications/appeals/995/utils/upload.js
+++ b/src/applications/appeals/995/utils/upload.js
@@ -23,14 +23,12 @@ export const fileUploadUi = content => ({
     minSize: 1024,
     createPayload,
     parseResponse,
-    attachmentSchema: (/* { fileId, index } */) => ({
+    attachmentSchema: ({ fileName }) => ({
       'ui:title': 'Document type',
       'ui:disabled': false,
       'ui:webComponentField': VaSelectField,
       'ui:options': {
-        // TO DO: not implemented - see vets-design-system-documentation #2587;
-        // Need to get file name from within element with ID of fileId
-        // 'message-aria-describedby': // ???
+        messageAriaDescribedby: `Choose a document type for ${fileName}`,
       },
     }),
     hideLabelText: !content.label,

--- a/src/applications/appeals/shared/components/FileField.jsx
+++ b/src/applications/appeals/shared/components/FileField.jsx
@@ -480,7 +480,11 @@ const FileField = props => {
 
             const getUiSchema = innerUiSchema =>
               typeof innerUiSchema === 'function'
-                ? innerUiSchema({ fileId: fileNameId, index })
+                ? innerUiSchema({
+                    fileId: fileNameId,
+                    index,
+                    fileName: file.name,
+                  })
                 : innerUiSchema;
 
             // make index available to widgets in attachment ui schema

--- a/src/applications/appeals/shared/tests/components/FileField.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/FileField.unit.spec.jsx
@@ -1173,9 +1173,10 @@ describe('Schemaform <FileField>', () => {
     };
     const uiSchema = fileUploadUI('Files', {
       attachmentName: false,
-      attachmentSchema: ({ fileId, index }) => ({
+      attachmentSchema: ({ fileId, index, fileName }) => ({
         'ui:title': 'Document type',
         'ui:options': {
+          messageAriaDescribedby: `test with ${fileName}`,
           widgetProps: {
             'aria-describedby': fileId,
             'data-index': index,
@@ -1220,6 +1221,9 @@ describe('Schemaform <FileField>', () => {
     expect(testProps.registry.formContext.pagePerItemIndex).to.eq(0);
     expect(options.widgetProps['aria-describedby']).to.eq('field_file_name_0');
     expect(options.widgetProps['data-index']).to.eq(0);
+    expect(options.messageAriaDescribedby).to.contain(
+      'test with Test file name.pdf',
+    );
   });
 
   // Accessibility checks

--- a/src/applications/appeals/shared/tests/components/FileField.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/FileField.unit.spec.jsx
@@ -125,6 +125,7 @@ describe('Schemaform <FileField>', () => {
       {
         confirmationCode: 'abcdef',
         name: 'Test file name.pdf',
+        size: 100000,
       },
     ];
     const registry = {
@@ -147,6 +148,9 @@ describe('Schemaform <FileField>', () => {
 
     expect($('.delete-upload', container)).to.exist;
     expect($('#upload-button', container)).to.exist;
+    const content = $('.schemaform-file-list li', container).textContent;
+    expect(content).to.contain('Test file name.pdf');
+    expect(content).to.contain('98KB');
   });
 
   it('should remove files with empty file object when initializing', async () => {
@@ -1211,11 +1215,11 @@ describe('Schemaform <FileField>', () => {
     );
 
     // check ids & index passed into SchemaField
-    const { widgetProps } = testProps.uiSchema['ui:options'];
+    const options = testProps.uiSchema['ui:options'];
     expect(testProps.schema).to.equal(schema.items[0].properties.attachmentId);
     expect(testProps.registry.formContext.pagePerItemIndex).to.eq(0);
-    expect(widgetProps['aria-describedby']).to.eq('field_file_name_0');
-    expect(widgetProps['data-index']).to.eq(0);
+    expect(options.widgetProps['aria-describedby']).to.eq('field_file_name_0');
+    expect(options.widgetProps['data-index']).to.eq(0);
   });
 
   // Accessibility checks

--- a/src/applications/appeals/shared/tests/utils/upload.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/upload.unit.spec.js
@@ -39,10 +39,11 @@ describe('parseResponse', () => {
   it('should return parsed file name & confirmation code', () => {
     const result = parseResponse(
       { data: { attributes: { guid: 'uuid-1234' } } },
-      { name: 'test-file.pdf' },
+      { name: 'test-file.pdf', size: 100000 },
     );
     expect(result).to.deep.equal({
       name: 'test-file.pdf',
+      size: 100000,
       confirmationCode: 'uuid-1234',
       attachmentId: '',
     });

--- a/src/applications/appeals/shared/utils/upload.js
+++ b/src/applications/appeals/shared/utils/upload.js
@@ -40,13 +40,14 @@ export const createPayload = (file, _formId, password) => {
   return payload;
 };
 
-export const parseResponse = (response, { name }) => {
+export const parseResponse = (response, { name, size }) => {
   setTimeout(() => {
     focusFileCard(name);
   });
 
   return {
     name,
+    size,
     confirmationCode: response.data.attributes.guid,
     attachmentId: '',
   };

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -497,7 +497,11 @@ const FileField = props => {
 
             const getUiSchema = innerUiSchema =>
               typeof innerUiSchema === 'function'
-                ? innerUiSchema({ fileId: fileNameId, index })
+                ? innerUiSchema({
+                    fileId: fileNameId,
+                    index,
+                    fileName: file.name,
+                  })
                 : innerUiSchema;
 
             // make index available to widgets in attachment ui schema

--- a/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
@@ -117,6 +117,7 @@ describe('Schemaform <FileField>', () => {
       {
         confirmationCode: 'abcdef',
         name: 'Test file name.pdf',
+        size: 100000,
       },
     ];
     const registry = {
@@ -137,8 +138,11 @@ describe('Schemaform <FileField>', () => {
       />,
     );
 
-    expect($('.delete-upload[uswds]', container)).to.exist;
-    expect($('#upload-button[uswds]', container)).to.exist;
+    expect($('.delete-upload', container)).to.exist;
+    expect($('#upload-button', container)).to.exist;
+    const content = $('.schemaform-file-list li', container).textContent;
+    expect(content).to.contain('Test file name.pdf');
+    expect(content).to.contain('98KB');
   });
 
   it('should remove files with empty file object when initializing', async () => {
@@ -947,9 +951,10 @@ describe('Schemaform <FileField>', () => {
     };
     const uiSchema = fileUploadUI('Files', {
       attachmentName: false,
-      attachmentSchema: ({ fileId, index }) => ({
+      attachmentSchema: ({ fileId, index, fileName }) => ({
         'ui:title': 'Document type',
         'ui:options': {
+          messageAriaDescribedby: `test with ${fileName}`,
           widgetProps: {
             'aria-describedby': fileId,
             'data-index': index,
@@ -989,11 +994,14 @@ describe('Schemaform <FileField>', () => {
     );
 
     // check ids & index passed into SchemaField
-    const { widgetProps } = testProps.uiSchema['ui:options'];
+    const options = testProps.uiSchema['ui:options'];
     expect(testProps.schema).to.equal(schema.items[0].properties.attachmentId);
     expect(testProps.registry.formContext.pagePerItemIndex).to.eq(0);
-    expect(widgetProps['aria-describedby']).to.eq('field_file_name_0');
-    expect(widgetProps['data-index']).to.eq(0);
+    expect(options.widgetProps['aria-describedby']).to.eq('field_file_name_0');
+    expect(options.widgetProps['data-index']).to.eq(0);
+    expect(options.messageAriaDescribedby).to.contain(
+      'test with Test file name.pdf',
+    );
   });
 
   // Accessibility checks


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > After switching the document type select to use USWDS v3 for appeals forms (see #28547), it was noted that the `va-select` did not reference the file name (see [#19696](https://github.com/department-of-veterans-affairs/va.gov-team/issues/19696#issuecomment-2037510331)). The main issue was that the `va-select` did not provide a `mesage-aria-describedby` property. [it was recently added](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2587)), which allows the creation of this PR to update the `FileField` to pass the file name to the `attachmentSchema` callback and include a file name. This file name can then be added to a `messageAriaDescribedby` ui option.
  >
  > Note: The component library was updated with the fix, but it has not yet been published to npm, nor updated within the vets-website repo; so while testing, you'll see the `message-aria-describedby` property added to the `va-select`, but internally, you won't see the comment included until the library has been updated
  >
  > Additionally, we noticed that the uploaded file card was not including the file size which it had previously displayed. So this code was also updated.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Easiest method to associate the `va-select` with the file name
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- [#19696](https://github.com/department-of-veterans-affairs/va.gov-team/issues/19696)
- [#73828](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73828) and PR [#28547](https://github.com/department-of-veterans-affairs/vets-website/pull/28547)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Updated unit tests
- _Describe the steps required to verify your changes are working as expected_
  > Inspect Supplemental Claim upload `va-select` in review instance & look for added file size
- _Describe the tests completed and the results_
  > Updated SC & shared (NOD) upload page unit tests and updated FileField unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| NOD | <img width="552" alt="Screenshot 2024-04-05 at 12 43 32 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/16f60dd8-c5bb-4872-b227-0dd3c4f176e4"> | <img width="539" alt="Screenshot 2024-04-05 at 12 43 39 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/9bbb9e4a-a2cb-4755-a531-94a516541859"> |
| SC | <img width="531" alt="Screenshot 2024-04-05 at 12 46 18 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/df014317-78e5-4ed6-9a56-61bb790c80bf"> | <img width="544" alt="Screenshot 2024-04-05 at 12 33 13 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/b4583b17-d3d3-4680-bed2-38377424631d"> |

## What areas of the site does it impact?

NOD, Supplemental Claims & forms that add an `attachmentSchema` (but have to include `fileName` parameter to see the change)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
