### PR TITLE
Reenable ConfirmedAppointmentDetailsPage tests

### DIFF
--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.js
@@ -51,7 +51,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
     mockFacilitiesFetchByVersion();
   });
 
-  it.skip('should show confirmed appointments detail page', async () => {
+  it('should show confirmed appointments detail page', async () => {
     // Arrange
     const response = new MockAppointmentResponse();
     response
@@ -123,7 +123,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
     );
   });
 
-  it.skip('should show confirmed phone appointments detail page', async () => {
+  it('should show confirmed phone appointments detail page', async () => {
     // Arrange
     const response = new MockAppointmentResponse({
       kind: TYPE_OF_VISIT_ID.phone,
@@ -215,7 +215,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
     );
   });
 
-  it.skip('should show who cancel phone appointments detail page', async () => {
+  it('should show who cancel phone appointments detail page', async () => {
     // Given a phone appointment
     const myInitialState = {
       ...initialState,
@@ -349,7 +349,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
     );
   });
 
-  it.skip('should show details without clinic name when clinic call fails', async () => {
+  it('should show details without clinic name when clinic call fails', async () => {
     const myInitialState = {
       ...initialState,
       featureToggles: {
@@ -542,7 +542,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
     expect(screen.getByText(/Cancel appointment/)).to.be.ok;
   });
 
-  it.skip('should show past confirmed appointments detail page', async () => {
+  it('should show past confirmed appointments detail page', async () => {
     // Arrange
     const now = moment().tz('America/Denver');
     const yesterday = moment(now).subtract(1, 'day');
@@ -593,7 +593,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
     expect(screen.baseElement).not.to.contain.text('Cancel appointment');
   });
 
-  it.skip('should allow cancellation', async () => {
+  it('should allow cancellation', async () => {
     // Arrange
     // Given a veteran has VA appointments
     const response = new MockAppointmentResponse();
@@ -640,7 +640,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
     );
   });
 
-  it.skip('should not allow cancellation of COVID-19 vaccine appointments', async () => {
+  it('should not allow cancellation of COVID-19 vaccine appointments', async () => {
     // Arrange
     const response = new MockAppointmentResponse({
       serviceType: 'covid',
@@ -670,7 +670,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
     );
   });
 
-  it.skip('should display who canceled the appointment', async () => {
+  it('should display who canceled the appointment', async () => {
     // Arrange
     const response = new MockAppointmentResponse({
       status: APPOINTMENT_STATUS.cancelled,
@@ -696,7 +696,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
       .exist;
   });
 
-  it.skip('should display who canceled the appointment for past appointments', async () => {
+  it('should display who canceled the appointment for past appointments', async () => {
     // Arrange
     const response = new MockAppointmentResponse({
       localStartTime: moment().subtract(1, 'day'),
@@ -725,7 +725,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
       .exist;
   });
 
-  it.skip('should fire a print request when print button clicked', async () => {
+  it('should fire a print request when print button clicked', async () => {
     // Arrange
     const oldPrint = global.window.print;
     const printSpy = sinon.spy();
@@ -752,7 +752,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
     global.window.print = oldPrint;
   });
 
-  it.skip('should show error message when single fetch errors', async () => {
+  it('should show error message when single fetch errors', async () => {
     // Arrange
     mockAppointmentApi({
       response: new MockAppointmentResponse(),
@@ -778,7 +778,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
     });
   });
 
-  it.skip('should allow the user to close the cancel modal without canceling', async () => {
+  it('should allow the user to close the cancel modal without canceling', async () => {
     // Arrange
     const response = new MockAppointmentResponse();
     mockAppointmentApi({ response });
@@ -805,7 +805,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
     );
   });
 
-  it.skip('should allow the user to go back to the appointment list', async () => {
+  it('should allow the user to go back to the appointment list', async () => {
     // Arrange
     const response = new MockAppointmentResponse();
 


### PR DESCRIPTION
## Summary

- These tests were disabled in https://github.com/department-of-veterans-affairs/vets-website/pull/28455 but are now passing locally so I'm reenabling them.
- I examined the tests and didn't find any that could be affected by DST.
- Possible hardening by using UTC time or specifying specific time and hours instead of relying on `moment`'s now behavior, specifically to mitigate risks of time arithmetic [here](https://github.com/department-of-veterans-affairs/vets-website/blob/7f43320d4a8af472550397e3b246fe8f8b2e84c5/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.js#L548).

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/77463

## Testing done

- Tested these unit tests locally at the specified time indicated by the cron job.

## Screenshots

<img width="862" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2030323/180fd637-5f82-460a-ab95-123b4d4c3d0f">

## What areas of the site does it impact?

N/A

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
