### PR TITLE
VACMS-17560 CTA link fix

### DIFF
--- a/src/applications/static-pages/cta-widget/index.js
+++ b/src/applications/static-pages/cta-widget/index.js
@@ -511,7 +511,11 @@ export class CallToActionWidget extends Component {
 
     // Show the CTA link.
     return (
-      <a href={this._toolUrl} target={target}>
+      <a
+        className="vads-c-action-link--green"
+        href={this._toolUrl}
+        target={target}
+      >
         {linkText}
       </a>
     );


### PR DESCRIPTION
## Summary
When [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/27307) was merged in, the classes giving this link styling were removed: 

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/4217e85d-df99-454e-9ac3-50ee5dc15831)

This PR adds styles to make this link a green action link instead:

<img width="266" alt="Screenshot 2024-04-08 at 3 00 50 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/53557bb8-0cf7-4711-b472-28322305d00f">

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17560

## Testing done
Not sure how to log in locally; I added this class to this link in staging and verified that this link is used in all CTA widgets and the styling will be handled appropriately.

## Acceptance criteria

- [x] CTA widgets while authenticated present the CTA as an Action link