### PR TITLE
Migrate FontAwesome to va-icon in Health Care Application

### DIFF
--- a/src/applications/hca/components/FormFields/DependentList.jsx
+++ b/src/applications/hca/components/FormFields/DependentList.jsx
@@ -117,9 +117,11 @@ const DependentList = ({ labelledBy, list, mode, onDelete }) => {
           >
             Edit{' '}
             <span className="sr-only dd-privacy-mask">{dependentName}</span>{' '}
-            <i
-              role="presentation"
-              className="fas fa-chevron-right vads-u-margin-left--0p5"
+            <va-icon
+              class="vads-u-margin-left--0p5"
+              icon="chevron_right"
+              size={3}
+              aria-hidden="true"
             />
           </Link>
           {/* eslint-disable-next-line @department-of-veterans-affairs/prefer-button-component */}
@@ -128,9 +130,11 @@ const DependentList = ({ labelledBy, list, mode, onDelete }) => {
             className="va-button-link hca-button-remove"
             onClick={() => handlers.showConfirm({ index, name: dependentName })}
           >
-            <i
-              role="presentation"
-              className="fas fa-times vads-u-margin-right--0p5"
+            <va-icon
+              class="vads-u-margin-right--0p5"
+              icon="close"
+              size={3}
+              aria-hidden="true"
             />{' '}
             Remove{' '}
             <span className="sr-only dd-privacy-mask">{dependentName}</span>

--- a/src/applications/hca/sass/_buttons.scss
+++ b/src/applications/hca/sass/_buttons.scss
@@ -1,5 +1,6 @@
 .hca-button-link, .hca-button-remove {
   &:hover, &:focus, &:active { padding: 4px 8px !important; }
+  va-icon { vertical-align: middle; }
 }
 .hca-button-remove { border-radius: 5px; color: var(--vads-color-secondary-dark)!important; font-weight: 700; text-decoration: none; text-transform: uppercase;
   &:hover, &:focus, &:active { background: var(--vads-color-secondary-lightest) !important; }

--- a/src/applications/hca/sass/_dependentList.scss
+++ b/src/applications/hca/sass/_dependentList.scss
@@ -1,5 +1,4 @@
 .hca-dependent-list { list-style: none !important; margin: 0; max-width: 26em; padding: 0; }
 .hca-dependent-list--card { margin-bottom: 1em; padding: 1em; }
-.hca-dependent-list--card .fas { font-size: .875em; }
 
 legend.schemaform-block-title:focus { outline: none !important; }


### PR DESCRIPTION
## Summary

The Design System Team will be deprecating the use of FontAwesome icons on June 8, 2024. This PR updates the Health Care Application to utilize `va-icon` component in lieu of the FA icons.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#80850

## Screenshots

<img width="307" alt="Screenshot 2024-04-30 at 10 52 53" src="https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/346d1c02-f721-4ed1-b80b-9297a01eec20">

## Acceptance criteria

- Health Care Application is free from upcoming deprecated patterns

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution