### PR TITLE
copies sprite.svg into build/localhost/img; this is a test

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -498,6 +498,11 @@ module.exports = async (env = {}) => {
               'node_modules/@department-of-veterans-affairs/component-library/dist/assets',
             to: `${buildPath}/assets`,
           },
+          {
+            from:
+              'node_modules/@department-of-veterans-affairs/component-library/dist/assets/sprite.svg',
+            to: `${buildPath}/img`,
+          },
         ],
       }),
 


### PR DESCRIPTION

## Summary

- _This PR makes an additional copy of the sprite.svg from component library in the img directory of build;  this is also to see if that will be placed in the same structure in content-build via a sim link.
- _ It atempts to fix a bug with va-icon that causes va-con to show in local builds, not prod, dev, or staging
-  This will either work, or we wil have to do an additional copy int contentbuild dist root,  or correct the structure of va-icon  in to match  content build

https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2680