### PR TITLE
[CST] - Update page focus on the claim letter page

### DIFF
--- a/src/applications/claims-status/containers/YourClaimLetters/index.jsx
+++ b/src/applications/claims-status/containers/YourClaimLetters/index.jsx
@@ -67,14 +67,9 @@ export const YourClaimLetters = ({ isLoading, showClaimLetters }) => {
     setDocumentTitle('Your VA Claim Letters');
   }, []);
 
-  useEffect(
-    () => {
-      if (!lettersLoading) {
-        setPageFocus();
-      }
-    },
-    [lettersLoading],
-  );
+  useEffect(() => {
+    setPageFocus();
+  });
 
   /**
    * This commented code was deemed likely to be needed.


### PR DESCRIPTION
## Summary

- Updated the page focus to occur regardless of if the page was loading - Julie had noticed that when the page contents took a while to load, the claim letter page would sometimes open initially on the footer section and then focus would occur after the page contents loaded which created a weird experience. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#81241

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## What areas of the site does it impact?
Claim Status Tool

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
