### PR TITLE
Use transformedData object when checking for other risk in 20-10207

### DIFF
--- a/src/applications/simple-forms/20-10207/config/submit-transformer.js
+++ b/src/applications/simple-forms/20-10207/config/submit-transformer.js
@@ -1,6 +1,4 @@
 import sharedTransformForSubmit from '../../shared/config/submit-transformer';
-import livingSituation from '../pages/livingSituation';
-
 import { PREPARER_TYPES } from './constants';
 
 export default function transformForSubmit(formConfig, form) {
@@ -121,7 +119,7 @@ export default function transformForSubmit(formConfig, form) {
   }
 
   // delete unneeded otherHousingRisks data based on livingSituation
-  if (!livingSituation.OTHER_RISK) {
+  if (!transformedData.livingSituation.OTHER_RISK) {
     delete transformedData.otherHousingRisks;
   }
 


### PR DESCRIPTION
## Summary
This PR fixes a small bug where we were accessing `livingSituation` (the schema object) rather than the object on `transformedData` in the submit transformer for 20-10207.