### PR TITLE
Update home address key in prefill transformer - form 10-7959f-1

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/prefillTransformer.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/prefillTransformer.js
@@ -5,7 +5,7 @@ const prefillTransformer = (pages, formData, metadata) => {
       ...formData,
       veteranFullName: formData.veteranFullName,
       veteranAddress: formData.veteranAddress,
-      veteranResidentialAddress: formData.veteranPhysicalAddress,
+      physicalAddress: formData.veteranPhysicalAddress,
       veteranDateOfBirth: formData.veteranDateOfBirth,
       veteranSocialSecurityNumber: {
         ssn: formData.veteranSocialSecurityNumber,

--- a/src/applications/ivc-champva/10-7959f-1/tests/e2e/fixtures/mocks/sip-get.json
+++ b/src/applications/ivc-champva/10-7959f-1/tests/e2e/fixtures/mocks/sip-get.json
@@ -3,6 +3,13 @@
     "veteranFullName": {
       "first": "John",
       "last": "Preparer"
+    },
+    "veteranPhysicalAddress": {
+      "country": "USA",
+      "street": "456 Street Circle",
+      "city": "Anyburg",
+      "state": "AK",
+      "postalCode": "12323"
     }
   },
   "metadata": {


### PR DESCRIPTION
## Summary

This PR updates the prefill transformer so that it properly sets the `physicalAddress` key on the formdata object when a logged in user's physical address is provided.

- Changes keyname in prefill transformer to match what form is expecting
- Adds address to mock API SIP Get file for testing
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81646

## Testing done

- Manual

## Screenshots
|         | Prefilled |
| ------- | ------ | 
| Desktop |![Screenshot 2024-05-17 at 13 18 46](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/00d7de5e-c9a9-47e9-8e24-5da186dd375e)| 

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA