### PR TITLE
Mhv 57891/update breadcrumb component

### DIFF
--- a/src/applications/mhv-medical-records/components/MrBreadcrumbs.jsx
+++ b/src/applications/mhv-medical-records/components/MrBreadcrumbs.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { BreadcrumbLink } from '@department-of-veterans-affairs/mhv/exports';
 
 const MrBreadcrumbs = () => {
   const crumbs = useSelector(state => state.mr.breadcrumbs.list);
@@ -13,12 +13,10 @@ const MrBreadcrumbs = () => {
           label="Breadcrumb"
           data-testid="breadcrumbs"
         >
-          <span className="breadcrumb-angle vads-u-padding-right--1">
-            {'\u2039'}{' '}
-          </span>
-          <Link to={crumbs[0].url?.toLowerCase()}>
-            Back to {crumbs[0].label?.toLowerCase()}
-          </Link>
+          <BreadcrumbLink
+            to={crumbs[0].url?.toLowerCase()}
+            label={`Back to ${crumbs[0].label?.toLowerCase()}`}
+          />
         </div>
       ) : (
         <div

--- a/src/applications/mhv-secure-messaging/components/shared/SmBreadcrumbs.jsx
+++ b/src/applications/mhv-secure-messaging/components/shared/SmBreadcrumbs.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link, useHistory, useLocation } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router-dom';
+import { BreadcrumbLink } from '@department-of-veterans-affairs/mhv/exports';
 import { setBreadcrumbs } from '../../actions/breadcrumbs';
 import * as Constants from '../../util/constants';
 import { retrieveFolder } from '../../actions/folders';
@@ -137,7 +138,10 @@ const SmBreadcrumbs = () => {
         <nav aria-label="Breadcrumb">
           <ul className={breadcrumbSize()}>
             <li className="sm-breadcrumb-list-item">
-              <Link to={crumbs.path?.toLowerCase()}>{crumbs.label}</Link>
+              <BreadcrumbLink
+                to={crumbs.path?.toLowerCase()}
+                label={crumbs.label}
+              />
             </li>
           </ul>
         </nav>

--- a/src/applications/mhv/medications/containers/RxBreadcrumbs.jsx
+++ b/src/applications/mhv/medications/containers/RxBreadcrumbs.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 // import { replaceWithStagingDomain } from '~/platform/utilities/environment/stagingDomains';
-import { Link, useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
+import { BreadcrumbLink } from '@department-of-veterans-affairs/mhv/exports';
 import { removeBreadcrumbs, setBreadcrumbs } from '../actions/breadcrumbs';
 import { medicationsUrls } from '../util/constants';
 
@@ -38,12 +39,11 @@ const RxBreadcrumbs = () => {
               label="Breadcrumb"
               data-testid="rx-breadcrumb"
             >
-              <span className="breadcrumb-angle vads-u-padding-right--1">
-                {'\u2039'}{' '}
-              </span>
-              <Link to={crumbs[oneLevelDeepCrumb]?.url} onClick={backLink}>
-                Back to {crumbs[oneLevelDeepCrumb]?.label}
-              </Link>
+              <BreadcrumbLink
+                to={crumbs[oneLevelDeepCrumb]?.url}
+                onClick={backLink}
+                label={`Back to ${crumbs[oneLevelDeepCrumb]?.label}`}
+              />
             </div>
           </div>
         )}

--- a/src/applications/mhv/medications/sass/medications.scss
+++ b/src/applications/mhv/medications/sass/medications.scss
@@ -289,3 +289,28 @@ va-checkbox.select-all-checkbox::part(label) {
 .hide-visited-link:visited {
   color: var(--vads-color-link) !important;
 }
+
+@mixin arrow-before($arrow-svg) {
+  &::before {
+    content: "";
+    display: inline-block;
+    width: 2ex;
+    height: 2ex;
+    mask-image: url("data:image/svg+xml,%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22 width%3D%2224%22 height%3D%2224%22 viewBox%3D%220 0 24 24%22%3E%3Cpath d%3D%22M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z%22%2F%3E%3C%2Fsvg%3E");
+    -webkit-mask-size: contain;
+    mask-size: 2ex 2ex;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    mask-position: center center;
+    bottom: -0.2em;
+    position: relative;
+    font-size: 16.96px;
+    color: rgb(27, 27, 27);
+    background: var(--vads-color-gray-medium);
+    rotate: 180deg;
+  }
+}
+
+.include-back-arrow {
+  @include arrow-before(url("data:image/svg+xml,%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22 width%3D%2224%22 height%3D%2224%22 viewBox%3D%220 0 24 24%22%3E%3Cpath d%3D%22M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z%22%2F%3E%3C%2Fsvg%3E"));
+}

--- a/src/platform/mhv/components/BreadcrumbLink.jsx
+++ b/src/platform/mhv/components/BreadcrumbLink.jsx
@@ -3,12 +3,13 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import '../sass/breadcrumb-link.scss';
 
-const BreadcrumbLink = ({ to, label, onClick, className }) => {
+const BreadcrumbLink = ({ to, label, onClick, datadogActionName }) => {
   return (
     <Link
       to={to}
       onClick={onClick}
-      className={`include-back-arrow ${className}`}
+      data-dd-action-name={datadogActionName}
+      className="include-back-arrow"
     >
       {label}
     </Link>
@@ -18,7 +19,7 @@ const BreadcrumbLink = ({ to, label, onClick, className }) => {
 BreadcrumbLink.propTypes = {
   label: PropTypes.string.isRequired,
   to: PropTypes.string.isRequired,
-  className: PropTypes.string,
+  datadogActionName: PropTypes.string,
   onClick: PropTypes.func,
 };
 

--- a/src/platform/mhv/components/BreadcrumbLink.jsx
+++ b/src/platform/mhv/components/BreadcrumbLink.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import '../sass/breadcrumb-link.scss';
+
+const BreadcrumbLink = ({ to, label, onClick, className }) => {
+  return (
+    <Link
+      to={to}
+      onClick={onClick}
+      className={`include-back-arrow ${className}`}
+    >
+      {label}
+    </Link>
+  );
+};
+
+BreadcrumbLink.propTypes = {
+  label: PropTypes.string.isRequired,
+  to: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  onClick: PropTypes.func,
+};
+
+export default BreadcrumbLink;

--- a/src/platform/mhv/exportsFile.js
+++ b/src/platform/mhv/exportsFile.js
@@ -19,3 +19,4 @@ export {
   reportGeneratedBy,
 } from './util/constants';
 export { trapFocus } from './util/ui/index';
+export { default as BreadcrumbLink } from './components/BreadcrumbLink';

--- a/src/platform/mhv/sass/breadcrumb-link.scss
+++ b/src/platform/mhv/sass/breadcrumb-link.scss
@@ -4,7 +4,7 @@
       display: inline-block;
       width: 2ex;
       height: 2ex;
-      mask-image: url("data:image/svg+xml,%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22 width%3D%2224%22 height%3D%2224%22 viewBox%3D%220 0 24 24%22%3E%3Cpath d%3D%22M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z%22%2F%3E%3C%2Fsvg%3E");
+      mask-image: $arrow-svg;
       -webkit-mask-size: contain;
       mask-size: 2ex 2ex;
       -webkit-mask-repeat: no-repeat;

--- a/src/platform/mhv/sass/breadcrumb-link.scss
+++ b/src/platform/mhv/sass/breadcrumb-link.scss
@@ -1,0 +1,32 @@
+@mixin arrow-before($arrow-svg) {
+    &::before {
+      content: "";
+      display: inline-block;
+      width: 2ex;
+      height: 2ex;
+      mask-image: url("data:image/svg+xml,%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22 width%3D%2224%22 height%3D%2224%22 viewBox%3D%220 0 24 24%22%3E%3Cpath d%3D%22M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z%22%2F%3E%3C%2Fsvg%3E");
+      -webkit-mask-size: contain;
+      mask-size: 2ex 2ex;
+      -webkit-mask-repeat: no-repeat;
+      mask-repeat: no-repeat;
+      mask-position: center center;
+      bottom: -0.2em;
+      position: relative;
+      font-size: 16.96px;
+      color: rgb(27, 27, 27);
+      background: var(--vads-color-gray-medium);
+      rotate: 180deg;
+    }
+  }
+
+.include-back-arrow {
+  padding-right: 0.25em;
+  &:hover {
+    color: var(--vads-color-primary-dark) !important;
+    background-color: unset;
+  }
+  &:focus {
+    outline: none;
+  }
+  @include arrow-before(url("data:image/svg+xml,%3Csvg xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22 width%3D%2224%22 height%3D%2224%22 viewBox%3D%220 0 24 24%22%3E%3Cpath d%3D%22M10 6 8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z%22%2F%3E%3C%2Fsvg%3E"));
+}


### PR DESCRIPTION
## Summary

Created a shared breadcrumb link component that works for all MHV tools for consistency when using a SR.

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-57891
> User story: As a user of MHV tools (SM, MR, Rx), I want to see the same breadcrumb link visually and have it react the same way when using a screenreader.
> AC1: Create a shared breadcrumb component to use across MHV breadcrumb components 
> AC2: The SR handles the breadcrumb link the same way across the tools. It should not announce the arrow or be a navigable item

## Testing done

- Ran unit tests
- Tested locally

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | ![Screenshot 2024-05-01 at 11 26 31 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/146013972/69719293-ed79-4707-a6bf-9e4b31026e22) | ![Screenshot 2024-05-01 at 11 26 09 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/146013972/79f1a0cf-b635-4fc6-9fc8-d9f087a0ee0b) |

## What areas of the site does it impact?

MHV medications, SM and MR breadcrumbs

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
