### PR TITLE
HLR | Fix subtask title

### DIFF
--- a/src/applications/appeals/996/subtask/pages/start.jsx
+++ b/src/applications/appeals/996/subtask/pages/start.jsx
@@ -12,7 +12,8 @@ import { BASE_URL } from '../../constants';
 import pageNames from './pageNames';
 
 const content = {
-  groupLabel: 'What type of claim are you requesting a Higher-Level Review?',
+  groupLabel:
+    'What type of claim are you requesting a Higher-Level Review for?',
   errorMessage: 'You must choose a claim type.',
 };
 

--- a/src/applications/appeals/996/tests/subtask/subtask.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/subtask/subtask.unit.spec.jsx
@@ -113,7 +113,7 @@ describe('the HLR Sub-task', () => {
       event: 'howToWizard-formChange',
       'form-field-type': 'form-radio-buttons',
       'form-field-label':
-        'What type of claim are you requesting a Higher-Level Review?',
+        'What type of claim are you requesting a Higher-Level Review for?',
       'form-field-value': 'compensation',
     });
 


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > The Higher-Level Review subtask. start page does not include the correct label content. It's missing the word "for" at the end (see screenshots)
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Update the title
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#57821](https://github.com/department-of-veterans-affairs/va.gov-team/issues/57821)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Subtask start  | <img width="737" alt="Screenshot 2024-04-17 at 12 30 11 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/9de27ec0-b0ec-4f06-ab74-991d3b71dca7"> | <img width="712" alt="Screenshot 2024-04-17 at 12 29 03 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/e904ece1-9304-4030-8a8e-7391cd3002b9"> |

## What areas of the site does it impact?

HLR

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
