### PR TITLE
Ask VA 875 - Design Changes for Relationships - "Your relationship to the Veteran"

### DIFF
--- a/src/applications/ask-va/config/chapters/personalInformation/relationshipToVeteran.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/relationshipToVeteran.js
@@ -1,27 +1,53 @@
-import React from 'react';
-import { radioUI, radioSchema } from '../../schema-helpers/radioHelper';
-import { CHAPTER_3, relationshipOptions } from '../../../constants';
-
-const question = (
-  <h3 className="vads-u-display--inline">
-    {CHAPTER_3.RELATIONSHIP_TO_VET.TITLE}
-  </h3>
-);
+import {
+  radioSchema,
+  radioUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import PageFieldSummary from '../../../components/PageFieldSummary';
+import {
+  CHAPTER_3,
+  relationshipOptionsMyself,
+  relationshipOptionsSomeoneElse,
+} from '../../../constants';
 
 const relationshipToVeteranPage = {
   uiSchema: {
-    'ui:title': question,
-    'ui:description': CHAPTER_3.RELATIONSHIP_TO_VET.PAGE_DESCRIPTION,
+    'ui:objectViewField': PageFieldSummary,
     personalRelationship: radioUI({
-      title: CHAPTER_3.RELATIONSHIP_TO_VET.QUESTION_1,
-      labels: relationshipOptions,
+      title: CHAPTER_3.RELATIONSHIP_TO_VET.TITLE,
+      labelHeaderLevel: '3',
+      labels: relationshipOptionsSomeoneElse,
+      required: () => true,
     }),
+    'ui:options': {
+      updateSchema: (formData, formSchema) => {
+        if (formData.questionAbout === 'MYSELF') {
+          return {
+            ...formSchema,
+            properties: {
+              personalRelationship: radioSchema(
+                Object.keys(relationshipOptionsMyself),
+              ),
+            },
+          };
+        }
+        return {
+          ...formSchema,
+          properties: {
+            personalRelationship: radioSchema(
+              Object.keys(relationshipOptionsSomeoneElse),
+            ),
+          },
+        };
+      },
+    },
   },
   schema: {
     type: 'object',
     required: ['personalRelationship'],
     properties: {
-      personalRelationship: radioSchema(Object.keys(relationshipOptions)),
+      personalRelationship: radioSchema(
+        Object.keys(relationshipOptionsSomeoneElse),
+      ),
     },
   },
 };

--- a/src/applications/ask-va/constants.js
+++ b/src/applications/ask-va/constants.js
@@ -65,8 +65,14 @@ export const yesNoOptions = {
   NO: 'No',
 };
 
-// Relationship options
-export const relationshipOptions = {
+// Relationship options for Myself
+export const relationshipOptionsMyself = {
+  VETERAN: "I'm the Veteran",
+  FAMILY_MEMBER: "I'm a family member of a Veteran",
+};
+
+// Relationship options for SomeoneElse
+export const relationshipOptionsSomeoneElse = {
   VETERAN: "I'm the Veteran",
   FAMILY_MEMBER: "I'm a family member of a Veteran",
   WORK:
@@ -237,10 +243,9 @@ export const CHAPTER_3 = {
   CHAPTER_TITLE: 'Personal Information',
   RELATIONSHIP_TO_VET: {
     PATH: 'relationship-to-veteran',
-    TITLE: 'Your relationship to the Veteran',
-    PAGE_DESCRIPTION:
-      "Now we'll ask for some personal information. We use this information to help us understand your question and find the answers you need.",
-    QUESTION_1: 'Select your relationship to the Veteran:',
+    TITLE: 'What is your relationship to the Veteran?',
+    PAGE_DESCRIPTION: '',
+    QUESTION_1: '',
   },
   ABOUT_YOUR_RELATIONSHIP: {
     TITLE: 'Tell us more about your relationship to the Veteran',

--- a/src/applications/ask-va/tests/config/personalInformation/relationshipToVeteran.unit.spec.js
+++ b/src/applications/ask-va/tests/config/personalInformation/relationshipToVeteran.unit.spec.js
@@ -1,12 +1,9 @@
-import React from 'react';
-import { expect } from 'chai';
-import { render } from '@testing-library/react';
-import { Provider } from 'react-redux';
+import { $$ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
-import {
-  $,
-  $$,
-} from '@department-of-veterans-affairs/platform-forms-system/ui';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import React from 'react';
+import { Provider } from 'react-redux';
 
 import formConfig from '../../../config/form';
 import { getData } from '../../fixtures/data/mock-form-data';
@@ -31,6 +28,8 @@ describe('relationshipToVeteranPage', () => {
       </Provider>,
     );
 
+    // screen.debug();
+
     const radioLabels = $$('.form-radio-buttons > label', container);
     const radioLabelList = [
       "I'm the Veteran",
@@ -38,9 +37,11 @@ describe('relationshipToVeteranPage', () => {
       "I'm connected to the Veteran through my work (for example, as a School Certifying Official or fiduciary)",
     ];
 
-    expect($('h3', container).textContent).to.eq(
-      'Your relationship to the Veteran',
+    const vaRadio = container.querySelector('va-radio');
+    expect(vaRadio.getAttribute('label')).to.equal(
+      'What is your relationship to the Veteran?',
     );
+
     radioLabels.forEach(
       radio => expect(radioLabelList.includes(radio.textContent)).to.be.true,
     );


### PR DESCRIPTION
## Summary

- Changes to the layout **Relationships** (as [described in Figma](https://www.figma.com/file/aQ6JsjD4pvMxSVPAZHllMX/AVA-Page-Library?type=design&node-id=1-3&mode=design&t=GDWULX98X9ZZq0W0-0) have been incorporated
- Added conditional per Mural flow based on Who question is about? (Myself, Someone else, or General)
  - Myself includes "I'm the Veteran" and "I'm a family member of a Veteran"
  - Someone else includes "I'm the Veteran", "I'm a family member of a Veteran" and "I'm connected to the Veteran through my work"
  - General skips this question
- The Ask VA team owns this 

## Related issue(s)

- Link to ticket [here](https://app.zenhub.com/workspaces/ask-va-647a476551689d06655cc815/issues/gh/department-of-veterans-affairs/ask-va/875)

## Testing done

- Updated Existing tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

![Screenshot 2024-04-22 at 1 29 07 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/49699643/2ad4c00e-8fa4-4c67-9c78-45bc8b4bce25)
![Screenshot 2024-04-22 at 1 29 17 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/49699643/31d1f77b-d3dd-4686-ab7d-012024ac1c06)

## What areas of the site does it impact?

- This only impacts the Ask VA form

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
