### PR TITLE
[MHV-56866] Replacing aria-label with aria-described by on links

### DIFF
--- a/src/applications/mhv-secure-messaging/components/ThreadList/ThreadListItem.jsx
+++ b/src/applications/mhv-secure-messaging/components/ThreadList/ThreadListItem.jsx
@@ -101,7 +101,7 @@ const ThreadListItem = props => {
       </div>
       <div className="vads-l-col vads-u-margin-left--1">
         <Link
-          aria-describedby="received-date"
+          aria-describedby="received-message-date"
           className="message-subject-link vads-u-margin-y--0 vads-u-line-height--4 vads-u-font-size--lg"
           to={`${Paths.MESSAGE_THREAD}${messageId}/`}
           data-dd-privacy="mask"
@@ -137,7 +137,7 @@ const ThreadListItem = props => {
         <div
           className="vads-u-font-weight--normal vads-u-color--gray-medium vads-u-margin-top--0p5"
           data-testid="received-date"
-          id="received-date"
+          id="received-message-date"
         >
           {formattedDate()}
         </div>
@@ -233,7 +233,7 @@ const ThreadListItem = props => {
         </div>
         <Link
           data-dd-action-name="Link to Message Subject Details"
-          aria-describedby="thread-date"
+          aria-describedby="thread-message-date"
           className="message-subject-link vads-u-margin-y--0p5"
           to={`${Paths.MESSAGE_THREAD}${messageId}/`}
           data-dd-privacy="mask"
@@ -261,7 +261,7 @@ const ThreadListItem = props => {
           )}
           <span
             data-testid="thread-date"
-            id="thread-date"
+            id="thread-message-date"
             data-dd-privacy="mask"
           >
             {formattedDate()}

--- a/src/applications/mhv-secure-messaging/components/ThreadList/ThreadListItem.jsx
+++ b/src/applications/mhv-secure-messaging/components/ThreadList/ThreadListItem.jsx
@@ -101,11 +101,7 @@ const ThreadListItem = props => {
       </div>
       <div className="vads-l-col vads-u-margin-left--1">
         <Link
-          aria-label={`${
-            unreadMessages ? 'Unread message. Subject:' : 'Message subject:'
-          } ${categoryLabel}: ${subject}, ${formattedDate()}. ${
-            hasAttachment ? ' Has attachment.' : ''
-          }`}
+          aria-describedby="received-date"
           className="message-subject-link vads-u-margin-y--0 vads-u-line-height--4 vads-u-font-size--lg"
           to={`${Paths.MESSAGE_THREAD}${messageId}/`}
           data-dd-privacy="mask"
@@ -141,6 +137,7 @@ const ThreadListItem = props => {
         <div
           className="vads-u-font-weight--normal vads-u-color--gray-medium vads-u-margin-top--0p5"
           data-testid="received-date"
+          id="received-date"
         >
           {formattedDate()}
         </div>
@@ -236,11 +233,7 @@ const ThreadListItem = props => {
         </div>
         <Link
           data-dd-action-name="Link to Message Subject Details"
-          aria-label={`${
-            unreadMessages ? 'Unread message.' : ''
-          } Message subject: ${categoryLabel}: ${subject}, ${formattedDate()}. ${
-            hasAttachment ? ' Has attachment.' : ''
-          }`}
+          aria-describedby="thread-date"
           className="message-subject-link vads-u-margin-y--0p5"
           to={`${Paths.MESSAGE_THREAD}${messageId}/`}
           data-dd-privacy="mask"
@@ -266,7 +259,11 @@ const ThreadListItem = props => {
               alt="Attachment icon"
             />
           )}
-          <span data-testid="thread-date" data-dd-privacy="mask">
+          <span
+            data-testid="thread-date"
+            id="thread-date"
+            data-dd-privacy="mask"
+          >
             {formattedDate()}
           </span>
         </p>

--- a/src/applications/mhv-secure-messaging/components/ThreadList/ThreadListItem.jsx
+++ b/src/applications/mhv-secure-messaging/components/ThreadList/ThreadListItem.jsx
@@ -106,26 +106,18 @@ const ThreadListItem = props => {
           to={`${Paths.MESSAGE_THREAD}${messageId}/`}
           data-dd-privacy="mask"
         >
-          {hasAttachment ? (
-            <span
-              id={`message-link-has-attachment-${messageId}`}
-              className={`vads-u-font-size--lg ${
-                unreadMessages ? 'vads-u-font-weight--bold' : ''
-              }`}
-            >
-              {categoryLabel}: {getHighlightedText(subject)}
-              <span className="sr-only">Has attachment</span>
-            </span>
-          ) : (
-            <span
-              id={`message-link-${messageId}`}
-              className={`vads-u-font-size--lg ${
-                unreadMessages ? 'vads-u-font-weight--bold' : ''
-              }`}
-            >
-              {categoryLabel}: {getHighlightedText(subject)}
-            </span>
-          )}
+          <span
+            id={`message-link${
+              hasAttachment ? '-has-attachment' : ''
+            }-${messageId}`}
+            className={`vads-u-font-size--lg ${
+              unreadMessages ? 'vads-u-font-weight--bold' : ''
+            }`}
+          >
+            {unreadMessages && <span className="sr-only">Unread message.</span>}
+            {categoryLabel}: {getHighlightedText(subject)}
+            {hasAttachment && <span className="sr-only">Has attachment.</span>}
+          </span>
         </Link>
         <div className={getClassNames()} data-dd-privacy="mask">
           {location.pathname !== Paths.SENT ? (
@@ -202,7 +194,7 @@ const ThreadListItem = props => {
                     <span className="thread-list-draft">(Draft)</span> -{' '}
                   </>
                 )}
-              </span>{' '}
+              </span>
               {unreadMessages ? (
                 <span data-testid="triageGroupName">
                   {getHighlightedText(senderName)} (Team: {triageGroupName})
@@ -213,7 +205,7 @@ const ThreadListItem = props => {
                   {getHighlightedText(senderName)} (Team: {triageGroupName})
                 </span>
               )}
-              <span />{' '}
+              <span />
               {messageCount > 1 && (
                 <span className="message-count" data-testid="message-count">
                   ({messageCount} messages)
@@ -224,7 +216,7 @@ const ThreadListItem = props => {
             <div>
               <div>
                 To: {recipientName} (Team: {triageGroupName}){' '}
-              </div>{' '}
+              </div>
               {messageCount > 1 && (
                 <span className="message-count">({messageCount} messages)</span>
               )}
@@ -238,16 +230,15 @@ const ThreadListItem = props => {
           to={`${Paths.MESSAGE_THREAD}${messageId}/`}
           data-dd-privacy="mask"
         >
-          {hasAttachment ? (
-            <span id={`message-link-has-attachment-${messageId}`}>
-              {categoryLabel}: {getHighlightedText(subject)}
-              <span className="sr-only">Has attachment</span>
-            </span>
-          ) : (
-            <span id={`message-link-${messageId}`}>
-              {categoryLabel}: {getHighlightedText(subject)}
-            </span>
-          )}
+          <span
+            id={`message-link${
+              hasAttachment ? '-has-attachment' : ''
+            }-${messageId}`}
+          >
+            {unreadMessages && <span className="sr-only">Unread message.</span>}
+            {categoryLabel}: {getHighlightedText(subject)}
+            {hasAttachment && <span className="sr-only">Has attachment.</span>}
+          </span>
         </Link>
 
         <p className="received-date vads-u-margin-y--0p5">

--- a/src/applications/mhv-secure-messaging/components/ThreadList/ThreadListItem.jsx
+++ b/src/applications/mhv-secure-messaging/components/ThreadList/ThreadListItem.jsx
@@ -101,7 +101,7 @@ const ThreadListItem = props => {
       </div>
       <div className="vads-l-col vads-u-margin-left--1">
         <Link
-          aria-describedby="received-message-date"
+          aria-describedby={`received-message-date-${messageId}`}
           className="message-subject-link vads-u-margin-y--0 vads-u-line-height--4 vads-u-font-size--lg"
           to={`${Paths.MESSAGE_THREAD}${messageId}/`}
           data-dd-privacy="mask"
@@ -137,7 +137,7 @@ const ThreadListItem = props => {
         <div
           className="vads-u-font-weight--normal vads-u-color--gray-medium vads-u-margin-top--0p5"
           data-testid="received-date"
-          id="received-message-date"
+          id={`received-message-date-${messageId}`}
         >
           {formattedDate()}
         </div>
@@ -233,7 +233,7 @@ const ThreadListItem = props => {
         </div>
         <Link
           data-dd-action-name="Link to Message Subject Details"
-          aria-describedby="thread-message-date"
+          aria-describedby={`thread-message-date-${messageId}`}
           className="message-subject-link vads-u-margin-y--0p5"
           to={`${Paths.MESSAGE_THREAD}${messageId}/`}
           data-dd-privacy="mask"
@@ -261,7 +261,7 @@ const ThreadListItem = props => {
           )}
           <span
             data-testid="thread-date"
-            id="thread-message-date"
+            id={`thread-message-date-${messageId}`}
             data-dd-privacy="mask"
           >
             {formattedDate()}


### PR DESCRIPTION
## Summary
>
- In Secure Messaging, the message details links are not accessible.
- This update replaces the use of aria-label on links to use aria-describedby instead.
- When a screen reader is used on the links, it should read the link's text and the date associated with the message.
- This change is updated on the Inbox, Drafts, Send, and Trash screens.
>
## Related issue(s)
>
> ### [[MHV-56866]](https://jira.devops.va.gov/browse/MHV-56866) SM - Aria labels for list page links - 2.5.3 Label in Name (A)
>
> #### Description:
> All links are in violation of 2.5.3 Label in Name (A).
> The accessible code must match its visible label.
>
> For SM, on Inbox, Drafts, Sent, and Trash pages. The message details links in have the code of<a aria-label="Message subject: General: TEST, April 9, 2024. " ">General: TEST</span></a>
>
> We must remove the aria-label and use aria-describedby instead.
> The most useful thing here would be to associate the link in cards with the time/date via aria-describedby. @BobbyBaileyRB 
>
## Testing done
>
- N/A
>
## Screenshots
>
_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._
>
|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |
>
## What areas of the site does it impact?
>
*Va.gov - Secure Messaging*
>
## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
