### PR TITLE
DR | Only show v3 progress bar

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -102,6 +102,8 @@ const formConfig = {
   // when true, initial focus on page to H3s by default, and enable page
   // scrollAndFocusTarget (selector string or function to scroll & focus)
   useCustomScrollAndFocus: true,
+  // Fix double headers (only show v3)
+  v3SegmentedProgressBar: true,
 
   chapters: {
     infoPages: {

--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -114,6 +114,8 @@ const formConfig = {
   // when true, initial focus on page to H3s by default, and enable page
   // scrollAndFocusTarget (selector string or function to scroll & focus)
   useCustomScrollAndFocus: true,
+  // Fix double headers (only show v3)
+  v3SegmentedProgressBar: true,
 
   additionalRoutes: [
     {

--- a/src/applications/appeals/996/config/form.js
+++ b/src/applications/appeals/996/config/form.js
@@ -100,6 +100,8 @@ const formConfig = {
   // when true, initial focus on page to H3s by default, and enable page
   // scrollAndFocusTarget (selector string or function to scroll & focus)
   useCustomScrollAndFocus: true,
+  // Fix double headers (only show v3)
+  v3SegmentedProgressBar: true,
 
   additionalRoutes: [
     {


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Our Decision Review forms are showing both the old progress bar and the new V3 progress bar at the same time. Adding a `v3SegmentedProgressBar: true` to the form config fixes the issue.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Recommended solution until [main ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/79012) work is completed 
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#80632](https://github.com/department-of-veterans-affairs/va.gov-team/issues/80632)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Double headers
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Visual testing only
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="680" alt="Screenshot 2024-04-11 at 1 41 22 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/539f1437-9468-4660-8889-25659fa1df1a"> | <img width="701" alt="Screenshot 2024-04-11 at 1 41 15 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/c48663dd-221a-4250-b4c8-934c9af5ffc5"> |

## What areas of the site does it impact?

Decision Reviews forms - HLR, NOD & Supplemental Claims

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
