### PR TITLE
Fixed duplicate stepper bug

### DIFF
--- a/src/applications/ezr/config/form.js
+++ b/src/applications/ezr/config/form.js
@@ -99,6 +99,7 @@ const formConfig = {
   formId: VA_FORM_IDS.FORM_10_10EZR,
   version: 0,
   trackingPrefix: 'ezr-',
+  v3SegmentedProgressBar: true,
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
   submitUrl: `${environment.API_URL}/v0/form1010_ezrs`,


### PR DESCRIPTION
## Description
In response to a recent update in the Forms Library introducing the v3 progress stepper, this PR adds a new configuration option to eliminate duplicate progress stepper language.

## Screenshot

Before
![Duplicate-stepper(Before)](https://github.com/department-of-veterans-affairs/vets-website/assets/131277002/dff18e99-ac57-411f-8c88-27ed17ad049f)

After
![Duplicate-stepper(After)](https://github.com/department-of-veterans-affairs/vets-website/assets/131277002/35bdd1ef-dd7f-4577-b541-8e17c00ae9ea)


## Tasks
- [x] Add `v3SegmentedProgressBar` to form config
- [x] Validate duplicate stepper has been removed  