### PR TITLE
[CST] Remove "sighted language" for primary alerts (1P evidence requests)

### DIFF
--- a/src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx
@@ -17,12 +17,12 @@ function FilesNeeded({ item }) {
       </p>
       <div className="link-action-container">
         <Link
-          aria-label={`View details for ${item.displayName}`}
-          title={`View details for ${item.displayName}`}
+          aria-label={`Details for ${item.displayName}`}
+          title={`Details for ${item.displayName}`}
           className="vads-c-action-link--blue"
           to={`../document-request/${item.id}`}
         >
-          View details
+          Details
         </Link>
       </div>
     </va-alert>

--- a/src/applications/claims-status/tests/components/claim-files-tab/FilesNeeded.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab/FilesNeeded.unit.spec.jsx
@@ -14,5 +14,6 @@ describe('<FilesNeeded>', () => {
     const screen = renderWithRouter(<FilesNeeded item={item} />);
     screen.getByText(item.displayName);
     screen.getByText(item.description);
+    screen.getByText('Details');
   });
 });

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
@@ -358,7 +358,7 @@ class TrackClaimsPageV2 {
       .first()
       .shadow()
       .get('va-alert.primary-alert:first-of-type a')
-      .should('contain', 'View details');
+      .should('contain', 'Details');
     cy.get('va-alert.primary-alert')
       .first()
       .shadow()


### PR DESCRIPTION
## Summary

- Updated the link language on FilesNeeded.jsx from 'View details' to 'Details'
- Updated the link aria label on FilesNeeded.jsx to no longer have 'View details' 
- Updated the link hover title text on FilesNeeded.jsx to no longer have 'View details' 
- Added a unit test around the above language changes
- Update cypress test for src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#80625

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Primary Alert on Status Tab | ![](https://api.zenhub.com/attachedFiles/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBOUJUQkE9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--0c0a77bb0b44a4e87b507c2fe68a6ab727424ed2/Screenshot%202024-04-11%20at%201.24.54%E2%80%AFPM.png) | ![Screenshot 2024-04-25 at 4 33 56 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/6847ae2f-5932-470d-9ebc-7a52f517154d) |
| Primary Alert on Files Tab | ![](https://api.zenhub.com/attachedFiles/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBOUJUQkE9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--0c0a77bb0b44a4e87b507c2fe68a6ab727424ed2/Screenshot%202024-04-11%20at%201.24.54%E2%80%AFPM.png) | ![Screenshot 2024-04-25 at 4 33 45 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/6b434d29-89d6-493f-ab1a-688e26905659) |

Updated hover text:
![Screenshot 2024-04-26 at 9 26 24 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/4f3f85a6-1f0a-43fa-8eb0-ab4a2f720c02)

Updated aria-label:
![Screenshot 2024-04-26 at 9 28 31 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/26593a42-9d2f-40ab-a1c4-c4121bad5c34)

## What areas of the site does it impact?

Claim Status Tool

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

