### PR TITLE
Add exception to plusplus rule for for loops

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,6 +90,7 @@ module.exports = {
       files: ['*'],
       rules: {
         'cypress/unsafe-to-chain-command': 'warn',
+        'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
       },
     },
     {


### PR DESCRIPTION
## Summary

Adjusts linting rules to allow `++` and `--` unary operators in for loops only. After merge, this format will be allowed:

```
for (i = 0; i < l; i++) {
    doSomething(i);
}
```

I believe this exception follows the spirit of the rule, and will be a quality of life improvement for developers since this is a very common pattern.

More docs: https://eslint.org/docs/latest/rules/no-plusplus#allowforloopafterthoughts

## Related issue(s)

related slack thread: https://dsva.slack.com/archives/CBU0KDSB1/p1714052994227679
