### PR TITLE
Add hint text / updated error message to HCA Other Toxins TERA page

### DIFF
--- a/src/applications/hca/components/FormDescriptions/index.jsx
+++ b/src/applications/hca/components/FormDescriptions/index.jsx
@@ -230,6 +230,13 @@ export const OtherToxicExposureDescription = (
   </div>
 );
 
+export const OtherToxicExposureHint = (
+  <div className="vads-u-color--gray-medium">
+    If you’re listing multiple toxins or hazards, list them without commas or
+    any other special characters
+  </div>
+);
+
 /** CHAPTER 4: Household Information */
 export const DeductibleExpensesDescription = () => (
   <legend className="schemaform-block-title">

--- a/src/applications/hca/config/chapters/militaryService/otherToxicExposureDetails.js
+++ b/src/applications/hca/config/chapters/militaryService/otherToxicExposureDetails.js
@@ -1,6 +1,9 @@
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
-import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
-import { OtherToxicExposureDescription } from '../../../components/FormDescriptions';
+import { titleUI } from '~/platform/forms-system/src/js/web-component-patterns';
+import {
+  OtherToxicExposureDescription,
+  OtherToxicExposureHint,
+} from '../../../components/FormDescriptions';
 
 const { otherToxicExposure } = fullSchemaHca.properties;
 
@@ -13,8 +16,10 @@ export default {
     'ui:description': OtherToxicExposureDescription,
     otherToxicExposure: {
       'ui:title': 'Enter any toxins or hazards you\u2019ve been exposed to',
+      'ui:description': OtherToxicExposureHint,
       'ui:errorMessages': {
-        pattern: 'Please enter a valid toxin or hazard',
+        pattern:
+          'You entered a character we can\u2019t accept. Remove any special characters like commas or dashes',
       },
     },
   },


### PR DESCRIPTION
## Summary

During a usability session around the Toxic Exposure questions on the Health Care Application, a participant had issues with the Other toxic exposures open text field questions/page. They were entering multiple toxins separated by a comma (when those characters cannot be accepted in the field). This PR adds some hint text and updates the error message displayed when a user has entered characters that aren't allowed.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#80265

## Testing done

- Validated with manual testing

## Screenshots

**Without error:**

![Screenshot 2024-04-15 at 12 54 12](https://github.com/department-of-veterans-affairs/va.gov-team/assets/6738544/d159590e-d6cf-44e1-8091-22d4a4f11536)

**With error:**

![Screenshot 2024-04-15 at 12 48 04](https://github.com/department-of-veterans-affairs/va.gov-team/assets/6738544/1691c821-e6ef-4d82-8d25-1bf190bf5b4c)

## Acceptance criteria

- Hint text and error messaging are helpful to users

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution