### PR TITLE
10-7959f-1 Adding subtitle and headers

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -132,8 +132,7 @@ const formConfig = {
       pages: {
         page3: {
           path: 'home-address',
-          title: 'Home address',
-          reviewTitle: 'Home Address',
+          title: "Veteran's Home address",
           uiSchema: {
             ...titleUI(
               'Home Address',
@@ -169,8 +168,7 @@ const formConfig = {
       pages: {
         page4: {
           path: 'mailing-address',
-          title: 'Mailing address',
-          reviewTitle: 'Mailing Address',
+          title: "Veteran's Mailing address",
           uiSchema: {
             ...titleUI(
               'Mailing address',

--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -70,7 +70,7 @@ const formConfig = {
       'Please sign in again to continue your application for CHAMPVA benefits.',
   },
   title: 'Register for the Foreign Medical Program (FMP)',
-  subTitle: 'Form 10-10d',
+  subTitle: 'Form 10-7959f-1',
   defaultDefinitions: {},
   chapters: {
     applicantInformationChapter: {

--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -70,6 +70,7 @@ const formConfig = {
       'Please sign in again to continue your application for CHAMPVA benefits.',
   },
   title: 'Register for the Foreign Medical Program (FMP)',
+  subTitle: 'Form 10-10d',
   defaultDefinitions: {},
   chapters: {
     applicantInformationChapter: {

--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -69,7 +69,7 @@ const formConfig = {
     noAuth:
       'Please sign in again to continue your application for CHAMPVA benefits.',
   },
-  title: 'Foreign Medical Program (FMP) Registration Form',
+  title: 'Register for the Foreign Medical Program (FMP)',
   defaultDefinitions: {},
   chapters: {
     applicantInformationChapter: {
@@ -78,7 +78,7 @@ const formConfig = {
         page1: {
           initialData: mockdata.data,
           path: 'veteran-information',
-          title: 'Name and date of birth',
+          title: 'Personal Information',
           uiSchema: {
             ...titleUI(
               'Name and date of birth',
@@ -132,7 +132,8 @@ const formConfig = {
       pages: {
         page3: {
           path: 'home-address',
-          title: 'Home Address',
+          title: 'Home address',
+          reviewTitle: 'Home Address',
           uiSchema: {
             ...titleUI(
               'Home Address',
@@ -169,6 +170,7 @@ const formConfig = {
         page4: {
           path: 'mailing-address',
           title: 'Mailing address',
+          reviewTitle: 'Mailing Address',
           uiSchema: {
             ...titleUI(
               'Mailing address',

--- a/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
@@ -17,7 +17,7 @@ class IntroductionPage extends React.Component {
     return (
       <article className="schemaform-intro">
         <FormTitle
-          title="Register for the Foreign Medical Program"
+          title="Register for the Foreign Medical Program (FMP)"
           subtitle="Form 10-7959f-1"
         />
         <VaAlert status="info" visible uswds>

--- a/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
@@ -18,7 +18,7 @@ class IntroductionPage extends React.Component {
       <article className="schemaform-intro">
         <FormTitle
           title="Register for the Foreign Medical Program (FMP)"
-          subtitle="Form 10-7959f-1"
+          subTitle="Form 10-7959f-1"
         />
         <VaAlert status="info" visible uswds>
           <h2>Have you applied for VA health care before?</h2>


### PR DESCRIPTION
## Summary
This PR is a small one to add headers to the review page (did not realize they needed to be added in).

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/80180

## Testing done
This was just a few string changes, so visual testing was completed to ensure matches to Figma.

## Screenshots
![Screenshot 2024-04-16 at 7 42 59 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/9f67d8bd-3de0-4656-9986-c66a29c3fcc2)
![Screenshot 2024-04-16 at 8 03 10 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/e7a7bff5-fc5b-40f4-9463-578811a9909f)

## What areas of the site does it impact?
only this form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA
