### PR TITLE
Refactor usage of ApplicantRelationshipPage base custom page in form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/constants.js
+++ b/src/applications/ivc-champva/10-10D/config/constants.js
@@ -1,0 +1,19 @@
+import PropTypes from 'prop-types';
+
+// These proptypes are used with the custom pages that use ApplicantRelationshipPage
+export const pageProps = {
+  data: PropTypes.object,
+  goBack: PropTypes.func,
+  goForward: PropTypes.func,
+  pagePerItemIndex: PropTypes.any,
+  setFormData: PropTypes.func,
+  updatePage: PropTypes.func,
+  onReviewPage: PropTypes.bool,
+};
+export const reviewPageProps = {
+  data: PropTypes.object,
+  editPage: PropTypes.func,
+  pagePerItemIndex: PropTypes.any,
+  props: PropTypes.object,
+  title: PropTypes.func,
+};

--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -899,7 +899,7 @@ const formConfig = {
                   'intendsToEnroll',
                   'over18HelplessChild',
                 ]),
-                otherStatus: { type: 'string' },
+                _unused: { type: 'string' },
               },
             },
           }),

--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -1160,7 +1160,7 @@ const formConfig = {
               type: 'object',
               properties: {
                 eligibility: { type: 'string' },
-                otherIneligible: { type: 'string' },
+                _unused: { type: 'string' },
               },
             },
           }),

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantDependentStatus.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantDependentStatus.jsx
@@ -3,28 +3,21 @@ import ApplicantRelationshipPage, {
   appRelBoilerplate,
 } from '../../shared/components/applicantLists/ApplicantRelationshipPage';
 
-const KEYNAME = 'applicantDependentStatus';
-const PRIMARY = 'status';
-const SECONDARY = 'otherStatus';
+const PROPERTY_NAMES = {
+  keyname: 'applicantDependentStatus',
+  primary: 'status',
+  secondary: '_unused',
+};
 
 function generateOptions({ data, pagePerItemIndex }) {
-  const {
-    currentListItem,
-    personTitle,
-    applicant,
-    useFirstPerson,
-    relative,
-    beingVerbPresent,
-    relativePossessive,
-  } = appRelBoilerplate({ data, pagePerItemIndex });
-
-  const customTitle = `${applicant}’s status`;
-
-  const relativeBeingVerb = `${relative} ${beingVerbPresent}`;
-
+  const bp = appRelBoilerplate({ data, pagePerItemIndex });
+  const customTitle = `${bp.applicant}’s status`;
+  const relativeBeingVerb = `${bp.relative} ${bp.beingVerbPresent}`;
   const options = [
     {
-      label: `${relativeBeingVerb} between the ages of 18 and 23 years old and ${beingVerbPresent} enrolled as a student in a high school, college, or vocational school`,
+      label: `${relativeBeingVerb} between the ages of 18 and 23 years old and ${
+        bp.beingVerbPresent
+      } enrolled as a student in a high school, college, or vocational school`,
       value: 'enrolled',
     },
     {
@@ -39,26 +32,18 @@ function generateOptions({ data, pagePerItemIndex }) {
 
   return {
     options,
-    useFirstPerson,
-    relativePossessive,
     relativeBeingVerb,
-    applicant,
-    personTitle,
-    keyname: KEYNAME,
-    primary: PRIMARY,
-    secondary: SECONDARY,
-    currentListItem,
+    ...bp,
+    ...PROPERTY_NAMES,
     customTitle,
-    description: `Which of these best describes ${applicant}?`,
+    description: `Which of these best describes ${bp.applicant}?`,
   };
 }
 
 export function ApplicantDependentStatusPage(props) {
   const newProps = {
     ...props,
-    keyname: KEYNAME,
-    primary: PRIMARY,
-    secondary: SECONDARY,
+    ...PROPERTY_NAMES,
     genOp: generateOptions,
   };
   return ApplicantRelationshipPage(newProps);
@@ -66,9 +51,7 @@ export function ApplicantDependentStatusPage(props) {
 export function ApplicantDependentStatusReviewPage(props) {
   const newProps = {
     ...props,
-    keyname: KEYNAME,
-    primary: PRIMARY,
-    secondary: SECONDARY,
+    ...PROPERTY_NAMES,
     genOp: generateOptions,
   };
   return ApplicantRelationshipReviewPage(newProps);

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantMedicareStatusContinuedPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantMedicareStatusContinuedPage.jsx
@@ -1,24 +1,17 @@
-import PropTypes from 'prop-types';
-
+import { pageProps, reviewPageProps } from '../config/constants';
 import ApplicantRelationshipPage, {
   ApplicantRelationshipReviewPage,
   appRelBoilerplate,
 } from '../../shared/components/applicantLists/ApplicantRelationshipPage';
 
-const KEYNAME = 'applicantMedicarePartD';
-const PRIMARY = 'enrollment';
-const SECONDARY = 'otherEnrollment'; // unused
+const PROPERTY_NAMES = {
+  keyname: 'applicantMedicarePartD',
+  primary: 'enrollment',
+  secondary: '_unused',
+};
 
 export function generateOptions({ data, pagePerItemIndex }) {
-  const {
-    currentListItem,
-    personTitle,
-    applicant,
-    useFirstPerson,
-    relative,
-    beingVerbPresent,
-    relativePossessive,
-  } = appRelBoilerplate({ data, pagePerItemIndex });
+  const bp = appRelBoilerplate({ data, pagePerItemIndex });
 
   const options = [
     {
@@ -31,20 +24,14 @@ export function generateOptions({ data, pagePerItemIndex }) {
     },
   ];
 
-  const prompt = `Is ${applicant} enrolled in Medicare Part D?`;
+  const prompt = `Is ${bp.applicant} enrolled in Medicare Part D?`;
 
   return {
     options,
-    currentListItem,
-    personTitle,
-    relativePossessive,
-    relativeBeingVerb: `${relative} ${beingVerbPresent}`,
-    useFirstPerson,
-    applicant,
-    keyname: KEYNAME,
-    primary: PRIMARY,
-    secondary: SECONDARY,
-    customTitle: `${applicant}'s Medicare status`,
+    ...bp,
+    relativeBeingVerb: `${bp.relative} ${bp.beingVerbPresent}`,
+    ...PROPERTY_NAMES,
+    customTitle: `${bp.applicant}'s Medicare status`,
     description: prompt,
   };
 }
@@ -54,9 +41,7 @@ export function generateOptions({ data, pagePerItemIndex }) {
 export function ApplicantMedicareStatusContinuedPage(props) {
   const newProps = {
     ...props,
-    keyname: KEYNAME,
-    primary: PRIMARY,
-    secondary: SECONDARY,
+    ...PROPERTY_NAMES,
     genOp: generateOptions,
   };
   return ApplicantRelationshipPage(newProps);
@@ -64,28 +49,11 @@ export function ApplicantMedicareStatusContinuedPage(props) {
 export function ApplicantMedicareStatusContinuedReviewPage(props) {
   const newProps = {
     ...props,
-    keyname: KEYNAME,
-    primary: PRIMARY,
-    secondary: SECONDARY,
+    ...PROPERTY_NAMES,
     genOp: generateOptions,
   };
   return ApplicantRelationshipReviewPage(newProps);
 }
 
-ApplicantMedicareStatusContinuedReviewPage.propTypes = {
-  data: PropTypes.object,
-  editPage: PropTypes.func,
-  pagePerItemIndex: PropTypes.number,
-  props: PropTypes.object,
-  title: PropTypes.func,
-};
-
-ApplicantMedicareStatusContinuedPage.propTypes = {
-  data: PropTypes.object,
-  goBack: PropTypes.func,
-  goForward: PropTypes.func,
-  pagePerItemIndex: PropTypes.string,
-  setFormData: PropTypes.func,
-  updatePage: PropTypes.func,
-  onReviewPage: PropTypes.bool,
-};
+ApplicantMedicareStatusContinuedReviewPage.propTypes = reviewPageProps;
+ApplicantMedicareStatusContinuedPage.propTypes = pageProps;

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantMedicareStatusPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantMedicareStatusPage.jsx
@@ -1,54 +1,44 @@
-import PropTypes from 'prop-types';
+import { reviewPageProps, pageProps } from '../config/constants';
 
 import ApplicantRelationshipPage, {
   ApplicantRelationshipReviewPage,
   appRelBoilerplate,
 } from '../../shared/components/applicantLists/ApplicantRelationshipPage';
 
-const KEYNAME = 'applicantMedicareStatus';
-const PRIMARY = 'eligibility';
-const SECONDARY = 'otherIneligible';
+const PROPERTY_NAMES = {
+  keyname: 'applicantMedicareStatus',
+  primary: 'eligibility',
+  secondary: '_unused',
+};
 
 export function generateOptions({ data, pagePerItemIndex }) {
-  const {
-    currentListItem,
-    personTitle,
-    applicant,
-    useFirstPerson,
-    relative,
-    beingVerbPresent,
-    relativePossessive,
-  } = appRelBoilerplate({ data, pagePerItemIndex });
+  const bp = appRelBoilerplate({ data, pagePerItemIndex });
 
   const options = [
     {
-      label: `Yes, ${applicant} is enrolled in Medicare`,
+      label: `Yes, ${bp.applicant} is enrolled in Medicare`,
       value: 'enrolled',
     },
     {
-      label: `No, ${applicant} is not eligible for Medicare`,
+      label: `No, ${bp.applicant} is not eligible for Medicare`,
       value: 'ineligible',
     },
     {
-      label: `No, ${applicant} is eligible for Medicare but has not been signed up for it yet`,
+      label: `No, ${
+        bp.applicant
+      } is eligible for Medicare but has not been signed up for it yet`,
       value: 'eligibleNotSignedUp',
     },
   ];
 
-  const prompt = `Is ${applicant} enrolled in Medicare Parts A & B?`;
+  const prompt = `Is ${bp.applicant} enrolled in Medicare Parts A & B?`;
 
   return {
     options,
-    currentListItem,
-    personTitle,
-    relativePossessive,
-    relativeBeingVerb: `${relative} ${beingVerbPresent}`,
-    useFirstPerson,
-    applicant,
-    keyname: KEYNAME,
-    primary: PRIMARY,
-    secondary: SECONDARY,
-    customTitle: `${applicant}'s Medicare status`,
+    ...bp,
+    relativeBeingVerb: `${bp.relative} ${bp.beingVerbPresent}`,
+    ...PROPERTY_NAMES,
+    customTitle: `${bp.applicant}'s Medicare status`,
     description: prompt,
   };
 }
@@ -58,9 +48,7 @@ export function generateOptions({ data, pagePerItemIndex }) {
 export function ApplicantMedicareStatusPage(props) {
   const newProps = {
     ...props,
-    keyname: KEYNAME,
-    primary: PRIMARY,
-    secondary: SECONDARY,
+    ...PROPERTY_NAMES,
     genOp: generateOptions,
   };
   return ApplicantRelationshipPage(newProps);
@@ -68,28 +56,11 @@ export function ApplicantMedicareStatusPage(props) {
 export function ApplicantMedicareStatusReviewPage(props) {
   const newProps = {
     ...props,
-    keyname: KEYNAME,
-    primary: PRIMARY,
-    secondary: SECONDARY,
+    ...PROPERTY_NAMES,
     genOp: generateOptions,
   };
   return ApplicantRelationshipReviewPage(newProps);
 }
 
-ApplicantMedicareStatusReviewPage.propTypes = {
-  data: PropTypes.object,
-  editPage: PropTypes.func,
-  pagePerItemIndex: PropTypes.number,
-  props: PropTypes.object,
-  title: PropTypes.func,
-};
-
-ApplicantMedicareStatusPage.propTypes = {
-  data: PropTypes.object,
-  goBack: PropTypes.func,
-  goForward: PropTypes.func,
-  pagePerItemIndex: PropTypes.string,
-  setFormData: PropTypes.func,
-  updatePage: PropTypes.func,
-  onReviewPage: PropTypes.bool,
-};
+ApplicantMedicareStatusReviewPage.propTypes = reviewPageProps;
+ApplicantMedicareStatusPage.propTypes = pageProps;

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantOhiStatusPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantOhiStatusPage.jsx
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import { reviewPageProps, pageProps } from '../config/constants';
 
 import ApplicantRelationshipPage, {
   ApplicantRelationshipReviewPage,
@@ -49,16 +49,5 @@ export function ApplicantOhiStatusReviewPage(props) {
   });
 }
 
-ApplicantOhiStatusReviewPage.propTypes = {
-  data: PropTypes.object,
-};
-
-ApplicantOhiStatusPage.propTypes = {
-  data: PropTypes.object,
-  goBack: PropTypes.func,
-  goForward: PropTypes.func,
-  pagePerItemIndex: PropTypes.string,
-  setFormData: PropTypes.func,
-  updatePage: PropTypes.func,
-  onReviewPage: PropTypes.bool,
-};
+ApplicantOhiStatusReviewPage.propTypes = reviewPageProps;
+ApplicantOhiStatusPage.propTypes = pageProps;

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantRelOriginPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantRelOriginPage.jsx
@@ -6,46 +6,36 @@ import ApplicantRelationshipPage, {
 const KEYNAME = 'applicantRelationshipOrigin';
 
 function generateOptions({ data, pagePerItemIndex }) {
-  const {
-    currentListItem,
-    personTitle,
-    applicant,
-    useFirstPerson,
-    relative,
-    beingVerbPresent,
-    relativePossessive,
-  } = appRelBoilerplate({ data, pagePerItemIndex });
-
-  const customTitle = `${applicant}’s relationship to the ${personTitle}`;
-
-  const relativeBeingVerb = `${relative} ${beingVerbPresent}`;
+  const bp = appRelBoilerplate({ data, pagePerItemIndex });
+  const customTitle = `${bp.applicant}’s relationship to the ${bp.personTitle}`;
+  const relativeBeingVerb = `${bp.relative} ${bp.beingVerbPresent}`;
   const surv = data.sponsorIsDeceased ? 'surviving' : '';
 
   // Create dynamic radio labels based on above phrasing
   const options = [
     {
-      label: `${relativeBeingVerb} the ${personTitle}’s ${surv} biological child`,
+      label: `${relativeBeingVerb} the ${
+        bp.personTitle
+      }’s ${surv} biological child`,
       value: 'blood',
     },
     {
-      label: `${relativeBeingVerb} the ${personTitle}’s ${surv} step child`,
+      label: `${relativeBeingVerb} the ${bp.personTitle}’s ${surv} step child`,
       value: 'step',
     },
     {
-      label: `${relativeBeingVerb} the ${personTitle}’s ${surv} adopted child`,
+      label: `${relativeBeingVerb} the ${
+        bp.personTitle
+      }’s ${surv} adopted child`,
       value: 'adoption',
     },
   ];
 
   return {
     options,
-    useFirstPerson,
-    relativePossessive,
+    ...bp,
     relativeBeingVerb,
-    applicant,
-    personTitle,
     keyname: KEYNAME,
-    currentListItem,
     customTitle,
     description: `What’s ${customTitle}?`,
   };

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantSponsorMarriageDetailsPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantSponsorMarriageDetailsPage.jsx
@@ -26,30 +26,33 @@ This page is displayed when the sponsor is deceased and the
 applicant indicated they were married to the sponsor at some point.
 */
 function generateOptions({ data, pagePerItemIndex }) {
-  const {
-    currentListItem,
-    personTitle,
-    applicant,
-    useFirstPerson,
-    relative,
-    relativePossessive,
-  } = appRelBoilerplate({ data, pagePerItemIndex });
+  const bp = appRelBoilerplate({ data, pagePerItemIndex });
 
-  const customTitle = `${applicant}’s marriage to the ${personTitle}`;
+  const customTitle = `${bp.applicant}’s marriage to the ${bp.personTitle}`;
 
-  const description = `Which of these best describes ${applicant}’s marriage to their ${personTitle}?`;
+  const description = `Which of these best describes ${
+    bp.applicant
+  }’s marriage to their ${bp.personTitle}?`;
 
   const options = [
     {
-      label: `${relative} was married to the ${personTitle} at the time of their death and didn’t remarry`,
+      label: `${bp.relative} was married to the ${
+        bp.personTitle
+      } at the time of their death and didn’t remarry`,
       value: 'marriedTillDeathNoRemarriage',
     },
     {
-      label: `${relative} was legally separated from ${personTitle} before their death`,
+      label: `${bp.relative} was legally separated from ${
+        bp.personTitle
+      } before their death`,
       value: 'marriageDissolved',
     },
     {
-      label: `${relative} was married to the ${personTitle} at the time of their death and remarried someone else on or after ${relativePossessive} 55th birthday`,
+      label: `${bp.relative} was married to the ${
+        bp.personTitle
+      } at the time of their death and remarried someone else on or after ${
+        bp.relativePossessive
+      } 55th birthday`,
       value: 'marriedTillDeathRemarriedAfter55',
     },
     {
@@ -60,12 +63,8 @@ function generateOptions({ data, pagePerItemIndex }) {
 
   return {
     options,
-    useFirstPerson,
-    relativePossessive,
-    applicant,
-    personTitle,
+    ...bp,
     keyname: KEYNAME,
-    currentListItem,
     customTitle,
     description,
   };

--- a/src/applications/ivc-champva/10-7959C/config/constants.js
+++ b/src/applications/ivc-champva/10-7959C/config/constants.js
@@ -1,24 +1,3 @@
-import PropTypes from 'prop-types';
-
-// These proptypes are used with the custom pages that use
-// ApplicantRelationshipPage
-export const pageProps = {
-  data: PropTypes.object,
-  goBack: PropTypes.func,
-  goForward: PropTypes.func,
-  pagePerItemIndex: PropTypes.any,
-  setFormData: PropTypes.func,
-  updatePage: PropTypes.func,
-  onReviewPage: PropTypes.bool,
-};
-export const reviewPageProps = {
-  data: PropTypes.object,
-  editPage: PropTypes.func,
-  pagePerItemIndex: PropTypes.any,
-  props: PropTypes.object,
-  title: PropTypes.func,
-};
-
 /* List of required files - not enforced by the form because we want
 users to be able to opt into mailing these documents. This object 
 performs double duty by also providing a map to presentable names. */


### PR DESCRIPTION
## Summary

This PR condenses/refactors several places in form 10-10d that use the same base CustomPage to display radio options with dynamic wording. The main goal is to reduce unnecessary boilerplate and streamline this custompage usage a bit.

The key differences are
- Eliminate unnecessary variable destructuring
- Pull out common proptypes to a shared constants file
- Condense `PRIMARY` and `SECONDARY` keys into single object so they can be spread as necessary rather than being repeatedly spelled out in custompage calls
- Team: IVC CHAMPVA
- Flipper: NA

## Testing done

- Verified existing unit and E2E specs still pass (no new functionality/behavior was introduced)

## What areas of the site does it impact?

Form 10-10d only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA