### PR TITLE
Correct minor typo on Dependent education expenses page

### DIFF
--- a/src/applications/hca/definitions/dependent.js
+++ b/src/applications/hca/definitions/dependent.js
@@ -60,7 +60,7 @@ export const dependentUISchema = {
     },
     dependentEducationExpenses: {
       ...currencyUI(
-        'Enter the total amount of money your dependent paid for college, vocational rehabilitation, or training (like tuition, book, or supplies)',
+        'Enter the total amount of money your dependent paid for college, vocational rehabilitation, or training (like tuition, books, or supplies)',
       ),
       'ui:description': DependentEducationExpensesDescription,
       'ui:validations': [validateCurrency],


### PR DESCRIPTION
## Summary

This PR corrects a minor typo in the dependents education expenses section of the Health Care Application.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#70857

## Acceptance criteria

 - Education expenses content is free from typos

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution