### PR TITLE
80217 url and title updates

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
@@ -12,6 +12,7 @@ import {
   gulfWar1990PageTitle,
   showCheckboxLoopDetailsPage,
   startDateApproximate,
+  teSubtitle,
 } from '../../content/toxicExposure';
 import { GULF_WAR_1990_LOCATIONS, TE_URL_PREFIX } from '../../constants';
 
@@ -107,7 +108,12 @@ export function makePages() {
       const pageName = `gulf-war-1990-location-${locationId}`;
       return {
         [pageName]: {
-          title: gulfWar1990PageTitle,
+          title: formData =>
+            teSubtitle(
+              getKeyIndex(locationId, 'gulfWar1990', { formData }),
+              getSelectedCount('gulfWar1990', { formData }),
+              GULF_WAR_1990_LOCATIONS[locationId],
+            ),
           path: `${TE_URL_PREFIX}/${pageName}`,
           uiSchema: makeUiSchema(locationId),
           schema: makeSchema(locationId),

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Summary.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Summary.js
@@ -12,7 +12,7 @@ export const uiSchema = {
       GULF_WAR_1990_LOCATIONS,
       'gulfWar1990Details',
       'go back and edit locations and dates for service after August 2, 1990',
-      `${TE_URL_PREFIX}/gulf-war-hazard-1990`,
+      `${TE_URL_PREFIX}/gulf-war-1990`,
     ),
 };
 

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
@@ -27,7 +27,7 @@ export const toxicExposurePages = {
   },
   gulfWar1990Locations: {
     title: gulfWar1990PageTitle,
-    path: `${TE_URL_PREFIX}/gulf-war-hazard-1990`,
+    path: `${TE_URL_PREFIX}/gulf-war-1990`,
     depends: formData => isClaimingTECondition(formData),
     uiSchema: gulfWar1990Locations.uiSchema,
     schema: gulfWar1990Locations.schema,

--- a/src/applications/disability-benefits/all-claims/tests/content/toxicExposureSummary.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/toxicExposureSummary.unit.spec.jsx
@@ -22,7 +22,7 @@ describe('toxicExposureSummary', () => {
         GULF_WAR_1990_LOCATIONS,
         'gulfWar1990Details',
         'go back and edit locations and dates for service after August 2, 1990',
-        `${TE_URL_PREFIX}/gulf-war-hazard-1990`,
+        `${TE_URL_PREFIX}/gulf-war-1990`,
       ),
     );
 
@@ -59,7 +59,7 @@ describe('toxicExposureSummary', () => {
         GULF_WAR_1990_LOCATIONS,
         'gulfWar1990Details',
         'go back and edit locations and dates for service after August 2, 1990',
-        `${TE_URL_PREFIX}/gulf-war-hazard-1990`,
+        `${TE_URL_PREFIX}/gulf-war-1990`,
       ),
     );
 
@@ -100,7 +100,7 @@ describe('toxicExposureSummary', () => {
         GULF_WAR_1990_LOCATIONS,
         'gulfWar1990Details',
         'go back and edit locations and dates for service after August 2, 1990',
-        `${TE_URL_PREFIX}/gulf-war-hazard-1990`,
+        `${TE_URL_PREFIX}/gulf-war-1990`,
       ),
     );
 
@@ -144,7 +144,7 @@ describe('toxicExposureSummary', () => {
         GULF_WAR_1990_LOCATIONS,
         'gulfWar1990Details',
         'go back and edit locations and dates for service after August 2, 1990',
-        `${TE_URL_PREFIX}/gulf-war-hazard-1990`,
+        `${TE_URL_PREFIX}/gulf-war-1990`,
       ),
     );
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/gulfWar1990Details.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/gulfWar1990Details.unit.spec.jsx
@@ -31,59 +31,66 @@ describe('gulfWar1990Details', () => {
     },
   };
 
-  Object.keys(GULF_WAR_1990_LOCATIONS)
-    .filter(locationId => locationId !== 'none')
-    .forEach(locationId => {
-      it(`should render for ${locationId}`, () => {
-        const { container, getByText } = render(
-          <DefinitionTester
-            schema={schemas[`gulf-war-1990-location-${locationId}`]?.schema}
-            uiSchema={schemas[`gulf-war-1990-location-${locationId}`]?.uiSchema}
-            data={formData}
-          />,
+  Object.keys(GULF_WAR_1990_LOCATIONS).forEach(locationId => {
+    const pageSchema = schemas[`gulf-war-1990-location-${locationId}`];
+    it(`should render for ${locationId}`, () => {
+      const { container, getByText } = render(
+        <DefinitionTester
+          schema={pageSchema.schema}
+          uiSchema={pageSchema.uiSchema}
+          data={formData}
+        />,
+      );
+
+      getByText(gulfWar1990PageTitle);
+      getByText(dateRangeDescription);
+
+      const addlInfo = container.querySelector('va-additional-info');
+      expect(addlInfo).to.have.attribute(
+        'trigger',
+        'What if I have more than one date range?',
+      );
+
+      expect($(`va-memorable-date[label="${startDateApproximate}"]`, container))
+        .to.exist;
+      expect($(`va-memorable-date[label="${endDateApproximate}"]`, container))
+        .to.exist;
+
+      if (locationId === 'afghanistan') {
+        getByText(`Location 1 of 2: ${GULF_WAR_1990_LOCATIONS.afghanistan}`, {
+          exact: false,
+        });
+        expect(pageSchema.title(formData)).to.equal(
+          `Location 1 of 2: ${GULF_WAR_1990_LOCATIONS.afghanistan}`,
         );
-
-        getByText(gulfWar1990PageTitle);
-        getByText(dateRangeDescription);
-
-        const addlInfo = container.querySelector('va-additional-info');
-        expect(addlInfo).to.have.attribute(
-          'trigger',
-          'What if I have more than one date range?',
+      } else if (locationId === 'airspace') {
+        getByText(`Location 2 of 2: ${GULF_WAR_1990_LOCATIONS.airspace}`, {
+          exact: false,
+        });
+        expect(pageSchema.title(formData)).to.equal(
+          `Location 2 of 2: ${GULF_WAR_1990_LOCATIONS.airspace}`,
         );
-
-        expect(
-          $(`va-memorable-date[label="${startDateApproximate}"]`, container),
-        ).to.exist;
-        expect($(`va-memorable-date[label="${endDateApproximate}"]`, container))
-          .to.exist;
-
-        if (locationId === 'afghanistan') {
-          getByText(`1 of 2: ${GULF_WAR_1990_LOCATIONS.afghanistan}`, {
-            exact: false,
-          });
-        } else if (locationId === 'airspace') {
-          getByText(`2 of 2: ${GULF_WAR_1990_LOCATIONS.airspace}`, {
-            exact: false,
-          });
-        } else {
-          getByText(GULF_WAR_1990_LOCATIONS[locationId]);
-        }
-      });
-
-      it(`should submit without dates for ${locationId}`, () => {
-        const onSubmit = sinon.spy();
-        const { getByText } = render(
-          <DefinitionTester
-            schema={schemas[`gulf-war-1990-location-${locationId}`]?.schema}
-            uiSchema={schemas[`gulf-war-1990-location-${locationId}`]?.uiSchema}
-            data={formData}
-            onSubmit={onSubmit}
-          />,
+      } else {
+        getByText(GULF_WAR_1990_LOCATIONS[locationId]);
+        expect(pageSchema.title(formData)).to.equal(
+          `${GULF_WAR_1990_LOCATIONS[locationId]}`,
         );
-
-        userEvent.click(getByText('Submit'));
-        expect(onSubmit.calledOnce).to.be.true;
-      });
+      }
     });
+
+    it(`should submit without dates for ${locationId}`, () => {
+      const onSubmit = sinon.spy();
+      const { getByText } = render(
+        <DefinitionTester
+          schema={schemas[`gulf-war-1990-location-${locationId}`]?.schema}
+          uiSchema={schemas[`gulf-war-1990-location-${locationId}`]?.uiSchema}
+          data={formData}
+          onSubmit={onSubmit}
+        />,
+      );
+
+      userEvent.click(getByText('Submit'));
+      expect(onSubmit.calledOnce).to.be.true;
+    });
+  });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/gulfWar1990Details.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/gulfWar1990Details.unit.spec.jsx
@@ -31,66 +31,69 @@ describe('gulfWar1990Details', () => {
     },
   };
 
-  Object.keys(GULF_WAR_1990_LOCATIONS).forEach(locationId => {
-    const pageSchema = schemas[`gulf-war-1990-location-${locationId}`];
-    it(`should render for ${locationId}`, () => {
-      const { container, getByText } = render(
-        <DefinitionTester
-          schema={pageSchema.schema}
-          uiSchema={pageSchema.uiSchema}
-          data={formData}
-        />,
-      );
-
-      getByText(gulfWar1990PageTitle);
-      getByText(dateRangeDescription);
-
-      const addlInfo = container.querySelector('va-additional-info');
-      expect(addlInfo).to.have.attribute(
-        'trigger',
-        'What if I have more than one date range?',
-      );
-
-      expect($(`va-memorable-date[label="${startDateApproximate}"]`, container))
-        .to.exist;
-      expect($(`va-memorable-date[label="${endDateApproximate}"]`, container))
-        .to.exist;
-
-      if (locationId === 'afghanistan') {
-        getByText(`Location 1 of 2: ${GULF_WAR_1990_LOCATIONS.afghanistan}`, {
-          exact: false,
-        });
-        expect(pageSchema.title(formData)).to.equal(
-          `Location 1 of 2: ${GULF_WAR_1990_LOCATIONS.afghanistan}`,
+  Object.keys(GULF_WAR_1990_LOCATIONS)
+    .filter(locationId => locationId !== 'none')
+    .forEach(locationId => {
+      const pageSchema = schemas[`gulf-war-1990-location-${locationId}`];
+      it(`should render for ${locationId}`, () => {
+        const { container, getByText } = render(
+          <DefinitionTester
+            schema={pageSchema.schema}
+            uiSchema={pageSchema.uiSchema}
+            data={formData}
+          />,
         );
-      } else if (locationId === 'airspace') {
-        getByText(`Location 2 of 2: ${GULF_WAR_1990_LOCATIONS.airspace}`, {
-          exact: false,
-        });
-        expect(pageSchema.title(formData)).to.equal(
-          `Location 2 of 2: ${GULF_WAR_1990_LOCATIONS.airspace}`,
+
+        getByText(gulfWar1990PageTitle);
+        getByText(dateRangeDescription);
+
+        const addlInfo = container.querySelector('va-additional-info');
+        expect(addlInfo).to.have.attribute(
+          'trigger',
+          'What if I have more than one date range?',
         );
-      } else {
-        getByText(GULF_WAR_1990_LOCATIONS[locationId]);
-        expect(pageSchema.title(formData)).to.equal(
-          `${GULF_WAR_1990_LOCATIONS[locationId]}`,
+
+        expect(
+          $(`va-memorable-date[label="${startDateApproximate}"]`, container),
+        ).to.exist;
+        expect($(`va-memorable-date[label="${endDateApproximate}"]`, container))
+          .to.exist;
+
+        if (locationId === 'afghanistan') {
+          getByText(`Location 1 of 2: ${GULF_WAR_1990_LOCATIONS.afghanistan}`, {
+            exact: false,
+          });
+          expect(pageSchema.title(formData)).to.equal(
+            `Location 1 of 2: ${GULF_WAR_1990_LOCATIONS.afghanistan}`,
+          );
+        } else if (locationId === 'airspace') {
+          getByText(`Location 2 of 2: ${GULF_WAR_1990_LOCATIONS.airspace}`, {
+            exact: false,
+          });
+          expect(pageSchema.title(formData)).to.equal(
+            `Location 2 of 2: ${GULF_WAR_1990_LOCATIONS.airspace}`,
+          );
+        } else {
+          getByText(GULF_WAR_1990_LOCATIONS[locationId]);
+          expect(pageSchema.title(formData)).to.equal(
+            `${GULF_WAR_1990_LOCATIONS[locationId]}`,
+          );
+        }
+      });
+
+      it(`should submit without dates for ${locationId}`, () => {
+        const onSubmit = sinon.spy();
+        const { getByText } = render(
+          <DefinitionTester
+            schema={schemas[`gulf-war-1990-location-${locationId}`]?.schema}
+            uiSchema={schemas[`gulf-war-1990-location-${locationId}`]?.uiSchema}
+            data={formData}
+            onSubmit={onSubmit}
+          />,
         );
-      }
+
+        userEvent.click(getByText('Submit'));
+        expect(onSubmit.calledOnce).to.be.true;
+      });
     });
-
-    it(`should submit without dates for ${locationId}`, () => {
-      const onSubmit = sinon.spy();
-      const { getByText } = render(
-        <DefinitionTester
-          schema={schemas[`gulf-war-1990-location-${locationId}`]?.schema}
-          uiSchema={schemas[`gulf-war-1990-location-${locationId}`]?.uiSchema}
-          data={formData}
-          onSubmit={onSubmit}
-        />,
-      );
-
-      userEvent.click(getByText('Submit'));
-      expect(onSubmit.calledOnce).to.be.true;
-    });
-  });
 });


### PR DESCRIPTION
## Summary
- Remove 'hazard' from gulf war 1990 url
- Use unique titles on the review and submit page for details pages

team: @department-of-veterans-affairs/dbex-trex 🦖
flipper: https://github.com/department-of-veterans-affairs/va.gov-team/issues/65089

## Related issue(s)

department-of-veterans-affairs/va.gov-team#80217

## Testing done
Updated unit tests and performed manual tests

- _Describe what the old behavior was prior to the change_
Old behavior had duplicative titles and url was `toxic-exposure/gulf-war-hazard-1990` instead of `toxic-exposure/gulf-war-1990`
- _Describe the steps required to verify your changes are working as expected_

**Setup steps**
1. Enable toggle `disability_526_toxic_exposure`
2. Start a new claim with new conditions
3. On the toxic-exposure/conditions page, select at least one new condition

**Manual Verification steps** 
1. **Verify**: When you get to the page titled 'Service after August 2, 1990', verify that the url now ends with `/toxic-exposure/gulf-war-1990`
2. Select at least two locations and then continue filling out the form until you get to the review and submit page
3. **Verify**: On the review and submit page, verify the details pages for 'Service after August 2, 1990' now have unique titles with the format '**Location** _n_ **of** _m_**:** _location name_'

## Screenshots
1. url changes
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/ae731c1c-c922-4bd6-9a24-9d5437a882bb)

2. review and submit changes
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/8821e3a8-ead7-495e-97c2-c3c058ad3613)

## What areas of the site does it impact?
526EZ

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
