### PR TITLE
Replace Moment with Date-Fns in Caregivers Application

### DIFF
--- a/src/applications/caregivers/components/ConfirmationPage/ConfirmationPrintView.jsx
+++ b/src/applications/caregivers/components/ConfirmationPage/ConfirmationPrintView.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
+import { format } from 'date-fns';
 
 const ConfirmationPrintView = ({ name, timestamp }) => {
   return (
@@ -44,7 +44,7 @@ const ConfirmationPrintView = ({ name, timestamp }) => {
               Date you applied
             </dt>
             <dd data-testid="cg-timestamp">
-              {moment(timestamp).format('MMM D, YYYY')}
+              {format(new Date(timestamp), 'MMM. d, yyyy')}
             </dd>
           </div>
         )}

--- a/src/applications/caregivers/components/ConfirmationPage/ConfirmationScreenView.jsx
+++ b/src/applications/caregivers/components/ConfirmationPage/ConfirmationScreenView.jsx
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import moment from 'moment';
+import { format } from 'date-fns';
 
-import { focusElement } from 'platform/utilities/ui';
-import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import { focusElement } from '~/platform/utilities/ui';
+import scrollToTop from '~/platform/utilities/ui/scrollToTop';
 import ApplicationDownloadLink from '../ApplicationDownloadLink';
 
 const ConfirmationScreenView = ({ form, name, timestamp }) => {
@@ -38,7 +38,7 @@ const ConfirmationScreenView = ({ form, name, timestamp }) => {
           <>
             <h4>Date you applied</h4>
             <p data-testid="cg-submission-date">
-              {moment(timestamp).format('MMM D, YYYY')}
+              {format(new Date(timestamp), 'MMM. d, yyyy')}
             </p>
           </>
         ) : null}


### PR DESCRIPTION
## Summary
In an effort to improve application performance and migrate away from deprecated libs/utils, the 1010 team is migrating from `Moment.js` to `Date-Fns`. This PR replaces all usage of Moment with the Date-Fns equivalent. 

## Related issue(s)

department-of-veterans-affairs/va.gov-team#81939

## Testing done

- Validated formatting utilizing unit testing that was already in place

## Acceptance criteria

- Application is free from deprecated utils

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution