### PR TITLE
Updated MHV resource and spotlight links in landing page

### DIFF
--- a/src/applications/mhv-landing-page/utilities/data/index.js
+++ b/src/applications/mhv-landing-page/utilities/data/index.js
@@ -235,7 +235,7 @@ const resolveLandingPageLinks = (
         text: 'VA’s Whole Health living',
       },
       {
-        href: mhvUrl(false, 'ss20200320-va-video-connect'),
+        href: mhvUrl(authdWithSSOe, 'ss20200320-va-video-connect'),
         text: 'How to use VA Video Connect',
       },
     ],
@@ -248,19 +248,22 @@ const resolveLandingPageLinks = (
       {
         text: 'Try Messages on VA.gov',
         href: null,
-        oldHref: mhvUrl(false, 'ss20231205-try-messages-va'),
+        oldHref: mhvUrl(authdWithSSOe, 'ss20231205-try-messages-va'),
         toggle: null,
       },
       {
         text: 'A Better Night’s Sleep',
         href: null,
-        oldHref: mhvUrl(false, 'ss20220516-tips-to-sleep-better'),
+        oldHref: mhvUrl(authdWithSSOe, 'ss20220516-tips-to-sleep-better'),
         toggle: null,
       },
       {
         text: 'Take Charge with the DASH Diet',
         href: null,
-        oldHref: mhvUrl(false, 'ss20210712-lower-blood-pressure-dash-diet'),
+        oldHref: mhvUrl(
+          authdWithSSOe,
+          'ss20210712-lower-blood-pressure-dash-diet',
+        ),
         toggle: null,
       },
     ],

--- a/src/applications/mhv-landing-page/utilities/data/index.js
+++ b/src/applications/mhv-landing-page/utilities/data/index.js
@@ -242,7 +242,6 @@ const resolveLandingPageLinks = (
     featureToggles,
   );
 
-  // Spotlight links are non-authed, so we always pass `false` to mhvUrl
   const spotlightLinks = resolveLinkCollection(
     [
       {


### PR DESCRIPTION
## Summary
This PR updates a few landing page links that are part of the MHV portal. Most of the MHV portal links looked at the SSOe session to provide authenticated links were possible, but some links were not using this check.

## Related issue(s)
https://app.zenhub.com/workspaces/mhv-on-vagov-landing-page-62619a987d74510018ecc546/issues/gh/department-of-veterans-affairs/va.gov-team/77358

## Testing done
- Manual testing

## Screenshots
No changes to the UI.

## What areas of the site does it impact?
- MHV landing page

## Acceptance criteria
- A veteran is taken to the MHV portal authenticated pages when accessing an MHV article from the MHV landing page.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
