### PR TITLE
MHV-56873/update-print-preview-header

### DIFF
--- a/src/platform/mhv/hooks/usePrintTitle.jsx
+++ b/src/platform/mhv/hooks/usePrintTitle.jsx
@@ -9,7 +9,10 @@ const usePrintTitle = (baseTitle, userDetails, dob, updatePageTitle) => {
         .filter(part => part !== undefined && part !== null)
         .join(' ')
         .trim();
-      const pageTitle = `${name} | ${formatDateShort(new Date(dob))}`;
+      // eslint-disable-next-line no-irregular-whitespace
+      const pageTitle = `${name}${name ? '\u2003' : ''}​DOB:​${formatDateShort(
+        new Date(dob),
+      )}`;
 
       const beforePrintHandler = () => {
         updatePageTitle(pageTitle);


### PR DESCRIPTION
## Summary

- Added a space to the page title during print view + added "DOB:" before the date of birth for print view
- Removed '|' as the seperator for name and DOB

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-56873
>User Story: As a user attempting to print a single medication or a list of medications, I should be able to view a helpful header containing the full name and date of birth (DOB) to easily identify the individual to whom the medications belong.
>Format: "First Last     DOB: 06/18/1976"

## Testing done

- Tested locally
- Ran unit tests

## Screenshots

Before:
![Screenshot 2024-04-10 at 4 33 02 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/146013972/0e9c3fb2-79b1-43d9-800e-e4c7fa2fa1d5)

After:
![Screenshot 2024-04-10 at 4 33 40 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/146013972/ab489aa6-6b4d-46a9-b26e-50d4b010f610)

## What areas of the site does it impact?

MHV medications and MR print preview pages

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
