### PR TITLE
[DBEX] correct VA med record treatment date validation

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -1,5 +1,5 @@
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
-import dateUI from 'platform/forms-system/src/js/definitions/monthYear';
+import dateUI from 'platform/forms-system/src/js/definitions/currentOrPastMonthYear';
 import { treatmentView } from '../content/vaMedicalRecords';
 import { hasVAEvidence } from '../utils';
 import { makeSchemaForAllDisabilities } from '../utils/schemas';

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
+import moment from 'moment';
 import formConfig from '../../config/form';
 
 describe('VA Medical Records', () => {
@@ -230,6 +231,138 @@ describe('VA Medical Records', () => {
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error-message').length).to.equal(0);
     expect(onSubmit.calledOnce).to.be.true;
+    form.unmount();
+  });
+
+  it('should submit when treatment start date year without month equals earliest service start date year', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          ...claimType,
+          ratedDisabilities,
+          vaTreatmentFacilities: [
+            {
+              treatmentCenterName: 'Sommerset VA Clinic',
+              treatedDisabilityNames: {
+                diabetesmelitus: true,
+              },
+              treatmentDateRange: {
+                from: '2001-XX-XX',
+              },
+              treatmentCenterAddress: {
+                country: 'USA',
+                city: 'Sommerset',
+                state: 'VA',
+              },
+            },
+          ],
+          serviceInformation: {
+            servicePeriods: [
+              { dateRange: { from: '2012-01-12' }, serviceBranch: 'Army' },
+              { dateRange: { from: '2001-05-30' }, serviceBranch: 'Army' },
+            ],
+          },
+        }}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(0);
+    expect(onSubmit.calledOnce).to.be.true;
+    form.unmount();
+  });
+
+  it('should not submit when treatment start date includes a month but no year', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          ...claimType,
+          ratedDisabilities,
+          vaTreatmentFacilities: [
+            {
+              treatmentCenterName: 'Sommerset VA Clinic',
+              treatedDisabilityNames: {
+                diabetesmelitus: true,
+              },
+              treatmentDateRange: {
+                from: 'XXXX-05-XX',
+              },
+              treatmentCenterAddress: {
+                country: 'USA',
+                city: 'Sommerset',
+                state: 'VA',
+              },
+            },
+          ],
+          serviceInformation: {
+            servicePeriods: [
+              { dateRange: { from: '2012-01-12' } },
+              { dateRange: { from: '2001-06-30' } },
+            ],
+          },
+        }}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+
+  it('should not submit when treatment start date is in the future', () => {
+    const onSubmit = sinon.spy();
+    const futureDate = `${moment()
+      .add(1, 'month')
+      .format('YYYY-MM')}-XX`;
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          ...claimType,
+          ratedDisabilities,
+          vaTreatmentFacilities: [
+            {
+              treatmentCenterName: 'Sommerset VA Clinic',
+              treatedDisabilityNames: {
+                diabetesmelitus: true,
+              },
+              treatmentDateRange: {
+                from: futureDate,
+              },
+              treatmentCenterAddress: {
+                country: 'USA',
+                city: 'Sommerset',
+                state: 'VA',
+              },
+            },
+          ],
+          serviceInformation: {
+            servicePeriods: [
+              { dateRange: { from: '2012-01-12' } },
+              { dateRange: { from: '2001-06-30' } },
+            ],
+          },
+        }}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error-message').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
     form.unmount();
   });
 

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -267,7 +267,7 @@ describe('526 All Claims validations', () => {
       expect(err.addError.called).to.be.false;
     });
 
-    it('should add error if no treatment start date year is entered', () => {
+    it('should add error if only treatment start date month is entered', () => {
       const err = { addError: sinon.spy() };
 
       const formData = {

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -217,6 +217,31 @@ describe('526 All Claims validations', () => {
       expect(err.addError.called).to.be.false;
     });
 
+    it('should not add error if treatment start date year is the same as earliest active service start date year', () => {
+      const err = { addError: sinon.spy() };
+
+      const formData = {
+        serviceInformation: {
+          servicePeriods: [
+            { dateRange: { from: '2003-03-12' }, serviceBranch: 'Army' },
+            {
+              dateRange: { from: '2000-01-14' },
+              serviceBranch: 'Coast Guard Reserves',
+            },
+            { dateRange: { from: '2011-12-25' }, serviceBranch: 'Coast Guard' },
+            // ignored
+            {
+              dateRange: { from: '1990-10-11' },
+              serviceBranch: '',
+            },
+          ],
+        },
+      };
+
+      startedAfterServicePeriod(err, '2000-XX-XX', formData);
+      expect(err.addError.called).to.be.false;
+    });
+
     it('should not add error if treatment start date is after earliest active service start date', () => {
       const err = { addError: sinon.spy() };
 
@@ -240,6 +265,31 @@ describe('526 All Claims validations', () => {
 
       startedAfterServicePeriod(err, '2000-02-XX', formData);
       expect(err.addError.called).to.be.false;
+    });
+
+    it('should add error if no treatment start date year is entered', () => {
+      const err = { addError: sinon.spy() };
+
+      const formData = {
+        serviceInformation: {
+          servicePeriods: [
+            { dateRange: { from: '2003-03-12' }, serviceBranch: 'Army' },
+            {
+              dateRange: { from: '2000-01-14' },
+              serviceBranch: 'Army Reserves',
+            },
+            { dateRange: { from: '2011-12-25' }, serviceBranch: 'Army' },
+            // ignored
+            {
+              dateRange: { from: '1990-10-11' },
+              serviceBranch: '', // missing branch name
+            },
+          ],
+        },
+      };
+
+      startedAfterServicePeriod(err, 'XXXX-12-XX', formData);
+      expect(err.addError.calledOnce).to.be.true;
     });
 
     it('should not add error if serviceInformation is missing', () => {

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -344,8 +344,9 @@ export function startedAfterServicePeriod(err, fieldData, formData) {
   const treatmentStartDate = moment(fieldData, 'YYYY-MM');
   // If the moment is earlier than the moment passed to moment.diff(),
   // the return value will be negative.
-  if (
-    fieldData.match(/^XXXX-\d{2}-XX$/) ||
+  if (fieldData.match(/^XXXX-\d{2}-XX$/)) {
+    err.addError('Enter a month and year.');
+  } else if (
     (fieldData.match(/^\d{4}-XX-XX$/) &&
       treatmentStartDate.diff(earliestServiceStartDate, 'year') < 0) ||
     (fieldData.match(/^\d{4}-\d{2}-XX$/) &&

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -343,7 +343,7 @@ export function startedAfterServicePeriod(err, fieldData, formData) {
 
   const treatmentStartDate = moment(fieldData, 'YYYY-MM');
   // If the moment is earlier than the moment passed to moment.diff(),
-  // the return value will be negative
+  // the return value will be negative.
   if (
     fieldData.match(/^XXXX-\d{2}-XX$/) ||
     (fieldData.match(/^\d{4}-XX-XX$/) &&

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -346,7 +346,9 @@ export function startedAfterServicePeriod(err, fieldData, formData) {
   // the return value will be negative.
   if (fieldData.match(/^XXXX-\d{2}-XX$/)) {
     err.addError('Enter a month and year.');
-  } else if (
+    return;
+  }
+  if (
     (fieldData.match(/^\d{4}-XX-XX$/) &&
       treatmentStartDate.diff(earliestServiceStartDate, 'year') < 0) ||
     (fieldData.match(/^\d{4}-\d{2}-XX$/) &&

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -336,27 +336,32 @@ export function findEarliestServiceStartDate(servicePeriods) {
       moment(),
     );
 }
-
+export function isMonthOnly(fieldData) {
+  return /^XXXX-\d{2}-XX$/.test(fieldData);
+}
+export function isYearOnly(fieldData) {
+  return /^\d{4}-XX-XX$/.test(fieldData);
+}
+export function isYearMonth(fieldData) {
+  return /^\d{4}-\d{2}-XX$/.test(fieldData);
+}
 export function startedAfterServicePeriod(err, fieldData, formData) {
   if (!_.get('servicePeriods.length', formData.serviceInformation, false)) {
     return;
   }
 
-  const isMonthOnly = /^XXXX-\d{2}-XX$/.test(fieldData);
-  const isYearOnly = /^\d{4}-XX-XX$/.test(fieldData);
-  const isYearMonth = /^\d{4}-\d{2}-XX$/.test(fieldData);
   const treatmentStartDate = moment(fieldData, 'YYYY-MM');
   const { servicePeriods } = formData.serviceInformation;
   const earliestServiceStartDate = findEarliestServiceStartDate(servicePeriods);
 
-  if (isMonthOnly) {
+  if (isMonthOnly(fieldData)) {
     err.addError('Enter a month and year.');
     return;
   }
   if (
-    (isYearOnly &&
+    (isYearOnly(fieldData) &&
       treatmentStartDate.diff(earliestServiceStartDate, 'year') < 0) ||
-    (isYearMonth &&
+    (isYearMonth(fieldData) &&
       treatmentStartDate.diff(earliestServiceStartDate, 'month') < 0)
   ) {
     err.addError(

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -326,12 +326,8 @@ export const isValidYear = (err, fieldData) => {
  * first visited the facility.
  * @param {Object} formData - Full formData for the form
  */
-export function startedAfterServicePeriod(err, fieldData, formData) {
-  if (!_.get('servicePeriods.length', formData.serviceInformation, false)) {
-    return;
-  }
-
-  const earliestServiceStartDate = formData.serviceInformation.servicePeriods
+export function findEarliestServiceStartDate(servicePeriods) {
+  return servicePeriods
     .filter(({ serviceBranch } = {}) => (serviceBranch || '') !== '')
     .map(period => moment(period.dateRange.from, 'YYYY-MM-DD'))
     .reduce(
@@ -339,11 +335,19 @@ export function startedAfterServicePeriod(err, fieldData, formData) {
         current.isBefore(earliestDate) ? current : earliestDate,
       moment(),
     );
+}
 
-  const isYearMonth = /^\d{4}-\d{2}-XX$/.test(fieldData);
-  const isYearOnly = /^\d{4}-XX-XX$/.test(fieldData);
+export function startedAfterServicePeriod(err, fieldData, formData) {
+  if (!_.get('servicePeriods.length', formData.serviceInformation, false)) {
+    return;
+  }
+
   const isMonthOnly = /^XXXX-\d{2}-XX$/.test(fieldData);
+  const isYearOnly = /^\d{4}-XX-XX$/.test(fieldData);
+  const isYearMonth = /^\d{4}-\d{2}-XX$/.test(fieldData);
   const treatmentStartDate = moment(fieldData, 'YYYY-MM');
+  const { servicePeriods } = formData.serviceInformation;
+  const earliestServiceStartDate = findEarliestServiceStartDate(servicePeriods);
 
   if (isMonthOnly) {
     err.addError('Enter a month and year.');

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -343,8 +343,14 @@ export function startedAfterServicePeriod(err, fieldData, formData) {
 
   const treatmentStartDate = moment(fieldData, 'YYYY-MM');
   // If the moment is earlier than the moment passed to moment.diff(),
-  // the return value will be negative.
-  if (treatmentStartDate.diff(earliestServiceStartDate, 'month') < 0) {
+  // the return value will be negative
+  if (
+    fieldData.match(/^XXXX-\d{2}-XX$/) ||
+    (fieldData.match(/^\d{4}-XX-XX$/) &&
+      treatmentStartDate.diff(earliestServiceStartDate, 'year') < 0) ||
+    (fieldData.match(/^\d{4}-\d{2}-XX$/) &&
+      treatmentStartDate.diff(earliestServiceStartDate, 'month') < 0)
+  ) {
     err.addError(
       'Your first treatment date needs to be after the start of your earliest service period.',
     );


### PR DESCRIPTION
The current treatment date validation logic does not compare against the earliest service start date year when only a treatment year is provided. For example, if the earliest service period was May 1, 2000, and only the treatment year of 2000 is entered, an error is returned. If only a treatment month is entered, and no year, the date is considered valid. A future treatment date is also valid. This PR corrects for these identified validation issues.

## Summary

- Conditional logic was modified to address identified issues and tests were added
  - Future dates are now invalid
  - Entering only a month is now invalid
  - A treatment year equal to the earliest service start date year is now valid
- Disability Benefits Experience Team 2 (dBeX Carbs 🥖)

## Related issue(s)

- [69020](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/69020)
- [77849](https://github.com/department-of-veterans-affairs/va.gov-team/issues/77849)

## Testing done

- Prior to the change:
  - entering a future date would **not** return an error
  - entering only a month and no year would **not** return an error
  - entering only a year that was equal to the earliest service start date year would return an error
- In addition to manual testing, supplemental tests were created to verify updates to the conditional logic that correct for these undesirable outcomes

## Screenshots

Depicts updates to conditional error messaging given an earliest service start date of February 28, 2000:

<img width="292" alt="Screenshot 2024-04-11 at 11 46 23 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/50811220/12561ac8-b5ae-4591-9548-ea7c62bf0658">
<img width="292" alt="Screenshot 2024-04-11 at 11 45 55 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/50811220/64e6a978-d504-4dfd-9152-52a587cb7562">
<img width="292" alt="Screenshot 2024-04-11 at 11 46 16 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/50811220/a74488f0-ac74-481b-9fab-d0d5836844a3">
<img width="292" alt="Screenshot 2024-04-11 at 11 46 10 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/50811220/f54990af-321e-40f3-8e62-d21cd73539d1">
<img width="292" alt="Screenshot 2024-04-11 at 11 46 04 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/50811220/50d485bc-46a0-472c-baec-803279b97033">

**N.b.** Treatment date input is optional. 

## What areas of the site does it impact?

Form 526 > Supporting Evidence > VA Medical Records > First treatment date

## Acceptance criteria

### Quality Assurance & Testing

- [X] I added unit tests and integration tests for each feature
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Screenshot of the developed feature is added

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user
