### PR TITLE
EZR: Fix va-additional-info on Spouse Finanical Info page

### DIFF
--- a/src/applications/ezr/components/FormDescriptions/SpouseFinancialSupportDescription.jsx
+++ b/src/applications/ezr/components/FormDescriptions/SpouseFinancialSupportDescription.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 const SpouseFinancialSupportDescription = (
   <va-additional-info
     trigger="What we consider financial support for a spouse"
-    class="vads-u-margin-bottom--4"
+    class="vads-u-margin-bottom--4 hydrated"
     uswds
   >
     <div>

--- a/src/applications/ezr/components/FormPages/VeteranProfileInformation.jsx
+++ b/src/applications/ezr/components/FormPages/VeteranProfileInformation.jsx
@@ -9,7 +9,14 @@ import { genderLabels } from 'platform/static-data/labels';
 import { maskSSN, normalizeFullName } from '../../utils/helpers/general';
 import { APP_URLS } from '../../utils/constants';
 
-const VeteranProfileInformation = ({ goBack, goForward, profile, veteran }) => {
+const VeteranProfileInformation = ({
+  goBack,
+  goForward,
+  profile,
+  veteran,
+  contentBeforeButtons,
+  contentAfterButtons,
+}) => {
   const { userFullName, dob, gender } = profile;
   const { veteranSocialSecurityNumber } = veteran;
 
@@ -93,12 +100,16 @@ const VeteranProfileInformation = ({ goBack, goForward, profile, veteran }) => {
           />
         </p>
       </div>
+      {contentBeforeButtons}
       <FormNavButtons goBack={goBack} goForward={goForward} />
+      {contentAfterButtons}
     </>
   );
 };
 
 VeteranProfileInformation.propTypes = {
+  contentAfterButtons: PropTypes.element,
+  contentBeforeButtons: PropTypes.element,
   goBack: PropTypes.func,
   goForward: PropTypes.func,
   profile: PropTypes.object,


### PR DESCRIPTION
## Summary
Updated to match Figma mockups
- [x] Veteran Info, Personal Info page; missing "Finish this form later" component. **(already fixed in a previous PR)**
- [x] Spouse Additional Financial Support; missing 'additional info' component and its content.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#76620

## Testing done

- Unit specs updated
- Manual visual confirmation of changes

## What areas of the site does it impact?
Form 10-10 EZR

## Acceptance criteria
- [ ] Veteran Info, Personal Info page; missing "Finish this form later" component.  **(already fixed in a previous PR)**
- [ ] Veteran Info, Personal Info page; missing Autosave alert component. **(already fixed in a previous PR)**
- [ ] Spouse Additional Info Page; missing "Required" label for the "Did you live with your spouse..." question.
- [ ] Spouse Additional Financial Support; missing "Required" label for the "Did you provide financial support" question.
- [ ] Spouse Additional Financial Support; missing 'additional info' component and its content.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
