### PR TITLE
[CST] Adding extra statuses to getStatusContent

### DIFF
--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -731,7 +731,7 @@ export function getStatusContents(appeal, name = {}) {
       );
       break;
     }
-    // TODO: Remove this if Caseflow fixes the issue on their end
+    // TODO: Remove this if Caseflow fixes the typo issue on their end
     case 'sc_recieved':
     case STATUS_TYPES.scReceived:
       contents.title = 'A reviewer is examining your new evidence';
@@ -864,6 +864,22 @@ export function getStatusContents(appeal, name = {}) {
           and will return your case to the Board of Veterans’ Appeals.
         </p>
       );
+      break;
+    // We need to add content for these, but adding cases for them so that they
+    // don't get logged to Sentry anymore. This will help prevent other unknown
+    // statuses from getting overshadowed by these
+    // Github Tickets
+    // motion:
+    //   https://github.com/department-of-veterans-affairs/va.gov-team/issues/80665
+    // pre_docketed:
+    //   https://github.com/department-of-veterans-affairs/va.gov-team/issues/80647
+    case 'motion':
+    case 'pre_docketed':
+      contents.title = 'We don’t know your status';
+      contents.description = (
+        <p>We’re sorry, VA.gov will soon be updated to show your status.</p>
+      );
+
       break;
     default:
       contents.title = 'We don’t know your status';


### PR DESCRIPTION
## Summary
Adding cases for appeal statuses `motion` and `pre_docketed` so that we don't log messages to Sentry whenever these 2 statuses are encountered anymore. We see 30+ messages a day related to unknown appeal statuses which makes it time consuming to manually go through every one of them to determine if there are other statuses that are not one of these 2 that are unaccounted for. We have separate tickets for creating new content for these statuses as well

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#80669

## Screenshots
<img width="492" alt="Screenshot 2024-04-12 at 10 57 21 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/a4c6d52a-dbb7-4760-b792-30ea5ec2f43f">

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
