### PR TITLE
Ask VA 949 - Design Changes for Your Contact information - "Your contact information" - conditionals

### DIFF
--- a/src/applications/ask-va/config/chapters/personalInformation/yourContactInformation.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/yourContactInformation.js
@@ -1,5 +1,3 @@
-// import emailUI from '@department-of-veterans-affairs/platform-forms-system/email';
-// import phoneUI from '@department-of-veterans-affairs/platform-forms-system/phone';
 import {
   emailSchema,
   emailUI,
@@ -10,6 +8,7 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import PrefillAlertAndTitle from '../../../components/PrefillAlertAndTitle';
 import { CHAPTER_3, contactOptions } from '../../../constants';
+import { getContactMethods, isEqualToOnlyEmail } from '../../helpers';
 
 const yourContactInformationPage = {
   uiSchema: {
@@ -19,8 +18,41 @@ const yourContactInformationPage = {
     contactPreference: radioUI({
       title: CHAPTER_3.CONTACT_PREF.QUESTION_1,
       description: '',
-      labels: contactOptions,
+      labels: {
+        PHONE: 'Phone call',
+        EMAIL: 'Email',
+        US_MAIL: 'U.S. mail',
+      },
     }),
+    'ui:options': {
+      updateSchema: (formData, formSchema) => {
+        const updatedCategoryTopicContactPreferences = getContactMethods(
+          formData.category,
+          formData.topic,
+        );
+        if (isEqualToOnlyEmail(updatedCategoryTopicContactPreferences)) {
+          return {
+            ...formSchema,
+            required: ['phoneNumber', 'emailAddress'],
+            properties: {
+              phoneNumber: phoneSchema,
+              emailAddress: emailSchema,
+            },
+          };
+        }
+        return {
+          ...formSchema,
+          properties: {
+            phoneNumber: phoneSchema,
+            emailAddress: emailSchema,
+            contactPreference: radioSchema(
+              Object.keys(updatedCategoryTopicContactPreferences),
+            ),
+          },
+          required: ['phoneNumber', 'emailAddress', 'contactPreference'],
+        };
+      },
+    },
   },
   schema: {
     type: 'object',

--- a/src/applications/ask-va/config/helpers.jsx
+++ b/src/applications/ask-va/config/helpers.jsx
@@ -14,3 +14,208 @@ export const ServerErrorAlert = () => (
     </p>
   </>
 );
+
+export const contactRules = {
+  'Benefits issues outside the U.S.': {
+    'Disability compensation': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Education benefits and work study': ['EMAIL'],
+  },
+  'Burials and memorials': {
+    'Pre-need eligibility for burial': ['EMAIL', 'PHONE'],
+    'Burial allowance': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Burial allowance for unclaimed Veteran remains': ['EMAIL', 'PHONE'],
+    'Burial in a VA national cemetery': ['EMAIL', 'PHONE'],
+    'Burial in a VA grant-funded state or tribal cemetery': ['EMAIL', 'PHONE'],
+    'Memorial items': ['EMAIL', 'PHONE'],
+    Other: ['EMAIL', 'PHONE'],
+  },
+  'Center for Minority Veterans': {
+    'Programs and policies': ['EMAIL', 'PHONE', 'US_MAIL'],
+  },
+  'Center for Women Veterans': {
+    'Programs and policies': ['EMAIL', 'US_MAIL'],
+    'General question': ['EMAIL'],
+  },
+  'Debt for benefit overpayments and copay bills': {
+    'School Certifying Officials (SCOs) or other school officials': [
+      'EMAIL',
+      'PHONE',
+      'US_MAIL',
+    ],
+    'Cemetery debt': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Disability compensation overpayment': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Disputing a debt': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Drill pay debt': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Education benefit overpayment': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Home loan debt': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Copay debt': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Pension benefit overpayment': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Separation debt': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Severance pay debt': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Veteran Readiness and Employment debt': ['EMAIL', 'PHONE', 'US_MAIL'],
+  },
+  'Decision reviews and appeals': {
+    'Higher-Level Reviews or Supplemental Claims': [
+      'EMAIL',
+      'PHONE',
+      'US_MAIL',
+    ],
+    'Board Appeals': ['EMAIL', 'PHONE', 'US_MAIL'],
+  },
+  'DEERS (Defense Enrollment Eligibility Reporting System)': {
+    'Adding requests': ['EMAIL'],
+    'Updating DEERS records': ['EMAIL'],
+  },
+  'Disability compensation': {
+    'Aid and Attendance or Housebound benefits': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Direct deposit': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'How to file a disability claim': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Guardianship, custodianship, or fiduciary issues': [
+      'EMAIL',
+      'PHONE',
+      'US_MAIL',
+    ],
+    'Issue with compensation received': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Checking claim status': ['EMAIL', 'PHONE', 'US_MAIL'],
+  },
+  'Education benefits and work study': {
+    'Transferring benefits after a death': ['EMAIL'],
+    'Compliance surveys': ['EMAIL'],
+    'On-the-job training and apprenticeships': ['EMAIL'],
+    'Post-9/11 GI Bill': ['EMAIL'],
+    'School Certifying Officials (SCOs)': ['EMAIL'],
+    'Benefits for survivors and dependents': ['EMAIL'],
+    'Transferred education benefits for family members': ['EMAIL'],
+    'Tuition Assistance Top-Up': ['EMAIL'],
+    'Web Automated Verification of Enrollment (WAVE)': ['EMAIL'],
+    'Work study': ['EMAIL'],
+    'Educational and career counseling': ['EMAIL'],
+    'Montgomery GI Bill Active Duty (Chapter 30)': ['EMAIL'],
+    'Montgomery GI Bill Selected Reserve (Chapter 1606)': ['EMAIL'],
+    'Reserve Educational Assistance Program (Chapter 1607)': ['EMAIL'],
+    'Veterans’ Educational Assistance Program (Chapter 32)': ['EMAIL'],
+    'Veteran Readiness and Employment (Chapter 31)': [
+      'EMAIL',
+      'PHONE',
+      'US_MAIL',
+    ],
+    'Verify school enrollment': ['EMAIL'],
+    'Request Certificate of Eligibility (COE) or Statement of Benefits': [
+      'EMAIL',
+    ],
+    'Licensing and testing fees': ['EMAIL'],
+    'Upload documents': ['EMAIL'],
+  },
+  'Guardianship, custodianship, or fiduciary issues': {
+    'Accounting issue': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Investigations and field examinations': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'About the program': ['EMAIL', 'PHONE', 'US_MAIL'],
+  },
+  'Health care': {
+    'Family health benefits': ['EMAIL', 'PHONE'],
+    'Eligibility and how to apply': ['EMAIL'],
+    'Getting care at a local VA medical center': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Career opportunities at VA health facilities': ['EMAIL', 'PHONE'],
+    'Caregiver support program': ['EMAIL', 'PHONE'],
+    'Vet Centers and readjustment counseling': ['EMAIL'],
+    'Audiology and hearing aids': ['EMAIL'],
+    Prosthetics: ['EMAIL'],
+    "Women's health services": ['EMAIL', 'PHONE'],
+    'Foreign Medical Program': ['EMAIL', 'PHONE'],
+  },
+  'Housing assistance and home loans': {
+    Appraisals: ['EMAIL', 'PHONE'],
+    'Funding fee refund': ['EMAIL', 'PHONE'],
+    'Home Loan Certificate of Eligibility (COE) or Restoration of Entitlement (ROE)': [
+      'EMAIL',
+      'PHONE',
+    ],
+    'Help to avoid foreclosure': ['EMAIL', 'PHONE'],
+    'Native American Direct Loan (NADL)': ['EMAIL', 'PHONE'],
+    'Specially Adapted Housing (SAH) and Special Home Adaptation (SHA) grants': [
+      'EMAIL',
+      'PHONE',
+    ],
+    'Home loan benefits': ['EMAIL', 'PHONE'],
+    'Homes for sale by VA': ['EMAIL', 'PHONE'],
+    'Property titles and taxes for homes sold by VA': ['EMAIL', 'PHONE'],
+  },
+  'Life insurance': {
+    'Insurance claims': ['EMAIL', 'PHONE'],
+    'Insurance premiums': ['EMAIL', 'PHONE'],
+    'Insurance website issues': ['EMAIL', 'PHONE'],
+    'Accessing your policy online': ['EMAIL', 'PHONE'],
+    'Policy loans': ['EMAIL', 'PHONE'],
+    'Service-Disabled Veterans Life Insurance (S-DVI)': ['EMAIL', 'PHONE'],
+    'Servicemembers’ Group Life Insurance (SGLI)': ['EMAIL', 'PHONE'],
+    'Family Servicemembers’ Group Life Insurance (FSGLI)': ['EMAIL', 'PHONE'],
+    'Veterans’ Group Life Insurance (VGLI)': ['EMAIL', 'PHONE'],
+    'Veterans’ Mortgage Life Insurance (VMLI)': ['EMAIL', 'PHONE'],
+    'Veterans Affairs Life Insurance (VALife)': ['EMAIL', 'PHONE'],
+    Other: ['EMAIL', 'PHONE'],
+  },
+  Pension: {
+    'Aid and Attendance or Housebound benefits': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Direct deposit': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'How to apply for pension benefits': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Guardianship, custodianship, or fiduciary issues': [
+      'EMAIL',
+      'PHONE',
+      'US_MAIL',
+    ],
+    'Issue with payment': ['EMAIL', 'PHONE', 'US_MAIL'],
+  },
+  'Sign in and technical issues': {
+    'Topics TBD': ['EMAIL'],
+  },
+  'Survivor benefits': {
+    'Aid and Attendance or Housebound benefits': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Direct deposit': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'How to apply for benefits': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Guardianship, custodianship, or fiduciary issues': [
+      'EMAIL',
+      'PHONE',
+      'US_MAIL',
+    ],
+    'Issue with benefit payment': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Checking claim status': ['EMAIL', 'PHONE', 'US_MAIL'],
+  },
+  'Veteran ID Card (VIC)': {
+    'Veteran ID Card (VIC) for discounts': ['EMAIL'],
+    'Veteran Health Identification Card (VHIC) for health appointments': [
+      'EMAIL',
+    ],
+  },
+  'Veteran Readiness and Employment': {
+    'Financial issues': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'How to apply': ['EMAIL', 'PHONE', 'US_MAIL'],
+    'Follow up on application or contact counselor': [
+      'EMAIL',
+      'PHONE',
+      'US_MAIL',
+    ],
+    Other: ['EMAIL', 'PHONE', 'US_MAIL'],
+  },
+};
+
+export const getContactMethods = (category, topic) => {
+  // const contactRules = initializeContactRules();
+  const allContactMethods = {
+    PHONE: 'Phone call',
+    EMAIL: 'Email',
+    US_MAIL: 'U.S. mail',
+  };
+
+  if (contactRules[category] && contactRules[category][topic]) {
+    return contactRules[category][topic].reduce((acc, method) => {
+      acc[method] = allContactMethods[method];
+      return acc;
+    }, {});
+  }
+  return allContactMethods;
+};
+
+export const isEqualToOnlyEmail = obj => {
+  const keys = Object.keys(obj);
+  return keys.length === 1 && keys[0] === 'EMAIL' && obj.EMAIL === 'Email';
+};


### PR DESCRIPTION
## Summary

- This is a follow up ticket to add the [conditionals](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/ask-va/design/Fields%2C%20options%20and%20labels/Contact%20options%20by%20business%20line.md#contact-rules-by-topic)
- Rules are based on business line requirements and take category and topic to determine final contact methods per [figma](https://www.figma.com/design/aQ6JsjD4pvMxSVPAZHllMX/AVA-Page-Library?node-id=6-25472&t=CPKnnUCR27uimPJk-0)
- UI previously built, only adding logic and updating schema
- The Ask VA team owns this page
- This is part of our POC

## Related issue(s)

- Link to ticket [here](https://app.zenhub.com/workspaces/ask-va-647a476551689d06655cc815/issues/gh/department-of-veterans-affairs/ask-va/949)

## Testing done

- Manual testing with conditionals

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/49699643/8af84ed8-041b-4bdf-905f-98c14f7f2206)
## What areas of the site does it impact?

- This only impacts the Ask VA form

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
