### PR TITLE
removed console logging from 10-7959f-1 now that SIP works

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -19,11 +19,6 @@ import {
   // checkboxGroupUI,
   // checkboxGroupSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-
-import {
-  getNextPagePath,
-  checkValidPagePath,
-} from '@department-of-veterans-affairs/platform-forms-system/routing';
 import transformForSubmit from './submitTransformer';
 import manifest from '../manifest.json';
 import prefillTransformer from './prefillTransformer';
@@ -52,31 +47,6 @@ const formConfig = {
   v3SegmentedProgressBar: true,
   customText: {
     appType: 'form',
-  },
-  // This is here temporarily to allow us to log SIP/Prefill data on staging
-  onFormLoaded: props => {
-    // TODO: Remove all this when we've verified we're getting the right data.
-    const { formData, returnUrl } = props;
-    // Check valid return URL; copied from RoutedSavableApp
-    const isValidReturnUrl = checkValidPagePath(
-      props.routes[props.routes.length - 1].pageList,
-      formData,
-      returnUrl,
-    );
-    if (isValidReturnUrl) {
-      props.router.push(returnUrl);
-    } else {
-      const nextPagePath = getNextPagePath(
-        props.routes[props.routes.length - 1].pageList,
-        formData,
-        '/introduction',
-      );
-      props.router.push(nextPagePath);
-    }
-    // Show whatever formData we have at this time, which should include data
-    // produced by the prefill transformer
-    // eslint-disable-next-line no-console
-    console.log('Form loaded - data: ', formData);
   },
   preSubmitInfo: {
     statementOfTruth: {


### PR DESCRIPTION
## Summary

This PR removes some startup console logging from form 10-7959f-1 that was used while we troubleshot the SIP functionality.

- Removes console logging from form 10-7959f-1
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- NA

## Testing done

- Manual

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA