### PR TITLE
MHV-57100 + MHV-57131: minor UI updates

### DIFF
--- a/src/applications/mhv/medications/components/RefillPrescriptions/RenewablePrescriptions.jsx
+++ b/src/applications/mhv/medications/components/RefillPrescriptions/RenewablePrescriptions.jsx
@@ -85,7 +85,7 @@ const RenewablePrescriptions = ({ renewablePrescriptionsList = [] }) => {
           </Link>
         </p>
       </div>
-      <h3 className="vads-u-margin-bottom--0">
+      <h3 className="vads-u-margin-bottom--0" data-testid="renewable-rx">
         Prescriptions you may need to renew
       </h3>
       {renewablePrescriptionsList.length > 0 && (

--- a/src/applications/mhv/medications/components/RefillPrescriptions/RenewablePrescriptions.jsx
+++ b/src/applications/mhv/medications/components/RefillPrescriptions/RenewablePrescriptions.jsx
@@ -85,6 +85,9 @@ const RenewablePrescriptions = ({ renewablePrescriptionsList = [] }) => {
           </Link>
         </p>
       </div>
+      <h3 className="vads-u-margin-bottom--0">
+        Prescriptions you may need to renew
+      </h3>
       {renewablePrescriptionsList.length > 0 && (
         <>
           <p data-testid="renew-page-list-count">

--- a/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv/medications/containers/PrescriptionDetails.jsx
@@ -191,7 +191,7 @@ const PrescriptionDetails = () => {
     setPdfTxtGenerateStatus({
       status: PDF_TXT_GENERATE_STATUS.InProgress,
       format,
-      message: 'Downloading your file...',
+      message: 'Loading...',
     });
     await Promise.allSettled([!allergies && dispatch(getAllergiesList())]);
   };

--- a/src/applications/mhv/medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv/medications/containers/Prescriptions.jsx
@@ -431,7 +431,7 @@ const Prescriptions = () => {
       (format === PRINT_FORMAT.PRINT_FULL_LIST && !prescriptionsFullList.length)
     ) {
       if (!prescriptionsFullList.length) setIsRetrievingFullList(true);
-      updateLoadingStatus(true, 'Downloading your file...');
+      updateLoadingStatus(true, 'Loading...');
     }
     setPdfTxtGenerateStatus({
       status: PDF_TXT_GENERATE_STATUS.InProgress,

--- a/src/applications/mhv/medications/tests/e2e/medications-renew-section-refill-page-nav.cypress.spec.js
+++ b/src/applications/mhv/medications/tests/e2e/medications-renew-section-refill-page-nav.cypress.spec.js
@@ -12,6 +12,7 @@ describe('Medications Renew Section on Refill Page', () => {
     cy.injectAxe();
     cy.axeCheck('main');
     refillPage.verifyRefillPageTitle();
+    refillPage.verifyRenewableSectionHeaderOnRefillPage();
     refillPage.verifyRenewListCountonRefillPage(1, 20, listLength);
   });
 });

--- a/src/applications/mhv/medications/tests/e2e/pages/MedicationsRefillPage.js
+++ b/src/applications/mhv/medications/tests/e2e/pages/MedicationsRefillPage.js
@@ -347,6 +347,13 @@ class MedicationsRefillPage {
       `Showing ${displayedStartNumber} - ${displayedEndNumber} of ${listLength} prescriptions`,
     );
   };
+
+  verifyRenewableSectionHeaderOnRefillPage = () => {
+    cy.get('[data-testid="renewable-rx"]').should(
+      'contain',
+      'Prescriptions you may need to renew',
+    );
+  };
 }
 
 export default MedicationsRefillPage;


### PR DESCRIPTION
## Summary

Minor UI updates to the Refill page + Rx loading spinner

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-56947
https://jira.devops.va.gov/browse/MHV-57071

<img width="903" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/799cd0b2-87f3-4977-aad1-a87326be9e46">

<img width="917" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/4e87dd93-4af4-418d-b77a-96b7979974de">

## Screenshots

<img width="1725" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/f29b535a-39f3-4bf4-8002-b16a52b9a908">

<img width="1448" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/586f2df0-a3b7-4d68-8670-07d3be10d799">

## Testing done

- Manual testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Add the new h3 to the renew section of the refill page

AC1: When you click the print button, the spinner says "Downloading your file" when it should just say "Loading..."

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
