### PR TITLE
Update accordion styling & HLR header

### DIFF
--- a/src/applications/appeals/996/config/form.js
+++ b/src/applications/appeals/996/config/form.js
@@ -188,7 +188,9 @@ const formConfig = {
       pages: {
         requestConference: {
           path: 'informal-conference',
-          title: 'Request an informal conference',
+          // Adding trailing space so this title and chapter title are different
+          // then the page header renders on the review & submit page
+          title: 'Request an informal conference ',
           uiSchema: informalConference.uiSchema,
           schema: informalConference.schema,
         },

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -510,7 +510,7 @@ legend.schemaform-label.schemaform-file-label {
   .form-review-panel-page-header-row {
     padding: 1em 0.5em;
     margin: -1em -1.2em 0 -1.2em;
-    background-color: var(--vads-color-secondary-lightest);
+    background-color: var(--vads-color-error-lighter);
     &:before {
       display: block;
       content: " ";
@@ -538,10 +538,10 @@ legend.schemaform-label.schemaform-file-label {
 /* Highlight accordion item with content that needs attention */
 va-accordion-item[data-unviewed-pages="true"] {
   &::part(accordion-header) {
-    background-color: #{var(--vads-color-secondary-lightest)};
+    background-color: #{var(--vads-color-error-lighter)};
   }
   &::part(accordion-content) {
-    border-color: #{var(--vads-color-secondary-lightest)};
+    border-color: #{var(--vads-color-error-lighter)};
   }
 }
 


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > When a chapter title and page title are exactly the same, the page title doesn't render on the review & submit page (see screenshots). This PR adds a trailing space to the title to make it different and render the page title. In addition, in a [discussion with the design system team](https://dsva.slack.com/archives/C01DBGX4P45/p1713985282547149?thread_ts=1713978604.682149&cid=C01DBGX4P45), we're updating the accordion error style to match the USWDS color palette.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- [#65747](https://github.com/department-of-veterans-affairs/va.gov-team/issues/65747)
- [Accordion error styling discussion](https://dsva.slack.com/archives/C01DBGX4P45/p1713978604682149)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="644" alt="Screenshot 2024-04-24 at 3 35 25 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/4b93a795-0606-439c-8077-04c74e843011"> | <img width="642" alt="Screenshot 2024-04-24 at 3 38 08 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/f45e2173-0d81-4c94-b165-be3f25dbedc2"> |

## What areas of the site does it impact?

- HLR page title on review & submit
- All forms that use the review & submit page

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
