### PR TITLE
EZR: Fixes the error message for medicare claim number

### DIFF
--- a/src/applications/ezr/config/chapters/insuranceInformation/partAEffectiveDate.js
+++ b/src/applications/ezr/config/chapters/insuranceInformation/partAEffectiveDate.js
@@ -25,7 +25,7 @@ export default {
         hint: content['insurance-medicare-claim-number-hint'],
       },
       'ui:errorMessages': {
-        required: content['validation-medicare-claim-number'],
+        pattern: content['validation-medicare-claim-number'],
       },
     },
   },


### PR DESCRIPTION
## Summary

Fix for [29633](https://github.com/department-of-veterans-affairs/vets-website/pull/29633)

Form 10-10 EZR: Rejects whitespace only values in required text fields.

Fixes the error message shown for the medicare claim number field.

Fields updated:
- medicare claim number

## Related issue(s)

department-of-veterans-affairs/va.gov-team#78895

[vets-json-schema](https://github.com/department-of-veterans-affairs/vets-json-schema/pull/893)

## Testing done

Updated tests in vets-json-schema

## What areas of the site does it impact?

Form 10-10 EZR

## Acceptance criteria

- Required text inputs reject whitespace only values

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
