### PR TITLE
21-4138 - fix: misc ui fixes

### DIFF
--- a/src/applications/simple-forms/21-4138/config/constants.js
+++ b/src/applications/simple-forms/21-4138/config/constants.js
@@ -56,6 +56,16 @@ export const DECISION_REVIEW_TYPE_DESCRIPTIONS = Object.freeze({
     'You can also submit new evidence with certain types of Board Appeals.',
 });
 
+const PrimaryActionLink = ({ href, children }) => (
+  <div className="arrow" style={{ maxWidth: '75%' }}>
+    <div className="vads-u-background-color--primary vads-u-padding--1">
+      <a className="vads-c-action-link--white" href={href}>
+        {children}
+      </a>
+    </div>
+  </div>
+);
+
 export const ESCAPE_HATCH = Object.freeze(
   <div className="vads-u-margin-y--4">
     If you’d like to use VA Form 21-4138 for your statement without selecting an
@@ -90,16 +100,9 @@ export const LAY_OR_WITNESS_HANDOFF = Object.freeze(
         statement, use a new form for each statement.
       </li>
     </ul>
-    <div className="arrow" style={{ maxWidth: '75%' }}>
-      <div className="vads-u-background-color--primary vads-u-padding--1">
-        <a
-          className="vads-c-action-link--white"
-          href="/supporting-forms-for-claims/lay-witness-statement-form-21-10210/introduction"
-        >
-          Start your statement
-        </a>
-      </div>
-    </div>
+    <PrimaryActionLink href="/supporting-forms-for-claims/lay-witness-statement-form-21-10210/introduction">
+      Start your statement
+    </PrimaryActionLink>
     <va-omb-info
       res-burden={10}
       omb-number="2900-0881"
@@ -121,16 +124,9 @@ export const NOD_OLD_HANDOFF = Object.freeze(
       records) to support your claim.
     </p>
     <p>A reviewer will decide if this new evidence changes the decision.</p>
-    <div className="arrow" style={{ maxWidth: '75%' }}>
-      <div className="vads-u-background-color--primary vads-u-padding--1">
-        <a
-          className="vads-c-action-link--white"
-          href="/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/start"
-        >
-          File a Supplemental Claim online
-        </a>
-      </div>
-    </div>
+    <PrimaryActionLink href="/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/start">
+      File a Supplemental Claim online
+    </PrimaryActionLink>
     <div className="vads-u-margin-y--4">
       <a
         href="/decision-reviews/supplemental-claim/"
@@ -155,16 +151,9 @@ export const NOD_SUPPLEMENTAL_HANDOFF = Object.freeze(
       records) to support your claim.
     </p>
     <p>A reviewer will decide if this new evidence changes the decision.</p>
-    <div className="arrow" style={{ maxWidth: '75%' }}>
-      <div className="vads-u-background-color--primary vads-u-padding--1">
-        <a
-          className="vads-c-action-link--white"
-          href="/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/start"
-        >
-          File a Supplemental Claim online
-        </a>
-      </div>
-    </div>
+    <PrimaryActionLink href="/decision-reviews/supplemental-claim/file-supplemental-claim-form-20-0995/start">
+      File a Supplemental Claim online
+    </PrimaryActionLink>
     <div className="vads-u-margin-y--4">
       <a
         href="/decision-reviews/supplemental-claim/"
@@ -194,16 +183,9 @@ export const NOD_HLR_HANDOFF = Object.freeze(
       For disability compensation claims, you can request a Higher-Level Review
       online.
     </p>
-    <div className="arrow" style={{ maxWidth: '75%' }}>
-      <div className="vads-u-background-color--primary vads-u-padding--1">
-        <a
-          className="vads-c-action-link--white"
-          href="/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996/"
-        >
-          Request a High-Level Review online
-        </a>
-      </div>
-    </div>
+    <PrimaryActionLink href="/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996/">
+      Request a High-Level Review online
+    </PrimaryActionLink>
     <p>
       <strong>Note:</strong> At this time, you can use our online Higher-Level
       Review form for only disability compensation claims. For other types of
@@ -377,16 +359,9 @@ export const PRIORITY_PROCESSING_QUALIFIED = Object.freeze(
         application in progress and come back later to finish filling it out.
       </va-alert>
     </div>
-    <div className="arrow" style={{ maxWidth: '75%' }}>
-      <div className="vads-u-background-color--primary vads-u-padding--1">
-        <a
-          className="vads-c-action-link--white"
-          href="/supporting-forms-for-claims/request-priority-processing-form-20-10207/introduction"
-        >
-          Start your request
-        </a>
-      </div>
-    </div>
+    <PrimaryActionLink href="/supporting-forms-for-claims/request-priority-processing-form-20-10207/introduction">
+      Start your request
+    </PrimaryActionLink>
     <h2 className="vads-u-font-size--h3">Types of evidence to submit</h2>
     <p>You can submit any of these types of evidence.</p>
     <p>
@@ -569,16 +544,9 @@ export const RECORDS_REQUEST_HANDOFF = Object.freeze(
         application in progress and come back later to finish filling it out.
       </va-alert>
     </div>
-    <div className="arrow" style={{ maxWidth: '75%' }}>
-      <div className="vads-u-background-color--primary vads-u-padding--1">
-        <a
-          className="vads-c-action-link--white"
-          href="/records/request-personal-records-form-20-10206/introduction"
-        >
-          Start your request
-        </a>
-      </div>
-    </div>
+    <PrimaryActionLink href="/records/request-personal-records-form-20-10206/introduction">
+      Start your request
+    </PrimaryActionLink>
     <va-omb-info
       res-burden={5}
       omb-number="2900-0736"
@@ -595,16 +563,9 @@ export const NEW_EVIDENCE_HANDOFF = Object.freeze(
       If you have an open claim, you can add evidence to support it. Evidence
       may include documents like court papers or service treatment records.
     </p>
-    <div className="arrow" style={{ maxWidth: '75%' }}>
-      <div className="vads-u-background-color--primary vads-u-padding--1">
-        <a
-          className="vads-c-action-link--white"
-          href="/track-claims/your-claims"
-        >
-          Upload evidence using our claim status tool
-        </a>
-      </div>
-    </div>
+    <PrimaryActionLink href="/track-claims/your-claims">
+      Upload evidence using our claim status tool
+    </PrimaryActionLink>
     <p>
       If you prefer to mail copies of your documents, we recommend filling out
       and including VA Form 20-10208 (Document Evidence Submission) along with

--- a/src/applications/simple-forms/21-4138/config/constants.js
+++ b/src/applications/simple-forms/21-4138/config/constants.js
@@ -22,7 +22,7 @@ export const STATEMENT_TYPES = Object.freeze({
 
 export const STATEMENT_TYPE_LABELS = Object.freeze({
   [STATEMENT_TYPES.BUDDY_STATEMENT]:
-    'I want to sumbit a formal statement to support my claim or someone else\'s claim. This is also known as a "buddy statement."',
+    'I want to submit a formal statement to support my claim or someone else’s claim. This is also known as a “buddy statement.”',
   [STATEMENT_TYPES.DECISION_REVIEW]:
     'I want to request a decision review for my claim.',
   [STATEMENT_TYPES.PRIORITY_PROCESSING]:

--- a/src/applications/simple-forms/21-4138/config/constants.js
+++ b/src/applications/simple-forms/21-4138/config/constants.js
@@ -238,16 +238,9 @@ export const NOD_BA_HANDOFF = Object.freeze(
         Law Judge (with or without new evidence)
       </li>
     </ul>
-    <div className="arrow" style={{ maxWidth: '75%' }}>
-      <div className="vads-u-background-color--primary vads-u-padding--1 vads-u-margin-top--4">
-        <a
-          className="vads-c-action-link--white"
-          href="/decision-reviews/board-appeal/request-board-appeal-form-10182/introduction"
-        >
-          Request a Board Appeal online
-        </a>
-      </div>
-    </div>
+    <PrimaryActionLink href="/decision-reviews/board-appeal/request-board-appeal-form-10182/introduction">
+      Request a Board Appeal online
+    </PrimaryActionLink>
     <div className="vads-u-margin-y--4">
       <a
         href="/decision-reviews/board-appeal/"

--- a/src/applications/simple-forms/21-4138/config/constants.js
+++ b/src/applications/simple-forms/21-4138/config/constants.js
@@ -51,7 +51,7 @@ export const DECISION_REVIEW_TYPE_LABELS = Object.freeze({
 
 export const DECISION_REVIEW_TYPE_DESCRIPTIONS = Object.freeze({
   [DECISION_REVIEW_TYPES.ERROR_MADE]:
-    "Don't select this option if you have new evidence to submit",
+    "Don't select this option if you have new evidence to submit.",
   [DECISION_REVIEW_TYPES.BVA_REQUEST]:
     'You can also submit new evidence with certain types of Board Appeals.',
 });

--- a/src/applications/simple-forms/21-4138/config/constants.js
+++ b/src/applications/simple-forms/21-4138/config/constants.js
@@ -56,6 +56,16 @@ export const DECISION_REVIEW_TYPE_DESCRIPTIONS = Object.freeze({
     'You can also submit new evidence with certain types of Board Appeals.',
 });
 
+export const ESCAPE_HATCH = Object.freeze(
+  <div className="vads-u-margin-y--4">
+    If you’d like to use VA Form 21-4138 for your statement without selecting an
+    answer here, you can{' '}
+    <a href="/supporting-forms-for-claims/support-statement-21-4138/name-and-date-of-birth">
+      go to VA Form 21-4138 now.
+    </a>
+  </div>,
+);
+
 export const LAY_OR_WITNESS_HANDOFF = Object.freeze(
   <div>
     <p>
@@ -80,7 +90,7 @@ export const LAY_OR_WITNESS_HANDOFF = Object.freeze(
         statement, use a new form for each statement.
       </li>
     </ul>
-    <div style={{ maxWidth: '75%' }}>
+    <div className="arrow" style={{ maxWidth: '75%' }}>
       <div className="vads-u-background-color--primary vads-u-padding--1">
         <a
           className="vads-c-action-link--white"
@@ -96,13 +106,7 @@ export const LAY_OR_WITNESS_HANDOFF = Object.freeze(
       exp-date="06/30/2024"
       class="vads-u-margin-y--4"
     />
-    <div className="vads-u-margin-y--4">
-      If you’d like to use VA Form 21-4138 for your statement without selecting
-      an answer here, you can{' '}
-      <a href="/supporting-forms-for-claims/support-statement-21-4138/name-and-date-of-birth">
-        go to VA Form 21-4138 now.
-      </a>
-    </div>
+    {ESCAPE_HATCH}
   </div>,
 );
 
@@ -117,7 +121,7 @@ export const NOD_OLD_HANDOFF = Object.freeze(
       records) to support your claim.
     </p>
     <p>A reviewer will decide if this new evidence changes the decision.</p>
-    <div style={{ maxWidth: '75%' }}>
+    <div className="arrow" style={{ maxWidth: '75%' }}>
       <div className="vads-u-background-color--primary vads-u-padding--1">
         <a
           className="vads-c-action-link--white"
@@ -136,13 +140,7 @@ export const NOD_OLD_HANDOFF = Object.freeze(
         Learn more about supplemental claims (opens in new tab)
       </a>
     </div>
-    <div className="vads-u-margin-y--4">
-      If you’d like to use VA Form 21-4138 for your statement without selecting
-      an answer here, you can{' '}
-      <a href="/supporting-forms-for-claims/support-statement-21-4138/name-and-date-of-birth">
-        go to VA Form 21-4138 now.
-      </a>
-    </div>
+    {ESCAPE_HATCH}
   </div>,
 );
 
@@ -157,7 +155,7 @@ export const NOD_SUPPLEMENTAL_HANDOFF = Object.freeze(
       records) to support your claim.
     </p>
     <p>A reviewer will decide if this new evidence changes the decision.</p>
-    <div style={{ maxWidth: '75%' }}>
+    <div className="arrow" style={{ maxWidth: '75%' }}>
       <div className="vads-u-background-color--primary vads-u-padding--1">
         <a
           className="vads-c-action-link--white"
@@ -176,13 +174,7 @@ export const NOD_SUPPLEMENTAL_HANDOFF = Object.freeze(
         Learn more about supplemental claims (opens in new tab)
       </a>
     </div>
-    <div className="vads-u-margin-y--4">
-      If you’d like to use VA Form 21-4138 for your statement without selecting
-      an answer here, you can{' '}
-      <a href="/supporting-forms-for-claims/support-statement-21-4138/name-and-date-of-birth">
-        go to VA Form 21-4138 now.
-      </a>
-    </div>
+    {ESCAPE_HATCH}
   </div>,
 );
 
@@ -202,7 +194,7 @@ export const NOD_HLR_HANDOFF = Object.freeze(
       For disability compensation claims, you can request a Higher-Level Review
       online.
     </p>
-    <div style={{ maxWidth: '75%' }}>
+    <div className="arrow" style={{ maxWidth: '75%' }}>
       <div className="vads-u-background-color--primary vads-u-padding--1">
         <a
           className="vads-c-action-link--white"
@@ -235,13 +227,7 @@ export const NOD_HLR_HANDOFF = Object.freeze(
         new tab)
       </a>
     </div>
-    <div className="vads-u-margin-y--4">
-      If you’d like to use VA Form 21-4138 for your statement without selecting
-      an answer here, you can{' '}
-      <a href="/supporting-forms-for-claims/support-statement-21-4138/name-and-date-of-birth">
-        go to VA Form 21-4138 now.
-      </a>
-    </div>
+    {ESCAPE_HATCH}
   </div>,
 );
 
@@ -270,7 +256,7 @@ export const NOD_BA_HANDOFF = Object.freeze(
         Law Judge (with or without new evidence)
       </li>
     </ul>
-    <div style={{ maxWidth: '75%' }}>
+    <div className="arrow" style={{ maxWidth: '75%' }}>
       <div className="vads-u-background-color--primary vads-u-padding--1 vads-u-margin-top--4">
         <a
           className="vads-c-action-link--white"
@@ -289,13 +275,7 @@ export const NOD_BA_HANDOFF = Object.freeze(
         Learn more about Board Appeals and how to request one (opens in new tab)
       </a>
     </div>
-    <div className="vads-u-margin-y--4">
-      If you’d like to use VA Form 21-4138 for your statement without selecting
-      an answer here, you can{' '}
-      <a href="/supporting-forms-for-claims/support-statement-21-4138/name-and-date-of-birth">
-        go to VA Form 21-4138 now.
-      </a>
-    </div>
+    {ESCAPE_HATCH}
   </div>,
 );
 
@@ -397,7 +377,7 @@ export const PRIORITY_PROCESSING_QUALIFIED = Object.freeze(
         application in progress and come back later to finish filling it out.
       </va-alert>
     </div>
-    <div style={{ maxWidth: '75%' }}>
+    <div className="arrow" style={{ maxWidth: '75%' }}>
       <div className="vads-u-background-color--primary vads-u-padding--1">
         <a
           className="vads-c-action-link--white"
@@ -589,7 +569,7 @@ export const RECORDS_REQUEST_HANDOFF = Object.freeze(
         application in progress and come back later to finish filling it out.
       </va-alert>
     </div>
-    <div style={{ maxWidth: '75%' }}>
+    <div className="arrow" style={{ maxWidth: '75%' }}>
       <div className="vads-u-background-color--primary vads-u-padding--1">
         <a
           className="vads-c-action-link--white"
@@ -605,13 +585,7 @@ export const RECORDS_REQUEST_HANDOFF = Object.freeze(
       exp-date="02/28/2026"
       class="vads-u-margin-y--4"
     />
-    <div className="vads-u-margin-y--4">
-      If you’d like to use VA Form 21-4138 for your statement without selecting
-      an answer here, you can{' '}
-      <a href="/supporting-forms-for-claims/support-statement-21-4138/name-and-date-of-birth">
-        go to VA Form 21-4138 now.
-      </a>
-    </div>
+    {ESCAPE_HATCH}
   </div>,
 );
 
@@ -621,7 +595,7 @@ export const NEW_EVIDENCE_HANDOFF = Object.freeze(
       If you have an open claim, you can add evidence to support it. Evidence
       may include documents like court papers or service treatment records.
     </p>
-    <div style={{ maxWidth: '75%' }}>
+    <div className="arrow" style={{ maxWidth: '75%' }}>
       <div className="vads-u-background-color--primary vads-u-padding--1">
         <a
           className="vads-c-action-link--white"
@@ -684,13 +658,7 @@ export const NEW_EVIDENCE_HANDOFF = Object.freeze(
     <a className="vads-u-font-weight--bold" href="/track-claims/your-claims">
       Check the status of your claim
     </a>
-    <div className="vads-u-margin-y--4">
-      If you’d like to use VA Form 21-4138 for your statement without selecting
-      an answer here, you can{' '}
-      <a href="/supporting-forms-for-claims/support-statement-21-4138/name-and-date-of-birth">
-        go to VA Form 21-4138 now.
-      </a>
-    </div>
+    {ESCAPE_HATCH}
   </div>,
 );
 
@@ -736,12 +704,6 @@ export const VRE_REQUEST_HANDOFF = Object.freeze(
       exp-date="02/29/2024"
       class="vads-u-margin-y--4"
     />
-    <div className="vads-u-margin-y--4">
-      If you’d like to use VA Form 21-4138 for your statement without selecting
-      an answer here, you can{' '}
-      <a href="/supporting-forms-for-claims/support-statement-21-4138/name-and-date-of-birth">
-        go to VA Form 21-4138 now.
-      </a>
-    </div>
+    {ESCAPE_HATCH}
   </div>,
 );

--- a/src/applications/simple-forms/21-4138/config/form.js
+++ b/src/applications/simple-forms/21-4138/config/form.js
@@ -126,7 +126,7 @@ const formConfig = {
         noticeOfDisagreementOldHandoffPage: {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.DECISION_REVIEW &&
-            new Date(formData.decisionDate) > oneYearAgo,
+            new Date(formData.decisionDate) >= oneYearAgo,
           path: 'notice-of-disagreement-old-handoff',
           title: 'What to know before you request a decision review',
           uiSchema: nodOldHandoffPage.uiSchema,
@@ -136,7 +136,7 @@ const formConfig = {
         decisionReviewTypePage: {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.DECISION_REVIEW &&
-            new Date(formData.decisionDate) <= oneYearAgo,
+            new Date(formData.decisionDate) < oneYearAgo,
           path: 'decision-review-type',
           title: 'Which description is true for you?',
           uiSchema: decisionReviewTypePage.uiSchema,
@@ -146,7 +146,7 @@ const formConfig = {
         noticeOfDisagreementSupplementalHandoffPage: {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.DECISION_REVIEW &&
-            new Date(formData.decisionDate) <= oneYearAgo &&
+            new Date(formData.decisionDate) < oneYearAgo &&
             formData.decisionReviewType === DECISION_REVIEW_TYPES.NEW_EVIDENCE,
           path: 'notice-of-disagreement-supplemental-handoff',
           title: 'What to know before you request a decision review',
@@ -157,7 +157,7 @@ const formConfig = {
         noticeOfDisagreementHLRHandoffPage: {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.DECISION_REVIEW &&
-            new Date(formData.decisionDate) <= oneYearAgo &&
+            new Date(formData.decisionDate) < oneYearAgo &&
             formData.decisionReviewType === DECISION_REVIEW_TYPES.ERROR_MADE,
           path: 'notice-of-disagreement-hlr-handoff',
           title: "There's a better way for you to ask for a decision review",
@@ -168,7 +168,7 @@ const formConfig = {
         noticeOfDisagreementBAHandoffPage: {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.DECISION_REVIEW &&
-            new Date(formData.decisionDate) <= oneYearAgo &&
+            new Date(formData.decisionDate) < oneYearAgo &&
             formData.decisionReviewType === DECISION_REVIEW_TYPES.BVA_REQUEST,
           path: 'notice-of-disagreement-ba-handoff',
           title: "There's a better way for you to ask for a decision review",

--- a/src/applications/simple-forms/21-4138/config/form.js
+++ b/src/applications/simple-forms/21-4138/config/form.js
@@ -1,6 +1,5 @@
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import footerContent from '~/platform/forms/components/FormFooter';
-import { startOfDay, subYears } from 'date-fns';
 import manifest from '../manifest.json';
 import getHelp from '../../shared/components/GetFormHelp';
 import IntroductionPage from '../containers/IntroductionPage';
@@ -42,7 +41,7 @@ import { identificationInformationPage } from '../pages/identificationInfo';
 import { mailingAddressPage } from '../pages/mailingAddress';
 import { phoneAndEmailPage } from '../pages/phoneAndEmail';
 import { statementPage } from '../pages/statement';
-import { getMockData } from '../helpers';
+import { getMockData, isEligibleForDecisionReview } from '../helpers';
 
 // export isLocalhost() to facilitate unit-testing
 export function isLocalhost() {
@@ -53,7 +52,6 @@ export function isLocalhost() {
 import testData from '../tests/e2e/fixtures/data/user.json';
 
 const mockData = testData.data;
-const oneYearAgo = startOfDay(subYears(new Date(), 1));
 
 /** @type {FormConfig} */
 const formConfig = {
@@ -126,7 +124,7 @@ const formConfig = {
         noticeOfDisagreementOldHandoffPage: {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.DECISION_REVIEW &&
-            new Date(formData.decisionDate) >= oneYearAgo,
+            !isEligibleForDecisionReview(formData.decisionDate),
           path: 'notice-of-disagreement-old-handoff',
           title: 'What to know before you request a decision review',
           uiSchema: nodOldHandoffPage.uiSchema,
@@ -136,7 +134,7 @@ const formConfig = {
         decisionReviewTypePage: {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.DECISION_REVIEW &&
-            new Date(formData.decisionDate) < oneYearAgo,
+            isEligibleForDecisionReview(formData.decisionDate),
           path: 'decision-review-type',
           title: 'Which description is true for you?',
           uiSchema: decisionReviewTypePage.uiSchema,
@@ -146,7 +144,7 @@ const formConfig = {
         noticeOfDisagreementSupplementalHandoffPage: {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.DECISION_REVIEW &&
-            new Date(formData.decisionDate) < oneYearAgo &&
+            isEligibleForDecisionReview(formData.decisionDate) &&
             formData.decisionReviewType === DECISION_REVIEW_TYPES.NEW_EVIDENCE,
           path: 'notice-of-disagreement-supplemental-handoff',
           title: 'What to know before you request a decision review',
@@ -157,7 +155,7 @@ const formConfig = {
         noticeOfDisagreementHLRHandoffPage: {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.DECISION_REVIEW &&
-            new Date(formData.decisionDate) < oneYearAgo &&
+            isEligibleForDecisionReview(formData.decisionDate) &&
             formData.decisionReviewType === DECISION_REVIEW_TYPES.ERROR_MADE,
           path: 'notice-of-disagreement-hlr-handoff',
           title: "There's a better way for you to ask for a decision review",
@@ -168,7 +166,7 @@ const formConfig = {
         noticeOfDisagreementBAHandoffPage: {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.DECISION_REVIEW &&
-            new Date(formData.decisionDate) < oneYearAgo &&
+            isEligibleForDecisionReview(formData.decisionDate) &&
             formData.decisionReviewType === DECISION_REVIEW_TYPES.BVA_REQUEST,
           path: 'notice-of-disagreement-ba-handoff',
           title: "There's a better way for you to ask for a decision review",
@@ -359,7 +357,7 @@ const formConfig = {
         'I confirm that the identifying information in this form is accurate and has been represented correctly.',
       messageAriaDescribedby:
         'I confirm that the identifying information in this form is accurate and has been represented correctly.',
-      // fullNamePath: formData => statementOfTruthFullNamePath({ formData }),
+      fullNamePath: 'fullName',
       checkboxLabel:
         'I confirm that the information above is correct and true to the best of my knowledge and belief.',
     },

--- a/src/applications/simple-forms/21-4138/helpers.js
+++ b/src/applications/simple-forms/21-4138/helpers.js
@@ -1,3 +1,5 @@
+import { startOfDay, subYears, isBefore } from 'date-fns';
+
 export function getMockData(mockData, isLocalhost) {
   return !!mockData && isLocalhost() && !window.Cypress ? mockData : undefined;
 }
@@ -23,3 +25,10 @@ export function validateLivingSituation(errors, fields) {
     );
   }
 }
+
+export const isEligibleForDecisionReview = decisionDate => {
+  if (!decisionDate) return false;
+  const oneYearAgo = startOfDay(subYears(new Date(), 1));
+  const decisionDateTime = startOfDay(new Date(decisionDate.split('-')));
+  return isBefore(oneYearAgo, decisionDateTime);
+};

--- a/src/applications/simple-forms/21-4138/pages/statementType.js
+++ b/src/applications/simple-forms/21-4138/pages/statementType.js
@@ -1,9 +1,12 @@
-import React from 'react';
 import {
   radioUI,
   radioSchema,
 } from '~/platform/forms-system/src/js/web-component-patterns';
-import { STATEMENT_TYPES, STATEMENT_TYPE_LABELS } from '../config/constants';
+import {
+  ESCAPE_HATCH,
+  STATEMENT_TYPES,
+  STATEMENT_TYPE_LABELS,
+} from '../config/constants';
 
 /** @type {PageSchema} */
 export const statementTypePage = {
@@ -22,15 +25,7 @@ export const statementTypePage = {
       }),
     },
     'view:additionalInfoStatementType': {
-      'ui:description': (
-        <>
-          If you’d like to use VA Form 21-4138 for your statement without
-          selecting an answer here, you can{' '}
-          <a href="/supporting-forms-for-claims/support-statement-21-4138/name-and-date-of-birth">
-            go to VA Form 21-4138 now.
-          </a>
-        </>
-      ),
+      'ui:description': ESCAPE_HATCH,
     },
   },
   schema: {

--- a/src/applications/simple-forms/21-4138/sass/4138-ss.scss
+++ b/src/applications/simple-forms/21-4138/sass/4138-ss.scss
@@ -5,3 +5,19 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "../../../../platform/forms/sass/m-form-confirmation";
+
+.arrow {
+  position: relative;
+}
+
+.arrow::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: -24px;
+  width: 0;
+  height: 0;
+  border-top: 24px solid transparent;
+  border-bottom: 24px solid transparent;
+  border-left: 24px solid var(--vads-color-primary);
+}


### PR DESCRIPTION
## Summary

- Misc. UI updates/fixes/tweaks for Statement in Support of a Claim (21-4138):
  - 1288 - subtask: add period to option hint text
  - 1284 - fix typo on statement type list page
  - update primary action links to look like arrows
  - 1285 - subtask: decision date logic is reversed
- Team: Veteran Facing Forms
- Flipper not implemented

## Related issue(s)

- department-of-veterans-affairs/va.gov-team-forms#1183
- department-of-veterans-affairs/va.gov-team-forms#1288
- department-of-veterans-affairs/va.gov-team-forms#1284
- department-of-veterans-affairs/va.gov-team-forms#1285
- department-of-veterans-affairs/va.gov-team-forms#1292

## Testing done

- Local browser functions successfully
- Unit tests successful
- E2E tests successful


## What areas of the site does it impact?

This form ONLY.