### PR TITLE
Check in/81541/remove when no data

### DIFF
--- a/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
@@ -292,19 +292,6 @@ describe('check-in experience', () => {
         });
       });
       describe('All appointments - data exists', () => {
-        it('does not render stopcode if exists', () => {
-          const { getByTestId } = render(
-            <CheckInProvider
-              store={preCheckInStore}
-              router={appointmentTwoRoute}
-            >
-              <AppointmentDetails />
-            </CheckInProvider>,
-          );
-          expect(
-            getByTestId('appointment-details--appointment-value'),
-          ).to.have.text('VA appointment');
-        });
         it('renders doctor name if exists', () => {
           const { getByTestId } = render(
             <CheckInProvider
@@ -329,32 +316,6 @@ describe('check-in experience', () => {
         });
       });
       describe("All appointments - data doesn't exist", () => {
-        it('renders VA appointment when no stopcode', () => {
-          const { getByTestId } = render(
-            <CheckInProvider
-              store={preCheckInStore}
-              router={appointmentOneRoute}
-            >
-              <AppointmentDetails />
-            </CheckInProvider>,
-          );
-          expect(
-            getByTestId('appointment-details--appointment-value'),
-          ).to.have.text('VA appointment');
-        });
-        it('renders generic appointment if stopCodeName is empty string', () => {
-          const { getByTestId } = render(
-            <CheckInProvider
-              store={preCheckInStore}
-              router={appointmentThreeRoute}
-            >
-              <AppointmentDetails />
-            </CheckInProvider>,
-          );
-          expect(
-            getByTestId('appointment-details--appointment-value'),
-          ).to.have.text('VA appointment');
-        });
         it('does not render doctor name if missing', () => {
           const { queryByTestId } = render(
             <CheckInProvider

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -164,12 +164,6 @@ const AppointmentDetails = props => {
                     t('appointment-day', { date: appointmentDay })}
                 </div>
               </div>
-              <div data-testid="appointment-details--what">
-                <h2 className="vads-u-font-size--sm">{t('what')}</h2>
-                <div data-testid="appointment-details--appointment-value">
-                  {t('VA-appointment')}
-                </div>
-              </div>
               {appointment.doctorName && (
                 <div data-testid="appointment-details--provider">
                   <h2 className="vads-u-font-size--sm">{t('provider')}</h2>

--- a/src/applications/check-in/day-of/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
@@ -60,7 +60,6 @@ describe('Check In Experience', () => {
       Appointments.clickDetails(2);
       AppointmentDetails.validatePageLoadedInPerson();
       AppointmentDetails.validateWhen();
-      AppointmentDetails.validateWhat();
       AppointmentDetails.validateProvider();
       AppointmentDetails.validateWhere();
       AppointmentDetails.validateFacilityAddress(true);
@@ -77,7 +76,6 @@ describe('Check In Experience', () => {
       Appointments.clickDetails(2);
       AppointmentDetails.validatePageLoadedInPerson();
       AppointmentDetails.validateWhen();
-      AppointmentDetails.validateWhat();
       AppointmentDetails.validateProvider();
       AppointmentDetails.validateWhere();
       AppointmentDetails.validatePhone();
@@ -91,7 +89,6 @@ describe('Check In Experience', () => {
       Appointments.clickDetails();
       AppointmentDetails.validatePageLoadedInPerson();
       AppointmentDetails.validateWhen();
-      AppointmentDetails.validateWhat();
       AppointmentDetails.validateProvider();
       AppointmentDetails.validateWhere();
       AppointmentDetails.validatePhone();

--- a/src/applications/check-in/pre-check-in/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/appointment-details-display/appointment-details.display.cypress.spec.js
@@ -50,7 +50,6 @@ describe('Pre-Check In Experience', () => {
       AppointmentDetails.validatePageLoadedInPerson();
       AppointmentDetails.validateSubtitleInPerson();
       AppointmentDetails.validateWhen();
-      AppointmentDetails.validateWhat();
       AppointmentDetails.validateProvider();
       AppointmentDetails.validateWhere();
       AppointmentDetails.validateFacilityAddress(true);
@@ -150,7 +149,6 @@ describe('Pre-Check In Experience', () => {
       AppointmentDetails.validatePageLoadedPhone();
       AppointmentDetails.validateSubtitlePhone();
       AppointmentDetails.validateWhen();
-      AppointmentDetails.validateWhat();
       AppointmentDetails.validateProvider();
       AppointmentDetails.validateNeedToMakeChanges();
       AppointmentDetails.validatePhone();

--- a/src/applications/check-in/tests/e2e/pages/AppointmentDetails.js
+++ b/src/applications/check-in/tests/e2e/pages/AppointmentDetails.js
@@ -30,13 +30,6 @@ class AppointmentDetails {
     );
   };
 
-  validateWhat = () => {
-    cy.get('div[data-testid="appointment-details--what"]').should('be.visible');
-    cy.get('div[data-testid="appointment-details--appointment-value"]').should(
-      'be.visible',
-    );
-  };
-
   validateProvider = () => {
     cy.get('div[data-testid="appointment-details--provider"]').should(
       'be.visible',


### PR DESCRIPTION
## Summary

Removes the "What" section from the appointment details page. Including related tests.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#81541

## Testing done

Visual and test updates

## Screenshots

<img src="https://github.com/department-of-veterans-affairs/vets-website/assets/13967174/20d51146-59e9-43d3-9e10-b3af7dc850a4" width="388px" />
<img src="https://github.com/department-of-veterans-affairs/vets-website/assets/13967174/f2f7d626-60f8-422f-8513-9a4766fea6e8" width="388px" />


## What areas of the site does it impact?

day-of and pre-check-in

## Acceptance criteria

 - [ ] there is no "what" section
 - [ ] There is no provider section with the provider name is empty

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
