### PR TITLE
NOD | Update error messages

### DIFF
--- a/src/applications/appeals/10182/content/boardReview.jsx
+++ b/src/applications/appeals/10182/content/boardReview.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const boardReviewErrorMessage =
-  'Choose a Board review option to proceed';
+  'You must choose a Board review option to proceed';
 
 export const boardReviewTitle = 'Select a Board review option:';
 

--- a/src/applications/appeals/10182/content/extensionReason.jsx
+++ b/src/applications/appeals/10182/content/extensionReason.jsx
@@ -16,7 +16,7 @@ export const content = {
   description: '',
   label: 'Reason for requesting an extension:',
   hint: `${MAX_LENGTH.NOD_EXTENSION_REASON} characters max.`,
-  errorMessage: 'This field cannot be left blank.',
+  errorMessage: 'You must provide a reason if you’re requesting an extension.',
 };
 
 export const ExtensionReasonReviewField = ({ children }) => (

--- a/src/applications/appeals/10182/content/hearingType.js
+++ b/src/applications/appeals/10182/content/hearingType.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const missingHearingTypeErrorMessage =
-  'You must choose a conference type';
+  'You must select a conference type';
 
 export const hearingTypeTitle =
   'What type of hearing would you like to request?';

--- a/src/applications/appeals/10182/content/hearingType.js
+++ b/src/applications/appeals/10182/content/hearingType.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
-export const missingHearingTypeErrorMessage = 'Choose a conference type';
+export const missingHearingTypeErrorMessage =
+  'You must choose a conference type';
 
 export const hearingTypeTitle =
   'What type of hearing would you like to request?';

--- a/src/applications/appeals/995/content/IssueSummary.jsx
+++ b/src/applications/appeals/995/content/IssueSummary.jsx
@@ -33,7 +33,7 @@ const IssueSummary = ({ formData }) => {
           issues.map((issue, index) => (
             <li key={index} className={listClassNames}>
               <h4
-                className="capitalize vads-u-margin-top--0 vads-u-padding-right--2 dd-privacy-hidden"
+                className="capitalize word-break-all vads-u-margin-top--0 vads-u-padding-right--2 dd-privacy-hidden"
                 data-dd-action-name="rated issue name"
               >
                 {issue.attributes?.ratingIssueSubjectText || issue.issue || ''}

--- a/src/applications/appeals/995/sass/995-supplemental-claim.scss
+++ b/src/applications/appeals/995/sass/995-supplemental-claim.scss
@@ -25,6 +25,11 @@
   word-break: break-word;
 }
 
+/* Fix long labels on VA & private evidence pages */
+va-checkbox[name="issues"]::part(label) {
+  word-break: break-all;
+}
+
 ul.issues-summary,
 ul.evidence-summary,
 .usa-accordion-bordered ul li ul.evidence-summary,

--- a/src/applications/appeals/shared/components/IssueCard.jsx
+++ b/src/applications/appeals/shared/components/IssueCard.jsx
@@ -140,6 +140,7 @@ export const IssueCard = ({
     'vads-u-font-size--h4',
     'vads-u-margin--0',
     'capitalize',
+    'overflow-wrap-word',
   ].join(' ');
 
   const removeButtonClass = [

--- a/src/applications/appeals/shared/components/ShowIssuesList.jsx
+++ b/src/applications/appeals/shared/components/ShowIssuesList.jsx
@@ -8,7 +8,7 @@ const ShowIssuesList = ({ issues }) => (
     {issues.map((issue, index) => (
       <li key={index}>
         <strong
-          className="capitalize dd-privacy-hidden"
+          className="capitalize dd-privacy-hidden overflow-wrap-word"
           data-dd-action-name="issue name"
         >
           {issue.attributes?.ratingIssueSubjectText || issue.issue || ''}

--- a/src/applications/appeals/shared/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/shared/content/areaOfDisagreement.jsx
@@ -44,7 +44,10 @@ export const getIssueTitle = (data = {}, { plainText } = {}) => {
   ) : (
     <>
       {prefix}
-      <span className="dd-privacy-hidden" data-dd-action-name="issue name">
+      <span
+        className="dd-privacy-hidden word-break-all"
+        data-dd-action-name="issue name"
+      >
         {name}
       </span>
       {joiner}

--- a/src/applications/appeals/shared/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/shared/content/areaOfDisagreement.jsx
@@ -11,7 +11,7 @@ import { parseDate } from '../utils/dates';
 
 export const errorMessages = {
   maxOtherEntry: max => `This field should be less than ${max} characters`,
-  missingDisagreement: 'You must choose or enter a reason for disagreement',
+  missingDisagreement: 'You must select or enter a reason for disagreement',
 };
 
 export const content = {

--- a/src/applications/appeals/shared/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/shared/content/areaOfDisagreement.jsx
@@ -11,7 +11,7 @@ import { parseDate } from '../utils/dates';
 
 export const errorMessages = {
   maxOtherEntry: max => `This field should be less than ${max} characters`,
-  missingDisagreement: 'Choose or enter a reason for disagreement',
+  missingDisagreement: 'You must choose or enter a reason for disagreement',
 };
 
 export const content = {

--- a/src/applications/appeals/shared/content/contestableIssues.jsx
+++ b/src/applications/appeals/shared/content/contestableIssues.jsx
@@ -60,7 +60,7 @@ export const MaxSelectionsAlert = ({ closeModal, appName }) => (
   >
     You are limited to {MAX_LENGTH.SELECTIONS} selected issues for each{' '}
     {appName} request. If you would like to select more than{' '}
-    {MAX_LENGTH.SELECTIONS}, submit this request and create a new request for
+    {MAX_LENGTH.SELECTIONS}, submit this request. Then create a new request for
     the remaining issues.
   </VaModal>
 );
@@ -183,7 +183,10 @@ export const removeModalContent = {
   description: issueName => (
     <span>
       We’ll remove{' '}
-      <strong className="dd-privacy-hidden" data-dd-action-name="issue name">
+      <strong
+        className="dd-privacy-hidden word-break-all"
+        data-dd-action-name="issue name"
+      >
         {issueName}
       </strong>{' '}
       from the issues you’d like us to review

--- a/src/applications/appeals/shared/sass/appeals.scss
+++ b/src/applications/appeals/shared/sass/appeals.scss
@@ -6,15 +6,17 @@
 .capitalize {
   text-transform: capitalize;
 }
+.word-break-all {
+  word-break: break-all;
+}
+.overflow-wrap-word {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
 
 fieldset.vads-u-margin-y--2 {
   margin-top: 0 !important;
 }
-
-// .rjsf-object-field:empty {
-//   display: none;
-// }
-
 
 /* area of disagreement input error removes top margin */
 va-checkbox-group va-text-input[error]::part(label) {

--- a/src/applications/appeals/shared/tests/components/AreaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/AreaOfDisagreement.unit.spec.jsx
@@ -222,7 +222,7 @@ describe('<AreaOfDisagreement>', () => {
       expect(goSpy.called).to.be.false;
       expect(
         $('va-checkbox-group[error]', container)?.getAttribute('error'),
-      ).to.contain('Choose or enter a reason for disagreement');
+      ).to.contain('You must select or enter a reason for disagreement');
     });
   });
 


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Adding "You must" to most error messages to align with the [content source of truth](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/decision-reviews/Notice-of-Disagreement/design/sourceofcontenttruth.md#proposed-errors). And, while testing the add issue input error message, I left in an issue name with 180 characters and noticed a problem with text not wrapping properly on multiple pages - added CSS to fix that.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Including "You must" as part of required fields was requested by the CAIA team
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews 
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#64710](https://github.com/department-of-veterans-affairs/va.gov-team/issues/64710)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Old content
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

| Page | After  | 
| ------- | ----- |
| Reason for extension | <img width="450" alt="Screenshot 2024-04-30 at 12 46 26 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/1e64e933-6de1-4850-b8f8-baf08e607a69"> |
| Contestable issues with > 100 selected | <img width="450" alt="Screenshot 2024-04-30 at 1 16 05 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/8baffd2d-16de-49d2-81f3-55d312e8a870"> |
| Area of Disagreement | <img width="450" alt="Screenshot 2024-04-30 at 1 02 16 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/65b41a3e-832b-403c-98f1-7bde8e31d572"> |
| Board review option | <img width="450" alt="Screenshot 2024-04-30 at 1 02 44 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/6cb7a50e-e92c-44ce-861d-6ab25e4e3eb0"> |
| Hearing type | <img width="450" alt="Screenshot 2024-04-30 at 1 03 00 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/daf2ebc0-a448-4544-9d0a-961515cb8143"> |


| Page | Issue name of 180 characters with no spaces |
| --- | --- |
| Add issue | <img width="450" alt="Screenshot 2024-04-30 at 1 21 41 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/83ab4a05-c527-42a3-b139-3e2fc256f4b4"> |
| Contestable issues | <img width="450" alt="Screenshot 2024-04-30 at 1 23 54 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/3ff3b7e0-01d6-4cbf-92d4-ddca109e4be9"> |
| Area of disagreement title | <img width="450" alt="Screenshot 2024-04-30 at 1 24 14 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/2e31b55e-dd5c-4fda-b3b7-6e5baa81a31e"> |
| Issue summary | <img width="450" alt="Screenshot 2024-04-30 at 1 24 29 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/4ef743f8-865f-4987-a8bd-3ed41be0354c"> |
| Review & submit | <img width="450" alt="Screenshot 2024-04-30 at 1 24 49 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/72a68c68-9f79-4067-adf5-736c78afc181"> |

## What areas of the site does it impact?

Decision Reviews: NOD, HLR & SC

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
