### PR TITLE
VYE-372

### DIFF
--- a/src/applications/verify-your-enrollment/components/MGIBEnrollmentStatement.jsx
+++ b/src/applications/verify-your-enrollment/components/MGIBEnrollmentStatement.jsx
@@ -6,10 +6,9 @@ const MGIBEnrollmentStatement = () => {
       <h1>Montgomery GI Bill® enrollment verification</h1>
 
       <p className="va-introtext">
-        If you have an active benefit award for the Montgomery GI Bill® you’ll
-        need to verify your enrollment at the end of each month to keep
-        receiving payments. Active records are those with activity in the last
-        12 months.
+        If you are receiving Montgomery GI Bill® benefits, you’ll need to verify
+        your enrollment at the end of each month to keep receiving payments.
+        Active records are those with activity in the last 12 months.
       </p>
     </div>
   );

--- a/src/applications/verify-your-enrollment/helpers.jsx
+++ b/src/applications/verify-your-enrollment/helpers.jsx
@@ -504,9 +504,7 @@ export const getSignlePreviousEnrollments = awards => {
               </p>
               <div className="vads-u-font-style--italic">
                 You verified on{' '}
-                {translateDateIntoMonthDayYearFormat(
-                  awards.PendingVerificationSubmitted,
-                )}
+                {translateDateIntoMonthDayYearFormat(awards.verifiedDate)}
               </div>
             </va-additional-info>
           </>

--- a/src/applications/verify-your-enrollment/tests/components/MGIBEnrollmentStatement.unit.spec.js
+++ b/src/applications/verify-your-enrollment/tests/components/MGIBEnrollmentStatement.unit.spec.js
@@ -16,7 +16,7 @@ describe('<MGIBEnrollmentStatement />', () => {
 
     // Using React Testing Library to check elements
     expect(getByText('Montgomery GI Bill® enrollment verification')).to.exist;
-    expect(getByText(/If you have an active benefit award/)).to.exist;
+    expect(getByText(/If you are receiving Montgomery GI/)).to.exist;
 
     // Using Enzyme for additional checks
     const wrapper = shallow(<MGIBEnrollmentStatement />);
@@ -24,7 +24,7 @@ describe('<MGIBEnrollmentStatement />', () => {
       'Montgomery GI Bill® enrollment verification',
     );
     expect(wrapper.find('.va-introtext').text()).to.include(
-      'If you have an active benefit award',
+      'If you are receiving Montgomery GI Bill® benefits',
     );
 
     wrapper.unmount();


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
- - Update to the MGIB statement from 
- - "If you have an active benefit award for the Montgomery GI Bill® you’ll need to verify your enrollment at the end of each month to keep receiving payments. Active records are those with activity in the last 12 months."
- to
- - "If you are receiving Montgomery GI Bill® benefits, you’ll need to verify your enrollment at the end of each month to keep receiving payments. Active records are those with activity in the last 12 months."
- Also fix the issue with the "You verified on" date no displaying
- _(If bug, how to reproduce)_ Not a bug
- _(What is the solution, why is this the solution)_
- - Text update is based on EDU request. Need to make sure the date displays as intended.
- _(Which team do you work for, does your team own the maintenance of this component?)_
- - I work for GovCIO we are code owners of this change
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
- - Application in staging, not in prod

## Related issue(s)

Jira Ticket -> https://jira.devops.va.gov/browse/VYE-372
### As:
- Frontend developer
### I need:
- To update text on the main MGIB enrollment verification page from "If you have an active benefit award for the - Montgomery GI Bill, you'll need to verify your enrollment at the end of each month to keep receiving payments." to "If you - are receiving Montgomery GI Bill benefits, you'll need to verify your enrollment..."
### So that:
- VYE Team can comply with EDU's direction
### Considerations:
- A photo of what this ticket is referring to is attached in a comment below.
### Acceptance Criteria:
- Enter the acceptance criteria that will be used to test the user story.
- - AC 1: "If you have an active benefit award for the Montgomery GI Bill, you'll need to verify your enrollment at the end of each month to keep receiving payments." is replaced by "If you are receiving Montgomery GI Bill benefits, you'll need to verify your enrollment..."
- - AC 2: Fix the verified on text for single enrollment data after verification, to show the actual date. Currently it is blank. See screenshot for example.
### Testing Considerations:
- review of the change will be conducted by QA in staging. Unit tests will be updated.
### Other Considerations:
- There are no other considerations

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

### BEFORE STATEMENT CHANGE
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/88905347/96edc62c-b0d7-4ea1-bc92-878ac39a562e)

### AFTER STATEMENT CHANGE
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/88905347/581bb3ce-378c-4b16-aa32-09891bb26b7e)

### BEFORE YOU VERIFIED DATE ADDED
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/88905347/964e7164-a6de-4f3c-a7c5-73542a3bf82f)

### AFTER YOU VERIFIED DATE ADDED
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/88905347/204100d9-70e2-4d5b-8ef0-562a0be5f714)



## What areas of the site does it impact?
- This change is only for the VYE application
*(Describe what parts of the site are impacted **if** code touched other areas)*
- no impact on other areas
- 
## Acceptance criteria
- - AC 1: "If you have an active benefit award for the Montgomery GI Bill, you'll need to verify your enrollment at the end of each month to keep receiving payments." is replaced by "If you are receiving Montgomery GI Bill benefits, you'll need to verify your enrollment..."
- - AC 2: Fix the verified on text for single enrollment data after verification, to show the actual date. Currently, it is blank.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
