### PR TITLE
Update primary action link & remove useless prop

### DIFF
--- a/src/applications/simple-forms/21-4138/config/constants.js
+++ b/src/applications/simple-forms/21-4138/config/constants.js
@@ -96,7 +96,7 @@ export const OTHER_REASONS_OPTIONAL = Object.freeze({
 });
 
 export const PrimaryActionLink = ({ href = '/', children, onClick = null }) => (
-  <div className="arrow" style={{ maxWidth: '75%' }}>
+  <div className="action-bar-arrow" style={{ maxWidth: '75%' }}>
     <div className="vads-u-background-color--primary vads-u-padding--1">
       <a className="vads-c-action-link--white" href={href} onClick={onClick}>
         {children}

--- a/src/applications/simple-forms/21-4138/sass/4138-ss.scss
+++ b/src/applications/simple-forms/21-4138/sass/4138-ss.scss
@@ -5,19 +5,3 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "../../../../platform/forms/sass/m-form-confirmation";
-
-.arrow {
-  position: relative;
-}
-
-.arrow::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  right: -24px;
-  width: 0;
-  height: 0;
-  border-top: 24px solid transparent;
-  border-bottom: 24px solid transparent;
-  border-left: 24px solid var(--vads-color-primary);
-}

--- a/src/applications/static-pages/simple-forms/form-upload/App.js
+++ b/src/applications/static-pages/simple-forms/form-upload/App.js
@@ -7,19 +7,20 @@ import {
   VaAlert,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { toggleLoginModal as toggleLoginModalAction } from '@department-of-veterans-affairs/platform-site-wide/actions';
+import './stylesheet.scss';
 
-export const App = ({ shouldDisplayFormUpload, formNumber, hasOnlineTool }) => {
+export const App = ({ formNumber, hasOnlineTool }) => {
   const dispatch = useDispatch();
 
   // TODO: Confirm this accurately detects if the user is logged in.
   const userLoggedIn = useSelector(state => isLoggedIn(state));
   const onSignInClicked = () => dispatch(toggleLoginModalAction(true));
 
-  if (shouldDisplayFormUpload === undefined || hasOnlineTool === undefined) {
+  if (hasOnlineTool === undefined) {
     return <va-loading-indicator message="Loading..." />;
   }
 
-  if (shouldDisplayFormUpload && !hasOnlineTool) {
+  if (!hasOnlineTool) {
     return (
       <>
         <h3>Submit completed form</h3>
@@ -27,12 +28,16 @@ export const App = ({ shouldDisplayFormUpload, formNumber, hasOnlineTool }) => {
           Once you’ve completed the form you can return here to upload it to us.
         </p>
         {userLoggedIn ? (
-          <a
-            className="vads-c-action-link--blue"
-            href={`/form-upload/${formNumber}`}
-          >
-            Start uploading your form
-          </a>
+          <div className="arrow" style={{ maxWidth: '75%' }}>
+            <div className="vads-u-background-color--primary vads-u-padding--1">
+              <a
+                className="vads-c-action-link--white"
+                href={`/form-upload/${formNumber}`}
+              >
+                Start uploading your form
+              </a>
+            </div>
+          </div>
         ) : (
           <VaAlert status="info" data-testid="form-upload-sign-in-alert" uswds>
             <h2 slot="headline">Sign in now to submit a completed form</h2>
@@ -54,7 +59,6 @@ export const App = ({ shouldDisplayFormUpload, formNumber, hasOnlineTool }) => {
 
 App.propTypes = {
   hasOnlineTool: PropTypes.bool.isRequired,
-  shouldDisplayFormUpload: PropTypes.bool.isRequired,
   toggleLoginModal: PropTypes.func.isRequired,
   formNumber: PropTypes.string,
 };

--- a/src/applications/static-pages/simple-forms/form-upload/App.js
+++ b/src/applications/static-pages/simple-forms/form-upload/App.js
@@ -28,7 +28,7 @@ export const App = ({ formNumber, hasOnlineTool }) => {
           Once you’ve completed the form you can return here to upload it to us.
         </p>
         {userLoggedIn ? (
-          <div className="arrow" style={{ maxWidth: '75%' }}>
+          <div className="action-bar-arrow" style={{ maxWidth: '75%' }}>
             <div className="vads-u-background-color--primary vads-u-padding--1">
               <a
                 className="vads-c-action-link--white"

--- a/src/applications/static-pages/simple-forms/form-upload/entry.js
+++ b/src/applications/static-pages/simple-forms/form-upload/entry.js
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 
 export default function createFormUploadAccess(store, widgetType) {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
-  const { hasOnlineTool, formNumber, shouldDisplayFormUpload } = root.dataset;
+  const { hasOnlineTool, formNumber } = root.dataset;
 
   if (root) {
     import(/* webpackChunkName: "form-upload" */ './App.js').then(module => {
@@ -15,7 +15,6 @@ export default function createFormUploadAccess(store, widgetType) {
           <App
             hasOnlineTool={hasOnlineTool === 'true'}
             formNumber={formNumber}
-            shouldDisplayFormUpload={shouldDisplayFormUpload === 'true'}
           />
         </Provider>,
         root,

--- a/src/applications/static-pages/simple-forms/form-upload/stylesheet.scss
+++ b/src/applications/static-pages/simple-forms/form-upload/stylesheet.scss
@@ -1,0 +1,15 @@
+.arrow {
+  position: relative;
+}
+
+.arrow::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: -24px;
+  width: 0;
+  height: 0;
+  border-top: 24px solid transparent;
+  border-bottom: 24px solid transparent;
+  border-left: 24px solid var(--vads-color-primary);
+}

--- a/src/applications/static-pages/simple-forms/form-upload/stylesheet.scss
+++ b/src/applications/static-pages/simple-forms/form-upload/stylesheet.scss
@@ -1,15 +1,7 @@
-.arrow {
-  position: relative;
-}
-
-.arrow::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  right: -24px;
-  width: 0;
-  height: 0;
-  border-top: 24px solid transparent;
-  border-bottom: 24px solid transparent;
-  border-left: 24px solid var(--vads-color-primary);
-}
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+@import "~@department-of-veterans-affairs/formation/sass/modules/m-process-list";
+@import "~@department-of-veterans-affairs/formation/sass/modules/m-form-process";
+@import "../../../../platform/forms/sass/m-schemaform";
+@import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
+@import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
+@import "../../../../platform/forms/sass/m-form-confirmation";

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -738,11 +738,11 @@ va-checkbox.statement-of-truth-va-checkbox::part(checkbox) {
   max-width: 100%;
 }
 
-.arrow {
+.action-bar-arrow {
   position: relative;
 }
 
-.arrow::after {
+.action-bar-arrow::after {
   content: "";
   position: absolute;
   top: 0;

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -737,3 +737,19 @@ i.fa-angles-right::before {
 va-checkbox.statement-of-truth-va-checkbox::part(checkbox) {
   max-width: 100%;
 }
+
+.arrow {
+  position: relative;
+}
+
+.arrow::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: -24px;
+  width: 0;
+  height: 0;
+  border-top: 24px solid transparent;
+  border-bottom: 24px solid transparent;
+  border-left: 24px solid var(--vads-color-primary);
+}


### PR DESCRIPTION
## Summary
This PR updates the primary action link on the form upload flow. It also removes a prop that we don't use on the `content-build` side so it is useless. We'll switch on whether a form has the form upload flow purely on the `content-build` side, not here.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1280

## Screenshots
<img width="1158" alt="Screenshot 2024-05-17 at 11 08 01 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/10481391/37364c7a-936a-4259-ad63-4c858c8fbb78">
