### PR TITLE
mhv-57243/add-back-refill-section

### DIFF
--- a/src/applications/mhv/medications/containers/RefillPrescriptions.jsx
+++ b/src/applications/mhv/medications/containers/RefillPrescriptions.jsx
@@ -132,14 +132,14 @@ const RefillPrescriptions = ({ refillList = [], isLoadingList = true }) => {
     }
     return (
       <div>
-        {fullRefillList?.length > 0 && (
+        <h1
+          className="vads-u-margin-top--neg1 vads-u-margin-bottom--4"
+          data-testid="refill-page-title"
+        >
+          Refill prescriptions
+        </h1>
+        {fullRefillList?.length > 0 ? (
           <div>
-            <h1
-              className="vads-u-margin-top--neg1 vads-u-margin-bottom--4"
-              data-testid="refill-page-title"
-            >
-              Refill prescriptions
-            </h1>
             <RefillNotification refillResult={refillResult} />
             <h2
               className="vads-u-margin-top--3"
@@ -235,6 +235,11 @@ const RefillPrescriptions = ({ refillList = [], isLoadingList = true }) => {
               }`}
             />
           </div>
+        ) : (
+          <p>
+            You don’t have any VA prescriptions with refills available. If you
+            need a prescription, contact your care team.
+          </p>
         )}
         <RenewablePrescriptions renewablePrescriptionsList={fullRenewList} />
       </div>

--- a/src/applications/mhv/medications/tests/containers/RefillPrescriptions.unit.spec.jsx
+++ b/src/applications/mhv/medications/tests/containers/RefillPrescriptions.unit.spec.jsx
@@ -185,4 +185,16 @@ describe('Refill Prescriptions Component', () => {
     const button = await screen.findByTestId('request-refill-button');
     button.click();
   });
+
+  it('Shows h1 and note if no prescriptions are refillable', async () => {
+    const screen = setup(initialState, []);
+    const title = await screen.findByTestId('refill-page-title');
+    expect(title).to.exist;
+    expect(title).to.have.text('Refill prescriptions');
+    expect(
+      screen.getByText(
+        'You don’t have any VA prescriptions with refills available. If you need a prescription, contact your care team.',
+      ),
+    ).to.exist;
+  });
 });


### PR DESCRIPTION
## Summary

Added back the h1 for refill page when a user has no medications

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-57243
>Make sure there is still an H1 and that the refill section is still on the page when a user has no meds

## Testing done

- Ran unit tests
- Tested locally
- Updated unit test

## Screenshots

UI:
![Screenshot 2024-04-18 at 11 30 34 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/146013972/810d6ee1-ca9b-4a20-ba7f-152a19b28167)

Tests:
![Screenshot 2024-04-18 at 11 29 30 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/146013972/030529fa-daad-4943-a429-8dfd473658e9)


## What areas of the site does it impact?

MHV medications app refill page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
