### PR TITLE
arf.78633 update ARP poaRequests.js to match rails controller

### DIFF
--- a/src/applications/accredited-representative-portal/actions/poaRequests.js
+++ b/src/applications/accredited-representative-portal/actions/poaRequests.js
@@ -1,22 +1,22 @@
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
 
-const handlePOARequest = async (poaId, action) => {
+const handlePOARequest = async (procId, action) => {
   try {
-    const resource = `/accredited_representative_portal/v0/power_of_attorney_requests/${poaId}/${action}`;
+    const resource = `/accredited_representative_portal/v0/power_of_attorney_requests/${procId}/${action}`;
     return await apiRequest(resource, { method: 'POST' });
   } catch (error) {
     return error;
   }
 };
 
-export const getPOARequestsByCode = async poaCode => {
+export const getPOARequestsByCodes = async poaCodes => {
   try {
-    const resource = `/accredited_representative_portal/v0/power_of_attorney_requests?poaCode=${poaCode}`;
+    const resource = `/accredited_representative_portal/v0/power_of_attorney_requests?poa_codes=${poaCodes}`;
     return await apiRequest(resource);
   } catch (error) {
     return error;
   }
 };
 
-export const acceptPOARequest = poaId => handlePOARequest(poaId, 'accept');
-export const declinePOARequest = poaId => handlePOARequest(poaId, 'decline');
+export const acceptPOARequest = procId => handlePOARequest(procId, 'accept');
+export const declinePOARequest = procId => handlePOARequest(procId, 'decline');

--- a/src/applications/accredited-representative-portal/tests/actions/poaRequests.unit.spec.js
+++ b/src/applications/accredited-representative-portal/tests/actions/poaRequests.unit.spec.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import {
   acceptPOARequest,
   declinePOARequest,
-  getPOARequestsByCode,
+  getPOARequestsByCodes,
 } from '../../actions/poaRequests';
 import environment from '~/platform/utilities/environment';
 
@@ -17,11 +17,93 @@ afterEach(() => {
   server.close();
 });
 
+const mockResponseData = {
+  records: [
+    {
+      procId: '9453972527',
+      type: 'powerOfAttorneyRequest',
+      attributes: {
+        poaCode: 'A1Q',
+        secondaryStatus: 'pending',
+        dateRequestReceived: '2024-03-07',
+        dateRequestActioned: '2024-04-14',
+        declinedReason: null,
+        healthInfoAuth: 'Y',
+        changeAddressAuth: 'Y',
+        claimant: {
+          firstName: 'Darcel',
+          lastName: 'Stamm',
+          city: 'Greenburgh',
+          state: 'MN',
+          zip: '56339',
+          country: 'Guinea',
+          militaryPO: null,
+          militaryPostalCode: null,
+          participantID: '7585030129',
+          relationship: 'Child',
+        },
+        veteran: {
+          firstName: 'Annamarie',
+          lastName: 'Adams',
+          middleName: 'Wolff',
+          participantID: '1539825090',
+          sensitivityLevel: 'Low',
+        },
+        VSORepresentative: {
+          email: 'silvana@erdman.example',
+          firstName: 'Maureen',
+          lastName: 'Predovic',
+        },
+      },
+    },
+    {
+      procId: '3692378881',
+      type: 'powerOfAttorneyRequest',
+      attributes: {
+        poaCode: '091',
+        secondaryStatus: 'obsolete',
+        dateRequestReceived: '2024-03-18',
+        dateRequestActioned: '2024-04-14',
+        declinedReason: 'Consectetur facilis placeat est.',
+        healthInfoAuth: 'N',
+        changeAddressAuth: 'N',
+        claimant: {
+          firstName: 'Kelley',
+          lastName: 'Bosco',
+          city: 'South Vinnie',
+          state: 'ME',
+          zip: '16385',
+          country: 'Guadeloupe',
+          militaryPO: null,
+          militaryPostalCode: null,
+          participantID: '9156371702',
+          relationship: 'Parent',
+        },
+        veteran: {
+          firstName: 'Madelaine',
+          lastName: 'Langosh',
+          middleName: 'Davis',
+          participantID: '4570953379',
+          sensitivityLevel: 'Medium',
+        },
+        VSORepresentative: {
+          email: 'young.tremblay@kuphal-borer.test',
+          firstName: 'Ethelyn',
+          lastName: 'Rath',
+        },
+      },
+    },
+  ],
+  meta: {
+    totalRecords: '2',
+  },
+};
+
 describe('POA Request Handling', () => {
   it('handles acceptPOARequest successfully', async () => {
     server.use(
       rest.post(
-        `${prefix}/v0/power_of_attorney_requests/:poaId/accept`,
+        `${prefix}/v0/power_of_attorney_requests/:procId/accept`,
         (_, res, ctx) => {
           return res(ctx.json({ status: 'success' }), ctx.status(200));
         },
@@ -35,7 +117,7 @@ describe('POA Request Handling', () => {
   it('handles declinePOARequest successfully', async () => {
     server.use(
       rest.post(
-        `${prefix}/v0/power_of_attorney_requests/:poaId/decline`,
+        `${prefix}/v0/power_of_attorney_requests/:procId/decline`,
         (_, res, ctx) => {
           return res(ctx.json({ status: 'success' }), ctx.status(200));
         },
@@ -49,7 +131,7 @@ describe('POA Request Handling', () => {
   it('returns an error status when the server responds with an error for accept', async () => {
     server.use(
       rest.post(
-        `${prefix}/v0/power_of_attorney_requests/:poaId/accept`,
+        `${prefix}/v0/power_of_attorney_requests/:procId/accept`,
         (_, res, ctx) => {
           return res(ctx.status(500));
         },
@@ -64,7 +146,7 @@ describe('POA Request Handling', () => {
   it('returns an error status when the server responds with an error for decline', async () => {
     server.use(
       rest.post(
-        `${prefix}/v0/power_of_attorney_requests/:poaId/decline`,
+        `${prefix}/v0/power_of_attorney_requests/:procId/decline`,
         (_, res, ctx) => {
           return res(ctx.status(500));
         },
@@ -79,7 +161,7 @@ describe('POA Request Handling', () => {
   it('handles network errors gracefully for accept', async () => {
     server.use(
       rest.post(
-        `${prefix}/v0/power_of_attorney_requests/:poaId/accept`,
+        `${prefix}/v0/power_of_attorney_requests/:procId/accept`,
         (_, res, ctx) => {
           return res(ctx.status(503));
         },
@@ -94,7 +176,7 @@ describe('POA Request Handling', () => {
   it('handles network errors gracefully for decline', async () => {
     server.use(
       rest.post(
-        `${prefix}/v0/power_of_attorney_requests/:poaId/decline`,
+        `${prefix}/v0/power_of_attorney_requests/:procId/decline`,
         (_, res, ctx) => {
           return res(ctx.status(503));
         },
@@ -108,25 +190,23 @@ describe('POA Request Handling', () => {
 });
 
 describe('POA Requests Retrieval', () => {
-  it('retrieves POA requests successfully', async () => {
-    const testPoaCode = 'AB123';
+  it('retrieves POA requests successfully for multiple codes', async () => {
+    const testPoaCodes = 'AB123,CD456';
     server.use(
       rest.get(`${prefix}/v0/power_of_attorney_requests`, (req, res, ctx) => {
-        const queryPoaCode = req.url.searchParams.get('poaCode');
-        if (queryPoaCode === testPoaCode) {
-          return res(
-            ctx.json([{ id: '1', status: 'pending', poaCode: testPoaCode }]),
-            ctx.status(200),
-          );
+        const queryPoaCodes = req.url.searchParams.get('poa_codes');
+        if (queryPoaCodes === testPoaCodes) {
+          return res(ctx.json(mockResponseData), ctx.status(200));
         }
         return res(ctx.status(404));
       }),
     );
 
-    const response = await getPOARequestsByCode(testPoaCode);
-    expect(response).to.deep.equal([
-      { id: '1', status: 'pending', poaCode: testPoaCode },
-    ]);
+    const response = await getPOARequestsByCodes(testPoaCodes);
+    expect(response.records).to.deep.equal(mockResponseData.records);
+    expect(response.meta.totalRecords).to.equal(
+      mockResponseData.meta.totalRecords,
+    );
   });
 
   it('returns an error status when the server responds with an error', async () => {
@@ -136,7 +216,7 @@ describe('POA Requests Retrieval', () => {
       }),
     );
 
-    const response = await getPOARequestsByCode('AB123');
+    const response = await getPOARequestsByCodes('AB123');
     expect(response.status).to.equal(500);
     expect(response.statusText).to.equal('Internal Server Error');
   });
@@ -148,7 +228,7 @@ describe('POA Requests Retrieval', () => {
       }),
     );
 
-    const response = await getPOARequestsByCode('AB123');
+    const response = await getPOARequestsByCodes('AB123');
     expect(response.status).to.equal(503);
     expect(response.statusText).to.equal('Service Unavailable');
   });


### PR DESCRIPTION
See backend PR: https://github.com/department-of-veterans-affairs/vets-api/pull/16218/files

## Summary

- *This work is behind a feature toggle (flipper): YES*
### Description
While we do not yet have a `GET /veteran-service-organizations/power-of-attorney-requests` LH Claims API endpoint, we should consider building some mock data that we can use to support further development and staging demos.

#### Prerequisites/Dependencies
* The LH Team has to confirm the return value of `GET /veteran-service-organizations/power-of-attorney-requests`. See [this issue for more details](https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/78435).
* Take a best guess at the structure of the above endpoint, and mock that data in the ARP engine.
    * Note: [this Canvas](https://dsva.slack.com/docs/T03FECE8V/F06PSMUPEH0) has a hypothetical response that should serve as a fairly solid guide on what data will be returned by the LH Claims API

## Related issue(s)
https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/78633

Loosely based on @nihil2501's [Dash PR](https://github.com/department-of-veterans-affairs/vets-api/pull/16125/files#diff-a53174a4a0dfe5a4a2b0316eb84bc925763c6d646871d81bc1dee827228dd910) and [ongoing LH work](https://dsva.slack.com/archives/C06ABHUNBRS/p1712333756404439?thread_ts=1712263855.274379&cid=C06ABHUNBRS)

## Testing done

- [X] *New code is covered by unit tests*

## What areas of the site does it impact?
The ARP Engine

## Acceptance criteria
- The `power_of_attorney_requests` ARP Engine  PowerOfAttorneyRequestsController#index returns mock POA requests.