### PR TITLE
VACMS-17815 Find Forms icons

### DIFF
--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -238,12 +238,11 @@ const SearchResult = ({
           onClick={pdfDownloadHandler}
           {...linkProps}
         >
-          <i
-            aria-hidden="true"
-            className="fas fa-download fa-lg vads-u-margin-right--1"
-            role="presentation"
-          />
-          <span lang={language} className="vads-u-text-decoration--underline">
+          <va-icon icon="file_download" size="3" />
+          <span
+            lang={language}
+            className="vads-u-text-decoration--underline vads-u-margin-left--0p5"
+          >
             {deriveLanguageTranslation(language, 'downloadVaForm', formName)}
           </span>
         </button>

--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -279,10 +279,10 @@ export const SearchResults = ({
               rel="noreferrer noopener"
               target="_blank"
             >
-              <i
-                aria-hidden="true"
-                className="fas fa-download fa-lg vads-u-margin-right--1"
-                role="presentation"
+              <va-icon
+                className="vads-u-margin-right--1"
+                icon="file_download"
+                size="3"
               />
               <span className="vads-u-text-decoration--underline">
                 Download VA Form {pdfSelected}


### PR DESCRIPTION
## Summary
Update the `<i>` elements in the content-build portion of the Find Forms app to `<va-icon>`. This is only for the search / search results portion of this app. content-build handles the form detail pages. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17815

## Testing done
Tested locally at `/find-forms/?q=1010`. The vets-website portion of this application is the search/ search results view only.

## Screenshots
<img width="283" alt="Screenshot 2024-05-13 at 4 40 16 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/b69e43d6-7c50-4498-9a16-98e67906d09d">

<img width="421" alt="Screenshot 2024-05-13 at 4 40 23 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/d51b107f-88fc-41b0-96c1-2bafcd710b12">
