### PR TITLE
[VA-17414] Remove custom margin on facilities header

### DIFF
--- a/src/platform/site-wide/sass/modules/facilities/_m-facilities-general.scss
+++ b/src/platform/site-wide/sass/modules/facilities/_m-facilities-general.scss
@@ -272,14 +272,6 @@
 }
 
 .facilities_health_service {
-  h3 {
-    margin-top: 1em;
-  }
-
-  h4 {
-    margin-top: 1em;
-  }
-
   .usa-button {
     margin-bottom: 0;
   }


### PR DESCRIPTION
## Summary

This removes some of the custom heading margins in the facilities headers, which keeps the spacings more consistent and in line with the design system defaults.

## Related issue(s)

- _Link to ticket created in va.gov-cms repo_
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17414

## Testing done

Visual, see [screenshots in comments.](https://github.com/department-of-veterans-affairs/vets-website/pull/29332#issuecomment-2072184422)

## What areas of the site does it impact?

Facilities pages

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)