### PR TITLE
Fix footer links to add 'www'

### DIFF
--- a/src/platform/site-wide/va-footer/components/LanguageSupport.jsx
+++ b/src/platform/site-wide/va-footer/components/LanguageSupport.jsx
@@ -7,7 +7,6 @@ import {
 import { TRANSLATED_LANGUAGES } from 'applications/static-pages/i18Select/utilities/constants';
 import { FOOTER_EVENTS } from '../helpers';
 import recordEvent from '../../../monitoring/record-event';
-import { replaceWithStagingDomain } from '../../../utilities/environment/stagingDomains';
 
 const langAssistanceLabel = 'Language assistance';
 
@@ -15,18 +14,18 @@ export const languageLinks = [
   {
     label: 'Español',
     lang: 'es',
-    href: 'https://va.gov/asistencia-y-recursos-en-espanol',
+    href: 'https://www.va.gov/asistencia-y-recursos-en-espanol',
   },
   {
     label: 'Tagalog',
     lang: 'tl',
-    href: 'https://va.gov/tagalog-wika-mapagkukunan-at-tulong',
+    href: 'https://www.va.gov/tagalog-wika-mapagkukunan-at-tulong',
   },
   {
     label: 'Other languages',
     lang: 'en',
     href:
-      'https://va.gov/resources/how-to-get-free-language-assistance-from-va/',
+      'https://www.va.gov/resources/how-to-get-free-language-assistance-from-va/',
   },
 ];
 
@@ -36,7 +35,7 @@ function LanguagesListTemplate({ dispatchLanguageSelection }) {
       {languageLinks.map((link, i) => (
         <li key={i}>
           <a
-            href={replaceWithStagingDomain(link.href)}
+            href={link.href}
             lang={link.lang}
             hrefLang={link.lang}
             onClick={() => {

--- a/src/platform/site-wide/va-footer/tests/cypress/footer-links.js
+++ b/src/platform/site-wide/va-footer/tests/cypress/footer-links.js
@@ -135,15 +135,15 @@ export const topRail = [
 export const language = [
   {
     text: 'Español',
-    href: '/asistencia-y-recursos-en-espanol',
+    href: 'https://www.va.gov/asistencia-y-recursos-en-espanol',
   },
   {
     text: 'Tagalog',
-    href: '/tagalog-wika-mapagkukunan-at-tulong',
+    href: 'https://www.va.gov/tagalog-wika-mapagkukunan-at-tulong',
   },
   {
     text: 'Other languages',
-    href: '/how-to-get-free-language-assistance-from-va',
+    href: 'https://www.va.gov/how-to-get-free-language-assistance-from-va',
   },
 ];
 


### PR DESCRIPTION
## Summary
If you're accessing things on the VA network, links don't work unless the `www` is added. This fixes that issue.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17812

## Testing done
Tested VA.gov and injected header locally.