### PR TITLE
Convert to va-icon on provider selection page

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelect.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSelect.jsx
@@ -33,10 +33,7 @@ export default function SelectedProvider({
             recordEvent({ event: `${GA_PREFIX}-choose-provider-click` });
           }}
         >
-          <i
-            className="fas fa-plus vads-u-padding-right--0p5"
-            aria-hidden="true"
-          />
+          <va-icon icon="add" size="3" aria-hidden="true" />
           Find a provider
         </button>
       )}


### PR DESCRIPTION

## Summary

This PR converts font awesome icon to use va-icon web component on the provider selection page. It update the `+` (plus) icon


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#79355


## Testing done

Visual inspection

## Screenshots

![Screenshot 2024-05-08 at 7 28 46 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/593df3cd-fdf2-4e98-b742-865d5c0bdb56)


## What areas of the site does it impact?

Provider selection page

## Acceptance criteria

- [ ] Convert the font awesome plus icon to use va-icon web component on the provider selection page

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
