### PR TITLE
Add non-www handling to injected header for Cemeteries teamsite

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -41,11 +41,15 @@
       "cookieOnly": false
     },
     {
+      "hostname": "cem.va.gov",
+      "pathnameBeginning": "/",
+      "cookieOnly": false
+    },
+    {
       "hostname": "www.cem.va.gov",
       "pathnameBeginning": "/",
       "cookieOnly": false
     },
-
     {
       "hostname": "www.choose.va.gov",
       "pathnameBeginning": "/",


### PR DESCRIPTION
The National Cemetery Assn teamsites uses the injected header. Rules were added for www.cem.va.gov to inject, but not the non-www URL: cem.va.gov.

https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18120

## With www
Injected header appears: 
![Screenshot 2024-05-13 at 1 05 50 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/85581471/7cc95c98-910e-4937-8b1b-015b759aa3d4)

## Without www
Injected header does not appear: 
![Screenshot 2024-05-13 at 1 05 41 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/85581471/5e9ace55-f09f-45af-867a-1ab878894883)


This PR adds handling for the non-www version, matching the way benefits.va.gov is listed in the file directly above the changed lines, so that both will get injection.