### PR TITLE
Remove duplicate progress stepper from Health Care Application

### DIFF
--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -141,6 +141,7 @@ const formConfig = {
   },
   transformForSubmit: transform,
   introduction: IntroductionPage,
+  v3SegmentedProgressBar: true,
   additionalRoutes: [
     {
       path: 'id-form',


### PR DESCRIPTION
## Summary
This PR updates the Health Care Application form config to fix the duplicate progress steppers.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#81159

## Screenshots

| Before   | After     |
| -------- | ------- |
| <img width="699" alt="Screenshot 2024-04-19 at 13 22 17" src="https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/f2920e7f-44d3-481e-8759-0d9b7e0251b5"> | <img width="699" alt="Screenshot 2024-04-19 at 13 22 50" src="https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/b3e446c7-c11e-434c-a3d4-0a5b859310f2"> |

## Acceptance criteria

- Only one stepper is displayed on the application

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution