### PR TITLE
fix: update heading text

### DIFF
--- a/src/applications/personalization/profile/tests/e2e/contact-information/modals.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/contact-information/modals.cypress.spec.js
@@ -76,7 +76,7 @@ const checkModals = options => {
 
   cy.findByTestId('confirm-cancel-modal')
     .shadow()
-    .findByText('Are you sure?')
+    .findByText('Cancel changes?')
     .should('exist');
 
   cy.findByTestId('confirm-cancel-modal')

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/legacy/update-flow.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/legacy/update-flow.cypress.spec.js
@@ -149,12 +149,12 @@ describe('Direct Deposit', () => {
       fillInBankInfoForm('CNP');
       exitBankInfoForm('CNP');
       cy.get('va-modal').should('exist');
-      cy.get('va-modal').contains(/are you sure/i);
+      cy.get('va-modal').contains(/cancel changes/i);
       cy.get('va-modal').contains(
         /disability compensation and pension direct deposit information/i,
       );
       cy.get('va-modal')
-        .contains(/cancel/i)
+        .contains(/cancel my changes/i)
         .click();
       cy.get('va-modal').should('not.exist');
       cy.findByRole('button', {
@@ -178,7 +178,9 @@ describe('Direct Deposit', () => {
       fillInBankInfoForm('CNP');
       exitBankInfoForm('CNP');
       cy.get('va-modal').should('exist');
-      cy.get('va-modal').contains(/are you sure/i);
+      cy.get('va-modal')
+        .shadow()
+        .contains(/cancel changes/i);
       cy.get('va-modal').contains(
         /disability compensation and pension direct deposit information/i,
       );
@@ -248,10 +250,10 @@ describe('Direct Deposit', () => {
       fillInBankInfoForm('EDU');
       exitBankInfoForm('EDU');
       cy.get('va-modal').should('exist');
-      cy.get('va-modal').contains(/are you sure/i);
+      cy.get('va-modal').contains(/cancel changes/i);
       cy.get('va-modal').contains(/education direct deposit information/i);
       cy.get('va-modal')
-        .contains(/cancel/i)
+        .contains(/cancel my changes/i)
         .click();
       cy.get('va-modal').should('not.exist');
       cy.findByRole('button', {
@@ -273,7 +275,7 @@ describe('Direct Deposit', () => {
       fillInBankInfoForm('EDU');
       exitBankInfoForm('EDU');
       cy.get('va-modal').should('exist');
-      cy.get('va-modal').contains(/are you sure/i);
+      cy.get('va-modal').contains(/cancel changes/i);
       cy.get('va-modal').contains(/education direct deposit information/i);
       cy.get('va-modal')
         .contains(/back to editing/i)

--- a/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmCancelModal.jsx
+++ b/src/platform/user/profile/vap-svc/components/ContactInformationFieldInfo/ConfirmCancelModal.jsx
@@ -21,7 +21,7 @@ const ConfirmCancelModal = props => {
 
   return (
     <VaModal
-      modalTitle="Are you sure?"
+      modalTitle="Cancel changes?"
       status="warning"
       visible={isVisible}
       onCloseEvent={onHide}


### PR DESCRIPTION
## Summary

- Updates the heading of the cancel changes modal based on content recommendation.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/80994

## Testing done

- Just a content change, tested locally.
- Updated a couple e2e tests for this change

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Modal  | ![Screenshot 2024-05-06 at 12 00 33 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/63f84005-6eeb-4cdd-bcdf-9d104cd85fea) | ![Screenshot 2024-05-06 at 12 00 02 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/555e95f3-4db8-4cd7-a1da-98be00cc85ad) |


## What areas of the site does it impact?

Profile

## Acceptance criteria

- Heading updated in the cancel changes modal

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed