### PR TITLE
NOD | Add comment about trailing space

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -197,6 +197,9 @@ const formConfig = {
       title: 'Board review option',
       pages: {
         boardReviewOption: {
+          // Adding trailing space so this title and chapter title are different
+          // then the page header renders on the review & submit page, see:
+          // https://github.com/department-of-veterans-affairs/vets-website/pull/29514#discussion_r1586347078
           title: 'Board review option ',
           path: 'board-review-option',
           uiSchema: boardReview.uiSchema,


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > When a chapter and page title are exactly the same, the page title won't render in the review & submit accordion. Adding a trailing space fixes it; this PR adds a comment to prevent 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- [#80752](https://github.com/department-of-veterans-affairs/va.gov-team/issues/80752)
- [Related comment](https://github.com/department-of-veterans-affairs/vets-website/pull/29514#discussion_r1586347078)

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

Notice of Disagreement

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
