### PR TITLE
VACMS-16528 Remove 2024 new limits alert

### DIFF
--- a/src/applications/income-limits/containers/HomePage.jsx
+++ b/src/applications/income-limits/containers/HomePage.jsx
@@ -54,20 +54,6 @@ const HomePage = ({
 
   return (
     <>
-      <va-alert
-        class="vads-u-margin-top--1 vads-u-margin-bottom--3"
-        close-btn-aria-label="Close notification"
-        status="info"
-        visible
-        uswds
-      >
-        <h2 slot="headline">
-          We’ve updated this tool to check 2024 income limits
-        </h2>
-        <p className="vads-u-margin-bottom--0">
-          You can check your income limits for 2024 now.
-        </p>
-      </va-alert>
       <h1>{H1}</h1>
       <p>
         Answer 2 questions to find out how your income may affect your VA health


### PR DESCRIPTION
## Summary
We added an alert at the beginning of the year to alert Income Limits users that we had new limits updated for 2024. As it is now several months into the year, we can remove this alert.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16528

## Testing done
Tested locally.

## Screenshots

### Before
<img width="700" alt="Screenshot 2024-04-24 at 1 44 07 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/ad0e1756-b8fa-4714-9fcd-24ebbfaed9f6">
<img width="300" alt="Screenshot 2024-04-24 at 1 45 44 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/84ede1c3-4c3b-4bec-973f-72e57dd48d5c">

### After
<img width="700" alt="Screenshot 2024-04-24 at 1 44 02 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/79d27bca-0cc7-4660-8c46-ae70a8b3aa8b">
<img width="300" alt="Screenshot 2024-04-24 at 1 45 38 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/38c9e9cf-de4c-4bfa-b670-b1fbaadef85c">

## What areas of the site does it impact?

Income Limits only

## Acceptance criteria

- [x]  Income limits warning alert re: 2024 data is no longer visible