### PR TITLE
Add mhv route guard to EZR

### DIFF
--- a/src/applications/ezr/routes.jsx
+++ b/src/applications/ezr/routes.jsx
@@ -1,14 +1,28 @@
 import { createRoutesWithSaveInProgress } from '@department-of-veterans-affairs/platform-forms/save-in-progress/helpers';
+import { useMyHealthAccessGuard } from '~/platform/mhv/hooks/useMyHealthAccessGuard';
 import formConfig from './config/form';
 import App from './containers/App';
 
+const AccessGuardWrapper = ({ children }) => {
+  const redirectToMyHealth = useMyHealthAccessGuard();
+  if (redirectToMyHealth) {
+    return null;
+  }
+  return children;
+};
+
 const route = {
   path: '/',
-  component: App,
+  component: AccessGuardWrapper,
   indexRoute: {
     onEnter: (nextState, replace) => replace('/introduction'),
   },
-  childRoutes: createRoutesWithSaveInProgress(formConfig),
+  childRoutes: [
+    {
+      component: App,
+      childRoutes: createRoutesWithSaveInProgress(formConfig),
+    },
+  ],
 };
 
 export default route;

--- a/src/platform/mhv/hooks/useMyHealthAccessGuard.jsx
+++ b/src/platform/mhv/hooks/useMyHealthAccessGuard.jsx
@@ -1,0 +1,17 @@
+import { useSelector } from 'react-redux';
+
+/**
+ * Route guard hook that will redirect the user to the /my-health landing page if mhvAccountState is 'NONE'
+ */
+
+export const useMyHealthAccessGuard = () => {
+  const mhvAccountState = useSelector(
+    state => state?.user?.profile?.mhvAccountState,
+  );
+
+  if (mhvAccountState === 'NONE') {
+    return window.location.replace('/my-health');
+  }
+
+  return null;
+};


### PR DESCRIPTION
The purpose of this PR is to implement a route guard for the tool pages under the /my-health/ umbrella. The route guard checks for the presence of mhvAccountState having a value of ‘OK’ or ‘MULTIPLE’ to indicate whether a user has an MHV account. When a user does not have an MHV account, the property mhvAccountState will have a value of ‘NONE’. When a user has an MHV account, they are permitted to access the various tools under /my-health/. When a user does not have an MHV account, the route guard will redirect the user to the /my-health/ landing page where an alert notification will be shown explaining that they do not have an MHV account and need to register. This route guard will prevent the need to have this alert notification on each of the /my-health/ too pages. 

When a user does not have an MHV account, they are redirected to the /my-health/ landing page and will see the following:

<img width="1061" alt="Screenshot 2024-04-24 at 1 37 20 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/7745936/06ae012e-8a18-481b-894b-ed2d65b968b1">

Ticket:
https://app.zenhub.com/workspaces/mhv-on-vagov-landing-page-62619a987d74510018ecc546/issues/gh/department-of-veterans-affairs/va.gov-team/77237

## Testing done

To test this, mock user data must be used and toggled between values of 'NONE' = no mhv account and 'OK' or 'MULTIPLE' = has an mhv Account.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
