### PR TITLE
DR | Update submission error to va-alert

### DIFF
--- a/src/platform/forms-system/src/js/review/submit-states/ErrorLinks.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ErrorLinks.jsx
@@ -34,63 +34,63 @@ const ErrorLinks = props => {
   );
 
   return (
-    <div
-      className="usa-alert usa-alert-error schemaform-failure-alert"
+    <va-alert
+      status="error"
+      class="schemaform-failure-alert vads-u-margin-top--4"
       data-testid={testId}
     >
-      <div className="usa-alert-body">
-        <h3
-          aria-describedby="missing-info-alert-legend"
-          className="schemaform-warning-header vads-u-margin-top--0"
-          tabIndex={-1}
-          ref={errorRef}
-        >
-          {resolved
-            ? `Thank you for completing your ${appType}`
-            : `Your ${appType} is missing some information`}
-        </h3>
-        {resolved ? (
-          `Try submitting your ${appType} again.`
-        ) : (
-          <>
-            <p aria-describedby="missing-info-alert-legend">
-              You’ll need to fill in the missing information before you can
-              submit your {appType}
-            </p>
-            <fieldset>
-              <legend
-                id="missing-info-alert-legend"
-                className="vads-u-font-size--base"
-              >
-                {`Please return to the following ${
-                  errors.length === 1 ? 'part' : `${errors.length} parts`
-                } of the form:`}
-              </legend>
-              <ul className="vads-u-margin-left--2 error-message-list">
-                {errors.map(error => (
-                  <li key={error.name}>
-                    {error.chapterKey ? (
-                      <a // eslint-disable-line jsx-a11y/anchor-is-valid
-                        href="#"
-                        onClick={event => {
-                          event.preventDefault();
-                          scrollToReviewElement(error);
-                          openAndEditChapter(error);
-                        }}
-                      >
-                        {error.message}
-                      </a>
-                    ) : (
-                      error.message
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </fieldset>
-          </>
-        )}
-      </div>
-    </div>
+      <h2
+        slot="headline"
+        aria-describedby="missing-info-alert-legend"
+        className="schemaform-warning-header vads-u-margin-top--0"
+        tabIndex={-1}
+        ref={errorRef}
+      >
+        {resolved
+          ? `Thank you for completing your ${appType}`
+          : `Your ${appType} is missing some information`}
+      </h2>
+      {resolved ? (
+        `Try submitting your ${appType} again.`
+      ) : (
+        <>
+          <p aria-describedby="missing-info-alert-legend">
+            You’ll need to fill in the missing information before you can submit
+            your {appType}
+          </p>
+          <fieldset>
+            <legend
+              id="missing-info-alert-legend"
+              className="vads-u-font-size--base"
+            >
+              {`Please return to the following ${
+                errors.length === 1 ? 'part' : `${errors.length} parts`
+              } of the form:`}
+            </legend>
+            <ul className="vads-u-margin-left--2 error-message-list">
+              {errors.map(error => (
+                <li key={error.name}>
+                  {error.chapterKey ? (
+                    <a // eslint-disable-line jsx-a11y/anchor-is-valid
+                      href="#"
+                      onClick={event => {
+                        event.preventDefault();
+                        scrollToReviewElement(error);
+                        openAndEditChapter(error);
+                      }}
+                    >
+                      {error.message}
+                    </a>
+                  ) : (
+                    error.message
+                  )}
+                </li>
+              ))}
+            </ul>
+          </fieldset>
+        </>
+      )}
+    </va-alert>
   );
 };
 

--- a/src/platform/forms/components/common/alerts/ErrorMessage.jsx
+++ b/src/platform/forms/components/common/alerts/ErrorMessage.jsx
@@ -1,5 +1,6 @@
 // libs
 import React from 'react';
+import PropTypes from 'prop-types';
 
 /**
  * A column layout component
@@ -11,23 +12,27 @@ import React from 'react';
 function ErrorMessage(props) {
   const { active, children, message, testId, title } = props;
 
-  if (!active) return null;
-  else {
-    return (
-      <div
-        className="usa-alert usa-alert-error schemaform-failure-alert"
-        data-testid={testId}
-      >
-        <div className="usa-alert-body">
-          <p className="schemaform-warning-header">
-            <strong>{title}</strong>
-          </p>
-          <p>{message}</p>
-          {children}
-        </div>
-      </div>
-    );
-  }
+  return !active ? null : (
+    <va-alert
+      status="error"
+      class="schemaform-failure-alert vads-u-margin-top--4"
+      data-testid={testId}
+    >
+      <h2 slot="headline" className="schemaform-warning-header">
+        {title}
+      </h2>
+      <p>{message}</p>
+      {children}
+    </va-alert>
+  );
 }
+
+ErrorMessage.propTypes = {
+  active: PropTypes.bool,
+  children: PropTypes.node,
+  message: PropTypes.string,
+  testId: PropTypes.string,
+  title: PropTypes.string,
+};
 
 export default ErrorMessage;

--- a/src/platform/forms/tests/components/common/alerts/__snapshots__/ErrorMessage.unit.spec.jsx.mocha-snapshot
+++ b/src/platform/forms/tests/components/common/alerts/__snapshots__/ErrorMessage.unit.spec.jsx.mocha-snapshot
@@ -1,10 +1,10 @@
-exports["Common ErrorMessage component/should render title if passed as a prop(0)"] = "<div class=\"usa-alert usa-alert-error schemaform-failure-alert\" data-testid=\"12345\"><div class=\"usa-alert-body\"><p class=\"schemaform-warning-header\"><strong>i am a title</strong></p><p></p></div></div>";
+exports["Common ErrorMessage component/should render title if passed as a prop(0)"] = "<va-alert status=\"error\" class=\"schemaform-failure-alert vads-u-margin-top--4\" data-testid=\"12345\"><h2 slot=\"headline\" class=\"schemaform-warning-header\">i am a title</h2><p></p></va-alert>";
 
-exports["Common ErrorMessage component/should render message if passed as a prop(0)"] = "<div class=\"usa-alert usa-alert-error schemaform-failure-alert\"><div class=\"usa-alert-body\"><p class=\"schemaform-warning-header\"><strong></strong></p><p>i am a message</p></div></div>";
+exports["Common ErrorMessage component/should render message if passed as a prop(0)"] = "<va-alert status=\"error\" class=\"schemaform-failure-alert vads-u-margin-top--4\"><h2 slot=\"headline\" class=\"schemaform-warning-header\"></h2><p>i am a message</p></va-alert>";
 
-exports["Common ErrorMessage component/should render children if passed as a prop(0)"] = "<div class=\"usa-alert usa-alert-error schemaform-failure-alert\"><div class=\"usa-alert-body\"><p class=\"schemaform-warning-header\"><strong></strong></p><p></p>i am a child component</div></div>";
+exports["Common ErrorMessage component/should render children if passed as a prop(0)"] = "<va-alert status=\"error\" class=\"schemaform-failure-alert vads-u-margin-top--4\"><h2 slot=\"headline\" class=\"schemaform-warning-header\"></h2><p></p>i am a child component</va-alert>";
 
-exports["Common ErrorMessage component/should render if active(0)"] = "<div class=\"usa-alert usa-alert-error schemaform-failure-alert\" data-testid=\"12345\"><div class=\"usa-alert-body\"><p class=\"schemaform-warning-header\"><strong></strong></p><p></p></div></div>";
+exports["Common ErrorMessage component/should render if active(0)"] = "<va-alert status=\"error\" class=\"schemaform-failure-alert vads-u-margin-top--4\" data-testid=\"12345\"><h2 slot=\"headline\" class=\"schemaform-warning-header\"></h2><p></p></va-alert>";
 
 exports["Common ErrorMessage component/should not render if not active(0)"] = "";
 


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > The submission validation error alert is still using a `div` with an alert class to show the alert. This PR updates it to use the `va-alert` web component
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Update HTML
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#80680](https://github.com/department-of-veterans-affairs/va.gov-team/issues/80680)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Alert using `div` with alert class name
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| DR  | <img width="630" alt="Screenshot 2024-04-24 at 10 36 14 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/97ac0370-5281-4d9c-adfb-ac59c4c287df"> | <img width="634" alt="Screenshot 2024-04-24 at 11 53 33 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/2c3fca3a-7d6b-4c1b-ba49-093393b12112"> |
| 526 (review errors) | <img width="638" alt="Screenshot 2024-04-24 at 11 21 20 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/01435c5a-8991-44df-959b-1d4b251ca8b5"> | <img width="661" alt="Screenshot 2024-04-24 at 11 19 52 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/dab11633-62cf-48c1-a269-bd66f6f0b393"> |

## What areas of the site does it impact?

All forms that use the review & submit page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
