### PR TITLE
Revert v8 form migration for TERA in Health Care Application

### DIFF
--- a/src/applications/hca/config/migrations.js
+++ b/src/applications/hca/config/migrations.js
@@ -1,7 +1,7 @@
-import get from 'platform/utilities/data/get';
-import omit from 'platform/utilities/data/omit';
-import set from 'platform/utilities/data/set';
-import unset from 'platform/utilities/data/unset';
+import get from '~/platform/utilities/data/get';
+import omit from '~/platform/utilities/data/omit';
+import set from '~/platform/utilities/data/set';
+import unset from '~/platform/utilities/data/unset';
 
 export default [
   // 0 -> 1, we had a bug where isSpanishHispanicLatino was defaulted in the wrong place
@@ -245,9 +245,10 @@ export default [
   // 7 -> 8, with the addition of the Toxic Exposure questions, we need to ensure all
   // users go through these, so we will send users back to the start of the form
   ({ formData, metadata }) => {
-    const returnUrl = '/veteran-information/personal-information';
-    let newMetadata = metadata;
-    newMetadata = set('returnUrl', returnUrl, newMetadata);
-    return { formData, metadata: newMetadata };
+    /**
+     * This original migration was reverted due to only needing to update the return
+     * URL for a 60-day window while current SIP forms were allowed to expire.
+     */
+    return { formData, metadata };
   },
 ];

--- a/src/applications/hca/tests/unit/config/migrations.unit.spec.js
+++ b/src/applications/hca/tests/unit/config/migrations.unit.spec.js
@@ -329,12 +329,11 @@ describe('hca migrations', () => {
   context('when v8 migration runs', () => {
     const migration = migrations[7];
 
-    it('should update the return URL to the person information URL', () => {
+    it('should include the correct return URL', () => {
       const returnUrl = '/household-information/spouse-contact-information';
-      const desiredUrl = '/veteran-information/personal-information';
       const data = { formData: {}, metadata: { returnUrl } };
       const { metadata } = migration(data);
-      expect(metadata.returnUrl).to.eq(desiredUrl);
+      expect(metadata.returnUrl).to.eq(returnUrl);
     });
   });
 });


### PR DESCRIPTION
## Summary

During a recent rollout of additional questions related to Toxic Exposure, the Health Enrollment team added a migration to the form config to force all users with In-Progress forms back to the beginning of the form, to ensure they were given the opportunity to answer the exposure questions. With the 60-day window passed for in-progress saved forms, we want to nullify that migration to allow users to pick up where they left off. This PR removed the conditionals related to that migration.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#77335

## Testing done

- Updated unit testing to match the empty migration logic

## Acceptance criteria

 - Users can successfully pick up where they left off in the application

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution