### PR TITLE
81363 increase unit test coverage for form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/components/Applicant/applicantFileUpload.js
+++ b/src/applications/ivc-champva/10-10D/components/Applicant/applicantFileUpload.js
@@ -20,7 +20,7 @@ import {
  * formContext contained one or more properties that intersect with the
  * requiredFiles object
  */
-function isRequiredFile(formContext) {
+export function isRequiredFile(formContext) {
   return Object.keys(formContext?.schema?.properties || {}).filter(v =>
     Object.keys(requiredFiles).includes(v),
   ).length >= 1
@@ -115,14 +115,10 @@ export const applicantSchoolCertUploadUiSchema = {
           return (
             <>
               You’ll need to submit a copy of a document showing proof of{' '}
-              <b>{posessive}</b> school enrollment. If{' '}
-              <b>{nonPosessive === 'you' ? 'you’re' : posessive}</b> planning to
-              enroll,{' '}
-              <b>
-                {nonPosessive === 'you' ? 'you’ll' : `${nonPosessive} will`}
-              </b>{' '}
-              need to upload a document showing information about{' '}
-              <b>{posessive}</b> plan to enroll.
+              <b>{posessive}</b> school enrollment. If <b>{posessive}</b>{' '}
+              planning to enroll, <b>{nonPosessive} will</b> need to upload a
+              document showing information about <b>{posessive}</b> plan to
+              enroll.
               <br />
               <br />
               {mailOrFaxLaterMsg}
@@ -154,9 +150,8 @@ export const applicantSchoolCertUploadUiSchema = {
                   principal)
                 </li>
               </ul>
-              If {nonPosessive === 'you' ? 'you’re' : `${nonPosessive} is`} not
-              enrolled, upload a copy of {posessive} acceptance letter from the
-              school.
+              If {nonPosessive} is not enrolled, upload a copy of {posessive}{' '}
+              acceptance letter from the school.
             </>
           );
         },
@@ -399,16 +394,13 @@ export const appMedicareOver65IneligibleUploadUiSchema = {
           );
           return (
             <>
-              <b>{nonPosessive === 'You' ? 'You’re' : `${nonPosessive} is`}</b>{' '}
-              65 years or older and you selected that{' '}
-              <b>{nonPosessive === 'You' ? 'you’re' : 'they’re'}</b> not
-              eligible for Medicare.
+              <b>{nonPosessive}</b> is 65 years or older and you selected that{' '}
+              they’re not eligible for Medicare.
               <br />
               <br />
               You’ll need to submit a copy of a letter from the Social Security
-              Administration that confirms that{' '}
-              <b>{nonPosessive === 'You' ? 'you' : 'they'}</b> don’t qualify for
-              Medicare benefits under anyone’s Social Security number.
+              Administration that confirms that they don’t qualify for Medicare
+              benefits under anyone’s Social Security number.
               {mailOrFaxLaterMsg}
             </>
           );

--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -967,7 +967,7 @@ const formConfig = {
           path: 'applicant-marriage/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
-          title: item => `${applicantWording(item)} marriage documents`,
+          title: item => `${applicantWording(item)} marriage details`,
           depends: (formData, index) => {
             if (index === undefined) return true;
             return (
@@ -992,6 +992,7 @@ const formConfig = {
           }),
           uiSchema: {
             applicants: {
+              'ui:options': { viewField: ApplicantField },
               items: {},
             },
           },

--- a/src/applications/ivc-champva/10-10D/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-10D/config/submitTransformer.js
@@ -69,13 +69,13 @@ function parseCertifier(transformedData) {
     date: new Date().toJSON().slice(0, 10),
     firstName: transformedData.veteransFullName.first || '',
     lastName: transformedData.veteransFullName.last || '',
-    middleInitial: transformedData?.veteransFullName.middle || '',
+    middleInitial: transformedData?.veteransFullName?.middle || '',
     phone_number: transformedData?.sponsorPhone || '',
     relationship: '',
-    streetAddress: transformedData.sponsorAddress.street || '',
-    city: transformedData.sponsorAddress.city || '',
-    state: transformedData.sponsorAddress.state || '',
-    postal_code: transformedData.sponsorAddress.postal_code || '',
+    streetAddress: transformedData?.sponsorAddress?.street || '',
+    city: transformedData?.sponsorAddress?.city || '',
+    state: transformedData?.sponsorAddress?.state || '',
+    postal_code: transformedData?.sponsorAddress?.postal_code || '',
   };
 }
 

--- a/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
@@ -82,29 +82,29 @@ export function ConfirmationPage(props) {
         <h3 className="vads-u-margin-top--0 vads-u-font-size--h4">
           Your submission information
         </h3>
-        {data.statementOfTruthSignature ? (
+        {data.statementOfTruthSignature && (
           <span className="veterans-full-name">
             <strong>Who submitted this form</strong>
             <br />
             {data.statementOfTruthSignature}
             <br />
           </span>
-        ) : null}
+        )}
         <br />
-        {data.statementOfTruthSignature ? (
+        {data.statementOfTruthSignature && (
           <span className="veterans-full-name">
             <strong>Confirmation number</strong>
             <br />
             {form.submission?.response?.confirmationNumber || ''}
           </span>
-        ) : null}
-        {isValid(submitDate) ? (
+        )}
+        {isValid(submitDate) && (
           <p className="date-submitted">
             <strong>Date submitted</strong>
             <br />
             <span>{format(submitDate, 'MMMM d, yyyy')}</span>
           </p>
-        ) : null}
+        )}
         <span className="veterans-full-name">
           <strong>Confirmation for your records</strong>
           <br />

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantDependentStatus.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantDependentStatus.jsx
@@ -18,7 +18,7 @@ function generateOptions({ data, pagePerItemIndex }) {
     relativePossessive,
   } = appRelBoilerplate({ data, pagePerItemIndex });
 
-  const customTitle = `${useFirstPerson ? `Your` : `${applicant}’s`} status`;
+  const customTitle = `${applicant}’s status`;
 
   const relativeBeingVerb = `${relative} ${beingVerbPresent}`;
 
@@ -49,9 +49,7 @@ function generateOptions({ data, pagePerItemIndex }) {
     secondary: SECONDARY,
     currentListItem,
     customTitle,
-    description: `Which of these best describes ${
-      useFirstPerson ? 'you' : applicant
-    }?`,
+    description: `Which of these best describes ${applicant}?`,
   };
 }
 

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantMedicareStatusContinuedPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantMedicareStatusContinuedPage.jsx
@@ -31,9 +31,7 @@ export function generateOptions({ data, pagePerItemIndex }) {
     },
   ];
 
-  const prompt = `${
-    useFirstPerson ? 'Are you' : `Is ${applicant}`
-  } enrolled in Medicare Part D?`;
+  const prompt = `Is ${applicant} enrolled in Medicare Part D?`;
 
   return {
     options,
@@ -46,9 +44,7 @@ export function generateOptions({ data, pagePerItemIndex }) {
     keyname: KEYNAME,
     primary: PRIMARY,
     secondary: SECONDARY,
-    customTitle: `${
-      useFirstPerson ? `Your` : `${applicant}'s`
-    } Medicare status`,
+    customTitle: `${applicant}'s Medicare status`,
     description: prompt,
   };
 }
@@ -88,7 +84,7 @@ ApplicantMedicareStatusContinuedPage.propTypes = {
   data: PropTypes.object,
   goBack: PropTypes.func,
   goForward: PropTypes.func,
-  pagePerItemIndex: PropTypes.string || PropTypes.number,
+  pagePerItemIndex: PropTypes.string,
   setFormData: PropTypes.func,
   updatePage: PropTypes.func,
   onReviewPage: PropTypes.bool,

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantMedicareStatusPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantMedicareStatusPage.jsx
@@ -22,30 +22,20 @@ export function generateOptions({ data, pagePerItemIndex }) {
 
   const options = [
     {
-      label: `Yes, ${
-        useFirstPerson ? 'I‘m' : `${applicant} is `
-      } enrolled in Medicare`,
+      label: `Yes, ${applicant} is enrolled in Medicare`,
       value: 'enrolled',
     },
     {
-      label: `No, ${
-        useFirstPerson ? "I'm" : `${applicant} is `
-      } not eligible for Medicare`,
+      label: `No, ${applicant} is not eligible for Medicare`,
       value: 'ineligible',
     },
     {
-      label: `No, ${
-        useFirstPerson ? "I'm" : `${applicant} is `
-      } eligible for Medicare but ${
-        useFirstPerson ? 'have' : 'has'
-      } not been signed up for it yet`,
+      label: `No, ${applicant} is eligible for Medicare but has not been signed up for it yet`,
       value: 'eligibleNotSignedUp',
     },
   ];
 
-  const prompt = `${
-    useFirstPerson ? 'Are you' : `Is ${applicant}`
-  } enrolled in Medicare Parts A & B?`;
+  const prompt = `Is ${applicant} enrolled in Medicare Parts A & B?`;
 
   return {
     options,
@@ -58,9 +48,7 @@ export function generateOptions({ data, pagePerItemIndex }) {
     keyname: KEYNAME,
     primary: PRIMARY,
     secondary: SECONDARY,
-    customTitle: `${
-      useFirstPerson ? `Your` : `${applicant}'s`
-    } Medicare status`,
+    customTitle: `${applicant}'s Medicare status`,
     description: prompt,
   };
 }
@@ -100,7 +88,7 @@ ApplicantMedicareStatusPage.propTypes = {
   data: PropTypes.object,
   goBack: PropTypes.func,
   goForward: PropTypes.func,
-  pagePerItemIndex: PropTypes.string || PropTypes.number,
+  pagePerItemIndex: PropTypes.string,
   setFormData: PropTypes.func,
   updatePage: PropTypes.func,
   onReviewPage: PropTypes.bool,

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantOhiStatusPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantOhiStatusPage.jsx
@@ -57,7 +57,7 @@ ApplicantOhiStatusPage.propTypes = {
   data: PropTypes.object,
   goBack: PropTypes.func,
   goForward: PropTypes.func,
-  pagePerItemIndex: PropTypes.string || PropTypes.number,
+  pagePerItemIndex: PropTypes.string,
   setFormData: PropTypes.func,
   updatePage: PropTypes.func,
   onReviewPage: PropTypes.bool,

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantRelOriginPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantRelOriginPage.jsx
@@ -16,9 +16,7 @@ function generateOptions({ data, pagePerItemIndex }) {
     relativePossessive,
   } = appRelBoilerplate({ data, pagePerItemIndex });
 
-  const customTitle = `${
-    useFirstPerson ? `Your` : `${applicant}’s`
-  } relationship to the ${personTitle}`;
+  const customTitle = `${applicant}’s relationship to the ${personTitle}`;
 
   const relativeBeingVerb = `${relative} ${beingVerbPresent}`;
   const surv = data.sponsorIsDeceased ? 'surviving' : '';

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantSponsorMarriageDetailsPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantSponsorMarriageDetailsPage.jsx
@@ -35,13 +35,9 @@ function generateOptions({ data, pagePerItemIndex }) {
     relativePossessive,
   } = appRelBoilerplate({ data, pagePerItemIndex });
 
-  const customTitle = `${
-    useFirstPerson ? `Your` : `${applicant}’s`
-  } marriage to the ${personTitle}`;
+  const customTitle = `${applicant}’s marriage to the ${personTitle}`;
 
-  const description = `Which of these best describes ${
-    useFirstPerson ? `your` : `${applicant}’s`
-  } marriage to ${useFirstPerson ? `your` : 'their'} ${personTitle}?`;
+  const description = `Which of these best describes ${applicant}’s marriage to their ${personTitle}?`;
 
   const options = [
     {
@@ -53,9 +49,7 @@ function generateOptions({ data, pagePerItemIndex }) {
       value: 'marriageDissolved',
     },
     {
-      label: `${relative} was married to the ${personTitle} at the time of their death and remarried someone else on or after ${
-        useFirstPerson ? 'my' : relativePossessive
-      } 55th birthday`,
+      label: `${relative} was married to the ${personTitle} at the time of their death and remarried someone else on or after ${relativePossessive} 55th birthday`,
       value: 'marriedTillDeathRemarriedAfter55',
     },
     {

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantSponsorMarriageDetailsPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantSponsorMarriageDetailsPage.jsx
@@ -260,6 +260,7 @@ but was still getting silent validation failures on review page.
 export const marriageDatesSchema = {
   noRemarriageUiSchema: {
     applicants: {
+      'ui:options': { viewField: ApplicantField },
       items: {
         'ui:options': marriageTitle(
           ' date of marriage to sponsor',
@@ -271,6 +272,7 @@ export const marriageDatesSchema = {
   },
   separatedUiSchema: {
     applicants: {
+      'ui:options': { viewField: ApplicantField },
       items: {
         'ui:options': marriageTitle(' marriage and legal separation dates', ''),
         dateOfMarriageToSponsor,
@@ -280,6 +282,7 @@ export const marriageDatesSchema = {
   },
   remarriageUiSchema: {
     applicants: {
+      'ui:options': { viewField: ApplicantField },
       items: {
         'ui:options': marriageTitle(' marriage dates', ''),
         dateOfMarriageToSponsor,
@@ -289,6 +292,7 @@ export const marriageDatesSchema = {
   },
   remarriageSeparatedUiSchema: {
     applicants: {
+      'ui:options': { viewField: ApplicantField },
       items: {
         'ui:options': marriageTitle(' marriage and legal separation dates', ''),
         dateOfMarriageToSponsor,

--- a/src/applications/ivc-champva/10-10D/tests/unit/components/File/MissingFileOverview.unit.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/unit/components/File/MissingFileOverview.unit.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import SupportingDocumentsPage from '../../../../pages/SupportingDocumentsPage';
+import { MissingFileConsentPage } from '../../../../pages/MissingFileConsentPage';
 import { testComponentRender } from '../../../../../shared/tests/pages/pageTests.spec';
 import {
   hasReq,
@@ -123,6 +124,21 @@ describe('checkFlags', () => {
 testComponentRender(
   'SupportingDocumentsPage',
   <SupportingDocumentsPage
+    data={mockData.data}
+    contentAfterButtons={{ props: { formConfig } }}
+    goBack={() => {}}
+    goForward={() => {}}
+    setFormData={() => {}}
+    disableLinks={false}
+    heading={<>test heading</>}
+    showMail={false}
+    showConsent={false}
+  />,
+);
+
+testComponentRender(
+  'MissingFileConsentPage',
+  <MissingFileConsentPage
     data={mockData.data}
     contentAfterButtons={{ props: { formConfig } }}
     goBack={() => {}}

--- a/src/applications/ivc-champva/10-10D/tests/unit/components/sponsorFileUploads.unit.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/unit/components/sponsorFileUploads.unit.spec.js
@@ -1,5 +1,10 @@
 import { expect } from 'chai';
-import { uploadWithInfoComponent } from '../../../components/Sponsor/sponsorFileUploads';
+import { render } from '@testing-library/react';
+import React from 'react';
+import {
+  uploadWithInfoComponent,
+  acceptableFiles,
+} from '../../../components/Sponsor/sponsorFileUploads';
 
 describe('uploadWithInfoComponent', () => {
   it('should accept resource links', async () => {
@@ -7,5 +12,34 @@ describe('uploadWithInfoComponent', () => {
       { href: 'www.test.gov', text: 'Test' },
     ]);
     expect(upload.uiSchema).to.exist;
+  });
+});
+
+describe('uploadWithInfoComponent', () => {
+  it('should render list of acceptable files and links', async () => {
+    const upload = uploadWithInfoComponent(
+      acceptableFiles.va7959cCert,
+      '',
+      false,
+    );
+    const { container } = render(
+      <>{upload.uiSchema['view:acceptableFilesList']['ui:description']}</>,
+    );
+    expect(container.querySelector('va-link').getAttribute('text')).to.equal(
+      acceptableFiles.va7959cCert[0].text,
+    );
+  });
+  it('should render nested bulleted list of acceptable files with links if present', async () => {
+    const upload = uploadWithInfoComponent(
+      acceptableFiles.schoolCert,
+      '',
+      false,
+    );
+    const { container } = render(
+      <>{upload.uiSchema['view:acceptableFilesList']['ui:description']}</>,
+    );
+    expect(container.querySelector('va-link').getAttribute('text')).to.equal(
+      acceptableFiles.schoolCert[0].bullets[0].text,
+    );
   });
 });

--- a/src/applications/ivc-champva/10-10D/tests/unit/config/form.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10D/tests/unit/config/form.unit.spec.jsx
@@ -10,6 +10,8 @@ import {
 import ApplicantRelationshipPage from '../../../../shared/components/applicantLists/ApplicantRelationshipPage';
 import formConfig from '../../../config/form';
 import { getFileSize } from '../../../helpers/utilities';
+import { isRequiredFile } from '../../../components/Applicant/applicantFileUpload';
+import { requiredFiles } from '../../../config/requiredUploads';
 
 import FileFieldCustom from '../../../../shared/components/fileUploads/FileUpload';
 
@@ -121,6 +123,15 @@ testNumberOfWebComponentFields(
 
 testNumberOfWebComponentFields(
   formConfig,
+  formConfig.chapters.applicantInformation.pages.page18b2.schema,
+  formConfig.chapters.applicantInformation.pages.page18b2.uiSchema,
+  0,
+  'Applicant - helpless child documentation',
+  { ...mockData.data },
+);
+
+testNumberOfWebComponentFields(
+  formConfig,
   formConfig.chapters.applicantInformation.pages.page18c.schema,
   formConfig.chapters.applicantInformation.pages.page18c.uiSchema,
   0,
@@ -157,6 +168,24 @@ testNumberOfWebComponentFields(
 
 testNumberOfWebComponentFields(
   formConfig,
+  formConfig.chapters.applicantInformation.pages.page18f7.schema,
+  formConfig.chapters.applicantInformation.pages.page18f7.uiSchema,
+  0,
+  'Applicant - second marriage documents',
+  { ...mockData.data },
+);
+
+testNumberOfWebComponentFields(
+  formConfig,
+  formConfig.chapters.applicantInformation.pages.page18f8.schema,
+  formConfig.chapters.applicantInformation.pages.page18f8.uiSchema,
+  0,
+  'Applicant - second marriage divorce documents',
+  { ...mockData.data },
+);
+
+testNumberOfWebComponentFields(
+  formConfig,
   formConfig.chapters.applicantInformation.pages.page20a.schema,
   formConfig.chapters.applicantInformation.pages.page20a.uiSchema,
   0,
@@ -170,6 +199,15 @@ testNumberOfWebComponentFields(
   formConfig.chapters.applicantInformation.pages.page20b.uiSchema,
   0,
   'Applicant - medicare part D upload',
+  { ...mockData.data },
+);
+
+testNumberOfWebComponentFields(
+  formConfig,
+  formConfig.chapters.applicantInformation.pages.page20c.schema,
+  formConfig.chapters.applicantInformation.pages.page20c.uiSchema,
+  0,
+  'Applicant - over 65 ineligible',
   { ...mockData.data },
 );
 
@@ -282,3 +320,14 @@ describe('submit property of formConfig', () => {
   });
 });
 */
+
+describe('isRequiredFile', () => {
+  it("should return '(Required)' if required file in formContext", () => {
+    // Grab whatever the first required file key is and toss into this
+    // mocked context object:
+    const context = {
+      schema: { properties: { [Object.keys(requiredFiles)[0]]: '' } },
+    };
+    expect(isRequiredFile(context)).to.equal('(Required)');
+  });
+});

--- a/src/applications/ivc-champva/10-10D/tests/unit/config/form.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10D/tests/unit/config/form.unit.spec.jsx
@@ -33,6 +33,19 @@ const applicants = [
 
 testNumberOfWebComponentFields(
   formConfig,
+  formConfig.chapters.certifierInformation.pages.page5.schema,
+  formConfig.chapters.certifierInformation.pages.page5.uiSchema,
+  6,
+  'Signer relationship',
+  {
+    certifierRelationship: {
+      relationshipToVeteran: { other: true },
+    },
+  },
+);
+
+testNumberOfWebComponentFields(
+  formConfig,
   formConfig.chapters.sponsorInformation.pages.page6.schema,
   formConfig.chapters.sponsorInformation.pages.page6.uiSchema,
   5,
@@ -65,6 +78,34 @@ testNumberOfWebComponentFields(
   1,
   "Sponsor's phone number",
   { sponsorIsDeceased: false },
+);
+
+// certifierRole: 'sponsor' triggers the 'your' custom wording branch
+testNumberOfWebComponentFields(
+  formConfig,
+  formConfig.chapters.sponsorInformation.pages.page11.schema,
+  formConfig.chapters.sponsorInformation.pages.page11.uiSchema,
+  1,
+  "Sponsor's phone number",
+  { sponsorIsDeceased: false, certifierRole: 'sponsor' },
+);
+
+testNumberOfWebComponentFields(
+  formConfig,
+  formConfig.chapters.applicantInformation.pages.page13.schema,
+  formConfig.chapters.applicantInformation.pages.page13.uiSchema,
+  5,
+  'Applicant - Name DOB',
+  { ...mockData.data },
+);
+
+testNumberOfWebComponentFields(
+  formConfig,
+  formConfig.chapters.applicantInformation.pages.page13a.schema,
+  formConfig.chapters.applicantInformation.pages.page13a.uiSchema,
+  0,
+  'Applicant - Start screen',
+  { ...mockData.data },
 );
 
 testNumberOfWebComponentFields(

--- a/src/applications/ivc-champva/10-10D/tests/unit/config/form.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10D/tests/unit/config/form.unit.spec.jsx
@@ -198,12 +198,72 @@ testNumberOfWebComponentFields(
   { ...mockData.data },
 );
 
+const marriageData = JSON.parse(JSON.stringify(mockData));
+marriageData.data.applicants[0].applicantRelationshipToSponsor.relationshipToVeteran =
+  'spouse';
+marriageData.data.sponsorIsDeceased = true;
+
 testNumberOfWebComponentFields(
   formConfig,
   formConfig.chapters.applicantInformation.pages.page18f.schema,
   formConfig.chapters.applicantInformation.pages.page18f.uiSchema,
   0,
   'Applicant - marriage documents',
+  { ...mockData.data },
+);
+
+// marriageData.data.sponsorIsDeceased = true;
+testNumberOfWebComponentFields(
+  formConfig,
+  formConfig.chapters.applicantInformation.pages.page18f1.schema,
+  formConfig.chapters.applicantInformation.pages.page18f1.uiSchema,
+  0,
+  'Applicant - marriage details',
+  { ...marriageData.data },
+);
+
+testNumberOfWebComponentFields(
+  formConfig,
+  formConfig.chapters.applicantInformation.pages.page18f2.schema,
+  formConfig.chapters.applicantInformation.pages.page18f2.uiSchema,
+  1,
+  'Applicant - remarriage status',
+  { ...mockData.data },
+);
+
+testNumberOfWebComponentFields(
+  formConfig,
+  formConfig.chapters.applicantInformation.pages.page18f3.schema,
+  formConfig.chapters.applicantInformation.pages.page18f3.uiSchema,
+  1,
+  'Applicant - marriage dates (to sponsor)',
+  { ...marriageData.data },
+);
+
+testNumberOfWebComponentFields(
+  formConfig,
+  formConfig.chapters.applicantInformation.pages.page18f4.schema,
+  formConfig.chapters.applicantInformation.pages.page18f4.uiSchema,
+  2,
+  'Applicant - marriage dates (remarriage after sponsor death)',
+  { ...mockData.data },
+);
+
+testNumberOfWebComponentFields(
+  formConfig,
+  formConfig.chapters.applicantInformation.pages.page18f5.schema,
+  formConfig.chapters.applicantInformation.pages.page18f5.uiSchema,
+  3,
+  'Applicant - marriage dates (remarriage after sponsor death, divorced 2nd)',
+  { ...mockData.data },
+);
+
+testNumberOfWebComponentFields(
+  formConfig,
+  formConfig.chapters.applicantInformation.pages.page18f6.schema,
+  formConfig.chapters.applicantInformation.pages.page18f6.uiSchema,
+  2,
+  'Applicant - marriage dates (divorced sponsor)',
   { ...mockData.data },
 );
 

--- a/src/applications/ivc-champva/10-10D/tests/unit/config/form.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10D/tests/unit/config/form.unit.spec.jsx
@@ -53,6 +53,26 @@ testNumberOfWebComponentFields(
   { ...mockData.data },
 );
 
+// Cover alternate path for when certifierRole == 'sponsor'
+testNumberOfWebComponentFields(
+  formConfig,
+  formConfig.chapters.sponsorInformation.pages.page6.schema,
+  formConfig.chapters.sponsorInformation.pages.page6.uiSchema,
+  5,
+  'Sponsor - name and date of birth (alternate)',
+  { ...mockData.data, certifierRole: 'sponsor' },
+);
+
+// Cover when certifierRole !== sponsor or applicant
+testNumberOfWebComponentFields(
+  formConfig,
+  formConfig.chapters.sponsorInformation.pages.page6.schema,
+  formConfig.chapters.sponsorInformation.pages.page6.uiSchema,
+  5,
+  'Sponsor - name and date of birth (alternate 2)',
+  { ...mockData.data, certifierRole: 'other' },
+);
+
 testNumberOfWebComponentFields(
   formConfig,
   formConfig.chapters.sponsorInformation.pages.page7.schema,

--- a/src/applications/ivc-champva/10-10D/tests/unit/config/form.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10D/tests/unit/config/form.unit.spec.jsx
@@ -45,8 +45,8 @@ testNumberOfWebComponentFields(
   formConfig.chapters.sponsorInformation.pages.page7.schema,
   formConfig.chapters.sponsorInformation.pages.page7.uiSchema,
   2,
-  'Sponsor - identification information',
-  { ...mockData.data },
+  'Sponsor - SSN (with VA File Number)',
+  { ssn: { vaFileNumber: '123123123' } },
 );
 
 testNumberOfWebComponentFields(
@@ -329,5 +329,14 @@ describe('isRequiredFile', () => {
       schema: { properties: { [Object.keys(requiredFiles)[0]]: '' } },
     };
     expect(isRequiredFile(context)).to.equal('(Required)');
+  });
+});
+
+import FileFieldWrapped from '../../../components/FileUploadWrapper';
+
+describe('FileFieldWrapped', () => {
+  it('should be called', () => {
+    const ffw = FileFieldWrapped({});
+    expect(ffw).to.not.be.undefined;
   });
 });

--- a/src/applications/ivc-champva/10-10D/tests/unit/config/submitTransformer.unit.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/unit/config/submitTransformer.unit.spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import formConfig from '../../../config/form';
 import transformForSubmit from '../../../config/submitTransformer';
+import mockData from '../../e2e/fixtures/data/test-data.json';
 
 describe('transform for submit', () => {
   it('should adjust zip code keyname', () => {
@@ -60,5 +61,25 @@ describe('transform for submit', () => {
       transformForSubmit(formConfig, { data: {} }),
     );
     expect(transformed.veteran.ssn_or_tin).to.equal('');
+  });
+  it('should format certifier information', () => {
+    const modified = JSON.parse(JSON.stringify(mockData));
+    modified.data.certifierRole = 'sponsor';
+    const transformed = JSON.parse(transformForSubmit(formConfig, modified));
+    expect(transformed.certification.firstName).equals(
+      modified.data.veteransFullName.first,
+    );
+  });
+  it('should attach applicant name to each uploaded file', () => {
+    const modified = JSON.parse(JSON.stringify(mockData));
+    modified.data.applicants[0].applicantMedicareCardFront = [
+      {
+        name: 'file.png',
+      },
+    ];
+    const transformed = JSON.parse(transformForSubmit(formConfig, modified));
+    expect(transformed.supporting_docs[0].applicantName.first).to.equal(
+      transformed.applicants[0].full_name.first,
+    );
   });
 });

--- a/src/applications/ivc-champva/10-10D/tests/unit/containers/ConfirmationPage.unit.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/unit/containers/ConfirmationPage.unit.spec.js
@@ -1,10 +1,11 @@
-/* import React from 'react';
+import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { expect } from 'chai';
-import ConfirmationPage from '../../containers/ConfirmationPage'; */
+// import ConfirmationPage from '../../containers/ConfirmationPage';
+import ConfirmationPage from '../../../containers/ConfirmationPage';
 import formConfig from '../../../config/form';
 
 import mockData from '../../e2e/fixtures/data/test-data.json';
@@ -36,15 +37,10 @@ const storeBase = {
   },
 };
 
-/* const fullName = `${mockData.data.veteransFullName.first} ${
-  mockData.data.veteransFullName.last
-}`; */
-
 // Prepare some alternate data for different tests
 const storeBaseNoSubmissionDate = JSON.parse(JSON.stringify(storeBase));
 storeBaseNoSubmissionDate.form.submission.timestamp = '';
 
-/*
 // TODO: These tests need rework. Commenting out until that can be tackled.
 describe('Confirmation page', () => {
   const middleware = [thunk];
@@ -60,34 +56,33 @@ describe('Confirmation page', () => {
     expect(container).to.exist;
   });
 
-  it('should display correct name of person', () => {
-    const { getByText } = render(
-      <Provider store={mockStore(storeBase)}>
-        <ConfirmationPage />
-      </Provider>,
-    );
+  // it('should display correct name of person', () => {
+  //   const { getByText } = render(
+  //     <Provider store={mockStore(storeBase)}>
+  //       <ConfirmationPage />
+  //     </Provider>,
+  //   );
 
-    expect(getByText(fullName)).to.exist;
-  });
+  //   expect(getByText(fullName)).to.exist;
+  // });
 
-  it('should not display submission date if it is invalid', () => {
-    const { container } = render(
-      <Provider store={mockStore(storeBaseNoSubmissionDate)}>
-        <ConfirmationPage />
-      </Provider>,
-    );
+  // it('should not display submission date if it is invalid', () => {
+  //   const { container } = render(
+  //     <Provider store={mockStore(storeBaseNoSubmissionDate)}>
+  //       <ConfirmationPage />
+  //     </Provider>,
+  //   );
 
-    expect(container.querySelector('.date-submitted')).to.not.exist;
-  });
+  //   expect(container.querySelector('.date-submitted')).to.not.exist;
+  // });
 
-  it('should display submission date if it is valid', () => {
-    const { getByText } = render(
-      <Provider store={mockStore(storeBase)}>
-        <ConfirmationPage />
-      </Provider>,
-    );
+  // it('should display submission date if it is valid', () => {
+  //   const { getByText } = render(
+  //     <Provider store={mockStore(storeBase)}>
+  //       <ConfirmationPage />
+  //     </Provider>,
+  //   );
 
-    expect(getByText(/November 13, 2023/)).to.exist;
-  });
+  //   expect(getByText(/November 13, 2023/)).to.exist;
+  // });
 });
-*/

--- a/src/applications/ivc-champva/10-10D/tests/unit/helpers/helpers.unit.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/unit/helpers/helpers.unit.spec.js
@@ -1,10 +1,22 @@
 import { expect } from 'chai';
 import React from 'react';
 import { applicantWording, getAgeInYears } from '../../../../shared/utilities';
+import { sponsorWording } from '../../../helpers/wordingCustomization';
 import { isInRange } from '../../../helpers/utilities';
 import ApplicantField from '../../../../shared/components/applicantLists/ApplicantField';
 import { testComponentRender } from '../../../../shared/tests/pages/pageTests.spec';
 import mockData from '../../e2e/fixtures/data/test-data.json';
+
+describe('sponsorWording helper', () => {
+  it('should return non-possesive form when isPosessive == false', () => {
+    expect(sponsorWording({ certifierRole: 'sponsor' }, false, false)).to.equal(
+      'you',
+    );
+    expect(sponsorWording({ certifierRole: 'applicant' }, false)).to.equal(
+      'Sponsor',
+    );
+  });
+});
 
 describe('applicantWording helper', () => {
   it('should concatenate first and last names', () => {

--- a/src/applications/ivc-champva/10-10D/tests/unit/pages/applicantMedicareStatusContinuedPage.unit.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/unit/pages/applicantMedicareStatusContinuedPage.unit.spec.js
@@ -8,7 +8,10 @@ import {
   testComponentRender,
   // getProps,
 } from '../../../../shared/tests/pages/pageTests.spec';
-import { ApplicantMedicareStatusContinuedPage } from '../../../pages/ApplicantMedicareStatusContinuedPage';
+import {
+  ApplicantMedicareStatusContinuedPage,
+  ApplicantMedicareStatusContinuedReviewPage,
+} from '../../../pages/ApplicantMedicareStatusContinuedPage';
 import mockData from '../../e2e/fixtures/data/test-data.json';
 
 // The tests in here need to be re-worked. This medicare component was overhauled.
@@ -23,15 +26,24 @@ import mockData from '../../e2e/fixtures/data/test-data.json';
 //   <ApplicantMedicareStatusContinuedPage data={{}} />,
 // );
 
-// Causes 'useFirstPerson' to be true:
 testComponentRender(
-  'ApplicantMedicareStatusPage',
+  'ApplicantMedicareStatusContinuedPage',
   <ApplicantMedicareStatusContinuedPage
     data={{
       ...mockData.data,
-      certifierRole: 'applicant',
     }}
     pagePerItemIndex="0"
+  />,
+);
+
+testComponentRender(
+  'ApplicantMedicareStatusContinuedReviewPage',
+  <ApplicantMedicareStatusContinuedReviewPage
+    data={{
+      ...mockData.data,
+    }}
+    pagePerItemIndex="0"
+    title={() => {}}
   />,
 );
 

--- a/src/applications/ivc-champva/10-10D/tests/unit/pages/combinedPageTests.unit.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/unit/pages/combinedPageTests.unit.spec.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { testComponentRender } from '../../../../shared/tests/pages/pageTests.spec';
+import { ApplicantDependentStatusPage } from '../../../pages/ApplicantDependentStatus';
+import {
+  ApplicantGenderPage,
+  ApplicantGenderReviewPage,
+} from '../../../pages/ApplicantGenderPage';
+import {
+  ApplicantSponsorMarriageDetailsPage,
+  ApplicantSponsorMarriageDetailsReviewPage,
+} from '../../../pages/ApplicantSponsorMarriageDetailsPage';
+import ApplicantOhiStatusPage from '../../../pages/ApplicantOhiStatusPage';
+import { ApplicantRelOriginPage } from '../../../pages/ApplicantRelOriginPage';
+import mockData from '../../e2e/fixtures/data/test-data.json';
+
+// Basic render tests:
+
+testComponentRender(
+  'ApplicantDependentStatusPage',
+  <ApplicantDependentStatusPage
+    data={{ ...mockData.data }}
+    pagePerItemIndex="0"
+  />,
+);
+testComponentRender(
+  'Applicant marriage details',
+  <ApplicantSponsorMarriageDetailsPage data={{ ...mockData.data }} />,
+);
+testComponentRender(
+  'Applicant marriage details',
+  <ApplicantSponsorMarriageDetailsReviewPage
+    data={{ ...mockData.data }}
+    title={() => {}}
+  />,
+);
+testComponentRender(
+  'ApplicantGenderPage',
+  <ApplicantGenderPage data={{ ...mockData.data }} />,
+);
+testComponentRender(
+  'ApplicantGenderReviewPage',
+  <ApplicantGenderReviewPage data={{ ...mockData.data }} title={() => {}} />,
+);
+testComponentRender(
+  'ApplicantOhiStatusPage',
+  <ApplicantOhiStatusPage data={{ ...mockData.data }} />,
+);
+testComponentRender(
+  'ApplicantRelOriginPage',
+  <ApplicantRelOriginPage data={{ ...mockData.data }} />,
+);

--- a/src/applications/ivc-champva/10-10D/tests/unit/pages/combinedPageTests.unit.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/unit/pages/combinedPageTests.unit.spec.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import { testComponentRender } from '../../../../shared/tests/pages/pageTests.spec';
-import { ApplicantDependentStatusPage } from '../../../pages/ApplicantDependentStatus';
+import {
+  ApplicantDependentStatusPage,
+  ApplicantDependentStatusReviewPage,
+} from '../../../pages/ApplicantDependentStatus';
 import {
   ApplicantGenderPage,
   ApplicantGenderReviewPage,
@@ -9,8 +12,13 @@ import {
   ApplicantSponsorMarriageDetailsPage,
   ApplicantSponsorMarriageDetailsReviewPage,
 } from '../../../pages/ApplicantSponsorMarriageDetailsPage';
-import ApplicantOhiStatusPage from '../../../pages/ApplicantOhiStatusPage';
-import { ApplicantRelOriginPage } from '../../../pages/ApplicantRelOriginPage';
+import ApplicantOhiStatusPage, {
+  ApplicantOhiStatusReviewPage,
+} from '../../../pages/ApplicantOhiStatusPage';
+import {
+  ApplicantRelOriginPage,
+  ApplicantRelOriginReviewPage,
+} from '../../../pages/ApplicantRelOriginPage';
 import mockData from '../../e2e/fixtures/data/test-data.json';
 
 // Basic render tests:
@@ -20,6 +28,14 @@ testComponentRender(
   <ApplicantDependentStatusPage
     data={{ ...mockData.data }}
     pagePerItemIndex="0"
+  />,
+);
+testComponentRender(
+  'ApplicantDependentStatusReviewPage',
+  <ApplicantDependentStatusReviewPage
+    data={{ ...mockData.data }}
+    pagePerItemIndex="0"
+    title={() => {}}
   />,
 );
 testComponentRender(
@@ -46,6 +62,17 @@ testComponentRender(
   <ApplicantOhiStatusPage data={{ ...mockData.data }} />,
 );
 testComponentRender(
+  'ApplicantOhiStatusReviewPage',
+  <ApplicantOhiStatusReviewPage data={{ ...mockData.data }} title={() => {}} />,
+);
+testComponentRender(
   'ApplicantRelOriginPage',
   <ApplicantRelOriginPage data={{ ...mockData.data }} />,
+);
+testComponentRender(
+  'ApplicantRelOriginReviewPage',
+  <ApplicantRelOriginReviewPage
+    data={{ ...mockData.data, sponsorIsDeceased: false }}
+    title={() => {}}
+  />,
 );


### PR DESCRIPTION
## Summary

This PR increases unit test coverage for form 10-10d to >90% and refactors/removes some unnecessary code.

- Added new unit tests to reach >90% coverage
- Removed most `useFirstPerson` conditional string formatting as it's not needed any longer
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81363

## Testing done

- Added new unit tests

## Screenshots

|         | Coverage |
| ------- | ------ |
| Before |![before](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/fbf23f82-6d0c-4ada-95ae-22fb7916cf1c)|
| After | ![after](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/07f37675-2a21-424c-a4c6-3633d93ed61f)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
