### PR TITLE
[CST] - Remove aria described by message

### DIFF
--- a/src/applications/claims-status/components/AddFilesFormOld.jsx
+++ b/src/applications/claims-status/components/AddFilesFormOld.jsx
@@ -274,7 +274,6 @@ class AddFilesFormOld extends React.Component {
           }}
           checked={this.state.checked}
           error={this.state.errorMessageCheckbox}
-          message-aria-describedby="To submit supporting documents for a new disability claim, please visit our How to File a Claim page link below."
           label="The files I uploaded are supporting documents for this claim only."
         />
         <div className="vads-u-padding-top--2 vads-u-padding-bottom--2 vads-u-padding-left--4">

--- a/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
@@ -261,7 +261,6 @@ class AddFilesForm extends React.Component {
         <VaCheckbox
           label="The files I uploaded support this claim only."
           className="vads-u-margin-y--3"
-          message-aria-describedby="To submit supporting documents for a new disability claim, please visit our How to File a Claim page link below."
           checked={this.state.checked}
           error={this.state.errorMessageCheckbox}
           onVaChange={event => {


### PR DESCRIPTION
## Summary

Removed the `message-aria-describedby` from the files tab on AddFilesForm.jsx and AddFilesFormOld.jsx

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#78891

## Screenshots
**Before:**

![](https://api.zenhub.com/attachedFiles/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMjc1QXc9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--9da8de7a20185fd77de1e67c87e7bfc7a71342cf/image.png)


**After:**
![Screenshot 2024-04-16 at 2 22 15 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/f0191bd8-55bb-4a04-af2e-3bc58fec9ab6)

## What areas of the site does it impact?

Claim Status Tool

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
