### PR TITLE
[CST] - Update alert description and hide due date when item type is a 5103 notice

### DIFF
--- a/src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx
@@ -6,15 +6,45 @@ import { truncateDescription } from '../../utils/helpers';
 import DueDate from '../DueDate';
 
 function FilesNeeded({ item }) {
+  // We will not use the truncateDescription() here as these descriptions are custom and specific to what we want
+  // the user to see based on the given item type.
+  const itemsWithNewDescriptions = [
+    {
+      type: 'Automated 5103 Notice Response',
+      description: (
+        <>
+          <p>
+            We sent you a "5103 notice" letter that lists the types of evidence
+            we may need to decide your claim.
+          </p>
+          <p>
+            Upload the waiver attached to letter if you’re finished adding
+            evidence.
+          </p>
+        </>
+      ),
+    },
+  ];
+
+  const getItemDescription = () => {
+    const itemWithNewDescription = itemsWithNewDescriptions.find(
+      i => i.type === item.displayName,
+    );
+    return itemWithNewDescription !== undefined
+      ? itemWithNewDescription.description
+      : truncateDescription(item.description); // Truncating the item description to only 200 characters incase it is long
+  };
+
+  // Hide the due date when item type is Automated 5103 Notice Response
+  const hideDueDate = item.displayName === 'Automated 5103 Notice Response';
+
   return (
     <va-alert class="primary-alert vads-u-margin-bottom--2" status="warning">
       <h4 slot="headline" className="alert-title">
         {item.displayName}
       </h4>
-      <DueDate date={item.suspenseDate} />
-      <p className="alert-description">
-        {truncateDescription(item.description, 200)}
-      </p>
+      {!hideDueDate && <DueDate date={item.suspenseDate} />}
+      <p className="alert-description">{getItemDescription()}</p>
       <div className="link-action-container">
         <Link
           aria-label={`Details for ${item.displayName}`}

--- a/src/applications/claims-status/tests/components/claim-files-tab/FilesNeeded.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab/FilesNeeded.unit.spec.jsx
@@ -12,10 +12,8 @@ const item = {
 
 describe('<FilesNeeded>', () => {
   it('should render va-alert with item data and show DueDate', () => {
-    const { queryByText, getByText } = renderWithRouter(
-      <FilesNeeded item={item} />,
-    );
-    queryByText('December 1, 2024');
+    const { getByText } = renderWithRouter(<FilesNeeded item={item} />);
+    getByText('December 1, 2024', { exact: false });
     getByText(item.displayName);
     getByText(item.description);
     getByText('Details');

--- a/src/applications/claims-status/tests/components/claim-files-tab/FilesNeeded.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab/FilesNeeded.unit.spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { expect } from 'chai';
 
 import FilesNeeded from '../../../components/claim-files-tab/FilesNeeded';
 import { renderWithRouter } from '../../utils';
@@ -10,10 +11,37 @@ const item = {
 };
 
 describe('<FilesNeeded>', () => {
-  it('should render va-alert with item data', () => {
-    const screen = renderWithRouter(<FilesNeeded item={item} />);
-    screen.getByText(item.displayName);
-    screen.getByText(item.description);
-    screen.getByText('Details');
+  it('should render va-alert with item data and show DueDate', () => {
+    const { queryByText, getByText } = renderWithRouter(
+      <FilesNeeded item={item} />,
+    );
+    queryByText('December 1, 2024');
+    getByText(item.displayName);
+    getByText(item.description);
+    getByText('Details');
+  });
+
+  context('when item type is Automated 5103 Notice Response', () => {
+    const item5103 = {
+      displayName: 'Automated 5103 Notice Response',
+      description: 'This is a alert',
+      suspenseDate: '2024-12-01',
+    };
+    it('should render va-alert with item data and hide DueDate', () => {
+      const { queryByText, getByText } = renderWithRouter(
+        <FilesNeeded item={item5103} />,
+      );
+
+      expect(queryByText('December 1, 2024')).to.not.exist;
+      expect(queryByText(item5103.description)).to.not.exist;
+      getByText(item5103.displayName);
+      getByText(
+        `We sent you a "5103 notice" letter that lists the types of evidence we may need to decide your claim.`,
+      );
+      getByText(
+        `Upload the waiver attached to letter if you’re finished adding evidence.`,
+      );
+      getByText('Details');
+    });
   });
 });


### PR DESCRIPTION
## Summary

Updated `FilesNeeded.jsx` for the following:
- The DueDate component is hidden when the item type is `Automated 5103 Notice Response`
- The item description is changed to a customized description for 5103 notices
- Code is forward thinking and can be used to create custom language for any tracked item request.

Added tests to `FilesNeeded.unit.spec.jsx`

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#81396

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| 5103 Notice - Primary Alert on Status Page| ![Screenshot 2024-05-14 at 10 58 54 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/ebd6494c-4a81-4ccc-8429-238bfbe2085b) | ![Screenshot 2024-05-14 at 10 57 03 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/2e9032f4-2a4c-47fd-9d67-719b9e5d7df6) |
| Non 5103 Notice - Primary Alert on Status Page | ![Screenshot 2024-05-14 at 10 46 10 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/350d2bed-4523-4aff-ab98-fdf2b36ec40b) |  ![Screenshot 2024-05-14 at 10 46 10 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/350d2bed-4523-4aff-ab98-fdf2b36ec40b) |
| 5103 Notice - Primary Alert on Files Page| ![Screenshot 2024-05-14 at 10 58 45 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/a046d58f-b968-4116-b1f4-dc6f5b416178) | ![Screenshot 2024-05-14 at 10 57 11 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/db7ac0ef-8ca4-44ff-b414-6ca3f7efa1ab) |
| Non 5103 Notice - Primary Alert on Files Page | ![Screenshot 2024-05-14 at 10 46 21 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/4b925d79-bc58-4fe3-aa5e-4e7c12824ae3) | ![Screenshot 2024-05-14 at 10 46 21 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/4b925d79-bc58-4fe3-aa5e-4e7c12824ae3) |

## What areas of the site does it impact?

Claim Status Tool

## Acceptance criteria
 
- [x] The body text of the alert makes it clearer what a 5103 alert request is
- [x] The body language of alert is updated for both the files page and the status page version of the alert.
- [x] The "Needed from you by..." text is hidden when the alert is for 5103
- [x] Solution should be future forward in that it can be used to create custom language for any tracked item request.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
