### PR TITLE
HLR & SC | Add subtask form bottom margin

### DIFF
--- a/src/applications/appeals/995/subtask/pages/other.jsx
+++ b/src/applications/appeals/995/subtask/pages/other.jsx
@@ -29,7 +29,7 @@ const DecisionReviewPage = () => {
   };
 
   return (
-    <div id={pageNames.other}>
+    <div id={pageNames.other} className="vads-u-padding-bottom--2">
       <h1 className="vads-u-margin-bottom--0">File a Supplemental Claim</h1>
       <div className="schemaform-subtitle vads-u-font-size--lg">
         VA Form 20-0995

--- a/src/applications/appeals/996/subtask/pages/other.jsx
+++ b/src/applications/appeals/996/subtask/pages/other.jsx
@@ -29,7 +29,7 @@ const DecisionReviewPage = () => {
   };
 
   return (
-    <div id={pageNames.other}>
+    <div id={pageNames.other} className="vads-u-padding-bottom--2">
       <h1 className="vads-u-margin-bottom--0">Request a Higher-Level Review</h1>
       <div className="schemaform-subtitle vads-u-font-size--lg">
         VA Form 20-0996

--- a/src/platform/forms/sub-task/index.js
+++ b/src/platform/forms/sub-task/index.js
@@ -163,6 +163,7 @@ export const SubTask = props => {
         ref={formRef}
         onSubmit={e => e.preventDefault()}
         data-page={currentPage.name}
+        className="vads-u-margin-bottom--2"
       >
         <div className="subtask-content">
           <Page


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > The HLR & SC subtask navigation buttons do not include any margin or padding between the subtask page content and the buttons. In my local dev environment, I noticed that the form has a user agent stylesheet for the form that include a `margin-block-end` (bottom margin), but when checked in staging, the margin is gone (see screenshots). So this PR adds a form bottom margin to the subtask and adds extra padding to our form "other" pages for HLR & SC. I was going to add 4 rem padding to the bottom, but the spacing looks excessive on the start page (with radios) because they have inherent spacing around them. 
- _(If bug, how to reproduce)_
  > Go to [HLR subtask](https://staging.va.gov/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996/start) or [SC subtask](https://staging.va.gov/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/start) and look at the "A claim other than disability compensation" page
- _(What is the solution, why is this the solution)_
  > Adjust margin within subtask form to add spacing above the back & continue buttons
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- [#57821](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57821)
- [Design](https://www.figma.com/file/OxukHeNtSkCDbdmLxD5k9A/Higher-Level-Review-(VA-0996)?type=design&node-id=0-43&mode=design&t=V5zu3JzD2qqBKt2F-0)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Form bottom margin disappearing
- _Describe the steps required to verify your changes are working as expected_
  > Follow summary reproduce but steps
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Local dev | Staging |
| ------- | ------ | ----- |
| Form user style | <img width="325" alt="Screenshot 2024-04-12 at 2 29 19 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/f5ebda53-66c1-442d-993e-0c5bff516028"> | <img width="330" alt="Screenshot 2024-04-12 at 2 30 06 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/dfdad6dd-271e-4bae-a0e4-3606c960951a"> |

|         | Before | After |
| ------- | ------ | ----- |
| HLR & SC subtask  | <img width="675" alt="Screenshot 2024-04-12 at 2 34 39 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/247b617a-5298-4071-8afa-320e9d84054c"> | <img width="644" alt="Screenshot 2024-04-12 at 2 49 03 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/bcb85ae7-6faf-4749-99c5-d52a6b4477f3"> |

## What areas of the site does it impact?

HLR & SC subtask pages

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
