### PR TITLE
Fix SSO looping bug on terms of use page

### DIFF
--- a/src/platform/utilities/sso/index.js
+++ b/src/platform/utilities/sso/index.js
@@ -34,8 +34,14 @@ export const verifySession = () => {
   const sessionExpiration = localStorage
     .getItem('sessionExpirationSSO')
     ?.toString();
+  const isValidPath = !window.location.pathname?.includes('terms-of-use');
 
-  return hasSessionSSO && loginAttempted && sessionExpiration?.length > 0;
+  return (
+    isValidPath &&
+    hasSessionSSO &&
+    loginAttempted &&
+    sessionExpiration?.length > 0
+  );
 };
 
 export async function ssoKeepAliveSession() {

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -690,7 +690,11 @@ describe('generateAuthnContext', () => {
 });
 
 describe('verifySession', () => {
+  beforeEach(() => {
+    fakeWindow();
+  });
   afterEach(() => {
+    global.window = oldWindow;
     localStorage.clear();
   });
   it('should return true when conditions', () => {
@@ -704,6 +708,14 @@ describe('verifySession', () => {
     localStorage.setItem('loginAttempted', true);
     expect(verifySession()).to.eql(false);
     localStorage.clear();
+    expect(verifySession()).to.eql(false);
+  });
+  it('should return false if the pathname is terms-of-use', () => {
+    global.window.location.origin = 'http://localhost';
+    global.window.location.pathname = '/terms-of-use/';
+    localStorage.setItem('hasSessionSSO', true);
+    localStorage.setItem('loginAttempted', true);
+    localStorage.setItem('sessionExpirationSSO', new Date());
     expect(verifySession()).to.eql(false);
   });
 });


### PR DESCRIPTION
## Summary
This PR fixes the single sign-on bug on the `/terms-of-use` page

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#82990

## Testing done
Added unit tests + manual (see steps below in Requested Feedback)

## Screenshots
n/a

## What areas of the site does it impact?
This will impact all areas of VA.gov

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
### Setup
1. Start `vets-website` and `vets-api`
2. The following local storage items need to be set in the DevTools console. Copy and paste the below code into the console of your browser after starting `vets-website`

```javascript
localStorage.setItem('loginAttempted', true); // prevents infinite loop of attempting ot call `custom` endpoint
localStorage.setItem('hasSessionSSO', true); // set by the keepalive request
localStorage.setItem('sessionExpirationSSO', new Date().toString()) // set by keepalive request
```

3. In local environments, the `/keepalive` call does not exist and instead a mock call is used by modifying query parameters. `keepalive-ttl`, `keepalive-authn`, and `csp_type` are the query parameters that are used to mock the `/keepalive` header values.

### Testing
| Response from `/keepalive`  | URL | Result  |
| ----- | ----------- | ------ |
| Session alive<br/> TTL: 900 | http://localhost:3001/?keepalive-ttl=900&keepalive-authn=http://idmanagement.gov/ns/assurance/loa/3&csp_type=IDME      | User SHOULD BE navigated to eAuth   |
| Session dead<br/> TTL: 0    | http://localhost:3001/?keepalive-ttl=0&keepalive-authn=http://idmanagement.gov/ns/assurance/loa/3&csp_type=IDME     | User SHOULD NOT be redirected to eAuth |
| Session alive<br/> TTL: 900 | http://localhost:3001/terms-of-use/?keepalive-ttl=900&keepalive-authn=http://idmanagement.gov/ns/assurance/loa/3&csp_type=IDME    | User SHOULD NOT be redirected to eAuth |
| Session alive<br/> TTL: 900 | http://localhost:3001/education/apply-for-education-benefits/application/1990/introduction?keepalive-ttl=900&keepalive-authn=http://idmanagement.gov/ns/assurance/loa/3&csp_type=IDME | User SHOULD BE navigated to eAuth   |