### PR TITLE
[SIMPLE-FORMS] feat: add ability to hide form title per chapter

### DIFF
--- a/src/applications/simple-forms/21-4138/config/form.js
+++ b/src/applications/simple-forms/21-4138/config/form.js
@@ -94,6 +94,7 @@ const formConfig = {
     statementTypeChapter: {
       title: 'What kind of statement do you want to submit?',
       hideFormNavProgress: true,
+      hideFormTitle: true,
       pages: {
         statementTypePage: {
           path: 'statement-type',
@@ -278,6 +279,7 @@ const formConfig = {
     },
     personalInformationChapter: {
       title: 'Your personal information',
+      hideFormTitle: true,
       pages: {
         nameAndDateOfBirthPage: {
           depends: formData =>
@@ -292,6 +294,7 @@ const formConfig = {
     },
     identificationChapter: {
       title: 'Your identification information',
+      hideFormTitle: true,
       pages: {
         identificationInformationPage: {
           depends: formData =>
@@ -306,6 +309,7 @@ const formConfig = {
     },
     mailingAddressChapter: {
       title: 'Your mailing address',
+      hideFormTitle: true,
       pages: {
         mailingAddressPage: {
           depends: formData =>
@@ -320,6 +324,7 @@ const formConfig = {
     },
     contactInformationChapter: {
       title: 'Your contact information',
+      hideFormTitle: true,
       pages: {
         phoneAndEmailPage: {
           depends: formData =>
@@ -334,6 +339,7 @@ const formConfig = {
     },
     statementChapter: {
       title: 'Your statement',
+      hideFormTitle: true,
       pages: {
         statement: {
           depends: formData =>

--- a/src/platform/forms-system/src/js/containers/FormApp.jsx
+++ b/src/platform/forms-system/src/js/containers/FormApp.jsx
@@ -44,7 +44,7 @@ class FormApp extends React.Component {
         : formConfig.title;
     const { noTitle, noTopNav, fullWidth } = formConfig?.formOptions || {};
     const notProd = !environment.isProduction();
-    const hiddenFormTitle = hideFormTitle(formConfig, trimmedPathname);
+    const hasHiddenFormTitle = hideFormTitle(formConfig, trimmedPathname);
 
     let formTitle;
     let formNav;
@@ -53,7 +53,7 @@ class FormApp extends React.Component {
     // 1. we're not on the intro page *or* one of the additionalRoutes
     //    specified in the form config
     // 2. there is a title specified in the form config
-    if (!isIntroductionPage && !isNonFormPage && !hiddenFormTitle && title) {
+    if (!isIntroductionPage && !isNonFormPage && !hasHiddenFormTitle && title) {
       formTitle = <FormTitle title={title} subTitle={formConfig.subTitle} />;
     }
 

--- a/src/platform/forms-system/src/js/containers/FormApp.jsx
+++ b/src/platform/forms-system/src/js/containers/FormApp.jsx
@@ -7,7 +7,7 @@ import { isLoggedIn } from 'platform/user/selectors';
 
 import FormNav from '../components/FormNav';
 import FormTitle from '../components/FormTitle';
-import { isInProgress } from '../helpers';
+import { isInProgress, hideFormTitle } from '../helpers';
 import { setGlobalScroll } from '../utilities/ui';
 
 const { Element } = Scroll;
@@ -44,6 +44,7 @@ class FormApp extends React.Component {
         : formConfig.title;
     const { noTitle, noTopNav, fullWidth } = formConfig?.formOptions || {};
     const notProd = !environment.isProduction();
+    const hiddenFormTitle = hideFormTitle(formConfig, trimmedPathname);
 
     let formTitle;
     let formNav;
@@ -52,7 +53,7 @@ class FormApp extends React.Component {
     // 1. we're not on the intro page *or* one of the additionalRoutes
     //    specified in the form config
     // 2. there is a title specified in the form config
-    if (!isIntroductionPage && !isNonFormPage && title) {
+    if (!isIntroductionPage && !isNonFormPage && !hiddenFormTitle && title) {
       formTitle = <FormTitle title={title} subTitle={formConfig.subTitle} />;
     }
 

--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -82,13 +82,19 @@ export function getInactivePages(pages, data) {
 }
 
 export function createFormPageList(formConfig) {
-  return Object.keys(formConfig.chapters).reduce((pageList, chapter) => {
-    const chapterTitle = formConfig.chapters[chapter].title;
-    const pages = Object.keys(formConfig.chapters[chapter].pages).map(page => ({
-      ...formConfig.chapters[chapter].pages[page],
+  if (!formConfig?.chapters) return [];
+
+  return Object.keys(formConfig.chapters).reduce((pageList, chapterKey) => {
+    const chapter = formConfig.chapters[chapterKey];
+
+    if (!chapter?.pages) return pageList;
+
+    const chapterTitle = chapter?.title ?? formConfig.title;
+    const pages = Object.keys(chapter.pages).map(pageKey => ({
+      ...chapter.pages[pageKey],
       chapterTitle,
-      chapterKey: chapter,
-      pageKey: page,
+      chapterKey,
+      pageKey,
     }));
     return pageList.concat(pages);
   }, []);
@@ -135,10 +141,20 @@ export function createPageList(formConfig, formPages) {
 }
 
 export function hideFormTitle(formConfig, pathName) {
+  if (
+    !formConfig?.chapters ||
+    !Array.isArray(formConfig.chapters) ||
+    formConfig.chapters.length === 0
+  )
+    return false;
+
   const formPages = createFormPageList(formConfig);
   const pageList = createPageList(formConfig, formPages);
-  const page = pageList.filter(p => p.path === pathName)[0];
-  return formConfig?.chapters[page.chapterKey]?.hideFormTitle;
+  const page = pageList.find(p => p.path === pathName);
+
+  if (!page || !page.chapterKey) return false;
+
+  return formConfig.chapters[page.chapterKey]?.hideFormTitle ?? false;
 }
 
 function formatDayMonth(val) {

--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -134,6 +134,13 @@ export function createPageList(formConfig, formPages) {
     );
 }
 
+export function hideFormTitle(formConfig, pathName) {
+  const formPages = createFormPageList(formConfig);
+  const pageList = createPageList(formConfig, formPages);
+  const page = pageList.filter(p => p.path === pathName)[0];
+  return formConfig?.chapters[page.chapterKey]?.hideFormTitle;
+}
+
 function formatDayMonth(val) {
   if (val) {
     const dayOrMonth = val.toString();

--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -143,7 +143,7 @@ export function createPageList(formConfig, formPages) {
 export function hideFormTitle(formConfig, pathName) {
   if (
     !formConfig?.chapters ||
-    !Array.isArray(formConfig.chapters) ||
+    typeof formConfig.chapters !== 'object' ||
     formConfig.chapters.length === 0
   )
     return false;

--- a/src/platform/forms-system/test/js/containers/FormApp.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/containers/FormApp.unit.spec.jsx
@@ -4,6 +4,20 @@ import SkinDeep from 'skin-deep';
 
 import { FormApp } from '../../../src/js/containers/FormApp';
 
+const shallowFormApp = ({ formConfig, currentLocation, formData = null }) => {
+  const routes = [{ pageList: [{ path: currentLocation.pathname }] }];
+  return SkinDeep.shallowRender(
+    <FormApp
+      formConfig={formConfig}
+      routes={routes}
+      currentLocation={currentLocation}
+      formData={formData}
+    >
+      <div className="child" />
+    </FormApp>,
+  );
+};
+
 describe('Schemaform <FormApp>', () => {
   it('should render children on intro page, but not form title or nav', () => {
     const formConfig = {};
@@ -11,51 +25,25 @@ describe('Schemaform <FormApp>', () => {
       pathname: 'introduction',
       search: '',
     };
-    const routes = [
-      {
-        pageList: [{ path: currentLocation.pathname }],
-      },
-    ];
-
-    const tree = SkinDeep.shallowRender(
-      <FormApp
-        formConfig={formConfig}
-        routes={routes}
-        currentLocation={currentLocation}
-      >
-        <div className="child" />
-      </FormApp>,
-    );
+    const tree = shallowFormApp({ formConfig, currentLocation });
 
     expect(tree.everySubTree('.child')).not.to.be.empty;
     expect(tree.everySubTree('FormNav')).to.be.empty;
     expect(tree.everySubTree('FormTitle')).to.be.empty;
   });
+
   it('should show nav when the form is in progress', () => {
     const formConfig = {};
     const currentLocation = {
       pathname: '/veteran-information/personal-information',
       search: '',
     };
-    const routes = [
-      {
-        pageList: [{ path: currentLocation.pathname }],
-      },
-    ];
-
-    const tree = SkinDeep.shallowRender(
-      <FormApp
-        formConfig={formConfig}
-        routes={routes}
-        currentLocation={currentLocation}
-      >
-        <div className="child" />
-      </FormApp>,
-    );
+    const tree = shallowFormApp({ formConfig, currentLocation });
 
     expect(tree.everySubTree('.child')).not.to.be.empty;
     expect(tree.everySubTree('FormNav')).not.to.be.empty;
   });
+
   it('should show dynamic title', () => {
     const titles = ['Main title', 'Alternate title'];
     const formData = { test: false };
@@ -66,22 +54,8 @@ describe('Schemaform <FormApp>', () => {
       pathname: '/veteran-information/personal-information',
       search: '',
     };
-    const routes = [
-      {
-        pageList: [{ path: currentLocation.pathname }],
-      },
-    ];
 
-    const tree = SkinDeep.shallowRender(
-      <FormApp
-        formConfig={formConfig}
-        formData={formData}
-        routes={routes}
-        currentLocation={currentLocation}
-      >
-        <div className="child" />
-      </FormApp>,
-    );
+    const tree = shallowFormApp({ formConfig, currentLocation, formData });
 
     expect(tree.everySubTree('FormTitle')[0].props.title).to.equal(titles[0]);
     formData.test = true;
@@ -97,24 +71,75 @@ describe('Schemaform <FormApp>', () => {
       pathname: '/veteran-information/personal-information',
       search: '',
     };
-    const routes = [
-      {
-        pageList: [{ path: currentLocation.pathname }],
-      },
-    ];
+    const tree = shallowFormApp({ formConfig, currentLocation });
 
-    const tree = SkinDeep.shallowRender(
-      <FormApp
-        formConfig={formConfig}
-        routes={routes}
-        currentLocation={currentLocation}
-      >
-        <div className="child" />
-      </FormApp>,
-    );
     expect(tree.everySubTree('.child')).not.to.be.empty;
     expect(tree.everySubTree('FormTitle')).to.be.empty;
     expect(tree.everySubTree('.row')).to.be.empty;
     expect(tree.everySubTree('.usa-width-two-thirds')).to.be.empty;
+  });
+
+  describe('hiding and displaying form title', () => {
+    const formConfig = {
+      formOptions: {
+        title: 'Form Title',
+        subTitle: 'Form Subtitle',
+        chapters: {
+          formTitleHiddenChapter: {
+            title: 'Form Title Hidden',
+            hideFormTitle: true,
+            pages: { page1: { path: 'form-title-hidden' } },
+          },
+          formTitleExplicitlyDisplayedChapter: {
+            title: 'Form Title Explicitly Displayed',
+            hideFormTitle: false,
+            pages: { page1: { path: 'form-title-explicitly-displayed' } },
+          },
+          formTitleImplictlyDisplayedChapter: {
+            title: 'Form Title Implicitly Displayed',
+            pages: { page1: { path: 'form-title-implicitly-displayed' } },
+          },
+        },
+      },
+    };
+
+    describe('when on a page where form title is hidden', () => {
+      it('should hide the form title', () => {
+        const currentLocation = {
+          pathname: '/form-title-hidden',
+          search: '',
+        };
+        const tree = shallowFormApp({ formConfig, currentLocation });
+
+        expect(tree.everySubTree('.schemaform-title')).to.have.lengthOf(0);
+        expect(tree.everySubTree('.schemaform-subtitle')).to.have.lengthOf(0);
+      });
+    });
+
+    describe('when on a page where form title is explicitly displayed', () => {
+      it('should display the form title', () => {
+        const currentLocation = {
+          pathname: '/form-title-explicitly-displayed',
+          search: '',
+        };
+        const tree = shallowFormApp({ formConfig, currentLocation });
+
+        expect(tree.everySubTree('.schemaform-title')).to.have.lengthOf(1);
+        expect(tree.everySubTree('.schemaform-subtitle')).to.have.lengthOf(1);
+      });
+    });
+
+    describe('when on a page where form title is implicitly displayed', () => {
+      it('should display the form title', () => {
+        const currentLocation = {
+          pathname: '/form-title-implicitly-displayed',
+          search: '',
+        };
+        const tree = shallowFormApp({ formConfig, currentLocation });
+
+        expect(tree.everySubTree('.schemaform-title')).to.have.lengthOf(1);
+        expect(tree.everySubTree('.schemaform-subtitle')).to.have.lengthOf(1);
+      });
+    });
   });
 });

--- a/src/platform/forms-system/test/js/containers/FormApp.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/containers/FormApp.unit.spec.jsx
@@ -81,7 +81,7 @@ describe('Schemaform <FormApp>', () => {
 
   describe('hiding and displaying form title', () => {
     const mockPage = path => ({
-      page1: { path, schema: { type: 'object', properties: {} } },
+      firstPage: { path, schema: { type: 'object', properties: {} } },
     });
     const formConfig = {
       title: 'Form Title',
@@ -90,22 +90,22 @@ describe('Schemaform <FormApp>', () => {
         formTitleHiddenChapter: {
           title: 'Form Title Hidden',
           hideFormTitle: true,
-          pages: mockPage('form-title-hidden'),
+          pages: mockPage('/form-title-hidden'),
         },
         formTitleExplicitlyDisplayedChapter: {
           title: 'Form Title Explicitly Displayed',
           hideFormTitle: false,
-          pages: mockPage('form-title-explicitly-displayed'),
+          pages: mockPage('/form-title-explicitly-displayed'),
         },
         formTitleImplictlyDisplayedChapter: {
           title: 'Form Title Implicitly Displayed',
-          pages: mockPage('form-title-implicitly-displayed'),
+          pages: mockPage('/form-title-implicitly-displayed'),
         },
       },
     };
 
     describe('when on a page where form title is hidden', () => {
-      it('should hide the form title', () => {
+      it('hides the form title', () => {
         const currentLocation = {
           pathname: '/form-title-hidden',
           search: '',
@@ -117,7 +117,7 @@ describe('Schemaform <FormApp>', () => {
     });
 
     describe('when on a page where form title is explicitly displayed', () => {
-      it('should display the form title', () => {
+      it('displays the form title', () => {
         const currentLocation = {
           pathname: '/form-title-explicitly-displayed',
           search: '',
@@ -129,7 +129,7 @@ describe('Schemaform <FormApp>', () => {
     });
 
     describe('when on a page where form title is implicitly displayed', () => {
-      it('should display the form title', () => {
+      it('displays the form title', () => {
         const currentLocation = {
           pathname: '/form-title-implicitly-displayed',
           search: '',

--- a/src/platform/forms-system/test/js/containers/FormApp.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/containers/FormApp.unit.spec.jsx
@@ -80,25 +80,26 @@ describe('Schemaform <FormApp>', () => {
   });
 
   describe('hiding and displaying form title', () => {
+    const mockPage = path => ({
+      page1: { path, schema: { type: 'object', properties: {} } },
+    });
     const formConfig = {
-      formOptions: {
-        title: 'Form Title',
-        subTitle: 'Form Subtitle',
-        chapters: {
-          formTitleHiddenChapter: {
-            title: 'Form Title Hidden',
-            hideFormTitle: true,
-            pages: { page1: { path: 'form-title-hidden' } },
-          },
-          formTitleExplicitlyDisplayedChapter: {
-            title: 'Form Title Explicitly Displayed',
-            hideFormTitle: false,
-            pages: { page1: { path: 'form-title-explicitly-displayed' } },
-          },
-          formTitleImplictlyDisplayedChapter: {
-            title: 'Form Title Implicitly Displayed',
-            pages: { page1: { path: 'form-title-implicitly-displayed' } },
-          },
+      title: 'Form Title',
+      subTitle: 'Form Subtitle',
+      chapters: {
+        formTitleHiddenChapter: {
+          title: 'Form Title Hidden',
+          hideFormTitle: true,
+          pages: mockPage('form-title-hidden'),
+        },
+        formTitleExplicitlyDisplayedChapter: {
+          title: 'Form Title Explicitly Displayed',
+          hideFormTitle: false,
+          pages: mockPage('form-title-explicitly-displayed'),
+        },
+        formTitleImplictlyDisplayedChapter: {
+          title: 'Form Title Implicitly Displayed',
+          pages: mockPage('form-title-implicitly-displayed'),
         },
       },
     };
@@ -111,8 +112,7 @@ describe('Schemaform <FormApp>', () => {
         };
         const tree = shallowFormApp({ formConfig, currentLocation });
 
-        expect(tree.everySubTree('.schemaform-title')).to.have.lengthOf(0);
-        expect(tree.everySubTree('.schemaform-subtitle')).to.have.lengthOf(0);
+        expect(tree.everySubTree('FormTitle')).to.be.empty;
       });
     });
 
@@ -124,8 +124,7 @@ describe('Schemaform <FormApp>', () => {
         };
         const tree = shallowFormApp({ formConfig, currentLocation });
 
-        expect(tree.everySubTree('.schemaform-title')).to.have.lengthOf(1);
-        expect(tree.everySubTree('.schemaform-subtitle')).to.have.lengthOf(1);
+        expect(tree.everySubTree('FormTitle')).not.to.be.empty;
       });
     });
 
@@ -137,8 +136,7 @@ describe('Schemaform <FormApp>', () => {
         };
         const tree = shallowFormApp({ formConfig, currentLocation });
 
-        expect(tree.everySubTree('.schemaform-title')).to.have.lengthOf(1);
-        expect(tree.everySubTree('.schemaform-subtitle')).to.have.lengthOf(1);
+        expect(tree.everySubTree('FormTitle')).not.to.be.empty;
       });
     });
   });


### PR DESCRIPTION
## Summary

- Added the ability to hide the form title per page of a form
- Added unit test coverage for new logic
- Updates 21-4138 configuration to include hidden form titles

## Related issue(s)

- _Link to ticket created in va.gov-team-forms repo_
department-of-veterans-affairs/va.gov-team-forms/1183

## Testing done

- Browser testing
- Unit testing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

- All areas that use `FormApp` component

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
