### PR TITLE
[SIMPLE_FORMS] fix: 21-4138 - update priority processing logic

### DIFF
--- a/src/applications/simple-forms/21-4138/config/form.js
+++ b/src/applications/simple-forms/21-4138/config/form.js
@@ -229,7 +229,7 @@ const formConfig = {
         priorityProcessingNotQualifiedPage: {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.PRIORITY_PROCESSING &&
-            (formData.livingSituation.NONE && formData.otherReasons?.NONE),
+            (!formData.livingSituation.NONE && formData.otherReasons?.NONE),
           path: 'priority-processing-not-qualified',
           title: 'You may not qualify for priority processing',
           uiSchema: ppNotQualifiedPage.uiSchema,
@@ -240,7 +240,7 @@ const formConfig = {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.PRIORITY_PROCESSING &&
             (!formData.livingSituation.NONE ||
-              (formData.livingSituation.NONE && !formData.otherReasons?.NONE)),
+              (formData.livingSituation.NONE && formData.otherReasons?.NONE)),
           path: 'priority-processing-qualified-handoff',
           title: "There's a better way to request priority processing",
           uiSchema: ppQualifiedHandoffPage.uiSchema,

--- a/src/applications/simple-forms/21-4138/config/form.js
+++ b/src/applications/simple-forms/21-4138/config/form.js
@@ -209,7 +209,7 @@ const formConfig = {
         priorityProcessingOtherReasonsOptionalPage: {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.PRIORITY_PROCESSING &&
-            !formData.livingSituation.NONE,
+            formData.livingSituation.NONE,
           path: 'priority-processing-other-reasons-optional',
           title: 'Other reasons for request',
           uiSchema: ppOtherReasonsOptionalPage.uiSchema,
@@ -219,7 +219,7 @@ const formConfig = {
         priorityProcessingOtherReasonsRequiredPage: {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.PRIORITY_PROCESSING &&
-            formData.livingSituation.NONE,
+            !formData.livingSituation.NONE,
           path: 'priority-processing-other-reasons',
           title: 'Other reasons for request',
           uiSchema: ppOtherReasonsRequiredPage.uiSchema,

--- a/src/applications/simple-forms/21-4138/config/form.js
+++ b/src/applications/simple-forms/21-4138/config/form.js
@@ -229,7 +229,7 @@ const formConfig = {
         priorityProcessingNotQualifiedPage: {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.PRIORITY_PROCESSING &&
-            (!formData.livingSituation.NONE && formData.otherReasons?.NONE),
+            (formData.livingSituation.NONE && formData.otherReasons?.NONE),
           path: 'priority-processing-not-qualified',
           title: 'You may not qualify for priority processing',
           uiSchema: ppNotQualifiedPage.uiSchema,
@@ -240,7 +240,7 @@ const formConfig = {
           depends: formData =>
             formData.statementType === STATEMENT_TYPES.PRIORITY_PROCESSING &&
             (!formData.livingSituation.NONE ||
-              (formData.livingSituation.NONE && formData.otherReasons?.NONE)),
+              (formData.livingSituation.NONE && !formData.otherReasons?.NONE)),
           path: 'priority-processing-qualified-handoff',
           title: "There's a better way to request priority processing",
           uiSchema: ppQualifiedHandoffPage.uiSchema,


### PR DESCRIPTION
## Summary

- Updated priority processing logic to the specified expectations:
  - Users who don't select a qualifying housing situation continue to an OPTIONAL list of other hardships. These users can continue without selecting anything.
  - Folks who don't qualify via living situation are required to select an "other hardship" option. That list should include a "None of these situations apply to me" option.
  - 2 "None of these options apply to me" answers results in the "you may not qualify" endpoint. On continue, those folks will start completing the 21-4138.
- Team: Veteran Facing Forms
- Flipper not implemented

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#82791

## Testing done

- Local browser functions successfully
- Unit tests successful
- E2E tests successful


## What areas of the site does it impact?

This form ONLY.