### PR TITLE
[SIMPLE_FORMS] fix: 21-4138 - remove typo on confirmation page

### DIFF
--- a/src/applications/simple-forms/21-4138/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-4138/containers/ConfirmationPage.jsx
@@ -9,7 +9,7 @@ const content = {
     <>
       <p>
         We’ll review your statement. If we have any questions or need additional
-        information from you, we’ll contact you.",
+        information from you, we’ll contact you.
       </p>
     </>
   ),


### PR DESCRIPTION
## Summary

- Remove typo on confirmation page
- Team: Veteran Facing Forms
- Flipper not implemented

## Related issue(s)

- department-of-veterans-affairs/va.gov-team-forms#1303

## Testing done

- Local browser functions successfully
- Unit tests successful
- E2E tests successful


## What areas of the site does it impact?

This form ONLY.