### PR TITLE
10-7959f-1 Introduction Changes

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -71,7 +71,7 @@ const formConfig = {
       'Please sign in again to continue your application for CHAMPVA benefits.',
   },
   title: 'Register for the Foreign Medical Program (FMP)',
-  subTitle: 'Form 10-7959f-1',
+  subTitle: 'FMP Registration Form (VA Form 10-7959f-1)',
   defaultDefinitions: {},
   chapters: {
     applicantInformationChapter: {

--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -45,6 +45,9 @@ const formConfig = {
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   v3SegmentedProgressBar: true,
+  customText: {
+    appType: 'form',
+  },
   preSubmitInfo: {
     statementOfTruth: {
       body:
@@ -57,18 +60,18 @@ const formConfig = {
   formId: '10-7959F-1',
   saveInProgress: {
     messages: {
-      inProgress: 'Your CHAMPVA application (10-7959F-1) is in progress.',
+      inProgress: 'Your FMP registration (10-7959F-1) is in progress.',
       expired:
-        'Your saved CHAMPVA benefits application (10-7959F-1) has expired. If you want to apply for Foriegn Medical Program benefits, please start a new application.',
-      saved: 'Your CHAMPVA benefits application has been saved.',
+        'Your saved FMP benefits registration (10-7959F-1) has expired. If you want to register for Foriegn Medical Program benefits, please start a new application.',
+      saved: 'Your FMP benefits registration has been saved.',
     },
   },
   version: 0,
   prefillEnabled: true,
   savedFormMessages: {
-    notFound: 'Please start over to apply for CHAMPVA benefits.',
+    notFound: 'Please start over to register for FMP benefits.',
     noAuth:
-      'Please sign in again to continue your application for CHAMPVA benefits.',
+      'Please sign in again to continue your registration for FMP benefits.',
   },
   title: 'Register for the Foreign Medical Program (FMP)',
   subTitle: 'FMP Registration Form (VA Form 10-7959f-1)',

--- a/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
@@ -5,17 +5,9 @@ import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressI
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { Link } from 'react-router';
 import { getNextPagePath } from '@department-of-veterans-affairs/platform-forms-system/routing';
-import recordEvent from '@department-of-veterans-affairs/platform-monitoring/record-event';
-
-// class IntroductionPage extends React.Component {
-//   componentDidMount() {
-//     focusElement('.va-nav-breadcrumbs-list');
-//   }
+import recordEvent from 'platform/monitoring/record-event';
 
 const IntroductionPage = props => {
-  // componentDidMount() {
-  //   focusElement('.va-nav-breadcrumbs-list');
-  // }
   const { route } = props;
   const { formConfig, pageList, formData, pathname } = route;
 
@@ -35,10 +27,6 @@ const IntroductionPage = props => {
     },
     [props],
   );
-
-  // render() {
-  //   const { route } = this.props;
-  //   const { formConfig, pageList } = route;
 
   return (
     <article className="schemaform-intro">

--- a/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import '../sass/10-7959f-1-FMP.scss';
 import { focusElement } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';

--- a/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
@@ -1,79 +1,111 @@
-import React from 'react';
-
+import React, { useEffect } from 'react';
+import '../sass/10-7959f-1-FMP.scss';
 import { focusElement } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { Link } from 'react-router';
+import { getNextPagePath } from '@department-of-veterans-affairs/platform-forms-system/routing';
+import recordEvent from '@department-of-veterans-affairs/platform-monitoring/record-event';
 
-class IntroductionPage extends React.Component {
-  componentDidMount() {
-    focusElement('.va-nav-breadcrumbs-list');
-  }
+// class IntroductionPage extends React.Component {
+//   componentDidMount() {
+//     focusElement('.va-nav-breadcrumbs-list');
+//   }
 
-  render() {
-    const { route } = this.props;
-    const { formConfig, pageList } = route;
+const IntroductionPage = props => {
+  // componentDidMount() {
+  //   focusElement('.va-nav-breadcrumbs-list');
+  // }
+  const { route } = props;
+  const { formConfig, pageList, formData, pathname } = route;
 
-    return (
-      <article className="schemaform-intro">
-        <FormTitle
-          title="Register for the Foreign Medical Program (FMP)"
-          subTitle="FMP Registration Form (VA Form 10-7959f-1)"
-        />
+  const getStartPage = () => {
+    const data = formData || {};
+    if (pathname) return getNextPagePath(pageList, data, pathname);
+    return pageList[1].path;
+  };
+
+  const handleClick = () => {
+    recordEvent({ event: 'no-login-start-form' });
+  };
+
+  useEffect(
+    () => {
+      focusElement('.va-nav-breadcrumbs-list');
+    },
+    [props],
+  );
+
+  // render() {
+  //   const { route } = this.props;
+  //   const { formConfig, pageList } = route;
+
+  return (
+    <article className="schemaform-intro">
+      <FormTitle
+        title="Register for the Foreign Medical Program (FMP)"
+        subTitle="FMP Registration Form (VA Form 10-7959f-1)"
+      />
+      <p>
+        If you’re a Veteran who gets medical care outside the U.S. for a
+        service-connected condition, we may cover the cost of your care. Use
+        this form to register for the Foreign Medical Program.
+      </p>
+      <va-process-list uswds="false" class="process-list">
+        <h3>What to know before you fill out this form</h3>
+        <ul>
+          <li>
+            You’ll need your Social Security number or your VA file number.
+          </li>
+          <li>
+            After you register, we’ll send you a benefits authorization letter.
+            This letter will list your service-connected conditions that we’ll
+            cover. Then you can file FMP claims for care related to the covered
+            conditions.
+          </li>
+        </ul>
+      </va-process-list>
+      <VaAlert status="info" visible uswds>
+        <h2>Sign in now to save time and save your work in progress</h2>
+        <p>Here’s how signing in now helps you:</p>
+        <ul>
+          <li>
+            We can fill in some of your information for you to save you time.
+          </li>
+          <li>
+            You can save your work in progress. You’ll have 60 days from when
+            you start, or make updates, to come back and finish it.
+          </li>
+        </ul>
         <p>
-          If you're a Veteran who gets medical care outside the U.S. for a
-          service-connected condition, we may cover the cost of your care. Use
-          this form to register for the Foreign Medical Program.
+          <strong>Note:</strong> You can sign in after you start your
+          registration form. But you’ll lose any information you already filled
+          in.
         </p>
-        <va-process-list uswds="false">
-          <h3>What to know before you fill out this form</h3>
-          <ul>
-            <li>
-              You'll need your Social Security number or your VA file number.
-            </li>
-            <li>
-              After you register, we'll send you a benefits authorization
-              letter. This letter will list your service-connected conditions
-              that we'll cover. Then you can file FMP claims for care related to
-              the covered conditions.
-            </li>
-          </ul>
-        </va-process-list>
-        <VaAlert status="info" visible uswds>
-          <h2>Sign in now to save time and save your work in progress</h2>
-          <p>Here’s how signing in now helps you:</p>
-          <ul>
-            <li>
-              We can fill in some of your information for you to save you time.
-            </li>
-            <li>
-              You can save your work in progress. You’ll have 60 days from when
-              you start or make updates to your application to come back and
-              finish it.
-            </li>
-          </ul>
-          <p>
-            <strong>Note:</strong> You can sign in after you start your
-            application. But you’ll lose any information you already filled in.
-          </p>
-          <SaveInProgressIntro
-            buttonOnly
-            headingLevel={2}
-            prefillEnabled={formConfig.prefillEnabled}
-            messages={formConfig.savedFormMessages}
-            pageList={pageList}
-            startText="Sign in to start your application"
-          />
-        </VaAlert>
-        <p />
-        <va-omb-info
-          res-burden={4}
-          omb-number="2900-0648"
-          exp-date="03/31/2027"
+        <SaveInProgressIntro
+          buttonOnly
+          headingLevel={2}
+          prefillEnabled={formConfig.prefillEnabled}
+          messages={formConfig.savedFormMessages}
+          pageList={pageList}
+          unauthStartText="Sign in to start your form"
+          hideUnauthedStartLink
         />
-      </article>
-    );
-  }
-}
+        <p className="vads-u-margin-top--2">
+          <Link onClick={handleClick} to={getStartPage}>
+            Start your form without signing in
+          </Link>
+        </p>
+      </VaAlert>
+      <p />
+      <va-omb-info
+        res-burden={4}
+        omb-number="2900-0648"
+        exp-date="03/31/2027"
+      />
+    </article>
+  );
+};
 
 export default IntroductionPage;

--- a/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
@@ -18,62 +18,26 @@ class IntroductionPage extends React.Component {
       <article className="schemaform-intro">
         <FormTitle
           title="Register for the Foreign Medical Program (FMP)"
-          subTitle="Form 10-7959f-1"
+          subTitle="FMP Registration Form (VA Form 10-7959f-1)"
         />
-        <VaAlert status="info" visible uswds>
-          <h2>Have you applied for VA health care before?</h2>
-          <SaveInProgressIntro
-            buttonOnly
-            headingLevel={2}
-            prefillEnabled={formConfig.prefillEnabled}
-            messages={formConfig.savedFormMessages}
-            pageList={pageList}
-            unauthStartText="Sign in to check your application status"
-            hideUnauthedStartLink
-          />
-        </VaAlert>
-        <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
-          Follow the steps below to apply for Foreign Medical Program benefits.
-        </h2>
+        <p>
+          If you're a Veteran who gets medical care outside the U.S. for a
+          service-connected condition, we may cover the cost of your care. Use
+          this form to register for the Foreign Medical Program.
+        </p>
         <va-process-list uswds="false">
-          <li>
-            <h3>Prepare</h3>
-            <h4>To fill out this application, you’ll need your:</h4>
-            <ul>
-              <li>Social Security number (required)</li>
-            </ul>
-            <p>
-              <strong>What if I need help filling out my application?</strong>{' '}
-              An accredited representative, like a Veterans Service Officer
-              (VSO), can help you fill out your claim.{' '}
-              <a href="/disability-benefits/apply/help/index.html">
-                Get help filing your claim
-              </a>
-            </p>
-          </li>
-          <li>
-            <h3>Apply</h3>
-            <p>Complete this CHAMPVA benefits form.</p>
-            <p>
-              After submitting the form, you’ll get a confirmation message. You
-              can print this for your records.
-            </p>
-          </li>
-          <li>
-            <h3>VA Review</h3>
-            <p>
-              We process claims within a week. If more than a week has passed
-              since you submitted your application and you haven’t heard back,
-              please don’t apply again. Call us at.
-            </p>
-          </li>
-          <li>
-            <h3>Decision</h3>
-            <p>
-              Once we’ve processed your claim, you’ll get a notice in the mail
-              with our decision.
-            </p>
-          </li>
+          <h3>What to know before you fill out this form</h3>
+          <ul>
+            <li>
+              You'll need your Social Security number or your VA file number.
+            </li>
+            <li>
+              After you register, we'll send you a benefits authorization
+              letter. This letter will list your service-connected conditions
+              that we'll cover. Then you can file FMP claims for care related to
+              the covered conditions.
+            </li>
+          </ul>
         </va-process-list>
         <VaAlert status="info" visible uswds>
           <h2>Sign in now to save time and save your work in progress</h2>
@@ -98,21 +62,10 @@ class IntroductionPage extends React.Component {
             prefillEnabled={formConfig.prefillEnabled}
             messages={formConfig.savedFormMessages}
             pageList={pageList}
-            startText="Start the Application"
+            startText="Sign in to start your application"
           />
         </VaAlert>
         <p />
-        <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
-          What if I need help filling out my application?
-        </h2>
-        <p>
-          An accredited representative, like a Veterans Service Officer (VSO),
-          can help you fill out your application.
-          <a href="https://www.va.gov/COMMUNITYCARE/programs/dependents/champva/CITI.asp">
-            Find out if you can get care at a local VA medical center when
-            you’re covered under CHAMPVA
-          </a>
-        </p>
       </article>
     );
   }

--- a/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
@@ -66,6 +66,11 @@ class IntroductionPage extends React.Component {
           />
         </VaAlert>
         <p />
+        <va-omb-info
+          res-burden={4}
+          omb-number="2900-0648"
+          exp-date="03/31/2027"
+        />
       </article>
     );
   }

--- a/src/applications/ivc-champva/10-7959f-1/sass/10-7959f-1-FMP.scss
+++ b/src/applications/ivc-champva/10-7959f-1/sass/10-7959f-1-FMP.scss
@@ -5,3 +5,7 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "../../../../platform/forms/sass/m-form-confirmation";
+
+.process-list {
+    padding: 0
+}


### PR DESCRIPTION
## Summary
This PR updated the intro page to match Figma (including changing the subtitle on all pages). 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/81332

## Testing done
Manual and visual testing, as edits didn't include any functionality, just changes to text.

## Screenshots
![Screenshot 2024-04-29 at 9 51 54 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/ce5c2462-02ab-4b1b-92e5-1fbf28cc730c)
![Screenshot 2024-04-29 at 9 52 04 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/f85ebf66-e475-4a81-8008-33e9cf2bfd3b)

## What areas of the site does it impact?
only this form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA