### PR TITLE
[SIMPLE_FORMS] fix: 21-4138 - add validation to other checkbox selection

### DIFF
--- a/src/applications/simple-forms/21-4138/helpers.js
+++ b/src/applications/simple-forms/21-4138/helpers.js
@@ -13,7 +13,7 @@ export function getFullNameLabels(label, skipMiddleCheck = false) {
   return label.charAt(0).toUpperCase() + label.slice(1);
 }
 
-export function validateLivingSituation(errors, fields) {
+export function validateCheckboxSelection(errors, fields) {
   const selectedSituations = Object.keys(fields.livingSituation).filter(
     key => fields.livingSituation[key],
   );

--- a/src/applications/simple-forms/21-4138/pages/priorityProcessing.js
+++ b/src/applications/simple-forms/21-4138/pages/priorityProcessing.js
@@ -13,7 +13,7 @@ import {
   PRIORITY_PROCESSING_NOT_QUALIFIED,
   PRIORITY_PROCESSING_QUALIFIED,
 } from '../config/constants';
-import { validateLivingSituation } from '../helpers';
+import { validateCheckboxSelection } from '../helpers';
 
 /** @type {PageSchema} */
 export const ppIntroPage = {
@@ -62,7 +62,7 @@ export const ppLivingSituationPage = {
         required: 'Select the appropriate living situation',
       },
     }),
-    'ui:validations': [validateLivingSituation],
+    'ui:validations': [validateCheckboxSelection],
   },
   schema: {
     type: 'object',
@@ -141,6 +141,7 @@ export const ppOtherReasonsRequiredPage = {
         required: 'Select at least one description',
       },
     }),
+    'ui:validations': [validateCheckboxSelection],
   },
   schema: {
     type: 'object',


### PR DESCRIPTION
## Summary

- Updates checkbox validation function name to be more generic
- Updates other reasons checkbox group to use this validation
- Configured form 21-4138 to utilize new custom link logic
- Team: Veteran Facing Forms
- Flipper not implemented

## Related issue(s)

- department-of-veterans-affairs/va.gov-team-forms#1296

## Testing done

- Local browser functions successfully
- Unit tests successful
- E2E tests successful


## What areas of the site does it impact?

This form ONLY.