### PR TITLE
VACMS-16964 VAMC Locations web components

### DIFF
--- a/src/applications/static-pages/facilities/FacilityApiAlert.jsx
+++ b/src/applications/static-pages/facilities/FacilityApiAlert.jsx
@@ -7,7 +7,7 @@ const FacilityApiAlert = () => (
       <p>
         Our location finder isn’t working right now. We’re sorry about that.
         Please check back a bit later. Or, if you need location details right
-        away, you can try searching for
+        away, you can try searching for&nbsp;&nbsp;
         <a
           href="https://www.google.com/maps/search/?api=1&query=VA+locations+near+me"
           target="_blank"

--- a/src/applications/static-pages/facilities/OtherFacilityListWidget.jsx
+++ b/src/applications/static-pages/facilities/OtherFacilityListWidget.jsx
@@ -51,9 +51,10 @@ export default class OtherFacilityListWidget extends React.Component {
         >
           <section key={facility.id} className="usa-width-one-half">
             <h3 className="vads-u-margin-bottom--1 vads-u-font-size--md medium-screen:vads-u-font-size--lg">
-              <a href={`/find-locations/facility/${facility.id}`}>
-                {facility.attributes.name}
-              </a>
+              <va-link
+                href={`/find-locations/facility/${facility.id}`}
+                text={facility.attributes.name}
+              />
             </h3>
             <FacilityAddress facility={facility} />
             <div className="vads-u-margin-bottom--0">

--- a/src/applications/static-pages/facilities/tests/OtherFacilityListWidget.unit.spec.jsx
+++ b/src/applications/static-pages/facilities/tests/OtherFacilityListWidget.unit.spec.jsx
@@ -29,11 +29,6 @@ describe('facilities <OtherFacilityListWidget>', () => {
       tree.update();
       expect(tree.find('va-loading-indicator').exists()).to.be.false;
 
-      const facilityName = tree.find('h3');
-      expect(facilityName.text()).to.contain(
-        'Pittsburgh VA Medical Center-University Drive',
-      );
-
       const facilityAddressComponent = tree.find('FacilityAddress').dive();
       const address = facilityAddressComponent.find('address');
       expect(address.text()).to.contain(


### PR DESCRIPTION
## Summary
Convert facilities names to `<va-link>` in the `Other nearby VA locations` section of the Locations page.

Also adds a space to the alert at the bottom of the page that shows when the service fails. We needed a space before the link.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/16964

## Testing done
Tested `/huntington-health-care/locations/` locally. **This is only for the `Other nearby VA locations` section**

## Screenshots

### va-link
<img width="1262" alt="Screenshot 2024-05-07 at 12 39 29 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/16901db8-774c-41f0-9fbe-4704078ae5c4">


### Bug fix - space between text and link

#### Before
<img width="500" alt="Screenshot 2024-05-07 at 12 42 27 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/3259cd2d-bde6-46ff-a5eb-3ed204bf0d50">

#### After
<img width="500" alt="Screenshot 2024-05-07 at 12 43 40 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/5ed0d410-fedc-4b52-a441-12c62b867e7d">