### PR TITLE
Remove duplicate progress stepper from Caregivers application

### DIFF
--- a/src/applications/caregivers/config/form.js
+++ b/src/applications/caregivers/config/form.js
@@ -66,6 +66,7 @@ const formConfig = {
   submitUrl: `${environment.API_URL}/v0/caregivers_assistance_claims`,
   transformForSubmit: submitTransform,
   trackingPrefix: 'caregivers-10-10cg-',
+  v3SegmentedProgressBar: true,
   introduction: IntroductionPage,
   footerContent: FormFooter,
   getHelp: GetHelpFooter,


### PR DESCRIPTION
## Summary
This PR updates the Caregivers Application form config to fix the duplicate progress steppers.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#81164

## Screenshots

| Before   | After     |
| -------- | ------- |
| <img width="699" alt="Screenshot 2024-04-19 at 13 30 07" src="https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/4ab36638-e956-4a6d-a3ff-3f9a0e9969d8"> | <img width="699" alt="Screenshot 2024-04-19 at 13 41 01" src="https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/76566089-4c9c-4986-ba82-a3e31923fd56"> |

## Acceptance criteria

- Only one stepper is displayed on the application

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution