### PR TITLE
[DBEX] validate if service date is same or before DOB

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/pages/militaryHistory.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/militaryHistory.unit.spec.jsx
@@ -116,7 +116,7 @@ describe('Military history', () => {
     fillDate(
       form,
       'root_serviceInformation_servicePeriods_0_dateRange_from',
-      '2003-01-01',
+      '2003-01-02',
     );
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error-message').length).to.equal(0);

--- a/src/applications/disability-benefits/all-claims/tests/pages/militaryHistory.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/militaryHistory.unit.spec.jsx
@@ -102,7 +102,7 @@ describe('Military history', () => {
     fillDate(
       form,
       'root_serviceInformation_servicePeriods_0_dateRange_from',
-      '2002-12-31',
+      '2003-01-01',
     );
     fillDate(
       form,

--- a/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/validations.unit.spec.js
@@ -531,17 +531,17 @@ describe('526 All Claims validations', () => {
 
   describe('validateAge', () => {
     const _ = null;
-    it('should not allow age < 13 years at start of service', () => {
+    it('should not allow age <= 13 years at start of service', () => {
       const errors = { addError: sinon.spy() };
       const dob = '2000-01-01';
       // 13th birthday (needs to be _after_ 13th birthday)
-      const age = formatDate(add(new Date(dob), { years: 13, days: -1 }));
+      const age = formatDate(add(new Date(dob), { years: 13, days: 0 }));
       validateAge(errors, age, _, _, _, _, { dob });
 
       expect(errors.addError.called).to.be.true;
       expect(errors.addError.args[0][0]).to.contain('after your 13th birthday');
     });
-    it('should allow age 13 years at start of service', () => {
+    it('should allow age > 13 years at start of service', () => {
       const errors = { addError: sinon.spy() };
       const dob = '2000-01-01';
       // Add 1 extra day to ensure we're after 13th birthday

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -589,7 +589,8 @@ export const validateAge = (
   _currentIndex,
   appStateData,
 ) => {
-  if (moment(dateString).isBefore(moment(appStateData.dob).add(13, 'years'))) {
+  const dob = moment(appStateData.dob).add(13, 'years');
+  if (moment(dateString).isSameOrBefore(dob)) {
     errors.addError('Your start date must be after your 13th birthday');
   }
 };


### PR DESCRIPTION
According to [EVSS form526 validation rules](https://confluence.devops.va.gov/pages/viewpage.action?spaceKey=VAExternal&title=Form526+Validation+Rules), a claim is invalid if the earliest `activeDutyBeginDate` is on or before the claimant's 13th birthday. This PR corrects the online form validation to match that expectation.

## Summary

- Method and corresponding tests were modified to address identified validation discrepancy
  - A service start date that is on or before a claimant's 13th birthday is now invalid
- Disability Benefits Experience Team 2 (dBeX Carbs 🥖)

## Related issue(s)

- [69011](https://app.zenhub.com/workspaces/disability-benefits-experience-team-carbs-6470c8bfffee9809b2634a52/issues/gh/department-of-veterans-affairs/va.gov-team/69011)

## Testing done

- Prior to the change, entering a service start date that was the same as the claimant's 13th birthday would **not** return an error
- In addition to manual testing, pre-existing tests were modified to verify the update met expectations

## Screenshots

Depicts validation update given a birthdate of October 4, 1950:

![Screenshot 2024-04-23 at 2 09 18 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/50811220/fb66c50f-ad3a-48ad-accf-e87b07badac0)

## What areas of the site does it impact?

Form 526 > Military service history > Active service start date

## Acceptance criteria

### Quality Assurance & Testing

- [X] I **modified** unit tests
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Screenshot of the update is added

### Error Handling

- [X] Browser console contains no warnings or errors.

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user
