### PR TITLE
MHV-58150: Changes to focus state and aria live for downloads

### DIFF
--- a/src/applications/mhv-medications/components/RefillPrescriptions/RenewablePrescriptions.jsx
+++ b/src/applications/mhv-medications/components/RefillPrescriptions/RenewablePrescriptions.jsx
@@ -87,11 +87,11 @@ const RenewablePrescriptions = ({ renewablePrescriptionsList = [] }) => {
           </Link>
         </p>
       </div>
-      <h3 className="vads-u-margin-bottom--0" data-testid="renewable-rx">
-        Prescriptions you may need to renew
-      </h3>
       {renewablePrescriptionsList.length > 0 && (
         <>
+          <h3 className="vads-u-margin-bottom--0" data-testid="renewable-rx">
+            Prescriptions you may need to renew
+          </h3>
           <p data-testid="renew-page-list-count">
             Showing
             <span>{` ${displayRange[0]} - ${displayRange[1]} of`}</span>

--- a/src/applications/mhv-medications/components/shared/PrintDownload.jsx
+++ b/src/applications/mhv-medications/components/shared/PrintDownload.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef } from 'react';
 import PropTypes from 'prop-types';
-import FeedbackEmail from './FeedbackEmail';
 import { DD_ACTIONS_PAGE_TYPE } from '../../util/constants';
 
 export const DOWNLOAD_FORMAT = {
@@ -82,11 +81,10 @@ const PrintDownload = props => {
     <>
       {isSuccess && (
         <div
-          aria-live="polite"
           className="vads-u-margin-bottom--3"
           data-testid="download-success-banner"
         >
-          <va-alert status="success" background-only uswds>
+          <va-alert role="alert" status="success" background-only uswds>
             <h2 slot="headline">Download started</h2>
             <p className="vads-u-margin--0">
               Check your device’s downloads location for your file.
@@ -96,13 +94,18 @@ const PrintDownload = props => {
       )}
       {isError && (
         <div className="vads-u-margin-bottom--3">
-          <va-alert status="error" uswds>
+          <va-alert role="alert" status="error" uswds>
             <h2 slot="headline">We can’t download your records right now</h2>
             <p>
               We’re sorry. There’s a problem with our system. Check back later.
             </p>
             <p className="vads-u-margin--0">
-              If it still doesn’t work, email us at <FeedbackEmail />
+              If it still doesn’t work, call us at{' '}
+              <va-telephone contact="8773270022" /> (
+              <va-telephone tty contact="711" />
+              ).
+              <br />
+              We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
             </p>
           </va-alert>
         </div>


### PR DESCRIPTION
## Summary

Download alerts:  
- Replace aria-live="polite" with role="alert".
- Verbiage update

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-58150
https://jira.devops.va.gov/browse/MHV-58290

<img width="926" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/e00fec7e-6cc0-4ef3-a171-4296f7c8ff5a">

<img width="914" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/bdbbebc8-137b-4ed8-b9d6-a7b4cfde198b">

## Screenshots

<img width="970" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/850c66ca-cb97-46d4-acb9-08e207881dc8">

## Testing done

- Manual testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1:  Set focus state on the success or failure banner. Replace aria-live="polite" with aria-live="assertive" or role="alert".
AC2: If download fails use the error alert
AC3: If download starts successfully, use success alert 
AC4: Alerts should appear above the print/download button with 24 px between top of button and bottom of alert
AC5: The menu button should close after the user clicks on their selection
AC6: Content updated to match UCD mocks

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
