### PR TITLE
[CST] - Added Tests to increase coverage of CST

### DIFF
--- a/src/applications/claims-status/selectors/index.js
+++ b/src/applications/claims-status/selectors/index.js
@@ -30,6 +30,7 @@ export const cstUseLighthouse = (state, endpoint) => {
   // undefined and the feature toggle should always return true anyways
   // Note: Checking for window.Cypress here because some of the Cypress
   // tests are written for EVSS and will fail if this only returns true
+
   if (endpoint === 'show' && !window.Cypress) return true;
 
   return toggleValues(state)[

--- a/src/applications/claims-status/tests/selectors/index.unit.spec.js
+++ b/src/applications/claims-status/tests/selectors/index.unit.spec.js
@@ -1,0 +1,427 @@
+import { expect } from 'chai';
+
+import FEATURE_FLAG_NAMES from '@department-of-veterans-affairs/platform-utilities/featureFlagNames';
+import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
+
+import * as selectors from '../../selectors';
+
+describe('selectors', () => {
+  describe('isLoadingFeatures', () => {
+    const state = {
+      featureToggles: {
+        loading: true,
+      },
+    };
+
+    it('should return true', () => {
+      expect(selectors.isLoadingFeatures(state)).to.be.true;
+    });
+
+    it('should return false', () => {
+      state.featureToggles.loading = false;
+
+      expect(selectors.isLoadingFeatures(state)).to.be.false;
+    });
+  });
+
+  describe('showClaimLettersFeature', () => {
+    const state = {
+      featureToggles: {
+        claimLettersAccess: true,
+        // eslint-disable-next-line camelcase
+        claim_letters_access: true,
+      },
+    };
+
+    it('should return true', () => {
+      expect(selectors.showClaimLettersFeature(state)).to.be.true;
+    });
+
+    it('should return false', () => {
+      state.featureToggles.claimLettersAccess = false;
+      // eslint-disable-next-line camelcase
+      state.featureToggles.claim_letters_access = false;
+
+      expect(selectors.showClaimLettersFeature(state)).to.be.false;
+    });
+  });
+
+  describe('cstUseLighthouse', () => {
+    context('when endpoint is show', () => {
+      const endpoint = 'show';
+      const cstUseLighthouseShow =
+        FEATURE_FLAG_NAMES[`cstUseLighthouse#${endpoint}`];
+      context('when featureToggles are true', () => {
+        const state = {
+          featureToggles: {
+            [cstUseLighthouseShow]: true,
+            // eslint-disable-next-line camelcase
+            cst_use_lighthouse_5103: true,
+          },
+        };
+        context('when cstFlipperOverrideMode is set to featureToggle', () => {
+          it('should return true when window.cypress false', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'featureToggle');
+            window.Cypress = false;
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.true;
+          });
+
+          it('should return true when window.cypress true', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'featureToggle');
+            window.Cypress = true;
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.true;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is set to evss', () => {
+          it('should return false', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'evss');
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.false;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is set to lighthouse', () => {
+          it('should return true', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'lighthouse');
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.true;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is null', () => {
+          it('should return true when window.cypress false', () => {
+            // sessionStorage.setItem('cstFlipperOverrideMode', '');
+            window.Cypress = false;
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.true;
+          });
+
+          it('should return true when window.cypress true', () => {
+            // sessionStorage.setItem('cstFlipperOverrideMode', '');
+            window.Cypress = true;
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.true;
+          });
+        });
+      });
+
+      context('when featureToggles are false', () => {
+        const state = {
+          featureToggles: {
+            [cstUseLighthouseShow]: false,
+            // eslint-disable-next-line camelcase
+            cst_use_lighthouse_5103: false,
+          },
+        };
+        context('when cstFlipperOverrideMode is set to featureToggle', () => {
+          it('should return true when window.cypress false', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'featureToggle');
+            window.Cypress = false;
+
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.true;
+          });
+
+          it('should return true when window.cypress true', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'featureToggle');
+            window.Cypress = true;
+
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.false;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is set to evss', () => {
+          it('should return false', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'evss');
+
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.false;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is set to lighthouse', () => {
+          it('should return true', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'lighthouse');
+
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.true;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is null', () => {
+          it('should return true when window.cypress false', () => {
+            // sessionStorage.setItem('cstFlipperOverrideMode', '');
+            window.Cypress = false;
+
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.true;
+          });
+
+          it('should return true when window.cypress true', () => {
+            // sessionStorage.setItem('cstFlipperOverrideMode', '');
+            window.Cypress = true;
+
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.false;
+          });
+        });
+      });
+    });
+
+    context('when endpoint is index', () => {
+      const endpoint = 'index';
+      const cstUseLighthouseShow =
+        FEATURE_FLAG_NAMES[`cstUseLighthouse#${endpoint}`];
+      context('when featureToggles are true', () => {
+        const state = {
+          featureToggles: {
+            [cstUseLighthouseShow]: true,
+            // eslint-disable-next-line camelcase
+            cst_use_lighthouse_5103: true,
+          },
+        };
+        context('when cstFlipperOverrideMode is set to featureToggle', () => {
+          it('should return true ', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'featureToggle');
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.true;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is set to evss', () => {
+          it('should return false', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'evss');
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.false;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is set to lighthouse', () => {
+          it('should return true', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'lighthouse');
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.true;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is null', () => {
+          it('should return true', () => {
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.true;
+          });
+        });
+      });
+
+      context('when featureToggles are false', () => {
+        const state = {
+          featureToggles: {
+            [cstUseLighthouseShow]: false,
+            // eslint-disable-next-line camelcase
+            cst_use_lighthouse_5103: false,
+          },
+        };
+        context('when cstFlipperOverrideMode is set to featureToggle', () => {
+          it('should return false', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'featureToggle');
+
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.false;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is set to evss', () => {
+          it('should return false', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'evss');
+
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.false;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is set to lighthouse', () => {
+          it('should return true', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'lighthouse');
+
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.true;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is null', () => {
+          it('should return false', () => {
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.false;
+          });
+        });
+      });
+    });
+
+    context('when endpoint is 5103', () => {
+      const endpoint = '5103';
+      const cstUseLighthouseShow =
+        FEATURE_FLAG_NAMES[`cstUseLighthouse#${endpoint}`];
+      context('when featureToggles are true', () => {
+        const state = {
+          featureToggles: {
+            [cstUseLighthouseShow]: true,
+            // eslint-disable-next-line camelcase
+            cst_use_lighthouse_5103: true,
+          },
+        };
+        context('when cstFlipperOverrideMode is set to featureToggle', () => {
+          it('should return true ', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'featureToggle');
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.true;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is set to evss', () => {
+          it('should return false', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'evss');
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.false;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is set to lighthouse', () => {
+          it('should return true', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'lighthouse');
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.true;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is null', () => {
+          it('should return true', () => {
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.true;
+          });
+        });
+      });
+
+      context('when featureToggles are false', () => {
+        const state = {
+          featureToggles: {
+            [cstUseLighthouseShow]: false,
+            // eslint-disable-next-line camelcase
+            cst_use_lighthouse_5103: false,
+          },
+        };
+        context('when cstFlipperOverrideMode is set to featureToggle', () => {
+          it('should return false', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'featureToggle');
+
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.false;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is set to evss', () => {
+          it('should return false', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'evss');
+
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.false;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is set to lighthouse', () => {
+          it('should return true', () => {
+            sessionStorage.setItem('cstFlipperOverrideMode', 'lighthouse');
+
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.true;
+          });
+        });
+
+        context('when cstFlipperOverrideMode is null', () => {
+          it('should return false', () => {
+            expect(selectors.cstUseLighthouse(state, endpoint)).to.be.false;
+          });
+        });
+      });
+    });
+  });
+
+  describe('cstIncludeDdlBoaLetters', () => {
+    const state = {
+      featureToggles: {
+        cstIncludeDdlBoaLetters: true,
+        // eslint-disable-next-line camelcase
+        cst_include_ddl_boa_letters: true,
+      },
+    };
+
+    it('should return true', () => {
+      expect(selectors.cstIncludeDdlBoaLetters(state)).to.be.true;
+    });
+
+    it('should return false', () => {
+      state.featureToggles.cstIncludeDdlBoaLetters = false;
+      // eslint-disable-next-line camelcase
+      state.featureToggles.cst_include_ddl_boa_letters = false;
+
+      expect(selectors.cstIncludeDdlBoaLetters(state)).to.be.false;
+    });
+  });
+
+  describe('cstIncludeDdl5103Letters', () => {
+    const state = {
+      featureToggles: {
+        cstIncludeDdl5103Letters: true,
+        // eslint-disable-next-line camelcase
+        cst_include_ddl_5103_letters: true,
+      },
+    };
+
+    it('should return true', () => {
+      expect(selectors.cstIncludeDdl5103Letters(state)).to.be.true;
+    });
+
+    it('should return false', () => {
+      state.featureToggles.cstIncludeDdl5103Letters = false;
+      // eslint-disable-next-line camelcase
+      state.featureToggles.cst_include_ddl_5103_letters = false;
+
+      expect(selectors.cstIncludeDdl5103Letters(state)).to.be.false;
+    });
+  });
+
+  describe('benefitsDocumentsUseLighthouse', () => {
+    const state = {
+      featureToggles: {
+        benefitsDocumentsUseLighthouse: true,
+        // eslint-disable-next-line camelcase
+        benefits_documents_use_lighthouse: true,
+      },
+    };
+
+    it('should return true', () => {
+      expect(selectors.benefitsDocumentsUseLighthouse(state)).to.be.true;
+    });
+
+    it('should return false', () => {
+      state.featureToggles.benefitsDocumentsUseLighthouse = false;
+      // eslint-disable-next-line camelcase
+      state.featureToggles.benefits_documents_use_lighthouse = false;
+
+      expect(selectors.benefitsDocumentsUseLighthouse(state)).to.be.false;
+    });
+  });
+
+  describe('cstUseClaimDetailsV2', () => {
+    const state = {
+      featureToggles: {
+        cstUseClaimDetailsV2: true,
+        // eslint-disable-next-line camelcase
+        cst_use_claim_details_v2: true,
+      },
+    };
+
+    it('should return true', () => {
+      expect(selectors.cstUseClaimDetailsV2(state)).to.be.true;
+    });
+
+    it('should return false', () => {
+      state.featureToggles.cstUseClaimDetailsV2 = false;
+      // eslint-disable-next-line camelcase
+      state.featureToggles.cst_use_claim_details_v2 = false;
+
+      expect(selectors.cstUseClaimDetailsV2(state)).to.be.false;
+    });
+  });
+
+  describe('getBackendServices', () => {
+    const state = {
+      user: {
+        profile: {
+          services: [backendServices.APPEALS_STATUS],
+        },
+      },
+    };
+
+    it('should include backend services', () => {
+      expect(selectors.getBackendServices(state)).to.contain(
+        backendServices.APPEALS_STATUS,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Added test file for selectors in CST and increased coverage from 34% to 96 % 
![Screenshot 2024-04-09 at 3 49 34 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/5e966c53-19d1-47d5-87ab-9b9a28dfd08f)


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#79845

## What areas of the site does it impact?

Claim Status Tool

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
