### PR TITLE
Add primary contact info to submit transformer

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-10D/config/submitTransformer.js
@@ -50,7 +50,7 @@ function transformApplicants(applicants) {
         app?.applicantOtherInsuranceCertification,
         app?.applicantHelplessCert,
       ],
-      address: app.applicantAddress ?? '',
+      address: app.applicantAddress ?? {},
       gender: app.applicantGender?.gender ?? '',
     };
 
@@ -76,6 +76,37 @@ function parseCertifier(transformedData) {
     city: transformedData?.sponsorAddress?.city || '',
     state: transformedData?.sponsorAddress?.state || '',
     postal_code: transformedData?.sponsorAddress?.postal_code || '',
+  };
+}
+
+function getPrimaryContact(data) {
+  // If a certification name is present, we know the form was filled by
+  // a third party or the sponsor, and that they should be primary contact.
+  const useCert =
+    data?.certification?.firstName && data?.certification?.firstName !== '';
+
+  // Depending on the result of useCert, grab the first and last name, phone,
+  // and email from either the `certification` object or the first applicant,
+  // then return so we can set up the `primaryContactInfo` for the backend
+  // notification API service.
+  return {
+    name: {
+      first:
+        (useCert
+          ? data?.certification?.firstName
+          : data?.applicants?.[0]?.full_name?.first) ?? false,
+      last:
+        (useCert
+          ? data?.certification?.lastName
+          : data?.applicants?.[0]?.full_name?.last) ?? false,
+    },
+    email:
+      (useCert ? data?.certification?.email : data?.applicants?.[0]?.email) ??
+      false,
+    phone:
+      (useCert
+        ? data?.certification?.phone_number
+        : data?.applicants?.[0]?.phone_number) ?? false,
   };
 }
 
@@ -155,6 +186,11 @@ export default function transformForSubmit(formConfig, form) {
   dataPostTransform.veteran.address['postal_code'] =
     dataPostTransform.veteran.address.postalCode || '';
   delete dataPostTransform.veteran.address.postalCode;
+
+  // For our backend callback API, we need to designate which contact info
+  // should be used if there is a notification event pertaining to this specific
+  // form submission. We do this by adding the `primaryContactInfo` key:
+  dataPostTransform.primaryContactInfo = getPrimaryContact(dataPostTransform);
 
   return JSON.stringify({
     ...dataPostTransform,

--- a/src/applications/ivc-champva/10-10D/tests/unit/config/submitTransformer.unit.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/unit/config/submitTransformer.unit.spec.js
@@ -82,4 +82,74 @@ describe('transform for submit', () => {
       transformed.applicants[0].full_name.first,
     );
   });
+  it('should set sponsor info as primary contact if certifierRole == sponsor', () => {
+    const sponsorCert = {
+      data: {
+        certifierRole: 'sponsor',
+        sponsorPhone: '1231231234',
+        veteransFullName: { first: 'Jack', last: 'Veteran' },
+      },
+    };
+    const transformed = JSON.parse(transformForSubmit(formConfig, sponsorCert));
+    expect(transformed.primaryContactInfo.name.first).to.equal(
+      sponsorCert.data.veteransFullName.first,
+    );
+    expect(transformed.primaryContactInfo.name.last).to.equal(
+      sponsorCert.data.veteransFullName.last,
+    );
+    expect(transformed.primaryContactInfo.phone).to.equal(
+      sponsorCert.data.sponsorPhone,
+    );
+  });
+  it('should set certifier info as primary contact if certifierRole == other', () => {
+    const certifierCert = {
+      data: {
+        certifierRole: 'other',
+        certifierPhone: '1231231234',
+        certifierName: { first: 'Jack', last: 'Certifier' },
+      },
+    };
+    const transformed = JSON.parse(
+      transformForSubmit(formConfig, certifierCert),
+    );
+    expect(transformed.primaryContactInfo.name.first).to.equal(
+      certifierCert.data.certifierName.first,
+    );
+    expect(transformed.primaryContactInfo.name.last).to.equal(
+      certifierCert.data.certifierName.last,
+    );
+    expect(transformed.primaryContactInfo.phone).to.equal(
+      certifierCert.data.certifierPhone,
+    );
+  });
+  it('should set first applicant info as primary contact if certifierRole == applicant', () => {
+    const appCert = {
+      data: {
+        certifierRole: 'applicant',
+        applicants: [
+          {
+            applicantAddress: {},
+            applicantName: { first: 'Jack', last: 'Applicant' },
+            applicantPhone: '1231231234',
+          },
+        ],
+      },
+    };
+    const transformed = JSON.parse(transformForSubmit(formConfig, appCert));
+    expect(transformed.primaryContactInfo.name.first).to.equal(
+      appCert.data.applicants[0].applicantName.first,
+    );
+    expect(transformed.primaryContactInfo.name.last).to.equal(
+      appCert.data.applicants[0].applicantName.last,
+    );
+    expect(transformed.primaryContactInfo.phone).to.equal(
+      appCert.data.applicants[0].applicantPhone,
+    );
+  });
+  it('should set primary contact keys to false if data is missing', () => {
+    const transformed = JSON.parse(
+      transformForSubmit(formConfig, { data: {} }),
+    );
+    expect(transformed.primaryContactInfo.name.first).to.be.false;
+  });
 });


### PR DESCRIPTION
## Summary

This PR updates the submit transformer on form 10-10d to include a `primaryContactInfo` key that will be used by our backend callback API. This prevents the backend from having to know anything about this particular form while still knowing who to contact if we have a notification event.

This data is in the format:
```json
"primaryContactInfo": {
  "name": {"first": "", "last": ""},
  "email": "",
  "phone": ""
}
```

- Adds new logic to the submit transformer to send backend the right contact info
- Added new unit tests to verify the functionality
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- NA

## Testing done

- Unit tests

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA