### PR TITLE
[View Payments] Fixing issue related to off-by-one dates

### DIFF
--- a/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
+++ b/src/applications/disability-benefits/view-payments/components/view-payments-lists/helpers.js
@@ -9,7 +9,12 @@ export const isValidDate = dateString => {
 
 export const formatDate = dateString => {
   const formatString = 'MMMM d, yyyy';
-  const parsedDate = parseISO(dateString);
+
+  // We only care about the date portion of the string here.
+  // Including the time portion can lead to off-by-one issues
+  // depending on the users time zone
+  const [datePart] = dateString.split('T');
+  const parsedDate = parseISO(datePart);
 
   return isValid(parsedDate)
     ? format(parsedDate, formatString)

--- a/src/applications/disability-benefits/view-payments/tests/helpers/index.unit.spec.js
+++ b/src/applications/disability-benefits/view-payments/tests/helpers/index.unit.spec.js
@@ -43,7 +43,7 @@ describe('helper functions', () => {
   describe('formatDate', () => {
     context('when given a valid date in the correct format', () => {
       it('returns a date in the correct format', () => {
-        const inputs = ['2019-04-12T00:00:00.000-06:00', '2019-04-12'];
+        const inputs = ['2019-04-12T00:00:00.000-03:00', '2019-04-12'];
 
         for (const input of inputs) {
           const output = formatDate(input);
@@ -74,7 +74,7 @@ describe('helper functions', () => {
   describe('isValidDate', () => {
     context('when given a valid date', () => {
       it('returns ’true’', () => {
-        const inputs = ['2019-04-12T00:00:00.000-06:00', '2019-04-12'];
+        const inputs = ['2019-04-12T00:00:00.000-03:00', '2019-04-12'];
 
         for (const input of inputs) {
           const output = isValidDate(input);


### PR DESCRIPTION
## Summary
BGS always returns the paycheck dates in Central Time (-06:00), so users in different time zones will potentially see different dates. We don't want that as the date displayed should be the same regardless of the time zone and should match the date on the check. We can fix this by removing the timestamp portion of the date string

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#79738

## Testing done
Updated tests so that the old version of the code will fail as long as the user running the tests is located in the US.

## Screenshots
### Server response
These are the dates that show up in the first column of the table. The table is not sorted so the elements are in the same order as they appear here. **Note:** Notice how the first date doesn't include the timestamp and is unaffected by the timezone difference
<img width="368" alt="Screenshot 2024-04-08 at 11 17 40 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/d0b28454-9775-4b09-aed8-105112fbdf95">

### Before
This is what someone on the West Coast will see
<img width="510" alt="Screenshot 2024-04-08 at 11 18 09 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/4134c8f5-3cc9-44d5-a75d-06ea3e3e8bdd">

### After
Same as before, this is what someone on the West Coast will see
<img width="507" alt="Screenshot 2024-04-08 at 11 23 29 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/a5042b9e-9780-44c5-8b40-cd99bb76bc92">

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
