### PR TITLE
updated link for video sign-in instructions

### DIFF
--- a/src/applications/check-in/pre-check-in/pages/Error/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/index.jsx
@@ -77,7 +77,7 @@ const Error = () => {
       <div className="vads-u-margin-top--2">{t('video-error-help-text')}</div>
       <div className="vads-u-margin-top--2">
         <ExternalLink
-          href="https://www.va.gov/resources/signing-in-to-vagov/"
+          href="https://www.va.gov/health-care/schedule-view-va-appointments/"
           hrefLang="en"
           eventId="sign-in-to-find--link-clicked"
           eventPrefix="nav"


### PR DESCRIPTION
## Summary

This PR updates the sign-in link in the video appointment help message on error pages.

## Testing done

Visual

## What areas of the site does it impact?

pre-check-in error pages.

## Acceptance criteria

 - [ ] sign-in link goes to https://www.va.gov/health-care/schedule-view-va-appointments/
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

