### PR TITLE
Update request military records to align with design

### DIFF
--- a/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile/components/military-information/MilitaryInformation.jsx
@@ -4,7 +4,6 @@ import { some } from 'lodash';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 import { connect, useSelector } from 'react-redux';
 import { selectProfileShowProofOfVeteranStatusToggle } from '@@profile/selectors';
-import ProofOfVeteranStatus from '../proof-of-veteran-status/ProofOfVeteranStatus';
 
 import { DevTools } from '~/applications/personalization/common/components/devtools/DevTools';
 
@@ -13,6 +12,7 @@ import DowntimeNotification, {
 } from '~/platform/monitoring/DowntimeNotification';
 import { focusElement } from '~/platform/utilities/ui';
 import { selectVeteranStatus } from '~/platform/user/selectors';
+import ProofOfVeteranStatus from '../proof-of-veteran-status/ProofOfVeteranStatus';
 
 import LoadFail from '../alerts/LoadFail';
 import { handleDowntimeForSection } from '../alerts/DowntimeBanner';
@@ -169,7 +169,7 @@ const MilitaryInformationContent = ({ militaryInformation, veteranStatus }) => {
         asList
       />
 
-      <div className="vads-u-margin-y--4">
+      <div className="vads-u-margin-bottom--4 vads-u-margin-top--1">
         <va-additional-info
           trigger="What if I don't think my military service information is correct?"
           uswds
@@ -228,15 +228,21 @@ const MilitaryInformation = ({ militaryInformation, veteranStatus }) => {
           veteranStatus={veteranStatus}
         />
       </DowntimeNotification>
-      <va-summary-box uswds>
-        <h3 className="vads-u-margin-top--0" slot="headline">
-          Request your military records (DD214)
-        </h3>
-        <va-link
-          href="/records/get-military-service-records"
-          text="Learn how to request your DD214 and other military records"
-        />
-      </va-summary-box>
+
+      <h3 className="vads-u-margin--0 vads-u-font-size--h2">
+        Request your military service records
+      </h3>
+
+      <p className="vads-u-margin-y--1">
+        You can request a copy of your DD214 and other military service records
+        from the National Archives.
+      </p>
+
+      <va-link
+        href="/records/get-military-service-records"
+        text="Learn how to request your DD214 and other military records"
+        active
+      />
 
       {profileShowProofOfVeteranStatus &&
         militaryInformation?.serviceHistory?.serviceHistory && (

--- a/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatus.jsx
+++ b/src/applications/personalization/profile/components/proof-of-veteran-status/ProofOfVeteranStatus.jsx
@@ -68,7 +68,7 @@ const ProofOfVeteranStatus = ({
     <>
       {serviceHistory.length > 0 && eligibilityMap.includes('Y') ? (
         <div id="proof-of-veteran-status">
-          <h2 className="vads-u-font-size--h3 vads-u-margin-top--4 vads-u-margin-bottom--1p5">
+          <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--1p5">
             Proof of Veteran status
           </h2>
           <p>


### PR DESCRIPTION
## Summary

- Pretty basic changes to remove the section to request military records to now be a regular heading -> paragraph -> link instead of the previous `va-summary-box` usage.
- NOTE: one issue with the design is that the action link does not seem to be supported or available in the design system components at this time. The closest thing that i found was the 'active' variant of the va-link component, so that is what I used. I will confer with design when they are back from their time off, but for now this should suffice.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75211

- design file is here:
https://www.figma.com/file/zb5ecY9yMnupiLjaH9UmSc/Profile---Military-Information?type=design&node-id=104%3A996&mode=design&t=7A8fsiful5QPjJm2-1

## Testing done

- Just content changes at this point. No functionality is being changed.

## Screenshots

| Before | After |
| ------ | ----- |
| ![Screenshot 2024-05-08 at 9 46 36 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/5122eaec-0644-4167-a057-cd303e0d50e5) | ![Screenshot 2024-05-08 at 9 45 20 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/0e9f02b5-200d-4905-b335-dbce25df04c2) |


## What areas of the site does it impact?

Profile -> Military Information

## Acceptance criteria

- FE now reflects design file

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
