### PR TITLE
Conditional retirement dslogon mhv direct deposit users

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
@@ -27,19 +27,25 @@ import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 const cardHeadingId = 'bank-account-information';
 
 // layout wrapper for common styling
-const Wrapper = ({ children }) => {
+const Wrapper = ({ children, withPaymentHistory }) => {
   return (
     <div className="vads-u-margin-y--2">
       <Headline dataTestId="unified-direct-deposit">
         Direct deposit information
       </Headline>
       {children}
+      {withPaymentHistory && <PaymentHistoryCard />}
     </div>
   );
 };
 
 Wrapper.propTypes = {
   children: PropTypes.node.isRequired,
+  withPaymentHistory: PropTypes.bool,
+};
+
+Wrapper.defaultProps = {
+  withPaymentHistory: true,
 };
 
 export const DirectDeposit = () => {
@@ -82,7 +88,7 @@ export const DirectDeposit = () => {
 
   if (togglesLoading) {
     return (
-      <Wrapper>
+      <Wrapper withPaymentHistory={false}>
         <va-loading-indicator />
       </Wrapper>
     );
@@ -92,7 +98,6 @@ export const DirectDeposit = () => {
     return (
       <Wrapper>
         <TemporaryOutage customMessaging />
-        <PaymentHistoryCard />
       </Wrapper>
     );
   }
@@ -101,14 +106,13 @@ export const DirectDeposit = () => {
     return (
       <Wrapper>
         <LoadFail />
-        <PaymentHistoryCard />
       </Wrapper>
     );
   }
 
   if (isBlocked) {
     return (
-      <Wrapper>
+      <Wrapper withPaymentHistory={false}>
         <DirectDepositBlocked />
       </Wrapper>
     );
@@ -126,7 +130,6 @@ export const DirectDeposit = () => {
     return (
       <Wrapper>
         <Ineligible />
-        <PaymentHistoryCard />
       </Wrapper>
     );
   }
@@ -182,8 +185,6 @@ export const DirectDeposit = () => {
         />
 
         <FraudVictimSummary />
-
-        <PaymentHistoryCard />
       </Wrapper>
     </div>
   );

--- a/src/applications/personalization/profile/components/direct-deposit/alerts/TemporaryOutage.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/alerts/TemporaryOutage.jsx
@@ -14,7 +14,7 @@ const CustomMessaging = () => (
 
     <p>
       We’re updating our systems for online direct deposit management. We expect
-      to complete this work by Thursday, May 2, 2024, at TBD.
+      to complete this work by Thursday, May 2, 2024, at 8:00 p.m. ET.
     </p>
     <p className="vads-u-margin-bottom--0">
       If you need to manage your direct deposit information for disability

--- a/src/applications/personalization/profile/components/direct-deposit/alerts/TemporaryOutage.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/alerts/TemporaryOutage.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+
 import HelpDeskContact from '../../HelpDeskContact';
 
 const CustomMessaging = () => (
@@ -51,3 +53,7 @@ export const TemporaryOutage = ({ customMessaging = false }) => (
     )}
   </div>
 );
+
+TemporaryOutage.propTypes = {
+  customMessaging: PropTypes.bool,
+};

--- a/src/applications/personalization/profile/components/direct-deposit/alerts/VerifyIdentity.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/alerts/VerifyIdentity.jsx
@@ -1,8 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CSP_IDS } from 'platform/user/authentication/constants';
-import CreateAccountLink from 'platform/user/authentication/components/CreateAccountLink';
-import VerifyAccountLink from 'platform/user/authentication/components/VerifyAccountLink';
+import { useSelector } from 'react-redux';
+import {
+  CSP_IDS,
+  SERVICE_PROVIDERS,
+} from '~/platform/user/authentication/constants';
+import CreateAccountLink from '~/platform/user/authentication/components/CreateAccountLink';
+import VerifyAccountLink from '~/platform/user/authentication/components/VerifyAccountLink';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
+import { signInServiceName } from '~/platform/user/authentication/selectors';
+
+const CredentialRetirementMessaging = () => {
+  const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
+  const showCredentialRetirementMessaging = useToggleValue(
+    TOGGLE_NAMES.profileShowCredentialRetirementMessaging,
+  );
+  const signInService = useSelector(signInServiceName);
+  const serviceLabel = SERVICE_PROVIDERS[signInService]?.label;
+  return showCredentialRetirementMessaging ? (
+    <>
+      Starting December 31, 2024, you’ll no longer be able to sign in with your
+      {` ${serviceLabel}` || ''} username and password.
+    </>
+  ) : null;
+};
 
 export default function VerifyIdentity({ useOAuth }) {
   const { ID_ME, LOGIN_GOV } = CSP_IDS;
@@ -24,7 +45,7 @@ export default function VerifyIdentity({ useOAuth }) {
       </p>
       <p>
         <strong>If you don’t have one of these accounts</strong>, you can create
-        one and verify your identity now.
+        one and verify your identity now. <CredentialRetirementMessaging />
       </p>
       {[ID_ME, LOGIN_GOV].map(policy => (
         <p key={policy}>

--- a/src/applications/personalization/profile/components/direct-deposit/alerts/VerifyIdentity.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/alerts/VerifyIdentity.jsx
@@ -16,11 +16,12 @@ const CredentialRetirementMessaging = () => {
     TOGGLE_NAMES.profileShowCredentialRetirementMessaging,
   );
   const signInService = useSelector(signInServiceName);
-  const serviceLabel = SERVICE_PROVIDERS[signInService]?.label;
+  const serviceLabel = SERVICE_PROVIDERS?.[signInService]?.label;
+  const serviceLabelFormatted = serviceLabel ? ` ${serviceLabel}` : '';
   return showCredentialRetirementMessaging ? (
     <>
       Starting December 31, 2024, you’ll no longer be able to sign in with your
-      {` ${serviceLabel}` || ''} username and password.
+      {serviceLabelFormatted} username and password.
     </>
   ) : null;
 };

--- a/src/applications/personalization/profile/tests/components/direct-deposit/VerifyIdentity.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/direct-deposit/VerifyIdentity.unit.spec.jsx
@@ -1,11 +1,24 @@
 import React from 'react';
-import { render, cleanup, waitFor } from '@testing-library/react';
+import { cleanup, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
-import { axeCheck } from 'platform/forms-system/test/config/helpers';
 import { mockCrypto } from 'platform/utilities/oauth/mockCrypto';
-import VerifyIdentity from '../../../../../components/direct-deposit/alerts/VerifyIdentity';
+import { renderInReduxProvider } from '~/platform/testing/unit/react-testing-library-helpers';
+import VerifyIdentity from '../../../components/direct-deposit/alerts/VerifyIdentity';
 
 const oldCrypto = global.window.crypto;
+
+const initialState = {
+  featureToggles: {
+    profileShowCredentialRetirementMessaging: true,
+  },
+  user: {
+    profile: {
+      signIn: {
+        service: 'idme',
+      },
+    },
+  },
+};
 
 describe('authenticated experience -- profile -- direct deposit', () => {
   describe('VerifyIdentity', () => {
@@ -19,12 +32,11 @@ describe('authenticated experience -- profile -- direct deposit', () => {
       cleanup();
     });
 
-    it('passes axeCheck', () => {
-      axeCheck(<VerifyIdentity />);
-    });
-
     it('renders the proper URLs for VerifyIdentity (SAML)', async () => {
-      const screen = render(<VerifyIdentity useOAuth={false} />);
+      const screen = renderInReduxProvider(
+        <VerifyIdentity useOAuth={false} />,
+        { initialState },
+      );
       const loginGovAnchor = await screen.findByTestId('logingov');
       const idmeAnchor = await screen.findByTestId('idme');
 
@@ -38,7 +50,9 @@ describe('authenticated experience -- profile -- direct deposit', () => {
     });
 
     it('renders the proper URLs for VerifyIdentity (OAuth)', async () => {
-      const screen = render(<VerifyIdentity useOAuth />);
+      const screen = renderInReduxProvider(<VerifyIdentity useOAuth />, {
+        initialState,
+      });
       const loginGovAnchor = await screen.findByTestId('logingov');
       const idmeAnchor = await screen.findByTestId('idme');
 


### PR DESCRIPTION
## Summary

- Added some additional content to the verify identity alert around credential retirement. That content is shown based on the toggle: `profile_show_credential_retirement_messaging`. This toggle is not live on production yet.
- Cleaned up the wrapper component to show the payment history component by default instead of having it repeated over and over. `withPaymentHistory` is a boolean prop that can be set to false on the wrapper to hide the component when needed.
- Added end time to TemporaryOutage component as requested

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/77466

## Testing done

- Updated unit tests

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| VerifyIdentity w/toggle on  | ![Screenshot 2024-04-24 at 8 46 40 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/431eba32-a711-47fb-93fe-785583f6d195) | ![Screenshot 2024-04-24 at 8 46 58 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/5bad10f7-5f7d-4411-b2b8-24c28f1b7023) |
| Outage Alert | ![Screenshot 2024-04-24 at 8 53 59 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/945ffd17-c483-4eea-a3a3-482a4bde2f8e) | ![Screenshot 2024-04-24 at 8 48 56 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/2a77dde5-0bb8-4a1a-816e-a143bdca16a5) |

## What areas of the site does it impact?

Profile -> Direct Deposit

## Acceptance criteria

- Content updated

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
