### PR TITLE
helper & error text for currency field

### DIFF
--- a/src/applications/burials-v2/config/chapters/04-benefits-selection/plotAllowancePartOne.js
+++ b/src/applications/burials-v2/config/chapters/04-benefits-selection/plotAllowancePartOne.js
@@ -5,7 +5,7 @@ import {
   numberSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import { CurrencyReviewRowView } from '../../../components/ReviewRowView';
-import { generateTitle } from '../../../utils/helpers';
+import { generateHelpText, generateTitle } from '../../../utils/helpers';
 
 const { govtContributions } = fullSchemaBurials.properties;
 
@@ -23,7 +23,15 @@ export default {
     amountGovtContribution: {
       ...numberUI({
         title: 'Amount the government or employer paid',
+        description: generateHelpText(
+          'Enter an amount with numbers only. Don\'t include symbols or special characters like "$," commas, or periods.',
+          'vads-u-color--gray vads-u-font-size--md vads-u-margin-top--2 vads-u-display--inline-block',
+        ),
         hideIf: form => !form?.govtContributions,
+        errorMessages: {
+          pattern:
+            'You entered a character we can\'t accept. Remove symbols or special characters like "$," commas, or periods.',
+        },
         min: 0,
       }),
       'ui:required': form => form?.govtContributions,

--- a/src/applications/burials-v2/utils/helpers.jsx
+++ b/src/applications/burials-v2/utils/helpers.jsx
@@ -140,10 +140,11 @@ export const generateTitle = text => {
   return <h3 className="vads-u-margin-top--0 vads-u-color--base">{text}</h3>;
 };
 
-export const generateHelpText = text => {
-  return (
-    <span className="vads-u-color--gray vads-u-font-size--md">{text}</span>
-  );
+export const generateHelpText = (
+  text,
+  className = 'vads-u-color--gray vads-u-font-size--md',
+) => {
+  return <span className={className}>{text}</span>;
 };
 
 export const checkboxGroupSchemaWithReviewLabels = keys => {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- Adds helper text and & error message for number input

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/80168

## Testing done

- Proceed to http://localhost:3001/burials-and-memorials-v2/application/530/benefits/plot-allowance/contributions
- Verify helper text is visible
- enter invalid chars into input field. 
- Verify error message is correct
## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

<img width="595" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133443504/869b309e-01b5-4a62-90b5-8788902dec38">
<img width="595" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133443504/f5337478-d28f-4d7b-ac69-440475b1c8e8">


|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

burials v2

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

