### PR TITLE
Preparing for rep status widget go-live

### DIFF
--- a/src/applications/representative-search/containers/SearchPage.jsx
+++ b/src/applications/representative-search/containers/SearchPage.jsx
@@ -8,6 +8,7 @@ import {
   VaModal,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles/useFeatureToggle';
 import { isEmpty } from 'lodash';
 import appendQuery from 'append-query';
 import { browserHistory } from 'react-router';
@@ -59,6 +60,12 @@ const SearchPage = props => {
     isEmpty(props.location.query);
 
   const store = useStore();
+
+  const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
+
+  const widgetEnabled = useToggleValue(
+    TOGGLE_NAMES.representativeStatusEnabled,
+  );
 
   const updateUrlParams = params => {
     const { location, currentQuery } = props;
@@ -355,7 +362,7 @@ const SearchPage = props => {
           </p>
         </div>
 
-        {!environment.isProduction() && (
+        {widgetEnabled && (
           <>
             <h2>Check if you already have an accredited representative</h2>
             <p>
@@ -366,7 +373,9 @@ const SearchPage = props => {
               If you appoint a new accredited representative, they will replace
               your current one.
             </p>
-            <div data-widget-type="representative-status" />
+            <div tabIndex="-1">
+              <div data-widget-type="representative-status" />
+            </div>
           </>
         )}
 

--- a/src/applications/static-pages/representative-status/components/States/Auth.jsx
+++ b/src/applications/static-pages/representative-status/components/States/Auth.jsx
@@ -54,11 +54,7 @@ export const Auth = ({
         <va-card show-shadow>
           <div className="auth-card">
             <div className="auth-header-icon">
-              <va-icon
-                icon="account_circle"
-                size={4}
-                srtext="Your representative"
-              />{' '}
+              <va-icon icon="account_circle" size={4} />{' '}
             </div>
             <div className="auth-rep-text">
               <div className="auth-rep-header">
@@ -140,11 +136,7 @@ export const Auth = ({
                   (contact || email) && (
                     <div className="vads-u-display--flex vads-u-margin-top--1p5">
                       <div className="vads-u-margin-right--1 vads-u-display--flex vads-u-align-items--flex-start vads-u-margin-top--0p5">
-                        <va-icon
-                          icon="file_download"
-                          size={2}
-                          srtext="Download your accredited representative's contact information"
-                        />
+                        <va-icon icon="file_download" size={2} />
                       </div>
                       <va-link
                         filetype="VCF"
@@ -156,11 +148,7 @@ export const Auth = ({
                   )}
                 <div className="vads-u-display--flex vads-u-margin-top--1p5">
                   <div className="vads-u-margin-right--1 vads-u-display--flex vads-u-align-items--flex-start vads-u-margin-top--0p5">
-                    <va-icon
-                      icon="search"
-                      size={2}
-                      srtext="Learn about accredited representatives"
-                    />
+                    <va-icon icon="search" size={2} />
                   </div>
                   <va-link
                     href="https://www.va.gov/resources/va-accredited-representative-faqs/"
@@ -211,7 +199,9 @@ export const Auth = ({
       uswds
       visible
     >
-      <h2 slot="headline">We don’t seem to have your records</h2>
+      <DynamicHeader slot="headline">
+        We don’t seem to have your records
+      </DynamicHeader>
       <React.Fragment key=".1">
         <p>We’re sorry. We can’t match your information to our records.</p>
 


### PR DESCRIPTION
## Summary

- Removed unnecessary srtext from rep status widget
- Replaced `<h2>` in rep status widget with dynamic header
- Wrapped widget instantiation in a feature toggle

## Screenshot
<img width="844" alt="Screenshot 2024-05-06 at 3 29 08 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/143013011/d1560e94-10e6-4a02-9524-2d81ba7cec87">
