### PR TITLE
fix: add max length for email address, tweak connected app styling in mobile

### DIFF
--- a/src/applications/personalization/profile/components/connected-apps/ConnectedAppDeleteModal.jsx
+++ b/src/applications/personalization/profile/components/connected-apps/ConnectedAppDeleteModal.jsx
@@ -35,20 +35,22 @@ export function ConnectedAppDeleteModal({
             onClick={confirmDelete}
             data-testid={`confirm-disconnect-${title}`}
             text="Disconnect"
+            class="vads-u-width--full small-screen:vads-u-width--auto vads-u-margin-bottom--2 small-screen:vads-u-margin-bottom--0"
           />
           <va-button
             secondary
             onClick={closeModal}
             text="No, cancel this change"
+            class="vads-u-width--full small-screen:vads-u-width--auto"
           />
         </>
       )}
 
       {deleting && (
         <va-button
-          className="usa-button-primary"
           disabled
           text="Processing update..."
+          class="vads-u-width--full small-screen:vads-u-width--auto"
         />
       )}
     </VaModal>

--- a/src/platform/user/profile/vap-svc/util/contact-information/emailUtils.js
+++ b/src/platform/user/profile/vap-svc/util/contact-information/emailUtils.js
@@ -6,6 +6,7 @@ export const emailFormSchema = {
     emailAddress: {
       type: 'string',
       format: 'email',
+      maxLength: 255,
       // This regex was taken from the HCA but modified to allow leading and
       // trailing whitespace to reduce false errors. The `convertDataToPayload`
       // method will clean up the whitespace before submission


### PR DESCRIPTION
## Summary

- Small tweaks, add a max length of 255 characters to the email bc if you did go over that you would get an api error that resulted in a generic UI error message being shown. It's a very rare remote case, but one that is easily fixed here.
- I also noticed a small styling defect where there wasn't margin between the remove app modal buttons on the connect apps page, so I went ahead and tweaked that as a hotfix.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/75309

## Testing done

- Tested 255 limit on email locally
- Tested modal visually margin locally

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | ![Screenshot 2024-05-13 at 10 38 10 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/7859bc32-0c22-4060-b9f3-61f46654501a) | ![Screenshot 2024-05-13 at 10 37 01 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/780ed73a-f3f1-435c-8dd7-30e7277597a9) |
| Desktop |   no visual changes     |       |

## What areas of the site does it impact?

Profile

## Acceptance criteria

- Email character limit added

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
