### PR TITLE
[CST] Removing getTrackedItemId helper

### DIFF
--- a/src/applications/claims-status/actions/index.js
+++ b/src/applications/claims-status/actions/index.js
@@ -7,13 +7,7 @@ import environment from '@department-of-veterans-affairs/platform-utilities/envi
 import localStorage from 'platform/utilities/storage/localStorage';
 
 import { getErrorStatus, UNKNOWN_STATUS } from '../utils/appeals-v2-helpers';
-import {
-  // START lighthouse_migration
-  getTrackedItemId,
-  // END lighthouse_migration
-  makeAuthRequest,
-  roundToNearest,
-} from '../utils/helpers';
+import { makeAuthRequest, roundToNearest } from '../utils/helpers';
 import { mockApi } from '../tests/e2e/fixtures/mocks/mock-api';
 import manifest from '../manifest.json';
 
@@ -347,9 +341,8 @@ export function submitFiles(claimId, trackedItem, files) {
   let hasError = false;
   const totalSize = files.reduce((sum, file) => sum + file.file.size, 0);
   const totalFiles = files.length;
-  // START lighthouse_migration
-  const trackedItemId = trackedItem ? getTrackedItemId(trackedItem) : null;
-  // END lighthouse_migration
+  const trackedItemId = trackedItem ? trackedItem.id : null;
+
   recordEvent({
     event: 'claims-upload-start',
   });
@@ -529,9 +522,8 @@ export function submitFilesLighthouse(claimId, trackedItem, files) {
   let hasError = false;
   const totalSize = files.reduce((sum, file) => sum + file.file.size, 0);
   const totalFiles = files.length;
-  // START lighthouse_migration
-  const trackedItemId = trackedItem ? getTrackedItemId(trackedItem) : null;
-  // END lighthouse_migration
+  const trackedItemId = trackedItem ? trackedItem.id : null;
+
   recordEvent({
     event: 'claims-upload-start',
   });

--- a/src/applications/claims-status/components/FilesOptionalOld.jsx
+++ b/src/applications/claims-status/components/FilesOptionalOld.jsx
@@ -1,9 +1,10 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom-v5-compat';
-import { getTrackedItemId, truncateDescription } from '../utils/helpers';
 
-function FilesOptionalOld({ item }) {
+import { truncateDescription } from '../utils/helpers';
+
+export default function FilesOptionalOld({ item }) {
   return (
     <div className="file-request-list-item usa-alert file-request-list-item-optional background-color-only alert-with-details">
       <div className="item-container">
@@ -21,7 +22,7 @@ function FilesOptionalOld({ item }) {
           aria-label={`View Details for ${item.displayName}`}
           title={`View Details for ${item.displayName}`}
           className="usa-button usa-button-secondary view-details-button"
-          to={`../document-request/${getTrackedItemId(item)}`}
+          to={`../document-request/${item.id}`}
         >
           View Details
         </Link>
@@ -33,5 +34,3 @@ function FilesOptionalOld({ item }) {
 FilesOptionalOld.propTypes = {
   item: PropTypes.object.isRequired,
 };
-
-export default FilesOptionalOld;

--- a/src/applications/claims-status/components/RequestedFilesInfo.jsx
+++ b/src/applications/claims-status/components/RequestedFilesInfo.jsx
@@ -1,29 +1,27 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import AdditionalEvidencePageOld from '../containers/AdditionalEvidencePageOld';
-import { getTrackedItemId } from '../utils/helpers';
 import FilesOptionalOld from './FilesOptionalOld';
 import FilesNeededOld from './FilesNeededOld';
 
 export default function RequestedFilesInfo({ id, filesNeeded, optionalFiles }) {
+  const documentsNeeded = filesNeeded.length + optionalFiles.length === 0;
   return (
     <div className="claims-requested-files-container">
       <div className="file-request-list">
         <h2 className="claim-file-border">File requests</h2>
 
-        {filesNeeded.length + optionalFiles.length === 0 ? (
-          <div className="no-documents">
-            <p>You don’t need to turn in any documents to VA.</p>
-          </div>
-        ) : null}
+        {documentsNeeded && (
+          <p>You don’t need to turn in any documents to VA.</p>
+        )}
 
         {filesNeeded.map(item => (
-          <FilesNeededOld key={getTrackedItemId(item)} id={id} item={item} />
+          <FilesNeededOld key={item.id} id={id} item={item} />
         ))}
 
         {optionalFiles.map(item => (
-          <FilesOptionalOld key={getTrackedItemId(item)} id={id} item={item} />
+          <FilesOptionalOld key={item.id} id={id} item={item} />
         ))}
       </div>
 

--- a/src/applications/claims-status/components/RequestedFilesInfo.jsx
+++ b/src/applications/claims-status/components/RequestedFilesInfo.jsx
@@ -7,6 +7,7 @@ import FilesNeededOld from './FilesNeededOld';
 
 export default function RequestedFilesInfo({ id, filesNeeded, optionalFiles }) {
   const documentsNeeded = filesNeeded.length + optionalFiles.length === 0;
+
   return (
     <div className="claims-requested-files-container">
       <div className="file-request-list">

--- a/src/applications/claims-status/tests/components/AskVAPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AskVAPage.unit.spec.jsx
@@ -14,6 +14,9 @@ import { renderWithRouter, rerenderWithRouter } from '../utils';
 const getRouter = () => ({ push: sinon.spy() });
 
 const store = createStore(() => ({
+  disability: {
+    status: {},
+  },
   featureToggles: {},
 }));
 

--- a/src/applications/claims-status/tests/components/AskVAPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AskVAPage.unit.spec.jsx
@@ -14,9 +14,6 @@ import { renderWithRouter, rerenderWithRouter } from '../utils';
 const getRouter = () => ({ push: sinon.spy() });
 
 const store = createStore(() => ({
-  disability: {
-    status: {},
-  },
   featureToggles: {},
 }));
 

--- a/src/applications/claims-status/tests/components/RequestedFilesInfo.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/RequestedFilesInfo.unit.spec.jsx
@@ -1,23 +1,31 @@
 import React from 'react';
 import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import sinon from 'sinon';
 
+import * as AdditionalEvidencePageOld from '../../containers/AdditionalEvidencePageOld';
 import RequestedFilesInfo from '../../components/RequestedFilesInfo';
 
-describe('<RequestedFilesInfo>', () => {
-  it('should display no documents messages', () => {
-    const filesNeeded = [];
-    const optionalFiles = [];
+let stub;
 
-    const tree = SkinDeep.shallowRender(
-      <RequestedFilesInfo
-        id="1"
-        filesNeeded={filesNeeded}
-        optionalFiles={optionalFiles}
-      />,
-    );
-    expect(tree.everySubTree('.no-documents')).not.to.be.empty;
+describe('<RequestedFilesInfo>', () => {
+  before(() => {
+    stub = sinon.stub(AdditionalEvidencePageOld, 'default');
+    stub.returns(<div data-testid="additional-evidence-page-old" />);
   });
+
+  after(() => {
+    stub.restore();
+  });
+  it('should display no documents messages', () => {
+    const screen = render(
+      <RequestedFilesInfo id="1" filesNeeded={[]} optionalFiles={[]} />,
+    );
+
+    screen.getByText('You don’t need to turn in any documents to VA.');
+  });
+
   it('should display requested items', () => {
     const filesNeeded = [
       {
@@ -49,6 +57,7 @@ describe('<RequestedFilesInfo>', () => {
       '<Link />',
     );
   });
+
   it('should display optional files', () => {
     const optionalFiles = [
       {

--- a/src/applications/claims-status/tests/components/RequestedFilesInfo.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/RequestedFilesInfo.unit.spec.jsx
@@ -11,6 +11,8 @@ let stub;
 
 describe('<RequestedFilesInfo>', () => {
   before(() => {
+    // Stubbing AdditionalEvidencePageOld as we aren't interested
+    // in testing the functionality of this component
     stub = sinon.stub(AdditionalEvidencePageOld, 'default');
     stub.returns(<div data-testid="additional-evidence-page-old" />);
   });
@@ -18,6 +20,7 @@ describe('<RequestedFilesInfo>', () => {
   after(() => {
     stub.restore();
   });
+
   it('should display no documents messages', () => {
     const screen = render(
       <RequestedFilesInfo id="1" filesNeeded={[]} optionalFiles={[]} />,

--- a/src/applications/claims-status/tests/utils/helpers.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/helpers.unit.spec.js
@@ -10,7 +10,6 @@ import {
   hasBeenReviewed,
   getDocTypeDescription,
   displayFileSize,
-  getTrackedItemId,
   getFilesNeeded,
   getFilesOptional,
   getUserPhase,
@@ -383,49 +382,6 @@ describe('Disability benefits helpers: ', () => {
       expect(size).to.equal('2MB');
     });
   });
-
-  // START lighthouse_migration
-  describe('getTrackedItemId', () => {
-    it('should return the value of the id key for Lighthouse claims', () => {
-      const trackedItem = {
-        id: 1,
-        documents: [],
-      };
-
-      const id = getTrackedItemId(trackedItem);
-      expect(id).to.equal(1);
-    });
-
-    it('should return the value of the trackedItemId key for EVSS claims', () => {
-      const trackedItem = {
-        trackedItemId: 1,
-        documents: [],
-      };
-
-      const id = getTrackedItemId(trackedItem);
-      expect(id).to.equal(1);
-    });
-
-    it('should return null if both the id and trackedItemId keys are not present', () => {
-      const trackedItem = {
-        documents: [],
-      };
-
-      const id = getTrackedItemId(trackedItem);
-      expect(id).to.equal(undefined);
-    });
-
-    it('should return null if either the id or trackedItemId keys are null', () => {
-      const trackedItem = {
-        trackedItemId: null,
-        documents: [],
-      };
-
-      const id = getTrackedItemId(trackedItem);
-      expect(id).to.equal(undefined);
-    });
-  });
-  // END lighthouse_migration
 
   describe('getFilesNeeded', () => {
     context('when useLighthouse is true', () => {

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -124,9 +124,6 @@ function isInEvidenceGathering(claim) {
 }
 
 // START lighthouse_migration
-export const getTrackedItemId = trackedItem =>
-  trackedItem.trackedItemId || trackedItem.id;
-
 export const getTrackedItemDate = item => {
   return item.closedDate || item.receivedDate || item.requestedDate;
 };


### PR DESCRIPTION
## Summary
Removing the `getTrackedItemId` helper as it was only intended to be used during the EVSS-to-Lighthouse migration. Since we are no longer using EVSS, the only way to get the id for a tracked item is via the `id` key

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#80266

## Testing done
- Updated one of the tests for the `RequestedFilesInfo` component to use react-testing-library
- Removed tests related to the `getTrackedItemId` helper

## Screenshots
### RequestedFilesInfo
<img width="500" alt="Screenshot 2024-04-08 at 1 04 10 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/9c467dbf-6ccd-443a-b1e7-a60d51c0e32e">

### FilesOptionalOld
<img width="672" alt="Screenshot 2024-04-08 at 1 04 25 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/bbc33e1a-6af3-49e4-b2e7-e40d50c0256d">

## What areas of the site does it impact?
Claim Status Tool

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
