### PR TITLE
MHV-56947/57071: Rx Download Alert Updates

### DIFF
--- a/src/applications/mhv/medications/components/shared/PrintDownload.jsx
+++ b/src/applications/mhv/medications/components/shared/PrintDownload.jsx
@@ -81,10 +81,11 @@ const PrintDownload = props => {
     <>
       {isSuccess && (
         <div
+          aria-live="polite"
           className="vads-u-margin-bottom--3"
           data-testid="download-success-banner"
         >
-          <va-alert status="success" aria-live="polite" background-only uswds>
+          <va-alert status="success" background-only uswds>
             <h2 slot="headline">Download started</h2>
             <p className="vads-u-margin--0">
               Check your device’s downloads location for your file.

--- a/src/applications/mhv/medications/components/shared/PrintDownload.jsx
+++ b/src/applications/mhv/medications/components/shared/PrintDownload.jsx
@@ -34,6 +34,7 @@ const PrintDownload = props => {
 
   const handleDownload = async format => {
     try {
+      setMenuOpen(!menuOpen);
       setIsError(false);
       await download(format);
     } catch {
@@ -80,18 +81,21 @@ const PrintDownload = props => {
     <>
       {isSuccess && (
         <div
-          className="vads-u-margin-bottom--2"
+          className="vads-u-margin-bottom--3"
           data-testid="download-success-banner"
         >
-          <va-alert status="success" background-only uswds>
-            <p className="vads-u-margin--0">Download complete</p>
+          <va-alert status="success" aria-live="polite" background-only uswds>
+            <h2 slot="headline">Download started</h2>
+            <p className="vads-u-margin--0">
+              Check your device’s downloads location for your file.
+            </p>
           </va-alert>
         </div>
       )}
       {isError && (
-        <div className="vads-u-margin-bottom--2">
+        <div className="vads-u-margin-bottom--3">
           <va-alert status="error" uswds>
-            <h2 slot="headline">We can’t access your medications right now</h2>
+            <h2 slot="headline">We can’t download your records right now</h2>
             <p className="vads-u-margin-bottom--0">
               We’re sorry. There’s a problem with our system. Check back later.
             </p>

--- a/src/applications/mhv/medications/components/shared/PrintDownload.jsx
+++ b/src/applications/mhv/medications/components/shared/PrintDownload.jsx
@@ -96,7 +96,7 @@ const PrintDownload = props => {
         <div className="vads-u-margin-bottom--3">
           <va-alert status="error" uswds>
             <h2 slot="headline">We can’t download your records right now</h2>
-            <p className="vads-u-margin-bottom--0">
+            <p>
               We’re sorry. There’s a problem with our system. Check back later.
             </p>
             <p className="vads-u-margin--0">

--- a/src/applications/mhv/medications/containers/LandingPage.jsx
+++ b/src/applications/mhv/medications/containers/LandingPage.jsx
@@ -183,7 +183,7 @@ const LandingPage = () => {
             <h2>Questions about this tool</h2>
             <section>
               <va-accordion bordered data-testid="accordion-dropdown" uswds>
-                <va-accordion-item>
+                <va-accordion-item bordered="true">
                   <h3 className="vads-u-font-size--h6" slot="headline">
                     Does this tool list all my medications and supplies?
                   </h3>
@@ -242,7 +242,7 @@ const LandingPage = () => {
                     </li>
                   </ul>
                 </va-accordion-item>
-                <va-accordion-item>
+                <va-accordion-item bordered="true">
                   <h3 className="vads-u-font-size--h6" slot="headline">
                     What types of prescriptions can I refill and track in this
                     tool?
@@ -268,7 +268,7 @@ const LandingPage = () => {
                     Learn how to renew prescriptions
                   </a>
                 </va-accordion-item>
-                <va-accordion-item>
+                <va-accordion-item bordered="true">
                   <h3 className="vads-u-font-size--h6" slot="headline">
                     How long will it take to get my prescriptions?
                   </h3>
@@ -292,7 +292,7 @@ const LandingPage = () => {
                     <strong>at least 15 days</strong> before you need more.
                   </p>
                 </va-accordion-item>
-                <va-accordion-item>
+                <va-accordion-item bordered="true">
                   <h3 className="vads-u-font-size--h6" slot="headline">
                     Will VA protect my personal health information?
                   </h3>
@@ -316,7 +316,7 @@ const LandingPage = () => {
                     public computer.
                   </p>
                 </va-accordion-item>
-                <va-accordion-item>
+                <va-accordion-item bordered="true">
                   <h3 className="vads-u-font-size--h6" slot="headline">
                     What if I have more questions?
                   </h3>
@@ -360,7 +360,10 @@ const LandingPage = () => {
             </p>
             <section>
               <va-accordion uswds bordered data-testid="more-ways-to-manage">
-                <va-accordion-item open={isRxRenewAccordionOpen}>
+                <va-accordion-item
+                  open={isRxRenewAccordionOpen}
+                  bordered="true"
+                >
                   <h3 className="vads-u-font-size--h6" slot="headline">
                     How to renew prescriptions
                   </h3>
@@ -432,7 +435,7 @@ const LandingPage = () => {
                     message with all of your requests.
                   </p>
                 </va-accordion-item>
-                <va-accordion-item>
+                <va-accordion-item bordered="true">
                   <h3 className="vads-u-font-size--h6" slot="headline">
                     How to confirm or update your mailing address
                   </h3>
@@ -453,7 +456,7 @@ const LandingPage = () => {
                     Find your VA health facility
                   </a>
                 </va-accordion-item>
-                <va-accordion-item>
+                <va-accordion-item bordered="true">
                   <h3 className="vads-u-font-size--h6" slot="headline">
                     How to manage notifications for prescription shipments
                   </h3>
@@ -479,7 +482,7 @@ const LandingPage = () => {
                     Go to your profile on the My HealtheVet website
                   </a>
                 </va-accordion-item>
-                <va-accordion-item>
+                <va-accordion-item bordered="true">
                   <h3 className="vads-u-font-size--h6" slot="headline">
                     How to review your allergies and reactions
                   </h3>

--- a/src/applications/mhv/medications/tests/components/shared/PrintDownload.unit.spec.jsx
+++ b/src/applications/mhv/medications/tests/components/shared/PrintDownload.unit.spec.jsx
@@ -49,7 +49,7 @@ describe('Medicaitons Print/Download button component', () => {
     fireEvent.click(downloadButton);
 
     const errorMessage = await screen.getByText(
-      'We can’t access your medications right now',
+      'We can’t download your records right now',
     );
     expect(errorMessage).to.exist;
   });
@@ -57,7 +57,7 @@ describe('Medicaitons Print/Download button component', () => {
   it('displays success message ', () => {
     const screen = setup(handleFullListDownload, true);
 
-    const sucessMessage = screen.getByText('Download complete');
+    const sucessMessage = screen.getByText('Download started');
     expect(sucessMessage).to.exist;
   });
 

--- a/src/applications/mhv/medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv/medications/tests/e2e/pages/MedicationsListPage.js
@@ -123,7 +123,7 @@ class MedicationsListPage {
   verifyDownloadCompleteSuccessMessageBanner = () => {
     cy.get('[data-testid="download-success-banner"]').should(
       'contain',
-      'Download complete',
+      'Download started',
     );
   };
 

--- a/src/applications/mhv/medications/util/constants.js
+++ b/src/applications/mhv/medications/util/constants.js
@@ -170,7 +170,7 @@ export const INCLUDE_IMAGE_ENDPOINT = '&include_image=true';
 export const PDF_TXT_GENERATE_STATUS = {
   NotStarted: 'PDF_GENERATE_NOT_STARTED',
   InProgress: 'PDF_GENERATE_IN_PROGRESS',
-  Success: 'PDF_GENERATE_SUCESS',
+  Success: 'PDF_GENERATE_SUCCESS',
 };
 
 export const defaultSelectedSortOption =


### PR DESCRIPTION
## Summary

- Rx Download alert changes
- Rx About Medications page made accordions bordered

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-56947
https://jira.devops.va.gov/browse/MHV-57071

<img width="917" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/35e8ff93-2c22-420c-9db9-3c14bc79b2e1">

<img width="932" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/8c090c60-04df-416a-b45f-775ac54aa7b3">

## Screenshots

<img width="870" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/58efb02d-ad5c-4840-bb4f-c67e7dfb3dfc">

<img width="865" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/b914cd57-a036-4c1d-81d4-ed19aa7f6987">

<img width="897" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/de188a3a-acfb-40b1-925f-ca7e2e807970">

## Testing done

- Manual testing with data mocking (i.e. errors thrown)
- Unit tests updated
- E2E tests updated

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: If download fails the error alert should show
AC2: If download starts successfully the success alert should show
AC3: Alert should appear above the print/download button with 24 px between top of button and bottom of alert
AC4: The menu button should close after the user clicks any section
AC5: If downloading, the alert gets an aria-live="polite" and focus lands on the print/download button

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
