### PR TITLE
fix form nav button imports

### DIFF
--- a/src/applications/financial-status-report/components/resolution/ResolutionExplainerWidget.jsx
+++ b/src/applications/financial-status-report/components/resolution/ResolutionExplainerWidget.jsx
@@ -31,7 +31,7 @@ const ResolutionExplainerWidget = ({
   };
   React.useEffect(() => {
     // focus on the h3  when the page loads for screen readers
-    waitForRenderThenFocus('h3', document.querySelector('va-alert').shadowRoot);
+    waitForRenderThenFocus('h3');
   }, []);
   return (
     <form

--- a/src/applications/financial-status-report/components/resolution/ResolutionExplainerWidget.jsx
+++ b/src/applications/financial-status-report/components/resolution/ResolutionExplainerWidget.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import FormNavButtons from '@department-of-veterans-affairs/platform-forms-system/FormNavButtons';
+import { waitForRenderThenFocus } from '@department-of-veterans-affairs/platform-utilities/ui';
 import ReviewPageNavigationAlert from '../alerts/ReviewPageNavigationAlert';
 
 const ResolutionExplainerWidget = ({
@@ -28,7 +29,10 @@ const ResolutionExplainerWidget = ({
       goBack();
     }
   };
-
+  React.useEffect(() => {
+    // focus on the h3  when the page loads for screen readers
+    waitForRenderThenFocus('h3', document.querySelector('va-alert').shadowRoot);
+  }, []);
   return (
     <form
       onSubmit={event => {
@@ -41,9 +45,8 @@ const ResolutionExplainerWidget = ({
           close-btn-aria-label="Close notification"
           disable-analytics="false"
           full-width="false"
-          show-icon
           status="info"
-          visible="true"
+          visible
         >
           <h3 slot="headline">
             Next, you’ll be asked to choose a relief option for each debt you

--- a/src/applications/financial-status-report/components/shared/ExplainerComponent.jsx
+++ b/src/applications/financial-status-report/components/shared/ExplainerComponent.jsx
@@ -14,7 +14,7 @@ const ExplainerComponent = ({
 }) => {
   React.useEffect(() => {
     // focus on the h3  when the page loads for screen readers
-    waitForRenderThenFocus('h3', document.querySelector('va-alert').shadowRoot);
+    waitForRenderThenFocus('h3');
   }, []);
   return (
     <form>

--- a/src/applications/financial-status-report/components/shared/ExplainerComponent.jsx
+++ b/src/applications/financial-status-report/components/shared/ExplainerComponent.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import FormNavButtons from '@department-of-veterans-affairs/platform-forms-system/FormNavButtons';
+import { waitForRenderThenFocus } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 const ExplainerComponent = ({
   headline,
@@ -11,6 +12,10 @@ const ExplainerComponent = ({
   goBack,
   goForward,
 }) => {
+  React.useEffect(() => {
+    // focus on the h3  when the page loads for screen readers
+    waitForRenderThenFocus('h3', document.querySelector('va-alert').shadowRoot);
+  }, []);
   return (
     <form>
       <fieldset className="vads-u-margin-y--2">


### PR DESCRIPTION
We noticed when participants were using Voiceovers on a Mac and go to the Streamlined Waiver transition page, it wouldn't set focus on the heading in the va-alert component.

Screenshot of fix:

<img width="681" alt="Screenshot 2024-05-09 at 1 28 46 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/b474206b-bf2c-42a4-a4d6-d2aa5b94c4e2">



## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#69366


## Testing
Screen reader verification macbook pro m3