### PR TITLE
Fix breadcrumb to match page title for CC appointment flow

### DIFF
--- a/src/applications/vaos/components/Breadcrumbs.jsx
+++ b/src/applications/vaos/components/Breadcrumbs.jsx
@@ -4,12 +4,7 @@ import { useLocation } from 'react-router-dom';
 import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { useSelector } from 'react-redux';
 import manifest from '../manifest.json';
-import {
-  getFormPageInfo,
-  getTypeOfCare,
-  getFacilityPageV2Info,
-} from '../new-appointment/redux/selectors';
-import { lowerCase } from '../utils/formatters';
+import { getFacilityPageV2Info } from '../new-appointment/redux/selectors';
 import { getUrlLabel } from '../new-appointment/newAppointmentFlow';
 import { getCovidUrlLabel } from '../covid-19-vaccine/flow';
 
@@ -19,10 +14,6 @@ export default function VAOSBreadcrumbs({ children }) {
   const { singleValidVALocation } = useSelector(state =>
     getFacilityPageV2Info(state),
   );
-  // get form data that contains selected type of care
-  const { data } = useSelector(state => getFormPageInfo(state));
-  const typeOfCare = getTypeOfCare(data);
-  const { facilityType } = data;
   const [breadcrumb, setBreadcrumb] = useState([]);
 
   const label = useSelector(state => getUrlLabel(state, location));
@@ -39,9 +30,6 @@ export default function VAOSBreadcrumbs({ children }) {
   const getBreadcrumbList = () => {
     const isPast = location.pathname.includes('/past');
     const isPending = location.pathname.includes('/pending');
-    const isPreferredProvider = location.pathname.includes(
-      '/preferred-provider',
-    );
 
     const BREADCRUMB_BASE = [
       {
@@ -82,32 +70,10 @@ export default function VAOSBreadcrumbs({ children }) {
         },
       ];
     }
-    if (isPreferredProvider) {
-      return [
-        ...BREADCRUMB_BASE,
-        {
-          href: window.location.href,
-          label: `Request a ${lowerCase(typeOfCare.name)} provider`,
-        },
-      ];
-    }
     if (singleValidVALocation && breadcrumb === 'Choose a VA location') {
       return [
         ...BREADCRUMB_BASE,
         { href: window.location.href, label: 'Your appointment location' },
-      ];
-    }
-    // community care's reason page is text entry only
-    if (
-      facilityType === 'communityCare' &&
-      breadcrumb === 'Choose a reason for this appointment'
-    ) {
-      return [
-        ...BREADCRUMB_BASE,
-        {
-          href: window.location.href,
-          label: 'Tell us the reason for this appointment',
-        },
       ];
     }
     return [

--- a/src/applications/vaos/new-appointment/components/ClosestCityStatePage.jsx
+++ b/src/applications/vaos/new-appointment/components/ClosestCityStatePage.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
-import PropTypes from 'prop-types';
 import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
 import { useHistory } from 'react-router-dom';
 import { VaRadioField } from '@department-of-veterans-affairs/platform-forms-system/web-component-fields';
@@ -16,31 +15,29 @@ import {
 } from '../redux/selectors';
 import { scrollAndFocus } from '../../utils/scrollAndFocus';
 import useFormState from '../../hooks/useFormState';
-import { selectFeatureBreadcrumbUrlUpdate } from '../../redux/selectors';
-
-const pageTitle = 'What’s the nearest city to you?';
-const uiSchema = {
-  communityCareSystemId: {
-    'ui:title': pageTitle,
-    'ui:widget': 'radio', // Required
-    'ui:webComponentField': VaRadioField,
-    'ui:errorMessages': {
-      required: 'Select a city',
-    },
-    'ui:options': {
-      classNames: 'vads-u-margin-top--neg2',
-      showFieldLabel: false,
-      labelHeaderLevel: '1',
-    },
-  },
-};
+import { getPageTitle } from '../newAppointmentFlow';
 
 const pageKey = 'ccClosestCity';
 
-export default function ClosestCityStatePage({ changeCrumb }) {
-  const featureBreadcrumbUrlUpdate = useSelector(state =>
-    selectFeatureBreadcrumbUrlUpdate(state),
-  );
+export default function ClosestCityStatePage() {
+  const pageTitle = useSelector(state => getPageTitle(state, pageKey));
+
+  const uiSchema = {
+    communityCareSystemId: {
+      'ui:title': pageTitle,
+      'ui:widget': 'radio', // Required
+      'ui:webComponentField': VaRadioField,
+      'ui:errorMessages': {
+        required: 'Select a city',
+      },
+      'ui:options': {
+        classNames: 'vads-u-margin-top--neg2',
+        showFieldLabel: false,
+        labelHeaderLevel: '1',
+      },
+    },
+  };
+
   const history = useHistory();
   const dispatch = useDispatch();
   const pageChangeInProgress = useSelector(selectPageChangeInProgress);
@@ -50,9 +47,6 @@ export default function ClosestCityStatePage({ changeCrumb }) {
   useEffect(() => {
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
-    if (featureBreadcrumbUrlUpdate) {
-      changeCrumb(pageTitle);
-    }
   }, []);
 
   const { data, schema, setData } = useFormState({
@@ -112,7 +106,3 @@ export default function ClosestCityStatePage({ changeCrumb }) {
     </div>
   );
 }
-
-ClosestCityStatePage.propTypes = {
-  changeCrumb: PropTypes.func,
-};

--- a/src/applications/vaos/new-appointment/components/CommunityCareLanguagePage.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareLanguagePage.jsx
@@ -8,7 +8,7 @@ import FormButtons from '../../components/FormButtons';
 import { LANGUAGES } from '../../utils/constants';
 import * as actions from '../redux/actions';
 import { getFormPageInfo } from '../redux/selectors';
-import { selectFeatureBreadcrumbUrlUpdate } from '../../redux/selectors';
+import { getPageTitle } from '../newAppointmentFlow';
 
 const initialSchema = {
   type: 'object',
@@ -32,7 +32,6 @@ const uiSchema = {
 };
 
 const pageKey = 'ccLanguage';
-const pageTitle = 'What language do you prefer?';
 
 function CommunityCareLanguagePage({
   schema,
@@ -42,11 +41,8 @@ function CommunityCareLanguagePage({
   routeToPreviousAppointmentPage,
   updateFormData,
   openFormPage,
-  changeCrumb,
 }) {
-  const featureBreadcrumbUrlUpdate = useSelector(state =>
-    selectFeatureBreadcrumbUrlUpdate(state),
-  );
+  const pageTitle = useSelector(state => getPageTitle(state, pageKey));
 
   const history = useHistory();
   useEffect(
@@ -54,9 +50,6 @@ function CommunityCareLanguagePage({
       document.title = `${pageTitle} | Veterans Affairs`;
       scrollAndFocus();
       openFormPage(pageKey, uiSchema, initialSchema);
-      if (featureBreadcrumbUrlUpdate) {
-        changeCrumb(pageTitle);
-      }
     },
     [openFormPage],
   );
@@ -110,6 +103,5 @@ CommunityCareLanguagePage.propTypes = {
   routeToNextAppointmentPage: PropTypes.func.isRequired,
   routeToPreviousAppointmentPage: PropTypes.func.isRequired,
   updateFormData: PropTypes.func.isRequired,
-  changeCrumb: PropTypes.func,
   schema: PropTypes.object,
 };

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/index.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
-import PropTypes from 'prop-types';
 import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
 import recordEvent from '@department-of-veterans-affairs/platform-monitoring/record-event';
 import FormButtons from '../../../components/FormButtons';
@@ -15,7 +14,7 @@ import {
 import { getFormPageInfo } from '../../redux/selectors';
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import ProviderSelectionField from './ProviderSelectionField';
-import { selectFeatureBreadcrumbUrlUpdate } from '../../../redux/selectors';
+import { getPageTitle } from '../../newAppointmentFlow';
 
 const initialSchema = {
   type: 'object',
@@ -29,17 +28,15 @@ const initialSchema = {
 
 const pageKey = 'ccPreferences';
 
-export default function CommunityCareProviderSelectionPage({ changeCrumb }) {
-  const featureBreadcrumbUrlUpdate = useSelector(state =>
-    selectFeatureBreadcrumbUrlUpdate(state),
-  );
+export default function CommunityCareProviderSelectionPage() {
+  const pageTitle = useSelector(state => getPageTitle(state, pageKey));
+
   const dispatch = useDispatch();
   const { data, pageChangeInProgress, schema } = useSelector(
     state => getFormPageInfo(state, pageKey),
     shallowEqual,
   );
   const history = useHistory();
-  const pageTitle = 'Which provider do you prefer?';
 
   const uiSchema = {
     communityCareProvider: {
@@ -56,9 +53,6 @@ export default function CommunityCareProviderSelectionPage({ changeCrumb }) {
     recordEvent({
       event: `${GA_PREFIX}-community-care-provider-selection-page`,
     });
-    if (featureBreadcrumbUrlUpdate) {
-      changeCrumb(pageTitle);
-    }
   }, []);
 
   return (
@@ -106,7 +100,3 @@ export default function CommunityCareProviderSelectionPage({ changeCrumb }) {
     </div>
   );
 }
-
-CommunityCareProviderSelectionPage.propTypes = {
-  changeCrumb: PropTypes.func,
-};

--- a/src/applications/vaos/new-appointment/components/ContactInfoPage.jsx
+++ b/src/applications/vaos/new-appointment/components/ContactInfoPage.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import PropTypes from 'prop-types';
 import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
 import phoneUI from '@department-of-veterans-affairs/platform-forms-system/phone';
 import { validateBooleanGroup } from '@department-of-veterans-affairs/platform-forms-system/validation';
@@ -27,7 +26,7 @@ import {
 import NewTabAnchor from '../../components/NewTabAnchor';
 import useFormState from '../../hooks/useFormState';
 import { FACILITY_TYPES, FLOW_TYPES, GA_PREFIX } from '../../utils/constants';
-import { selectFeatureBreadcrumbUrlUpdate } from '../../redux/selectors';
+import { getPageTitle } from '../newAppointmentFlow';
 
 const initialSchema = {
   type: 'object',
@@ -133,10 +132,8 @@ function Description() {
   return <ContactInformationParagraph />;
 }
 
-export default function ContactInfoPage({ changeCrumb }) {
-  const featureBreadcrumbUrlUpdate = useSelector(state =>
-    selectFeatureBreadcrumbUrlUpdate(state),
-  );
+export default function ContactInfoPage() {
+  const pageTitle = useSelector(state => getPageTitle(state, pageKey));
 
   const history = useHistory();
   const dispatch = useDispatch();
@@ -146,18 +143,11 @@ export default function ContactInfoPage({ changeCrumb }) {
   const homePhone = useSelector(selectVAPHomePhoneString);
   const mobilePhone = useSelector(selectVAPMobilePhoneString);
   const flowType = useSelector(getFlowType);
-  const pageTitle =
-    FLOW_TYPES.DIRECT === flowType
-      ? 'Confirm your contact information'
-      : 'How should we contact you?';
 
   useEffect(() => {
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
     recordPopulatedEvents(email, mobilePhone || homePhone);
-    if (featureBreadcrumbUrlUpdate) {
-      changeCrumb(pageTitle);
-    }
   }, []);
 
   const uiSchema = {
@@ -272,7 +262,3 @@ export default function ContactInfoPage({ changeCrumb }) {
     </div>
   );
 }
-
-ContactInfoPage.propTypes = {
-  changeCrumb: PropTypes.func,
-};

--- a/src/applications/vaos/new-appointment/components/DateTimeRequestPage/CommunityCare.jsx
+++ b/src/applications/vaos/new-appointment/components/DateTimeRequestPage/CommunityCare.jsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import moment from 'moment';
-import PropTypes from 'prop-types';
 import {
   onCalendarChange,
   routeToNextAppointmentPage,
@@ -19,10 +18,9 @@ import {
 import DateTimeRequestOptions from './DateTimeRequestOptions';
 import SelectedIndicator, { getSelectedLabel } from './SelectedIndicator';
 import { FETCH_STATUS, FLOW_TYPES } from '../../../utils/constants';
-import { selectFeatureBreadcrumbUrlUpdate } from '../../../redux/selectors';
+import { getPageTitle } from '../../newAppointmentFlow';
 
 const pageKey = 'ccRequestDateTime';
-const pageTitle = 'When would you like an appointment?';
 
 const maxSelections = 3;
 
@@ -47,10 +45,8 @@ function goForward({ dispatch, data, history, setSubmitted }) {
   }
 }
 
-export default function CCRequest({ changeCrumb }) {
-  const featureBreadcrumbUrlUpdate = useSelector(state =>
-    selectFeatureBreadcrumbUrlUpdate(state),
-  );
+export default function CCRequest() {
+  const pageTitle = useSelector(state => getPageTitle(state, pageKey));
 
   const { data, pageChangeInProgress } = useSelector(
     state => getFormPageInfo(state, pageKey),
@@ -68,9 +64,6 @@ export default function CCRequest({ changeCrumb }) {
   useEffect(() => {
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
-    if (featureBreadcrumbUrlUpdate) {
-      changeCrumb(pageTitle);
-    }
   }, []);
 
   const { selectedDates } = data;
@@ -138,7 +131,3 @@ export default function CCRequest({ changeCrumb }) {
     </div>
   );
 }
-
-CCRequest.propTypes = {
-  changeCrumb: PropTypes.func,
-};

--- a/src/applications/vaos/new-appointment/components/ReviewPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/index.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { Redirect, useHistory } from 'react-router-dom';
-import PropTypes from 'prop-types';
 import LoadingButton from '@department-of-veterans-affairs/platform-site-wide/LoadingButton';
 import classNames from 'classnames';
 import { selectReviewPage } from '../../redux/selectors';
@@ -12,12 +11,12 @@ import ReviewRequestInfo from './ReviewRequestInfo';
 import { submitAppointmentOrRequest } from '../../redux/actions';
 import FacilityAddress from '../../../components/FacilityAddress';
 import InfoAlert from '../../../components/InfoAlert';
-import { selectFeatureBreadcrumbUrlUpdate } from '../../../redux/selectors';
+import { getPageTitle } from '../../newAppointmentFlow';
 
-export default function ReviewPage({ changeCrumb }) {
-  const featureBreadcrumbUrlUpdate = useSelector(state =>
-    selectFeatureBreadcrumbUrlUpdate(state),
-  );
+const pageKey = 'review';
+
+export default function ReviewPage() {
+  const pageTitle = useSelector(state => getPageTitle(state, pageKey));
 
   const dispatch = useDispatch();
   const {
@@ -33,17 +32,10 @@ export default function ReviewPage({ changeCrumb }) {
     vaCityState,
   } = useSelector(selectReviewPage, shallowEqual);
   const history = useHistory();
-  const pageTitle =
-    FLOW_TYPES.DIRECT === flowType
-      ? 'Review your appointment details'
-      : 'Review and submit your request';
 
   useEffect(() => {
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();
-    if (featureBreadcrumbUrlUpdate) {
-      changeCrumb(pageTitle);
-    }
   }, []);
 
   useEffect(
@@ -142,7 +134,3 @@ export default function ReviewPage({ changeCrumb }) {
     </div>
   );
 }
-
-ReviewPage.propTypes = {
-  changeCrumb: PropTypes.func,
-};

--- a/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/TypeOfCarePage/index.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import PropTypes from 'prop-types';
 // eslint-disable-next-line import/no-unresolved
 import SchemaForm from '@department-of-veterans-affairs/platform-forms-system/SchemaForm';
 import recordEvent from '@department-of-veterans-affairs/platform-monitoring/record-event';
@@ -23,15 +22,12 @@ import { resetDataLayer } from '../../../utils/events';
 import { PODIATRY_ID, TYPES_OF_CARE } from '../../../utils/constants';
 import useFormState from '../../../hooks/useFormState';
 import { getLongTermAppointmentHistoryV2 } from '../../../services/appointment';
-import { selectFeatureBreadcrumbUrlUpdate } from '../../../redux/selectors';
+import { getPageTitle } from '../../newAppointmentFlow';
 
 const pageKey = 'typeOfCare';
-const pageTitle = 'Choose the type of care you need';
 
-export default function TypeOfCarePage({ changeCrumb }) {
-  const featureBreadcrumbUrlUpdate = useSelector(state =>
-    selectFeatureBreadcrumbUrlUpdate(state),
-  );
+export default function TypeOfCarePage() {
+  const pageTitle = useSelector(state => getPageTitle(state, pageKey));
 
   const dispatch = useDispatch();
   const {
@@ -69,15 +65,6 @@ export default function TypeOfCarePage({ changeCrumb }) {
       dispatch(startDirectScheduleFlow({ isRecordEvent: false }));
     },
     [showUpdateAddressAlert, dispatch],
-  );
-
-  useEffect(
-    () => {
-      if (featureBreadcrumbUrlUpdate) {
-        changeCrumb(pageTitle);
-      }
-    },
-    [changeCrumb, featureBreadcrumbUrlUpdate],
   );
 
   const { data, schema, setData, uiSchema } = useFormState({
@@ -164,7 +151,3 @@ export default function TypeOfCarePage({ changeCrumb }) {
     </div>
   );
 }
-
-TypeOfCarePage.propTypes = {
-  changeCrumb: PropTypes.func,
-};

--- a/src/applications/vaos/new-appointment/newAppointmentFlow.js
+++ b/src/applications/vaos/new-appointment/newAppointmentFlow.js
@@ -217,17 +217,17 @@ const flow = {
   },
   ccPreferences: {
     url: '/new-appointment/community-care-preferences',
-    label: 'Request a preferred provider',
+    label: 'Which provider do you prefer?',
     next: 'ccLanguage',
   },
   ccLanguage: {
     url: '/new-appointment/community-care-language',
-    label: 'Choose a preferred language',
+    label: 'What language do you prefer?',
     next: 'reasonForAppointment',
   },
   ccClosestCity: {
     url: '/new-appointment/choose-closest-city',
-    label: 'What’s the closest city to you?',
+    label: 'What’s the nearest city to you?',
     next: 'ccPreferences',
   },
   vaFacility: {
@@ -385,6 +385,10 @@ export default function getNewAppointmentFlow(state) {
     },
     reasonForAppointment: {
       ...flow.reasonForAppointment,
+      label:
+        FLOW_TYPES.DIRECT === flowType
+          ? 'Tell us the reason for this appointment'
+          : 'What’s the reason for this appointment?',
       url: featureBreadcrumbUrlUpdate
         ? 'reason'
         : '/new-appointment/reason-appointment',
@@ -426,10 +430,6 @@ export default function getNewAppointmentFlow(state) {
         ? 'date-time'
         : '/new-appointment/select-date',
     },
-    // typeOfAppointment: {
-    //   ...flow.typeOfAppointment,
-    //   url: featureBreadcrumbUrlUpdate ? 'type-of-care' : '/new-appointment',
-    // },
     typeOfCare: {
       ...flow.typeOfCare,
       url: featureBreadcrumbUrlUpdate
@@ -459,7 +459,7 @@ export default function getNewAppointmentFlow(state) {
       url: featureBreadcrumbUrlUpdate
         ? // IMPORTANT!!!
           // The trailing slash is needed for going back to the previous page to work properly.
-          // The trainling slash indicates that 'new-covid-19-vaccine-appointment' is a parent path
+          // The training slash indicates that 'new-covid-19-vaccine-appointment' is a parent path
           // with children.
           //
           // Ex. /schedule/new-covid-19-vaccine-appointment/
@@ -510,4 +510,18 @@ export function getUrlLabel(state, location) {
     return results[0].label;
   }
   return null;
+}
+
+/**
+ * Function to get label from the flow based on the pageKey
+ * returns the label which is the page title
+ *
+ * @export
+ * @param {object} state
+ * @param {string} pageKey
+ * @returns {string} the label string
+ */
+export function getPageTitle(state, pageKey) {
+  const _flow = getNewAppointmentFlow(state);
+  return _flow[pageKey].label;
 }

--- a/src/applications/vaos/tests/new-appointment/components/ContactInfoPage.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/components/ContactInfoPage.unit.spec.js
@@ -7,8 +7,8 @@ import ContactInfoPage from '../../../new-appointment/components/ContactInfoPage
 import { createTestStore, renderWithStoreAndRouter } from '../../mocks/setup';
 import { FACILITY_TYPES, FLOW_TYPES } from '../../../utils/constants';
 
-describe.skip('VAOS Page: ContactInfoPage', () => {
-  it('should accept email, phone, and preferred time and continue', async () => {
+describe('VAOS Page: ContactInfoPage', () => {
+  it.skip('should accept email, phone, and preferred time and continue', async () => {
     const store = createTestStore({
       user: {
         profile: {


### PR DESCRIPTION


## Summary
With the recent content updates, the breadcrumb no longer match the title page in the new appointment flow.
This PR updates the `newAppointmentFlow.js` component as the single source of truth to get the specific page title within the appointment flows. The breadcrumb and the form pages now uses the `newAppointmentFlow.js` to retrieve the page title. 

This PR addresses the community care request flow. A second PR will be created to update the VA appointment flow.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#80714


## Testing done

unit test

## Screenshots


**Before**
![Screenshot 2024-04-15 at 7 46 52 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/35023806-e1cf-4029-8b0e-2d1fba546ccd)
---
![Screenshot 2024-04-15 at 7 47 06 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/09d7789f-6534-449e-b8f5-2b66e366b5d0)
---
![Screenshot 2024-04-15 at 7 47 21 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/1011e8fa-22dd-4a7f-ba03-5b67756910eb)
---
After
![Screenshot 2024-04-17 at 2 19 13 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/a7fef303-8dbf-4a80-8b84-9fd6ef228a01)
---
![Screenshot 2024-04-17 at 2 19 26 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/0c414410-041e-4c0a-9d7a-22226aa59b81)
---
![Screenshot 2024-04-17 at 2 19 40 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/cb7eba86-734c-4d89-af9a-f3bdd8bd12e7)


## What areas of the site does it impact?

Breadcrumb and CC appointment flow

## Acceptance criteria

- [ ] Breadcrumb to match CC request flow page title

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user


