### PR TITLE
Updates SM links for the MHV Landing Page

### DIFF
--- a/src/applications/mhv-landing-page/constants.js
+++ b/src/applications/mhv-landing-page/constants.js
@@ -28,15 +28,15 @@ export const HEALTH_TOOL_LINKS = freeze({
   ]),
   MESSAGES: freeze([
     {
-      href: '/my-health/secure-messages/inbox',
+      href: '/my-health/secure-messages/inbox/',
       text: 'Inbox',
     },
     {
-      href: '/my-health/secure-messages/new-message',
+      href: '/my-health/secure-messages/new-message/',
       text: 'Send a new message',
     },
     {
-      href: '/my-health/secure-messages/folders',
+      href: '/my-health/secure-messages/folders/',
       text: 'Manage folders',
     },
   ]),


### PR DESCRIPTION
## Summary

- Updates Secure messaging URLs with a trailing slash
- Paths for `/my-health/secure-messages/${pathName}` are defined, [here](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/mhv-secure-messaging/util/constants.js#L4-L16)

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#80971
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#29379
