### PR TITLE
Update submit transformer

### DIFF
--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -132,6 +132,10 @@ const formConfig = {
   v3SegmentedProgressBar: true,
   formId: '10-7959C',
   transformForSubmit,
+  dev: {
+    showNavLinks: false,
+    collapsibleNavLinks: true,
+  },
   preSubmitInfo: {
     statementOfTruth: {
       body:
@@ -178,27 +182,27 @@ const formConfig = {
         name: {
           path: 'your-information/name',
           title: 'Your name',
-          depends: formData => get('certifierRole', formData) === 'other',
+          depends: formData => get('certifierRole', formData) !== 'applicant',
           ...certifierNameSchema,
         },
         address: {
           path: 'your-information/address',
           title: 'Your mailing address',
-          depends: formData => get('certifierRole', formData) === 'other',
+          depends: formData => get('certifierRole', formData) !== 'applicant',
           uiSchema: certifierAddress.uiSchema,
           schema: certifierAddress.schema,
         },
         phoneEmail: {
           path: 'your-information/phone-email',
           title: 'Your phone number',
-          depends: formData => get('certifierRole', formData) === 'other',
+          depends: formData => get('certifierRole', formData) !== 'applicant',
           uiSchema: certifierPhoneEmail.uiSchema,
           schema: certifierPhoneEmail.schema,
         },
         relationship: {
           path: 'your-information/relationship',
           title: 'Your relationship to the applicant',
-          depends: formData => get('certifierRole', formData) === 'other',
+          depends: formData => get('certifierRole', formData) !== 'applicant',
           uiSchema: certifierRelationship.uiSchema,
           schema: certifierRelationship.schema,
         },

--- a/src/applications/ivc-champva/10-7959C/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959C/config/submitTransformer.js
@@ -1,16 +1,72 @@
 import { transformForSubmit as formsSystemTransformForSubmit } from 'platform/forms-system/src/js/helpers';
 
+/**
+ * Convert a list of strings into an object with boolean
+ * keys indicating the presence or absence of a key. E.g.,
+ * if given list ['prop1', 'prop2'], return would be:
+ * {is_prop1: true, is_prop2: true}
+ * @param {array} listOfStr List of health insurance types (e.g., ['ppo', 'medigap'])
+ * @returns Object of boolean properties based on list of strings provided, e.g.,:
+ * {is_prop1: true, is_prop2: true}
+ */
+function listOfStrToBools(listOfStr) {
+  let retVal = {};
+  if (listOfStr !== undefined) {
+    listOfStr
+      .map(key => {
+        return { [`is_${key}`]: true };
+      })
+      .forEach(obj => {
+        retVal = { ...retVal, ...obj };
+      });
+  }
+  return retVal;
+}
+
+/**
+ * This function recursively finds all object properties with a value of "yes" or "no"
+ * and converts those values in-place to booleans. E.g., if provided obj = {prop1: "yes"},
+ * will modify obj so that it === {prop1: true}.
+ * @param {object} data Object we're searching for string values to convert to bools
+ * @param {number} depth Current recursion depth (used to prevent runaway)
+ * @param {number} maxDepth Maximum recursion depth
+ * @returns undefined, operates on obj in place
+ */
+function yesNoToBool(data, depth = 0, maxDepth = 5) {
+  const obj = data;
+  // Prevent infinite recursion if we somehow have self-referencing object
+  if (depth > maxDepth) return;
+  // Check all keys on current object and recurse if necessary
+  Object.keys(obj).forEach(k => {
+    if (obj[k] === 'yes') obj[k] = true;
+    else if (obj[k] === 'no') obj[k] = false;
+    else if (typeof obj[k] === 'object')
+      yesNoToBool(obj[k], depth + 1, maxDepth);
+  });
+}
+
 export default function transformForSubmit(formConfig, form) {
   const transformedData = JSON.parse(
     formsSystemTransformForSubmit(formConfig, form),
   );
 
-  //
-  // TODO: Make additional transformations here in the future
-  //
+  // Convert insurance types to array of boolean keys
+  transformedData.applicants.forEach(el => {
+    const app = el; // Updates will be in-place
+    app.applicantPrimaryInsuranceType = listOfStrToBools(
+      app?.applicantPrimaryInsuranceType?.split(',').map(v => v.trim()),
+    );
+    app.applicantSecondaryInsuranceType = listOfStrToBools(
+      app?.applicantSecondaryInsuranceType?.split(',').map(v => v.trim()),
+    );
+  });
+
+  // Convert all "yes" or "no" values to true booleans
+  const copyOfData = JSON.parse(JSON.stringify(transformedData));
+  yesNoToBool(copyOfData);
 
   return JSON.stringify({
-    ...transformedData,
+    ...copyOfData,
     formNumber: formConfig.formId,
   });
 }

--- a/src/applications/ivc-champva/10-7959C/tests/config/transformer.unit.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/config/transformer.unit.spec.js
@@ -1,0 +1,46 @@
+/* eslint-disable camelcase */
+import { expect } from 'chai';
+import formConfig from '../../config/form';
+import transformForSubmit from '../../config/submitTransformer';
+
+describe('transform for submit', () => {
+  it('should convert insurance types to list of boolean properties', () => {
+    const testData = {
+      data: {
+        applicants: [
+          {
+            applicantPrimaryInsuranceType: 'hmo, medigap',
+          },
+        ],
+      },
+    };
+    const transformed = JSON.parse(transformForSubmit(formConfig, testData));
+    expect(
+      JSON.stringify(transformed.applicants[0].applicantPrimaryInsuranceType),
+    ).to.equal(
+      JSON.stringify({
+        is_hmo: true,
+        is_medigap: true,
+      }),
+    );
+  });
+  it('should convert values of "yes" and "no" to booleans', () => {
+    const testData = {
+      data: {
+        applicants: [
+          {
+            applicantPrimaryEOB: { providesEOB: 'yes' },
+            applicantPrimaryThroughEmployer: { throughEmployer: 'no' },
+          },
+        ],
+      },
+    };
+    const transformed = JSON.parse(transformForSubmit(formConfig, testData));
+    expect(transformed.applicants[0].applicantPrimaryEOB.providesEOB).to.equal(
+      true,
+    );
+    expect(
+      transformed.applicants[0].applicantPrimaryThroughEmployer.throughEmployer,
+    ).to.equal(false);
+  });
+});

--- a/src/applications/ivc-champva/10-7959C/tests/fixtures/data/test-data.json
+++ b/src/applications/ivc-champva/10-7959C/tests/fixtures/data/test-data.json
@@ -69,6 +69,9 @@
       "state": "AL",
       "postalCode": "12345"
     },
-    "certifierRole": "other"
+    "certifierRole": "applicant",
+    "consentToMailMissingRequiredFiles": true,
+    "statementOfTruthCertified": true,
+    "statementOfTruthSignature": "Jimmy Alvin"
   }
 }


### PR DESCRIPTION
## Summary

This PR updates the submit transformer for form 10-7959c. It adds two helpers that convert string values to boolean values before sending the data to the backend.

Additionally, this PR includes a small fix for the `depends` functions that control when third party certifier info is collected on the form. This fixes a bug where the attestation block at the end of the form wouldn't know which name the user should put int he attestation text field if they previously selected `veteran` for certifierRole.

- Adds submit transformer helper functions
- Adds unit tests for submit transformer
- Updates formconfig `depends` logic that controls certifier screens
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- NA

## Testing done

- Manual testing
- Unit tests

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA