### PR TITLE
Migrate some 21-526EZ radio buttons to v3 patterns

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/evidenceTypesBDD.jsx
+++ b/src/applications/disability-benefits/all-claims/content/evidenceTypesBDD.jsx
@@ -1,16 +1,5 @@
 import React from 'react';
 
-export const HasEvidenceLabel = () => {
-  const content =
-    'Do you want to upload any other documents or evidence at this time?';
-
-  return (
-    <>
-      {content} <span className="schemaform-required-span">(*Required)</span>
-    </>
-  );
-};
-
 export const evidenceTypeTitle = (
   <h3 className="vads-u-font-size--h4">
     What type of evidence do you want to submit as part of your claim?

--- a/src/applications/disability-benefits/all-claims/pages/evidenceTypesBDD.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceTypesBDD.js
@@ -1,6 +1,10 @@
 import { validateBooleanGroup } from '@department-of-veterans-affairs/platform-forms-system/validation';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import _ from 'platform/utilities/data';
+import {
+  yesNoUI,
+  yesNoSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
 import get from '@department-of-veterans-affairs/platform-forms-system/get';
 import { validateIfHasEvidence } from '../validations';
 
@@ -9,29 +13,20 @@ import {
   privateMedicalRecords,
   evidenceTypeError,
   evidenceTypeHelp,
-  HasEvidenceLabel,
   bddShaOtherEvidence,
 } from '../content/evidenceTypesBDD';
 
 import { BddEvidenceSubmitLater } from '../content/bddEvidenceSubmitLater';
 
 export const uiSchema = {
-  'view:hasEvidence': {
-    'ui:title': ' ',
-    'ui:description': HasEvidenceLabel,
-    'ui:widget': 'yesNo',
-    'ui:options': {
-      labels: {
-        Y: 'Yes',
-        N: 'No, I will submit more information later',
-      },
-      widgetProps: {
-        N: {
-          'aria-describedby': 'submit-evidence-later',
-        },
-      },
+  'view:hasEvidence': yesNoUI({
+    title:
+      'Do you want to upload any other documents or evidence at this time?',
+    labels: {
+      Y: 'Yes',
+      N: 'No, I will submit more information later',
     },
-  },
+  }),
   'view:hasEvidenceFollowUp': {
     'ui:options': {
       expandUnder: 'view:hasEvidence',
@@ -79,10 +74,7 @@ export const schema = {
   type: 'object',
   required: ['view:hasEvidence'],
   properties: {
-    'view:hasEvidence': {
-      type: 'boolean',
-      default: true,
-    },
+    'view:hasEvidence': yesNoSchema,
     'view:hasEvidenceFollowUp': {
       type: 'object',
       properties: {

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -1,5 +1,9 @@
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
+  yesNoUI,
+  yesNoSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import {
   privateRecordsChoiceHelp,
   patientAcknowledgmentTitle,
   patientAcknowledgmentText,
@@ -15,22 +19,13 @@ export const uiSchema = {
       authorize their release.`,
   },
   'view:uploadPrivateRecordsQualifier': {
-    'view:hasPrivateRecordsToUpload': {
-      'ui:title': 'Do you want to upload your private medical records?',
-      'ui:widget': 'yesNo',
-      'ui:options': {
-        labels: {
-          Y: 'Yes',
-          N: 'No, please get my records from my doctor.',
-        },
-        widgetProps: {
-          N: {
-            'aria-describedby':
-              'root_view:patientAcknowledgement_view:acknowledgement',
-          },
-        },
+    'view:hasPrivateRecordsToUpload': yesNoUI({
+      title: 'Do you want to upload your private medical records?',
+      labels: {
+        Y: 'Yes',
+        N: 'No, please get my records from my doctor.',
       },
-    },
+    }),
     'view:privateRecordsChoiceHelp': {
       'ui:description': privateRecordsChoiceHelp,
     },
@@ -79,9 +74,7 @@ export const schema = {
           type: 'object',
           properties: {},
         },
-        'view:hasPrivateRecordsToUpload': {
-          type: 'boolean',
-        },
+        'view:hasPrivateRecordsToUpload': yesNoSchema,
         'view:privateRecordsChoiceHelp': {
           type: 'object',
           properties: {},

--- a/src/applications/disability-benefits/all-claims/pages/serviceTreatmentRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/serviceTreatmentRecords.js
@@ -1,25 +1,20 @@
 import _ from 'platform/utilities/data';
-
+import {
+  yesNoUI,
+  yesNoSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
 import { serviceTreatmentRecordsSubmitLater } from '../content/serviceTreatmentRecords';
 
 export const uiSchema = {
   'view:uploadServiceTreatmentRecordsQualifier': {
-    'view:hasServiceTreatmentRecordsToUpload': {
-      'ui:title': `Do you want to upload your service treatment records? (You’ll
+    'view:hasServiceTreatmentRecordsToUpload': yesNoUI({
+      title: `Do you want to upload your service treatment records? (You’ll
         have a chance to upload your medical records later in the application.)`,
-      'ui:widget': 'yesNo',
-      'ui:options': {
-        labels: {
-          Y: 'Yes',
-          N: 'No, I will submit them later.',
-        },
-        widgetProps: {
-          N: {
-            'aria-describedby': 'submit-str-asap',
-          },
-        },
+      labels: {
+        Y: 'Yes',
+        N: 'No, I will submit them later.',
       },
-    },
+    }),
   },
   'view:serviceTreatmentRecordsSubmitLater': {
     'ui:title': '',
@@ -42,9 +37,7 @@ export const schema = {
       required: ['view:hasServiceTreatmentRecordsToUpload'],
       type: 'object',
       properties: {
-        'view:hasServiceTreatmentRecordsToUpload': {
-          type: 'boolean',
-        },
+        'view:hasServiceTreatmentRecordsToUpload': yesNoSchema,
       },
     },
     'view:serviceTreatmentRecordsSubmitLater': {

--- a/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecords.unit.spec.jsx
@@ -1,19 +1,22 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { mount } from 'enzyme';
-
+import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
+import {
+  $,
+  $$,
+} from '@department-of-veterans-affairs/platform-forms-system/ui';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('526 All Claims Private medical records', () => {
-  const errorClass = '.usa-input-error-message';
   const page =
     formConfig.chapters.supportingEvidence.pages.privateMedicalRecords;
   const { schema, uiSchema } = page;
 
   it('should render', () => {
-    const form = mount(
+    render(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
         schema={schema}
@@ -23,13 +26,31 @@ describe('526 All Claims Private medical records', () => {
       />,
     );
 
-    expect(form.find('input').length).to.equal(2);
-    form.unmount();
+    expect($$('va-radio-option').length).to.equal(2);
+  });
+
+  it('should error when user makes no selection', () => {
+    const onSubmit = sinon.spy();
+    const { getByText } = render(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const submitButton = getByText('Submit');
+    userEvent.click(submitButton);
+    expect(onSubmit.calledOnce).to.be.false;
+    expect($('va-radio').error).to.eq('Please provide a response');
   });
 
   it('should submit when user selects "yes" to upload', () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { getByText } = render(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
         schema={schema}
@@ -44,16 +65,16 @@ describe('526 All Claims Private medical records', () => {
       />,
     );
 
-    form.find('form').simulate('submit');
+    const submitButton = getByText('Submit');
+    userEvent.click(submitButton);
     expect(onSubmit.calledOnce).to.be.true;
-    expect(form.find(errorClass).length).to.equal(0);
-    form.unmount();
+    expect($('va-radio').error).to.be.null;
   });
 
   // TODO: This will change once 4142 is integrated
   it('should submit when user selects "no" to upload', () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { getByText } = render(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
         schema={schema}
@@ -68,9 +89,9 @@ describe('526 All Claims Private medical records', () => {
       />,
     );
 
-    form.find('form').simulate('submit');
+    const submitButton = getByText('Submit');
+    userEvent.click(submitButton);
     expect(onSubmit.calledOnce).to.be.true;
-    expect(form.find(errorClass).length).to.equal(0);
-    form.unmount();
+    expect($('va-radio').error).to.be.null;
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/serviceTreatmentRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/serviceTreatmentRecords.unit.spec.jsx
@@ -1,20 +1,23 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
-
+import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
+import {
+  $,
+  $$,
+} from '@department-of-veterans-affairs/platform-forms-system/ui';
 import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('serviceTreatmentRecords', () => {
-  const errorClass = '.usa-input-error-message';
   const {
     uiSchema,
     schema,
   } = formConfig.chapters.supportingEvidence.pages.serviceTreatmentRecords;
 
   it('should render', () => {
-    const form = mount(
+    render(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
         uiSchema={uiSchema}
@@ -24,13 +27,12 @@ describe('serviceTreatmentRecords', () => {
       />,
     );
 
-    expect(form.find('input').length).to.equal(2);
-    form.unmount();
+    expect($$('va-radio-option').length).to.equal(2);
   });
 
   it('should submit when "yes" option selected', () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { getByText } = render(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
         uiSchema={uiSchema}
@@ -45,15 +47,15 @@ describe('serviceTreatmentRecords', () => {
       />,
     );
 
-    form.find('form').simulate('submit');
+    const submitButton = getByText('Submit');
+    userEvent.click(submitButton);
     expect(onSubmit.calledOnce).to.be.true;
-    expect(form.find(errorClass).length).to.equal(0);
-    form.unmount();
+    expect($('va-radio').error).to.be.null;
   });
 
   it('should submit when user selects "no" to upload', () => {
     const onSubmit = sinon.spy();
-    const form = mount(
+    const { getByText } = render(
       <DefinitionTester
         definitions={formConfig.defaultDefinitions}
         uiSchema={uiSchema}
@@ -68,14 +70,9 @@ describe('serviceTreatmentRecords', () => {
       />,
     );
 
-    form.find('form').simulate('submit');
+    const submitButton = getByText('Submit');
+    userEvent.click(submitButton);
+    expect($('va-radio').error).to.be.null;
     expect(onSubmit.calledOnce).to.be.true;
-    expect(form.find(errorClass).length).to.equal(0);
-    const noRadioId = form.find('input[value="N"]').props()['aria-describedby'];
-    const alertId = form.find('.service-treatment-records-submit-later').props()
-      .id;
-    expect(noRadioId).to.not.be.undefined;
-    expect(noRadioId).to.eq(alertId);
-    form.unmount();
   });
 });


### PR DESCRIPTION

## Summary

- Migrates a portion of radio buttons in 21-526EZ to use v3 patterns.
- `aria-describedby` values had to be removed because they do not appear to be supported by v3 radio buttons at this time
  - If this is a problem, the team will need to approach #platform-design-system in the DSVA slack. See a discussion [here](https://dsva.slack.com/archives/C5HP4GN3F/p1715112309112119). 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82350

## Testing done

- Manual testing to validate visuals
- Unit tests updated

## Screenshots

| Before | After |
| ------ | ----- |
|<img width="698" alt="evidenceTypesBDD-Before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/a9ba90cc-036e-45b1-9db5-ccb8853f2078">|<img width="701" alt="evidenceTypesBDD-After" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/a24e1508-f0e6-45ea-bb50-97a732c3d629">|
|<img width="686" alt="privateMedicalRecords-Before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/b1dfad83-4a60-46a7-a32b-f6b5123be127">|<img width="526" alt="privateMedicalRecords-After" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/ba388d43-df56-491d-a636-99dbf31f3086">|
|<img width="713" alt="serviceTreatmentRecord-Before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/67d3e973-a09c-47a5-aaae-a95377439bad">|<img width="560" alt="serviceTreatmentRecord-After" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2482403/70b5b3c2-368d-4045-b2f5-87bd954ec8fb">|


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions