### PR TITLE
add-ff-for-rx-breadcrumbs

### DIFF
--- a/src/applications/mhv/medications/mocks/api/feature-toggles/index.js
+++ b/src/applications/mhv/medications/mocks/api/feature-toggles/index.js
@@ -4,6 +4,7 @@ const generateFeatureToggles = (toggles = {}) => {
     mhvLandingPagePersonalization = true,
     mhvMedicationsToVaGovRelease = true,
     mhvMedicationsDisplayRefillContent = true,
+    mhvMedicationsBreadcrumbs = true,
   } = toggles;
 
   return {
@@ -25,6 +26,10 @@ const generateFeatureToggles = (toggles = {}) => {
         {
           name: 'mhv_medications_display_refill_content',
           value: mhvMedicationsDisplayRefillContent,
+        },
+        {
+          name: 'mhv_medications_breadcrumbs',
+          value: mhvMedicationsBreadcrumbs,
         },
       ],
     },

--- a/src/applications/mhv/medications/mocks/api/index.js
+++ b/src/applications/mhv/medications/mocks/api/index.js
@@ -20,6 +20,7 @@ const responses = {
   'GET /v0/user': user.defaultUser,
   'GET /v0/feature_toggles': featureToggles.generateFeatureToggles({
     mhvMedicationsToVaGovRelease: true,
+    mhvMedicationsDisplayRefillContent: true,
     mhvMedicationsBreadcrumbs: true,
   }),
   // VAMC facility data that apps query for on startup

--- a/src/applications/mhv/medications/mocks/api/index.js
+++ b/src/applications/mhv/medications/mocks/api/index.js
@@ -20,7 +20,7 @@ const responses = {
   'GET /v0/user': user.defaultUser,
   'GET /v0/feature_toggles': featureToggles.generateFeatureToggles({
     mhvMedicationsToVaGovRelease: true,
-    mhvMedicationsDisplayRefillContent: true,
+    mhvMedicationsBreadcrumbs: true,
   }),
   // VAMC facility data that apps query for on startup
   'GET /data/cms/vamc-ehr.json': vamcEhr,

--- a/src/applications/mhv/medications/util/selectors.js
+++ b/src/applications/mhv/medications/util/selectors.js
@@ -2,3 +2,6 @@ import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNa
 
 export const selectRefillContentFlag = state =>
   state.featureToggles[FEATURE_FLAG_NAMES.mhvMedicationsDisplayRefillContent];
+
+export const selectBreadcrumbFlag = state =>
+  state.featureToggles[FEATURE_FLAG_NAMES.mhvMedicationsBreadcrumbs];

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -119,6 +119,7 @@
   "mhvMedicalRecordsDisplayVitals": "mhv_medical_records_display_vitals",
   "mhvMedicalRecordsToVaGovRelease": "mhv_medical_records_to_va_gov_release",
   "mhvMedicationsToVaGovRelease": "mhv_medications_to_va_gov_release",
+  "mhvMedicationsBreadcrumbs": "mhv_medications_breadcrumbs",
   "mhvMedicationsDisplayRefillContent": "mhv_medications_display_refill_content",
   "myVaEnableNotificationComponent": "my_va_notification_component",
   "myVaUseExperimental": "my_va_experimental",


### PR DESCRIPTION
## Summary

Added feature flag to toggle future rx breadcrumbs updates

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-57271
Changes made for this ticket will require hiding behind a FF until all testing and validation is complete.

## Testing done

- Ran unit tests
- Tested locally

## Screenshots

None

## What areas of the site does it impact?

MHV Medications app

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
