### PR TITLE
10-7959f-2 Veteran Info Page

### DIFF
--- a/src/applications/ivc-champva/10-7959f-2/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-2/config/form.js
@@ -1,23 +1,44 @@
-// import fullSchema from 'vets-json-schema/dist/10-7959F-2-schema.json';
+import { cloneDeep } from 'lodash';
+
+import {
+  // ssnOrVaFileNumberSchema,
+  // ssnOrVaFileNumberNoHintUI,
+  fullNameUI,
+  fullNameSchema,
+  titleUI,
+  titleSchema,
+  dateOfBirthUI,
+  dateOfBirthSchema,
+  // addressUI,
+  // addressSchema,
+  // phoneUI,
+  // phoneSchema,
+  // emailUI,
+  // emailSchema,
+  // checkboxGroupUI,
+  // checkboxGroupSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
 
 import manifest from '../manifest.json';
-
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
+import GetFormHelp from '../../shared/components/GetFormHelp';
 
-// const { } = fullSchema.properties;
+const veteranFullNameUI = cloneDeep(fullNameUI());
+veteranFullNameUI.middle['ui:title'] = 'Middle initial';
 
-// const { } = fullSchema.definitions;
-
+/** @type {FormConfig} */
 const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
   // submitUrl: '/v0/api',
+  footerContent: GetFormHelp,
   submit: () =>
     Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
   trackingPrefix: 'fmp-cover-sheet-',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
+  v3SegmentedProgressBar: true,
   formId: '10-7959F-2',
   saveInProgress: {
     // messages: {
@@ -33,19 +54,29 @@ const formConfig = {
     noAuth:
       'Please sign in again to continue your application for health care benefits.',
   },
-  title: 'Foreign Medical Program  Cover Sheet',
+  title: 'File a Foreign Medical Program (FMP) Claim',
+  subTitle: 'FMP Claim Form (VA form 10-7959f-2)',
   defaultDefinitions: {},
   chapters: {
-    chapter1: {
-      title: 'Chapter 1',
+    veteranInfoChapter: {
+      title: 'Name and date of birth',
       pages: {
         page1: {
-          path: 'first-page',
-          title: 'First Page',
-          uiSchema: {},
+          path: 'veteran-info',
+          title: 'Personal Information',
+          uiSchema: {
+            ...titleUI('Name and date of birth'),
+            veteranFullName: veteranFullNameUI,
+            veteranDateOfBirth: dateOfBirthUI({ required: true }),
+          },
           schema: {
             type: 'object',
-            properties: {},
+            required: ['veteranFullName', 'veteranDateOfBirth'],
+            properties: {
+              titleSchema,
+              veteranFullName: fullNameSchema,
+              veteranDateOfBirth: dateOfBirthSchema,
+            },
           },
         },
       },

--- a/src/applications/ivc-champva/10-7959f-2/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-2/containers/IntroductionPage.jsx
@@ -1,104 +1,96 @@
 import React from 'react';
 
-import { focusElement } from 'platform/utilities/ui';
+// import { focusElement } from 'platform/utilities/ui';
+import { connect } from 'react-redux';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 
-class IntroductionPage extends React.Component {
-  componentDidMount() {
-    focusElement('.va-nav-breadcrumbs-list');
-  }
+const IntroductionPage = props => {
+  const { route } = props;
+  const { formConfig, pageList } = route;
 
-  render() {
-    const { route } = this.props;
-    const { formConfig, pageList } = route;
+  return (
+    <article className="schemaform-intro">
+      <FormTitle
+        title="File a Foreign Medical Program (FMP) Claim"
+        subTitle="FMP Claim Form (VA form 10-7959f-2)"
+      />
+      <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
+        Follow the steps below to apply for health care benefits.
+      </h2>
+      <va-process-list>
+        <li>
+          <h3>Prepare</h3>
+          <h4>To fill out this application, you’ll need your:</h4>
+          <ul>
+            <li>Social Security number (required)</li>
+          </ul>
+          <p>
+            <strong>What if I need help filling out my application?</strong> An
+            accredited representative, like a Veterans Service Officer (VSO),
+            can help you fill out your claim.{' '}
+            <a href="/disability-benefits/apply/help/index.html">
+              Get help filing your claim
+            </a>
+          </p>
+        </li>
+        <li>
+          <h3>Apply</h3>
+          <p>Complete this health care benefits form.</p>
+          <p>
+            After submitting the form, you’ll get a confirmation message. You
+            can print this for your records.
+          </p>
+        </li>
+        <li>
+          <h3>VA Review</h3>
+          <p>
+            We process claims within a week. If more than a week has passed
+            since you submitted your application and you haven’t heard back,
+            please don’t apply again. Call us at.
+          </p>
+        </li>
+        <li>
+          <h3>Decision</h3>
+          <p>
+            Once we’ve processed your claim, you’ll get a notice in the mail
+            with our decision.
+          </p>
+        </li>
+      </va-process-list>
+      <SaveInProgressIntro
+        buttonOnly
+        headingLevel={2}
+        prefillEnabled={formConfig.prefillEnabled}
+        messages={formConfig.savedFormMessages}
+        pageList={pageList}
+        startText="Start the Application"
+      />
+      <p />
+      <va-omb-info
+        res-burden={11}
+        omb-number="2900-0648"
+        exp-date="03/31/2027"
+      />
+      <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
+        What if I need help filling out my application?
+      </h2>
+      <p>
+        An accredited representative, like a Veterans Service Officer (VSO), can
+        help you fill out your application.
+        <a href="https://www.va.gov/COMMUNITYCARE/programs/dependents/champva/CITI.asp">
+          Find out if you can get care at a local VA medical center when you’re
+          covered under CHAMPVA
+        </a>
+      </p>
+    </article>
+  );
+};
 
-    return (
-      <article className="schemaform-intro">
-        <FormTitle
-          title="Foreign Medical Program (FMP) Cover Sheet"
-          subtitle="Equal to VA Form 10-7959F-2 (Foreign Medical Program Cover Sheet)"
-        />
-        <SaveInProgressIntro
-          headingLevel={2}
-          prefillEnabled={formConfig.prefillEnabled}
-          messages={formConfig.savedFormMessages}
-          pageList={pageList}
-          startText="Start the Application"
-        >
-          Please complete the 10-7959F-2 form to apply for health care benefits.
-        </SaveInProgressIntro>
-        <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
-          Follow the steps below to apply for health care benefits.
-        </h2>
-        <va-process-list>
-          <li>
-            <h3>Prepare</h3>
-            <h4>To fill out this application, you’ll need your:</h4>
-            <ul>
-              <li>Social Security number (required)</li>
-            </ul>
-            <p>
-              <strong>What if I need help filling out my application?</strong>{' '}
-              An accredited representative, like a Veterans Service Officer
-              (VSO), can help you fill out your claim.{' '}
-              <a href="/disability-benefits/apply/help/index.html">
-                Get help filing your claim
-              </a>
-            </p>
-          </li>
-          <li>
-            <h3>Apply</h3>
-            <p>Complete this health care benefits form.</p>
-            <p>
-              After submitting the form, you’ll get a confirmation message. You
-              can print this for your records.
-            </p>
-          </li>
-          <li>
-            <h3>VA Review</h3>
-            <p>
-              We process claims within a week. If more than a week has passed
-              since you submitted your application and you haven’t heard back,
-              please don’t apply again. Call us at.
-            </p>
-          </li>
-          <li>
-            <h3>Decision</h3>
-            <p>
-              Once we’ve processed your claim, you’ll get a notice in the mail
-              with our decision.
-            </p>
-          </li>
-        </va-process-list>
-        <SaveInProgressIntro
-          buttonOnly
-          headingLevel={2}
-          prefillEnabled={formConfig.prefillEnabled}
-          messages={formConfig.savedFormMessages}
-          pageList={pageList}
-          startText="Start the Application"
-        />
-        <p />
-        <va-omb-info
-          res-burden={11}
-          omb-number="2900-0648"
-          exp-date="03/31/2027"
-        />
-        <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
-          What if I need help filling out my application?
-        </h2>
-        <p>
-          An accredited representative, like a Veterans Service Officer (VSO),
-          can help you fill out your application.
-          <a href="https://www.va.gov/COMMUNITYCARE/programs/dependents/champva/CITI.asp">
-            Find out if you can get care at a local VA medical center when
-            you’re covered under CHAMPVA
-          </a>
-        </p>
-      </article>
-    );
-  }
-}
+const mapStateToProps = state => {
+  return {
+    isLoggedIn: state.user.login.currentlyLoggedIn,
+  };
+};
 
-export default IntroductionPage;
+export default connect(mapStateToProps)(IntroductionPage);


### PR DESCRIPTION
## Summary
This PR covers the veteran info page according to current designs on Figma. Some changes were made to the intro page also to facilitate the veteran info page.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/82067

## Testing done
Visual Testing as this is not a completed design yet, but is just basic. 

## Screenshots
![Screenshot 2024-05-17 at 2 46 59 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/16bb5817-dbb0-4533-af37-d133da277045)
![Screenshot 2024-05-17 at 2 47 14 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/3f0257b9-1c13-4a96-9405-c59f3eb9eb67)

## What areas of the site does it impact?
This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA
