### PR TITLE
Skip Pensions Kitchen Sink

### DIFF
--- a/src/applications/pensions/tests/e2e/pensionsKeyboardOnly.cypress.spec.js
+++ b/src/applications/pensions/tests/e2e/pensionsKeyboardOnly.cypress.spec.js
@@ -55,7 +55,7 @@ describe('Higher-Level Review keyboard only navigation', () => {
       });
     });
   });
-  context('Kitchen sink', () => {
+  context.skip('Kitchen sink', () => {
     it('keyboard navigates through the form', () => {
       cy.wrap(kitchenSinkFixture.data).as('testData');
       cypressSetup(cy);


### PR DESCRIPTION
## Summary

- The keyboard-only Kitchen Sink test is sporadically hanging in CI. We're skipping the test while we attempt to determine the cause of the issue.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81572

## Testing done

- Ran `yarn cy:run --spec src/applications/pensions/tests/e2e/pensionsKeyboardOnly.cypress.spec.js` locally and confirmed that the Kitchen Sink test didn't run

## What areas of the site does it impact?

Pension Benefits

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
