### PR TITLE
Add va-need-help to FormFooter

### DIFF
--- a/src/applications/appeals/shared/content/GetFormHelp.jsx
+++ b/src/applications/appeals/shared/content/GetFormHelp.jsx
@@ -3,7 +3,7 @@ import { CONTACTS } from '@department-of-veterans-affairs/component-library/cont
 
 export default function GetFormHelp() {
   return (
-    <div slot="content">
+    <>
       <p>
         If you have questions or need help filling out this form, please call us
         at <va-telephone contact={CONTACTS.VA_BENEFITS} />. We’re here Monday
@@ -13,6 +13,6 @@ export default function GetFormHelp() {
         If you have hearing loss, call{' '}
         <va-telephone contact={CONTACTS['711']} tty />.
       </p>
-    </div>
+    </>
   );
 }

--- a/src/applications/disability-benefits/all-claims/tests/containers/WizardContainer.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/WizardContainer.unit.spec.jsx
@@ -21,7 +21,7 @@ describe('Wizard Container', () => {
     expect($('h1', container)).to.exist;
     expect($('.wizard-container', container)).to.exist;
     expect($('.skip-wizard-link', container)).to.exist;
-    expect($('.help-footer-box', container)).to.exist;
+    expect($('va-need-help', container)).to.exist;
   });
   it('should update wizard status on bypass click', () => {
     const { container } = render(<WizardContainer />);

--- a/src/platform/forms/components/FormFooter.jsx
+++ b/src/platform/forms/components/FormFooter.jsx
@@ -1,26 +1,25 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default function FormFooter({ formConfig, currentLocation }) {
-  const GetFormHelp = formConfig.getHelp;
+  const GetFormHelp = formConfig?.getHelp;
+  const trimmedPathname = (currentLocation?.pathname || '').replace(/\/$/, '');
+  const isConfirmationPage = trimmedPathname.endsWith('confirmation');
 
-  if (currentLocation?.pathname.replace(/\/$/, '').endsWith('confirmation')) {
-    return null;
-  }
-
-  if (!GetFormHelp) {
-    return null;
-  }
-
-  return (
+  return isConfirmationPage || !GetFormHelp ? null : (
     <div className="row">
       <div className="usa-width-two-thirds medium-8 columns">
-        <div className="help-footer-box">
-          <h2 className="help-heading">Need help?</h2>
-          <div>
+        <va-need-help>
+          <div slot="content">
             <GetFormHelp formConfig={formConfig} />
           </div>
-        </div>
+        </va-need-help>
       </div>
     </div>
   );
 }
+
+FormFooter.propTypes = {
+  currentLocation: PropTypes.object,
+  formConfig: PropTypes.object,
+};

--- a/src/platform/forms/tests/components/FormFooter.unit.spec.jsx
+++ b/src/platform/forms/tests/components/FormFooter.unit.spec.jsx
@@ -1,54 +1,59 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import { expect } from 'chai';
+
+import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 
 import FormFooter from '../../components/FormFooter';
 
 describe('FormFooter', () => {
-  it('should render', () => {
-    const wrapper = shallow(
+  it('should not render with no getHelp value', () => {
+    const { container } = render(
       <FormFooter
         formConfig={{}}
         currentLocation={{ pathname: '/introduction' }}
       />,
     );
 
-    expect(wrapper.text()).to.be.empty;
-    wrapper.unmount();
+    expect($('va-need-help', container)).to.not.exist;
+    expect(container.textContent).to.be.empty;
+  });
+
+  it('should not render and not throw errors with no props', () => {
+    const { container } = render(<FormFooter />);
+    expect($('va-need-help', container)).to.not.exist;
+    expect(container.textContent).to.be.empty;
   });
 
   it('should not render if on the confirmation page', () => {
-    const GetFormHelp = function GetFormHelp() {
-      return <div>Help!</div>;
+    const GetFormHelp = () => {
+      return <div id="inner">Help!</div>;
     };
-    const wrapper = shallow(
+    const { container } = render(
       <FormFooter
         formConfig={{ getHelp: GetFormHelp }}
         currentLocation={{ pathname: '/confirmation' }}
       />,
     );
 
-    expect(wrapper.text()).to.be.empty;
-    wrapper.unmount();
+    expect($('va-need-help', container)).to.not.exist;
+    expect(container.textContent).to.be.empty;
   });
 
   it('should render <GetFormHelp> if passed to config', () => {
-    const GetFormHelp = function GetFormHelp() {
-      return <div>Help!</div>;
+    let renderedProps;
+    const GetFormHelp = props => {
+      renderedProps = props;
+      return <div id="inner">Help!</div>;
     };
-    const wrapper = shallow(
+    const { container } = render(
       <FormFooter
         formConfig={{ getHelp: GetFormHelp }}
         currentLocation={{ pathname: '/introduction' }}
       />,
     );
 
-    expect(
-      wrapper
-        .find('GetFormHelp')
-        .render()
-        .text(),
-    ).to.contain('Help!');
-    wrapper.unmount();
+    expect($('#inner', container).textContent).to.contain('Help!');
+    expect(renderedProps).to.haveOwnProperty('formConfig');
   });
 });


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Add `va-need-help` web component to platform `FormFooter` component
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Switching to a web component
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#77946](https://github.com/department-of-veterans-affairs/va.gov-team/issues/77946)

## Testing done

- _Describe what the old behavior was prior to the change_
  > CSS class adds the blue underline - this class name may be going away with foundation removal
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

No visual change before & after

<img width="707" alt="need help section from the Higher-Level Review form" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/94baaa23-8e36-4d3a-bbec-b5f14f992ae1">

## What areas of the site does it impact?

All forms that use platform's FormFooter component - there are a few that don't

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
