### PR TITLE
80071 Update back button to go to review page when in loop

### DIFF
--- a/src/applications/ivc-champva/10-10D/components/File/FileUpload.jsx
+++ b/src/applications/ivc-champva/10-10D/components/File/FileUpload.jsx
@@ -5,7 +5,6 @@ import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/Sc
 import MissingFileOverview, { hasReq } from './MissingFileOverview';
 
 export function FileFieldCustom(props) {
-  const navButtons = <FormNavButtons goBack={props.goBack} submitToContinue />;
   // eslint-disable-next-line @department-of-veterans-affairs/prefer-button-component
   const updateButton = (
     <button type="submit" onClick={props.updatePage}>
@@ -53,7 +52,7 @@ export function FileFieldCustom(props) {
     }
   }
 
-  const onGoForward = args => {
+  function onGoForward(args) {
     // Check if url is a review page
     const urlParams = new URLSearchParams(window?.location?.search);
     if (urlParams.get('fileReview') === 'true') {
@@ -69,7 +68,20 @@ export function FileFieldCustom(props) {
     } else {
       props.goForward(args);
     }
-  };
+  }
+
+  function onGoBack(args) {
+    const urlParams = new URLSearchParams(window?.location?.search);
+    // If fileReview is true we're in the special file review flow, so we should
+    // actually return to the file overview screen, which is technically forward.
+    if (urlParams.get('fileReview') === 'true') {
+      onGoForward(args);
+    } else {
+      props.goBack(args);
+    }
+  }
+
+  const navButtons = <FormNavButtons goBack={onGoBack} submitToContinue />;
 
   return (
     <>

--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -696,6 +696,7 @@ const formConfig = {
           arrayPath: 'applicants',
           showPagePerItem: true,
           keepInPageOnReview: false,
+          depends: (formData, index) => index > 0,
           title: item => `${applicantWording(item)} mailing address`,
           CustomPage: ApplicantAddressCopyPage,
           CustomPageReview: null,

--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -696,7 +696,6 @@ const formConfig = {
           arrayPath: 'applicants',
           showPagePerItem: true,
           keepInPageOnReview: false,
-          depends: (formData, index) => index > 0,
           title: item => `${applicantWording(item)} mailing address`,
           CustomPage: ApplicantAddressCopyPage,
           CustomPageReview: null,


### PR DESCRIPTION
## Summary

tl;dr: Back button now takes users to the custom file review screen when URL parameter is set

Before the `review-and-submit` screen, we display a screen to the user with all the optional/required file uploads they have not submitted yet. Clicking on a link to upload one of the missing files will take the user back in the form to the specific upload page they selected. A URL parameter is set to identify that the user is in this special state of uploading files, and the continue button (rather than just moving to the next page) sends the user back to the file review page at the end of the form. 

Previously, the back button on that file upload screen would take the user back one page in the form, and the user would have to then click "continue" through the entire rest of the form to reach the file overview page again. 

Per designer guidance, the back button now returns the user to the file review screen when the `fileReview` URL param is true. This prevents users from getting lost in the form when trying to upload their missing files.

- Back button behavior on file upload pages has been modified when in the file review loop
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80071

## Screenshots

| | File overview screen | File upload |
|--|--|--|
| |![Screenshot 2024-04-05 at 11 20 26](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/0ddf0bc9-d440-4f88-aa32-479ffe9c3a94)|![Screenshot 2024-04-05 at 13 19 42](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/302feeab-e89f-4862-8460-4d7e76b8690c)|


## Testing done

- Manual
- Verified unit tests run and pass

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA