### PR TITLE
EZR: Reject whitespace on required text fields

### DIFF
--- a/src/applications/ezr/config/chapters/insuranceInformation/policyInformation.js
+++ b/src/applications/ezr/config/chapters/insuranceInformation/policyInformation.js
@@ -30,10 +30,16 @@ export default {
     insuranceName: {
       'ui:title': content['insurance-provider-name-label'],
       'ui:webComponentField': VaTextInputField,
+      'ui:errorMessages': {
+        pattern: 'Enter the insurance provider name',
+      },
     },
     insurancePolicyHolderName: {
       'ui:title': content['insurance-policyholder-name-label'],
       'ui:webComponentField': VaTextInputField,
+      'ui:errorMessages': {
+        pattern: 'Enter the policyholder\u2019s name',
+      },
     },
     'view:policyOrGroup': {
       'ui:title': PolicyOrGroupDescription,
@@ -45,6 +51,9 @@ export default {
         'ui:options': {
           hint: content['insurance-policy-number-hint-text'],
         },
+        'ui:errorMessages': {
+          pattern: 'Enter a valid policy number',
+        },
       },
       'view:or': {
         ...descriptionUI(InsurancePolicyOrDescription),
@@ -54,6 +63,9 @@ export default {
         'ui:webComponentField': VaTextInputField,
         'ui:options': {
           hint: content['insurance-group-code-hint-text'],
+        },
+        'ui:errorMessages': {
+          pattern: 'Enter a valid group code',
         },
       },
     },


### PR DESCRIPTION
## Summary

Form 10-10 EZR: Rejects whitespace only values in required text fields.

Fields updated:
- insurance name
- insurance policy number
- insurance policy holder name
- insurance group code
- zip code
- medicare claim number

## Related issue(s)

department-of-veterans-affairs/va.gov-team#78895

[vets-json-schema](https://github.com/department-of-veterans-affairs/vets-json-schema/pull/893)

## Testing done

Updated tests in vets-json-schema

## What areas of the site does it impact?

Form 10-10 EZR

## Acceptance criteria

- Required text inputs reject whitespace only values

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
