### PR TITLE
Remove duplicate request headers from Caregiver download link

### DIFF
--- a/src/applications/caregivers/components/ApplicationDownloadLink.jsx
+++ b/src/applications/caregivers/components/ApplicationDownloadLink.jsx
@@ -6,7 +6,6 @@ import { apiRequest } from 'platform/utilities/api';
 import { focusElement } from 'platform/utilities/ui';
 import environment from 'platform/utilities/environment';
 import recordEvent from 'platform/monitoring/record-event';
-import localStorage from 'platform/utilities/storage/localStorage';
 import { downloadErrorsByCode } from '../definitions/content';
 import { submitTransform } from '../utils/helpers';
 import formConfig from '../config/form';
@@ -31,7 +30,6 @@ const ApplicationDownloadLink = ({ form }) => {
     return downloadErrorsByCode[code] || generic;
   };
 
-  const csrfTokenStored = localStorage.getItem('csrfToken');
   // define our method of retrieving the link to download
   const fetchDownloadUrl = body => {
     isLoading(true);
@@ -42,8 +40,6 @@ const ApplicationDownloadLink = ({ form }) => {
       body,
       headers: {
         'Content-Type': 'application/json',
-        'Source-App-Name': window.appName,
-        'X-CSRF-Token': csrfTokenStored,
       },
     })
       .then(response => response.blob())


### PR DESCRIPTION
## Summary

This PR clean up passing duplicate API request headers to a request to generate a download link for the Caregiver form. This is the first step in a larger effort to clean, refactor and (hopefully) eliminate some pesky CSRF token errors.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#80361

## Acceptance criteria

- Only necessary options are passed to the API request method.

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
