### PR TITLE
VFEP-1309 remove hidden community focus text.

### DIFF
--- a/src/applications/gi/containers/search/FilterBeforeResults.jsx
+++ b/src/applications/gi/containers/search/FilterBeforeResults.jsx
@@ -507,11 +507,6 @@ export function FilterBeforeResults({
           <CheckboxGroup
             class="vads-u-margin-y--4"
             className={isProductionOrTestProdEnv() ? 'my-filters-margin' : ''}
-            label={
-              <h3 className="visually-hidden" aria-level={2}>
-                Community focus
-              </h3>
-            }
             onChange={onChangeCheckbox}
             options={sortedOptions}
             setIsCleared={setIsCleared}


### PR DESCRIPTION
## Summary

- VFEP-1309 remove hidden community focus text.

## Problem

*Defect 18 | Low | Created*

*WCAG 2.4.6 Headings and Labels | Headings and labels describe topic or purpose.*

*On the main page,  there are two Headings labelled "Community Focus". One of them is visible and one is not visible on the page.    It is a little confusing when navigating with JAWS using the 'H' key to hear the same heading at the same level twice.*


## Testing done

- Verified Solution on the local machine

## Screenshots

![Screenshot 2024-04-30 at 10 50 42 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/95312667/49cc205d-44c9-42c2-ad20-5360f72d87e7)


