### PR TITLE
Update submit transformer for 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-10D/config/submitTransformer.js
@@ -29,6 +29,8 @@ function transformApplicants(applicants) {
       vet_relationship: transformRelationship(
         app.applicantRelationshipToSponsor?.relationshipToVeteran || 'NA',
       ),
+      sponsor_marriage_details:
+        app?.applicantSponsorMarriageDetails?.relationshipToVeteran || 'NA',
       applicant_supporting_documents: [
         app?.applicantMedicareCardFront,
         app?.applicantMedicareCardBack,
@@ -98,6 +100,7 @@ export default function transformForSubmit(formConfig, form) {
       },
       date_of_death: transformedData?.sponsorDOD || '',
       date_of_marriage: transformedData?.sponsorDOM || '',
+      is_active_service_death: transformedData?.sponsorDeathConditions || '',
     },
     applicants: transformApplicants(transformedData.applicants ?? []),
     certification: {


### PR DESCRIPTION
## Summary

This PR updates the submit transformer for IVC form 10-10d to include two new properties.

- Adds details about applicant marriage to sponsor if remarried after 55
- Adds property tracking if sponsor died while in active military duty
- Team: IVC CHAMPVA
- Flipper: NA

## Screenshots

active service now fills in on generated PDF:

![Screenshot 2024-04-09 at 12 26 52](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/c6385d91-b4a6-423c-9f4e-03adb28be37e)


## Related issue(s)

- NA

## Testing done

- Manual
- Verified unit tests run and pass

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA