### PR TITLE
Rep status widget url update

### DIFF
--- a/src/applications/static-pages/representative-status/api/RepresentativeStatusApi.js
+++ b/src/applications/static-pages/representative-status/api/RepresentativeStatusApi.js
@@ -4,7 +4,7 @@ import environment from '@department-of-veterans-affairs/platform-utilities/envi
 class RepresentativeStatusApi {
   static getRepresentativeStatus() {
     const requestUrl = `${
-      environment.BASE_URL
+      environment.API_URL
     }/representation_management/v0/power_of_attorney`;
     const apiSettings = {
       'Content-Type': 'application/json',


### PR DESCRIPTION

## Summary

One line change to the representative status widget (should use `environment.API_URL` rather than `environment.BASE_URL`)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/77602
