### PR TITLE
10-7959f-1 Adding Primary Customer key for backend mapping

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/submitTransformer.js
@@ -30,6 +30,14 @@ export default function transformForSubmit(formConfig, form) {
     },
     // statement_of_truth_signature: transformedData.fullName,
     current_date: new Date().toJSON().slice(0, 10),
+    primaryCustomer: {
+      name: {
+        first: transformedData.firstName,
+        last: transformedData.lastName,
+      },
+      email: transformedData.email_address,
+      phone: transformedData.phone_number,
+    },
   };
   return JSON.stringify({
     ...dataPostTransform,

--- a/src/applications/ivc-champva/10-7959f-1/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/submitTransformer.js
@@ -30,7 +30,7 @@ export default function transformForSubmit(formConfig, form) {
     },
     // statement_of_truth_signature: transformedData.fullName,
     current_date: new Date().toJSON().slice(0, 10),
-    primaryCustomer: {
+    primaryContactInfo: {
       name: {
         first: transformedData.firstName,
         last: transformedData.lastName,


### PR DESCRIPTION
## Summary
Added primaryCustomer key to submitTransformer. This information is necessary for the backend to use for contact information should that be needed. The data is in this format:

`"primaryContactInfo": {
  "name": {"first": "", "last": ""},
  "email": "",
  "phone": ""
}`

## Related issue(s)
NA

## Testing done
Manual testing

## What areas of the site does it impact?
this form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA
