### PR TITLE
MHV-58023: Download success message removed from print view

### DIFF
--- a/src/applications/mhv-medical-records/components/shared/DownloadSuccessAlert.jsx
+++ b/src/applications/mhv-medical-records/components/shared/DownloadSuccessAlert.jsx
@@ -18,7 +18,7 @@ const DownloadSuccessAlert = props => {
     <VaAlert
       status={ALERT_TYPE_SUCCESS}
       visible
-      class={`vads-u-margin-top--4 ${className}`}
+      class={`vads-u-margin-top--4 no-print ${className}`}
       aria-live="polite"
     >
       <h2 slot="headline" data-testid="download-success-alert-message">


### PR DESCRIPTION
## Summary
The pdf/txt download success message has been removed from print views. 

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-58023

> ### Remove the download success alert when it stays on the screen during printing
> 
> The download success alert stays on the screen when you go to print the page as well from the print/download button, and then it appears on the print view. Potential solution: Remove the download success alert when the print action is taken from the print/download button so that it does not appear on the print view. Is there a better way to fix that? Should we make a ticket for this? I'm not sure the LOE this would require!

## Testing done
Manual testing done locally

## Screenshots
<img width="601" alt="Screenshot 2024-05-06 at 4 15 15 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/2a96da2c-45dd-47fc-92c1-bf4221931a8f">
<img width="603" alt="Screenshot 2024-05-06 at 4 15 32 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/107576133/5a48c330-87a1-46c7-94ba-cbf0e35ec6bd">

## What areas of the site does it impact?
MHV medical records - all record list/detail pages with a print/download button. 

## Acceptance criteria
Download success no longer appears in print view. 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
