### PR TITLE
ASK VA 966/ Education search bug

### DIFF
--- a/src/applications/ask-va/components/search/SearchItem.jsx
+++ b/src/applications/ask-va/components/search/SearchItem.jsx
@@ -37,7 +37,7 @@ const SearchItem = ({
       <>
         <p>
           {`Showing ${facilityData.data.length} results for`}
-          <strong>{`"${searchInput}"`}</strong>{' '}
+          <strong>{`"${searchInput.place_name || searchInput}"`}</strong>{' '}
         </p>
         <p>
           The results are listed from nearest to farthest from your location.

--- a/src/applications/ask-va/config/chapters/personalInformation/searchSchools.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/searchSchools.js
@@ -15,7 +15,7 @@ const searchSchoolsPage = {
   },
   schema: {
     type: 'object',
-    required: [],
+    required: ['school'],
     properties: {
       school: {
         type: 'string',

--- a/src/applications/ask-va/config/chapters/personalInformation/searchVAMedicalCenter.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/searchVAMedicalCenter.js
@@ -15,7 +15,7 @@ const searchVAMedicalCenterPage = {
   },
   schema: {
     type: 'object',
-    required: [],
+    required: ['vaMedicalCenter'],
     properties: {
       vaMedicalCenter: {
         type: 'string',

--- a/src/applications/ask-va/constants.js
+++ b/src/applications/ask-va/constants.js
@@ -9,7 +9,7 @@ export const URL = {
   GET_INQUIRY: '',
   UPLOAD_ATTACHMENT: `${baseURL}/upload_attachment`,
   GET_HEALTH_FACILITY: `${baseURL}/health_facilities`,
-  GET_SCHOOL: `v0/gi/institutions/search?name=`,
+  GET_SCHOOL: `/v0/gi/institutions/search?name=`,
   SEND_REPLY: `/reply/new`,
 };
 


### PR DESCRIPTION
## Summary

- Fixing a bug in the Education search page also updated required questions. 
- There was a missing `/` in the string calling the endpoint.

## Related issue(s)

- Ticket [966](https://app.zenhub.com/workspaces/ask-va-647a476551689d06655cc815/issues/gh/department-of-veterans-affairs/ask-va/966)

## Testing done

- Manual tests done to confirm search is working.


## Screenshots

UI has not changed.

## What areas of the site does it impact?

This only impacts the Ask VA form.

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

