### PR TITLE
MHV-56826: Fix pagination on refill prescription page focus state

### DIFF
--- a/src/applications/mhv/medications/components/RefillPrescriptions/RenewablePrescriptions.jsx
+++ b/src/applications/mhv/medications/components/RefillPrescriptions/RenewablePrescriptions.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { VaPagination } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { waitForRenderThenFocus } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { setBreadcrumbs } from '../../actions/breadcrumbs';
 import { setPrescriptionDetails } from '../../actions/prescriptions';
 
@@ -27,6 +28,11 @@ const RenewablePrescriptions = ({ renewablePrescriptionsList = [] }) => {
       ...prevState,
       currentPage: page,
     }));
+    waitForRenderThenFocus(
+      "p[data-testid='renew-page-list-count']",
+      document,
+      500,
+    );
   };
 
   const startIdx = (pagination.currentPage - 1) * MAX_PAGE_LIST_LENGTH;


### PR DESCRIPTION
## Summary

Similar to how it is done on Medications List page, focus is set `onPageChange` via `waitForRenderThenFocus`.

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-56826

<img width="963" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/ab8ac187-78a3-43bc-9468-402d3cb23b54">

## Testing done

- Manual testing via Chrome DevTools Accessibility

## What areas of the site does it impact?

/my-health/medications/refill

## Acceptance criteria

AC1 On the Refill prescriptions page (If your prescription isn’t ready to refill, section). When someone interactions with the next or previous (or clicking on the numbers), the focus state should go straight to the Showing 31 prescriptions you may need to renew.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
