### PR TITLE
fix: add back hide on review page logic which was removed

### DIFF
--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -90,10 +90,12 @@ export function createFormPageList(formConfig) {
     if (!chapter?.pages) return pageList;
 
     const chapterTitle = chapter?.title ?? formConfig.title;
+    const hideOnReviewPage = chapter?.hideOnReviewPage || false;
     const pages = Object.keys(chapter.pages).map(pageKey => ({
       ...chapter.pages[pageKey],
       chapterTitle,
       chapterKey,
+      hideOnReviewPage,
       pageKey,
     }));
     return pageList.concat(pages);


### PR DESCRIPTION
This commit adds back logic which originally was intended to hide an entry on the ReviewPage for forms.

## Summary

- Add back logic which includes the `hideOnReviewPage` boolean to the chapter page list.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team-forms#1183

## Testing done

- Browser testing successful
