### PR TITLE
82026 Update urls per product guidance

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
@@ -136,15 +136,19 @@ export const appMedicareOver65IneligibleUploadSchema = {
         )}`,
       ({ formData }) => {
         const appName = nameWording(formData, false, true);
+        const nameWithBeingVerb =
+          appName === 'You' ? 'You are' : `${appName} is`;
         return (
           <>
-            <b>{appName}</b> is 65 years or older and you selected that they’re
-            not eligible for Medicare.
+            {nameWithBeingVerb} 65 years or older and you selected that{' '}
+            {nameWithBeingVerb === 'You' ? 'you' : nameWithBeingVerb} not
+            eligible for Medicare.
             <br />
             <br />
             You’ll need to submit a copy of a letter from the Social Security
-            Administration that confirms that <b>{appName}</b> doesn’t qualify
-            for Medicare benefits under anyone’s Social Security number.
+            Administration that confirms that{' '}
+            {appName === 'You' ? 'you don’t' : `${appName} doesn’t`} qualify for
+            Medicare benefits under anyone’s Social Security number.
             <br />
             If you don’t have a copy to upload now, you can send one by mail or
             fax

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -111,32 +111,32 @@ const formConfig = {
       title: 'Signer information',
       pages: {
         role: {
-          path: 'your-information/description',
+          path: 'signer-type',
           title: 'Which of these best describes you?',
           // initialData: mockdata.data,
           uiSchema: certifierRole.uiSchema,
           schema: certifierRole.schema,
         },
         name: {
-          path: 'your-information/name',
+          path: 'signer-info',
           title: 'Your name',
           depends: formData => get('certifierRole', formData) !== 'applicant',
           ...certifierNameSchema,
         },
         address: {
-          path: 'your-information/address',
+          path: 'signer-mailing-address',
           title: 'Your mailing address',
           depends: formData => get('certifierRole', formData) !== 'applicant',
           ...certifierAddress,
         },
         phoneEmail: {
-          path: 'your-information/phone-email',
+          path: 'signer-contact-info',
           title: 'Your phone number',
           depends: formData => get('certifierRole', formData) !== 'applicant',
           ...certifierPhoneEmail,
         },
         relationship: {
-          path: 'your-information/relationship',
+          path: 'signer-relationship',
           title: 'Your relationship to the applicant',
           depends: formData => get('certifierRole', formData) !== 'applicant',
           ...certifierRelationship,
@@ -147,7 +147,7 @@ const formConfig = {
       title: 'Applicant information',
       pages: {
         applicantNameDob: {
-          path: 'applicant-information',
+          path: 'applicant-info',
           title: formData =>
             `${
               formData.certifierRole === 'applicant' ? 'Your' : 'Applicant'
@@ -155,13 +155,13 @@ const formConfig = {
           ...applicantNameDobSchema,
         },
         applicantIdentity: {
-          path: 'applicant-information/ssn',
+          path: 'applicant-identification-info',
           title: formData =>
             `${nameWording(formData)} identification information`,
           ...applicantSsnSchema,
         },
         applicantAddressInfo: {
-          path: 'applicant-information/address',
+          path: 'applicant-mailing-address',
           title: formData => `${nameWording(formData)} mailing address`,
           ...applicantAddressInfoSchema,
         },
@@ -173,7 +173,7 @@ const formConfig = {
         // TODO: have conditional logic to check if third party and app
         // is under age 18 (contact page)
         applicantContactInfo: {
-          path: 'applicant-information/contact',
+          path: 'applicant-contact-info',
           title: formData => `${nameWording(formData)} contact information`,
           ...applicantContactInfoSchema,
         },
@@ -183,13 +183,13 @@ const formConfig = {
       title: 'Medicare information',
       pages: {
         hasMedicareAB: {
-          path: 'medicare-ab',
+          path: 'medicare-ab-status',
           title: formData => `${nameWording(formData)} Medicare status`,
           ...applicantHasMedicareABSchema,
         },
         // If 'no' to previous question:
         medicareABContext: {
-          path: 'no-medicare-ab',
+          path: 'medicare-ab-status-type',
           title: formData => `${nameWording(formData)} Medicare status`,
           depends: formData =>
             get('applicantMedicareStatus', formData) === false,
@@ -197,14 +197,14 @@ const formConfig = {
         },
         // If 'yes' to previous question:
         partACarrier: {
-          path: 'carrier-a',
+          path: 'medicare-a-carrier',
           title: formData => `${nameWording(formData)} Medicare Part A carrier`,
           depends: formData => get('applicantMedicareStatus', formData),
           ...applicantMedicarePartACarrierSchema,
         },
         // If ineligible and over 65, require user to upload proof of ineligibility
         medicareIneligible: {
-          path: 'ineligible',
+          path: 'medicare-ineligible-upload',
           title: 'Over 65 and ineligible for Medicare',
           depends: formData => {
             return (
@@ -217,26 +217,26 @@ const formConfig = {
           ...appMedicareOver65IneligibleUploadSchema,
         },
         partBCarrier: {
-          path: 'carrier-b',
+          path: 'medicare-b-carrier',
           title: formData => `${nameWording(formData)} Medicare Part B carrier`,
           depends: formData => get('applicantMedicareStatus', formData),
           ...applicantMedicarePartBCarrierSchema,
         },
         pharmacyBenefits: {
-          path: 'pharmacy',
+          path: 'medicare-pharmacy',
           title: formData =>
             `${nameWording(formData)} Medicare pharmacy benefits`,
           depends: formData => get('applicantMedicareStatus', formData),
           ...applicantMedicarePharmacySchema,
         },
         advantagePlan: {
-          path: 'advantage',
+          path: 'medicare-coverage',
           title: formData => `${nameWording(formData)} Medicare coverage`,
           depends: formData => get('applicantMedicareStatus', formData),
           ...applicantMedicareAdvantageSchema,
         },
         medicareABCards: {
-          path: 'ab-upload',
+          path: 'medicare-ab-upload',
           title: formData => `${nameWording(formData)} Medicare card (A/B)`,
           depends: formData => get('applicantMedicareStatus', formData),
           CustomPage: FileFieldWrapped,
@@ -244,13 +244,13 @@ const formConfig = {
           ...applicantMedicareABUploadSchema,
         },
         hasMedicareD: {
-          path: 'medicare-d',
+          path: 'medicare-d-status',
           title: formData => `${nameWording(formData)} Medicare status`,
           depends: formData => get('applicantMedicareStatus', formData),
           ...applicantHasMedicareDSchema,
         },
         partDCarrier: {
-          path: 'carrier-d',
+          path: 'medicare-d-carrier',
           title: formData => `${nameWording(formData)} Medicare Part D carrier`,
           depends: formData =>
             get('applicantMedicareStatus', formData) &&
@@ -258,7 +258,7 @@ const formConfig = {
           ...applicantMedicarePartDCarrierSchema,
         },
         medicareDCards: {
-          path: 'd-upload',
+          path: 'medicare-d-upload',
           title: formData => `${nameWording(formData)} Medicare card (D)`,
           depends: formData =>
             get('applicantMedicareStatus', formData) &&
@@ -274,20 +274,20 @@ const formConfig = {
       title: 'Healthcare information',
       pages: {
         hasPrimaryHealthInsurance: {
-          path: 'has-primary',
+          path: 'insurance-status',
           title: formData =>
             `${nameWording(formData)} primary health insurance`,
           ...applicantHasInsuranceSchema(true),
         },
         primaryProvider: {
-          path: 'primary-provider',
+          path: 'insurance-info',
           depends: formData => get('applicantHasPrimary', formData),
           title: formData =>
             `${nameWording(formData)} health insurance information`,
           ...applicantProviderSchema(true),
         },
         primaryThroughEmployer: {
-          path: 'primary-through-employer',
+          path: 'insurance-type',
           depends: formData => get('applicantHasPrimary', formData),
           title: formData =>
             `${nameWording(formData)} ${
@@ -296,7 +296,7 @@ const formConfig = {
           ...applicantInsuranceThroughEmployerSchema(true),
         },
         primaryPrescription: {
-          path: 'primary-prescription',
+          path: 'insurance-prescription',
           depends: formData => get('applicantHasPrimary', formData),
           title: formData =>
             `${nameWording(formData)} ${
@@ -305,7 +305,7 @@ const formConfig = {
           ...applicantInsurancePrescriptionSchema(true),
         },
         primaryEOB: {
-          path: 'primary-eob',
+          path: 'insurance-eob',
           depends: formData => get('applicantHasPrimary', formData),
           title: formData =>
             `${nameWording(formData)} ${
@@ -314,7 +314,7 @@ const formConfig = {
           ...applicantInsuranceEOBSchema(true),
         },
         primaryType: {
-          path: 'primary-insurance-type',
+          path: 'insurance-plan',
           depends: formData => get('applicantHasPrimary', formData),
           title: formData =>
             `${nameWording(formData)} ${
@@ -323,7 +323,7 @@ const formConfig = {
           ...applicantInsuranceTypeSchema(true),
         },
         primaryMedigap: {
-          path: 'primary-medigap',
+          path: 'insurance-medigap',
           depends: formData =>
             get('applicantHasPrimary', formData) &&
             get('applicantPrimaryInsuranceType.medigap', formData),
@@ -334,7 +334,7 @@ const formConfig = {
           ...applicantMedigapSchema(true),
         },
         primaryComments: {
-          path: 'primary-comments',
+          path: 'insurance-comments',
           depends: formData => get('applicantHasPrimary', formData),
           title: formData =>
             `${nameWording(formData)} ${
@@ -343,7 +343,7 @@ const formConfig = {
           ...applicantInsuranceCommentsSchema(true),
         },
         primaryCard: {
-          path: 'primary-card-upload',
+          path: 'insurance-upload',
           depends: formData => get('applicantHasPrimary', formData),
           title: formData =>
             `${nameWording(formData)} primary health insurance card`,
@@ -352,20 +352,20 @@ const formConfig = {
           ...applicantInsuranceCardSchema(true),
         },
         hasSecondaryHealthInsurance: {
-          path: 'has-secondary',
+          path: 'secondary-insurance',
           title: formData =>
             `${nameWording(formData)} secondary health insurance`,
           ...applicantHasInsuranceSchema(false),
         },
         secondaryProvider: {
-          path: 'secondary-provider',
+          path: 'secondary-insurance-info',
           depends: formData => get('applicantHasSecondary', formData),
           title: formData =>
             `${nameWording(formData)} secondary health insurance information`,
           ...applicantProviderSchema(false),
         },
         secondaryThroughEmployer: {
-          path: 'secondary-through-employer',
+          path: 'secondary-insurance-type',
           depends: formData => get('applicantHasSecondary', formData),
           title: formData =>
             `${nameWording(formData)} ${
@@ -374,7 +374,7 @@ const formConfig = {
           ...applicantInsuranceThroughEmployerSchema(false),
         },
         secondaryPrescription: {
-          path: 'secondary-prescription',
+          path: 'secondary-insurance-prescription',
           depends: formData => get('applicantHasSecondary', formData),
           title: formData =>
             `${nameWording(formData)} ${
@@ -383,7 +383,7 @@ const formConfig = {
           ...applicantInsurancePrescriptionSchema(false),
         },
         secondaryEOB: {
-          path: 'secondary-eob',
+          path: 'secondary-insurance-eob',
           depends: formData => get('applicantHasSecondary', formData),
           title: formData =>
             `${nameWording(formData)} ${
@@ -392,7 +392,7 @@ const formConfig = {
           ...applicantInsuranceEOBSchema(false),
         },
         secondaryType: {
-          path: 'secondary-insurance-type',
+          path: 'secondary-insurance-plan',
           depends: formData => get('applicantHasSecondary', formData),
           title: formData =>
             `${nameWording(formData)} ${
@@ -401,7 +401,7 @@ const formConfig = {
           ...applicantInsuranceTypeSchema(false),
         },
         secondaryMedigap: {
-          path: 'secondary-medigap',
+          path: 'secondary-insurance-medigap',
           depends: formData =>
             get('applicantHasSecondary', formData) &&
             get('applicantSecondaryInsuranceType.medigap', formData),
@@ -412,7 +412,7 @@ const formConfig = {
           ...applicantMedigapSchema(false),
         },
         secondaryComments: {
-          path: 'secondary-comments',
+          path: 'secondary-insurance-comments',
           depends: formData => get('applicantHasSecondary', formData),
           title: formData =>
             `${nameWording(formData)} ${
@@ -421,7 +421,7 @@ const formConfig = {
           ...applicantInsuranceCommentsSchema(false),
         },
         secondaryCard: {
-          path: 'secondary-card-upload',
+          path: 'secondary-insurance-card-upload',
           depends: formData => get('applicantHasSecondary', formData),
           title: formData =>
             `${nameWording(formData)} secondary health insurance card`,

--- a/src/applications/ivc-champva/10-7959C/manifest.json
+++ b/src/applications/ivc-champva/10-7959C/manifest.json
@@ -2,6 +2,6 @@
   "appName": "10-7959C CHAMPVA Other Health Insurance Certification form",
   "entryFile": "./app-entry.jsx",
   "entryName": "10-7959C",
-  "rootUrl": "/ivc-champva/10-7959C",
+  "rootUrl": "/health-care/champva/other-insurance-form-10-7959c",
   "productId": "db17fe5b-107e-40c0-a105-b3ba913cf731"
 }


### PR DESCRIPTION
## Summary

- Updates all URLs in form 10-7959c to match new guidance from product. See corresponding PR in [content-build](https://github.com/department-of-veterans-affairs/content-build/pull/2083)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82026
- https://github.com/department-of-veterans-affairs/content-build/pull/2083

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA