### PR TITLE
2704 - Updating rem values for dhp-connected-devices and discharge-wizard

### DIFF
--- a/src/applications/dhp-connected-devices/sass/dhp-consent-flow.scss
+++ b/src/applications/dhp-connected-devices/sass/dhp-consent-flow.scss
@@ -25,7 +25,7 @@
 
 .connected-header-text{
   font-family: "Bitter", "Georgia", "Cambria", "Times New Roman", "Times", serif;
-  font-size: 1.5rem;
+  font-size: 0.9375rem;
   font-weight: 400;
 }
 

--- a/src/applications/discharge-wizard/sass/discharge-wizard.scss
+++ b/src/applications/discharge-wizard/sass/discharge-wizard.scss
@@ -102,19 +102,19 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
 
   // Override styles for h2 semantic/ visual h4 headers(matches h4 visual styles)
   va-radio::part(header) {
-    font-size: 1.7rem;
+    font-size: 1.0625rem;
   }
 
   // Override styles for h2 semantic/ visual h4 headers(matches h4 visual styles)
   va-select::part(label) {
     font-family: "Bitter", "Georgia", "Cambria", "Times New Roman", "Times",
       serif;
-    font-size: 1.7rem;
+    font-size: 1.0625rem;
     font-weight: bold;
   }
 
   .converted-h4 {
-    font-size: 1.7rem;
+    font-size: 1.0625rem;
   }
 }
 .discharge-wizard-v2 {


### PR DESCRIPTION
## Summary

- The global base font-size is changing from 10px to 16px to be in alignment with USWDS. This change adjusts styles with rem units for that change as these units are based off of the old base font-size.
- This PR updates rem values for the dhp-connected-devices and discharge-wizard apps.
- I work for the Design System Team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2704

## Testing done

- Visual testing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
