### PR TITLE
[Rated Disabilities] Updating service connected decision logic to include 1151 granted

### DIFF
--- a/src/applications/rated-disabilities/components/RatingLists/helpers.jsx
+++ b/src/applications/rated-disabilities/components/RatingLists/helpers.jsx
@@ -12,7 +12,10 @@ export const getHeadingText = rating => {
   return headingParts.join(' ');
 };
 
-const isServiceConnected = item => item.decision === 'Service Connected';
+const serviceConnectedDecisions = ['1151 Granted', 'Service Connected'];
+
+const isServiceConnected = item =>
+  serviceConnectedDecisions.includes(item.decision);
 
 export const sortRatings = ratings => {
   return ratings.sort((a, b) => b.effectiveDate.localeCompare(a.effectiveDate));

--- a/src/applications/rated-disabilities/components/RatingLists/helpers.jsx
+++ b/src/applications/rated-disabilities/components/RatingLists/helpers.jsx
@@ -12,6 +12,10 @@ export const getHeadingText = rating => {
   return headingParts.join(' ');
 };
 
+// Possible decision values:
+//   1151 Denied, 1151 Granted, Not Service Connected, Service Connected
+// Decisions that should be considered Service Connected:
+//   1151 Granted and Service Connected
 const serviceConnectedDecisions = ['1151 Granted', 'Service Connected'];
 
 const isServiceConnected = item =>

--- a/src/applications/rated-disabilities/tests/components/RatingLists/RatingLists.unit.spec.jsx
+++ b/src/applications/rated-disabilities/tests/components/RatingLists/RatingLists.unit.spec.jsx
@@ -13,6 +13,8 @@ const nonServiceConnectedSectionTitle =
   'Conditions VA determined aren’t service-connected';
 const serviceConnectedSectionTitle = 'Service-connected ratings';
 
+// The possible decision values that we can get from vets-api currently are:
+//   1151 Denied, 1151 Granted, Not Service Connected, and Service Connected
 const ratings = [
   {
     decision: 'Service Connected',
@@ -29,7 +31,7 @@ const ratings = [
     ratingPercentage: 100,
   },
   {
-    decision: 'Service Connected',
+    decision: '1151 Granted',
     diagnosticText: 'Sarcoma Soft-Tissue',
     diagnosticTypeName: 'Soft tissue sarcoma (neurogenic origin)',
     effectiveDate: '2018-08-01',
@@ -43,7 +45,7 @@ const ratings = [
     ratingPercentage: null,
   },
   {
-    decision: 'Not Service Connected',
+    decision: '1151 Denied',
     diagnosticText: 'Diabetes',
     diagnosticTypeName: 'Diabetes mellitus',
     effectiveDate: null,


### PR DESCRIPTION
## Summary
With the switch to Lighthouse, there is no longer a field that indicates whether a rating is considered Service-connected or not like we had with EVSS. Based on discussions with VBA, any ratings with a decision of either `Service Connected` or `1151 Granted` should be considered `Service-connected`

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#71281

## Testing done
Updated the mock data to include all 4 possible decision values

## Screenshots
### Before
<img width="500" alt="decision-before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/3d48c3fe-52e9-4e31-b5ec-851c37306da0">

### After
<img width="500" alt="decision-after" src="https://github.com/department-of-veterans-affairs/vets-website/assets/13838621/a452c1df-acfc-48bc-a6c7-9ce18c10d8e3">

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
