### PR TITLE
Fix injected footer language links

### DIFF
--- a/src/platform/site-wide/va-footer/components/LanguageSupport.jsx
+++ b/src/platform/site-wide/va-footer/components/LanguageSupport.jsx
@@ -15,17 +15,18 @@ export const languageLinks = [
   {
     label: 'Español',
     lang: 'es',
-    href: '/asistencia-y-recursos-en-espanol',
+    href: 'https://va.gov/asistencia-y-recursos-en-espanol',
   },
   {
     label: 'Tagalog',
     lang: 'tl',
-    href: '/tagalog-wika-mapagkukunan-at-tulong',
+    href: 'https://va.gov/tagalog-wika-mapagkukunan-at-tulong',
   },
   {
     label: 'Other languages',
     lang: 'en',
-    href: '/resources/how-to-get-free-language-assistance-from-va/',
+    href:
+      'https://va.gov/resources/how-to-get-free-language-assistance-from-va/',
   },
 ];
 


### PR DESCRIPTION
## Summary
Our injected footer (e.g. https://www.cem.va.gov/) needs hardcoded va.gov links in the header and footer to navigate properly. We inadvertently broke this behavior in a 2023 PR, so now we need to revert it back to hardcoded for both the injected footer and the va.gov footer.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17812

## Testing done
Tested the injected footer locally and regression checked the va.gov footer.

## Screenshots
<img width="439" alt="Screenshot 2024-04-11 at 8 54 40 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/e5654955-b6c9-4279-ae3e-9741946c3877">
<img width="332" alt="Screenshot 2024-04-11 at 8 54 31 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/1d9594b5-d8bd-443c-9187-c82326b3ebb0">
<img width="302" alt="Screenshot 2024-04-11 at 8 54 28 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/a7ca8e85-dadf-4e31-945c-5b900b1a2577">

## What areas of the site does it impact?

Injected footer and va.gov footer.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [x] The vets-website header does not contain any web-components
- [x] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario