### PR TITLE
Rep Status widget styling

### DIFF
--- a/src/applications/representative-search/containers/SearchPage.jsx
+++ b/src/applications/representative-search/containers/SearchPage.jsx
@@ -299,9 +299,7 @@ const SearchPage = props => {
   // jump to results
   useEffect(
     () => {
-      if (isPostLogin) {
-        focusElement('.representative-status-widget');
-      } else if (isDisplayingResults) {
+      if (isDisplayingResults) {
         window.scrollTo(0, 600);
         focusElement('#search-results-subheader');
       }
@@ -368,10 +366,7 @@ const SearchPage = props => {
               If you appoint a new accredited representative, they will replace
               your current one.
             </p>
-            <div
-              className="representative-status-widget"
-              data-widget-type="representative-status"
-            />
+            <div data-widget-type="representative-status" />
           </>
         )}
 

--- a/src/applications/static-pages/representative-status/components/App/index.jsx
+++ b/src/applications/static-pages/representative-status/components/App/index.jsx
@@ -39,13 +39,18 @@ export const App = ({
   return (
     <>
       {loggedIn ? (
-        <>
+        <div
+          aria-live="polite"
+          aria-atomic
+          tabIndex="-1"
+          className="poa-display"
+        >
           <Auth
             DynamicHeader={DynamicHeader}
             DynamicSubheader={DynamicSubheader}
             useRepresentativeStatus={useRepresentativeStatus}
           />
-        </>
+        </div>
       ) : (
         <>
           <Unauth

--- a/src/applications/static-pages/representative-status/components/States/Auth.jsx
+++ b/src/applications/static-pages/representative-status/components/States/Auth.jsx
@@ -110,7 +110,7 @@ export const Auth = ({
                 {poaType === 'representative' &&
                   email && (
                     <div className="vads-u-display--flex vads-u-margin-top--1p5">
-                      <div className="vads-u-margin-right--1 vads-u-align-items--flex-start vads-u-margin-top--0p5">
+                      <div className="vads-u-margin-right--1 vads-u-display--flex vads-u-align-items--flex-start vads-u-margin-top--0p5">
                         <va-icon
                           icon="mail"
                           size={2}
@@ -122,7 +122,7 @@ export const Auth = ({
                   )}
                 {contact && (
                   <div className="vads-u-display--flex vads-u-margin-top--1p5">
-                    <div className="vads-u-margin-right--1 vads-u-align-items--flex-start vads-u-margin-top--0p5">
+                    <div className="vads-u-margin-right--1 vads-u-display--flex vads-u-align-items--flex-start vads-u-margin-top--0p5">
                       <va-icon
                         icon="phone"
                         size={2}
@@ -139,7 +139,7 @@ export const Auth = ({
                 {poaType === 'representative' &&
                   (contact || email) && (
                     <div className="vads-u-display--flex vads-u-margin-top--1p5">
-                      <div className="vads-u-margin-right--1 vads-u-align-items--flex-start vads-u-margin-top--0p5">
+                      <div className="vads-u-margin-right--1 vads-u-display--flex vads-u-align-items--flex-start vads-u-margin-top--0p5">
                         <va-icon
                           icon="file_download"
                           size={2}
@@ -155,7 +155,7 @@ export const Auth = ({
                     </div>
                   )}
                 <div className="vads-u-display--flex vads-u-margin-top--1p5">
-                  <div className="vads-u-margin-right--1 vads-u-align-items--flex-start vads-u-margin-top--0p5">
+                  <div className="vads-u-margin-right--1 vads-u-display--flex vads-u-align-items--flex-start vads-u-margin-top--0p5">
                     <va-icon
                       icon="search"
                       size={2}

--- a/src/applications/static-pages/representative-status/components/States/Auth.jsx
+++ b/src/applications/static-pages/representative-status/components/States/Auth.jsx
@@ -67,7 +67,7 @@ export const Auth = ({
               <div className="auth-rep-body">
                 {concatAddress && (
                   <div className="vads-u-display--flex vads-u-margin-top--1p5">
-                    <div className="vads-u-display--flex vads-u-align-items--flex-start vads-u-margin-right--1">
+                    <div className="vads-u-display--flex vads-u-align-items--flex-start vads-u-margin-top--0p5 vads-u-margin-right--1">
                       <va-icon
                         icon="location_on"
                         size={2}
@@ -98,7 +98,7 @@ export const Auth = ({
                 {poaType === 'representative' &&
                   email && (
                     <div className="vads-u-display--flex vads-u-margin-top--1p5">
-                      <div className="vads-u-margin-right--1">
+                      <div className="vads-u-margin-right--1 vads-u-align-items--flex-start vads-u-margin-top--0p5">
                         <va-icon
                           icon="mail"
                           size={2}
@@ -110,7 +110,7 @@ export const Auth = ({
                   )}
                 {contact && (
                   <div className="vads-u-display--flex vads-u-margin-top--1p5">
-                    <div className="vads-u-margin-right--1">
+                    <div className="vads-u-margin-right--1 vads-u-align-items--flex-start vads-u-margin-top--0p5">
                       <va-icon
                         icon="phone"
                         size={2}
@@ -127,7 +127,7 @@ export const Auth = ({
                 {poaType === 'representative' &&
                   (contact || email) && (
                     <div className="vads-u-display--flex vads-u-margin-top--1p5">
-                      <div className="vads-u-margin-right--1">
+                      <div className="vads-u-margin-right--1 vads-u-align-items--flex-start vads-u-margin-top--0p5">
                         <va-icon
                           icon="file_download"
                           size={2}
@@ -143,7 +143,7 @@ export const Auth = ({
                     </div>
                   )}
                 <div className="vads-u-display--flex vads-u-margin-top--1p5">
-                  <div className="vads-u-margin-right--1">
+                  <div className="vads-u-margin-right--1 vads-u-align-items--flex-start vads-u-margin-top--0p5">
                     <va-icon
                       icon="search"
                       size={2}

--- a/src/applications/static-pages/representative-status/components/States/Auth.jsx
+++ b/src/applications/static-pages/representative-status/components/States/Auth.jsx
@@ -66,8 +66,8 @@ export const Auth = ({
 
               <div className="auth-rep-body">
                 {concatAddress && (
-                  <div className="contact-info vads-u-margin-top--1p5">
-                    <div className="contact-icon">
+                  <div className="vads-u-display--flex vads-u-margin-top--1p5">
+                    <div className="vads-u-display--flex vads-u-align-items--flex-start vads-u-margin-right--1">
                       <va-icon
                         icon="location_on"
                         size={2}
@@ -97,8 +97,8 @@ export const Auth = ({
                 )}
                 {poaType === 'representative' &&
                   email && (
-                    <div className="contact-info vads-u-margin-top--1p5">
-                      <div className="contact-icon">
+                    <div className="vads-u-display--flex vads-u-margin-top--1p5">
+                      <div className="vads-u-margin-right--1">
                         <va-icon
                           icon="mail"
                           size={2}
@@ -109,8 +109,8 @@ export const Auth = ({
                     </div>
                   )}
                 {contact && (
-                  <div className="contact-info vads-u-margin-top--1p5">
-                    <div className="contact-icon">
+                  <div className="vads-u-display--flex vads-u-margin-top--1p5">
+                    <div className="vads-u-margin-right--1">
                       <va-icon
                         icon="phone"
                         size={2}
@@ -126,8 +126,8 @@ export const Auth = ({
                 )}
                 {poaType === 'representative' &&
                   (contact || email) && (
-                    <div className="contact-info vads-u-margin-top--1p5">
-                      <div className="contact-icon">
+                    <div className="vads-u-display--flex vads-u-margin-top--1p5">
+                      <div className="vads-u-margin-right--1">
                         <va-icon
                           icon="file_download"
                           size={2}
@@ -142,8 +142,8 @@ export const Auth = ({
                       />
                     </div>
                   )}
-                <div className="contact-info vads-u-margin-top--1p5">
-                  <div className="contact-icon">
+                <div className="vads-u-display--flex vads-u-margin-top--1p5">
+                  <div className="vads-u-margin-right--1">
                     <va-icon
                       icon="search"
                       size={2}

--- a/src/applications/static-pages/representative-status/components/States/Auth.jsx
+++ b/src/applications/static-pages/representative-status/components/States/Auth.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 export const Auth = ({
   DynamicHeader,
@@ -25,14 +26,25 @@ export const Auth = ({
     vcfUrl,
   } = representative ?? {};
 
+  const isPostLogin = document.location.search?.includes('postLogin=true');
+
+  useEffect(
+    () => {
+      if (isPostLogin) {
+        focusElement('.poa-display');
+      }
+    },
+    [id, isPostLogin],
+  );
+
   if (isLoading) {
     return (
-      <div>
+      <va-card show-shadow>
         <va-loading-indicator
           label="Loading"
           message="Loading your accredited representative information..."
         />
-      </div>
+      </va-card>
     );
   }
 

--- a/src/applications/static-pages/representative-status/stylesheet.scss
+++ b/src/applications/static-pages/representative-status/stylesheet.scss
@@ -47,13 +47,5 @@
         margin-bottom: 4px;
       }
     }
-
-    .contact-info {
-      display: flex;
-
-      .contact-icon {
-        margin: 5px 8px 0 0;
-      }
-    }
   }
 }

--- a/src/applications/static-pages/representative-status/utilities/formatContactInfo.js
+++ b/src/applications/static-pages/representative-status/utilities/formatContactInfo.js
@@ -39,9 +39,7 @@ export function formatContactInfo(poaAttributes) {
     'END:VCARD',
   ].join('\n');
 
-  const vCard = `data:text/vcard;charset=utf-8,${encodeURIComponent(vcfData)}`;
-
-  const blob = new Blob([vCard], { type: 'text/vcard' });
+  const blob = new Blob([vcfData], { type: 'text/vcard' });
   const vcfUrl = URL.createObjectURL(blob);
 
   return {


### PR DESCRIPTION
## Summary

- Replaced custom classes with vads classes. 
- Moved focus logic of the rep status widget to the widget itself 
- Fixed improperly formatted vcf file on download link

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82515
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82126
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81870

## Screenshots
<img width="831" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/143013011/4e0594bf-880f-4d6d-8d25-9f8a9643a75c">


### Error Handling

- [x] Browser console contains no warnings or errors.

