### PR TITLE
SC | Fix long text overflow

### DIFF
--- a/src/applications/appeals/995/components/EvidenceSummaryLists.jsx
+++ b/src/applications/appeals/995/components/EvidenceSummaryLists.jsx
@@ -110,14 +110,14 @@ export const VaContent = ({
               <div className={hasErrors ? errorClassNames : ''}>
                 {errors.name || (
                   <Header6
-                    className="dd-privacy-hidden"
+                    className="dd-privacy-hidden overflow-wrap-word"
                     data-dd-action-name="VA location name"
                   >
                     {locationAndName}
                   </Header6>
                 )}
                 <div
-                  className="dd-privacy-hidden"
+                  className="dd-privacy-hidden overflow-wrap-word"
                   data-dd-action-name="VA location treated issues"
                 >
                   {errors.issues || readableList(issues)}
@@ -229,14 +229,14 @@ export const PrivateContent = ({
               <div className={hasErrors ? errorClassNames : ''}>
                 {errors.name || (
                   <Header6
-                    className="dd-privacy-hidden"
+                    className="dd-privacy-hidden overflow-wrap-word"
                     data-dd-action-name="Private facility name"
                   >
                     {providerFacilityName}
                   </Header6>
                 )}
                 <div
-                  className="dd-privacy-hidden"
+                  className="dd-privacy-hidden overflow-wrap-word"
                   data-dd-action-name="Private facility treated issues"
                 >
                   {errors.issues || readableList(issues)}
@@ -356,7 +356,7 @@ export const UploadContent = ({
               className={hasErrors ? errorClassNames : listClassNames}
             >
               <Header6
-                className="dd-privacy-hidden"
+                className="dd-privacy-hidden overflow-wrap-word"
                 data-dd-action-name="Uploaded document file name"
               >
                 {upload.name}

--- a/src/applications/appeals/shared/utils/issues.jsx
+++ b/src/applications/appeals/shared/utils/issues.jsx
@@ -61,7 +61,7 @@ export const getSelected = formData => {
  */
 export const getIssuesListItems = data =>
   getSelected(data || []).map((issue, index) => (
-    <li key={index} className="vads-u-margin-bottom--0">
+    <li key={index} className="vads-u-margin-bottom--0 overflow-wrap-word">
       <span className="dd-privacy-hidden" data-dd-action-name="issue name">
         {getIssueName(issue)}
       </span>


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Uploading files with long file names (without any spaces) would cause the page to overflow instead of wrapping. While working on this, other evidence location & facility names and issue list 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Add CSS to wrap overflowed text
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#82749](https://github.com/department-of-veterans-affairs/va.gov-team/issues/82749)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Text overflows off the screen
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Evidence summary  | ![evidence summary page with VA location name, private facility name, contestable issues name and file names which are long without spaces causing overflow off the screen](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/e9100ccb-09c2-4787-a002-875d995f7d6d) | ![evidence summary page with VA location name, private facility name, contestable issues name and file names all wrapping within the page](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/4bcbd7ea-423e-47db-aa51-25bc043239af) |
| Review & submit | ![levidence summary page with VA location name, private facility name, contestable issues name and file names overflowing the accordion](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/7cb3cdc7-c597-446a-8a1a-e7ba006daadb) | ![evidence summary page with VA location name, private facility name, contestable issues name and file names all wrapping within the accordion](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/aab27851-1a3f-43c5-8725-f59b69bf7afd) |
| Confirmation page | <img width="1127" alt="confirmation page with contestable issues overflowing" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/13e5d37f-46d6-4952-924e-8b5e6495e73d"> | <img width="699" alt="confirmation page with contestable issues wrapping within the summary box" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/47b3a791-5612-4be6-a4b7-07a8691f90ea"> |

## What areas of the site does it impact?

Supplemental Claims

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
