### PR TITLE
Small fixes and e2e tests for direct deposit unified form

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/AccountInfoView.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/AccountInfoView.jsx
@@ -48,6 +48,7 @@ const AccountWithInfo = ({
         </TransitionGroup>
       </div>
       <VaButton
+        data-testid="edit-bank-info-button"
         data-field-name="direct-deposit"
         text="Edit"
         className="vads-u-margin--0 vads-u-margin-top--1p5"

--- a/src/applications/personalization/profile/components/direct-deposit/AccountUpdateView.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/AccountUpdateView.jsx
@@ -112,7 +112,12 @@ export const AccountUpdateView = props => {
         >
           Save
         </LoadingButton>
-        <va-button onClick={onCancel} secondary text="Cancel" />
+        <va-button
+          data-testid="cancel-direct-deposit"
+          onClick={onCancel}
+          secondary
+          text="Cancel"
+        />
       </SchemaForm>
 
       <ConfirmCancelModal

--- a/src/applications/personalization/profile/components/direct-deposit/AccountUpdateView.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/AccountUpdateView.jsx
@@ -42,23 +42,23 @@ const uiSchema = {
     'ui:webComponentField': VaRadioField,
     'ui:title': 'Account type',
     'ui:errorMessages': {
-      required: 'Please select the type that best describes your account',
+      required: 'Select the type that best describes your account',
     },
   },
   routingNumber: {
     'ui:webComponentField': VaTextInputField,
     'ui:title': 'Routing number',
     'ui:errorMessages': {
-      pattern: 'Please enter your bank’s 9-digit routing number',
-      required: 'Please enter your bank’s 9-digit routing number',
+      pattern: 'Enter your bank’s 9-digit routing number',
+      required: 'Enter your bank’s 9-digit routing number',
     },
   },
   accountNumber: {
     'ui:webComponentField': VaTextInputField,
     'ui:title': 'Account number (No more than 17 digits)',
     'ui:errorMessages': {
-      pattern: 'Please enter your account number',
-      required: 'Please enter your account number',
+      pattern: 'Enter your account number',
+      required: 'Enter your account number',
     },
   },
   'view:directDepositInfo': {

--- a/src/applications/personalization/profile/components/direct-deposit/AccountUpdateView.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/AccountUpdateView.jsx
@@ -24,7 +24,7 @@ const schema = {
     },
     accountNumber: {
       type: 'string',
-      pattern: '^\\d{1,17}$',
+      pattern: '^\\d{4,17}$',
     },
     'view:directDepositInfo': {
       type: 'object',
@@ -55,9 +55,9 @@ const uiSchema = {
   },
   accountNumber: {
     'ui:webComponentField': VaTextInputField,
-    'ui:title': 'Account number (No more than 17 digits)',
+    'ui:title': 'Account number',
     'ui:errorMessages': {
-      pattern: 'Enter your account number',
+      pattern: 'Enter an account number between 4 and 17 digits',
       required: 'Enter your account number',
     },
   },

--- a/src/applications/personalization/profile/components/direct-deposit/AccountUpdateView.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/AccountUpdateView.jsx
@@ -36,13 +36,13 @@ const schema = {
 
 const uiSchema = {
   'ui:description':
-    'Please provide your bank’s routing number as well as your current account and type.',
+    'Provide your account type, routing number, and account number.',
 
   accountType: {
     'ui:webComponentField': VaRadioField,
     'ui:title': 'Account type',
     'ui:errorMessages': {
-      required: 'Select the type that best describes your account',
+      required: 'Choose the type that best describes your account',
     },
   },
   routingNumber: {

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
@@ -59,6 +59,7 @@ export const DirectDeposit = () => {
     loadError,
     setFormData,
     hasUnsavedFormEdits,
+    isEligible,
   } = directDepositHookResult;
 
   useDirectDepositEffects({ ...directDepositHookResult, cardHeadingId });
@@ -117,7 +118,7 @@ export const DirectDeposit = () => {
     );
   }
 
-  if (controlInformation?.canUpdateDirectDeposit === false) {
+  if (!isEligible) {
     return (
       <Wrapper>
         <Ineligible />

--- a/src/applications/personalization/profile/components/direct-deposit/FraudVictimSummary.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/FraudVictimSummary.jsx
@@ -5,7 +5,7 @@ export const FraudVictimSummary = () => (
   <div className="vads-u-margin-top--4">
     <va-summary-box uswds>
       <h3 className="vads-u-font-size--md" slot="headline">
-        What to do if you think you’ve been the victim of bank fraud
+        What if I think I’ve been the victim of bank fraud?
       </h3>
       <p className="text-balance">
         Call us at <va-telephone contact={CONTACTS.VA_BENEFITS} /> (

--- a/src/applications/personalization/profile/hooks/useDirectDeposit.js
+++ b/src/applications/personalization/profile/hooks/useDirectDeposit.js
@@ -1,16 +1,18 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
+import { usePrevious } from '~/platform/utilities/react-hooks';
 import {
   isAuthenticatedWithOAuth,
   signInServiceName,
 } from '~/platform/user/authentication/selectors';
 import { CSP_IDS } from '~/platform/user/authentication/constants';
-import { usePrevious } from '~/platform/utilities/react-hooks';
 import {
+  createIsServiceAvailableSelector,
   isLOA3 as isLOA3Selector,
   isMultifactorEnabled as isMultifactorEnabledSelector,
 } from '~/platform/user/selectors';
+import backendServices from '~/platform/user/profile/constants/backendServices';
 
 import { getIsBlocked } from '../selectors';
 import {
@@ -75,6 +77,11 @@ export const useDirectDeposit = () => {
     [isLOA3, isMultifactorEnabled, isUsingEligibleSignInService],
   );
 
+  // based on user.icn.present? && user.participant_id.present? in vets-api policy
+  const isLighthouseAvailable = useSelector(
+    createIsServiceAvailableSelector(backendServices.LIGHTHOUSE),
+  );
+
   // function to exit the direct deposit update view
   // also will clear any pending form data in UI
   const exitUpdateView = useCallback(
@@ -137,5 +144,9 @@ export const useDirectDeposit = () => {
     wasSaving,
     wasEditing,
     hasUnsavedFormEdits,
+    isEligible:
+      isLighthouseAvailable &&
+      isIdentityVerified &&
+      controlInformation?.canUpdateDirectDeposit,
   };
 };

--- a/src/applications/personalization/profile/mocks/endpoints/user/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/user/index.js
@@ -1470,6 +1470,14 @@ const loa3UserWithoutMailingAddress = set(
   null,
 );
 
+const loa3UserWithoutLighthouseServiceAvailable = set(
+  cloneDeep(baseUserResponses.loa3User72),
+  'data.attributes.services',
+  baseUserResponses.loa3User72.data.attributes.services.filter(
+    service => service !== 'lighthouse',
+  ),
+);
+
 const responses = {
   ...baseUserResponses,
   ...mockErrorResponses,
@@ -1489,6 +1497,7 @@ const responses = {
   loa3UserWithNoRatingInfoClaim,
   loa3UserWithNoMilitaryHistoryClaim,
   loa3UserWithoutMailingAddress,
+  loa3UserWithoutLighthouseServiceAvailable,
 };
 
 // handler that can be used to customize the user data returned

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -65,7 +65,7 @@ const responses = {
           generateFeatureToggles({
             authExpVbaDowntimeMessage: false,
             profileContacts: true,
-            profileHideDirectDepositCompAndPen: false,
+            profileHideDirectDepositCompAndPen: true,
             profileShowCredentialRetirementMessaging: true,
             profileShowEmailNotificationSettings: true,
             profileShowMhvNotificationSettings: true,
@@ -93,6 +93,7 @@ const responses = {
     // return res.json(user.badAddress); // user with bad address
     // return res.json(user.nonVeteranUser); // non-veteran user
     // return res.json(user.externalServiceError); // external service error
+    // return res.json(user.loa3UserWithoutLighthouseServiceAvailable); // user without lighthouse service available / no icn or participant id
     // return res.json(user.loa3UserWithNoMobilePhone); // user with no mobile phone number
     // return res.json(user.loa3UserWithNoEmail); // user with no email address
     // return res.json(user.loa3UserWithNoEmailOrMobilePhone); // user without email or mobile phone

--- a/src/applications/personalization/profile/tests/components/direct-deposit/AccountUpdateView.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/AccountUpdateView.unit.spec.jsx
@@ -107,11 +107,8 @@ describe('<AccountUpdateView />', () => {
       .exist;
     expect(container.querySelector('va-text-input[label="Routing number"]')).to
       .exist;
-    expect(
-      container.querySelector(
-        'va-text-input[label="Account number (No more than 17 digits)"]',
-      ),
-    ).to.exist;
+    expect(container.querySelector('va-text-input[label="Account number"]')).to
+      .exist;
   });
 
   it('renders the UpdateErrorAlert when saveError is provided', () => {

--- a/src/applications/personalization/profile/tests/components/direct-deposit/DirectDeposit.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/DirectDeposit.unit.spec.jsx
@@ -69,6 +69,7 @@ const createInitialState = ({
           authBroker: 'sis',
         },
         loading: false,
+        services: ['lighthouse'],
       },
     },
     featureToggles: toggles || baseToggles,
@@ -186,6 +187,24 @@ describe('authenticated experience -- profile -- unified direct deposit', () => 
     it('renders ineligible state when canUpdateDirectDeposit is false', () => {
       const state = createInitialState();
       state.directDeposit.controlInformation.canUpdateDirectDeposit = false;
+
+      const { getByText } = renderWithProfileReducersAndRouter(
+        <DirectDeposit />,
+        {
+          initialState: state,
+        },
+      );
+
+      expect(
+        getByText(
+          /Our records show that you don’t receive benefit payments from VA/i,
+        ),
+      ).to.exist;
+    });
+
+    it('renders ineligible state when profile services do not include lighthouse', () => {
+      const state = createInitialState();
+      state.user.profile.services = [];
 
       const { getByText } = renderWithProfileReducersAndRouter(
         <DirectDeposit />,

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/unsupported-signin-provider.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/unsupported-signin-provider.cypress.spec.js
@@ -1,0 +1,86 @@
+import { mockGETEndpoints } from '@@profile/tests/e2e/helpers';
+
+import {
+  loa3User72,
+  dsLogonUser,
+  mvhUser,
+} from '../../../mocks/endpoints/user';
+import DirectDeposit from './page-objects/DirectDeposit';
+
+let getDirectDeposits;
+
+const directDeposit = new DirectDeposit();
+
+function directDepositAPIsNotCalled() {
+  cy.should(() => {
+    expect(getDirectDeposits).not.to.be.called;
+  });
+}
+
+describe('Direct Deposit', () => {
+  beforeEach(() => {
+    // explicitly mock all required APIs to be 500s to speed up the tests
+    mockGETEndpoints([
+      'v0/profile/personal_information',
+      'v0/profile/service_history',
+      'v0/profile/full_name',
+      'v0/profile/status',
+      'v0/mhv_account',
+      'v0/feature_toggles*',
+      '/v0/disability_compensation_form/rating_info',
+    ]);
+    getDirectDeposits = cy.stub();
+
+    cy.intercept('GET', 'v0/profile/direct-deposits', () => {
+      getDirectDeposits();
+    });
+
+    cy.login();
+  });
+  context('when user is a non-2FA ID.me user', () => {
+    /* This case will probably never happen in real life. I believe that you
+    must set up 2FA when you verify your ID with ID.me, so a user should never
+    be LOA3 _without_ also having 2FA set up. */
+    beforeEach(() => {
+      directDeposit.setup();
+      loa3User72.data.attributes.profile.multifactor = false;
+      cy.intercept('GET', 'v0/user', loa3User72);
+    });
+    it('should show a single "verify your account" alert and not call direct deposit APIs', () => {
+      directDeposit.visitPage();
+
+      directDeposit.checkVerifyMessageIsShowing();
+
+      directDepositAPIsNotCalled();
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+  context('when user has 2FA set up but signed in with DSLogon', () => {
+    beforeEach(() => {
+      directDeposit.setup();
+      cy.intercept('GET', 'v0/user', dsLogonUser);
+    });
+    it('should show a single "verify your account" alert and not call direct deposit APIs', () => {
+      directDeposit.visitPage();
+      directDeposit.checkVerifyMessageIsShowing();
+      directDepositAPIsNotCalled();
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+  context(
+    'when user has 2FA set up but signed in with MHV/My HealtheVet',
+    () => {
+      beforeEach(() => {
+        directDeposit.setup();
+        cy.intercept('GET', 'v0/user', mvhUser);
+      });
+      it('should show a single "verify your account" alert and not call direct deposit APIs', () => {
+        directDeposit.visitPage();
+        directDeposit.checkVerifyMessageIsShowing();
+
+        directDepositAPIsNotCalled();
+        cy.injectAxeThenAxeCheck();
+      });
+    },
+  );
+});

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/update-flow.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/update-flow.cypress.spec.js
@@ -1,0 +1,188 @@
+import { PROFILE_PATHS } from '@@profile/constants';
+
+import mockUser36 from '@@profile/tests/fixtures/users/user-36.json';
+import mockDirectDeposits from '@@profile/mocks/endpoints/direct-deposits';
+import { generateFeatureToggles } from '../../../mocks/endpoints/feature-toggles';
+
+import { mockGETEndpoints } from '../helpers';
+
+const TEST_ACCOUNT = {
+  NUMBER: '123123123',
+  ROUTING: '321321321',
+  TYPE: 'Checking',
+};
+
+function fillInBankInfoForm() {
+  cy.axeCheck();
+  cy.get('va-text-input[name="root_routingNumber"]')
+    .shadow()
+    .find('input')
+    .type(TEST_ACCOUNT.ROUTING);
+  cy.get('va-text-input[name="root_accountNumber"]')
+    .shadow()
+    .find('input')
+    .type(TEST_ACCOUNT.NUMBER);
+  cy.get('va-radio-option[value="Checking"]')
+    .find('#root_accountTypeCheckinginput')
+    .click({ force: true });
+}
+
+function dismissUnsavedChangesModal() {
+  cy.axeCheck();
+  cy.get('va-modal')
+    .shadow()
+    .find('.va-modal-close')
+    .click();
+}
+
+function exitBankInfoForm() {
+  cy.findByTestId('cancel-direct-deposit')
+    .shadow()
+    .find('button')
+    .click();
+}
+
+function saveNewBankInfo() {
+  cy.findByRole('button', { name: /save/i }).click({ force: true });
+  cy.axeCheck();
+}
+
+function saveSuccessAlertShown() {
+  cy.axeCheck();
+  cy.findByTestId('bankInfoUpdateSuccessAlert').contains(
+    new RegExp(`Update saved`, 'i'),
+  );
+}
+
+function saveSuccessAlertRemoved() {
+  cy.findByTestId('bankInfoUpdateSuccessAlert').should('not.exist');
+}
+
+function mockSaveError({
+  error = mockDirectDeposits.updates.errors.unspecified,
+  alias = 'unspecifiedSaveError',
+} = {}) {
+  cy.intercept('PUT', 'v0/profile/direct_deposits', {
+    statusCode: 400,
+    body: error,
+  }).as(alias);
+  return alias;
+}
+
+function mockSaveSuccess() {
+  cy.intercept(
+    'PUT',
+    'v0/profile/direct_deposits',
+    mockDirectDeposits.updates.success,
+  ).as('saveSuccess');
+}
+
+const testFailure = (failureName, error) => {
+  it(`shows error messaging for ${failureName}`, () => {
+    const failAlias = mockSaveError({
+      error,
+      alias: failureName,
+    });
+
+    cy.findByTestId('edit-bank-info-button')
+      .shadow()
+      .find('button')
+      .click({
+        force: true,
+      });
+
+    fillInBankInfoForm();
+
+    saveNewBankInfo();
+
+    cy.wait(`@${failAlias}`);
+
+    cy.findByTestId(failureName).should('exist');
+
+    cy.axeCheck();
+  });
+};
+
+describe('Direct Deposit - CNP using Lighthouse endpoint', () => {
+  beforeEach(() => {
+    cy.login(mockUser36);
+    mockGETEndpoints(
+      [
+        '/v0/disability_compensation_form/rating_info',
+        '/v0/user_transition_availabilities',
+        'v0/profile/personal_information',
+        'v0/profile/service_history',
+        'v0/profile/full_name',
+      ],
+      200,
+      {},
+    );
+    cy.intercept(
+      'GET',
+      'v0/profile/direct_deposits',
+      mockDirectDeposits.base,
+    ).as('getDirectDeposit');
+    cy.intercept(
+      'GET',
+      'v0/feature_toggles?*',
+      generateFeatureToggles({
+        profileShowDirectDepositSingleForm: true,
+      }),
+    );
+    cy.visit(PROFILE_PATHS.DIRECT_DEPOSIT);
+    cy.wait(['@getDirectDeposit']);
+    cy.injectAxeThenAxeCheck();
+  });
+  describe('happy path', () => {
+    it('should allow bank info updates, show WIP warning modals, show "success" banner', () => {
+      mockSaveSuccess();
+
+      cy.findByTestId('edit-bank-info-button')
+        .shadow()
+        .find('button')
+        .click({
+          force: true,
+        });
+
+      cy.get('#bank-account-information').should('be.focused');
+
+      fillInBankInfoForm();
+
+      exitBankInfoForm();
+
+      dismissUnsavedChangesModal();
+
+      saveNewBankInfo();
+
+      cy.findByTestId('edit-bank-info-button')
+        .shadow()
+        .find('button')
+        .should('exist');
+
+      saveSuccessAlertShown();
+
+      saveSuccessAlertRemoved();
+
+      cy.axeCheck();
+    });
+  });
+
+  describe('sad update paths for error responses', () => {
+    testFailure('generic-error', mockDirectDeposits.updates.errors.unspecified);
+
+    testFailure(
+      'flagged-account-error',
+      mockDirectDeposits.updates.errors.accountNumberFlagged,
+    );
+
+    testFailure(
+      'flagged-routing-number-error',
+      mockDirectDeposits.updates.errors.routingNumberFlagged,
+    );
+
+    testFailure(
+      'invalid-routing-number-error',
+      mockDirectDeposits.updates.errors.invalidRoutingNumber,
+    );
+  });
+});

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -14,7 +14,8 @@ export const isProfileLoading = state => selectProfile(state).loading;
 export const isLOA3 = state => selectProfile(state).loa.current === 3;
 export const isLOA1 = state => selectProfile(state).loa.current === 1;
 export const isMultifactorEnabled = state => selectProfile(state).multifactor;
-export const selectAvailableServices = state => selectProfile(state)?.services;
+export const selectAvailableServices = state =>
+  selectProfile(state)?.services || [];
 
 export const selectVAPContactInfo = state =>
   selectProfile(state).vapContactInfo;


### PR DESCRIPTION
## Summary

- Adds e2e tests for direct deposit unified form experience
  - Includes update flow e2e tests to cover various error cases
  - Unsupported sign in provider tests 
- Updates some field validation messages and labels.
  - The account number must be at least 4 characters in length and less than 17
  - Removed 'please' from validation messages 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/77466

## Testing done

- e2e tests added
- updated AccountUpdateView unit test for new message content

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | ![Screenshot 2024-04-15 at 9 06 30 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/85c93d4d-bd3b-4380-a333-d00577863dbd) | ![Screenshot 2024-04-15 at 9 02 01 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/9684dd36-e490-4b8e-b6bd-fb895ad42419) |

Also here is the new validation message for when an account number is less than 4 digits in length
![Screenshot 2024-04-15 at 9 02 20 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/c50beb93-c732-465d-8ae8-6673210b0a3c)


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
