### PR TITLE
[CST] [Frontend] Added cst_use_dd_rum feature flag for used with CST DataDog RUM logging

### DIFF
--- a/src/applications/claims-status/selectors/index.js
+++ b/src/applications/claims-status/selectors/index.js
@@ -53,5 +53,9 @@ export const benefitsDocumentsUseLighthouse = state =>
 export const cstUseClaimDetailsV2 = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.cstUseClaimDetailsV2];
 
+// 'cst_use_dd_rum'
+export const cstUseDataDogRUM = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.cstUseDataDogRUM];
+
 // Backend Services
 export const getBackendServices = state => state.user.profile.services;

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -48,6 +48,7 @@
   "cstIncludeDdlBoaLetters": "cst_include_ddl_boa_letters",
   "cstIncludeDdl5103Letters": "cst_include_ddl_5103_letters",
   "cstUseClaimDetailsV2": "cst_use_claim_details_v2",
+  "cstUseDataDogRUM": "cst_use_dd_rum",
   "debtLettersShowLetters": "debt_letters_show_letters",
   "debtLettersShowLettersVBMS": "debt_letters_show_letters_vbms",
   "dependencyVerification": "dependency_verification",


### PR DESCRIPTION
Added `cst_use_dd_rum` feature toggle to `vets-website`.

Files affected:

- src/platform/utilities/feature-toggles/featureFlagNames.json
- src/applications/claims-status/selectors/index.js

Ticket for this work: [Create feature toggle to test RUM PII masking](https://github.com/department-of-veterans-affairs/va.gov-team/issues/79925)
Related Backend PR: [[CST] [Backend] Added feature toggle for CST to use DataDog RUM monitoring](https://github.com/department-of-veterans-affairs/vets-api/pull/16258)