### PR TITLE
Add aria-label to employer edit button

### DIFF
--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/helpers.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/helpers.js
@@ -151,7 +151,7 @@ const generateEmployersUISchema = ({
     'ui:title': employerMessage,
     'ui:options': {
       itemName: 'Job',
-      itemAriaLabel: data => getJobTitleOrType(data.jobTitle),
+      itemAriaLabel: data => getJobTitleOrType(data),
       viewField: EmployerView,
       reviewTitle: employersReviewTitle,
       keepInPageOnReview: true,

--- a/src/applications/pensions/tests/unit/chapters/03-health-and-employment-information/employmentHistory.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/chapters/03-health-and-employment-information/employmentHistory.unit.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
+import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
 import {
   FakeProvider,
   testNumberOfErrorsOnSubmitForWebComponents,
@@ -63,6 +64,45 @@ describe('pensions employment history', () => {
     },
     pageTitle,
   );
+
+  it('should set the aria-label to the jobTitle or jobType', () => {
+    const { container } = render(
+      <FakeProvider>
+        <DefinitionTester
+          definitions={formConfig.defaultDefinitions}
+          schema={schema}
+          uiSchema={uiSchema}
+          data={{
+            currentEmployment: false,
+            employers: [
+              {
+                jobTitle: 'Cashier',
+                jobType: 'Customer service',
+                jobHoursWeek: '20',
+              },
+              {
+                jobTitle: 'Customer Service Representative',
+                jobType: 'Customer service',
+                jobHoursWeek: '20',
+              },
+            ],
+          }}
+        />
+      </FakeProvider>,
+    );
+
+    const cashierEditButton = container.querySelector(
+      '[aria-label="Edit Cashier"]',
+    );
+    const csrRemoveButton = container.querySelector(
+      '[aria-label="Remove Customer Service Representative"]',
+    );
+
+    // The first item is closed, so it only has an edit button
+    expect(cashierEditButton).to.exist;
+    // The second item is open, so it has a remove button instead
+    expect(csrRemoveButton).to.exist;
+  });
 
   describe('EmployerView', () => {
     it('should render a list view', () => {


### PR DESCRIPTION
## Summary

On [/employment/current/history](https://staging.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/employment/current/history), each Edit button had the same accessible name (aria-label="Edit job").

For screen reader users tabbing through these buttons, it was difficult to distinguish which button maps to which job.

Other instances of this pattern update the aria-label with the user input, eg. aria-label="Edit [job name]". The employer pages have been fixed to do the same. 

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/82853

## Testing done

- Reviewed /employment/current/history and /employment/previous/history and confirmed in developer tools that each edit and remove button contained an aria-label specifying the specific job to edit. 
- A test has been added to catch any future regressions. 

## What areas of the site does it impact?

Pension Benefits

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

