### PR TITLE
Pension 80641 isolate app

### DIFF
--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -106,6 +106,10 @@
     {
       "rootFolder": "accredited-representative-portal",
       "slackGroup": "@arfeng"
+    },
+    {
+      "rootFolder": "pensions",
+      "slackGroup": "<@C0667PCPVLM>"
     }
   ]
 }

--- a/src/applications/pensions/components/GetFormHelp.jsx
+++ b/src/applications/pensions/components/GetFormHelp.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+
+const GetFormHelp = () => (
+  <p className="help-talk">
+    Call us at <va-telephone contact={CONTACTS.VA_BENEFITS} />. We’re here
+    Monday through Friday, 8:00 a.m to 9:00 p.m ET. If you have hearing loss,
+    call <va-telephone contact={CONTACTS[711]} tty />.
+  </p>
+);
+
+export default GetFormHelp;

--- a/src/applications/pensions/config/form.js
+++ b/src/applications/pensions/config/form.js
@@ -1,7 +1,7 @@
 import { externalServices } from 'platform/monitoring/DowntimeNotification';
 import FormFooter from 'platform/forms/components/FormFooter';
-import GetFormHelp from 'applications/vre/components/GetFormHelp';
 import { VA_FORM_IDS } from 'platform/forms/constants';
+import GetFormHelp from '../components/GetFormHelp';
 
 import { submit } from '../helpers';
 


### PR DESCRIPTION
### Background
The pensions application is not currently part of the isolated app-builds allowlist. We are adding the application to the isolated app-builds allowlist to ease our development of data definitions.

### Value proposition
* PRs will be easier to see to completion because only tests for the letters application will need to pass when making changes to the code
  * Flakey tests in other applications can turn a PR that should take one day to get merged into a multi-day effort
* We won't have to wait for the daily production deploy anymore to push changes to prod

### Related documentation
[https://depo-platform-documentation.scrollhelp.site/developer-docs/isolated-application-builds](https://depo-platform-documentation.scrollhelp.site/developer-docs/isolated-application-builds)

## Steps
The platform documentation linked above has the full details about the process, but here is a breakdown of the steps we will need to take:
1) Run the `check-app-imports` script
This will check to see if our application is importing from other applications, and vice versa
```sh
yarn check-app-imports --app-folders pensions
```

2) Run the megaMenu test
This will ensure that the site megamenu can be rendered when the application is running
```sh
yarn cy:run --spec src/platform/site-wide/mega-menu/tests/cypress/megaMenu.cypress.spec.js --env app_url=/pension/apply-for-veteran-pension-form-21p-527ez
```

3) Add the application to the allow-list
Relevant file in vets-website: `config/changed-apps-build.json`
```
{
    "rootFolder": "pensions",
    "slackGroup": "<@C0667PCPVLM>"
}
```

```[tasklist]
### Tasks
- [x] Run the `check-app-imports` script
- [x] Run the `megaMenu` script
- [x] Add entry to the allow-list and create a PR
```

### Acceptance Criteria
- [x] The pensions application has been added to the isolated app build allowlist
