### PR TITLE
[CST] - Updated the due date header on the Files Needed Alert

### DIFF
--- a/src/applications/claims-status/components/DueDate.jsx
+++ b/src/applications/claims-status/components/DueDate.jsx
@@ -10,7 +10,7 @@ export default function DueDate({ date }) {
   const className = dueDate.isBefore(now) ? 'past-due' : 'due-file';
 
   const formattedClaimDate = buildDateFormatter()(date);
-  const dueDateHeader = `Needed from you by ${formattedClaimDate}`;
+  const dueDateHeader = `Needed from you by ${formattedClaimDate} - due ${dueDate.fromNow()}`;
 
   return (
     <div className="due-date-header">

--- a/src/applications/claims-status/components/DueDate.jsx
+++ b/src/applications/claims-status/components/DueDate.jsx
@@ -10,7 +10,7 @@ export default function DueDate({ date }) {
   const className = dueDate.isBefore(now) ? 'past-due' : 'due-file';
 
   const formattedClaimDate = buildDateFormatter()(date);
-  const dueDateHeader = `Needed from you by ${formattedClaimDate} - due ${dueDate.fromNow()}`;
+  const dueDateHeader = `Needed from you by ${formattedClaimDate} - Due ${dueDate.fromNow()}`;
 
   return (
     <div className="due-date-header">

--- a/src/applications/claims-status/components/DueDate.jsx
+++ b/src/applications/claims-status/components/DueDate.jsx
@@ -7,10 +7,13 @@ import { buildDateFormatter } from '../utils/helpers';
 export default function DueDate({ date }) {
   const now = moment();
   const dueDate = moment(date);
-  const className = dueDate.isBefore(now) ? 'past-due' : 'due-file';
+  const pastDueDate = dueDate.isBefore(now);
+  const className = pastDueDate ? 'past-due' : 'due-file';
 
   const formattedClaimDate = buildDateFormatter()(date);
-  const dueDateHeader = `Needed from you by ${formattedClaimDate} - Due ${dueDate.fromNow()}`;
+  const dueDateHeader = pastDueDate
+    ? `Needed from you by ${formattedClaimDate} - Due ${dueDate.fromNow()}`
+    : `Needed from you by ${formattedClaimDate}`;
 
   return (
     <div className="due-date-header">

--- a/src/applications/claims-status/components/DueDateOld.jsx
+++ b/src/applications/claims-status/components/DueDateOld.jsx
@@ -12,7 +12,7 @@ export default function DueDateOld({ date }) {
         <i className="fa fa-exclamation-triangle past-due-icon" /> Needed from
         you
       </strong>
-      <span className={className}> - Due {dueDate.fromNow()}</span>
+      <span className={className}> - due {dueDate.fromNow()}</span>
     </div>
   );
 }

--- a/src/applications/claims-status/components/DueDateOld.jsx
+++ b/src/applications/claims-status/components/DueDateOld.jsx
@@ -12,7 +12,7 @@ export default function DueDateOld({ date }) {
         <i className="fa fa-exclamation-triangle past-due-icon" /> Needed from
         you
       </strong>
-      <span className={className}> - due {dueDate.fromNow()}</span>
+      <span className={className}> - Due {dueDate.fromNow()}</span>
     </div>
   );
 }

--- a/src/applications/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/applications/claims-status/containers/DocumentRequestPage.jsx
@@ -10,7 +10,7 @@ import scrollToTop from '@department-of-veterans-affairs/platform-utilities/scro
 import AddFilesFormOld from '../components/AddFilesFormOld';
 import NeedHelp from '../components/NeedHelp';
 import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
-import DueDateOld from '../components/DueDateOld';
+import DueDate from '../components/DueDate';
 import Notification from '../components/Notification';
 import {
   addFile,
@@ -93,7 +93,7 @@ class DocumentRequestPage extends React.Component {
       <>
         <h1 className="claims-header">{trackedItem.displayName}</h1>
         {trackedItem.status === 'NEEDED_FROM_YOU' ? (
-          <DueDateOld date={trackedItem.suspenseDate} />
+          <DueDate date={trackedItem.suspenseDate} />
         ) : null}
         {trackedItem.status === 'NEEDED_FROM_OTHERS' ? (
           <div className="optional-upload">

--- a/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
@@ -184,10 +184,8 @@ describe('<DocumentRequestPage>', () => {
       <DocumentRequestPage {...defaultProps} trackedItem={trackedItem} />,
     );
 
-    expect(tree.subTree('DueDateOld')).not.to.be.false;
-    expect(tree.subTree('DueDateOld').props.date).to.eql(
-      trackedItem.suspenseDate,
-    );
+    expect(tree.subTree('DueDate')).not.to.be.false;
+    expect(tree.subTree('DueDate').props.date).to.eql(trackedItem.suspenseDate);
   });
 
   it('should render optional upload alert', () => {

--- a/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
@@ -1,95 +1,104 @@
 import React from 'react';
-import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 import moment from 'moment';
-
+import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import { buildDateFormatter } from '../../utils/helpers';
+import { renderWithRouter } from '../utils';
+
 import DueDate from '../../components/DueDate';
 
 const formatDate = buildDateFormatter();
 
 describe('<DueDate>', () => {
   it('should render past due class when theres more than a years difference', () => {
-    const date = moment()
-      .subtract(15, 'month')
-      .format('YYYY-MM-DD');
-    const tree = SkinDeep.shallowRender(<DueDate date={date} />);
-    const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate} - Due a year ago`;
-
-    expect(tree.everySubTree('.past-due')).not.to.be.empty;
-    expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
-      dueDateHeader,
+    const date = moment().subtract(15, 'month');
+    const dateString = date.format('YYYY-MM-DD');
+    const { container, getByText } = renderWithRouter(
+      <DueDate date={dateString} />,
     );
+    const formattedClaimDate = formatDate(dateString);
+
+    getByText(
+      `Needed from you by ${formattedClaimDate} - Due ${date.fromNow()}`,
+    );
+    expect($('.past-due', container)).to.exist;
   });
 
   it('should render past due class when theres more than a months difference', () => {
-    const date = moment()
-      .subtract(4, 'month')
-      .format('YYYY-MM-DD');
-    const tree = SkinDeep.shallowRender(<DueDate date={date} />);
-    const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate} - Due 4 months ago`;
-
-    expect(tree.everySubTree('.past-due')).not.to.be.empty;
-    expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
-      dueDateHeader,
+    const date = moment().subtract(4, 'month');
+    const dateString = date.format('YYYY-MM-DD');
+    const { container, getByText } = renderWithRouter(
+      <DueDate date={dateString} />,
     );
+    const formattedClaimDate = formatDate(dateString);
+
+    getByText(
+      `Needed from you by ${formattedClaimDate} - Due ${date.fromNow()}`,
+    );
+    expect($('.past-due', container)).to.exist;
   });
 
   it('should render past due class when theres more than a days difference', () => {
-    const date = moment()
-      .subtract(3, 'day')
-      .format('YYYY-MM-DD');
-    const tree = SkinDeep.shallowRender(<DueDate date={date} />);
-    const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate} - Due 3 days ago`;
-
-    expect(tree.everySubTree('.past-due')).not.to.be.empty;
-    expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
-      dueDateHeader,
+    const date = moment().subtract(3, 'day');
+    const dateString = date.format('YYYY-MM-DD');
+    const { container, getByText } = renderWithRouter(
+      <DueDate date={dateString} />,
     );
+    const formattedClaimDate = formatDate(dateString);
+
+    getByText(
+      `Needed from you by ${formattedClaimDate} - Due ${date.fromNow()}`,
+    );
+    expect($('.past-due', container)).to.exist;
+  });
+
+  it('should render past due class when theres more than a few hours difference', () => {
+    const date = moment().subtract(1, 'day');
+    const dateString = date.format('YYYY-MM-DD');
+    const { container, getByText } = renderWithRouter(
+      <DueDate date={dateString} />,
+    );
+    const formattedClaimDate = formatDate(dateString);
+
+    getByText(
+      `Needed from you by ${formattedClaimDate} - Due ${date.fromNow()}`,
+    );
+    expect($('.past-due', container)).to.exist;
   });
 
   it('should render file due class when more than a days difference', () => {
-    const date = moment()
-      .add(3, 'day')
-      .format('YYYY-MM-DD');
-    const tree = SkinDeep.shallowRender(<DueDate date={date} />);
-    const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate}`;
-
-    expect(tree.everySubTree('.due-file')).not.to.be.empty;
-    expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
-      dueDateHeader,
+    const date = moment().add(3, 'day');
+    const dateString = date.format('YYYY-MM-DD');
+    const { container, getByText } = renderWithRouter(
+      <DueDate date={dateString} />,
     );
+    const formattedClaimDate = formatDate(dateString);
+
+    getByText(`Needed from you by ${formattedClaimDate}`);
+    expect($('.due-file', container)).to.exist;
   });
 
   it('should render file due class when more than a months difference', () => {
-    const date = moment()
-      .add(10, 'month')
-      .format('YYYY-MM-DD');
-    const tree = SkinDeep.shallowRender(<DueDate date={date} />);
-    const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate}`;
-
-    expect(tree.everySubTree('.due-file')).not.to.be.empty;
-    expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
-      dueDateHeader,
+    const date = moment().add(10, 'month');
+    const dateString = date.format('YYYY-MM-DD');
+    const { container, getByText } = renderWithRouter(
+      <DueDate date={dateString} />,
     );
+    const formattedClaimDate = formatDate(dateString);
+
+    getByText(`Needed from you by ${formattedClaimDate}`);
+    expect($('.due-file', container)).to.exist;
   });
 
   it('should render file due class when more than a years difference', () => {
-    const date = moment()
-      .add(15, 'month')
-      .format('YYYY-MM-DD');
-    const tree = SkinDeep.shallowRender(<DueDate date={date} />);
-    const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate}`;
-
-    expect(tree.everySubTree('.due-file')).not.to.be.empty;
-    expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
-      dueDateHeader,
+    const date = moment().add(15, 'month');
+    const dateString = date.format('YYYY-MM-DD');
+    const { container, getByText } = renderWithRouter(
+      <DueDate date={dateString} />,
     );
+    const formattedClaimDate = formatDate(dateString);
+
+    getByText(`Needed from you by ${formattedClaimDate}`);
+    expect($('.due-file', container)).to.exist;
   });
 });

--- a/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
@@ -44,7 +44,8 @@ describe('<DueDate>', () => {
 
   it('should render past due class when theres more than a days difference', () => {
     const date = moment()
-      .tz('America/Los_Angeles')
+      .utcOffset(0)
+      .set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
       .subtract(3, 'day');
     const dateString = date.format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
@@ -60,7 +61,8 @@ describe('<DueDate>', () => {
 
   it('should render past due class when theres more than a few hours difference', () => {
     const date = moment()
-      .tz('America/Los_Angeles')
+      .utcOffset(0)
+      .set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
       .subtract(1, 'day');
     const dateString = date.format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(

--- a/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
@@ -25,11 +25,11 @@ describe('<DueDate>', () => {
 
   it('should render past due class when less than a months difference', () => {
     const date = moment()
-      .subtract(1, 'day')
+      .subtract(3, 'day')
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
     const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate} - due 2 days ago`;
+    const dueDateHeader = `Needed from you by ${formattedClaimDate} - due 4 days ago`;
 
     expect(tree.everySubTree('.past-due')).not.to.be.empty;
     expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
@@ -37,27 +37,13 @@ describe('<DueDate>', () => {
     );
   });
 
-  it('should render past due class when less than day difference', () => {
+  it('should render file due class when more than a days difference', () => {
     const date = moment()
-      .subtract(1, 'hour')
+      .add(3, 'day')
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
     const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate} - due 16 hours ago`;
-
-    expect(tree.everySubTree('.past-due')).not.to.be.empty;
-    expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
-      dueDateHeader,
-    );
-  });
-
-  it('should render file due class when less than a day difference', () => {
-    const date = moment()
-      .add(1, 'day')
-      .format('YYYY-MM-DD');
-    const tree = SkinDeep.shallowRender(<DueDate date={date} />);
-    const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate} - due in 8 hours`;
+    const dueDateHeader = `Needed from you by ${formattedClaimDate} - due in 2 days`;
 
     expect(tree.everySubTree('.due-file')).not.to.be.empty;
     expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(

--- a/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import { buildDateFormatter } from '../../utils/helpers';
 import { renderWithRouter } from '../utils';
@@ -11,7 +11,9 @@ const formatDate = buildDateFormatter();
 
 describe('<DueDate>', () => {
   it('should render past due class when theres more than a years difference', () => {
-    const date = moment().subtract(15, 'month');
+    const date = moment()
+      .tz('America/Los_Angeles')
+      .subtract(15, 'month');
     const dateString = date.format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,
@@ -25,7 +27,9 @@ describe('<DueDate>', () => {
   });
 
   it('should render past due class when theres more than a months difference', () => {
-    const date = moment().subtract(4, 'month');
+    const date = moment()
+      .tz('America/Los_Angeles')
+      .subtract(4, 'month');
     const dateString = date.format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,
@@ -39,7 +43,9 @@ describe('<DueDate>', () => {
   });
 
   it('should render past due class when theres more than a days difference', () => {
-    const date = moment().subtract(3, 'day');
+    const date = moment()
+      .tz('America/Los_Angeles')
+      .subtract(3, 'day');
     const dateString = date.format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,
@@ -53,7 +59,9 @@ describe('<DueDate>', () => {
   });
 
   it('should render past due class when theres more than a few hours difference', () => {
-    const date = moment().subtract(1, 'day');
+    const date = moment()
+      .tz('America/Los_Angeles')
+      .subtract(1, 'day');
     const dateString = date.format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,
@@ -67,7 +75,9 @@ describe('<DueDate>', () => {
   });
 
   it('should render file due class when more than a days difference', () => {
-    const date = moment().add(3, 'day');
+    const date = moment()
+      .tz('America/Los_Angeles')
+      .add(3, 'day');
     const dateString = date.format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,
@@ -79,7 +89,9 @@ describe('<DueDate>', () => {
   });
 
   it('should render file due class when more than a months difference', () => {
-    const date = moment().add(10, 'month');
+    const date = moment()
+      .tz('America/Los_Angeles')
+      .add(10, 'month');
     const dateString = date.format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,
@@ -91,7 +103,9 @@ describe('<DueDate>', () => {
   });
 
   it('should render file due class when more than a years difference', () => {
-    const date = moment().add(15, 'month');
+    const date = moment()
+      .tz('America/Los_Angeles')
+      .add(15, 'month');
     const dateString = date.format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,

--- a/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
@@ -9,7 +9,7 @@ import DueDate from '../../components/DueDate';
 const formatDate = buildDateFormatter();
 
 describe('<DueDate>', () => {
-  it('should render past due class when less than a years difference', () => {
+  it('should render past due class when theres more than a years difference', () => {
     const date = moment()
       .subtract(15, 'month')
       .format('YYYY-MM-DD');
@@ -23,13 +23,27 @@ describe('<DueDate>', () => {
     );
   });
 
-  it('should render past due class when less than a months difference', () => {
+  it('should render past due class when theres more than a months difference', () => {
+    const date = moment()
+      .subtract(4, 'month')
+      .format('YYYY-MM-DD');
+    const tree = SkinDeep.shallowRender(<DueDate date={date} />);
+    const formattedClaimDate = formatDate(date);
+    const dueDateHeader = `Needed from you by ${formattedClaimDate} - Due 4 months ago`;
+
+    expect(tree.everySubTree('.past-due')).not.to.be.empty;
+    expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
+      dueDateHeader,
+    );
+  });
+
+  it('should render past due class when theres more than a days difference', () => {
     const date = moment()
       .subtract(3, 'day')
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
     const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate} - Due 4 days ago`;
+    const dueDateHeader = `Needed from you by ${formattedClaimDate} - Due 3 days ago`;
 
     expect(tree.everySubTree('.past-due')).not.to.be.empty;
     expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
@@ -43,7 +57,7 @@ describe('<DueDate>', () => {
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
     const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate} - Due in 2 days`;
+    const dueDateHeader = `Needed from you by ${formattedClaimDate}`;
 
     expect(tree.everySubTree('.due-file')).not.to.be.empty;
     expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
@@ -57,7 +71,7 @@ describe('<DueDate>', () => {
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
     const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate} - Due in 10 months`;
+    const dueDateHeader = `Needed from you by ${formattedClaimDate}`;
 
     expect(tree.everySubTree('.due-file')).not.to.be.empty;
     expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
@@ -71,7 +85,7 @@ describe('<DueDate>', () => {
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
     const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate} - Due in a year`;
+    const dueDateHeader = `Needed from you by ${formattedClaimDate}`;
 
     expect(tree.everySubTree('.due-file')).not.to.be.empty;
     expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(

--- a/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
@@ -15,7 +15,7 @@ describe('<DueDate>', () => {
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
     const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate} - due a year ago`;
+    const dueDateHeader = `Needed from you by ${formattedClaimDate} - Due a year ago`;
 
     expect(tree.everySubTree('.past-due')).not.to.be.empty;
     expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
@@ -29,7 +29,7 @@ describe('<DueDate>', () => {
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
     const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate} - due 4 days ago`;
+    const dueDateHeader = `Needed from you by ${formattedClaimDate} - Due 4 days ago`;
 
     expect(tree.everySubTree('.past-due')).not.to.be.empty;
     expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
@@ -43,7 +43,7 @@ describe('<DueDate>', () => {
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
     const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate} - due in 2 days`;
+    const dueDateHeader = `Needed from you by ${formattedClaimDate} - Due in 2 days`;
 
     expect(tree.everySubTree('.due-file')).not.to.be.empty;
     expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
@@ -57,7 +57,7 @@ describe('<DueDate>', () => {
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
     const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate} - due in 10 months`;
+    const dueDateHeader = `Needed from you by ${formattedClaimDate} - Due in 10 months`;
 
     expect(tree.everySubTree('.due-file')).not.to.be.empty;
     expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
@@ -71,7 +71,7 @@ describe('<DueDate>', () => {
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
     const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate} - due in a year`;
+    const dueDateHeader = `Needed from you by ${formattedClaimDate} - Due in a year`;
 
     expect(tree.everySubTree('.due-file')).not.to.be.empty;
     expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(

--- a/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
@@ -77,9 +77,7 @@ describe('<DueDate>', () => {
   });
 
   it('should render file due class when more than a days difference', () => {
-    const date = moment()
-      .tz('America/Los_Angeles')
-      .add(3, 'day');
+    const date = moment().add(3, 'day');
     const dateString = date.format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,
@@ -91,9 +89,7 @@ describe('<DueDate>', () => {
   });
 
   it('should render file due class when more than a months difference', () => {
-    const date = moment()
-      .tz('America/Los_Angeles')
-      .add(10, 'month');
+    const date = moment().add(10, 'month');
     const dateString = date.format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,
@@ -105,9 +101,7 @@ describe('<DueDate>', () => {
   });
 
   it('should render file due class when more than a years difference', () => {
-    const date = moment()
-      .tz('America/Los_Angeles')
-      .add(15, 'month');
+    const date = moment().add(15, 'month');
     const dateString = date.format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,

--- a/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
@@ -9,13 +9,27 @@ import DueDate from '../../components/DueDate';
 const formatDate = buildDateFormatter();
 
 describe('<DueDate>', () => {
-  it('should render past due class', () => {
+  it('should render past due class when less than a years difference', () => {
+    const date = moment()
+      .subtract(15, 'month')
+      .format('YYYY-MM-DD');
+    const tree = SkinDeep.shallowRender(<DueDate date={date} />);
+    const formattedClaimDate = formatDate(date);
+    const dueDateHeader = `Needed from you by ${formattedClaimDate} - due a year ago`;
+
+    expect(tree.everySubTree('.past-due')).not.to.be.empty;
+    expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
+      dueDateHeader,
+    );
+  });
+
+  it('should render past due class when less than a months difference', () => {
     const date = moment()
       .subtract(1, 'day')
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
     const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate}`;
+    const dueDateHeader = `Needed from you by ${formattedClaimDate} - due 2 days ago`;
 
     expect(tree.everySubTree('.past-due')).not.to.be.empty;
     expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
@@ -29,7 +43,7 @@ describe('<DueDate>', () => {
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
     const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate}`;
+    const dueDateHeader = `Needed from you by ${formattedClaimDate} - due 16 hours ago`;
 
     expect(tree.everySubTree('.past-due')).not.to.be.empty;
     expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
@@ -37,13 +51,41 @@ describe('<DueDate>', () => {
     );
   });
 
-  it('should render file due class', () => {
+  it('should render file due class when less than a day difference', () => {
     const date = moment()
       .add(1, 'day')
       .format('YYYY-MM-DD');
     const tree = SkinDeep.shallowRender(<DueDate date={date} />);
     const formattedClaimDate = formatDate(date);
-    const dueDateHeader = `Needed from you by ${formattedClaimDate}`;
+    const dueDateHeader = `Needed from you by ${formattedClaimDate} - due in 8 hours`;
+
+    expect(tree.everySubTree('.due-file')).not.to.be.empty;
+    expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
+      dueDateHeader,
+    );
+  });
+
+  it('should render file due class when more than a months difference', () => {
+    const date = moment()
+      .add(10, 'month')
+      .format('YYYY-MM-DD');
+    const tree = SkinDeep.shallowRender(<DueDate date={date} />);
+    const formattedClaimDate = formatDate(date);
+    const dueDateHeader = `Needed from you by ${formattedClaimDate} - due in 10 months`;
+
+    expect(tree.everySubTree('.due-file')).not.to.be.empty;
+    expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(
+      dueDateHeader,
+    );
+  });
+
+  it('should render file due class when more than a years difference', () => {
+    const date = moment()
+      .add(15, 'month')
+      .format('YYYY-MM-DD');
+    const tree = SkinDeep.shallowRender(<DueDate date={date} />);
+    const formattedClaimDate = formatDate(date);
+    const dueDateHeader = `Needed from you by ${formattedClaimDate} - due in a year`;
 
     expect(tree.everySubTree('.due-file')).not.to.be.empty;
     expect(tree.everySubTree('.due-date-header')[0].text()).to.equal(


### PR DESCRIPTION
## Summary

Updated the due date header that is on the component `DueDate.jsx` 
- Added logic so that when the due date is over due the header is no longer `Needed from you by {DATE}` and is instead `Needed from you by {DATE} - Due {DUE_DATE_FROM_NOW}` in red text
- Added logic so that when the due date is not due yet the header still reads `Needed from you by {DATE}` in black text
- Updated `DocumentRequest.jsx` to use `DueDate.jsx` instead of `DueDateOld.jsx`

Added some tests to DueDate.unit.spec.jsx and updated to use renderwithrouter

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#80595

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots


|         | Before | After |
| ------- | ------ | ----- |
| Alert overdue  |  ![Screenshot 2024-04-16 at 3 47 01 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/86abe1ef-5596-4ea3-9bec-24c99a2caec4) | ![Screenshot 2024-04-17 at 9 13 51 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/423cb2c0-03d2-4911-b9c8-d82ea95a5653) |
| Alert not due yet | ![Screenshot 2024-04-16 at 3 44 28 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/a7c1f966-583c-42fc-b01c-6eff188666f1) |  ![Screenshot 2024-04-17 at 9 20 28 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/073ce56e-3608-4a78-8e08-3c44ada77441) |
| Document Request not due yet | ![Screenshot 2024-04-16 at 3 22 10 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/a6d55b52-1ff0-45b7-8c4d-61602fae1c16) | ![Screenshot 2024-04-17 at 9 20 17 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/45e78b0c-d36d-41e9-bf52-63fc729524fe) |
| Document Request overdue | ![Screenshot 2024-04-16 at 3 08 42 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/0174a797-c9f3-4c0a-8df7-8cbca9615571) | ![Screenshot 2024-04-17 at 9 15 51 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/03146e2d-3efa-44d5-8394-4e758495d874) |

## What areas of the site does it impact?

Claim Status Tool

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
