### PR TITLE
default cash in hand and cash in bank

### DIFF
--- a/src/applications/financial-status-report/components/monetary/CashInBank.jsx
+++ b/src/applications/financial-status-report/components/monetary/CashInBank.jsx
@@ -160,15 +160,15 @@ const CashInBankReview = ({ data, goToPath }) => {
 
     // if the user saw cash on hand/in bank, they should be routed to
     //  cash on hand page since it's the head of the chapter
-    if (
+    const gmtDepends =
       (gmtData?.isEligibleForStreamlined && gmtData?.incomeBelowGmt) ||
       (gmtData?.isEligibleForStreamlined &&
         gmtData?.incomeBelowOneFiftyGmt &&
-        data['view:streamlinedWaiverAssetUpdate'])
-    ) {
+        data['view:streamlinedWaiverAssetUpdate']);
+
+    if (gmtDepends || data['view:reviewPageNavigationToggle']) {
       return goToPath('/cash-on-hand');
     }
-
     return goToPath('/monetary-asset-checklist');
   };
 
@@ -203,6 +203,7 @@ const CashInBankReview = ({ data, goToPath }) => {
 
 CashInBankReview.propTypes = {
   data: PropTypes.shape({
+    'view:reviewPageNavigationToggle': PropTypes.bool,
     assets: PropTypes.shape({
       monetaryAssets: PropTypes.array,
     }),

--- a/src/applications/financial-status-report/components/monetary/MonetaryAssetsSummaryReview.jsx
+++ b/src/applications/financial-status-report/components/monetary/MonetaryAssetsSummaryReview.jsx
@@ -25,15 +25,16 @@ const MonetaryAssetsSummaryReview = ({ data, goToPath }) => {
 
     // if the user saw cash on hand/in bank, they should be routed to
     //  cash on hand page since it's the head of the chapter
-    if (
+
+    const gmtDepends =
       (gmtData?.isEligibleForStreamlined && gmtData?.incomeBelowGmt) ||
       (gmtData?.isEligibleForStreamlined &&
         gmtData?.incomeBelowOneFiftyGmt &&
-        data['view:streamlinedWaiverAssetUpdate'])
-    ) {
+        data['view:streamlinedWaiverAssetUpdate']);
+
+    if (gmtDepends || showReviewNavigation) {
       return goToPath('/cash-on-hand');
     }
-
     return goToPath('/monetary-asset-checklist');
   };
 

--- a/src/applications/financial-status-report/components/monetary/MonetaryCheckList.jsx
+++ b/src/applications/financial-status-report/components/monetary/MonetaryCheckList.jsx
@@ -86,9 +86,10 @@ const MonetaryCheckList = ({
       gmtData?.isEligibleForStreamlined &&
       gmtData?.incomeBelowOneFiftyGmt);
 
-  const adjustedAssetList = adjustForStreamlined
-    ? streamlinedList
-    : monetaryAssetList;
+  const adjustedAssetList =
+    adjustForStreamlined || showReviewNavigation
+      ? streamlinedList
+      : monetaryAssetList;
 
   // reviewDepends - only show/handle review alert and navigation if
   //  feature flag is on, user is in review mode, and they have not seen the cash pages

--- a/src/applications/financial-status-report/components/monetary/MonetaryInputList.jsx
+++ b/src/applications/financial-status-report/components/monetary/MonetaryInputList.jsx
@@ -70,9 +70,10 @@ const MonetaryInputList = props => {
       gmtData?.isEligibleForStreamlined &&
       gmtData?.incomeBelowOneFiftyGmt);
 
-  const adjustedAssetList = adjustForStreamlined
-    ? streamlinedList
-    : monetaryAssets;
+  const adjustedAssetList =
+    adjustForStreamlined || data['view:reviewPageNavigationToggle']
+      ? streamlinedList
+      : monetaryAssets;
 
   return (
     <InputList

--- a/src/applications/financial-status-report/components/otherAssets/RealEstateQuestionReview.jsx
+++ b/src/applications/financial-status-report/components/otherAssets/RealEstateQuestionReview.jsx
@@ -17,7 +17,9 @@ const RealEstateQuestionReview = ({ data, goToPath, title }) => {
         reviewNavigation: true,
       }),
     );
-    goToPath('/monetary-asset-checklist');
+    return data['view:reviewPageNavigationToggle']
+      ? goToPath('/cash-on-hand')
+      : goToPath('/monetary-asset-checklist');
   };
 
   return (
@@ -44,6 +46,7 @@ const RealEstateQuestionReview = ({ data, goToPath, title }) => {
 
 RealEstateQuestionReview.propTypes = {
   data: PropTypes.shape({
+    'view:reviewPageNavigationToggle': PropTypes.bool,
     assets: PropTypes.shape({
       monetaryAssets: PropTypes.array,
     }),

--- a/src/applications/financial-status-report/config/chapters/householdAssetsChapter.js
+++ b/src/applications/financial-status-report/config/chapters/householdAssetsChapter.js
@@ -46,12 +46,12 @@ export default {
         depends: formData => {
           const { gmtData } = formData;
           // Also show if the new asset update is true
-          return (
+          const gmtDepends =
             (gmtData?.isEligibleForStreamlined && gmtData?.incomeBelowGmt) ||
             (gmtData?.isEligibleForStreamlined &&
               gmtData?.incomeBelowOneFiftyGmt &&
-              formData['view:streamlinedWaiverAssetUpdate'])
-          );
+              formData['view:streamlinedWaiverAssetUpdate']);
+          return gmtDepends || formData['view:reviewPageNavigationToggle'];
         },
       },
       cashInBank: {
@@ -64,11 +64,11 @@ export default {
         depends: formData => {
           const { gmtData } = formData;
           // Only show if the new asset update is true
-          return (
+          const gmtDepends =
             gmtData?.isEligibleForStreamlined &&
             gmtData?.incomeBelowOneFiftyGmt &&
-            formData['view:streamlinedWaiverAssetUpdate']
-          );
+            formData['view:streamlinedWaiverAssetUpdate'];
+          return gmtDepends || formData['view:reviewPageNavigationToggle'];
         },
       },
       streamlinedShortTransitionPage: {
@@ -83,7 +83,6 @@ export default {
           formData?.gmtData?.isEligibleForStreamlined &&
           isStreamlinedShortForm(formData),
       },
-
       monetaryChecklist: {
         path: 'monetary-asset-checklist',
         title: 'Monetary asset options',
@@ -91,7 +90,12 @@ export default {
         schema: { type: 'object', properties: {} },
         CustomPage: MonetaryCheckList,
         CustomPageReview: null,
-        depends: formData => !isStreamlinedShortForm(formData),
+        depends: formData => {
+          return (
+            formData['view:reviewPageNavigationToggle'] ||
+            !isStreamlinedShortForm(formData)
+          );
+        },
       },
       monetaryValues: {
         path: 'monetary-asset-values',
@@ -110,7 +114,9 @@ export default {
           );
 
           return (
-            filteredLiquidAssets.length > 0 && !isStreamlinedShortForm(formData)
+            filteredLiquidAssets.length > 0 &&
+            (formData['view:reviewPageNavigationToggle'] ||
+              !isStreamlinedShortForm(formData))
           );
         },
       },

--- a/src/applications/financial-status-report/config/chapters/householdAssetsChapter.js
+++ b/src/applications/financial-status-report/config/chapters/householdAssetsChapter.js
@@ -92,7 +92,8 @@ export default {
         CustomPageReview: null,
         depends: formData => {
           return (
-            formData['view:reviewPageNavigationToggle'] ||
+            (formData['view:reviewPageNavigationToggle'] &&
+              !isStreamlinedShortForm(formData)) ||
             !isStreamlinedShortForm(formData)
           );
         },
@@ -114,8 +115,10 @@ export default {
           );
 
           return (
-            filteredLiquidAssets.length > 0 &&
-            (formData['view:reviewPageNavigationToggle'] ||
+            (filteredLiquidAssets.length > 0 &&
+              (formData['view:reviewPageNavigationToggle'] &&
+                !isStreamlinedShortForm(formData))) ||
+            (filteredLiquidAssets.length > 0 &&
               !isStreamlinedShortForm(formData))
           );
         },

--- a/src/applications/financial-status-report/mocks/development.js
+++ b/src/applications/financial-status-report/mocks/development.js
@@ -1,7 +1,7 @@
 // when USE_MOCK is true, the application will use the copay mock data below instead of live api data
-export const USE_COPAY_MOCK_DATA = false;
+export const USE_COPAY_MOCK_DATA = true;
 // when USE_GEOGRAPHIC_MOCK_DATA is true, the application will use the geographic mock data below instead of live api data
-export const USE_GEOGRAPHIC_MOCK_DATA = false;
+export const USE_GEOGRAPHIC_MOCK_DATA = true;
 // this is the value that will be used for GMT calculations when USE_GEOGRAPHIC_MOCK_DATA is true
 export const MOCK_GMT_VALUE = 78300;
 // when USE_STAGING_DATA is true, the application will use the staging api instead of the production api or USE_GEOGRAPHIC_MOCK_DATA

--- a/src/applications/financial-status-report/mocks/development.js
+++ b/src/applications/financial-status-report/mocks/development.js
@@ -1,7 +1,7 @@
 // when USE_MOCK is true, the application will use the copay mock data below instead of live api data
-export const USE_COPAY_MOCK_DATA = true;
+export const USE_COPAY_MOCK_DATA = false;
 // when USE_GEOGRAPHIC_MOCK_DATA is true, the application will use the geographic mock data below instead of live api data
-export const USE_GEOGRAPHIC_MOCK_DATA = true;
+export const USE_GEOGRAPHIC_MOCK_DATA = false;
 // this is the value that will be used for GMT calculations when USE_GEOGRAPHIC_MOCK_DATA is true
 export const MOCK_GMT_VALUE = 78300;
 // when USE_STAGING_DATA is true, the application will use the staging api instead of the production api or USE_GEOGRAPHIC_MOCK_DATA

--- a/src/applications/financial-status-report/tests/e2e/fixtures/data/initial-feature.json
+++ b/src/applications/financial-status-report/tests/e2e/fixtures/data/initial-feature.json
@@ -1,0 +1,114 @@
+{
+  "data": {
+    "view:components": {
+      "view:veteranInfo": {},
+      "view:maritalStatus": {},
+      "view:dependentsAdditionalInfo": {},
+      "view:vaBenefitsOnFile": {},
+      "view:realEstateAdditionalInfo": {},
+      "view:recVehicleInfo": {},
+      "view:contractsAdditionalInfo": {}
+    },
+    "personalData": {
+      "veteranFullName": {
+        "first": "Brendan",
+        "last": "Eich",
+        "middle": "JS"
+      },
+      "dateOfBirth": "1950-09-06",
+      "veteranContactInformation": {
+        "email": "test@user.com",
+        "mobilePhone": {
+          "areaCode": "505",
+          "countryCode": "1",
+          "createdAt": "2023-08-10T14:15:12.000+00:00",
+          "extension": null,
+          "effectiveEndDate": null,
+          "effectiveStartDate": "2023-08-14T16:56:53.000+00:00",
+          "id": 375052,
+          "isInternational": false,
+          "isTextable": null,
+          "isTextPermitted": null,
+          "isTty": null,
+          "isVoicemailable": null,
+          "phoneNumber": "2700638",
+          "phoneType": "MOBILE",
+          "sourceDate": "2023-08-14T16:56:53.000+00:00",
+          "sourceSystemUser": null,
+          "transactionId": "05f6f7a0-997b-40b0-8a02-ade3b7b1da39",
+          "updatedAt": "2023-08-14T16:56:56.000+00:00",
+          "vet360Id": "134281"
+        },
+        "address": {
+          "addressLine1": "1060 W Addison St",
+          "addressPou": "CORRESPONDENCE",
+          "addressType": "DOMESTIC",
+          "city": "Chicago",
+          "countryName": "United States",
+          "countryCodeIso2": "US",
+          "countryCodeIso3": "USA",
+          "countryCodeFips": null,
+          "countyCode": null,
+          "countyName": "Cook County",
+          "createdAt": "2024-03-19T15:34:10.000Z",
+          "effectiveEndDate": null,
+          "effectiveStartDate": "2024-03-19T15:34:10.000Z",
+          "geocodeDate": "2024-03-19T15:34:10.000Z",
+          "geocodePrecision": 32.0,
+          "id": 19652768,
+          "internationalPostalCode": null,
+          "latitude": 41.9475,
+          "longitude": -87.6547,
+          "province": null,
+          "sourceDate": "2024-03-19T15:34:10.000Z",
+          "sourceSystemUser": null,
+          "stateCode": "IL",
+          "transactionId": "a8f8153f-92dd-4ea5-93ae-5fe2a6ba8e2f",
+          "updatedAt": "2024-03-19T15:34:10.000Z",
+          "validationKey": null,
+          "vet360Id": "21306345",
+          "zipCode": "60613",
+          "zipCodeSuffix": null,
+          "badAddress": false
+        }
+      },
+      "spouseFullName": {},
+      "address": {
+        "street": "1060 W Addison St",
+        "city": "Chicago",
+        "state": "IL",
+        "country": "USA",
+        "postalCode": "60613"
+      },
+      "telephoneNumber": "6304825671",
+      "emailAddress": "test@user.com"
+    },
+    "personalIdentification": {
+      "ssn": "3018",
+      "fileNumber": "3018"
+    },
+    "selectedDebtsAndCopays": [],
+    "questions": {},
+    "additionalIncome": {
+      "spouse": {}
+    },
+    "benefits": {
+      "spouseBenefits": {}
+    },
+    "assets": {},
+    "expenses": {},
+    "additionalData": {
+      "bankruptcy": {}
+    },
+    "view:enhancedFinancialStatusReport": true,
+    "view:streamlinedWaiver": true,
+    "view:streamlinedWaiverAssetUpdate": true,
+    "view:reviewPageNavigationToggle": true,
+    "income": [
+      {
+        "veteranOrSpouse": "VETERAN",
+        "compensationAndPension": "1413.68"
+      }
+    ]
+  }
+}

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-complete.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-complete.cypress.spec.js
@@ -277,6 +277,26 @@ const testConfig = createTestConfig(
       // ============================================================
       // ================== householdAssetsChapter ==================
       // ============================================================
+      'cash-on-hand': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('#cash')
+            .first()
+            .shadow()
+            .find('input')
+            .type('125');
+          cy.get('.usa-button-primary').click();
+        });
+      },
+      'cash-in-bank': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('#cash')
+            .first()
+            .shadow()
+            .find('input')
+            .type('329.12');
+          cy.get('.usa-button-primary').click();
+        });
+      },
       'monetary-asset-checklist': ({ afterHook }) => {
         afterHook(() => {
           cy.get('[type=checkbox]')
@@ -293,6 +313,7 @@ const testConfig = createTestConfig(
       },
       'monetary-asset-values': ({ afterHook }) => {
         afterHook(() => {
+          // do U.S. Savings Bonds, and Retirement
           cy.get('va-number-input')
             .as('numberInputs')
             .should('have.length', 2);

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-minimal.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-minimal.cypress.spec.js
@@ -98,6 +98,26 @@ const testConfig = createTestConfig(
           });
         });
       },
+      'cash-on-hand': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('#cash')
+            .first()
+            .shadow()
+            .find('input')
+            .type('125');
+          cy.get('.usa-button-primary').click();
+        });
+      },
+      'cash-in-bank': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('#cash')
+            .first()
+            .shadow()
+            .find('input')
+            .type('329.12');
+          cy.get('.usa-button-primary').click();
+        });
+      },
       // ==============================================================
       // ================== resolutionOptionsChapter ==================
       // ==============================================================


### PR DESCRIPTION
The full FSR flow should include the Cash in bank and Cash on hand pages while removing the Cash, Checking accounts, Savings accounts from the monetary-asset-values page (monetary Assets array in checkboxSelections.js since the values are being tracked with the new pages.

Since this could effect in progress forms we should determine if it's necessary to shift this update behind a feature flag. This change should help with the review navigation implementation

[Here is the updated user flow on Figma](https://www.figma.com/file/fbJtTnxh1q6Z3i1vPtvucq/Streamlined-Waiver-User-Flows?type=design&node-id=0%3A1&mode=design&t=JFOe2iUooQDEB9rg-1)

Tasks

- [x]  Determine if this change needs to hide behind a feature flag
- [x]  Update depends for 'Cash in' so the pages are included in the full FSR
- [x]  Update monetary Assets array
- [x]  Update any relevant tests

Acceptance criteria

- [x]  Cash in bank and Cash on hand questions are added to the full FSR path
- [x]  monetary-asset-values page no longer shows Cash, Checking accounts, Savings accounts as checklist items
- [x]  All tests are passing

Testing

- [x]  Confirm changes wont interfere with in progress forms

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#79884

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#81538


## Testing done

-  Cash in Bank and Cash in Hand were originally included for streamlined only users




