### PR TITLE
VFEP-1276 added focus on birth year field after one back-space if applicant is under 18

### DIFF
--- a/src/applications/edu-benefits/1995/pages/applicantInformationUpdate.js
+++ b/src/applications/edu-benefits/1995/pages/applicantInformationUpdate.js
@@ -58,7 +58,7 @@ export const uiSchema = {
   minorHighSchoolQuestions: {
     'ui:description': ageWarning,
     'ui:options': {
-      expandUnder: ['dateOfBirth'],
+      // expandUnder: ['dateOfBirth'],
       hideIf: formData => eighteenOrOver(formData.dateOfBirth),
     },
     minorHighSchoolQuestion: {


### PR DESCRIPTION
## Summary
- Added focus on birth year field for under 18 applicants. 

## Screenshots
<img width="777" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/145523589/7f85f427-bea6-4775-95f7-455427c9bb26">

<img width="1728" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/145523589/d1cc3f68-d9f9-4db0-9d29-8d57349f79f4">

