### PR TITLE
Check in/63914/add accordion to appointments page

### DIFF
--- a/src/applications/check-in/components/pages/Appointments/AppointmentsPage.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/Appointments/AppointmentsPage.unit.spec.jsx
@@ -6,7 +6,6 @@ import format from 'date-fns/format';
 import { render } from '@testing-library/react';
 import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import AppointmentsPage from './index';
-import UpcomingAppointments from '../../UpcomingAppointments';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
 import * as useGetCheckInDataModule from '../../../hooks/useGetCheckInData';
 
@@ -32,8 +31,9 @@ describe('unified check-in experience', () => {
         </CheckInProvider>,
       );
 
+      expect(getByTestId('what-to-do-next')).to.exist;
       expect(getByTestId('upcoming-appointments')).to.exist;
-      expect(UpcomingAppointments).to.exist;
+      expect(getByTestId('appointments-accordions')).to.exist;
 
       // Restore the hook
       useGetCheckInDataStub.restore();

--- a/src/applications/check-in/components/pages/Appointments/index.jsx
+++ b/src/applications/check-in/components/pages/Appointments/index.jsx
@@ -10,6 +10,7 @@ import { makeSelectApp, makeSelectVeteranData } from '../../../selectors';
 import { useUpdateError } from '../../../hooks/useUpdateError';
 import UpcomingAppointments from '../../UpcomingAppointments';
 import ActionItemDisplay from '../../ActionItemDisplay';
+import ExternalLink from '../../ExternalLink';
 
 import { intervalUntilNextAppointmentIneligibleForCheckin } from '../../../utils/appointment';
 
@@ -112,6 +113,59 @@ const AppointmentsPage = props => {
       </div>
     );
   }
+
+  const accordionContent = [
+    {
+      header: t('what-to-do-if-you-cant-find-your-appointments'),
+      body: (
+        <>
+          <p>
+            {t('our-online-check-in-tool-doesnt-include-all--accordion-item')}
+          </p>
+          <p>
+            <ExternalLink
+              href="https://www.va.gov/my-health/appointments/"
+              hrefLang="en"
+            >
+              {t('go-to-all-your-va-appointments')}
+            </ExternalLink>
+          </p>
+        </>
+      ),
+      open: false,
+    },
+    {
+      header: t('will-va-protect-my-personal-health-information'),
+      body: (
+        <>
+          <p>
+            {t(
+              'we-make-every-effort-to-keep-your-personal-information-private-and-secure',
+            )}
+          </p>
+          <p>
+            <ExternalLink href="/privacy-policy/" hrefLang="en">
+              {t('read-more-about-privacy-and-security-on-va-gov')}
+            </ExternalLink>
+          </p>
+          <p>
+            {t(
+              'youre-also-responsible-for-protecting-your-personal-health-information',
+            )}
+          </p>
+          <p>
+            <ExternalLink
+              href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/protecting-your-personal-health-information"
+              hrefLang="en"
+            >
+              {t('get-tips-for-protecting-your-personal-health-information')}
+            </ExternalLink>
+          </p>
+        </>
+      ),
+    },
+  ];
+
   return (
     <Wrapper
       pageTitle={t('#-util-capitalize', { value: t('appointments') })}
@@ -119,7 +173,7 @@ const AppointmentsPage = props => {
     >
       <ActionItemDisplay router={router} />
       <UpcomingAppointments router={router} refresh={refresh} />
-      <div className="vads-u-display--flex vads-u-align-itmes--stretch vads-u-flex-direction--column vads-u-border-top--1px vads-u-padding-top--1p5 vads-u-border-color--gray-light">
+      <div className="vads-u-display--flex vads-u-align-itmes--stretch vads-u-flex-direction--column vads-u-border-top--1px vads-u-padding-top--1p5 vads-u-padding-bottom--5 vads-u-border-color--gray-light">
         <p data-testid="update-text">
           <Trans
             i18nKey="latest-update"
@@ -136,6 +190,19 @@ const AppointmentsPage = props => {
           data-testid="refresh-appointments-button"
         />
       </div>
+      <va-accordion uswds bordered data-testid="appointments-accordions">
+        {accordionContent.map((accordion, index) => (
+          <va-accordion-item
+            key={index}
+            header={accordion.header}
+            open={accordion.open}
+            uswds
+            bordered
+          >
+            {accordion.body}
+          </va-accordion-item>
+        ))}
+      </va-accordion>
     </Wrapper>
   );
 };

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -394,5 +394,7 @@
   "if-you-want-to-reschedule": "If you want to reschedule, call us at <0></0> (<1></1>) or schedule a new appointment online.",
   "sign-in-to-schedule": "Sign in to schedule a new appointment",
   "or-talk-staff-if-at-facility": "Or talk to a staff member if you’re at a VA facility.",
-  "video": "Video"
+  "video": "Video",
+  "what-to-do-if-you-cant-find-your-appointments": "What to do if you can’t find your appointments in this list",
+  "our-online-check-in-tool-doesnt-include-all--accordion-item": "Our online check-in tool doesn’t include all appointment types at this time. To find appointments that aren’t in this list, you’ll need to go to our appointments tool on VA.gov."
 }


### PR DESCRIPTION
## Summary

- Adds accordion to appointment page

[Wireframes](https://www.figma.com/design/7Ib7RxiIC4QB53FDBO2a8c/Unified-check-in-|-Check-in?node-id=961-51636&t=r8QFMe76Cbopunzm-0)

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
[department-of-veterans-affairs/va.gov-team#63914](https://github.com/department-of-veterans-affairs/va.gov-team/issues/63914)

## Testing done

- Unit
- Visual

## Screenshots
![Screenshot 2024-05-17 at 11 33 42 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/2982977/6ae90ee4-f8f1-4734-8a90-3f0a4a6059d0)


## What areas of the site does it impact?

Check-in -> New landing page 

## Acceptance criteria

- [ ] Content matches that of the wireframes
- [ ] Acceptable test coverage

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
