### PR TITLE
VACMS-14755 Events pagination focus management fix

### DIFF
--- a/src/applications/static-pages/events/components/Events/index.js
+++ b/src/applications/static-pages/events/components/Events/index.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import scrollToTop from '@department-of-veterans-affairs/platform-utilities/scrollToTop';
+import { focusElement } from '~/platform/utilities/ui';
 import Results from '../Results';
 import Search from '../Search';
 import {
@@ -82,6 +83,7 @@ export const Events = ({ rawEvents }) => {
   };
 
   const onPageSelect = newPage => {
+    focusElement('[data-events-focus]');
     setPage(newPage);
     setResults(deriveResults(events, newPage, perPage));
     scrollToTop();

--- a/src/applications/static-pages/events/components/Results/index.js
+++ b/src/applications/static-pages/events/components/Results/index.js
@@ -43,7 +43,10 @@ export const Results = ({
     <>
       {/* Showing 10 results for All upcoming */}
       {results && (
-        <h2 className="vads-u-margin--0 vads-u-margin-top--2 vads-u-margin-bottom--1 vads-u-font-size--base vads-u-font-weight--normal">
+        <h2
+          className="vads-u-margin--0 vads-u-margin-top--2 vads-u-margin-bottom--1 vads-u-font-size--base vads-u-font-weight--normal"
+          data-events-focus="true"
+        >
           <span>Displaying {resultsStartNumber}</span>
           <span className="vads-u-visibility--screen-reader">through</span>
           <span aria-hidden="true">&ndash;</span>
@@ -101,8 +104,10 @@ export const Results = ({
                     </p>
                     {event?.fieldDatetimeRangeTimezone?.length > 1 && (
                       <p className="vads-u-margin--0">
-                        <i
-                          className="fa fa-sync vads-u-font-size--sm vads-u-margin-right--0p5"
+                        <va-icon
+                          size={4}
+                          icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
+                          className="vads-u-font-size--sm vads-u-margin-right--0p5"
                           aria-hidden="true"
                         />{' '}
                         Repeats

--- a/src/applications/static-pages/events/components/Results/index.js
+++ b/src/applications/static-pages/events/components/Results/index.js
@@ -104,10 +104,8 @@ export const Results = ({
                     </p>
                     {event?.fieldDatetimeRangeTimezone?.length > 1 && (
                       <p className="vads-u-margin--0">
-                        <va-icon
-                          size={4}
-                          icon="see Storybook for icon names: https://design.va.gov/storybook/?path=/docs/uswds-va-icon--default"
-                          className="vads-u-font-size--sm vads-u-margin-right--0p5"
+                        <i
+                          className="fa fa-sync vads-u-font-size--sm vads-u-margin-right--0p5"
                           aria-hidden="true"
                         />{' '}
                         Repeats


### PR DESCRIPTION
## Summary
In prod currently, when a user clicks one of the pages of events (for Outreach or VAMC), the next set of results displays but the focus does not go to the top of the page / number of results. This fixes that defect and now events pagination mirrors the focus behavior of Find Forms.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/14755

## Testing done
Tested locally:

- /greater-los-angeles-health-care/events/ (desktop and mobile)
- /outreach-and-events/events/ (desktop and mobile)

## Screenshots
<img width="445" alt="Screenshot 2024-04-25 at 12 45 15 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/287e3312-ad0c-480a-b646-e93f1d79a3f8">
<img width="1066" alt="Screenshot 2024-04-25 at 12 45 07 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/5c262812-5e16-4770-9536-83a63ab080b6">

## What areas of the site does it impact?
Events (outreach and VAMC)

## Acceptance criteria
- [x] When the user activates pagination links, the page should load with the top of the results list in view (as Find a Form currently does)
- [x] Focus should go to "Showing XX - XX of XX results" when the user activates pagination links (as Find a Form currently does)
- [x] Accessibility review