### PR TITLE
Shorten length of shared address text in dropdown

### DIFF
--- a/src/applications/ivc-champva/shared/components/applicantLists/ApplicantAddressPage.jsx
+++ b/src/applications/ivc-champva/shared/components/applicantLists/ApplicantAddressPage.jsx
@@ -47,21 +47,24 @@ export function ApplicantAddressCopyPage({
   // applicants so we can display in <select> down below
   function getSelectOptions() {
     const allAddresses = [];
-    if (data.certifierAddress?.country && data.certifierName)
+    if (data.certifierAddress?.street && data.certifierName)
       allAddresses.push({
         originatorName: fullName(data.certifierName),
         originatorAddress: data.certifierAddress,
+        displayText: data.certifierAddress.street,
       });
-    if (data.sponsorAddress?.country && data.veteransFullName)
+    if (data.sponsorAddress?.street && data.veteransFullName)
       allAddresses.push({
         originatorName: fullName(data.veteransFullName),
         originatorAddress: data.sponsorAddress,
+        displayText: data.sponsorAddress.street,
       });
 
     data.applicants.filter(app => isValidOrigin(app)).forEach(app =>
       allAddresses.push({
         originatorName: fullName(app.applicantName),
         originatorAddress: app.applicantAddress,
+        displayText: app.applicantAddress?.street,
       }),
     );
     return allAddresses;
@@ -157,12 +160,10 @@ export function ApplicantAddressCopyPage({
           label={selectWording}
           name="shared-address-select"
         >
-          <option value="not-shared">
-            No, {curAppFullName} has a different address
-          </option>
+          <option value="not-shared">No, use a new address</option>
           {getSelectOptions().map(el => (
             <option key={el.originatorName} value={JSON.stringify(el)}>
-              Yes, {curAppFullName} has the same address as {el.originatorName}
+              Use {el.displayText}
             </option>
           ))}
         </VaSelect>


### PR DESCRIPTION
## Summary

This PR updates the wording on the shared address dropdown, making it more specific and (generally) shorter in length than the previous arrangement.

- Addresses now show street name/number rather than applicant name
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/78166

## Testing done

- Manual
- Verified unit tests run and pass

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![Screenshot 2024-04-08 at 11 29 41](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/85ab9c48-ff6b-4bfa-a09c-7ae4ce3e39a6)|![Screenshot 2024-04-09 at 14 19 08](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/bd896129-81be-425c-9be0-183d6a03a2ba)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
