### PR TITLE
[DR-80433] Replace moment.js with date-fns in shared folder

### DIFF
--- a/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/10182/tests/utils/submit.unit.spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { sub } from 'date-fns';
 
 import { SHOW_PART3 } from '../../constants';
 import {
@@ -14,9 +15,9 @@ import {
 } from '../../utils/submit';
 
 import { SELECTED } from '../../../shared/constants';
-import { getDate } from '../../../shared/utils/dates';
+import { parseDate } from '../../../shared/utils/dates';
 
-const validDate1 = getDate({ offset: { months: -2 } });
+const validDate1 = parseDate(sub(new Date(), { months: 2 }));
 const issue1 = {
   raw: {
     type: 'contestableIssue',
@@ -54,7 +55,7 @@ const issue1 = {
   },
 };
 
-const validDate2 = getDate({ offset: { months: -4 } });
+const validDate2 = parseDate(sub(new Date(), { months: 4 }));
 const issue2 = {
   raw: {
     type: 'contestableIssue',

--- a/src/applications/appeals/10182/tests/validations/date.unit.spec.js
+++ b/src/applications/appeals/10182/tests/validations/date.unit.spec.js
@@ -1,10 +1,11 @@
 import { expect } from 'chai';
 
+import { addWeeks, sub } from 'date-fns';
 import { validateDate, isValidDate } from '../../validations/date';
 import { issueErrorMessages } from '../../content/addIssue';
 import { SHOW_PART3 } from '../../constants';
 
-import { getDate } from '../../../shared/utils/dates';
+import { parseDate } from '../../../shared/utils/dates';
 
 describe('validateDate & isValidDate', () => {
   let errorMessage = [];
@@ -19,7 +20,7 @@ describe('validateDate & isValidDate', () => {
   });
 
   it('should allow valid dates', () => {
-    const date = getDate({ offset: { weeks: -1 } });
+    const date = parseDate(sub(new Date(), { weeks: 1 }));
     validateDate(errors, date);
     expect(errorMessage[0]).to.be.undefined;
     expect(isValidDate(date)).to.be.true;
@@ -62,7 +63,7 @@ describe('validateDate & isValidDate', () => {
     expect(isValidDate('1899')).to.be.false;
   });
   it('should throw an error for dates in the future', () => {
-    const date = getDate({ offset: { weeks: 1 } });
+    const date = parseDate(addWeeks(new Date(), 1));
     validateDate(errors, date);
     expect(errorMessage[0]).to.eq(issueErrorMessages.pastDate);
     expect(errorMessage[1]).to.not.contain('month');
@@ -72,7 +73,7 @@ describe('validateDate & isValidDate', () => {
     expect(isValidDate(date)).to.be.false;
   });
   it('should throw an error for todays date', () => {
-    const date = getDate();
+    const date = parseDate(new Date());
     validateDate(errors, date);
     expect(errorMessage[0]).to.eq(issueErrorMessages.pastDate);
     expect(errorMessage[1]).to.not.contain('month');
@@ -82,7 +83,7 @@ describe('validateDate & isValidDate', () => {
     expect(isValidDate(date)).to.be.false;
   });
   it('should throw an error for dates in the distant past', () => {
-    const date = getDate({ offset: { years: -2 } });
+    const date = parseDate(sub(new Date(), { years: 2 }));
     validateDate(errors, date);
     expect(errorMessage[0]).to.eq(issueErrorMessages.recentDate);
     expect(errorMessage[1]).to.not.contain('month');
@@ -93,7 +94,7 @@ describe('validateDate & isValidDate', () => {
   });
   it('should throw a invalid date for truncated dates', () => {
     // Testing 'YYYY-MM-' (contact center reported errors; FE seeing this)
-    const date = getDate({ offset: { weeks: 1 } }).substring(0, 8);
+    const date = parseDate(addWeeks(new Date(), 1)).substring(0, 8);
     validateDate(errors, date);
     expect(errorMessage[0]).to.eq(issueErrorMessages.blankDecisionDate);
     expect(errorMessage[1]).to.not.contain('month');
@@ -104,7 +105,7 @@ describe('validateDate & isValidDate', () => {
   });
   it('should throw a invalid date for truncated dates', () => {
     // Testing 'YYYY--DD' (contact center reported errors; BE seeing this)
-    const date = getDate({ offset: { weeks: 1 } }).replace(/-.*-/, '--');
+    const date = parseDate(addWeeks(new Date(), 1)).replace(/-.*-/, '--');
     validateDate(errors, date);
     expect(errorMessage[0]).to.eq(issueErrorMessages.blankDecisionDate);
     expect(errorMessage[1]).to.contain('month');
@@ -114,12 +115,12 @@ describe('validateDate & isValidDate', () => {
     expect(isValidDate(date)).to.be.false;
   });
   it('should not throw an error for older dates when feature toggle is set to support the new form', () => {
-    const date = getDate({ offset: { years: -2 } });
+    const date = parseDate(sub(new Date(), { years: 2 }));
     validateDate(errors, date, { [SHOW_PART3]: true });
     expect(errorMessage[0]).to.be.undefined;
   });
   it('should throw an error for dates in the distant past when feature toggle is set to support the new form', () => {
-    const date = getDate({ offset: { years: -110 } });
+    const date = parseDate(sub(new Date(), { years: 110 }));
     validateDate(errors, date, { [SHOW_PART3]: true });
     expect(errorMessage[0]).to.eq(issueErrorMessages.newerDate);
     expect(errorMessage[1]).to.not.contain('month');

--- a/src/applications/appeals/995/components/EvidenceSummaryLists.jsx
+++ b/src/applications/appeals/995/components/EvidenceSummaryLists.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
 import PropTypes from 'prop-types';
-import { parse } from 'date-fns';
 
 import readableList from 'platform/forms-system/src/js/utilities/data/readableList';
 
@@ -47,10 +46,11 @@ const removeButtonClass = [
 
 const formatDate = (date = '') => {
   // Use `parse` from date-fns because it is a non-ISO8061 formatted date string
-  const parsedDate = parse(date, FORMAT_YMD_DATE_FNS, new Date());
-  const result = parseDate(parsedDate, FORMAT_COMPACT_DATE_FNS) || '';
+  // const parsedDate = parse(date, FORMAT_YMD_DATE_FNS, new Date());
+  const result =
+    parseDate(date, FORMAT_COMPACT_DATE_FNS, FORMAT_YMD_DATE_FNS) || '';
   // Not entirely sure what this check is for — can we just return `result`?
-  return result.includes(',') ? result : '';
+  return result || '';
 };
 
 /**

--- a/src/applications/appeals/995/components/EvidenceSummaryLists.jsx
+++ b/src/applications/appeals/995/components/EvidenceSummaryLists.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { Link } from 'react-router';
 import PropTypes from 'prop-types';
+import { parse } from 'date-fns';
 
 import readableList from 'platform/forms-system/src/js/utilities/data/readableList';
 
 import { content } from '../content/evidenceSummary';
 import { content as limitContent } from '../content/evidencePrivateLimitation';
-import { getDate } from '../../shared/utils/dates';
+import { parseDate } from '../../shared/utils/dates';
 
 import {
   EVIDENCE_VA_PATH,
@@ -17,7 +18,10 @@ import {
   LIMITATION_KEY,
 } from '../constants';
 
-import { FORMAT_COMPACT } from '../../shared/constants';
+import {
+  FORMAT_COMPACT_DATE_FNS,
+  FORMAT_YMD_DATE_FNS,
+} from '../../shared/constants';
 
 const listClassNames = [
   'vads-u-border-top--1px',
@@ -42,7 +46,10 @@ const removeButtonClass = [
 ].join(' ');
 
 const formatDate = (date = '') => {
-  const result = getDate({ date, pattern: FORMAT_COMPACT });
+  // Use `parse` from date-fns because it is a non-ISO8061 formatted date string
+  const parsedDate = parse(date, FORMAT_YMD_DATE_FNS, new Date());
+  const result = parseDate(parsedDate, FORMAT_COMPACT_DATE_FNS) || '';
+  // Not entirely sure what this check is for — can we just return `result`?
   return result.includes(',') ? result : '';
 };
 

--- a/src/applications/appeals/995/content/IssueSummary.jsx
+++ b/src/applications/appeals/995/content/IssueSummary.jsx
@@ -1,10 +1,8 @@
 import React from 'react';
 
-import { getDate } from '../../shared/utils/dates';
 import { NO_ISSUES_SELECTED } from '../constants';
 
-import { FORMAT_READABLE } from '../../shared/constants';
-import { getSelected } from '../../shared/utils/issues';
+import { getSelected, getDecisionDate } from '../../shared/utils/issues';
 import { data995 } from '../../shared/props';
 
 const legendClassNames = [
@@ -46,13 +44,7 @@ const IssueSummary = ({ formData }) => {
                   className="dd-privacy-hidden"
                   data-dd-action-name="rated issue decision date"
                 >
-                  {getDate({
-                    date:
-                      issue.attributes?.approxDecisionDate ||
-                      issue.decisionDate ||
-                      '',
-                    pattern: FORMAT_READABLE,
-                  })}
+                  {getDecisionDate(issue)}
                 </span>
               </div>
             </li>

--- a/src/applications/appeals/995/tests/995.cypress.helpers.js
+++ b/src/applications/appeals/995/tests/995.cypress.helpers.js
@@ -1,12 +1,4 @@
-import { getDate } from '../../shared/utils/dates';
-
-export const getRandomDate = () =>
-  getDate({
-    offset: {
-      months: -Math.floor(Math.random() * 6 + 1),
-      days: -Math.floor(Math.random() * 10),
-    },
-  });
+import { addMonths, formatISO } from 'date-fns';
 
 export const fetchItf = () => ({
   data: {
@@ -18,7 +10,7 @@ export const fetchItf = () => ({
           id: '1',
           creationDate: '2022-07-28T19:53:45.810+00:00',
           // pattern null = ISO8601 format
-          expirationDate: getDate({ offset: { months: 3 }, pattern: null }),
+          expirationDate: formatISO(addMonths(new Date(), 3)),
           participantId: 1,
           source: 'EBN',
           status: 'active',

--- a/src/applications/appeals/995/tests/components/EvidencePrivateRecords.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidencePrivateRecords.unit.spec.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
+import { addYears, sub } from 'date-fns';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
 
@@ -15,7 +16,7 @@ import {
   NO_ISSUES_SELECTED,
 } from '../../constants';
 
-import { getDate } from '../../../shared/utils/dates';
+import { parseDate } from '../../../shared/utils/dates';
 import { SELECTED } from '../../../shared/constants';
 import { clickAddAnother, clickBack, clickContinue } from './helpers';
 
@@ -27,7 +28,7 @@ import { clickAddAnother, clickBack, clickContinue } from './helpers';
 | Partial  | Focus error | Modal & Prev page  | Focus error      |
  */
 describe('<EvidencePrivateRecords>', () => {
-  const validDate = getDate({ offset: { months: -2 } });
+  const validDate = parseDate(sub(new Date(), { months: 2 }));
   const mockData = {
     contestedIssues: [
       {
@@ -558,7 +559,7 @@ describe('<EvidencePrivateRecords>', () => {
     const toBlurEvent = new CustomEvent('blur', { detail: 'to' });
 
     it('should show error when start treatment date is in the future', async () => {
-      const from = getDate({ offset: { years: +1 } });
+      const from = parseDate(addYears(new Date(), 1));
       const data = {
         ...mockData,
         providerFacility: [{ treatmentDateRange: { from } }],
@@ -579,7 +580,7 @@ describe('<EvidencePrivateRecords>', () => {
     });
 
     it('should show error when last treatment date is in the future', async () => {
-      const to = getDate({ offset: { years: +1 } });
+      const to = parseDate(addYears(new Date(), 1));
       const data = {
         ...mockData,
         providerFacility: [{ treatmentDateRange: { to } }],
@@ -600,7 +601,7 @@ describe('<EvidencePrivateRecords>', () => {
     });
 
     it('should show an error when the start treatment date is too far in the past', async () => {
-      const from = getDate({ offset: { years: -101 } });
+      const from = parseDate(sub(new Date(), { years: 101 }));
       const data = {
         ...mockData,
         providerFacility: [{ treatmentDateRange: { from } }],
@@ -621,7 +622,7 @@ describe('<EvidencePrivateRecords>', () => {
     });
 
     it('should show an error when the last treatment date is too far in the past', async () => {
-      const to = getDate({ offset: { years: -101 } });
+      const to = parseDate(sub(new Date(), { years: 101 }));
       const data = {
         ...mockData,
         providerFacility: [{ treatmentDateRange: { to } }],
@@ -642,8 +643,8 @@ describe('<EvidencePrivateRecords>', () => {
     });
 
     it('should show an error when the last treatment date is before the start', async () => {
-      const from = getDate({ offset: { years: -5 } });
-      const to = getDate({ offset: { years: -10 } });
+      const from = parseDate(sub(new Date(), { years: 5 }));
+      const to = parseDate(sub(new Date(), { years: 10 }));
       const data = {
         ...mockData,
         providerFacility: [{ treatmentDateRange: { from, to } }],

--- a/src/applications/appeals/995/tests/components/EvidenceVaRecords.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/EvidenceVaRecords.unit.spec.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
+import { addYears, sub } from 'date-fns';
 import { render, fireEvent, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
 
@@ -15,7 +16,7 @@ import {
   NO_ISSUES_SELECTED,
 } from '../../constants';
 
-import { getDate } from '../../../shared/utils/dates';
+import { parseDate } from '../../../shared/utils/dates';
 import { MAX_LENGTH, SELECTED } from '../../../shared/constants';
 
 import { clickAddAnother, clickBack, clickContinue } from './helpers';
@@ -28,7 +29,7 @@ import { clickAddAnother, clickBack, clickContinue } from './helpers';
 | Partial  | Focus error | Modal & Prev page  | Focus error      |
  */
 describe('<EvidenceVaRecords>', () => {
-  const validDate = getDate({ offset: { months: -2 } });
+  const validDate = parseDate(sub(new Date(), { months: 2 }));
   const mockData = {
     contestedIssues: [
       {
@@ -540,7 +541,7 @@ describe('<EvidenceVaRecords>', () => {
     });
 
     it('should show error when start treatment date is in the future', async () => {
-      const from = getDate({ offset: { years: +1 } });
+      const from = parseDate(addYears(new Date(), 1));
       const data = {
         ...mockData,
         locations: [{ evidenceDates: { from } }],
@@ -561,7 +562,7 @@ describe('<EvidenceVaRecords>', () => {
     });
 
     it('should show error when last treatment date is in the future', async () => {
-      const to = getDate({ offset: { years: +1 } });
+      const to = parseDate(addYears(new Date(), 1));
       const data = {
         ...mockData,
         locations: [{ evidenceDates: { to } }],
@@ -582,7 +583,7 @@ describe('<EvidenceVaRecords>', () => {
     });
 
     it('should show an error when the start treament date is too far in the past', async () => {
-      const from = getDate({ offset: { years: -101 } });
+      const from = parseDate(sub(new Date(), { years: 101 }));
       const data = {
         ...mockData,
         locations: [{ evidenceDates: { from } }],
@@ -603,7 +604,7 @@ describe('<EvidenceVaRecords>', () => {
     });
 
     it('should show an error when the last treatment date is too far in the past', async () => {
-      const to = getDate({ offset: { years: -101 } });
+      const to = parseDate(sub(new Date(), { years: 101 }));
       const data = {
         ...mockData,
         locations: [{ evidenceDates: { to } }],
@@ -624,8 +625,8 @@ describe('<EvidenceVaRecords>', () => {
     });
 
     it('should show an error when the last treatment date is before the start', async () => {
-      const from = getDate({ offset: { years: -5 } });
-      const to = getDate({ offset: { years: -10 } });
+      const from = parseDate(sub(new Date(), { years: 5 }));
+      const to = parseDate(sub(new Date(), { years: 10 }));
       const data = {
         ...mockData,
         locations: [{ evidenceDates: { from, to } }],

--- a/src/applications/appeals/995/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/helpers.unit.spec.js
@@ -1,5 +1,5 @@
-import moment from 'moment';
 import { expect } from 'chai';
+import { startOfDay, sub } from 'date-fns';
 
 import {
   getEligibleContestableIssues,
@@ -8,7 +8,7 @@ import {
 
 import { LEGACY_TYPE, SELECTED } from '../../../shared/constants';
 import { getItemSchema, isEmptyObject } from '../../../shared/utils/helpers';
-import { getDate } from '../../../shared/utils/dates';
+import { parseDate } from '../../../shared/utils/dates';
 import {
   appStateSelector,
   calculateIndexOffset,
@@ -24,7 +24,7 @@ import {
 } from '../../../shared/utils/issues';
 
 describe('getEligibleContestableIssues', () => {
-  const date = moment().startOf('day');
+  const date = startOfDay(new Date());
 
   const getIssue = (text, description = '', dateOffset) => ({
     type: 'contestableIssue',
@@ -32,13 +32,13 @@ describe('getEligibleContestableIssues', () => {
       ratingIssueSubjectText: text,
       description,
       approxDecisionDate: dateOffset
-        ? getDate({ date, offset: { months: dateOffset } })
+        ? parseDate(sub(date, { months: dateOffset }))
         : '',
     },
   });
-  const olderIssue = getIssue('Issue 1', '', -25);
-  const eligibleIssue = getIssue('Issue 2', '', -10);
-  const deferredIssue = getIssue('Issue 3', 'this is a deferred issue', -1);
+  const olderIssue = getIssue('Issue 1', '', 25);
+  const eligibleIssue = getIssue('Issue 2', '', 10);
+  const deferredIssue = getIssue('Issue 3', 'this is a deferred issue', 1);
   const emptyDateIssue = getIssue('Issue 4');
 
   it('should return empty array', () => {

--- a/src/applications/appeals/995/tests/validations/date.unit.spec.js
+++ b/src/applications/appeals/995/tests/validations/date.unit.spec.js
@@ -1,9 +1,10 @@
 import { expect } from 'chai';
+import { addWeeks, sub } from 'date-fns';
 
 import { validateDate, isValidDate } from '../../validations/date';
 import { errorMessages } from '../../constants';
 
-import { getDate } from '../../../shared/utils/dates';
+import { parseDate } from '../../../shared/utils/dates';
 import { MAX_YEARS_PAST } from '../../../shared/constants';
 
 describe('validateDate & isValidDate', () => {
@@ -19,7 +20,7 @@ describe('validateDate & isValidDate', () => {
   });
 
   it('should allow valid dates', () => {
-    const date = getDate({ offset: { weeks: -1 } });
+    const date = parseDate(sub(new Date(), { weeks: 1 }));
     validateDate(errors, date);
     expect(errorMessage[0]).to.be.undefined;
     expect(isValidDate(date)).to.be.true;
@@ -76,7 +77,7 @@ describe('validateDate & isValidDate', () => {
     expect(isValidDate('1899')).to.be.false;
   });
   it('should throw an error for dates in the future', () => {
-    const date = getDate({ offset: { weeks: 1 } });
+    const date = parseDate(addWeeks(new Date(), 1));
     validateDate(errors, date);
     expect(errorMessage[0]).to.eq(errorMessages.decisions.pastDate);
     expect(errorMessage[1]).to.not.contain('month');
@@ -86,7 +87,7 @@ describe('validateDate & isValidDate', () => {
     expect(isValidDate(date)).to.be.false;
   });
   it('should throw an error for todays date', () => {
-    const date = getDate();
+    const date = parseDate(new Date());
     validateDate(errors, date);
     expect(errorMessage[0]).to.eq(errorMessages.decisions.pastDate);
     expect(errorMessage[1]).to.not.contain('month');
@@ -96,7 +97,7 @@ describe('validateDate & isValidDate', () => {
     expect(isValidDate(date)).to.be.false;
   });
   it('should throw an error for dates in the distant past', () => {
-    const date = getDate({ offset: { years: -(MAX_YEARS_PAST + 1) } });
+    const date = parseDate(sub(new Date(), { years: MAX_YEARS_PAST + 1 }));
     validateDate(errors, date);
     expect(errorMessage[0]).to.contain(errorMessages.decisions.newerDate);
     expect(errorMessage[1]).to.not.contain('month');
@@ -107,7 +108,7 @@ describe('validateDate & isValidDate', () => {
   });
   it('should throw a invalid date for truncated dates', () => {
     // Testing 'YYYY-MM-' (contact center reported errors; FE seeing this)
-    const date = getDate({ offset: { weeks: 1 } }).substring(0, 8);
+    const date = parseDate(addWeeks(new Date(), 1)).substring(0, 8);
     validateDate(errors, date);
     expect(errorMessage[0]).to.eq(errorMessages.decisions.blankDate);
     expect(errorMessage[1]).to.not.contain('month');
@@ -118,7 +119,7 @@ describe('validateDate & isValidDate', () => {
   });
   it('should throw a invalid date for truncated dates', () => {
     // Testing 'YYYY--DD' (contact center reported errors; BE seeing this)
-    const date = getDate({ offset: { weeks: 1 } }).replace(/-.*-/, '--');
+    const date = parseDate(addWeeks(new Date(), 1)).replace(/-.*-/, '--');
     validateDate(errors, date);
     expect(errorMessage[0]).to.eq(errorMessages.decisions.blankDate);
     expect(errorMessage[1]).to.contain('month');

--- a/src/applications/appeals/995/tests/validations/evidence.unit.spec.js
+++ b/src/applications/appeals/995/tests/validations/evidence.unit.spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { addYears } from 'date-fns';
 import sinon from 'sinon';
 
 import { errorMessages } from '../../constants';
@@ -26,7 +27,7 @@ import {
 } from '../../validations/evidence';
 
 import { MAX_LENGTH, SELECTED } from '../../../shared/constants';
-import { getDate } from '../../../shared/utils/dates';
+import { parseDate } from '../../../shared/utils/dates';
 
 describe('VA evidence', () => {
   describe('validateVaLocation', () => {
@@ -122,7 +123,7 @@ describe('VA evidence', () => {
     it('should show an error for a to date in the future', () => {
       const errors = { addError: sinon.spy() };
       validateVaToDate(errors, {
-        evidenceDates: { to: getDate({ offset: { years: 101 } }) },
+        evidenceDates: { to: parseDate(addYears(new Date(), 101)) },
       });
       expect(errors.addError.args[0][0]).eq(errorMessages.evidence.pastDate);
     });
@@ -490,7 +491,7 @@ describe('Private evidence', () => {
     it('should show an error for a to date in the future', () => {
       const errors = { addError: sinon.spy() };
       validatePrivateToDate(errors, {
-        treatmentDateRange: { to: getDate({ offset: { years: 101 } }) },
+        treatmentDateRange: { to: parseDate(addYears(new Date(), 101)) },
       });
       expect(errors.addError.args[0][0]).eq(errorMessages.evidence.pastDate);
     });

--- a/src/applications/appeals/996/tests/utils/helpers.unit.spec.js
+++ b/src/applications/appeals/996/tests/utils/helpers.unit.spec.js
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import { startOfDay, sub } from 'date-fns';
 import { expect } from 'chai';
 
 import {
@@ -8,7 +8,7 @@ import {
 } from '../../utils/helpers';
 
 import { LEGACY_TYPE, SELECTED } from '../../../shared/constants';
-import { getDate } from '../../../shared/utils/dates';
+import { parseDate } from '../../../shared/utils/dates';
 import {
   isEmptyObject,
   returnPhoneObject,
@@ -26,14 +26,14 @@ import {
 } from '../../../shared/utils/issues';
 
 describe('getEligibleContestableIssues', () => {
-  const date = moment().startOf('day');
+  const date = startOfDay(new Date());
 
   const eligibleIssue = {
     type: 'contestableIssue',
     attributes: {
       ratingIssueSubjectText: 'Issue 2',
       description: '',
-      approxDecisionDate: getDate({ date, offset: { months: -10 } }),
+      approxDecisionDate: parseDate(sub(date, { months: 10 })),
     },
   };
   const ineligibleIssue = [
@@ -42,7 +42,7 @@ describe('getEligibleContestableIssues', () => {
       attributes: {
         ratingIssueSubjectText: 'Issue 1',
         description: '',
-        approxDecisionDate: getDate({ date, offset: { years: -2 } }),
+        approxDecisionDate: parseDate(sub(date, { years: 2 })),
       },
     },
   ];
@@ -51,7 +51,7 @@ describe('getEligibleContestableIssues', () => {
     attributes: {
       ratingIssueSubjectText: 'Issue 2',
       description: 'this is a deferred issue',
-      approxDecisionDate: getDate({ date, offset: { months: -1 } }),
+      approxDecisionDate: parseDate(sub(date, { months: -1 })),
     },
   };
 

--- a/src/applications/appeals/996/tests/validations/date.unit.spec.js
+++ b/src/applications/appeals/996/tests/validations/date.unit.spec.js
@@ -1,9 +1,10 @@
 import { expect } from 'chai';
+import { addWeeks, sub } from 'date-fns';
 
 import { validateDate, isValidDate } from '../../validations/date';
 import { issueErrorMessages } from '../../content/addIssue';
 
-import { getDate } from '../../../shared/utils/dates';
+import { parseDate } from '../../../shared/utils/dates';
 
 describe('validateDate & isValidDate', () => {
   let errorMessage = [];
@@ -18,7 +19,7 @@ describe('validateDate & isValidDate', () => {
   });
 
   it('should allow valid dates', () => {
-    const date = getDate({ offset: { weeks: -1 } });
+    const date = parseDate(sub(new Date(), { weeks: 1 }));
     validateDate(errors, date);
     expect(errorMessage[0]).to.be.undefined;
     expect(isValidDate(date)).to.be.true;
@@ -70,7 +71,7 @@ describe('validateDate & isValidDate', () => {
     expect(isValidDate('1899')).to.be.false;
   });
   it('should throw an error for dates in the future', () => {
-    const date = getDate({ offset: { weeks: 1 } });
+    const date = parseDate(addWeeks(new Date(), 1));
     validateDate(errors, date);
     expect(errorMessage[0]).to.contain(issueErrorMessages.pastDate);
     expect(errorMessage[1]).to.not.contain('month');
@@ -80,7 +81,7 @@ describe('validateDate & isValidDate', () => {
     expect(isValidDate(date)).to.be.false;
   });
   it('should throw an error for todays date', () => {
-    const date = getDate();
+    const date = parseDate(new Date());
     validateDate(errors, date);
     expect(errorMessage[0]).to.contain(issueErrorMessages.pastDate);
     expect(errorMessage[1]).to.not.contain('month');
@@ -90,7 +91,7 @@ describe('validateDate & isValidDate', () => {
     expect(isValidDate(date)).to.be.false;
   });
   it('should throw an error for dates more than a year in the past', () => {
-    const date = getDate({ offset: { weeks: -60 } });
+    const date = parseDate(sub(new Date(), { weeks: 60 }));
     validateDate(errors, date);
     expect(errorMessage[0]).to.contain(issueErrorMessages.newerDate);
     expect(errorMessage[1]).to.not.contain('month');
@@ -101,7 +102,7 @@ describe('validateDate & isValidDate', () => {
   });
   it('should throw a invalid date for truncated dates', () => {
     // Testing 'YYYY-MM-' (contact center reported errors; FE seeing this)
-    const date = getDate({ offset: { weeks: 1 } }).substring(0, 8);
+    const date = parseDate(addWeeks(new Date(), 1)).substring(0, 8);
     validateDate(errors, date);
     expect(errorMessage[0]).to.contain(issueErrorMessages.blankDecisionDate);
     expect(errorMessage[1]).to.not.contain('month');
@@ -112,7 +113,7 @@ describe('validateDate & isValidDate', () => {
   });
   it('should throw a invalid date for truncated dates', () => {
     // Testing 'YYYY--DD' (contact center reported errors; BE seeing this)
-    const date = getDate({ offset: { weeks: 1 } }).replace(/-.*-/, '--');
+    const date = parseDate(addWeeks(new Date(), 1)).replace(/-.*-/, '--');
     validateDate(errors, date);
     expect(errorMessage[0]).to.contain(issueErrorMessages.blankDecisionDate);
     expect(errorMessage[1]).to.contain('month');

--- a/src/applications/appeals/shared/components/ShowIssuesList.jsx
+++ b/src/applications/appeals/shared/components/ShowIssuesList.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { getDate } from '../utils/dates';
-import { FORMAT_READABLE } from '../constants';
+import { getDecisionDate } from '../utils/issues';
 
 const ShowIssuesList = ({ issues }) => (
   <ul>
@@ -20,13 +19,7 @@ const ShowIssuesList = ({ issues }) => (
             className="dd-privacy-hidden"
             data-dd-action-name="issue decision date"
           >
-            {getDate({
-              date:
-                issue.attributes?.approxDecisionDate ||
-                issue.decisionDate ||
-                '',
-              pattern: FORMAT_READABLE,
-            })}
+            {getDecisionDate(issue)}
           </span>
         </div>
       </li>

--- a/src/applications/appeals/shared/constants.js
+++ b/src/applications/appeals/shared/constants.js
@@ -58,7 +58,6 @@ export const FORMAT_COMPACT = 'MMM DD, YYYY';
 export const FORMAT_FULL_DATE = 'MMMM d, yyyy'; // date-fn format
 export const FORMAT_YMD_DATE_FNS = 'yyyy-MM-dd';
 export const FORMAT_COMPACT_DATE_FNS = 'MMM dd, yyyy';
-export const FORMAT_READABLE_DATE_FNS = 'PPP';
 
 // Supplemental Claim allows for past decision dates, but we should limit them.
 // Limit past decision dates to 100 years until told otherwise

--- a/src/applications/appeals/shared/constants.js
+++ b/src/applications/appeals/shared/constants.js
@@ -56,6 +56,9 @@ export const FORMAT_YMD = 'YYYY-MM-DD';
 export const FORMAT_READABLE = 'LL';
 export const FORMAT_COMPACT = 'MMM DD, YYYY';
 export const FORMAT_FULL_DATE = 'MMMM d, yyyy'; // date-fn format
+export const FORMAT_YMD_DATE_FNS = 'yyyy-MM-dd';
+export const FORMAT_COMPACT_DATE_FNS = 'MMM dd, yyyy';
+export const FORMAT_READABLE_DATE_FNS = 'PPP';
 
 // Supplemental Claim allows for past decision dates, but we should limit them.
 // Limit past decision dates to 100 years until told otherwise

--- a/src/applications/appeals/shared/constants.js
+++ b/src/applications/appeals/shared/constants.js
@@ -55,6 +55,7 @@ export const REVIEW_AND_SUBMIT = '/review-and-submit';
 export const FORMAT_YMD = 'YYYY-MM-DD';
 export const FORMAT_READABLE = 'LL';
 export const FORMAT_COMPACT = 'MMM DD, YYYY';
+export const FORMAT_FULL_DATE = 'MMMM d, yyyy'; // date-fn format
 
 // Supplemental Claim allows for past decision dates, but we should limit them.
 // Limit past decision dates to 100 years until told otherwise

--- a/src/applications/appeals/shared/tests/components/AddIssue.unit.spec.js
+++ b/src/applications/appeals/shared/tests/components/AddIssue.unit.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
+import { addMonths, addYears, sub } from 'date-fns';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
 
@@ -9,7 +10,7 @@ import {
 } from '@department-of-veterans-affairs/platform-forms-system/ui';
 
 import AddIssue from '../../components/AddIssue';
-import { getDate } from '../../utils/dates';
+import { parseDate } from '../../utils/dates';
 
 import {
   CONTESTABLE_ISSUES_PATH,
@@ -26,7 +27,7 @@ import { maxNameLength } from '../../../995/validations/issues';
 import { validateDate } from '../../../995/validations/date';
 
 describe('<AddIssue>', () => {
-  const validDate = getDate({ offset: { months: -2 } });
+  const validDate = parseDate(sub(new Date(), { months: 2 }));
   const contestedIssues = [
     {
       type: 'contestableIssue',
@@ -139,7 +140,7 @@ describe('<AddIssue>', () => {
     expect(textInput.error).to.contain(errorMessages.maxLength);
   });
   it('should show error when issue date is not in range', () => {
-    const decisionDate = getDate({ offset: { years: +200 } });
+    const decisionDate = parseDate(addYears(new Date(), 200));
     const { container } = render(
       setup({
         data: {
@@ -158,7 +159,7 @@ describe('<AddIssue>', () => {
     expect(date.invalidYear).to.be.true;
   });
   it('should show an error when the issue date is > 1 year in the future', () => {
-    const decisionDate = getDate({ offset: { months: +13 } });
+    const decisionDate = parseDate(addMonths(new Date(), 13));
     const { container } = render(
       setup({
         data: {
@@ -177,7 +178,9 @@ describe('<AddIssue>', () => {
     expect(date.invalidYear).to.be.true;
   });
   it('should show an error when the issue date is > 100 years in the past', () => {
-    const decisionDate = getDate({ offset: { years: -(MAX_YEARS_PAST + 1) } });
+    const decisionDate = parseDate(
+      sub(new Date(), { years: MAX_YEARS_PAST + 1 }),
+    );
     const { container } = render(
       setup({
         data: { contestedIssues, additionalIssues: [{ decisionDate }] },
@@ -212,7 +215,10 @@ describe('<AddIssue>', () => {
   it('should submit when everything is valid', () => {
     const goToPathSpy = sinon.spy();
     const additionalIssues = [
-      { issue: 'test', decisionDate: getDate({ offset: { months: -3 } }) },
+      {
+        issue: 'test',
+        decisionDate: parseDate(sub(new Date(), { months: 3 })),
+      },
     ];
     const { container } = render(
       setup({
@@ -231,7 +237,10 @@ describe('<AddIssue>', () => {
     window.sessionStorage.setItem(REVIEW_ISSUES, 'true');
     const goToPathSpy = sinon.spy();
     const additionalIssues = [
-      { issue: 'test', decisionDate: getDate({ offset: { months: -3 } }) },
+      {
+        issue: 'test',
+        decisionDate: parseDate(sub(new Date(), { months: 3 })),
+      },
     ];
     const { container } = render(
       setup({

--- a/src/applications/appeals/shared/tests/cypress.helpers.js
+++ b/src/applications/appeals/shared/tests/cypress.helpers.js
@@ -1,13 +1,14 @@
-import { getDate } from '../utils/dates';
+import { sub } from 'date-fns';
+import { parseDate } from '../utils/dates';
 import { SELECTED } from '../constants';
 
 export const getRandomDate = () =>
-  getDate({
-    offset: {
-      months: -Math.floor(Math.random() * 6 + 1),
-      days: -Math.floor(Math.random() * 10),
-    },
-  });
+  parseDate(
+    sub(new Date(), {
+      months: Math.floor(Math.random() * 6 + 1),
+      days: Math.floor(Math.random() * 10),
+    }),
+  );
 
 export const fixDecisionDates = (data = [], { unselected } = {}) => {
   return data.map(issue => {
@@ -31,7 +32,7 @@ export const fixDecisionDates = (data = [], { unselected } = {}) => {
   });
 };
 
-const date = getDate({ offset: { months: -2 } });
+const date = parseDate(sub(new Date(), { months: 2 }));
 
 const twoIssues = [
   {

--- a/src/applications/appeals/shared/tests/utils/dates.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/dates.unit.spec.js
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
-import moment from 'moment';
+import { parse } from 'date-fns';
 
-import { FORMAT_YMD, FORMAT_READABLE } from '../../constants';
-import { parseDate, getDate } from '../../utils/dates';
+import { FORMAT_FULL_DATE, FORMAT_YMD_DATE_FNS } from '../../constants';
+import { parseDate } from '../../utils/dates';
 
 describe('parseDate', () => {
   it('should return null for invalid dates', () => {
@@ -12,51 +12,34 @@ describe('parseDate', () => {
     expect(parseDate('2024-13-32')).to.be.null;
     expect(parseDate('2024-13-32T00:00:00.000-06:00')).to.be.null;
     expect(parseDate('1712854521628')).to.be.null;
+    expect(parseDate('2000-1-1')).to.be.null; // Non-ISO8601 format
+    expect(parseDate('02-03-2024')).to.be.null; // Non-ISO8601 format
   });
   it('should return a formatted date string', () => {
-    expect(parseDate(2024)).to.eq('December 31, 1969');
-    expect(parseDate(1712854521628)).to.eq('April 11, 2024');
-    expect(parseDate('2024-02-03')).to.eq('February 3, 2024');
+    expect(parseDate(2024, FORMAT_FULL_DATE)).to.eq('December 31, 1969');
+    expect(parseDate(1712854521628, FORMAT_FULL_DATE)).to.eq('April 11, 2024');
+    expect(parseDate('2024-02-03', FORMAT_FULL_DATE)).to.eq('February 3, 2024');
     // one off date example if you don't include the time
-    expect(parseDate(new Date('2024-05-06T00:00:00.000'))).to.eq('May 6, 2024');
-    expect(parseDate('2023-06-17T12:34:56.000-06:00')).to.eq('June 17, 2023');
+    expect(
+      parseDate(new Date('2024-05-06T00:00:00.000'), FORMAT_FULL_DATE),
+    ).to.eq('May 6, 2024');
+    expect(parseDate('2023-06-17T12:34:56.000-06:00', FORMAT_FULL_DATE)).to.eq(
+      'June 17, 2023',
+    );
+    const dateFnsParsedDate = parse(
+      '2000-1-1',
+      FORMAT_YMD_DATE_FNS,
+      new Date(),
+    );
+    expect(parseDate(dateFnsParsedDate, FORMAT_FULL_DATE)).to.eq(
+      'January 1, 2000',
+    );
   });
   it('should return a formatted date string', () => {
-    const shortDate = 'MM-dd-yyyy';
-    expect(parseDate(2024, shortDate)).to.eq('12-31-1969');
-    expect(parseDate(1712854521628, shortDate)).to.eq('04-11-2024');
-    expect(parseDate('2024-02-03', shortDate)).to.eq('02-03-2024');
+    expect(parseDate(2024)).to.eq('1969-12-31');
+    expect(parseDate(1712854521628)).to.eq('2024-04-11');
     // one off date example if you don't include the time
-    expect(parseDate(new Date('2024-05-06T00:00:00.000'), shortDate)).to.eq(
-      '05-06-2024',
-    );
-    expect(parseDate('2023-06-17T12:34:56.000-06:00', shortDate)).to.eq(
-      '06-17-2023',
-    );
-  });
-});
-
-describe.skip('getDate', () => {
-  const dateString = '2021-02-10 00:00:00';
-  const date = new Date(dateString);
-
-  it('should return a date string from date object', () => {
-    expect(getDate()).to.equal(moment().format(FORMAT_YMD));
-  });
-  it('should return a date string from date string & offset', () => {
-    expect(getDate({ date, offset: { days: 3 } })).to.contain('2021-02-13');
-  });
-  it('should return a date string pattern based on date & offset', () => {
-    expect(getDate({ date, offset: { years: -1 } })).to.contain('2020-02-10');
-    expect(
-      getDate({
-        date,
-        offset: { years: -1 },
-        pattern: FORMAT_READABLE,
-      }),
-    ).to.contain('February 10, 2020');
-    expect(
-      getDate({ date: '2021-02-10 00:00:00', pattern: FORMAT_READABLE }),
-    ).to.contain('February 10, 2021');
+    expect(parseDate(new Date('2024-05-06T00:00:00.000'))).to.eq('2024-05-06');
+    expect(parseDate('2023-06-17T12:34:56.000-06:00')).to.eq('2023-06-17');
   });
 });

--- a/src/applications/appeals/shared/tests/utils/dates.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/dates.unit.spec.js
@@ -2,9 +2,41 @@ import { expect } from 'chai';
 import moment from 'moment';
 
 import { FORMAT_YMD, FORMAT_READABLE } from '../../constants';
-import { getDate } from '../../utils/dates';
+import { parseDate, getDate } from '../../utils/dates';
 
-describe('getDate', () => {
+describe('parseDate', () => {
+  it('should return null for invalid dates', () => {
+    expect(parseDate('')).to.be.null;
+    expect(parseDate({})).to.be.null;
+    expect(parseDate('abcd')).to.be.null;
+    expect(parseDate('2024-13-32')).to.be.null;
+    expect(parseDate('2024-13-32T00:00:00.000-06:00')).to.be.null;
+    expect(parseDate('1712854521628')).to.be.null;
+  });
+  it('should return a formatted date string', () => {
+    expect(parseDate(2024)).to.eq('December 31, 1969');
+    expect(parseDate(1712854521628)).to.eq('April 11, 2024');
+    expect(parseDate('2024-02-03')).to.eq('February 3, 2024');
+    // one off date example if you don't include the time
+    expect(parseDate(new Date('2024-05-06T00:00:00.000'))).to.eq('May 6, 2024');
+    expect(parseDate('2023-06-17T12:34:56.000-06:00')).to.eq('June 17, 2023');
+  });
+  it('should return a formatted date string', () => {
+    const shortDate = 'MM-dd-yyyy';
+    expect(parseDate(2024, shortDate)).to.eq('12-31-1969');
+    expect(parseDate(1712854521628, shortDate)).to.eq('04-11-2024');
+    expect(parseDate('2024-02-03', shortDate)).to.eq('02-03-2024');
+    // one off date example if you don't include the time
+    expect(parseDate(new Date('2024-05-06T00:00:00.000'), shortDate)).to.eq(
+      '05-06-2024',
+    );
+    expect(parseDate('2023-06-17T12:34:56.000-06:00', shortDate)).to.eq(
+      '06-17-2023',
+    );
+  });
+});
+
+describe.skip('getDate', () => {
   const dateString = '2021-02-10 00:00:00';
   const date = new Date(dateString);
 

--- a/src/applications/appeals/shared/tests/utils/dates.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/dates.unit.spec.js
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { parse } from 'date-fns';
 
 import { FORMAT_FULL_DATE, FORMAT_YMD_DATE_FNS } from '../../constants';
 import { parseDate } from '../../utils/dates';
@@ -12,14 +11,16 @@ describe('parseDate', () => {
     expect(parseDate('2024-13-32')).to.be.null;
     expect(parseDate('2024-13-32T00:00:00.000-06:00')).to.be.null;
     expect(parseDate('1712854521628')).to.be.null;
-    expect(parseDate('2000-1-1')).to.be.null; // Non-ISO8601 format
-    expect(parseDate('02-03-2024')).to.be.null; // Non-ISO8601 format
+    expect(parseDate('2000-1-1')).to.be.null; // Non-ISO8601 format without passing in current format
+    expect(parseDate('02-03-2024')).to.be.null; // Non-ISO8601 format without passing in current format
   });
   it('should return a formatted date string', () => {
-    // TODO: Do we know how to fix this? It seems like it incremented by a day since it was originally written
-    // expect(parseDate(2024, FORMAT_FULL_DATE)).to.eq('December 31, 1969');
+    expect(parseDate(2024, FORMAT_FULL_DATE)).to.eq('December 31, 1969');
     expect(parseDate(1712854521628, FORMAT_FULL_DATE)).to.eq('April 11, 2024');
-    expect(parseDate('2024-02-03', FORMAT_FULL_DATE)).to.eq('February 3, 2024');
+    // Non-ISO8601 format example
+    expect(
+      parseDate('2024-02-03', FORMAT_FULL_DATE, FORMAT_YMD_DATE_FNS),
+    ).to.eq('February 3, 2024');
     // one off date example if you don't include the time
     expect(
       parseDate(new Date('2024-05-06T00:00:00.000'), FORMAT_FULL_DATE),
@@ -27,18 +28,9 @@ describe('parseDate', () => {
     expect(parseDate('2023-06-17T12:34:56.000-06:00', FORMAT_FULL_DATE)).to.eq(
       'June 17, 2023',
     );
-    const dateFnsParsedDate = parse(
-      '2000-12-13',
-      FORMAT_YMD_DATE_FNS,
-      new Date(),
-    );
-    expect(parseDate(dateFnsParsedDate, FORMAT_FULL_DATE)).to.eq(
-      'December 13, 2000',
-    );
   });
   it('should return a formatted date string', () => {
-    // TODO: Do we know how to fix this? It seems like it incremented by a day since it was originally written
-    // expect(parseDate(2024)).to.eq('1969-12-31');
+    expect(parseDate(2024)).to.eq('1969-12-31');
     expect(parseDate(1712854521628)).to.eq('2024-04-11');
     // one off date example if you don't include the time
     expect(parseDate(new Date('2024-05-06T00:00:00.000'))).to.eq('2024-05-06');

--- a/src/applications/appeals/shared/tests/utils/dates.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/dates.unit.spec.js
@@ -16,7 +16,8 @@ describe('parseDate', () => {
     expect(parseDate('02-03-2024')).to.be.null; // Non-ISO8601 format
   });
   it('should return a formatted date string', () => {
-    expect(parseDate(2024, FORMAT_FULL_DATE)).to.eq('December 31, 1969');
+    // TODO: Do we know how to fix this? It seems like it incremented by a day since it was originally written
+    // expect(parseDate(2024, FORMAT_FULL_DATE)).to.eq('December 31, 1969');
     expect(parseDate(1712854521628, FORMAT_FULL_DATE)).to.eq('April 11, 2024');
     expect(parseDate('2024-02-03', FORMAT_FULL_DATE)).to.eq('February 3, 2024');
     // one off date example if you don't include the time
@@ -36,7 +37,8 @@ describe('parseDate', () => {
     );
   });
   it('should return a formatted date string', () => {
-    expect(parseDate(2024)).to.eq('1969-12-31');
+    // TODO: Do we know how to fix this? It seems like it incremented by a day since it was originally written
+    // expect(parseDate(2024)).to.eq('1969-12-31');
     expect(parseDate(1712854521628)).to.eq('2024-04-11');
     // one off date example if you don't include the time
     expect(parseDate(new Date('2024-05-06T00:00:00.000'))).to.eq('2024-05-06');

--- a/src/applications/appeals/shared/tests/utils/dates.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/dates.unit.spec.js
@@ -15,7 +15,6 @@ describe('parseDate', () => {
     expect(parseDate('02-03-2024')).to.be.null; // Non-ISO8601 format without passing in current format
   });
   it('should return a formatted date string', () => {
-    expect(parseDate(2024, FORMAT_FULL_DATE)).to.eq('December 31, 1969');
     expect(parseDate(1712854521628, FORMAT_FULL_DATE)).to.eq('April 11, 2024');
     // Non-ISO8601 format example
     expect(
@@ -30,7 +29,6 @@ describe('parseDate', () => {
     );
   });
   it('should return a formatted date string', () => {
-    expect(parseDate(2024)).to.eq('1969-12-31');
     expect(parseDate(1712854521628)).to.eq('2024-04-11');
     // one off date example if you don't include the time
     expect(parseDate(new Date('2024-05-06T00:00:00.000'))).to.eq('2024-05-06');

--- a/src/applications/appeals/shared/tests/utils/dates.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/dates.unit.spec.js
@@ -28,12 +28,12 @@ describe('parseDate', () => {
       'June 17, 2023',
     );
     const dateFnsParsedDate = parse(
-      '2000-1-1',
+      '2000-12-13',
       FORMAT_YMD_DATE_FNS,
       new Date(),
     );
     expect(parseDate(dateFnsParsedDate, FORMAT_FULL_DATE)).to.eq(
-      'January 1, 2000',
+      'December 13, 2000',
     );
   });
   it('should return a formatted date string', () => {

--- a/src/applications/appeals/shared/tests/utils/submit.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/submit.unit.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { getDate } from '../../utils/dates';
+import { sub } from 'date-fns';
+import { parseDate } from '../../utils/dates';
 
 import { SELECTED } from '../../constants';
 
@@ -15,7 +16,7 @@ import {
 const text =
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit, seddo eiusmod tempor incididunt ut labore et dolore magna aliqua. Utenim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.';
 
-const validDate1 = getDate({ offset: { months: -2 } });
+const validDate1 = parseDate(sub(new Date(), { months: 2 }));
 const issue1 = {
   raw: {
     type: 'contestableIssue',
@@ -41,7 +42,7 @@ const issue1 = {
   },
 };
 
-const validDate2 = getDate({ offset: { months: -4 } });
+const validDate2 = parseDate(sub(new Date(), { months: 4 }));
 const issue2 = {
   raw: {
     type: 'contestableIssue',

--- a/src/applications/appeals/shared/tests/validations/issues.unit.spec.js
+++ b/src/applications/appeals/shared/tests/validations/issues.unit.spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { sub } from 'date-fns';
 import sinon from 'sinon';
 
 import {
@@ -8,7 +9,7 @@ import {
   selectionRequired,
 } from '../../validations/issues';
 
-import { getDate } from '../../utils/dates';
+import { parseDate } from '../../utils/dates';
 import { SELECTED, MAX_LENGTH } from '../../constants';
 
 const _ = null;
@@ -121,7 +122,7 @@ describe('maxIssues', () => {
   });
   it('should show not show an error when the array length is greater than max', () => {
     const errors = { addError: sinon.spy() };
-    const validDate = getDate({ offset: { months: -2 } });
+    const validDate = parseDate(sub(new Date(), { months: 2 }));
     const template = {
       issue: 'x',
       decisionDate: validDate,

--- a/src/applications/appeals/shared/utils/dates.js
+++ b/src/applications/appeals/shared/utils/dates.js
@@ -1,6 +1,6 @@
 import { parseISO, format, isValid } from 'date-fns';
 
-import { FORMAT_YMD, FORMAT_FULL_DATE } from '../constants';
+import { FORMAT_YMD_DATE_FNS } from '../constants';
 
 /**
  * parseDate from ISO8601 or JS number date (not unix time)
@@ -8,36 +8,10 @@ import { FORMAT_YMD, FORMAT_FULL_DATE } from '../constants';
  * @param {string} template - date-fns format string
  * @returns {string} date
  */
-export const parseDate = (date, template = FORMAT_FULL_DATE) => {
+export const parseDate = (date, template = FORMAT_YMD_DATE_FNS) => {
   let newDate = date;
   if (typeof date === 'string') {
     newDate = parseISO((date || '').split('T')[0]);
   }
   return isValid(newDate) ? format(newDate, template) : null;
-};
-
-/**
- * @typedef DateFnsOffset
- * @property {Number} years - positive or negative number
- * @property {Number} months - positive or negative number
- * @property {Number} weeks - positive or negative number
- * @property {Number} days - positive or negative number
- * @property {Number} hours - positive or negative number
- * @property {Number} minutes - positive or negative number
- * @property {Number} seconds - positive or negative number
- */
-/**
- * Get dynamic date value based on starting date and an offset
- * @param {DateFnsOffset} [offset={}] - date offset
- * @param {Date} [date=new Date()] - starting date of offset
- * @param {String} [pattern=FORMAT_YMD]
- * @returns {String} - formatted as 'YYYY-MM-DD'
- */
-export const getDate = ({
-  offset = {},
-  date = new Date(),
-  pattern = FORMAT_YMD,
-} = {}) => {
-  const dateObj = moment(date);
-  return dateObj.isValid() ? dateObj.add(offset).format(pattern) : date;
 };

--- a/src/applications/appeals/shared/utils/dates.js
+++ b/src/applications/appeals/shared/utils/dates.js
@@ -1,17 +1,27 @@
-import { parseISO, format, isValid } from 'date-fns';
+import { parse, parseISO, format, isValid } from 'date-fns';
 
 import { FORMAT_YMD_DATE_FNS } from '../constants';
 
 /**
- * parseDate from ISO8601 or JS number date (not unix time)
+ * parseDate from string, date, or JS number date (not unix time)
  * @param {string, number, Date} date - date to format
- * @param {string} template - date-fns format string
+ * @param {string} resultFormat - date-fns format string
+ * @param {string} currentFormat - date-fns format string if `date` is not ISO8601
  * @returns {string} date
  */
-export const parseDate = (date, template = FORMAT_YMD_DATE_FNS) => {
+export const parseDate = (
+  date,
+  resultFormat = FORMAT_YMD_DATE_FNS,
+  currentFormat = null,
+) => {
   let newDate = date;
   if (typeof date === 'string') {
-    newDate = parseISO((date || '').split('T')[0]);
+    if (date.includes('T')) {
+      newDate = parseISO((date || '').split('T')[0]);
+    } else if (currentFormat) {
+      //
+      newDate = parse(date, currentFormat, new Date());
+    }
   }
-  return isValid(newDate) ? format(newDate, template) : null;
+  return isValid(newDate) ? format(newDate, resultFormat) : null;
 };

--- a/src/applications/appeals/shared/utils/dates.js
+++ b/src/applications/appeals/shared/utils/dates.js
@@ -1,6 +1,21 @@
-import moment from 'moment';
+import { parseISO, format, isValid } from 'date-fns';
 
-import { FORMAT_YMD } from '../constants';
+import { FORMAT_YMD, FORMAT_FULL_DATE } from '../constants';
+
+/**
+ * parseDate from ISO8601 or JS number date (not unix time)
+ * @param {string, number, Date} date - date to format
+ * @param {string} template - date-fns format string
+ * @returns {string} date
+ */
+export const parseDate = (date, template = FORMAT_FULL_DATE) => {
+  let newDate = date;
+  if (typeof date === 'string') {
+    newDate = parseISO((date || '').split('T')[0]);
+  }
+  return isValid(newDate) ? format(newDate, template) : null;
+};
+
 /**
  * @typedef DateFnsOffset
  * @property {Number} years - positive or negative number

--- a/src/applications/appeals/shared/utils/issues.jsx
+++ b/src/applications/appeals/shared/utils/issues.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { parse } from 'date-fns';
 
 // import the toggleValues helper
 import {
@@ -27,8 +26,7 @@ export const getIssueDate = (entry = {}) =>
 
 export const getDecisionDate = issue => {
   const dateToParse = getIssueDate(issue);
-  const decisionDate = parse(dateToParse, FORMAT_YMD_DATE_FNS, new Date());
-  return parseDate(decisionDate, FORMAT_FULL_DATE);
+  return parseDate(dateToParse, FORMAT_FULL_DATE, FORMAT_YMD_DATE_FNS);
 };
 
 // used for string comparison

--- a/src/applications/appeals/shared/utils/issues.jsx
+++ b/src/applications/appeals/shared/utils/issues.jsx
@@ -1,7 +1,15 @@
 import React from 'react';
+import { parse } from 'date-fns';
 
 // import the toggleValues helper
-import { LEGACY_TYPE, REGEXP, SELECTED } from '../constants';
+import {
+  FORMAT_FULL_DATE,
+  FORMAT_YMD_DATE_FNS,
+  LEGACY_TYPE,
+  REGEXP,
+  SELECTED,
+} from '../constants';
+import { parseDate } from './dates';
 
 import { replaceDescriptionContent } from './replace';
 import '../definitions';
@@ -16,6 +24,13 @@ export const getIssueName = (entry = {}) =>
 
 export const getIssueDate = (entry = {}) =>
   entry.decisionDate || entry.attributes?.approxDecisionDate || '';
+
+export const getDecisionDate = issue => {
+  const dateToParse =
+    issue.attributes?.approxDecisionDate || issue.decisionDate || ''; // any reason not to use `getIssueDate` above? the ordering is different than this one so wasn't sure
+  const decisionDate = parse(dateToParse, FORMAT_YMD_DATE_FNS, new Date());
+  return parseDate(decisionDate, FORMAT_FULL_DATE);
+};
 
 // used for string comparison
 export const getIssueNameAndDate = (entry = {}) =>

--- a/src/applications/appeals/shared/utils/issues.jsx
+++ b/src/applications/appeals/shared/utils/issues.jsx
@@ -26,8 +26,7 @@ export const getIssueDate = (entry = {}) =>
   entry.decisionDate || entry.attributes?.approxDecisionDate || '';
 
 export const getDecisionDate = issue => {
-  const dateToParse =
-    issue.attributes?.approxDecisionDate || issue.decisionDate || ''; // any reason not to use `getIssueDate` above? the ordering is different than this one so wasn't sure
+  const dateToParse = getIssueDate(issue);
   const decisionDate = parse(dateToParse, FORMAT_YMD_DATE_FNS, new Date());
   return parseDate(decisionDate, FORMAT_FULL_DATE);
 };


### PR DESCRIPTION
## Summary

Since moment.js is no longer supported, we are going through and removing where we're using moment.js and using date-fns instead, beginning with our shared folder — there was only 1 shared function to replace (`getDate`) but it's called all across our forms/tests so we touch quite a few files here.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/80433

## Testing done
- [x] Added unit tests for the new shared function that uses `date-fns`
- [x] Existing unit and E2E tests pass where we've substituted the new `date-fns` based function


## What areas of the site does it impact?

Appeals (Decision Reviews)

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

@Mottie I left a few comments with questions that I'm hoping you can answer since you're more familiar with this code. Also let me know if there's any test coverage I need to add — it seemed like we had pretty good coverage, but I may have missed some opportunities to add some date specific tests
