### PR TITLE
10-7959f-1 Added home address to prefill transformer

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/prefillTransformer.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/prefillTransformer.js
@@ -5,7 +5,7 @@ const prefillTransformer = (pages, formData, metadata) => {
       ...formData,
       veteranFullName: formData.veteranFullName,
       veteranAddress: formData.veteranAddress,
-      veteranHomßeAddress: formData.physicalAddress,
+      veteranResidentialAddress: formData.physicalAddress,
       veteranDateOfBirth: formData.veteranDateOfBirth,
       veteranSocialSecurityNumber: {
         ssn: formData.veteranSocialSecurityNumber,

--- a/src/applications/ivc-champva/10-7959f-1/config/prefillTransformer.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/prefillTransformer.js
@@ -5,7 +5,7 @@ const prefillTransformer = (pages, formData, metadata) => {
       ...formData,
       veteranFullName: formData.veteranFullName,
       veteranAddress: formData.veteranAddress,
-      veteranResidentialAddress: formData.physicalAddress,
+      veteranResidentialAddress: formData.veteranPhysicalAddress,
       veteranDateOfBirth: formData.veteranDateOfBirth,
       veteranSocialSecurityNumber: {
         ssn: formData.veteranSocialSecurityNumber,

--- a/src/applications/ivc-champva/10-7959f-1/config/prefillTransformer.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/prefillTransformer.js
@@ -5,6 +5,7 @@ const prefillTransformer = (pages, formData, metadata) => {
       ...formData,
       veteranFullName: formData.veteranFullName,
       veteranAddress: formData.veteranAddress,
+      veteranHomßeAddress: formData.physicalAddress,
       veteranDateOfBirth: formData.veteranDateOfBirth,
       veteranSocialSecurityNumber: {
         ssn: formData.veteranSocialSecurityNumber,

--- a/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
@@ -1,26 +1,15 @@
 import React, { useEffect } from 'react';
-import { connect } from 'react-redux';
 import { focusElement } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { Link } from 'react-router';
-import { getNextPagePath } from '@department-of-veterans-affairs/platform-forms-system/routing';
-import recordEvent from 'platform/monitoring/record-event';
 
 const IntroductionPage = props => {
-  const { route, isLoggedIn } = props;
-  const { formConfig, pageList, formData, pathname } = route;
+  const { route } = props;
+  const { formConfig, pageList } = route;
 
-  const getStartPage = () => {
-    const data = formData || {};
-    if (pathname) return getNextPagePath(pageList, data, pathname);
-    return pageList[1].path;
-  };
-
-  const handleClick = () => {
-    recordEvent({ event: 'no-login-start-form' });
-  };
+  const firstPage = pageList[1]?.path;
 
   useEffect(
     () => {
@@ -54,41 +43,37 @@ const IntroductionPage = props => {
           </li>
         </ul>
       </va-process-list>
-      {!isLoggedIn ? (
-        <VaAlert status="info" visible uswds>
-          <h2>Sign in now to save time and save your work in progress</h2>
-          <p>Here’s how signing in now helps you:</p>
-          <ul>
-            <li>
-              We can fill in some of your information for you to save you time.
-            </li>
-            <li>
-              You can save your work in progress. You’ll have 60 days from when
-              you start, or make updates, to come back and finish it.
-            </li>
-          </ul>
-          <p>
-            <strong>Note:</strong> You can sign in after you start your
-            registration form. But you’ll lose any information you already
-            filled in.
-          </p>
-          <p className="vads-u-margin-top--2">
-            <Link onClick={handleClick} to={getStartPage}>
-              Start your form without signing in
-            </Link>
-          </p>
-        </VaAlert>
-      ) : (
+      <VaAlert status="info" visible uswds>
+        <h2>Sign in now to save time and save your work in progress</h2>
+        <p>Here’s how signing in now helps you:</p>
+        <ul>
+          <li>
+            We can fill in some of your information for you to save you time.
+          </li>
+          <li>
+            You can save your work in progress. You’ll have 60 days from when
+            you start, or make updates, to come back and finish it.
+          </li>
+        </ul>
+        <p>
+          <strong>Note:</strong> You can sign in after you start your
+          registration form. But you’ll lose any information you already filled
+          in.
+        </p>
         <SaveInProgressIntro
-          formId={formConfig.formId}
+          buttonOnly
           headingLevel={2}
           prefillEnabled={formConfig.prefillEnabled}
           messages={formConfig.savedFormMessages}
           pageList={pageList}
-          startText="Start"
+          unauthStartText="Sign in to start your form"
+          hideUnauthedStartLink
         />
-      )}
-
+        <p className="vads-u-margin-top--2">
+          <Link to={firstPage}>Start your form without signing in</Link>
+        </p>
+      </VaAlert>
+      <p />
       <va-omb-info
         res-burden={4}
         omb-number="2900-0648"
@@ -98,10 +83,4 @@ const IntroductionPage = props => {
   );
 };
 
-const mapStateToProps = state => {
-  return {
-    isLoggedIn: state.user.login.currentlyLoggedIn,
-  };
-};
-
-export default connect(mapStateToProps)(IntroductionPage);
+export default IntroductionPage;

--- a/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { connect } from 'react-redux';
 import { focusElement } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
@@ -6,7 +7,7 @@ import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/
 import { Link } from 'react-router';
 
 const IntroductionPage = props => {
-  const { route } = props;
+  const { route, isLoggedIn } = props;
   const { formConfig, pageList } = route;
 
   const firstPage = pageList[1]?.path;
@@ -43,37 +44,39 @@ const IntroductionPage = props => {
           </li>
         </ul>
       </va-process-list>
-      <VaAlert status="info" visible uswds>
-        <h2>Sign in now to save time and save your work in progress</h2>
-        <p>Here’s how signing in now helps you:</p>
-        <ul>
-          <li>
-            We can fill in some of your information for you to save you time.
-          </li>
-          <li>
-            You can save your work in progress. You’ll have 60 days from when
-            you start, or make updates, to come back and finish it.
-          </li>
-        </ul>
-        <p>
-          <strong>Note:</strong> You can sign in after you start your
-          registration form. But you’ll lose any information you already filled
-          in.
-        </p>
+      {!isLoggedIn ? (
+        <VaAlert status="info" visible uswds>
+          <h2>Sign in now to save time and save your work in progress</h2>
+          <p>Here’s how signing in now helps you:</p>
+          <ul>
+            <li>
+              We can fill in some of your information for you to save you time.
+            </li>
+            <li>
+              You can save your work in progress. You’ll have 60 days from when
+              you start, or make updates, to come back and finish it.
+            </li>
+          </ul>
+          <p>
+            <strong>Note:</strong> You can sign in after you start your
+            registration form. But you’ll lose any information you already
+            filled in.
+          </p>
+          <p className="vads-u-margin-top--2">
+            <Link to={firstPage}>Start your form without signing in</Link>
+          </p>
+        </VaAlert>
+      ) : (
         <SaveInProgressIntro
-          buttonOnly
+          formId={formConfig.formId}
           headingLevel={2}
           prefillEnabled={formConfig.prefillEnabled}
           messages={formConfig.savedFormMessages}
           pageList={pageList}
-          unauthStartText="Sign in to start your form"
-          hideUnauthedStartLink
+          startText="Start"
         />
-        <p className="vads-u-margin-top--2">
-          <Link to={firstPage}>Start your form without signing in</Link>
-        </p>
-      </VaAlert>
-      <p />
+      )}
+
       <va-omb-info
         res-burden={4}
         omb-number="2900-0648"
@@ -83,4 +86,10 @@ const IntroductionPage = props => {
   );
 };
 
-export default IntroductionPage;
+const mapStateToProps = state => {
+  return {
+    isLoggedIn: state.user.login.currentlyLoggedIn,
+  };
+};
+
+export default connect(mapStateToProps)(IntroductionPage);


### PR DESCRIPTION
## Summary
This Pr adds home address to the prefill transformer so it can be prefilled

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/81646

## Testing done
Cannot complete testing until backend has added this and they re on staging

## What areas of the site does it impact?
this form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA