### PR TITLE
Explicitly update semver-regex to resolve vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -322,6 +322,7 @@
     "redux-thunk": "^2.3.0",
     "regenerator-runtime": "^0.13.9",
     "reselect": "^2.5.4",
+    "semver-regex": "^4.0.5",
     "styled-components": "^5.3.1",
     "url-search-params": "^1.1.0",
     "url-search-params-polyfill": "^8.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18311,6 +18311,11 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
+semver-regex@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-4.0.5.tgz#fbfa36c7ba70461311f5debcb3928821eb4f9180"
+  integrity sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==
+
 semver-truncate@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/semver-truncate/-/semver-truncate-1.1.2.tgz#57f41de69707a62709a7e0104ba2117109ea47e8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10239,7 +10239,7 @@ find-versions@^3.0.0:
   resolved "https://registry.yarnpkg.com/find-versions/-/find-versions-3.2.0.tgz#10297f98030a786829681690545ef659ed1d254e"
   integrity sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==
   dependencies:
-    semver-regex "^2.0.0"
+    semver-regex "^4.0.0"
 
 find-yarn-workspace-root2@1.2.16:
   version "1.2.16"
@@ -18306,12 +18306,7 @@ semver-diff@^3.1.1:
   dependencies:
     semver "^6.3.0"
 
-semver-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
-  integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
-
-semver-regex@^4.0.5:
+semver-regex@^4.0.0, semver-regex@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-4.0.5.tgz#fbfa36c7ba70461311f5debcb3928821eb4f9180"
   integrity sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==


### PR DESCRIPTION
## Summary
Since we are unable to update yeoman to the next major version (5.0.0) because it requires Node >= 18, I'm explicitly adding and updating semver-regex to package.json. In the future, once we are able to upgrade node to >= 18, we should remove the explicit requirement from package.json.

## Related issue(s)

- [This](https://app.zenhub.com/workspaces/reliability-team-633b069d2920b776613c93d8/issues/gh/department-of-veterans-affairs/va.gov-team/80584) is the ticket addressing the relevant dependabot alert.
- [Dependabot alert](https://github.com/department-of-veterans-affairs/vets-website/security/dependabot/8)

## Testing done
- Local install and build were successful
- Relying on CI to flag other dependency / vulnerability issues

## Screenshots
N/A

## What areas of the site does it impact?
None

## Acceptance criteria

### Quality Assurance & Testing
QA not conducted

### Error Handling
None

### Authentication
None

## Requested Feedback
None
