### PR TITLE
Removes mobile team as codeowners for src/applications/static-pages/widget-creators

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -209,7 +209,6 @@ src/applications/static-pages/view-modify-dependents @department-of-veterans-aff
 
 # Flagship Mobile Reviewers
 src/applications/static-pages/subscription-creators @department-of-veterans-affairs/flagship-mobile-reviewers @department-of-veterans-affairs/va-platform-cop-frontend
-src/applications/static-pages/widget-creators @department-of-veterans-affairs/flagship-mobile-reviewers @department-of-veterans-affairs/va-platform-cop-frontend
 
 # VAOS
 
@@ -225,6 +224,7 @@ src/applications/dhp-connected-devices @department-of-veterans-affairs/digital-h
 src/applications/virtual-agent @department-of-veterans-affairs/orchid @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/pre-need @department-of-veterans-affairs/bah-mbs-selfserv @department-of-veterans-affairs/va-platform-cop-frontend
 src/applications/pre-need-integration @department-of-veterans-affairs/bah-mbs-selfserv @department-of-veterans-affairs/va-platform-cop-frontend
+src/applications/static-pages/widget-creators @department-of-veterans-affairs/va-platform-cop-frontend
 
 # Need more specific owners
 


### PR DESCRIPTION
## Summary

- When working on [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/29499), the flagship-mobile-team was added as reviewers.
- [Slack thread](https://dsva.slack.com/archives/C018V2JCWRJ/p1714751391508209) stating they aren't interested in this folder.
- team: #mhv-on-vagov-cartography-team
