### PR TITLE
[CST] - Update "Last updated [date]" language for claims list item claim cards

### DIFF
--- a/src/applications/claims-status/components/ClaimsListItem.jsx
+++ b/src/applications/claims-status/components/ClaimsListItem.jsx
@@ -19,7 +19,7 @@ const getLastUpdated = claim => {
     claim.attributes.claimPhaseDates?.phaseChangeDate,
   );
 
-  return `Last updated: ${updatedOn}`;
+  return `Moved to this step on ${updatedOn}`;
 };
 
 const showPreDecisionCommunications = claim => {

--- a/src/applications/claims-status/tests/components/ClaimsListItem.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimsListItem.unit.spec.jsx
@@ -139,7 +139,7 @@ describe('<ClaimsListItem>', () => {
     };
 
     const screen = renderWithRouter(<ClaimsListItem claim={claim} />);
-    expect(screen.getByText(/Last updated: August 20, 2019/i)).to.exist;
+    expect(screen.getByText(/Moved to this step on August 20, 2019/i)).to.exist;
     expect(screen.getByText(/Received on February 10, 2019/i)).to.exist;
   });
 });

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
@@ -73,7 +73,7 @@ class TrackClaimsPage {
       .should('contain', `Claim for disability compensation`);
     cy.get('.card-status')
       .first()
-      .should('contain', `Last updated: October 31, 2016`);
+      .should('contain', `Moved to this step on October 31, 2016`);
     cy.get('.claim-list-item:first-child a.active-va-link')
       .click()
       .then(() => {

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
@@ -78,7 +78,7 @@ class TrackClaimsPageV2 {
       .should('contain', `Claim for disability compensation`);
     cy.get('.card-status')
       .first()
-      .should('contain', `Last updated: October 31, 2016`);
+      .should('contain', `Moved to this step October 31, 2016`);
     cy.get('.claim-list-item:first-child a.active-va-link')
       .click()
       .then(() => {


### PR DESCRIPTION
## Summary

- Updated ClaimsListItem.jsx so that the card status date now says `'Move to this step on <DATE>'`
- Updated unit tests in src/applications/claims-status/tests/components/ClaimsListItem.unit.spec.jsx
- Updated cypress tests in src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js and src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#77621

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| ClaimListItem Claim Card  | ![Screenshot 2024-04-25 at 1 05 41 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/32cc4a87-eebe-4c12-99c7-5f487f59a497) | ![Screenshot 2024-04-25 at 1 06 24 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/11f4a2b5-58ed-48fb-b140-7c1d44564cb6) |

## What areas of the site does it impact?

Claim Status Tool

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

