### PR TITLE
82390: mock wellhive network endpoint

### DIFF
--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -40,6 +40,7 @@ const confirmedV2 = require('./v2/confirmed.json');
 // CC Direct Scheduling mocks
 const wellHiveAppointments = require('./wellHive/appointments.json');
 const WHCancelReasons = require('./wellHive/cancelReasons.json');
+const driveTimes = require('./wellHive/driveTime.json');
 
 // Returns the meta object without any backend service errors
 const meta = require('./v2/meta.json');
@@ -516,7 +517,9 @@ const responses = {
     mockWellHiveAppts.push(submittedAppt);
     return res.json({ data: submittedAppt });
   },
-
+  'POST /vaos/v2/wellhive/drive-times': (req, res) => {
+    return res.json({ driveTimes });
+  },
   'GET /v0/user': {
     data: {
       attributes: {

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -42,6 +42,7 @@ const wellHiveAppointments = require('./wellHive/appointments.json');
 const WHCancelReasons = require('./wellHive/cancelReasons.json');
 const driveTimes = require('./wellHive/driveTime.json');
 const patients = require('./wellHive/patients.json');
+const WHNetworks = require('./wellHive/networks.json');
 
 // Returns the meta object without any backend service errors
 const meta = require('./v2/meta.json');
@@ -537,6 +538,16 @@ const responses = {
     ).identifier.find(identifier => identifier.system === req.params.system);
     return res.json({
       data: patientSystem,
+    });
+  },
+  'GET /vaos/v2/wellhive/networks': (req, res) => {
+    return res.json({ data: WHNetworks });
+  },
+  'GET /vaos/v2/wellhive/networks/:networkId': (req, res) => {
+    return res.json({
+      data: WHNetworks.networks.find(
+        network => network?.id === req.params.networkId,
+      ),
     });
   },
   'GET /v0/user': {

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -41,6 +41,7 @@ const confirmedV2 = require('./v2/confirmed.json');
 const wellHiveAppointments = require('./wellHive/appointments.json');
 const WHCancelReasons = require('./wellHive/cancelReasons.json');
 const driveTimes = require('./wellHive/driveTime.json');
+const patients = require('./wellHive/patients.json');
 
 // Returns the meta object without any backend service errors
 const meta = require('./v2/meta.json');
@@ -519,6 +520,24 @@ const responses = {
   },
   'POST /vaos/v2/wellhive/drive-times': (req, res) => {
     return res.json({ driveTimes });
+  },
+  'GET /vaos/v2/wellhive/patients/:patientId': (req, res) => {
+    const WHPatients = [patients];
+    return res.json({
+      data: WHPatients.find(patient => patient?.id === req.params.patientId),
+    });
+  },
+  'GET /vaos/v2/wellhive/patients/:patientId/identifier/:system': (
+    req,
+    res,
+  ) => {
+    const WHPatients = [patients];
+    const patientSystem = WHPatients.find(
+      patient => patient?.id === req.params.patientId,
+    ).identifier.find(identifier => identifier.system === req.params.system);
+    return res.json({
+      data: patientSystem,
+    });
   },
   'GET /v0/user': {
     data: {


### PR DESCRIPTION
## Summary
Mock wellhive network endpoint#82390



## Related issue(s)

- https://app.zenhub.com/workspaces/appointments-cc-direct-scheduling-660abc13699bfa00195d685a/issues/gh/department-of-veterans-affairs/va.gov-team/82390
- 
## Testing done
Tested mocks with postman.

`GET /vaos/v2/wellhive/networks`
<img width="953" alt="Screenshot 2024-05-15 at 12 18 32 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/47654119/6b5e0f23-054f-456e-8f05-60f3105a5de8">


'GET /vaos/v2/wellhive/networks/:networkId'
<img width="927" alt="Screenshot 2024-05-15 at 12 18 56 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/47654119/b4514cad-0a58-46d7-a418-d32e1aad0148">


WH API DOC:
<img width="1163" alt="Screenshot 2024-05-15 at 12 19 19 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/47654119/c74979c7-47cb-4e81-bfe2-34912e53a88f">



Postman Collection:
[WellHive Mock api collection.postman_collection.json](https://github.com/department-of-veterans-affairs/vets-website/files/15324899/WellHive.Mock.api.collection.postman_collection.json)

## Acceptance criteria
- [x] Mock wellHive Network endpoints.