### PR TITLE
added style fix for shared address dropdown

### DIFF
--- a/src/applications/ivc-champva/shared/components/applicantLists/ApplicantAddressPage.jsx
+++ b/src/applications/ivc-champva/shared/components/applicantLists/ApplicantAddressPage.jsx
@@ -3,6 +3,7 @@ import { VaSelect } from '@department-of-veterans-affairs/component-library/dist
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
 import PropTypes from 'prop-types';
+import { $ } from 'platform/forms-system/src/js/utilities/ui';
 import { applicantWording } from '../../utilities';
 
 export function ApplicantAddressCopyPage({
@@ -115,6 +116,15 @@ export function ApplicantAddressCopyPage({
 
   useEffect(
     () => {
+      const shadowSelect = $('va-select')?.shadowRoot;
+      if (shadowSelect) {
+        /* This adds padding to the .usa-select class inside the shadow dom,
+        which prevents long <option> text from overlapping the expansion arrow
+        on the right side of the <select>. (Needed for accessibility audit) */
+        const sheet = new CSSStyleSheet();
+        sheet.replaceSync('.usa-select {padding-right: 3rem}');
+        shadowSelect.adoptedStyleSheets.push(sheet);
+      }
       if (dirty) handlers.validate();
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary

Accessibility audit found that there was overlapping text/expansion arrow on the shared address `<select>` - this fixes it with a shadow DOM style tweak.

More in-depth: On the `<select>` used for the shared address functionality, text from long `<option>` tags can overlap with the expansion arrows. This style is controlled by USWDS `.usa-select` class, which in this particular component is nested in the `shadowRoot` for the VaSelect component. To fix, added a small style change to the `<select>` shadow DOM to add padding which eliminates the visual overlap.

- Added padding to `<select>` in shared address component
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/78181

## Testing done

- Manual
- Verified existing unit tests ran and passed

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Normal |![Screenshot 2024-04-08 at 11 29 58](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/9e03cb55-e11e-41e9-a026-d1f93d7efafc)|![Screenshot 2024-04-08 at 12 05 46](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/50cf6af3-234e-4536-a15d-a6ebe324dce2)|
| 400% Zoom |![Screenshot 2024-04-08 at 11 29 41](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/4ed072f5-3f19-4160-bcfa-a98e3ee0e415)|![Screenshot 2024-04-08 at 12 01 15](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/bd23c0a5-0894-42a7-8811-8304aea7998e)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
