### PR TITLE
[CST] Use `setDocumentTitle` helper instead of setting document.title manually

### DIFF
--- a/src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx
@@ -51,7 +51,6 @@ const filesPath = `../files`;
 class AdditionalEvidencePage extends React.Component {
   componentDidMount() {
     this.props.resetUploads();
-    document.title = 'Additional Evidence';
     if (!this.props.loading) {
       setUpPage();
     } else {

--- a/src/applications/claims-status/containers/AdditionalEvidencePageOld.jsx
+++ b/src/applications/claims-status/containers/AdditionalEvidencePageOld.jsx
@@ -44,7 +44,6 @@ const filesPath = '../files';
 class AdditionalEvidencePageOld extends React.Component {
   componentDidMount() {
     this.props.resetUploads();
-    document.title = 'Additional Evidence';
     if (!this.props.loading) {
       setUpPage();
     } else {

--- a/src/applications/claims-status/containers/AskVAPage.jsx
+++ b/src/applications/claims-status/containers/AskVAPage.jsx
@@ -17,6 +17,7 @@ import { cstUseLighthouse } from '../selectors';
 // END lighthouse_migration
 import { setUpPage } from '../utils/page';
 import withRouter from '../utils/withRouter';
+import { setDocumentTitle } from '../utils/helpers';
 
 class AskVAPage extends React.Component {
   constructor() {
@@ -27,7 +28,7 @@ class AskVAPage extends React.Component {
   }
 
   componentDidMount() {
-    document.title = 'Ask for your Claim Decision';
+    setDocumentTitle('Ask for your Claim Decision');
     setUpPage();
   }
 

--- a/src/applications/claims-status/containers/ClaimEstimationPage.jsx
+++ b/src/applications/claims-status/containers/ClaimEstimationPage.jsx
@@ -5,11 +5,12 @@ import CallVBACenter from '@department-of-veterans-affairs/platform-static-data/
 
 import NeedHelp from '../components/NeedHelp';
 import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
+import { setDocumentTitle } from '../utils/helpers';
 import { setUpPage } from '../utils/page';
 
 class ClaimEstimationPage extends React.Component {
   componentDidMount() {
-    document.title = 'How We Come Up with Your Estimated Decision Date';
+    setDocumentTitle('How We Come Up with Your Estimated Decision Date');
     setUpPage();
   }
 

--- a/src/applications/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/applications/claims-status/containers/DocumentRequestPage.jsx
@@ -31,7 +31,7 @@ import {
 // START lighthouse_migration
 import { benefitsDocumentsUseLighthouse } from '../selectors';
 // END lighthouse_migration
-import { scrubDescription } from '../utils/helpers';
+import { scrubDescription, setDocumentTitle } from '../utils/helpers';
 import { setPageFocus, setUpPage } from '../utils/page';
 import withRouter from '../utils/withRouter';
 
@@ -47,9 +47,9 @@ class DocumentRequestPage extends React.Component {
   componentDidMount() {
     this.props.resetUploads();
     if (this.props.trackedItem) {
-      document.title = `Request for ${this.props.trackedItem.displayName}`;
+      setDocumentTitle(`Request for ${this.props.trackedItem.displayName}`);
     } else {
-      document.title = 'Document Request';
+      setDocumentTitle('Document Request');
     }
     if (!this.props.loading) {
       setUpPage();

--- a/src/applications/claims-status/containers/StemClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/StemClaimStatusPage.jsx
@@ -9,10 +9,10 @@ import ClaimsUnavailable from '../components/ClaimsUnavailable';
 import StemDeniedDetails from '../components/StemDeniedDetails';
 import { setUpPage } from '../utils/page';
 import withRouter from '../utils/withRouter';
-import { claimAvailable } from '../utils/helpers';
+import { claimAvailable, setDocumentTitle } from '../utils/helpers';
 
 const setTitle = () => {
-  document.title = 'Your Edith Nourse Rogers STEM Scholarship application';
+  setDocumentTitle('Your Edith Nourse Rogers STEM Scholarship application');
 };
 
 class StemClaimStatusPage extends React.Component {

--- a/src/applications/claims-status/containers/YourClaimLetters/index.jsx
+++ b/src/applications/claims-status/containers/YourClaimLetters/index.jsx
@@ -13,6 +13,7 @@ import { isLoadingFeatures, showClaimLettersFeature } from '../../selectors';
 import NoLettersContent from './errorComponents/NoLettersContent';
 import ServerErrorContent from './errorComponents/ServerErrorContent';
 import UnauthenticatedContent from './errorComponents/UnauthenticatedContent';
+import { setDocumentTitle } from '../../utils/helpers';
 
 const paginateItems = items => {
   return items?.length ? chunk(items, ITEMS_PER_PAGE) : [[]];
@@ -50,7 +51,7 @@ export const YourClaimLetters = ({ isLoading, showClaimLetters }) => {
         setLettersLoading(false);
       });
 
-    document.title = 'Your VA Claim Letters | Veterans Affairs';
+    setDocumentTitle('Your VA Claim Letters');
   }, []);
 
   /**

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -39,7 +39,7 @@ import {
   sortByLastUpdated,
 } from '../utils/appeals-v2-helpers';
 import { setPageFocus, setUpPage } from '../utils/page';
-import { groupClaimsByDocsNeeded } from '../utils/helpers';
+import { groupClaimsByDocsNeeded, setDocumentTitle } from '../utils/helpers';
 
 class YourClaimsPageV2 extends React.Component {
   constructor(props) {
@@ -58,8 +58,7 @@ class YourClaimsPageV2 extends React.Component {
   }
 
   componentDidMount() {
-    document.title =
-      'Check your claim, decision review, or appeal status | Veterans Affairs';
+    setDocumentTitle('Check your claim, decision review, or appeal status');
 
     const {
       appealsLoading,

--- a/src/applications/claims-status/tests/components/AdditionalEvidencePageOld.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AdditionalEvidencePageOld.unit.spec.jsx
@@ -171,7 +171,6 @@ describe('<AdditionalEvidencePageOld>', () => {
         </Provider>,
       );
 
-      expect(document.title).to.equal('Additional Evidence');
       expect(resetUploads.called).to.be.true;
     });
 

--- a/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
@@ -35,7 +35,7 @@ describe('<DocumentRequestPage>', () => {
   it('when component mounts should set document title', () => {
     renderWithRouter(<DocumentRequestPage {...defaultProps} loading />);
 
-    expect(document.title).to.equal('Document Request');
+    expect(document.title).to.equal('Document Request | Veterans Affairs');
   });
 
   it('when component mounts should set document title', async () => {
@@ -291,7 +291,7 @@ describe('<DocumentRequestPage>', () => {
       </Provider>,
     );
 
-    expect(document.title).to.equal('Request for Testing');
+    expect(document.title).to.equal('Request for Testing | Veterans Affairs');
     expect(resetUploads.called).to.be.true;
   });
 

--- a/src/applications/claims-status/tests/components/StemClaimStatusPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/StemClaimStatusPage.unit.spec.jsx
@@ -8,6 +8,9 @@ import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import { StemClaimStatusPage } from '../../containers/StemClaimStatusPage';
 import { renderWithRouter } from '../utils';
 
+const documentTitle =
+  'Your Edith Nourse Rogers STEM Scholarship application | Veterans Affairs';
+
 const store = createStore(() => ({}));
 
 const props = {
@@ -29,9 +32,7 @@ describe('<StemClaimStatusPage>', () => {
         'You didn’t meet the following criteria for the Rogers STEM Scholarship:',
       ),
     ).to.not.exist;
-    expect(document.title).to.equal(
-      'Your Edith Nourse Rogers STEM Scholarship application',
-    );
+    expect(document.title).to.equal(documentTitle);
     getByText('Claim status is unavailable');
   });
 
@@ -46,9 +47,7 @@ describe('<StemClaimStatusPage>', () => {
         'You didn’t meet the following criteria for the Rogers STEM Scholarship:',
       ),
     ).to.not.exist;
-    expect(document.title).to.equal(
-      'Your Edith Nourse Rogers STEM Scholarship application',
-    );
+    expect(document.title).to.equal(documentTitle);
     getByText('Claim status is unavailable');
   });
 
@@ -63,9 +62,7 @@ describe('<StemClaimStatusPage>', () => {
         'You didn’t meet the following criteria for the Rogers STEM Scholarship:',
       ),
     ).to.not.exist;
-    expect(document.title).to.equal(
-      'Your Edith Nourse Rogers STEM Scholarship application',
-    );
+    expect(document.title).to.equal(documentTitle);
     expect($('va-loading-indicator', container)).to.exist;
   });
 
@@ -95,8 +92,6 @@ describe('<StemClaimStatusPage>', () => {
         'You didn’t meet the following criteria for the Rogers STEM Scholarship:',
       ),
     ).to.exist;
-    expect(document.title).to.equal(
-      'Your Edith Nourse Rogers STEM Scholarship application',
-    );
+    expect(document.title).to.equal(documentTitle);
   });
 });

--- a/src/applications/claims-status/tests/components/claim-files-tab/AdditionalEvidencePage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab/AdditionalEvidencePage.unit.spec.jsx
@@ -200,7 +200,6 @@ describe('<AdditionalEvidencePage>', () => {
         </Provider>,
       );
 
-      expect(document.title).to.equal('Additional Evidence');
       expect(resetUploads.called).to.be.true;
     });
 


### PR DESCRIPTION
## Summary
All page title slugs are supposed to end in `| Veterans Affairs`. Several of our pages are updating the title slug without including that. We have a helper that we are using on some of the other pages to set this properly - this PR updates all cases where we set document.title manually to use the helper. Removed the code setting `document.title` from the `AdditionalEvidencePage` and AdditionalEvidencePageOld` components as they are not their own pages and should not be updating the value of `document.title` themselves

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#80672

## Testing done
Updated a few tests to check for the correct `document.title` value.

## Screenshots
### AskVAPage
<img width="263" alt="Screenshot 2024-04-12 at 12 55 14 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/ad1d1605-a782-4c70-b763-26ab97dd33b7">

### DocumentRequestPage
<img width="268" alt="Screenshot 2024-04-12 at 12 54 57 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/891837ba-aa1f-4108-98a4-9e1f5656da14">

### StemClaimStatusPage
<img width="257" alt="Screenshot 2024-04-12 at 12 57 37 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/7bb3a1a2-94c4-4e48-a535-5eeb472cafc3">


### YourClaimLetters
<img width="266" alt="Screenshot 2024-04-12 at 12 56 15 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/f15abfdb-40f3-43bd-adf8-c5d7292ab104">

### YourClaimsPageV2
<img width="271" alt="Screenshot 2024-04-12 at 12 54 41 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/a48cbc5a-9b99-42b7-a01c-2135dd585904">


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
