### PR TITLE
Allow for same dates on TERA questions in Health Care Application

### DIFF
--- a/src/applications/hca/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/hca/tests/e2e/fixtures/data/maximal-test.json
@@ -116,10 +116,10 @@
       "exposureToWarfareAgents": true,
       "exposureToOther": true
     },
-    "otherToxicExposure": "sometoxinname",
+    "otherToxicExposure": "some toxin name",
     "view:toxicExposureDates": {
       "toxicExposureStartDate": "1990-09-XX",
-      "toxicExposureEndDate": "1991-01-XX"
+      "toxicExposureEndDate": "1990-09-XX"
     },
     "email": "test@test.com",
     "homePhone": "5555555555",

--- a/src/applications/hca/tests/unit/config/militaryService/gulfWarServiceDates.unit.spec.js
+++ b/src/applications/hca/tests/unit/config/militaryService/gulfWarServiceDates.unit.spec.js
@@ -84,42 +84,4 @@ describe('hca Gulf War Service Dates config', () => {
     expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(1);
     expect(onSubmit.called).to.be.false;
   });
-
-  it('should not submit when service start date is equal to service end date', () => {
-    const onSubmit = sinon.spy();
-    const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester
-        schema={schema}
-        definitions={definitions}
-        onSubmit={onSubmit}
-        uiSchema={uiSchema}
-      />,
-    );
-    const formDOM = findDOMNode(form);
-
-    simulateInputChange(
-      formDOM,
-      '#root_view\\3A gulfWarServiceDates_gulfWarStartDateMonth',
-      '5',
-    );
-    simulateInputChange(
-      formDOM,
-      '#root_view\\3A gulfWarServiceDates_gulfWarStartDateYear',
-      '1990',
-    );
-    simulateInputChange(
-      formDOM,
-      '#root_view\\3A gulfWarServiceDates_gulfWarEndDateMonth',
-      '5',
-    );
-    simulateInputChange(
-      formDOM,
-      '#root_view\\3A gulfWarServiceDates_gulfWarEndDateYear',
-      '1990',
-    );
-    submitForm(form);
-
-    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-  });
 });

--- a/src/applications/hca/tests/unit/config/militaryService/otherToxicExposureDates.unit.spec.js
+++ b/src/applications/hca/tests/unit/config/militaryService/otherToxicExposureDates.unit.spec.js
@@ -84,42 +84,4 @@ describe('hca Other Toxic Exposure Dates config', () => {
     expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(1);
     expect(onSubmit.called).to.be.false;
   });
-
-  it('should not submit when service start date is equal to service end date', () => {
-    const onSubmit = sinon.spy();
-    const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester
-        schema={schema}
-        definitions={definitions}
-        onSubmit={onSubmit}
-        uiSchema={uiSchema}
-      />,
-    );
-    const formDOM = findDOMNode(form);
-
-    simulateInputChange(
-      formDOM,
-      '#root_view\\3A toxicExposureDates_toxicExposureStartDateMonth',
-      '5',
-    );
-    simulateInputChange(
-      formDOM,
-      '#root_view\\3A toxicExposureDates_toxicExposureStartDateYear',
-      '1990',
-    );
-    simulateInputChange(
-      formDOM,
-      '#root_view\\3A toxicExposureDates_toxicExposureEndDateMonth',
-      '5',
-    );
-    simulateInputChange(
-      formDOM,
-      '#root_view\\3A toxicExposureDates_toxicExposureEndDateYear',
-      '1990',
-    );
-    submitForm(form);
-
-    expect(formDOM.querySelectorAll('.usa-input-error').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-  });
 });

--- a/src/applications/hca/tests/unit/utils/validation.unit.spec.js
+++ b/src/applications/hca/tests/unit/utils/validation.unit.spec.js
@@ -120,10 +120,20 @@ describe('hca `validateGulfWarDates` form validation', () => {
   });
 
   context('when form data is valid', () => {
-    const spy = sinon.spy();
-    const { errors, fieldData } = getData({ spy });
+    it('should not set error message when date range is valid', () => {
+      const spy = sinon.spy();
+      const { errors, fieldData } = getData({ spy });
+      validateGulfWarDates(errors, fieldData);
+      expect(spy.called).to.be.false;
+    });
 
-    it('should not set error message', () => {
+    it('should not set error message when date range is equal', () => {
+      const spy = sinon.spy();
+      const { errors, fieldData } = getData({
+        startDate: '1990-09-XX',
+        endDate: '1990-09-XX',
+        spy,
+      });
       validateGulfWarDates(errors, fieldData);
       expect(spy.called).to.be.false;
     });
@@ -189,10 +199,20 @@ describe('hca `validateExposureDates` form validation', () => {
   });
 
   context('when form data is valid', () => {
-    const spy = sinon.spy();
-    const { errors, fieldData } = getData({ spy });
+    it('should not set error message when date range is valid', () => {
+      const spy = sinon.spy();
+      const { errors, fieldData } = getData({ spy });
+      validateExposureDates(errors, fieldData);
+      expect(spy.called).to.be.false;
+    });
 
-    it('should not set error message', () => {
+    it('should not set error message when date range is equal', () => {
+      const spy = sinon.spy();
+      const { errors, fieldData } = getData({
+        startDate: '1990-09-XX',
+        endDate: '1990-09-XX',
+        spy,
+      });
       validateExposureDates(errors, fieldData);
       expect(spy.called).to.be.false;
     });

--- a/src/applications/hca/utils/validation.js
+++ b/src/applications/hca/utils/validation.js
@@ -1,3 +1,4 @@
+import { isEqual } from 'lodash';
 import moment from 'moment';
 import {
   convertToDateField,
@@ -57,7 +58,7 @@ export function validateGulfWarDates(
     errors.gulfWarEndDate.addError(messages.format);
   }
 
-  if (!isValidDateRange(fromDate, toDate)) {
+  if (!isValidDateRange(fromDate, toDate) && !isEqual(fromDate, toDate)) {
     errors.gulfWarEndDate.addError(messages.range);
   }
 }
@@ -81,7 +82,7 @@ export function validateExposureDates(
     errors.toxicExposureEndDate.addError(messages.format);
   }
 
-  if (!isValidDateRange(fromDate, toDate)) {
+  if (!isValidDateRange(fromDate, toDate) && !isEqual(fromDate, toDate)) {
     errors.toxicExposureEndDate.addError(messages.range);
   }
 }


### PR DESCRIPTION
## Summary

During recent research sessions, it was discovered Veterans would like to be able to enter the same month/year for the start and end date for the Toxic Exposure questions. This PR updates the date validation to allow for same month/year for start and end dates.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#81918

## Testing done

- [x] Updated cypress testing to have a same date range in one of the Toxic Exposure tests
- [x] Updated unit testing to accommodate use case
- [x] Manually validated all date validation    

## Screenshots

<img width="395" alt="Screenshot 2024-04-30 at 12 11 47" src="https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/bf1f75d2-d495-47c0-acbc-6144abffbc44">

## Acceptance criteria

- Veterans can successfully provide accurate date information for the Toxic Exposure questions

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution