### PR TITLE
[MHV-57908] Back to Medical records' link for 'Download all records' doesn't work

### DIFF
--- a/src/applications/mhv-medical-records/components/MrBreadcrumbs.jsx
+++ b/src/applications/mhv-medical-records/components/MrBreadcrumbs.jsx
@@ -14,7 +14,7 @@ const MrBreadcrumbs = () => {
           data-testid="breadcrumbs"
         >
           <span className="breadcrumb-angle vads-u-padding-right--0p5 vads-u-padding-top--0p5">
-            <va-icon icon="arrow_back" size={1} />
+            <va-icon icon="arrow_back" size={1} style={{ color: '#808080' }} />
           </span>
           <Link to={crumbs[0].url?.toLowerCase()}>
             Back to {crumbs[0].label}

--- a/src/applications/mhv-medical-records/containers/DownloadRecordsPage.jsx
+++ b/src/applications/mhv-medical-records/containers/DownloadRecordsPage.jsx
@@ -42,15 +42,7 @@ const DownloadRecordsPage = ({ runningUnitTest }) => {
 
   useEffect(
     () => {
-      dispatch(
-        setBreadcrumbs(
-          [{ url: '/my-health/medical-records', label: 'Medical records' }],
-          {
-            url: '/my-health/medical-records/download-all',
-            label: 'Download all medical records',
-          },
-        ),
-      );
+      dispatch(setBreadcrumbs([{ url: '/', label: 'Medical records' }]));
       focusElement(document.querySelector('h1'));
       updatePageTitle(pageTitles.DOWNLOAD_PAGE_TITLE);
     },

--- a/src/applications/mhv-medical-records/tests/containers/DownloadRecordsPage.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/DownloadRecordsPage.unit.spec.jsx
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { beforeEach } from 'mocha';
-import { fireEvent } from '@testing-library/dom';
+import { fireEvent, waitFor } from '@testing-library/dom';
 import reducer from '../../reducers';
 import DownloadRecordsPage from '../../containers/DownloadRecordsPage';
 import user from '../fixtures/user.json';
@@ -68,11 +68,15 @@ describe('DownloadRecordsPage with connection error', () => {
 
   it('should display download an error message when the download pdf button is clicked', () => {
     fireEvent.click(screen.getByTestId('download-blue-button-pdf'));
-    expect(screen.getByTestId('expired-alert-message')).to.exist;
+    waitFor(() => {
+      expect(screen.getByTestId('expired-alert-message')).to.exist;
+    });
   });
 
   it('should display download an error when the download txt file button is clicked', () => {
     fireEvent.click(screen.getByTestId('download-blue-button-txt'));
-    expect(screen.getByTestId('expired-alert-message')).to.exist;
+    waitFor(() => {
+      expect(screen.getByTestId('expired-alert-message')).to.exist;
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Updated URL in "setBreadcrumbs" function all txt downloads.
- Bug would cause a broken link.
- Removed old URL address.
- MHV Medical Records.

## Related issue(s)
### [MHV-MHV-57908](https://jira.devops.va.gov/browse/MHV-57908) - Back to Medical records' link for 'Download all records' doesn't work ###

![Screenshot 2024-05-02 at 12 14 07 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/9909777/8c47c34b-16f6-4a41-ba63-2993f3b60a1a)

## Testing done

-  Manual testing

## What areas of the site does it impact?
MHV Medical Records