### PR TITLE
fix: remove dd enrollment check for showing alert

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/legacy/alerts/EduMigrationAlert.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/legacy/alerts/EduMigrationAlert.jsx
@@ -1,14 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useLocation } from 'react-router-dom/cjs/react-router-dom.min';
-import { useSelector } from 'react-redux';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 import { ProfileLink } from '../../../ProfileLink';
-import {
-  cnpDirectDepositIsEligible,
-  eduDirectDepositIsSetUp,
-} from '../../../../selectors';
 import { useSessionStorage } from '../../../../../common/hooks/useSessionStorage';
 import HelpDeskContact from '../../../HelpDeskContact';
 
@@ -17,11 +12,6 @@ export const EduMigrationAlert = ({ className }) => {
 
   const path = useLocation().pathname;
   const includeExtraLinkAndDismiss = path !== directDepositPath;
-
-  const hasBothDirectDeposits = useSelector(
-    state =>
-      eduDirectDepositIsSetUp(state) && cnpDirectDepositIsEligible(state),
-  );
 
   const [dismissed, setDismissed] = useSessionStorage(
     'dismissedDirectDepositSingleFormAlert',
@@ -32,11 +22,7 @@ export const EduMigrationAlert = ({ className }) => {
     TOGGLE_NAMES.profileShowDirectDepositSingleFormAlert,
   );
 
-  if (
-    !isAlertToggleEnabled ||
-    !hasBothDirectDeposits ||
-    (dismissed && includeExtraLinkAndDismiss)
-  ) {
+  if (!isAlertToggleEnabled || (dismissed && includeExtraLinkAndDismiss)) {
     return null;
   }
 

--- a/src/applications/personalization/profile/components/direct-deposit/legacy/alerts/EduMigrationAlert.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/legacy/alerts/EduMigrationAlert.jsx
@@ -53,10 +53,10 @@ export const EduMigrationAlert = ({ className }) => {
       </p>
 
       <p className="vads-u-margin-bottom--0">
-        <strong>Start:</strong> Friday, April 26, 2024, at TBD
+        <strong>Start:</strong> Friday, April 26, 2024, at 8:00 p.m. ET
       </p>
       <p className="vads-u-margin-top--0">
-        <strong>End:</strong> Thursday, May 2, 2024, at TBD
+        <strong>End:</strong> Thursday, May 2, 2024, at 8:00 p.m. ET
       </p>
 
       {includeExtraLinkAndDismiss && (

--- a/src/applications/personalization/profile/components/direct-deposit/legacy/alerts/EduMigrationAlert.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/legacy/alerts/EduMigrationAlert.jsx
@@ -52,6 +52,13 @@ export const EduMigrationAlert = ({ className }) => {
         to 9:00 p.m. ET.
       </p>
 
+      <p className="vads-u-margin-bottom--0">
+        <strong>Start:</strong> Friday, April 26, 2024, at TBD
+      </p>
+      <p className="vads-u-margin-top--0">
+        <strong>End:</strong> Thursday, May 2, 2024, at TBD
+      </p>
+
       {includeExtraLinkAndDismiss && (
         <ProfileLink
           href={directDepositPath}


### PR DESCRIPTION
## Summary

- Forgot to remove the check for if the user is enrolled in both direct deposit accounts when showing the alert. This is no longer needed because the alert is more general and is notifying users of overall downtime that will be occurring for all users.
- Also added start and end date to the Upcoming Alert per request

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80982

## Testing done

- Tested locally, and ensured alert is showing up.

## Screenshots

Alerts with dates added.

![Screenshot 2024-04-22 at 12 12 11 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/cac9605d-4b0c-4dbe-9cbe-190e07f2af45)

![Screenshot 2024-04-22 at 12 12 02 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/ce50c11b-4678-4149-84b6-e7757efe0da6)


## What areas of the site does it impact?

Profile -> Hub/Direct Deposit

## Acceptance criteria

- Alert shows up regardless of direct deposit enrollment

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed