### PR TITLE
[CDP] #79964 VHA expand pay online component and add account number part 2

### DIFF
--- a/src/applications/combined-debt-portal/debt-letters/components/OnThisPageLinks.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/OnThisPageLinks.jsx
@@ -18,9 +18,11 @@ const OnThisPageLinks = ({ isDetailsPage, hasHistory }) => (
               data-testid="debts-jumplink"
               className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
             >
-              <i
+              <va-icon
+                size={2}
+                icon="arrow_downward"
                 aria-hidden="true"
-                className="fas fa-arrow-down vads-u-margin-right--1"
+                class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
               />
               Current debts
             </a>
@@ -31,9 +33,11 @@ const OnThisPageLinks = ({ isDetailsPage, hasHistory }) => (
               data-testid="history-jumplink"
               className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
             >
-              <i
+              <va-icon
+                size={2}
+                icon="arrow_downward"
                 aria-hidden="true"
-                className="fas fa-arrow-down vads-u-margin-right--1"
+                class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
               />
               Debt letter history
             </a>
@@ -44,9 +48,11 @@ const OnThisPageLinks = ({ isDetailsPage, hasHistory }) => (
               data-testid="download-jumplink"
               className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
             >
-              <i
+              <va-icon
+                size={2}
+                icon="arrow_downward"
                 aria-hidden="true"
-                className="fas fa-arrow-down vads-u-margin-right--1"
+                class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
               />
               Download debt letters
             </a>
@@ -56,9 +62,11 @@ const OnThisPageLinks = ({ isDetailsPage, hasHistory }) => (
             data-testid="howto-pay-jumplink"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={4}
+              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              className="vads-u-margin-right--1"
             />
             How do I pay my VA debt?
           </a>
@@ -67,9 +75,11 @@ const OnThisPageLinks = ({ isDetailsPage, hasHistory }) => (
             data-testid="howto-help-jumplink"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={4}
+              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              className="vads-u-margin-right--1"
             />
             How do I get financial help?
           </a>
@@ -78,9 +88,11 @@ const OnThisPageLinks = ({ isDetailsPage, hasHistory }) => (
             data-testid="howto-dispute-jumplink"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={4}
+              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              className="vads-u-margin-right--1"
             />
             How do I dispute a debt?
           </a>

--- a/src/applications/combined-debt-portal/debt-letters/components/OnThisPageLinks.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/OnThisPageLinks.jsx
@@ -19,7 +19,6 @@ const OnThisPageLinks = ({ isDetailsPage, hasHistory }) => (
               className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
             >
               <va-icon
-                size={2}
                 icon="arrow_downward"
                 aria-hidden="true"
                 class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
@@ -34,7 +33,6 @@ const OnThisPageLinks = ({ isDetailsPage, hasHistory }) => (
               className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
             >
               <va-icon
-                size={2}
                 icon="arrow_downward"
                 aria-hidden="true"
                 class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
@@ -49,7 +47,6 @@ const OnThisPageLinks = ({ isDetailsPage, hasHistory }) => (
               className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
             >
               <va-icon
-                size={2}
                 icon="arrow_downward"
                 aria-hidden="true"
                 class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"

--- a/src/applications/combined-debt-portal/medical-copays/components/AccountSummary.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/AccountSummary.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { currency } from '../../combined/utils/helpers';
 
-const AccountSummary = ({
+export const AccountSummary = ({
+  acctNum,
   currentBalance,
   newCharges,
   paymentsReceived,
@@ -32,7 +33,7 @@ const AccountSummary = ({
       <ul className="no-bullets vads-u-padding-x--0">
         <li
           data-testid="account-summary-previous"
-          clasName="vads-u-margin-bottom--0p5"
+          className="vads-u-margin-bottom--0p5"
         >
           {`Previous balance: ${currency(previousBalance)}`}
         </li>
@@ -49,11 +50,14 @@ const AccountSummary = ({
           {`New charges: ${currency(newCharges)}`}
         </li>
       </ul>
+      <h3 className="vads-u-margin-top--2">Accounnt number</h3>
+      <p>{acctNum}</p>
     </div>
   );
 };
 
 AccountSummary.propTypes = {
+  acctNum: PropTypes.string,
   currentBalance: PropTypes.number,
   newCharges: PropTypes.number,
   paymentsReceived: PropTypes.number,

--- a/src/applications/combined-debt-portal/medical-copays/components/AccountSummary.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/AccountSummary.jsx
@@ -50,7 +50,7 @@ export const AccountSummary = ({
           {`New charges: ${currency(newCharges)}`}
         </li>
       </ul>
-      <h3 className="vads-u-margin-top--2">Accounnt number</h3>
+      <h3 className="vads-u-margin-top--2">Account number</h3>
       <p>{acctNum}</p>
     </div>
   );

--- a/src/applications/combined-debt-portal/medical-copays/components/HowToPay.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/HowToPay.jsx
@@ -3,58 +3,54 @@ import PropTypes from 'prop-types';
 
 export const HowToPay = ({ isOverview, acctNum, facility }) => (
   <article className="vads-u-padding--0" data-testid="how-to-pay">
-    <h2 id="how-to-pay">How to pay your copay bill</h2>
+    <h2 id="how-to-pay">How to pay your copay bill online</h2>
     <p>
-      <strong>You can pay your bill in any of these 4 ways:</strong>
+      Pay directly from your bank account or by debit or credit card on the
+      secure
+      <a
+        className="vads-u-margin-left--0p25"
+        href="https://www.pay.gov/public/form/start/25987221"
+        aria-label="Pay.gov - Opens in new window"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Pay.gov website
+      </a>
+      .
     </p>
+    <p>
+      You will need to provide your account number to pay{' '}
+      {isOverview ? 'the' : 'this'} debt online.
+    </p>
+
+    <p>
+      <strong>Account number: </strong>
+      {acctNum}
+    </p>
+
+    <a
+      className="vads-c-action-link--blue"
+      href="https://www.pay.gov/public/form/start/25987221"
+      aria-label="Pay.gov - Opens in new window"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Pay your copay bill online at pay.gov
+    </a>
+    <p>
+      If you need help making a payment online, call us at{' '}
+      <va-telephone contact="8888274817" />. We’re available Monday through
+      Friday, 8:00 a.m. to 8:00 p.m. ET.
+    </p>
+    <h3>Other ways to pay your bill:</h3>
     <va-accordion>
-      <va-accordion-item header="Option 1: Pay online" open="true">
-        <p>
-          Pay directly from your bank account or by debit or credit card on the
-          secure
-          <a
-            className="vads-u-margin-left--0p25"
-            href="https://www.pay.gov/public/form/start/25987221"
-            aria-label="Pay.gov - Opens in new window"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Pay.gov website
-          </a>
-          .
-        </p>
-        <p>
-          You will need to provide your account number to pay{' '}
-          {isOverview ? 'the' : 'this'} debt online.
-        </p>
-
-        <p>
-          <strong>Account number: </strong>
-          {acctNum}
-        </p>
-
-        <a
-          className="vads-c-action-link--blue"
-          href="https://www.pay.gov/public/form/start/25987221"
-          aria-label="Pay.gov - Opens in new window"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Pay your copay bill online at pay.gov
-        </a>
-        <p>
-          If you need help making a payment online, call us at{' '}
-          <va-telephone contact="8888274817" />. We’re available Monday through
-          Friday, 8:00 a.m. to 8:00 p.m. ET.
-        </p>
-      </va-accordion-item>
-      <va-accordion-item header="Option 2: Pay by phone">
+      <va-accordion-item header="Pay by phone">
         <p>
           Call us at <va-telephone contact="8888274817" />. We’re here Monday
           through Friday, 8:00 a.m. to 8:00 p.m. ET.
         </p>
       </va-accordion-item>
-      <va-accordion-item header="Option 3: Pay by mail">
+      <va-accordion-item header="Pay by mail">
         <p>Please send us these items:</p>
         <ul>
           <li>
@@ -88,7 +84,7 @@ export const HowToPay = ({ isOverview, acctNum, facility }) => (
           <br />
         </p>
       </va-accordion-item>
-      <va-accordion-item header="Option 4: Pay in person">
+      <va-accordion-item header="Pay in person">
         <p>
           Visit {isOverview ? 'the facility' : facility?.facilityName} and ask
           for the agent cashier’s office. Bring your payment stub, along with a

--- a/src/applications/combined-debt-portal/medical-copays/components/OnThisPageDetails.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/OnThisPageDetails.jsx
@@ -16,7 +16,6 @@ export const OnThisPageDetails = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
@@ -28,7 +27,6 @@ export const OnThisPageDetails = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
@@ -40,7 +38,6 @@ export const OnThisPageDetails = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
@@ -52,7 +49,6 @@ export const OnThisPageDetails = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
@@ -64,7 +60,6 @@ export const OnThisPageDetails = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"

--- a/src/applications/combined-debt-portal/medical-copays/components/OnThisPageDetails.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/OnThisPageDetails.jsx
@@ -15,9 +15,11 @@ export const OnThisPageDetails = () => (
             href="#statement-list"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             Your statements
           </a>
@@ -25,9 +27,11 @@ export const OnThisPageDetails = () => (
             href="#how-to-pay"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             How to pay your copay bill
           </a>
@@ -35,9 +39,11 @@ export const OnThisPageDetails = () => (
             href="#how-to-get-financial-help"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             How to get financial help for your copays
           </a>
@@ -45,9 +51,11 @@ export const OnThisPageDetails = () => (
             href="#dispute-charges"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             How to dispute your copay charges
           </a>
@@ -55,9 +63,11 @@ export const OnThisPageDetails = () => (
             href="#balance-questions"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             What to do if you have questions about your balance
           </a>

--- a/src/applications/combined-debt-portal/medical-copays/components/OnThisPageOverview.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/OnThisPageOverview.jsx
@@ -16,9 +16,11 @@ export const OnThisPageOverview = () => (
             href="#balance-list"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             Your most recent statement balances for the last six months
           </a>
@@ -26,9 +28,11 @@ export const OnThisPageOverview = () => (
             href="#how-to-pay"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             How to pay your copay bill
           </a>
@@ -36,9 +40,11 @@ export const OnThisPageOverview = () => (
             href="#how-to-get-financial-help"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             How to get financial help for your copays
           </a>
@@ -46,9 +52,11 @@ export const OnThisPageOverview = () => (
             href="#dispute-charges"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             How to dispute your copay charges
           </a>
@@ -56,9 +64,11 @@ export const OnThisPageOverview = () => (
             href="#balance-questions"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             What to do if you have questions about your balance
           </a>

--- a/src/applications/combined-debt-portal/medical-copays/components/OnThisPageOverview.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/OnThisPageOverview.jsx
@@ -17,7 +17,6 @@ export const OnThisPageOverview = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
@@ -29,7 +28,6 @@ export const OnThisPageOverview = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
@@ -41,7 +39,6 @@ export const OnThisPageOverview = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
@@ -53,7 +50,6 @@ export const OnThisPageOverview = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
@@ -65,7 +61,6 @@ export const OnThisPageOverview = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"

--- a/src/applications/combined-debt-portal/medical-copays/components/OnThisPageStatements.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/OnThisPageStatements.jsx
@@ -15,9 +15,11 @@ export const OnThisPageStatements = () => (
             href="#account-summary"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={4}
+              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              className="vads-u-margin-right--1"
             />
             Account summary
           </a>
@@ -25,9 +27,11 @@ export const OnThisPageStatements = () => (
             href="#statement-charges"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={4}
+              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              className="vads-u-margin-right--1"
             />
             Statement charges
           </a>
@@ -35,21 +39,61 @@ export const OnThisPageStatements = () => (
             href="#statement-addresses"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={4}
+              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              className="vads-u-margin-right--1"
             />
             Statement addresses
           </a>
           <a
-            href="#what-do-questions"
+            href="#how-to-pay"
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
-            <i
+            <va-icon
+              size={4}
+              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
               aria-hidden="true"
-              className="fas fa-arrow-down vads-u-margin-right--1"
+              className="vads-u-margin-right--1"
             />
-            What to do if you have questions about your statement
+            How to pay your copay bill
+          </a>
+          <a
+            href="#how-to-get-financial-help"
+            className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
+          >
+            <va-icon
+              size={4}
+              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
+              aria-hidden="true"
+              className="vads-u-margin-right--1"
+            />
+            How to get financial help for your copays
+          </a>
+          <a
+            href="#dispute-charges"
+            className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
+          >
+            <va-icon
+              size={4}
+              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
+              aria-hidden="true"
+              className="vads-u-margin-right--1"
+            />
+            How to dispute your copay charges
+          </a>
+          <a
+            href="#balance-questions"
+            className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
+          >
+            <va-icon
+              size={4}
+              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
+              aria-hidden="true"
+              className="vads-u-margin-right--1"
+            />
+            What to do if you have questions about your balance
           </a>
         </dd>
       </dl>

--- a/src/applications/combined-debt-portal/medical-copays/components/OnThisPageStatements.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/OnThisPageStatements.jsx
@@ -16,10 +16,10 @@ export const OnThisPageStatements = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={4}
-              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             Account summary
           </a>
@@ -28,10 +28,10 @@ export const OnThisPageStatements = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={4}
-              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             Statement charges
           </a>
@@ -40,10 +40,10 @@ export const OnThisPageStatements = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={4}
-              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             Statement addresses
           </a>
@@ -52,10 +52,10 @@ export const OnThisPageStatements = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={4}
-              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             How to pay your copay bill
           </a>
@@ -64,10 +64,10 @@ export const OnThisPageStatements = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={4}
-              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             How to get financial help for your copays
           </a>
@@ -76,10 +76,10 @@ export const OnThisPageStatements = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={4}
-              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             How to dispute your copay charges
           </a>
@@ -88,10 +88,10 @@ export const OnThisPageStatements = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={4}
-              icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
+              size={2}
+              icon="arrow_downward"
               aria-hidden="true"
-              className="vads-u-margin-right--1"
+              class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
             />
             What to do if you have questions about your balance
           </a>

--- a/src/applications/combined-debt-portal/medical-copays/components/OnThisPageStatements.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/components/OnThisPageStatements.jsx
@@ -16,7 +16,6 @@ export const OnThisPageStatements = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
@@ -28,7 +27,6 @@ export const OnThisPageStatements = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
@@ -40,7 +38,6 @@ export const OnThisPageStatements = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
@@ -52,7 +49,6 @@ export const OnThisPageStatements = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
@@ -64,7 +60,6 @@ export const OnThisPageStatements = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
@@ -76,7 +71,6 @@ export const OnThisPageStatements = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"
@@ -88,7 +82,6 @@ export const OnThisPageStatements = () => (
             className="vads-u-display--flex vads-u-align-items--baseline vads-u-padding--1 vads-u-text-decoration--none"
           >
             <va-icon
-              size={2}
               icon="arrow_downward"
               aria-hidden="true"
               class="vads-u-margin-right--1 vads-u-margin-bottom--neg0p25"

--- a/src/applications/combined-debt-portal/medical-copays/containers/HTMLStatementPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/HTMLStatementPage.jsx
@@ -85,6 +85,7 @@ const HTMLStatementPage = ({ match }) => {
           paymentsReceived={selectedCopay.pHTotCredits}
           previousBalance={selectedCopay.pHPrevBal}
           statementDate={statementDate}
+          acctNum={statementsByUniqueFacility[0].pHAccountNumber}
         />
         <StatementCharges
           data-testid="statement-charges"
@@ -102,15 +103,6 @@ const HTMLStatementPage = ({ match }) => {
           data-testid="statement-addresses"
           copay={selectedCopay}
         />
-        <h2 id="what-do-questions">
-          What to do if you have questions about your statement
-        </h2>
-        <p>
-          Contact the VA Health Resource Center at{' '}
-          <va-telephone contact="8664001238" /> (
-          <va-telephone tty contact="711" />
-          ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
-        </p>
         <HowToPay
           acctNum={statementsByUniqueFacility[0].pHAccountNumber}
           facility={statementsByUniqueFacility[0].station}


### PR DESCRIPTION
## Summary

Here's a summary of the changes I've made in addition to adding the account number and having the pay online accordion be open by default:

- For all the pages, I moved the pay online section out of the accordion into its own content block.
- For the HTML Statement page, I added the account number at the top below the balance activity.
- Also updated On This page icon to use the new `va-icon` version

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#79964

## Testing done

- Tested locally

## Screenshots

| | Before | After |
| -------- | -------- | ------- |
| **Copay balances summary pages** | ![Copay balances summary page before](https://github.com/department-of-veterans-affairs/va.gov-team/assets/1631062/75706dc8-6ad4-4149-8f78-4a7e9d444399) | ![Copay balances summary page after](https://github.com/department-of-veterans-affairs/va.gov-team/assets/1631062/e847cf73-473f-446b-91fe-f029820bc438) |
| **Copay detail page** | <img width="750" alt="Copay-Detail-Before" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/1631062/36cb3e84-3c3f-4c1b-a537-d7bb1abadf5a"> | <img width="750" alt="Copay Detail After" src="https://github.com/department-of-veterans-affairs/va.gov-team/assets/1631062/5a0c34cb-e0c7-4ac0-b967-7cdd6331a1fe"> |
| **Copay HTML statement page** | ![Copay HTML statement page before](https://github.com/department-of-veterans-affairs/va.gov-team/assets/1631062/3397a454-123b-41eb-b088-dfc3f35021af) | ![Copay HTML statement page after](https://github.com/department-of-veterans-affairs/va.gov-team/assets/1631062/0924b76a-4977-4bdd-ac80-a0659364432e) |


## What areas of the site does it impact?

Combined debt portal

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
