### PR TITLE
[WIP] Adds analytics for va-alert

### DIFF
--- a/src/platform/site-wide/component-library-analytics-setup.js
+++ b/src/platform/site-wide/component-library-analytics-setup.js
@@ -97,6 +97,23 @@ const analyticsEvents = {
         },
       },
     },
+    {
+      action: 'load',
+      event: 'nav-alert-box-load',
+      prefix: 'alert-box',
+      ga4: {
+        event: 'interaction',
+        component_name: 'va-alert',
+        custom_string_1: 'component-library',
+        /* Component to GA4 parameters */
+        mapping: {
+          'alert-box-clickLabel': 'custom_string_2',
+          'alert-box-headline': 'heading_1',
+          'alert-box-status': 'status',
+          version: 'component_version',
+        },
+      },
+    },
   ],
   'va-alert-expandable': [
     {

--- a/src/platform/site-wide/tests/component-library-analytics-setup.unit.spec.js
+++ b/src/platform/site-wide/tests/component-library-analytics-setup.unit.spec.js
@@ -61,4 +61,32 @@ describe('Site-wide component library analytics', () => {
 
     expect(recordEvent.calledWith(dataLayerEvent)).to.be.true;
   });
+
+  it('should push events to the analytics dataLayer for va-alert web component', () => {
+    const recordEvent = sinon.spy();
+    const event = {
+      detail: {
+        componentName: 'va-alert',
+        action: 'load',
+        details: {
+          clickLabel: 'Click label',
+          headline: 'Headline text',
+          status: 'continue',
+        },
+      },
+    };
+
+    const dataLayerEvent = {
+      event: 'nav-alert-box-load',
+      'event-source': 'component-library',
+      'component-library-version': undefined,
+      'alert-box-clickLabel': 'Click label',
+      'alert-box-headline': 'Headline text',
+      'alert-box-status': 'continue',
+    };
+
+    subscribeComponentAnalyticsEvents(event, recordEvent);
+
+    expect(recordEvent.calledWith(dataLayerEvent)).to.be.true;
+  });
 });


### PR DESCRIPTION
## Summary

- Goal: Adds analytics for `<va-alert />` load action.
- Team: #mhv-on-vagov-cartography-team

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#68495

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

Do these changes send all the necessary details to GA for `<va-alert />` components? Are there any values that should be added or taken away?
