### PR TITLE
regex fix attempt 1

### DIFF
--- a/src/applications/proxy-rewrite/local-proxy-rewrite.js
+++ b/src/applications/proxy-rewrite/local-proxy-rewrite.js
@@ -10,7 +10,10 @@ const vaGovCache = {};
 
 function injectLocalBundle() {
   const prodBucket = BUCKETS[ENVIRONMENTS.VAGOVPROD];
-  const prodBucketRegex = new RegExp(prodBucket.replace(/\./g, '\\.'), 'g');
+  const prodBucketRegex = new RegExp(
+    prodBucket.replace(/\\/g, '\\\\').replace(/\./g, '\\.'),
+    'g',
+  );
 
   return async (req, res, next) => {
     const {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

These changes correct for a scan issue detected by a WASA scan.

## Related issue(s)

- _[Link to ticket created in va.gov-team repo](https://github.com/department-of-veterans-affairs/vets-website/security/code-scanning/1)_



## Testing done

- The function using regex for local-proxy-rewrite.js did not escape backslashes that could be injected in the input.
- An extra method was chained in to escape all backslashes in an input.
- Consulted with the sitewide team, was given the blessing to pick a final fix:  I went with keeping the offending function and just adding a method instead of dispensing with the use of regex input.

## What areas of the site does it impact?

*Sitewide, tied to the injected header/footer.*

## Acceptance criteria

- [ ] WASA scan no longer flags this file with any security alerts

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [x] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [x] I reached out in the `#sitewide-public-websites` Slack channel for questions

