### PR TITLE
MyVA | Add test for missing 21P-530 form and update configs

### DIFF
--- a/src/applications/personalization/dashboard/tests/e2e/in-progress-forms.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/in-progress-forms.cypress.spec.js
@@ -136,33 +136,33 @@ describe('The My VA Dashboard', () => {
     // TODO: add task to properly handle in-progress forms that have expired
   });
 
-  describe('regression test for SiP Forms (#78504)', () => {
+  describe('regression test for SiP Forms (#78504, #81525)', () => {
     beforeEach(() => {
       const now = Date.now() / 1000;
+      const mockMeta = (formId = 0) => ({
+        version: 0,
+        returnUrl: '/#',
+        savedAt: 1604951152710,
+        expiresAt: now + oneYearInSeconds,
+        lastUpdated: 1604951152,
+        inProgressFormId: formId,
+      });
+
       const savedForms = [
         {
           form: '26-1880',
-          metadata: {
-            version: 0,
-            returnUrl: '/#',
-            savedAt: 1604951152710,
-            expiresAt: now + oneYearInSeconds,
-            lastUpdated: 1604951152,
-            inProgressFormId: 5105,
-          },
-          lastUpdated: 1604951152,
+          metadata: mockMeta(5105),
+          lastUpdated: mockMeta.lastUpdated,
         },
         {
           form: '28-8832',
-          metadata: {
-            version: 0,
-            returnUrl: '/#',
-            savedAt: 1611946775267,
-            expiresAt: now + oneYearInSeconds,
-            lastUpdated: 1607012813,
-            inProgressFormId: 5179,
-          },
-          lastUpdated: 1607012813,
+          metadata: mockMeta(5179),
+          lastUpdated: mockMeta.lastUpdated,
+        },
+        {
+          form: '21P-530',
+          metadata: mockMeta(5199),
+          lastUpdated: mockMeta.lastUpdated,
         },
       ];
       mockUser.data.attributes.inProgressForms = savedForms;
@@ -170,9 +170,10 @@ describe('The My VA Dashboard', () => {
       cy.visit(manifest.rootUrl);
     });
 
-    it('should show in-progress 26-1880 and 28-8832 forms', () => {
+    it('should show in-progress 26-1880, 28-8832 and 21P-530 forms', () => {
       cy.findByText(/26-1880/i).should('exist');
       cy.findByText(/28-8832/i).should('exist');
+      cy.findByText(/21P-530/i).should('exist');
       // make the a11y check
       cy.injectAxe();
       cy.axeCheck();

--- a/src/platform/forms/constants.js
+++ b/src/platform/forms/constants.js
@@ -238,6 +238,8 @@ export const TRACKING_PREFIXES = {
   [VA_FORM_IDS.FORM_20_0996]: 'decision-reviews-va20-0996-',
   [VA_FORM_IDS.FORM_VA_2346A]: 'bam-2346a-',
   [VA_FORM_IDS.FORM_5655]: 'fsr-5655-',
+  [VA_FORM_IDS.FORM_28_8832]: '28-8832-',
+  [VA_FORM_IDS.FORM_26_1880]: '26-1880-',
 };
 
 export const SIP_ENABLED_FORMS = new Set([


### PR DESCRIPTION
## Summary

- in [#78504](https://github.com/department-of-veterans-affairs/va.gov-team/issues/78504), i forgot to add "tracking prefixes " for the missing forms. These didn't affect the accessibility of form drafts on MyVA, but affects the string value used in a thrown error, by using a dynamic lookup against this Set... i think in case non-SiP enabled forms get into our list somehow (unless other folks use these values in ways i don't know about or can't see?).  there was also another missing Form that i wrote a test for, but someone else must have added proper constants to this file before me, so i just left the test in to double check.
- add form 21P-530 to my va regression test in cypress
- MyVA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81525

## Testing done

- verified 21P-530 forms show in MyVA when provided in savedForms array via regression test
- i tested before and after these changes were made to constants file (fails before, passes after 👍 )
- ~i followed the code and tested locally to ensure the "TRACKING_PREFIXES" work as expected, but will verify with stakeholders that correct values are used and change before approval~ can't verify yet, but low risk given these IDs didn't exist here before. we'll make follow up ticket(s)/task(s) to take a closer look at these prefixes and usage


## What areas of the site does it impact?

MyVA or anyone using platform/forms/constants.js

## Acceptance criteria

21P-530 continues to show as expected on MyVA SiP list, and tracking codes are correct

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- ~[ ] Browser console contains no warnings or errors.~ none new
- [x] Events are being sent to the appropriate logging solution
- ~[ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)~

### Authentication

- ~[ ] Did you login to a local build and verify all authenticated routes work as expected with a test user~

## Requested Feedback
someone to verify tracking prefix values.
