### PR TITLE
#82389: Mock wellHive Drive Times endpoints

### DIFF
--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -40,6 +40,7 @@ const confirmedV2 = require('./v2/confirmed.json');
 // CC Direct Scheduling mocks
 const wellHiveAppointments = require('./wellHive/appointments.json');
 const WHCancelReasons = require('./wellHive/cancelReasons.json');
+const driveTimes = require('./wellHive/driveTime.json');
 
 // Returns the meta object without any backend service errors
 const meta = require('./v2/meta.json');
@@ -516,7 +517,9 @@ const responses = {
     mockWellHiveAppts.push(submittedAppt);
     return res.json({ data: submittedAppt });
   },
-
+  'POST /vaos/v2/wellhive/drive-times': (req, res) => {
+    return res.json({ driveTimes });
+  },
   'GET /v0/user': {
     data: {
       attributes: {


### PR DESCRIPTION
## Summary
Mock wellHive Drive Times endpoints #82389



## Related issue(s)

- https://app.zenhub.com/workspaces/appointments-cc-direct-scheduling-660abc13699bfa00195d685a/issues/gh/department-of-veterans-affairs/va.gov-team/82389
- 
## Testing done
Tested mocks with postman.

`POST /vaos/v2/wellhive/drive-times`
<img width="922" alt="Screenshot 2024-05-15 at 10 17 09 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/47654119/6ce58d47-5988-4a2d-a358-eacfbe654f1b">


WH API DOC:
<img width="1172" alt="Screenshot 2024-05-15 at 10 17 37 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/47654119/480eeddd-b902-49a0-9b05-369c5b1f03ee">

Postman Collection:
[WellHive Mock api collection.postman_collection.json](https://github.com/department-of-veterans-affairs/vets-website/files/15323638/WellHive.Mock.api.collection.postman_collection.json)

## Acceptance criteria
- [x] Mock wellHive Drive Times endpoints.
