### PR TITLE
[SIMPLE_FORMS] feat: add ability to use custom login links

### DIFF
--- a/src/applications/simple-forms/21-4138/config/constants.js
+++ b/src/applications/simple-forms/21-4138/config/constants.js
@@ -95,10 +95,10 @@ export const OTHER_REASONS_OPTIONAL = Object.freeze({
   MEDAL_AWARD: 'I’m a Medal of Honor or Purple Heart award recipient.',
 });
 
-const PrimaryActionLink = ({ href, children }) => (
+export const PrimaryActionLink = ({ href = '/', children, onClick = null }) => (
   <div className="arrow" style={{ maxWidth: '75%' }}>
     <div className="vads-u-background-color--primary vads-u-padding--1">
-      <a className="vads-c-action-link--white" href={href}>
+      <a className="vads-c-action-link--white" href={href} onClick={onClick}>
         {children}
       </a>
     </div>

--- a/src/applications/simple-forms/21-4138/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-4138/containers/IntroductionPage.jsx
@@ -49,6 +49,7 @@ const IntroductionPage = props => {
     unauthStartText: 'Sign in to start your statement',
     displayNonVeteranMessaging: true,
     hideSipIntro: userLoggedIn && !userIdVerified,
+    usePrimaryLink: true,
   };
 
   const ombInfo = {

--- a/src/applications/simple-forms/21-4138/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/21-4138/containers/IntroductionPage.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { isLOA3, isLoggedIn } from 'platform/user/selectors';
 import { IntroductionPageView } from '../../shared/components/IntroductionPageView';
-import { TITLE, SUBTITLE } from '../config/constants';
+import { TITLE, SUBTITLE, PrimaryActionLink } from '../config/constants';
 
 const IntroductionPage = props => {
   const { route } = props;
@@ -49,7 +49,7 @@ const IntroductionPage = props => {
     unauthStartText: 'Sign in to start your statement',
     displayNonVeteranMessaging: true,
     hideSipIntro: userLoggedIn && !userIdVerified,
-    usePrimaryLink: true,
+    customLink: PrimaryActionLink,
   };
 
   const ombInfo = {

--- a/src/applications/simple-forms/shared/components/IntroductionPageView.jsx
+++ b/src/applications/simple-forms/shared/components/IntroductionPageView.jsx
@@ -22,7 +22,7 @@ export const IntroductionPageView = ({
     unauthStartText,
     displayNonVeteranMessaging = false,
     verifiedPrefillAlert = null,
-    usePrimaryLink = false,
+    customLink = null,
   } = content;
   const { resBurden, ombNumber, expDate, customPrivacyActStmt } = ombInfo;
 
@@ -46,7 +46,7 @@ export const IntroductionPageView = ({
           verifiedPrefillAlert={verifiedPrefillAlert}
           formConfig={formConfig}
           hideUnauthedStartLink={formConfig.hideUnauthedStartLink ?? false}
-          usePrimaryLink={usePrimaryLink}
+          customLink={customLink}
         >
           {saveInProgressText}
         </SaveInProgressIntro>
@@ -92,7 +92,7 @@ IntroductionPageView.propTypes = {
     unauthStartText: PropTypes.string,
     displayNonVeteranMessaging: PropTypes.bool,
     verifiedPrefillAlert: PropTypes.object,
-    usePrimaryLink: PropTypes.bool,
+    customLink: PropTypes.any,
   }),
   ombInfo: PropTypes.shape(),
 };

--- a/src/applications/simple-forms/shared/components/IntroductionPageView.jsx
+++ b/src/applications/simple-forms/shared/components/IntroductionPageView.jsx
@@ -22,6 +22,7 @@ export const IntroductionPageView = ({
     unauthStartText,
     displayNonVeteranMessaging = false,
     verifiedPrefillAlert = null,
+    usePrimaryLink = false,
   } = content;
   const { resBurden, ombNumber, expDate, customPrivacyActStmt } = ombInfo;
 
@@ -45,6 +46,7 @@ export const IntroductionPageView = ({
           verifiedPrefillAlert={verifiedPrefillAlert}
           formConfig={formConfig}
           hideUnauthedStartLink={formConfig.hideUnauthedStartLink ?? false}
+          usePrimaryLink={usePrimaryLink}
         >
           {saveInProgressText}
         </SaveInProgressIntro>
@@ -90,6 +92,7 @@ IntroductionPageView.propTypes = {
     unauthStartText: PropTypes.string,
     displayNonVeteranMessaging: PropTypes.bool,
     verifiedPrefillAlert: PropTypes.object,
+    usePrimaryLink: PropTypes.bool,
   }),
   ombInfo: PropTypes.shape(),
 };

--- a/src/platform/forms/save-in-progress/FormStartControls.jsx
+++ b/src/platform/forms/save-in-progress/FormStartControls.jsx
@@ -5,12 +5,12 @@ import {
   VaButton,
   VaModal,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import recordEvent from '../../monitoring/record-event';
-
 import {
   WIZARD_STATUS,
   WIZARD_STATUS_RESTARTING,
 } from '~/platform/site-wide/wizard';
+import recordEvent from '../../monitoring/record-event';
+
 import {
   CONTINUE_APP_DEFAULT_MESSAGE,
   START_NEW_APP_DEFAULT_MESSAGE,
@@ -31,6 +31,7 @@ const FormStartControls = props => {
     formSaved,
     isExpired,
     resumeOnly,
+    usePrimaryLink = false,
   } = props;
 
   // get access to the formConfig object through this route
@@ -129,6 +130,25 @@ const FormStartControls = props => {
     );
   }
 
+  if (usePrimaryLink) {
+    return (
+      <div className="arrow" style={{ maxWidth: '75%' }}>
+        <div className="vads-u-background-color--primary vads-u-padding--1">
+          <a
+            className="vads-c-action-link--white"
+            href="#start"
+            onClick={event => {
+              event.preventDefault();
+              handleLoadPrefill();
+            }}
+          >
+            {startText}
+          </a>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <a
       href="#start"
@@ -171,6 +191,7 @@ FormStartControls.propTypes = {
   routes: PropTypes.array,
   startText: PropTypes.string,
   testActionLink: PropTypes.bool,
+  usePrimaryLink: PropTypes.bool,
 };
 
 FormStartControls.defaultProps = {

--- a/src/platform/forms/save-in-progress/FormStartControls.jsx
+++ b/src/platform/forms/save-in-progress/FormStartControls.jsx
@@ -27,11 +27,11 @@ const FormStartControls = props => {
     prefillTransformer,
     ariaLabel = null,
     ariaDescribedby = null,
+    customStartLink = null,
     startText,
     formSaved,
     isExpired,
     resumeOnly,
-    usePrimaryLink = false,
   } = props;
 
   // get access to the formConfig object through this route
@@ -130,22 +130,18 @@ const FormStartControls = props => {
     );
   }
 
-  if (usePrimaryLink) {
+  if (customStartLink) {
+    const CustomLink = customStartLink;
     return (
-      <div className="arrow" style={{ maxWidth: '75%' }}>
-        <div className="vads-u-background-color--primary vads-u-padding--1">
-          <a
-            className="vads-c-action-link--white"
-            href="#start"
-            onClick={event => {
-              event.preventDefault();
-              handleLoadPrefill();
-            }}
-          >
-            {startText}
-          </a>
-        </div>
-      </div>
+      <CustomLink
+        href="#start"
+        onClick={event => {
+          event.preventDefault();
+          handleLoadPrefill();
+        }}
+      >
+        {startText}
+      </CustomLink>
     );
   }
 
@@ -175,6 +171,7 @@ FormStartControls.propTypes = {
   startPage: PropTypes.string.isRequired,
   ariaDescribedby: PropTypes.string,
   ariaLabel: PropTypes.string,
+  customStartLink: PropTypes.any,
   formConfig: PropTypes.shape({
     customText: PropTypes.shape({
       startNewAppButtonText: PropTypes.string,
@@ -191,7 +188,6 @@ FormStartControls.propTypes = {
   routes: PropTypes.array,
   startText: PropTypes.string,
   testActionLink: PropTypes.bool,
-  usePrimaryLink: PropTypes.bool,
 };
 
 FormStartControls.defaultProps = {

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -55,6 +55,7 @@ class SaveInProgressIntro extends React.Component {
         gaStartEventName={this.props.gaStartEventName}
         ariaLabel={this.props.ariaLabel}
         ariaDescribedby={this.props.ariaDescribedby}
+        usePrimaryLink={this.props.usePrimaryLink}
       />
     );
   };
@@ -202,7 +203,22 @@ class SaveInProgressIntro extends React.Component {
         retentionPeriodStart,
         unauthStartText,
       } = this.props;
-      const unauthStartButton = (
+      const unauthStartButton = this.props.usePrimaryLink ? (
+        <div className="arrow" style={{ maxWidth: '75%' }}>
+          <div className="vads-u-background-color--primary vads-u-padding--1">
+            <a
+              className="vads-c-action-link--white"
+              href="#start"
+              onClick={event => {
+                event.preventDefault();
+                this.openLoginModal();
+              }}
+            >
+              {unauthStartText || UNAUTH_SIGN_IN_DEFAULT_MESSAGE}
+            </a>
+          </div>
+        </div>
+      ) : (
         <VaButton
           onClick={this.openLoginModal}
           label={ariaLabel}
@@ -456,6 +472,7 @@ SaveInProgressIntro.propTypes = {
   startText: PropTypes.string,
   unauthStartText: PropTypes.string,
   unverifiedPrefillAlert: PropTypes.element,
+  usePrimaryLink: PropTypes.bool,
   verifiedPrefillAlert: PropTypes.element,
   verifyRequiredPrefill: PropTypes.bool,
 };
@@ -473,6 +490,7 @@ SaveInProgressIntro.defaultProps = {
   headingLevel: 2,
   ariaLabel: null,
   ariaDescribedby: null,
+  usePrimaryLink: false,
 };
 
 function mapStateToProps(state) {

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -55,7 +55,7 @@ class SaveInProgressIntro extends React.Component {
         gaStartEventName={this.props.gaStartEventName}
         ariaLabel={this.props.ariaLabel}
         ariaDescribedby={this.props.ariaDescribedby}
-        usePrimaryLink={this.props.usePrimaryLink}
+        customStartLink={this.props.customLink}
       />
     );
   };
@@ -203,21 +203,17 @@ class SaveInProgressIntro extends React.Component {
         retentionPeriodStart,
         unauthStartText,
       } = this.props;
-      const unauthStartButton = this.props.usePrimaryLink ? (
-        <div className="arrow" style={{ maxWidth: '75%' }}>
-          <div className="vads-u-background-color--primary vads-u-padding--1">
-            <a
-              className="vads-c-action-link--white"
-              href="#start"
-              onClick={event => {
-                event.preventDefault();
-                this.openLoginModal();
-              }}
-            >
-              {unauthStartText || UNAUTH_SIGN_IN_DEFAULT_MESSAGE}
-            </a>
-          </div>
-        </div>
+      const CustomLink = this.props.customLink;
+      const unauthStartButton = CustomLink ? (
+        <CustomLink
+          href="#start"
+          onClick={event => {
+            event.preventDefault();
+            this.openLoginModal();
+          }}
+        >
+          {unauthStartText || UNAUTH_SIGN_IN_DEFAULT_MESSAGE}
+        </CustomLink>
       ) : (
         <VaButton
           onClick={this.openLoginModal}
@@ -442,6 +438,7 @@ SaveInProgressIntro.propTypes = {
   ariaLabel: PropTypes.string,
   buttonOnly: PropTypes.bool,
   children: PropTypes.any,
+  customLink: PropTypes.any,
   displayNonVeteranMessaging: PropTypes.bool,
   downtime: PropTypes.object,
   formConfig: PropTypes.shape({
@@ -472,7 +469,6 @@ SaveInProgressIntro.propTypes = {
   startText: PropTypes.string,
   unauthStartText: PropTypes.string,
   unverifiedPrefillAlert: PropTypes.element,
-  usePrimaryLink: PropTypes.bool,
   verifiedPrefillAlert: PropTypes.element,
   verifyRequiredPrefill: PropTypes.bool,
 };
@@ -490,7 +486,7 @@ SaveInProgressIntro.defaultProps = {
   headingLevel: 2,
   ariaLabel: null,
   ariaDescribedby: null,
-  usePrimaryLink: false,
+  customLink: null,
 };
 
 function mapStateToProps(state) {


### PR DESCRIPTION
## Summary

- Updated SIP Intro component logic to accept and display custom start links
- Configured form 21-4138 to utilize new custom link logic
- Team: Veteran Facing Forms
- Flipper not implemented

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#82306

## Testing done

- Local browser functions successfully
- Unit tests successful
- E2E tests successful


## What areas of the site does it impact?

This form ONLY.