### PR TITLE
Update TERA page display conditions for Health Care Application

### DIFF
--- a/src/applications/hca/tests/unit/utils/helpers/form-config.unit.spec.js
+++ b/src/applications/hca/tests/unit/utils/helpers/form-config.unit.spec.js
@@ -222,7 +222,9 @@ describe('hca form config helpers', () => {
   });
 
   context('when `includeGulfWarServiceDates` executes', () => {
-    const getData = ({ response = null }) => ({
+    const getData = ({ response = null, included = true }) => ({
+      'view:isTeraEnabled': true,
+      hasTeraResponse: included,
       gulfWarService: response,
     });
 
@@ -235,15 +237,28 @@ describe('hca form config helpers', () => {
       const formData = getData({ response: false });
       expect(includeGulfWarServiceDates(formData)).to.be.false;
     });
+
+    it('should return `false` when TERA response is `false`', () => {
+      const formData = getData({ included: false });
+      expect(includeGulfWarServiceDates(formData)).to.be.false;
+    });
   });
 
   context('when `includeOtherExposureDates` executes', () => {
-    const getData = ({ exposures = {} }) => ({
+    const getData = ({ exposures = {}, included = true }) => ({
+      'view:isTeraEnabled': true,
+      hasTeraResponse: included,
       'view:otherToxicExposures': exposures,
     });
 
+    it('should return `false` when TERA response is `false`', () => {
+      const formData = getData({ included: false });
+      expect(includeOtherExposureDates(formData)).to.be.false;
+    });
+
     it('should return `false` when form data does not include the data object', () => {
-      expect(includeOtherExposureDates({})).to.be.false;
+      const formData = { 'view:isTeraEnabled': true, hasTeraResponse: true };
+      expect(includeOtherExposureDates(formData)).to.be.false;
     });
 
     it('should return `false` when the form data object is empty', () => {
@@ -263,8 +278,15 @@ describe('hca form config helpers', () => {
   });
 
   context('when `includeOtherExposureDetails` executes', () => {
-    const getData = ({ exposures = {} }) => ({
+    const getData = ({ exposures = {}, included = true }) => ({
+      'view:isTeraEnabled': true,
+      hasTeraResponse: included,
       'view:otherToxicExposures': exposures,
+    });
+
+    it('should return `false` when TERA response is `false`', () => {
+      const formData = getData({ included: false });
+      expect(includeOtherExposureDetails(formData)).to.be.false;
     });
 
     it('should return `false` when the `exposureToOther` key is `false`', () => {

--- a/src/applications/hca/utils/helpers/form-config.js
+++ b/src/applications/hca/utils/helpers/form-config.js
@@ -124,7 +124,7 @@ export function includeTeraInformation(formData) {
  */
 export function includeGulfWarServiceDates(formData) {
   const { gulfWarService } = formData;
-  return gulfWarService;
+  return teraInformationEnabled(formData) && gulfWarService;
 }
 
 /**
@@ -137,7 +137,7 @@ export function includeGulfWarServiceDates(formData) {
 export function includeOtherExposureDates(formData) {
   const { 'view:otherToxicExposures': otherToxicExposures = {} } = formData;
   const exposures = Object.values(otherToxicExposures);
-  return exposures.some(o => o);
+  return teraInformationEnabled(formData) && exposures.some(o => o);
 }
 
 /**
@@ -148,7 +148,10 @@ export function includeOtherExposureDates(formData) {
  * that was not on the specified list
  */
 export function includeOtherExposureDetails(formData) {
-  return formData['view:otherToxicExposures']?.exposureToOther;
+  return (
+    teraInformationEnabled(formData) &&
+    formData['view:otherToxicExposures']?.exposureToOther
+  );
 }
 
 /**

--- a/src/applications/hca/utils/helpers/form-config.js
+++ b/src/applications/hca/utils/helpers/form-config.js
@@ -124,7 +124,7 @@ export function includeTeraInformation(formData) {
  */
 export function includeGulfWarServiceDates(formData) {
   const { gulfWarService } = formData;
-  return teraInformationEnabled(formData) && gulfWarService;
+  return includeTeraInformation(formData) && gulfWarService;
 }
 
 /**
@@ -137,7 +137,7 @@ export function includeGulfWarServiceDates(formData) {
 export function includeOtherExposureDates(formData) {
   const { 'view:otherToxicExposures': otherToxicExposures = {} } = formData;
   const exposures = Object.values(otherToxicExposures);
-  return teraInformationEnabled(formData) && exposures.some(o => o);
+  return includeTeraInformation(formData) && exposures.some(o => o);
 }
 
 /**
@@ -149,7 +149,7 @@ export function includeOtherExposureDates(formData) {
  */
 export function includeOtherExposureDetails(formData) {
   return (
-    teraInformationEnabled(formData) &&
+    includeTeraInformation(formData) &&
     formData['view:otherToxicExposures']?.exposureToOther
   );
 }


### PR DESCRIPTION
## Summary

This PR updates the conditional methods for page display of the TERA questions on the Health Care Application. It was found if users select "Yes" to the TERA section, then go back at a later time and decide change the response to "No", the service date screens will still show up but the other TERA questions will not.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#81757

## Acceptance criteria

- TERA screens are successfully shown and hidden based on the initial response of wanting to provide such responses.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution