### PR TITLE
Form upload entry and blank app

### DIFF
--- a/src/applications/simple-forms/form-upload/containers/FormUploadApp.jsx
+++ b/src/applications/simple-forms/form-upload/containers/FormUploadApp.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Outlet } from 'react-router-dom-v5-compat';
+import PropTypes from 'prop-types';
+
+import { RequiredLoginView } from '@department-of-veterans-affairs/platform-user/RequiredLoginView';
+
+function FormUploadApp({ user }) {
+  return (
+    <RequiredLoginView user={user} serviceRequired={[]}>
+      <Outlet />
+    </RequiredLoginView>
+  );
+}
+
+FormUploadApp.propTypes = {
+  user: PropTypes.object,
+};
+
+function mapStateToProps(state) {
+  return {
+    user: state.user,
+  };
+}
+
+export default connect(mapStateToProps)(FormUploadApp);
+
+export { FormUploadApp };

--- a/src/applications/simple-forms/form-upload/form-upload-entry.jsx
+++ b/src/applications/simple-forms/form-upload/form-upload-entry.jsx
@@ -1,0 +1,16 @@
+import '@department-of-veterans-affairs/platform-polyfills';
+import startApp from '@department-of-veterans-affairs/platform-startup/router';
+
+// TODO: Uncomment when we have an scss file.
+// import './sass/form-upload.scss';
+
+import routes from './routes';
+// TODO: Uncomment when we have reducers.
+// import reducer from './reducers';
+import manifest from './manifest.json';
+
+startApp({
+  url: manifest.rootUrl,
+  // reducer,
+  routes,
+});

--- a/src/applications/simple-forms/form-upload/manifest.json
+++ b/src/applications/simple-forms/form-upload/manifest.json
@@ -1,0 +1,7 @@
+{
+  "appName": "Form Upload",
+  "entryFile": "./form-upload-entry.jsx",
+  "entryName": "form-upload-flow",
+  "rootUrl": "/form-upload",
+  "productId": "88558f52-5c6c-447f-ab78-e006b01a32db"
+}

--- a/src/applications/simple-forms/form-upload/routes.jsx
+++ b/src/applications/simple-forms/form-upload/routes.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Route, Routes } from 'react-router-dom-v5-compat';
+
+import FormUploadApp from './containers/FormUploadApp';
+// TODO: Uncomment as we implement.
+// import UploadPage from './containers/UploadPage';
+// import ReviewPage from './containers/ReviewPage';
+// import SubmitPage from './containers/SubmitPage';
+// import ConfirmationPage from './containers/ConfirmationPage';
+
+const routes = (
+  <Routes>
+    <Route path="/:id" element={<FormUploadApp />}>
+      {/* <Route index element={<Navigate to="upload" replace />} />
+      <Route path="upload" element={<UploadPage />} />
+      <Route path="review" element={<ReviewPage />} />
+      <Route path="submit" element={<SubmitPage />} />
+      <Route path="confirmation" element={<ConfirmationPage />} /> */}
+    </Route>
+  </Routes>
+);
+
+export default routes;


### PR DESCRIPTION
## Summary
This PR adds a blank app for the Form Upload app. It's a small piece of another draft PR: https://github.com/department-of-veterans-affairs/vets-website/pull/29569

Note that this app will be accessible from the front end when this merges and is deployed but we figure that since nothing links to it, it will be ok to deploy. Happy to reconsider this decision if anyone thinks that's not how we should handle it.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1257
