### PR TITLE
Removed feature toggle profileShowProofOfVeteranStatus

### DIFF
--- a/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
@@ -2,8 +2,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { some } from 'lodash';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
-import { connect, useSelector } from 'react-redux';
-import { selectProfileShowProofOfVeteranStatusToggle } from '@@profile/selectors';
+import { connect } from 'react-redux';
 import ProofOfVeteranStatus from '../proof-of-veteran-status/ProofOfVeteranStatus';
 
 import { DevTools } from '~/applications/personalization/common/components/devtools/DevTools';
@@ -211,10 +210,6 @@ const MilitaryInformation = ({ militaryInformation, veteranStatus }) => {
     document.title = `Military Information | Veterans Affairs`;
   }, []);
 
-  const profileShowProofOfVeteranStatus = useSelector(
-    selectProfileShowProofOfVeteranStatusToggle,
-  );
-
   return (
     <div>
       <Headline>Military information</Headline>
@@ -238,12 +233,11 @@ const MilitaryInformation = ({ militaryInformation, veteranStatus }) => {
         />
       </va-summary-box>
 
-      {profileShowProofOfVeteranStatus &&
-        militaryInformation?.serviceHistory?.serviceHistory && (
-          <div className="vads-u-margin-y--4">
-            <ProofOfVeteranStatus />
-          </div>
-        )}
+      {militaryInformation?.serviceHistory?.serviceHistory && (
+        <div className="vads-u-margin-y--4">
+          <ProofOfVeteranStatus />
+        </div>
+      )}
       <DevTools devToolsData={{ militaryInformation, veteranStatus }} panel>
         <p>Profile devtools test, please ignore.</p>
       </DevTools>

--- a/src/applications/personalization/profile/constants.js
+++ b/src/applications/personalization/profile/constants.js
@@ -9,7 +9,6 @@ export const PROFILE_TOGGLES = {
   profileUseExperimental: false,
   profileShowQuickSubmitNotificationSetting: false,
   profileShowEmailNotificationSettings: false,
-  profileShowProofOfVeteranStatus: false,
   profileShowDirectDepositSingleForm: false,
   profileShowDirectDepositSingleFormAlert: false,
   profileShowDirectDepositSingleFormEduDowntime: false,

--- a/src/applications/personalization/profile/mocks/endpoints/feature-toggles/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/feature-toggles/index.js
@@ -16,7 +16,6 @@ const profileToggles = {
   profileShowDirectDepositSingleFormAlert: false,
   profileShowDirectDepositSingleFormEduDowntime: false,
   profileShowEmailNotificationSettings: false,
-  profileShowProofOfVeteranStatus: false,
 };
 
 const makeAllTogglesTrue = toggles => {

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -70,7 +70,6 @@ const responses = {
             profileShowEmailNotificationSettings: true,
             profileShowMhvNotificationSettings: true,
             profileShowPaymentsNotificationSetting: true,
-            profileShowProofOfVeteranStatus: true,
             profileShowQuickSubmitNotificationSetting: true,
             profileUseExperimental: true,
             profileShowDirectDepositSingleForm: true,

--- a/src/applications/personalization/profile/selectors.js
+++ b/src/applications/personalization/profile/selectors.js
@@ -134,9 +134,6 @@ export const selectIsBlocked = state => {
 export const selectProfileContactsToggle = state =>
   toggleValues(state)?.[FEATURE_FLAG_NAMES.profileContacts] || false;
 
-export const selectProfileShowProofOfVeteranStatusToggle = state =>
-  toggleValues(state)?.[FEATURE_FLAG_NAMES.profileShowProofOfVeteranStatus];
-
 export const selectProfileContacts = state => state?.profileContacts || {};
 
 export const selectHasRetiringSignInService = state => {

--- a/src/applications/personalization/profile/tests/components/MilitaryInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/MilitaryInformation.unit.spec.jsx
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 
 import { renderWithProfileReducers } from '../unit-test-helpers';
 
-import { Toggler } from '~/platform/utilities/feature-toggles';
 import MilitaryInformation from '../../components/military-information/MilitaryInformation';
 
 function createBasicInitialState(toggles = {}) {
@@ -214,23 +213,11 @@ describe('MilitaryInformation', () => {
     });
   });
   describe('when proof of veteran status exists', () => {
-    it('should show proof of veteran status component if toggle is on', () => {
-      initialState = createBasicInitialState({
-        [Toggler.TOGGLE_NAMES.profileShowProofOfVeteranStatus]: true,
-      });
+    it('should show proof of veteran status component', () => {
       view = renderWithProfileReducers(<MilitaryInformation />, {
         initialState,
       });
       expect(view.getByText(/Proof of Veteran status/)).to.exist;
-    });
-    it('should not show proof of veteran status component if toggle is off', () => {
-      initialState = createBasicInitialState({
-        [Toggler.TOGGLE_NAMES.profileShowProofOfVeteranStatus]: false,
-      });
-      view = renderWithProfileReducers(<MilitaryInformation />, {
-        initialState,
-      });
-      expect(view.queryByText(/Proof of Veteran status/)).not.to.exist;
     });
   });
 

--- a/src/applications/personalization/profile/tests/e2e/military-information/military-information-api-error.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/military-information/military-information-api-error.cypress.spec.js
@@ -14,7 +14,6 @@ describe('Military Information - Profile page', () => {
       '/v0/feature_toggles*',
       generateFeatureToggles({
         profileAlwaysShowDirectDepositDisplay: true,
-        profileShowProofOfVeteranStatus: true,
       }),
     );
     cy.intercept('GET', '/v0/user', loa3User72);
@@ -60,7 +59,6 @@ describe('Military Information - NonVeteran', () => {
       '/v0/feature_toggles*',
       generateFeatureToggles({
         profileAlwaysShowDirectDepositDisplay: true,
-        profileShowProofOfVeteranStatus: true,
       }),
     );
     cy.intercept('GET', '/v0/user', nonVeteranUser);
@@ -96,7 +94,6 @@ describe('Military Information - NotInDeers', () => {
       '/v0/feature_toggles*',
       generateFeatureToggles({
         profileAlwaysShowDirectDepositDisplay: true,
-        profileShowProofOfVeteranStatus: true,
       }),
     );
     cy.intercept('GET', '/v0/user', loa3User72);

--- a/src/applications/personalization/profile/tests/e2e/proof-of-veteran-status/proof-of-veteran-status.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/proof-of-veteran-status/proof-of-veteran-status.cypress.spec.js
@@ -1,7 +1,6 @@
 import fullName from '@@profile/tests/fixtures/full-name-success.json';
 
 import { PROFILE_PATHS } from '@@profile/constants';
-import { generateFeatureToggles } from '../../../mocks/endpoints/feature-toggles';
 import { loa3User72 } from '../../../mocks/endpoints/user';
 import {
   airForce,
@@ -13,13 +12,6 @@ import MilitaryInformation from '../military-information/MilitaryInformation';
 
 describe('Proof of Veteran status', () => {
   beforeEach(() => {
-    cy.intercept(
-      'GET',
-      '/v0/feature_toggles*',
-      generateFeatureToggles({
-        profileShowProofOfVeteranStatus: true,
-      }),
-    );
     cy.login(loa3User72);
     cy.intercept('GET', '/v0/user', loa3User72);
     cy.intercept('GET', '/v0/profile/full_name', fullName.success);
@@ -36,13 +28,6 @@ describe('Proof of Veteran status', () => {
 
 describe('Veteran is not eligible', () => {
   const login = ({ dischargeCode }) => {
-    cy.intercept(
-      'GET',
-      '/v0/feature_toggles*',
-      generateFeatureToggles({
-        profileShowProofOfVeteranStatus: true,
-      }),
-    );
     cy.login(loa3User72);
     cy.intercept('GET', '/v0/user', loa3User72);
     cy.intercept('GET', '/v0/profile/full_name', fullName.success);

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -139,7 +139,6 @@
   "profileShowEmailNotificationSettings": "profile_show_email_notification_settings",
   "profileShowMhvNotificationSettings": "profile_show_mhv_notification_settings",
   "profileShowPronounsAndSexualOrientation": "profile_show_pronouns_and_sexual_orientation",
-  "profileShowProofOfVeteranStatus": "profile_show_proof_of_veteran_status",
   "profileShowPaymentsNotificationSetting": "profile_show_payments_notification_setting",
   "profileShowQuickSubmitNotificationSetting": "profile_show_quick_submit_notification_setting",
   "profileUseExperimental": "profile_use_experimental",


### PR DESCRIPTION
## Summary

- Removed feature toggle profileShowProofOfVeteranStatus
- Not a bug
- Team IIR, we are the new owners of this component
- This component no longer needs to be behind a flipper

## Related issue(s)

- [Ticket 533](https://github.com/department-of-veterans-affairs/va-iir/issues/533)
- Not inside an epic

## Testing done

- Prior to this change, the proof of veteran status component was behind a flipper toggle
- To verify, confirm that the component on [this page](https://staging.va.gov/profile/military-information) is always available to users with an honorable discharge and at least one period of service.
- No tests were done locally.  We only know of one test user in staging that can access this component.  Testing will have to be done in staging.

## Screenshots

None

## What areas of the site does it impact?
This only impacts [one page](https://va.gov/profile/military-information).

## Acceptance criteria

### Quality Assurance & Testing

- [x] I updated unit tests for this feature.
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

None
