### PR TITLE
Check in/73331/canceld upcoming

### DIFF
--- a/src/applications/check-in/api/local-mock-api/mocks/v2/shared/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/shared/get.js
@@ -334,6 +334,7 @@ const createUpcomingAppointments = (token, number = 3) => {
       id: `123456`,
       friendlyName: `HEART CLINIC-E`,
       start: dateFns.addMonths(new Date('2023-09-26T14:00:00'), 2),
+      status: 'CANCELLED BY CLINIC',
     }),
   );
 

--- a/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
@@ -38,6 +38,33 @@ describe('check-in experience', () => {
       stationNo: '9999',
       clinicIen: '9999',
     };
+    upcomingAppointments[2] = {
+      ...upcomingAppointments[2],
+      kind: 'clinic',
+      appointmentIen: 6767,
+      doctorName: 'test doc',
+      stationNo: '6767',
+      clinicIen: '6767',
+      status: 'CANCELLED BY PATIENT',
+    };
+    upcomingAppointments[3] = {
+      ...upcomingAppointments[3],
+      kind: 'cvt',
+      appointmentIen: 6768,
+      doctorName: 'test doc',
+      stationNo: '6768',
+      clinicIen: '6768',
+      status: 'CANCELLED BY CLINIC',
+    };
+    upcomingAppointments[4] = {
+      ...upcomingAppointments[4],
+      kind: 'phone',
+      appointmentIen: 6769,
+      doctorName: 'test doc',
+      stationNo: '6769',
+      clinicIen: '6769',
+      status: 'CANCELLED',
+    };
     const initAppointments = [...multipleAppointments, ...singleAppointment];
     const now = format(new Date(), "yyyy-LL-dd'T'HH:mm:ss");
     initAppointments[0] = {
@@ -172,6 +199,24 @@ describe('check-in experience', () => {
       currentPage: '/appointment',
       params: {
         appointmentId: '9999-9999',
+      },
+    };
+    const upcomingAppointmentThreeRoute = {
+      currentPage: '/appointment',
+      params: {
+        appointmentId: '6767-6767',
+      },
+    };
+    const upcomingAppointmentFourRoute = {
+      currentPage: '/appointment',
+      params: {
+        appointmentId: '6768-6768',
+      },
+    };
+    const upcomingAppointmentFiveRoute = {
+      currentPage: '/appointment',
+      params: {
+        appointmentId: '6769-6769',
       },
     };
     describe('AppointmentDetails', () => {
@@ -504,6 +549,54 @@ describe('check-in experience', () => {
           );
           expect(queryByTestId('appointment-action-message')).to.not.exist;
           expect(queryByTestId('check-in-button')).to.not.exist;
+        });
+        describe('Canceled appointments', () => {
+          it('Renders the canceled alert', () => {
+            const { getByTestId } = render(
+              <CheckInProvider
+                store={dayOfCheckInStore}
+                router={upcomingAppointmentThreeRoute}
+              >
+                <AppointmentDetails />
+              </CheckInProvider>,
+            );
+            expect(getByTestId('canceled-message')).to.exist;
+          });
+          it('Renders the correct messege for patient cancelled', () => {
+            const { getByTestId } = render(
+              <CheckInProvider
+                store={dayOfCheckInStore}
+                router={upcomingAppointmentThreeRoute}
+              >
+                <AppointmentDetails />
+              </CheckInProvider>,
+            );
+            expect(getByTestId('canceled-by-patient')).to.exist;
+            expect(getByTestId('header')).to.contain.text('Canceled');
+          });
+          it('Renders the correct messege for facility canceld', () => {
+            const { getByTestId } = render(
+              <CheckInProvider
+                store={dayOfCheckInStore}
+                router={upcomingAppointmentFourRoute}
+              >
+                <AppointmentDetails />
+              </CheckInProvider>,
+            );
+            expect(getByTestId('canceled-by-faciity')).to.exist;
+          });
+          it('Renders the correct messege when canceller unknown', () => {
+            const { queryByTestId } = render(
+              <CheckInProvider
+                store={dayOfCheckInStore}
+                router={upcomingAppointmentFiveRoute}
+              >
+                <AppointmentDetails />
+              </CheckInProvider>,
+            );
+            expect(queryByTestId('canceled-by-patient')).to.not.exist;
+            expect(queryByTestId('canceled-by-faciity')).to.not.exist;
+          });
         });
       });
     });

--- a/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
@@ -25,7 +25,7 @@ describe('check-in experience', () => {
     upcomingAppointments[0] = {
       ...upcomingAppointments[0],
       kind: 'clinic',
-      appointmentIen: 2222,
+      id: '2222',
       doctorName: 'test doc',
       stationNo: '0001',
       clinicIen: '0001',
@@ -33,7 +33,7 @@ describe('check-in experience', () => {
     upcomingAppointments[1] = {
       ...upcomingAppointments[1],
       kind: 'clinic',
-      appointmentIen: 9999,
+      id: '9999',
       doctorName: 'test doc',
       stationNo: '9999',
       clinicIen: '9999',
@@ -41,7 +41,7 @@ describe('check-in experience', () => {
     upcomingAppointments[2] = {
       ...upcomingAppointments[2],
       kind: 'clinic',
-      appointmentIen: 6767,
+      id: '6767',
       doctorName: 'test doc',
       stationNo: '6767',
       clinicIen: '6767',
@@ -49,8 +49,8 @@ describe('check-in experience', () => {
     };
     upcomingAppointments[3] = {
       ...upcomingAppointments[3],
-      kind: 'cvt',
-      appointmentIen: 6768,
+      kind: 'clinic',
+      id: '6768',
       doctorName: 'test doc',
       stationNo: '6768',
       clinicIen: '6768',
@@ -59,7 +59,7 @@ describe('check-in experience', () => {
     upcomingAppointments[4] = {
       ...upcomingAppointments[4],
       kind: 'phone',
-      appointmentIen: 6769,
+      id: '6769',
       doctorName: 'test doc',
       stationNo: '6769',
       clinicIen: '6769',

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -211,12 +211,18 @@ const AppointmentDetails = props => {
                   <div>
                     <p className="vads-u-margin-top--0">
                       {appointment.status === 'CANCELLED BY PATIENT' && (
-                        <span className="vads-u-font-weight--bold">
+                        <span
+                          className="vads-u-font-weight--bold"
+                          data-testid="canceled-by-patient"
+                        >
                           {`${t('you-canceled')} `}
                         </span>
                       )}
                       {appointment.status === 'CANCELLED BY CLINIC' && (
-                        <span className="vads-u-font-weight--bold">
+                        <span
+                          className="vads-u-font-weight--bold"
+                          data-testid="canceled-by-faciity"
+                        >
                           {`${t('facility-canceled')} `}
                         </span>
                       )}

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useLayoutEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 import isValid from 'date-fns/isValid';
 import PropTypes from 'prop-types';
 // eslint-disable-next-line import/no-unresolved
@@ -17,7 +17,7 @@ import {
   findAppointment,
   findUpcomingAppointment,
 } from '../../../utils/appointment';
-import { APP_NAMES } from '../../../utils/appConstants';
+import { APP_NAMES, phoneNumbers } from '../../../utils/appConstants';
 
 import Wrapper from '../../layout/Wrapper';
 import BackButton from '../../BackButton';
@@ -26,6 +26,7 @@ import AppointmentMessage from '../../AppointmentDisplay/AppointmentMessage';
 import AddressBlock from '../../AddressBlock';
 
 import { makeSelectFeatureToggles } from '../../../utils/selectors/feature-toggles';
+import ExternalLink from '../../ExternalLink';
 
 const AppointmentDetails = props => {
   const { router } = props;
@@ -137,20 +138,29 @@ const AppointmentDetails = props => {
       </p>
     );
   }
-
+  const isCanceled = isUpcoming && appointment.status.includes('CANCELLED');
   const appointmentTitle = () => {
+    let title = '';
     switch (appointment?.kind) {
       case 'phone':
-        return `${t('phone')} ${t('appointment')}`;
+        title = `${t('phone')} ${t('appointment')}`;
+        break;
       case 'cvt':
-        return t('video-appointment-at-facility', {
+        title = t('video-appointment-at-facility', {
           facility: appointment.facility,
         });
+        break;
       case 'vvc':
-        return t('video-appointment--title');
+        title = t('video-appointment--title');
+        break;
       default:
-        return t('in-person-appointment');
+        title = t('in-person-appointment');
+        break;
     }
+    if (isCanceled) {
+      return `${t('canceled')} ${t('#-util-uncapitalize', { value: title })}`;
+    }
+    return title;
   };
 
   const showReviewButton =
@@ -188,6 +198,55 @@ const AppointmentDetails = props => {
                     </div>
                   )}
                 </>
+              )}
+              {isCanceled && (
+                <va-alert
+                  uswds
+                  slim
+                  status="error"
+                  show-icon
+                  data-testid="canceled-message"
+                  class="vads-u-margin-top--2"
+                >
+                  <div>
+                    <p className="vads-u-margin-top--0">
+                      {appointment.status === 'CANCELLED BY PATIENT' && (
+                        <span className="vads-u-font-weight--bold">
+                          {`${t('you-canceled')} `}
+                        </span>
+                      )}
+                      {appointment.status === 'CANCELLED BY CLINIC' && (
+                        <span className="vads-u-font-weight--bold">
+                          {`${t('facility-canceled')} `}
+                        </span>
+                      )}
+                      <Trans
+                        i18nKey="if-you-want-to-reschedule"
+                        components={[
+                          <va-telephone
+                            key={phoneNumbers.mainInfo}
+                            contact={phoneNumbers.mainInfo}
+                          />,
+                          <va-telephone
+                            key={phoneNumbers.tty}
+                            contact={phoneNumbers.tty}
+                            tty
+                            ariaLabel="7 1 1."
+                          />,
+                        ]}
+                      />
+                    </p>
+                    <p>
+                      <ExternalLink
+                        href="https://www.va.gov/health-care/schedule-view-va-appointments/"
+                        hrefLang="en"
+                      >
+                        {t('sign-in-to-schedule')}
+                      </ExternalLink>
+                    </p>
+                    <p>{t('or-talk-staff-if-at-facility')}</p>
+                  </div>
+                </va-alert>
               )}
               <div data-testid="appointment-details--when">
                 <h2 className="vads-u-font-size--sm">{t('when')}</h2>

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -1,5 +1,6 @@
 {
   "#-util-capitalize": "{{value, capitalize}}",
+  "#-util-uncapitalize": "{{value, uncapitalize}}",
   "add": "Add",
   "address": "Address",
   "and-select-0-were-here-24-7": "and select 0. We’re here 24/7.",
@@ -381,5 +382,11 @@
   "we-cant-find-any-upcoming-appointments": "We can't find any upcoming VA medical appointments for you",
   "our-online-check-in-tool-doesnt-include-all": "Our online check-in tool doesn’t include all appointment types at this time. To find all your appointments, you can use our appointments tool on VA.gov or call your VA or community care health facility.",
   "go-to-all-your-va-appointments": "Go to all your VA appointments",
-  "find-your-health-facilities-phone-number": "Find your health facility’s phone number"
+  "find-your-health-facilities-phone-number": "Find your health facility’s phone number",
+  "canceled": "Canceled",
+  "you-canceled": "You canceled this appointment.",
+  "facility-canceled": "Facility canceled this appointment.",
+  "if-you-want-to-reschedule": "If you want to reschedule, call us at <0></0> (<1></1>) or schedule a new appointment online.",
+  "sign-in-to-schedule": "Sign in to schedule a new appointment",
+  "or-talk-staff-if-at-facility": "Or talk to a staff member if you’re at a VA facility."
 }

--- a/src/applications/check-in/locales/es/translation.json
+++ b/src/applications/check-in/locales/es/translation.json
@@ -1,5 +1,6 @@
 {
   "#-util-capitalize": "{{value, capitalize}}",
+  "#-util-uncapitalize": "{{value, uncapitalize}}",
   "add": "Añadir",
   "address": "Dirección",
   "and-select-0-were-here-24-7": "y seleccione 0. Estamos aquí 24 horas al día, siete días a la semana.",

--- a/src/applications/check-in/locales/tl/translation.json
+++ b/src/applications/check-in/locales/tl/translation.json
@@ -1,5 +1,6 @@
 {
   "#-util-capitalize": "{{value, capitalize}}",
+  "#-util-uncapitalize": "{{value, uncapitalize}}",
   "a-staff-member-will-help-you-on-the-day-of-your-appointment-or-you-can-login-to-your-va-account-to-update-your-contact-information-online": "Tutulungan ka ng isang staff member sa araw ng iyong appointment. O maaari kang mag-login sa iyong VA account para i-update ang iyong impormasyon sa pakikipag-ugnayan online.",
   "a-staff-member-will-help-you-on-the-day-of-your-appointment-to-update-your-information": "Tutulungan ka ng isang staff member sa araw ng iyong appointment para i-update ang iyong impormasyon.",
   "add": "Magdagdag",

--- a/src/applications/check-in/utils/i18n/i18n.js
+++ b/src/applications/check-in/utils/i18n/i18n.js
@@ -88,8 +88,12 @@ const i18nOptions = {
         );
         return interpolator(value, format, lng, locale);
       }
-      if (format === 'capitalize')
+      if (format === 'capitalize') {
         return `${value.substr(0, 1).toUpperCase()}${value.substr(1)}`;
+      }
+      if (format === 'uncapitalize') {
+        return `${value.substr(0, 1).toLowerCase()}${value.substr(1)}`;
+      }
       return value;
     },
   },


### PR DESCRIPTION
## Summary
Adds canceled appointment display for Appointment Details page.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#73331

## Testing done

Added unit tests.

## Screenshots

![localhost_3001_health-care_appointment-check-in_appointment-details_0030-0001](https://github.com/department-of-veterans-affairs/vets-website/assets/13967174/cacaadec-3e33-4bfd-a806-0792fb398ad0)

## What areas of the site does it impact?

Day-of and pre-cehck-in unified appt. branch.

## Acceptance criteria

 - [ ] Canceled appointment matches mock with the exception of the alert style.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

