### PR TITLE
[VA-15664] Remove null set for facility locator service type

### DIFF
--- a/src/applications/facility-locator/components/SearchControls.jsx
+++ b/src/applications/facility-locator/components/SearchControls.jsx
@@ -121,8 +121,6 @@ const SearchControls = props => {
     });
 
     onSubmit();
-
-    setSelectedServiceType(null);
   };
 
   const handleGeolocationButtonClick = e => {


### PR DESCRIPTION
## Summary

The facility locator errors out for users when a service is selected, the search is run, and then the service is run again. The error is it says the user still needs to look for an available service when the previous one is still there.

An old line of code (three years ago) sets the facility locator state to `null` after each search. I checked the pull request that added it and the cause is unclear, but it may be a case where the code is just outdated. I removed that line and the bug appears to be fixed (pending the passing tests).

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[department-of-veterans-affairs/va.gov-team#15664](https://github.com/department-of-veterans-affairs/va.gov-cms/issues/15664)

## Testing done

Local, see below video

Can test this by going to the facility locator in the PR environment and following the replication steps in the original 15664 ticket.

## Screenshots

https://github.com/department-of-veterans-affairs/vets-website/assets/10790736/1a56acfd-97e6-4c36-8ee5-2be100682224

## What areas of the site does it impact?

* Facility Locator

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
