### PR TITLE
[CST] - Update DueDate component for flakey tests

### DIFF
--- a/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DueDate.unit.spec.jsx
@@ -11,74 +11,77 @@ const formatDate = buildDateFormatter();
 
 describe('<DueDate>', () => {
   it('should render past due class when theres more than a years difference', () => {
-    const date = moment()
-      .tz('America/Los_Angeles')
-      .subtract(15, 'month');
-    const dateString = date.format('YYYY-MM-DD');
+    const dateString = moment()
+      .subtract(15, 'month')
+      .format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,
     );
     const formattedClaimDate = formatDate(dateString);
 
     getByText(
-      `Needed from you by ${formattedClaimDate} - Due ${date.fromNow()}`,
+      `Needed from you by ${formattedClaimDate} - Due ${moment(
+        dateString,
+      ).fromNow()}`,
     );
     expect($('.past-due', container)).to.exist;
   });
 
   it('should render past due class when theres more than a months difference', () => {
-    const date = moment()
-      .tz('America/Los_Angeles')
-      .subtract(4, 'month');
-    const dateString = date.format('YYYY-MM-DD');
+    const dateString = moment()
+      .subtract(4, 'month')
+      .format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,
     );
     const formattedClaimDate = formatDate(dateString);
 
     getByText(
-      `Needed from you by ${formattedClaimDate} - Due ${date.fromNow()}`,
+      `Needed from you by ${formattedClaimDate} - Due ${moment(
+        dateString,
+      ).fromNow()}`,
     );
     expect($('.past-due', container)).to.exist;
   });
 
   it('should render past due class when theres more than a days difference', () => {
-    const date = moment()
-      .utcOffset(0)
-      .set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
-      .subtract(3, 'day');
-    const dateString = date.format('YYYY-MM-DD');
+    const dateString = moment()
+      .subtract(3, 'day')
+      .format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,
     );
     const formattedClaimDate = formatDate(dateString);
 
     getByText(
-      `Needed from you by ${formattedClaimDate} - Due ${date.fromNow()}`,
+      `Needed from you by ${formattedClaimDate} - Due ${moment(
+        dateString,
+      ).fromNow()}`,
     );
     expect($('.past-due', container)).to.exist;
   });
 
   it('should render past due class when theres more than a few hours difference', () => {
-    const date = moment()
-      .utcOffset(0)
-      .set({ hour: 0, minute: 0, second: 0, millisecond: 0 })
-      .subtract(1, 'day');
-    const dateString = date.format('YYYY-MM-DD');
+    const dateString = moment()
+      .subtract(1, 'day')
+      .format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,
     );
     const formattedClaimDate = formatDate(dateString);
 
     getByText(
-      `Needed from you by ${formattedClaimDate} - Due ${date.fromNow()}`,
+      `Needed from you by ${formattedClaimDate} - Due ${moment(
+        dateString,
+      ).fromNow()}`,
     );
     expect($('.past-due', container)).to.exist;
   });
 
   it('should render file due class when more than a days difference', () => {
-    const date = moment().add(3, 'day');
-    const dateString = date.format('YYYY-MM-DD');
+    const dateString = moment()
+      .add(3, 'day')
+      .format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,
     );
@@ -89,8 +92,9 @@ describe('<DueDate>', () => {
   });
 
   it('should render file due class when more than a months difference', () => {
-    const date = moment().add(10, 'month');
-    const dateString = date.format('YYYY-MM-DD');
+    const dateString = moment()
+      .add(10, 'month')
+      .format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,
     );
@@ -101,8 +105,9 @@ describe('<DueDate>', () => {
   });
 
   it('should render file due class when more than a years difference', () => {
-    const date = moment().add(15, 'month');
-    const dateString = date.format('YYYY-MM-DD');
+    const dateString = moment()
+      .add(15, 'month')
+      .format('YYYY-MM-DD');
     const { container, getByText } = renderWithRouter(
       <DueDate date={dateString} />,
     );


### PR DESCRIPTION
## Summary

Found that the DueDate unit tests were passing in the evening but failing in the morning. Updated the logic so that we were not trying to set the timezone/ use utcOffset. 

Tests should now pass without this issue.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#80595

## Testing done
Updating tests that were identified as flakey

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## What areas of the site does it impact?

Claim Status Tool

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
