### PR TITLE
HLR & SC | Fix subtask footers

### DIFF
--- a/src/applications/appeals/995/subtask/SubTaskContainer.jsx
+++ b/src/applications/appeals/995/subtask/SubTaskContainer.jsx
@@ -1,22 +1,9 @@
 import React from 'react';
 
-import SubTask from '~/platform/forms/sub-task';
-
 import pages from './pages';
 
-import GetFormHelp from '../../shared/content/GetFormHelp';
+import SubTaskWrap from '../../shared/components/SubTaskWrap';
 
-export const SubTaskContainer = () => {
-  return (
-    <>
-      <article data-page="start">
-        <SubTask pages={pages} />
-      </article>
-      <va-need-help>
-        <GetFormHelp />
-      </va-need-help>
-    </>
-  );
-};
+export const SubTaskContainer = () => <SubTaskWrap pages={pages} />;
 
 export default SubTaskContainer;

--- a/src/applications/appeals/996/subtask/SubTaskContainer.jsx
+++ b/src/applications/appeals/996/subtask/SubTaskContainer.jsx
@@ -1,22 +1,9 @@
 import React from 'react';
 
-import SubTask from '~/platform/forms/sub-task';
-
 import pages from './pages';
 
-import GetFormHelp from '../../shared/content/GetFormHelp';
+import SubTaskWrap from '../../shared/components/SubTaskWrap';
 
-export const SubTaskContainer = () => {
-  return (
-    <>
-      <article data-page="start">
-        <SubTask pages={pages} />
-      </article>
-      <va-need-help>
-        <GetFormHelp />
-      </va-need-help>
-    </>
-  );
-};
+export const SubTaskContainer = () => <SubTaskWrap pages={pages} />;
 
 export default SubTaskContainer;

--- a/src/applications/appeals/shared/components/SubTaskWrap.jsx
+++ b/src/applications/appeals/shared/components/SubTaskWrap.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import SubTask from '~/platform/forms/sub-task';
+
+import GetFormHelp from '../content/GetFormHelp';
+
+const SubTaskWrap = ({ pages }) => (
+  <>
+    <div className="vads-u-margin-bottom--4">
+      <SubTask pages={pages} />
+    </div>
+    <va-need-help>
+      <div slot="content">
+        <GetFormHelp />
+      </div>
+    </va-need-help>
+  </>
+);
+
+export default SubTaskWrap;


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > With the `FormFooter` changes merged in yesterday, the HLR & SC footers within their subtasks are not displaying any content. This is currently only an issue in staging.
- _(If bug, how to reproduce)_
  > Go to [HLR subtask](https://staging.va.gov/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996/start) or [SC subtask](https://staging.va.gov/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/start) and look at the need help section in the footer
- _(What is the solution, why is this the solution)_
  > - Update SubTask to include a `slot` for the `va-need-help` web component
  > - Move common SubTask code into the shared folder
  > - Adjust margin below subtask page to add spacing above the back & continue buttons
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#57821](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57821)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| HLR & SC subtask  | ![Screenshot 2024-04-12 at 10 43 51 AM](https://github.com/department-of-veterans-affairs/va.gov-team/assets/111457818/2f31e344-f61a-496f-b235-e3691f29122a) | <img width="709" alt="Screenshot 2024-04-12 at 11 14 34 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/88566828-8d4b-42c0-83bf-44753a428eee"> |

## What areas of the site does it impact?

HLR & SC subtask pages

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
