### PR TITLE
date size tweaks.

### DIFF
--- a/src/applications/check-in/components/UpcomingAppointmentsList.jsx
+++ b/src/applications/check-in/components/UpcomingAppointmentsList.jsx
@@ -59,7 +59,7 @@ const UpcomingAppointmentsList = props => {
                   <div className="vads-l-row">
                     <div className="vads-l-col--2 vads-u-border-top--1px">
                       <h4
-                        className="vads-u-text-align--center vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-top--2"
+                        className="vads-u-text-align--center vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-top--1p5"
                         data-testid="day-label"
                       >
                         <span className="vads-u-font-size--lg vads-u-font-family--serif vads-u-font-weight--bold vads-u-line-height--3">

--- a/src/applications/check-in/components/UpcomingAppointmentsList.jsx
+++ b/src/applications/check-in/components/UpcomingAppointmentsList.jsx
@@ -59,10 +59,10 @@ const UpcomingAppointmentsList = props => {
                   <div className="vads-l-row">
                     <div className="vads-l-col--2 vads-u-border-top--1px">
                       <h4
-                        className="vads-u-text-align--center vads-u-line-height--2 vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-top--2"
+                        className="vads-u-text-align--center vads-u-font-family--sans vads-u-font-weight--normal vads-u-margin-top--2"
                         data-testid="day-label"
                       >
-                        <span className="vads-u-font-size--md vads-u-font-weight--bold">
+                        <span className="vads-u-font-size--lg vads-u-font-family--serif vads-u-font-weight--bold vads-u-line-height--3">
                           {`${t('date-day-of-month', { date: dayStartTime })} `}
                         </span>
                         <br />


### PR DESCRIPTION
## Summary

Tweaks the size of the date number and spacing in the upcoming appointments list.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#69903

## Testing done

Visual

## Screenshots

<img src="https://github.com/department-of-veterans-affairs/vets-website/assets/13967174/bf8f2444-e999-4ffb-8ad9-68abb2c8f81c" width="347px"/>


## What areas of the site does it impact?

Upcoming appointments for day-of and pre-check-in

## Acceptance criteria

 - [ ] size and spacing matches [wireframe](https://www.figma.com/file/7Ib7RxiIC4QB53FDBO2a8c/Unified-check-in-%7C-Check-in?type=design&node-id=551-22550&mode=design&t=9Wsd9lTNbHxJ4gIj-0)

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

