### PR TITLE
Burials v2 correct logic

### DIFF
--- a/src/applications/burials-v2/config/form.js
+++ b/src/applications/burials-v2/config/form.js
@@ -279,7 +279,17 @@ const formConfig = {
           title: 'Burial allowance',
           reviewTitle: ' ',
           path: 'benefits/burial-allowance/statement-of-truth',
-          depends: form => get('burialAllowanceRequested.unclaimed', form),
+          depends: form => {
+            const burialsSelected = get(
+              'view:claimedBenefits.burialAllowance',
+              form,
+            );
+            const unclaimedSelected = get(
+              'burialAllowanceRequested.unclaimed',
+              form,
+            );
+            return burialsSelected && unclaimedSelected;
+          },
           uiSchema: burialAllowanceConfirmation.uiSchema,
           schema: burialAllowanceConfirmation.schema,
         },
@@ -299,7 +309,7 @@ const formConfig = {
             </div>
           ),
           path: 'benefits/final-resting-place',
-          depends: form => get('view:claimedBenefits.burialAllowance', form),
+          depends: form => get('view:claimedBenefits.plotAllowance', form),
           uiSchema: finalRestingPlace.uiSchema,
           schema: finalRestingPlace.schema,
         },
@@ -311,7 +321,7 @@ const formConfig = {
             </div>
           ),
           path: 'benefits/cemetery-type',
-          depends: form => get('view:claimedBenefits.burialAllowance', form),
+          depends: form => get('view:claimedBenefits.plotAllowance', form),
           uiSchema: nationalOrFederalCemetery.uiSchema,
           schema: nationalOrFederalCemetery.schema,
         },
@@ -320,7 +330,7 @@ const formConfig = {
           reviewTitle: ' ',
           path: 'benefits/cemetery-location',
           depends: form =>
-            get('view:claimedBenefits.burialAllowance', form) &&
+            get('view:claimedBenefits.plotAllowance', form) &&
             !get('nationalOrFederal', form),
           uiSchema: cemeteryLocationQuestion.uiSchema,
           schema: cemeteryLocationQuestion.schema,
@@ -330,7 +340,7 @@ const formConfig = {
           reviewTitle: ' ',
           path: 'benefits/cemetery-location/add',
           depends: form =>
-            get('view:claimedBenefits.burialAllowance', form) &&
+            get('view:claimedBenefits.plotAllowance', form) &&
             get('cemetaryLocationQuestion', form) === 'cemetery',
           uiSchema: cemeteryLocation.uiSchema,
           schema: cemeteryLocation.schema,
@@ -340,7 +350,7 @@ const formConfig = {
           reviewTitle: ' ',
           path: 'benefits/cemetery-location/tribal-land/add',
           depends: form =>
-            get('view:claimedBenefits.burialAllowance', form) &&
+            get('view:claimedBenefits.plotAllowance', form) &&
             get('cemetaryLocationQuestion', form) === 'tribalLand',
           uiSchema: tribalLandLocation.uiSchema,
           schema: tribalLandLocation.schema,

--- a/src/applications/burials-v2/tests/config/chapters/04-benefits-selection/burialAllowanceConfirmation.spec.jsx
+++ b/src/applications/burials-v2/tests/config/chapters/04-benefits-selection/burialAllowanceConfirmation.spec.jsx
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { expect } from 'chai';
+import React from 'react';
+import createCommonStore from '@department-of-veterans-affairs/platform-startup/store';
+import {
+  DefinitionTester,
+  getFormDOM,
+} from 'platform/testing/unit/schemaform-utils';
+import { $$ } from 'platform/forms-system/src/js/utilities/ui';
+import formConfig from '../../../../config/form';
+
+const defaultStore = createCommonStore();
+
+describe('Benefits Selection Confirmation', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.benefitsSelection.pages.burialAllowanceConfirmation;
+
+  it('should render', () => {
+    const form = render(
+      <Provider store={defaultStore}>
+        <DefinitionTester
+          schema={schema}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+          data={{}}
+        />
+      </Provider>,
+    );
+    const formDOM = getFormDOM(form);
+
+    expect($$('va-checkbox', formDOM).length).to.equal(1);
+  });
+});

--- a/src/applications/burials-v2/tests/config/form.unit.spec.jsx
+++ b/src/applications/burials-v2/tests/config/form.unit.spec.jsx
@@ -130,9 +130,30 @@ describe('Burials Form', () => {
       expect(result).to.eq(true);
     });
 
-    it('should depend correctly for burial allowance confirmation', () => {
+    it('should hide state of true when burial allowance not selected', () => {
       const result = formConfig.chapters.benefitsSelection.pages.burialAllowanceConfirmation.depends(
-        { burialAllowanceRequested: { unclaimed: true } },
+        {
+          'view:claimedBenefits': {
+            plotAllowance: true,
+          },
+          burialAllowanceRequested: {
+            unclaimed: true,
+          },
+        },
+      );
+      expect(result).to.eq(undefined);
+    });
+
+    it('should show state of true when burial allowance not selected', () => {
+      const result = formConfig.chapters.benefitsSelection.pages.burialAllowanceConfirmation.depends(
+        {
+          'view:claimedBenefits': {
+            burialAllowance: true,
+          },
+          burialAllowanceRequested: {
+            unclaimed: true,
+          },
+        },
       );
       expect(result).to.eq(true);
     });
@@ -153,7 +174,7 @@ describe('Burials Form', () => {
 
     it('should depend correctly for final resting place', () => {
       const result = formConfig.chapters.benefitsSelection.pages.finalRestingPlace.depends(
-        { 'view:claimedBenefits': { burialAllowance: true } },
+        { 'view:claimedBenefits': { plotAllowance: true } },
       );
       expect(result).to.eq(true);
     });
@@ -167,14 +188,14 @@ describe('Burials Form', () => {
 
     it('should depend correctly for national or federal cemetery', () => {
       const result = formConfig.chapters.benefitsSelection.pages.nationalOrFederalCemetery.depends(
-        { 'view:claimedBenefits': { burialAllowance: true } },
+        { 'view:claimedBenefits': { plotAllowance: true } },
       );
       expect(result).to.eq(true);
     });
 
     it('should depend correctly for cemetery location question', () => {
       const result = formConfig.chapters.benefitsSelection.pages.cemeteryLocationQuestion.depends(
-        { 'view:claimedBenefits': { burialAllowance: true } },
+        { 'view:claimedBenefits': { plotAllowance: true } },
       );
       expect(result).to.eq(true);
     });
@@ -182,7 +203,7 @@ describe('Burials Form', () => {
     it('should depend correctly for cemetery location', () => {
       const result = formConfig.chapters.benefitsSelection.pages.cemeteryLocation.depends(
         {
-          'view:claimedBenefits': { burialAllowance: true },
+          'view:claimedBenefits': { plotAllowance: true },
           cemetaryLocationQuestion: 'cemetery',
         },
       );
@@ -192,7 +213,7 @@ describe('Burials Form', () => {
     it('should depend correctly for tribal land location', () => {
       const result = formConfig.chapters.benefitsSelection.pages.tribalLandLocation.depends(
         {
-          'view:claimedBenefits': { burialAllowance: true },
+          'view:claimedBenefits': { plotAllowance: true },
           cemetaryLocationQuestion: 'tribalLand',
         },
       );


### PR DESCRIPTION


## Summary

- Correct depends on form pages so that pages load when the appropriate box is checked.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/80853

## Testing done

certifying remains page no longer shows when user first completes burials flow then transitions to plot flow
plot pages are now seen when the plot option is selected.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

burials v2

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

