### PR TITLE
Update other explanation field labels

### DIFF
--- a/src/applications/pensions/config/chapters/04-household-information/currentSpouseFormerMarriages.jsx
+++ b/src/applications/pensions/config/chapters/04-household-information/currentSpouseFormerMarriages.jsx
@@ -92,7 +92,7 @@ export default {
           classNames: 'vads-u-margin-bottom--2',
         }),
         otherExplanation: {
-          'ui:title': 'Please specify',
+          'ui:title': 'Tell us how the marriage ended',
           'ui:webComponentField': VaTextInputField,
           'ui:options': {
             expandUnder: 'reasonForSeparation',

--- a/src/applications/pensions/config/chapters/04-household-information/marriageHistory.js
+++ b/src/applications/pensions/config/chapters/04-household-information/marriageHistory.js
@@ -76,7 +76,7 @@ export default {
             required: (...args) => isCurrentMarriage(...args),
           }),
           otherExplanation: {
-            'ui:title': 'Please specify',
+            'ui:title': 'Tell us how you got married',
             'ui:webComponentField': VaTextInputField,
             'ui:required': (form, index) =>
               get(
@@ -102,7 +102,7 @@ export default {
             required: (...args) => !isCurrentMarriage(...args),
           }),
           otherExplanation: {
-            'ui:title': 'Please specify',
+            'ui:title': 'Tell us how the marriage ended',
             'ui:webComponentField': VaTextInputField,
             'ui:required': (form, index) =>
               get(

--- a/src/applications/pensions/config/chapters/05-financial-information/incomeSources.js
+++ b/src/applications/pensions/config/chapters/05-financial-information/incomeSources.js
@@ -49,7 +49,7 @@ export default {
           labels: typeOfIncomeLabels,
         }),
         otherTypeExplanation: {
-          'ui:title': 'Please specify',
+          'ui:title': 'Tell us the type of income',
           'ui:webComponentField': VaTextInputField,
           'ui:options': {
             expandUnder: 'typeOfIncome',


### PR DESCRIPTION
## Summary
Update the other explanation fields label text on the Pension Benefits form (21p-527EZ)

## Acceptance criteria
[Issue in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73980)

## How to run in local environment
1. Check out this branch locally
2. In your local environment, set the `pension_form_enabled` flipper to 'enabled' at http://localhost:3000/flipper/features/pension_form_enabled
3. Run `vets-website` and `vets-api`
4. Go to `http://localhost:3001/pension/application/527EZ` in your browser

## How to verify
### Marriages
1. Continue to the marriages pages in the 'Household information' chapter
2. Select 'Some other way' on the 'How did you get married?' question
3. Verify that the other explanation label text has been updated to 'Tell us how you got married'
4. Verify that the field is required
5. Verify that the form data is saved to the api and redux store

### Spouse Marriages
1. Continue to the spouse marriages pages in the 'Household information' chapter
2. Select 'Other' on the 'How did the marriage end?' question
3. Verify that the other explanation label text has been updated to 'Tell us how the marriage ended'
4. Verify that the field is required
6. Verify that the form data is saved to the api and redux store

### Income Sources
1. Continue to the income sources page in the 'Financial information' chapter
2. Select 'Other income' on the 'What type of income?' question
3. Verify that the other explanation label text has been updated to 'Tell us the type of income'
4. Verify that the field is required
7. Verify that the form data is saved to the api and redux store

## Related issue(s)
[Issue in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/73980)
[Epic in Github](https://github.com/department-of-veterans-affairs/va.gov-team/issues/65250)

## Testing done
- [ ] Existing unit tests updated
- [ ] New unit tests added
- [x] All unit tests passing

## Screenshots
### Marriages
| Before | After |
| ------ | ------ |
|![staging va gov_pension_apply-for-veteran-pension-form-21p-527ez_resume (1)](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/388a5d29-e17a-4a14-a68e-1f17587d0570)|![localhost_3001_pension_application_527ez_introduction (1)](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/7c5ea186-9cd1-43b2-894d-9d1cce2bff4d)

### Spouse Marriages
| Before | After |
| ------ | ------ |
|![staging va gov_pension_apply-for-veteran-pension-form-21p-527ez_resume (2)](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/31ec3c92-be93-417f-8103-ae35b44e029d)|![localhost_3001_pension_application_527ez_introduction (2)](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/d497cb7e-91b4-48e1-8bc1-397eaef3eb8b)

### Income Sources
| Before | After |
| ------ | ------ |
|![staging va gov_pension_apply-for-veteran-pension-form-21p-527ez_resume (3)](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/e4396f0f-6217-4893-b768-34b47c09a4a4)|![localhost_3001_pension_application_527ez_introduction (3)](https://github.com/department-of-veterans-affairs/vets-website/assets/7394764/0a4afd3b-9acc-40f0-b4a4-8833942432c6)

## What areas of the site does it impact?
Pension Benefits Application

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

