### PR TITLE
Extend E2E filler test for 10-7959c

### DIFF
--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-maximal-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-maximal-test.json
@@ -1,0 +1,92 @@
+{
+  "data": {
+    "secondaryAdditionalComments": "Secondary comments",
+    "secondaryMedigapPlan": "medigapPlanC",
+    "applicantSecondaryInsuranceType": {
+      "hmo": true,
+      "ppo": true,
+      "medigap": true
+    },
+    "applicantSecondaryEOB": "noEob",
+    "applicantSecondaryHasPrescription": false,
+    "applicantSecondaryThroughEmployer": false,
+    "applicantSecondaryProvider": "SecondaryProviderName",
+    "applicantSecondaryEffectiveDate": "2019-04-01",
+    "applicantSecondaryExpirationDate": "2024-04-02",
+    "applicantHasSecondary": true,
+    "primaryAdditionalComments": "Additional Comment 1",
+    "primaryMedigapPlan": "medigapPlanG",
+    "applicantPrimaryInsuranceType": {
+      "ppo": true,
+      "medicaid": true,
+      "rxDiscount": true,
+      "other": false,
+      "medigap": true
+    },
+    "applicantPrimaryEOB": "hasEob",
+    "applicantPrimaryHasPrescription": false,
+    "applicantPrimaryThroughEmployer": true,
+    "applicantPrimaryProvider": "PrimaryProviderName",
+    "applicantPrimaryEffectiveDate": "2019-04-01",
+    "applicantPrimaryExpirationDate": "2023-06-02",
+    "applicantHasPrimary": true,
+    "applicantMedicarePartDCarrier": "MedCarrierD",
+    "applicantMedicarePartDEffectiveDate": "2021-07-03",
+    "applicantMedicareStatusD": true,
+    "applicantMedicareAdvantage": false,
+    "applicantMedicarePharmacyBenefits": true,
+    "applicantMedicarePartBCarrier": "MedCarrierB",
+    "applicantMedicarePartBEffectiveDate": "2019-02-02",
+    "applicantMedicarePartACarrier": "MedCarrierA",
+    "applicantMedicarePartAEffectiveDate": "2020-01-05",
+    "applicantMedicareStatus": true,
+    "applicantPhone": "5551231234",
+    "applicantEmailAddress": "email@email.com",
+    "applicantAddress": {
+      "country": "USA",
+      "street": "123 Street Lane",
+      "city": "Cityburg",
+      "state": "AL",
+      "postalCode": "12312"
+    },
+    "applicantSsn": "123123123",
+    "applicantName": {
+      "first": "Applicant",
+      "middle": "Jerry",
+      "last": "Jones",
+      "suffix": "Jr."
+    },
+    "applicantDOB": "1950-01-02",
+    "certifierRole": "applicant",
+    "preparerType": "sponsor",
+    "missingUploads": [
+      {
+        "name": "applicantMedicarePartAPartBCard",
+        "path": "medicare-ab-upload",
+        "required": true,
+        "uploaded": false
+      },
+      {
+        "name": "applicantMedicarePartDCard",
+        "path": "medicare-d-upload",
+        "required": true,
+        "uploaded": false
+      },
+      {
+        "name": "primaryInsuranceCard",
+        "path": "insurance-upload",
+        "required": true,
+        "uploaded": false
+      },
+      {
+        "name": "secondaryInsuranceCard",
+        "path": "secondary-insurance-card-upload",
+        "required": true,
+        "uploaded": false
+      }
+    ],
+    "consentToMailMissingRequiredFiles": true,
+    "statementOfTruthSignature": "Applicant Jerry Jones",
+    "statementOfTruthCertified": true
+  }
+}

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-no-medicare-no-primary-no-secondary-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-no-medicare-no-primary-no-secondary-test.json
@@ -1,0 +1,30 @@
+{
+  "data": {
+    "applicantHasSecondary": false,
+    "applicantHasPrimary": false,
+    "applicantMedicareStatusContinued": "eligibleNotEnrolled",
+    "applicantMedicareStatus": false,
+    "applicantPhone": "1112221212",
+    "applicantEmailAddress": "email@email.ca",
+    "applicantAddress": {
+      "country": "USA",
+      "street": "888 Street Lane",
+      "city": "Citydale",
+      "state": "CA",
+      "postalCode": "12312"
+    },
+    "applicantSsn": "123123123",
+    "applicantName": {
+      "first": "Applicant",
+      "middle": "Jerry",
+      "last": "Jones",
+      "suffix": "IV"
+    },
+    "applicantDOB": "2009-01-02",
+    "certifierRole": "applicant",
+    "preparerType": "sponsor",
+    "consentToMailMissingRequiredFiles": false,
+    "statementOfTruthSignature": "Applicant Jerry Jones",
+    "statementOfTruthCertified": true
+  }
+}

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-no-medicare-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-no-medicare-test.json
@@ -1,0 +1,77 @@
+{
+  "data": {
+    "secondaryAdditionalComments": "Secondary comment",
+    "secondaryMedigapPlan": "medigapPlanD",
+    "applicantSecondaryInsuranceType": {
+      "hmo": true,
+      "ppo": true,
+      "other": true,
+      "medigap": true
+    },
+    "applicantSecondaryEOB": "hasEob",
+    "applicantSecondaryHasPrescription": true,
+    "applicantSecondaryThroughEmployer": true,
+    "applicantSecondaryProvider": "Secondary Provider Name",
+    "applicantSecondaryEffectiveDate": "2020-10-03",
+    "applicantSecondaryExpirationDate": "2023-06-02",
+    "applicantHasSecondary": true,
+    "primaryAdditionalComments": "Additional primary comment",
+    "primaryMedigapPlan": "medigapPlanB",
+    "applicantPrimaryInsuranceType": {
+      "hmo": true,
+      "ppo": true,
+      "medigap": true
+    },
+    "applicantPrimaryEOB": "noEob",
+    "applicantPrimaryHasPrescription": true,
+    "applicantPrimaryThroughEmployer": true,
+    "applicantPrimaryProvider": "Primary Provider Name",
+    "applicantPrimaryEffectiveDate": "2001-01-02",
+    "applicantPrimaryExpirationDate": "2020-03-03",
+    "applicantHasPrimary": true,
+    "applicantMedicareStatusContinued": "ineligible",
+    "applicantMedicareStatus": false,
+    "applicantPhone": "5551112222",
+    "applicantEmailAddress": "email@email.gov",
+    "applicantAddress": {
+      "country": "USA",
+      "street": "456 Street Avenue",
+      "city": "Cityland",
+      "state": "CA",
+      "postalCode": "43212"
+    },
+    "applicantSsn": "333221111",
+    "applicantName": {
+      "first": "Applicant",
+      "middle": "Jerry",
+      "last": "Jones",
+      "suffix": "Sr."
+    },
+    "applicantDOB": "1950-02-03",
+    "certifierRole": "applicant",
+    "preparerType": "sponsor",
+    "missingUploads": [
+      {
+        "name": "applicantMedicareIneligibleProof",
+        "path": "medicare-ineligible-upload",
+        "required": true,
+        "uploaded": false
+      },
+      {
+        "name": "primaryInsuranceCard",
+        "path": "insurance-upload",
+        "required": true,
+        "uploaded": false
+      },
+      {
+        "name": "secondaryInsuranceCard",
+        "path": "secondary-insurance-card-upload",
+        "required": true,
+        "uploaded": false
+      }
+    ],
+    "consentToMailMissingRequiredFiles": true,
+    "statementOfTruthSignature": "Applicant Jerry Jones",
+    "statementOfTruthCertified": true
+  }
+}

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-no-primary-yes-secondary-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-no-primary-yes-secondary-test.json
@@ -1,0 +1,50 @@
+{
+  "data": {
+    "secondaryAdditionalComments": "Secondary comments",
+    "secondaryMedigapPlan": "medigapPlanK",
+    "applicantSecondaryInsuranceType": {
+      "ppo": true,
+      "medigap": true
+    },
+    "applicantSecondaryEOB": "noEob",
+    "applicantSecondaryHasPrescription": false,
+    "applicantSecondaryThroughEmployer": true,
+    "applicantSecondaryProvider": "Secondary Provider Name",
+    "applicantSecondaryEffectiveDate": "2009-01-02",
+    "applicantSecondaryExpirationDate": "2010-09-03",
+    "applicantHasSecondary": true,
+    "applicantHasPrimary": false,
+    "applicantMedicareStatusContinued": "enrolledNoUpdates",
+    "applicantMedicareStatus": false,
+    "applicantPhone": "7771231234",
+    "applicantEmailAddress": "email@email.edu",
+    "applicantAddress": {
+      "country": "USA",
+      "street": "811 Street Circle",
+      "city": "Cityburg",
+      "state": "AR",
+      "postalCode": "77722"
+    },
+    "applicantSsn": "444221234",
+    "applicantName": {
+      "first": "Applicant",
+      "middle": "Jerry",
+      "last": "Jones",
+      "suffix": "II"
+    },
+    "applicantDOB": "1950-08-02",
+    "certifierRole": "applicant",
+    "preparerType": "sponsor",
+    "missingUploads": [
+      {
+        "name": "secondaryInsuranceCard",
+        "path": "secondary-insurance-card-upload",
+        "required": true,
+        "uploaded": false
+      }
+    ],
+    "consentToMailMissingRequiredFiles": true,
+    "statementOfTruthSignature": "Applicant Jerry Jones",
+    "statementOfTruthCertified": true
+  }
+}

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-no-secondary-yes-primary-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-no-secondary-yes-primary-test.json
@@ -1,0 +1,51 @@
+{
+  "data": {
+    "applicantHasSecondary": false,
+    "primaryAdditionalComments": "Primary comments",
+    "primaryMedigapPlan": "medigapPlanD",
+    "applicantPrimaryInsuranceType": {
+      "medicaid": true,
+      "rxDiscount": true,
+      "medigap": true
+    },
+    "applicantPrimaryEOB": "hasEob",
+    "applicantPrimaryHasPrescription": false,
+    "applicantPrimaryThroughEmployer": true,
+    "applicantPrimaryProvider": "Primary Provider Name",
+    "applicantPrimaryEffectiveDate": "2000-01-01",
+    "applicantPrimaryExpirationDate": "2024-01-01",
+    "applicantHasPrimary": true,
+    "applicantMedicareStatusContinued": "eligibleNotEnrolled",
+    "applicantMedicareStatus": false,
+    "applicantPhone": "6661231234",
+    "applicantEmailAddress": "email@email.net",
+    "applicantAddress": {
+      "country": "USA",
+      "street": "123 Avenue Road",
+      "city": "Citytown",
+      "state": "CT",
+      "postalCode": "33322"
+    },
+    "applicantSsn": "222111234",
+    "applicantName": {
+      "first": "Applicant",
+      "middle": "Jerry",
+      "last": "Jones",
+      "suffix": "IV"
+    },
+    "applicantDOB": "1950-01-01",
+    "certifierRole": "applicant",
+    "preparerType": "sponsor",
+    "missingUploads": [
+      {
+        "name": "primaryInsuranceCard",
+        "path": "insurance-upload",
+        "required": true,
+        "uploaded": false
+      }
+    ],
+    "consentToMailMissingRequiredFiles": true,
+    "statementOfTruthSignature": "Applicant Jerry Jones",
+    "statementOfTruthCertified": true
+  }
+}

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/thirdparty-no-medicare-no-primary-yes-secondary-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/thirdparty-no-medicare-no-primary-yes-secondary-test.json
@@ -1,0 +1,67 @@
+{
+  "data": {
+    "secondaryAdditionalComments": "Secondary comment - this applicant has no medicare, no primary, and does have secondary",
+    "applicantSecondaryInsuranceType": {
+      "hmo": true,
+      "ppo": true
+    },
+    "applicantSecondaryEOB": "hasEob",
+    "applicantSecondaryHasPrescription": false,
+    "applicantSecondaryThroughEmployer": true,
+    "applicantSecondaryProvider": "Secondary Provider",
+    "applicantSecondaryEffectiveDate": "2000-02-02",
+    "applicantSecondaryExpirationDate": "2023-05-02",
+    "applicantHasSecondary": true,
+    "applicantHasPrimary": false,
+    "applicantMedicareStatusContinued": "ineligible",
+    "applicantMedicareStatus": false,
+    "applicantPhone": "1231231234",
+    "applicantEmailAddress": "applicant@email.gov",
+    "applicantAddress": {
+      "country": "USA",
+      "street": "123 Circle Street",
+      "city": "Cityburg",
+      "state": "CA",
+      "postalCode": "12312"
+    },
+    "applicantSsn": "123123123",
+    "applicantName": {
+      "first": "Applicant",
+      "middle": "Quincy",
+      "last": "Jones",
+      "suffix": "III"
+    },
+    "applicantDOB": "2000-02-01",
+    "certifierRelationship": {
+      "relationshipToApplicants": "other",
+      "otherRelationshipToApplicants": "Other relationship here"
+    },
+    "certifierPhone": "1231231234",
+    "certifierEmail": "test@email.com",
+    "certifierAddress": {
+      "country": "USA",
+      "street": "123 Streettown",
+      "city": "Cityland",
+      "state": "DE",
+      "postalCode": "12312"
+    },
+    "certifierName": {
+      "first": "Certifier",
+      "middle": "Jerry",
+      "last": "Jones"
+    },
+    "certifierRole": "other",
+    "preparerType": "sponsor",
+    "missingUploads": [
+      {
+        "name": "secondaryInsuranceCard",
+        "path": "secondary-insurance-card-upload",
+        "required": true,
+        "uploaded": false
+      }
+    ],
+    "consentToMailMissingRequiredFiles": true,
+    "statementOfTruthSignature": "Certifier Jerry Jones",
+    "statementOfTruthCertified": true
+  }
+}

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/veteran-child-no-medicare-yes-primary-no-secondary-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/veteran-child-no-medicare-yes-primary-no-secondary-test.json
@@ -1,0 +1,67 @@
+{
+  "data": {
+    "applicantHasSecondary": false,
+    "primaryAdditionalComments": "Additional comment",
+    "applicantPrimaryInsuranceType": {
+      "rxDiscount": true,
+      "other": true,
+      "medigap": false
+    },
+    "applicantPrimaryEOB": "noEob",
+    "applicantPrimaryHasPrescription": false,
+    "applicantPrimaryThroughEmployer": false,
+    "applicantPrimaryProvider": "Primary Provider",
+    "applicantPrimaryEffectiveDate": "1999-01-01",
+    "applicantPrimaryExpirationDate": "2001-05-02",
+    "applicantHasPrimary": true,
+    "applicantMedicareStatusContinued": "eligibleNotEnrolled",
+    "applicantMedicareStatus": false,
+    "applicantPhone": "1231231234",
+    "applicantEmailAddress": "email@email.com",
+    "applicantAddress": {
+      "country": "USA",
+      "street": "123 Streetland",
+      "city": "Cityburg",
+      "state": "AK",
+      "postalCode": "12312"
+    },
+    "applicantSsn": "123123123",
+    "applicantName": {
+      "first": "Applicant",
+      "middle": "Child",
+      "last": "Jones"
+    },
+    "applicantDOB": "2001-03-02",
+    "certifierRelationship": {
+      "relationshipToApplicants": "parent"
+    },
+    "certifierPhone": "1231231234",
+    "certifierEmail": "123@email.gov",
+    "certifierAddress": {
+      "country": "USA",
+      "street": "123 Streetname",
+      "city": "Cityland",
+      "state": "AL",
+      "postalCode": "12312"
+    },
+    "certifierName": {
+      "first": "Veteran",
+      "middle": "Quincy",
+      "last": "Jones",
+      "suffix": "II"
+    },
+    "certifierRole": "sponsor",
+    "preparerType": "sponsor",
+    "missingUploads": [
+      {
+        "name": "primaryInsuranceCard",
+        "path": "insurance-upload",
+        "required": true,
+        "uploaded": false
+      }
+    ],
+    "consentToMailMissingRequiredFiles": true,
+    "statementOfTruthSignature": "Veteran Quincy Jones",
+    "statementOfTruthCertified": true
+  }
+}

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/veteran-spouse-medicare-no-ohi-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/veteran-spouse-medicare-no-ohi-test.json
@@ -1,0 +1,69 @@
+{
+  "data": {
+    "applicantHasSecondary": false,
+    "applicantHasPrimary": false,
+    "applicantMedicarePartDCarrier": "Medicare D carrier name",
+    "applicantMedicarePartDEffectiveDate": "2001-05-01",
+    "applicantMedicareStatusD": true,
+    "applicantMedicareAdvantage": true,
+    "applicantMedicarePharmacyBenefits": true,
+    "applicantMedicarePartBCarrier": "Medicare B carrier name",
+    "applicantMedicarePartBEffectiveDate": "2000-06-03",
+    "applicantMedicarePartACarrier": "Medicare A Carrier",
+    "applicantMedicarePartAEffectiveDate": "2001-02-02",
+    "applicantMedicareStatus": true,
+    "applicantPhone": "5551231234",
+    "applicantEmailAddress": "spouse@email.gov",
+    "applicantAddress": {
+      "country": "USA",
+      "street": "441 Lane Street",
+      "city": "Anyburg",
+      "state": "FM",
+      "postalCode": "12312"
+    },
+    "applicantSsn": "444121234",
+    "applicantName": {
+      "first": "Spouse",
+      "middle": "Terry",
+      "last": "Jones"
+    },
+    "applicantDOB": "1950-05-02",
+    "certifierRelationship": {
+      "relationshipToApplicants": "spouse"
+    },
+    "certifierPhone": "1231231234",
+    "certifierEmail": "veteran@email.edu",
+    "certifierAddress": {
+      "country": "USA",
+      "street": "771 Road Lane",
+      "city": "Citypolis",
+      "state": "AK",
+      "postalCode": "12312"
+    },
+    "certifierName": {
+      "first": "Veteran",
+      "middle": "Quincy",
+      "last": "Jones",
+      "suffix": "Jr."
+    },
+    "certifierRole": "sponsor",
+    "preparerType": "sponsor",
+    "missingUploads": [
+      {
+        "name": "applicantMedicarePartAPartBCard",
+        "path": "medicare-ab-upload",
+        "required": true,
+        "uploaded": false
+      },
+      {
+        "name": "applicantMedicarePartDCard",
+        "path": "medicare-d-upload",
+        "required": true,
+        "uploaded": false
+      }
+    ],
+    "consentToMailMissingRequiredFiles": true,
+    "statementOfTruthSignature": "Veteran Quincy Jones",
+    "statementOfTruthCertified": true
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds 8 new iterations of the E2E test, verifying multiple different conditional paths through form 10-7959c.

- 8 new E2E filler tests are implemented
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81996

## Testing done

- E2E

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Test Runs |![asdf](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/32f5ca38-90d2-4791-a95a-4ca435150f84)|![Screenshot 2024-05-17 at 12 45 53](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/a3a288d4-87d5-46b2-9eb2-e0a30faab2b8)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA