### PR TITLE
VACMS-73579 PACT Act focus issue fix

### DIFF
--- a/src/applications/pact-act/containers/questions/CheckboxGroup.jsx
+++ b/src/applications/pact-act/containers/questions/CheckboxGroup.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
@@ -6,6 +6,7 @@ import {
   VaCheckbox,
   VaCheckboxGroup,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import {
   navigateBackward,
   navigateForward,
@@ -35,6 +36,7 @@ const CheckboxGroup = ({
 }) => {
   const [valueHasChanged, setValueHasChanged] = useState(false);
   const [headerHasFocused, setHeaderHasFocused] = useState(false);
+  const checkboxRef = useRef(null);
 
   const onValueChange = event => {
     const { value } = event?.target;
@@ -68,6 +70,7 @@ const CheckboxGroup = ({
   const onContinueClick = () => {
     if (!formValue) {
       setFormError(true);
+      focusElement(checkboxRef.current);
     } else {
       if (valueHasChanged) {
         // Remove answers from the Redux store if the display path ahead has changed
@@ -97,6 +100,7 @@ const CheckboxGroup = ({
           headerHasFocused,
           setHeaderHasFocused,
         )}
+        ref={checkboxRef}
         uswds
       >
         {createCheckboxes()}

--- a/src/applications/pact-act/containers/questions/TernaryRadios.jsx
+++ b/src/applications/pact-act/containers/questions/TernaryRadios.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
@@ -6,6 +6,7 @@ import {
   VaRadio,
   VaRadioOption,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import {
   navigateBackward,
   navigateForward,
@@ -37,10 +38,12 @@ const TernaryRadios = ({
 }) => {
   const [valueHasChanged, setValueHasChanged] = useState(false);
   const [headerHasFocused, setHeaderHasFocused] = useState(false);
+  const radioRef = useRef(null);
 
   const onContinueClick = () => {
     if (!formValue) {
       setFormError(true);
+      focusElement(radioRef.current);
     } else {
       if (valueHasChanged) {
         // Remove answers from the Redux store if the display path ahead has changed
@@ -94,29 +97,33 @@ const TernaryRadios = ({
         id="paw-radio"
         onVaValueChange={e => onValueChange(e.detail.value)}
         onLoad={applyFocus('paw-radio', headerHasFocused, setHeaderHasFocused)}
+        ref={radioRef}
         use-forms-pattern="single"
         uswds
       >
-        {shortName === SHORT_NAME_MAP.ORANGE_2_2_2 && (
-          <div id="paw-orange-2-2-2-info" data-testid="paw-orange-2-2-2-info">
-            <va-additional-info
-              trigger="Learn more about C-123 airplanes"
-              uswds
-            >
-              <p className="vads-u-margin-top--0">
-                The U.S. Air Force used C-123 planes to spray Agent Orange to
-                clear jungles that provided enemy cover in Vietnam. After 1971,
-                the Air Force reassigned the remaining C-123 planes to Air Force
-                Reserve units in the U.S. for routine cargo and medical
-                evacuation missions. Veterans, including some Reservists, who
-                flew, trained, or worked on C-123 planes anytime from 1969 to
-                1986 may have had exposure to Agent Orange.
-              </p>
-            </va-additional-info>
-          </div>
-        )}
         {renderRadioOptions()}
-        <div slot="form-description">{locationList}</div>
+        <div slot="form-description">
+          {shortName === SHORT_NAME_MAP.ORANGE_2_2_2 && (
+            <div id="paw-orange-2-2-2-info" data-testid="paw-orange-2-2-2-info">
+              <va-additional-info
+                trigger="Learn more about C-123 airplanes"
+                uswds
+              >
+                <p className="vads-u-margin-top--0">
+                  The U.S. Air Force used C-123 planes to spray Agent Orange to
+                  clear jungles that provided enemy cover in Vietnam. After
+                  1971, the Air Force reassigned the remaining C-123 planes to
+                  Air Force Reserve units in the U.S. for routine cargo and
+                  medical evacuation missions. Veterans, including some
+                  Reservists, who flew, trained, or worked on C-123 planes
+                  anytime from 1969 to 1986 may have had exposure to Agent
+                  Orange.
+                </p>
+              </va-additional-info>
+            </div>
+          )}
+          {locationList}
+        </div>
       </VaRadio>
       <VaButtonPair
         class="vads-u-margin-top--3"

--- a/src/applications/pact-act/sass/pact-act.scss
+++ b/src/applications/pact-act/sass/pact-act.scss
@@ -22,7 +22,7 @@
   }
 
   #paw-orange-2-2-2-info {
-    margin-top: -22px;
+    margin-top: -12px;
   }
 
   va-button-pair {


### PR DESCRIPTION
## Summary
We have a focus issue with the PACT Act radio buttons and checkbox groups. When an error is triggered, the focus remains on the Continue button instead of bouncing back to the inputs. This fixes both types of inputs to focus properly.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/73579

## Testing done
Tested both radio button questions and checkbox group questions locally.

## Screenshots
<img width="713" alt="Screenshot 2024-04-08 at 4 51 01 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/c3facccb-9b27-469c-9fb4-6fa8737ccc3f">
<img width="779" alt="Screenshot 2024-04-08 at 4 50 51 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/f8e8d8ef-e7fc-44b8-aeb1-8f5e589b24ad">