### PR TITLE
[CST] Reverting to button to enhance a11y

### DIFF
--- a/src/applications/claims-status/components/ClaimPhase.jsx
+++ b/src/applications/claims-status/components/ClaimPhase.jsx
@@ -129,11 +129,16 @@ export default class ClaimPhase extends React.Component {
               <h5 className="vads-u-margin-top--2p5 vads-u-margin-bottom--2">
                 {`Past updates (${activityList.length - 1})`}
               </h5>
-              <va-button
-                secondary
-                text={`${showOlder ? 'Hide' : 'Show'} past updates`}
+              {/* eslint-disable-next-line @department-of-veterans-affairs/prefer-button-component */}
+              <button
+                type="button"
+                className="claim-older-updates usa-button-secondary"
+                aria-controls={`older-updates-${phase}`}
+                aria-expanded={showOlder}
                 onClick={this.showOlderActivity}
-              />
+              >
+                {`${showOlder ? 'Hide' : 'Show'} past updates`}
+              </button>
             </>
           ) : null}
           {showOlder && hasMoreActivity ? (

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
@@ -453,8 +453,7 @@ class TrackClaimsPageV2 {
   verifyOverviewShowPastUpdates() {
     cy.get('#tabOverview').click();
     cy.url().should('contain', '/your-claims/189685/overview');
-    cy.get('.process-step.list-three va-button')
-      .shadow()
+    cy.get('.process-step.list-three')
       .find('button')
       .click();
     cy.get('#older-updates-3').should('be.visible');


### PR DESCRIPTION
## Summary
Reverting our usage of `va-button` in the `ClaimPhase` component back to `button` because `va-button` does not support the `aria-controls` and `aria-expanded` attributes. This work is to remove a launch blocker for an upcoming launch

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#78904

## Testing done
Updated tests

## Screenshots
### After
<img width="500" alt="Screenshot 2024-04-23 at 1 51 12 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/3be09e56-6792-49ec-a0a9-896f1612d8c4">

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
