### PR TITLE
Bumping component-library up to 38.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
     "@babel/runtime": "^7.15.4",
     "@datadog/browser-logs": "^5.8.0",
     "@datadog/browser-rum": "^4.49.0",
-    "@department-of-veterans-affairs/component-library": "^38.0.3",
+    "@department-of-veterans-affairs/component-library": "^38.0.4",
     "@department-of-veterans-affairs/css-library": "^0.3.0",
     "@department-of-veterans-affairs/formation": "^10.1.2",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2863,13 +2863,13 @@
   resolved "https://registry.yarnpkg.com/@datadog/sketches-js/-/sketches-js-2.1.0.tgz#8c7e8028a5fc22ad102fa542b0a446c956830455"
   integrity sha512-smLocSfrt3s53H/XSVP3/1kP42oqvrkjUPtyaFd1F79ux24oE31BKt+q0c6lsa6hOYrFzsIwyc5GXAI5JmfOew==
 
-"@department-of-veterans-affairs/component-library@^38.0.3":
-  version "38.0.3"
-  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/component-library/-/component-library-38.0.3.tgz#13c0f2ea3bc4803be53d596c9f8bc8ef30008b76"
-  integrity sha512-PdOEwOr8VGc2QtwZwZoW9L7d0nf5NbGOnzNjnLksMDb9YsXHS5eTkMVIBsQ9OpuaVaWVAMvdTA5fGx6qF3HcAA==
+"@department-of-veterans-affairs/component-library@^38.0.4":
+  version "38.0.4"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/component-library/-/component-library-38.0.4.tgz#4b4c30309bf6b3ca1dac1001ce8e7abfe0fe561b"
+  integrity sha512-QXa8lK3hD8z3rn68Jya3+i8QoxMUr1JQkAYJWnct452mIiyvjKgzAFqd5u57pbwNHi7im5kfIkbtex9Vu/CyCA==
   dependencies:
     "@department-of-veterans-affairs/react-components" "28.0.0"
-    "@department-of-veterans-affairs/web-components" "6.0.5"
+    "@department-of-veterans-affairs/web-components" "6.0.7"
     i18next "^21.6.14"
     i18next-browser-languagedetector "^6.1.4"
     react-focus-on "^3.5.1"
@@ -2956,10 +2956,10 @@
   dependencies:
     minimist "^1.2.6"
 
-"@department-of-veterans-affairs/web-components@6.0.5":
-  version "6.0.5"
-  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/web-components/-/web-components-6.0.5.tgz#cb1ead1f5d923637edd1ded1110b102178b363c6"
-  integrity sha512-UkZ7DniN9q+TJkUvlxfr3RdsaVHaD9XE97utg3NqISiwTV2f86LSsivU3IVAt9mlmQKl9vLkAS6Q5oZMTTCReA==
+"@department-of-veterans-affairs/web-components@6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/web-components/-/web-components-6.0.7.tgz#17f6a0ba47f5d1498bbe929ef457d0ee4c62da0a"
+  integrity sha512-TPdOcdkF967C0wS3FBWBezzNqXvOREwrc8SYRofFrEJriZiOm6Mb9SXDyZG6v0CWIiGVESdlzBWwColPuL7dRA==
   dependencies:
     "@department-of-veterans-affairs/css-library" "^0.5.1"
     "@stencil/core" "^2.19.2"


### PR DESCRIPTION
## Summary

- Bumping component-library to 38.0.4
- Adds some new icons to va-icon

## Related issue(s)
N/A

## Testing done

None

## Screenshots

N/A

## What areas of the site does it impact?

- Makes new icons available wherever va-icon is being used.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [X] The vets-website header does not contain any web-components
- [X] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [X] I reached out in the `#sitewide-public-websites` Slack channel for questions
