### PR TITLE
Update submit transformer with primary contact info

### DIFF
--- a/src/applications/ivc-champva/10-7959C/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959C/config/submitTransformer.js
@@ -1,6 +1,18 @@
 /* eslint-disable camelcase */
 import { transformForSubmit as formsSystemTransformForSubmit } from 'platform/forms-system/src/js/helpers';
 
+function getPrimaryContact(data) {
+  // For callback API we need to know what data in the form should be
+  // treated as the primary contact. Determined based on `certifierRole`:
+  const useCert = data.certifierRole !== 'applicant';
+  return {
+    name: (useCert ? data?.certifierName : data?.applicantName) ?? false,
+    email:
+      (useCert ? data?.certifierEmail : data?.applicantEmailAddress) ?? false,
+    phone: (useCert ? data?.certifierPhone : data?.applicantPhone) ?? false,
+  };
+}
+
 export default function transformForSubmit(formConfig, form) {
   const transformedData = JSON.parse(
     formsSystemTransformForSubmit(formConfig, form),
@@ -35,6 +47,10 @@ export default function transformForSubmit(formConfig, form) {
   copyOfData.certificationDate = new Date()
     .toLocaleDateString('es-pa')
     .replace(/\//g, '-');
+
+  // Set this for the callback API so it knows who to contact if there's
+  // a status event notification
+  copyOfData.primaryContactInfo = getPrimaryContact(copyOfData);
 
   return JSON.stringify({
     ...copyOfData,

--- a/src/applications/ivc-champva/10-7959C/tests/containers/transformer.unit.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/containers/transformer.unit.spec.js
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+import formConfig from '../../config/form';
+import transformForSubmit from '../../config/submitTransformer';
+
+describe('transform for submit', () => {
+  it('should set certifier info as primary contact if certifierRole == other', () => {
+    const certifierCert = {
+      data: {
+        applicantName: { middle: 'unused' }, // prevents unrelated error
+        certifierRole: 'other',
+        certifierPhone: '1231231234',
+        certifierName: { first: 'Jack', last: 'Certifier' },
+        certifierEmail: 'certifier@email.gov',
+      },
+    };
+    const transformed = JSON.parse(
+      transformForSubmit(formConfig, certifierCert),
+    );
+    expect(transformed.primaryContactInfo.name.first).to.equal(
+      certifierCert.data.certifierName.first,
+    );
+    expect(transformed.primaryContactInfo.name.last).to.equal(
+      certifierCert.data.certifierName.last,
+    );
+    expect(transformed.primaryContactInfo.phone).to.equal(
+      certifierCert.data.certifierPhone,
+    );
+    expect(transformed.primaryContactInfo.email).to.equal(
+      certifierCert.data.certifierEmail,
+    );
+  });
+  it('should set applicant info as primary contact if certifierRole == applicant', () => {
+    const certifierCert = {
+      data: {
+        certifierRole: 'applicant',
+        applicantName: { first: 'Jack', middle: 'Middle', last: 'Applicant' },
+        applicantPhone: '1231231234',
+        applicantEmailAddress: 'applicant@email.gov',
+      },
+    };
+    const transformed = JSON.parse(
+      transformForSubmit(formConfig, certifierCert),
+    );
+    expect(transformed.primaryContactInfo.name.first).to.equal(
+      certifierCert.data.applicantName.first,
+    );
+    expect(transformed.primaryContactInfo.name.last).to.equal(
+      certifierCert.data.applicantName.last,
+    );
+    expect(transformed.primaryContactInfo.phone).to.equal(
+      certifierCert.data.applicantPhone,
+    );
+    expect(transformed.primaryContactInfo.email).to.equal(
+      certifierCert.data.applicantEmailAddress,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

This PR updates the submit transformer on form 10-7959c to include a `primaryContactInfo` key that will be used by our backend callback API. This prevents the backend from having to know anything about this particular form while still knowing who to contact if we have a notification event.

This data is in the format:
```json
"primaryContactInfo": {
  "name": {"first": "", "last": ""},
  "email": "",
  "phone": ""
}
```

- Adds new logic to the submit transformer to send backend the right contact info
- Added new unit tests to verify the functionality
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- NA

## Testing done

- Unit

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA