### PR TITLE
Convert rem values to be based on 16px base font-size instead of 10px

### DIFF
--- a/src/applications/ivc-champva/shared/components/applicantLists/ApplicantAddressPage.jsx
+++ b/src/applications/ivc-champva/shared/components/applicantLists/ApplicantAddressPage.jsx
@@ -125,7 +125,7 @@ export function ApplicantAddressCopyPage({
         which prevents long <option> text from overlapping the expansion arrow
         on the right side of the <select>. (Needed for accessibility audit) */
         const sheet = new CSSStyleSheet();
-        sheet.replaceSync('.usa-select {padding-right: 3rem}');
+        sheet.replaceSync('.usa-select {padding-right: 1.875rem}');
         shadowSelect.adoptedStyleSheets.push(sheet);
       }
       if (dirty) handlers.validate();

--- a/src/applications/veteran-id-card/sass/veteran-id-card.scss
+++ b/src/applications/veteran-id-card/sass/veteran-id-card.scss
@@ -4,7 +4,7 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 
 .vet-id-card {
-  padding: 0 0 2rem 2.4rem;
+  padding: 0 0 1.25rem 1.5rem;
 }
 
 .vet-id-email-capture {


### PR DESCRIPTION
## Summary

The global base font-size is changing from 10px to 16px to be in alignment with USWDS. This change adjusts styles with `rem` units for that change as these units are based off of the base font-size.

## Related issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2725

Global font-size/rem PR: https://github.com/department-of-veterans-affairs/vets-website/pull/26606/

## Testing done
Changes are minimal but testing should be done with a logged-in user. I will attempt to test in the review instance, but any help from the team would be greatly appreciated.

## What areas of the site does it impact?
- veteran-id-card
- ivc-champva applicant address page

## Acceptance criteria
There should be no noticeable style change between prod and this branch

### Quality Assurance & Testing

- [ x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ x] Linting warnings have been addressed
- [ x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ x] Screenshot of the developed feature is added
- [ x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ x] Browser console contains no warnings or errors.
- [ x] Events are being sent to the appropriate logging solution
- [ x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ x] The vets-website header does not contain any web-components
- [ x] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ x] I reached out in the `#sitewide-public-websites` Slack channel for questions
