### PR TITLE
display breadcrumb on SM Landing Page

### DIFF
--- a/src/applications/mhv-secure-messaging/components/shared/SmBreadcrumbs.jsx
+++ b/src/applications/mhv-secure-messaging/components/shared/SmBreadcrumbs.jsx
@@ -59,7 +59,7 @@ const SmBreadcrumbs = () => {
   useEffect(
     () => {
       if (!locationBasePath) {
-        dispatch(setBreadcrumbs({}, location));
+        dispatch(setBreadcrumbs(Constants.Breadcrumbs.MYHEALTH, null));
         return;
       }
 
@@ -137,7 +137,11 @@ const SmBreadcrumbs = () => {
         <nav aria-label="Breadcrumb">
           <ul className={breadcrumbSize()}>
             <li className="sm-breadcrumb-list-item">
-              <Link to={crumbs.path?.toLowerCase()}>{crumbs.label}</Link>
+              {!crumbs.path ? (
+                <a href="/my-health">{crumbs.label}</a>
+              ) : (
+                <Link to={crumbs.path?.toLowerCase()}>{crumbs.label}</Link>
+              )}
             </li>
           </ul>
         </nav>

--- a/src/applications/mhv-secure-messaging/tests/components/breadcrumbs.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/breadcrumbs.unit.spec.jsx
@@ -22,7 +22,7 @@ describe('Breadcrumbs', () => {
       reducers: reducer,
       path: `/`,
     });
-    const breadcrumb = await screen.findByText('Back to My HealtheVet', {
+    const breadcrumb = await screen.findByText('Back to My HealtheVet home', {
       exact: true,
     });
     expect(breadcrumb);

--- a/src/applications/mhv-secure-messaging/tests/components/breadcrumbs.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/breadcrumbs.unit.spec.jsx
@@ -16,6 +16,18 @@ describe('Breadcrumbs', () => {
     },
   };
 
+  it('renders with "Back to My HealtheVet" on Landing Page', async () => {
+    const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
+      initialState,
+      reducers: reducer,
+      path: `/`,
+    });
+    const breadcrumb = await screen.findByText('Back to My HealtheVet', {
+      exact: true,
+    });
+    expect(breadcrumb);
+  });
+
   it('finds parent breadcrumb that displays the label "Back to messages"', async () => {
     const screen = renderWithStoreAndRouter(<SmBreadcrumbs />, {
       initialState,

--- a/src/applications/mhv-secure-messaging/util/constants.js
+++ b/src/applications/mhv-secure-messaging/util/constants.js
@@ -2,6 +2,7 @@
 export const draftAutoSaveTimeout = 10000;
 
 export const Paths = {
+  MYHEALTH: null,
   INBOX: '/inbox/',
   SENT: '/sent/',
   DRAFTS: '/drafts/',
@@ -215,6 +216,7 @@ export const Prompts = {
 };
 
 export const Breadcrumbs = {
+  MYHEALTH: { path: Paths.MYHEALTH, label: 'Back to My HealtheVet' },
   MESSAGES: { path: '/', label: 'Back to messages' },
   COMPOSE: {
     path: Paths.COMPOSE,

--- a/src/applications/mhv-secure-messaging/util/constants.js
+++ b/src/applications/mhv-secure-messaging/util/constants.js
@@ -216,7 +216,7 @@ export const Prompts = {
 };
 
 export const Breadcrumbs = {
-  MYHEALTH: { path: Paths.MYHEALTH, label: 'Back to My HealtheVet' },
+  MYHEALTH: { path: Paths.MYHEALTH, label: 'Back to My HealtheVet home' },
   MESSAGES: { path: '/', label: 'Back to messages' },
   COMPOSE: {
     path: Paths.COMPOSE,


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- The Breadcrumb component has been added to the SM Landing Page that will take users back to the My HealtheVet homepage.

## Related issue(s)

### [MHV-57521](https://jira.devops.va.gov/browse/MHV-57521) - Tool landing pages should add breadcrumbs that connect < Back to My HealtheVet home with that specific language ###

> Tool landing pages should add breadcrumbs that connect < Back to My HealtheVet home with that specific language
> 
> NOTE:  Design is pending cartography team. Kickoff meeting 4/30/24
> 
> Implementation plan:
> 
> https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/digital-health-modernization/mhv-to-va.gov/rollout/integration-with-nav-release-plan-2024.md
> 
> https://dsva.slack.com/archives/CBU0KDSB1/p1714484333393809
> 
>  
> 
> User Story:  As a SM user, I want to use breadcrumbs that go the the MHV home  so that I can navigate to MHV.
> 
>  
> 
> GIVEN:
> 
> WHEN:
> 
> THEN:
> 
>  
> 
> Feature Flag Y/N ?
> 
> DataDog Analytics  Y/N ?
> 
> Manual Testing Y/N ? Y-Rakesh
> 
> Automated Testing Y/N ?
> 
> Accessibility Testing Y/N ?
> 
> UCD Validation Y/N
> 
>  
> 
> Acceptance Criteria:
> 
> AC1 Breadcrumbs have been added See cartography designs

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |<img width="363" alt="Screenshot 2024-05-15 at 7 35 52 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/79024398/a85122ce-2c52-4743-ba40-6a15c2a85f8c">|![Screenshot 2024-05-15 at 9 12 51 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/79024398/57f3364a-ce92-4830-9e00-88dec793811e)|
| Desktop |<img width="1134" alt="Screenshot 2024-05-15 at 7 35 04 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/79024398/cc09dcf0-3302-46ec-811f-df99da85e316">|![Screenshot 2024-05-15 at 9 13 50 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/79024398/4f1ad11d-3a21-4f82-8a08-055e09f5cc8f)|

## What areas of the site does it impact?

VA.gov - Secure Messaging

## Acceptance criteria

- AC1 Breadcrumbs have been added See cartography designs

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
