### PR TITLE
Disable isolated continuous deployment

### DIFF
--- a/config/changed-apps-build.json
+++ b/config/changed-apps-build.json
@@ -109,7 +109,8 @@
     },
     {
       "rootFolder": "pensions",
-      "slackGroup": "<@C0667PCPVLM>"
+      "slackGroup": "<@C0667PCPVLM>",
+      "continuousDeployment": false
     }
   ]
 }


### PR DESCRIPTION
### Background
The pensions application is not currently part of the isolated app-builds allowlist. We are adding the application to the isolated app-builds allowlist to ease our development of data definitions.

### Value proposition
* PRs will be easier to see to completion because only tests for the letters application will need to pass when making changes to the code
  * Flakey tests in other applications can turn a PR that should take one day to get merged into a multi-day effort

### Related documentation
[https://depo-platform-documentation.scrollhelp.site/developer-docs/isolated-application-builds](https://depo-platform-documentation.scrollhelp.site/developer-docs/isolated-application-builds)

## Steps
The platform documentation linked above has the full details about the process, but here is a breakdown of the steps we will need to take:
1) Run the `check-app-imports` script
This will check to see if our application is importing from other applications, and vice versa
```sh
yarn check-app-imports --app-folders pensions
```

2) Run the megaMenu test
This will ensure that the site megamenu can be rendered when the application is running
```sh
yarn cy:run --spec src/platform/site-wide/mega-menu/tests/cypress/megaMenu.cypress.spec.js --env app_url=/pension/apply-for-veteran-pension-form-21p-527ez
```

3) Add the application to the allow-list
Relevant file in vets-website: `config/changed-apps-build.json`
```
{
    "rootFolder": "pensions",
    "slackGroup": "<@C0667PCPVLM>",
    "continuousDeployment": false
}
```

```[tasklist]
### Tasks
- [x] Run the `check-app-imports` script
- [x] Run the `megaMenu` script
- [x] Add entry to the allow-list and create a PR
```

### Acceptance Criteria
- [x] The pensions application has been added to the isolated app build allowlist
