### PR TITLE
MHV-56865: Vitals spelling error fixed

### DIFF
--- a/src/applications/mhv/medical-records/containers/Vitals.jsx
+++ b/src/applications/mhv/medical-records/containers/Vitals.jsx
@@ -90,7 +90,7 @@ const Vitals = () => {
             <li>Blood pressure and blood oxygen level</li>
             <li>Breathing rate and heart rate</li>
             <li>Height and weight</li>
-            <li>Tempurature</li>
+            <li>Temperature</li>
           </ul>
           <NoRecordsMessage type={recordType.VITALS} />
         </>


### PR DESCRIPTION
## Summary
One letter spelling error fix

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-56865

> ### Vitals spelling error
> Temperature is incorrectly spelled "Tempurature" in the vitals list in message for when a user has no vitals. 

## Testing done
No new tests needed

## Screenshots
<img width="674" alt="Screenshot 2024-04-09 at 11 58 49 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/9f36a554-02ad-401a-b78f-e84b68567069">
 
## What areas of the site does it impact?
MHV medical records - vitals

## Acceptance criteria
Temperature is spelled correctly

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
