### PR TITLE
Added helper to collect supporting_docs in submit transformer - form 10-7959c

### DIFF
--- a/src/applications/ivc-champva/10-7959C/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959C/config/submitTransformer.js
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 import { transformForSubmit as formsSystemTransformForSubmit } from 'platform/forms-system/src/js/helpers';
+import { getObjectsWithAttachmentId } from '../helpers/utilities';
 
 function getPrimaryContact(data) {
   // For callback API we need to know what data in the form should be
@@ -47,6 +48,8 @@ export default function transformForSubmit(formConfig, form) {
   copyOfData.certificationDate = new Date()
     .toLocaleDateString('es-pa')
     .replace(/\//g, '-');
+
+  copyOfData.supportingDocs = getObjectsWithAttachmentId(copyOfData);
 
   // Set this for the callback API so it knows who to contact if there's
   // a status event notification

--- a/src/applications/ivc-champva/10-7959C/helpers/utilities.js
+++ b/src/applications/ivc-champva/10-7959C/helpers/utilities.js
@@ -25,39 +25,13 @@ export function nameWording(formData, isPosessive = true, cap = true) {
   return cap ? retVal.charAt(0).toUpperCase() + retVal.slice(1) : retVal;
 }
 
-/*
-For identifying all files the user has uploaded. Returns a list with
-each uploaded file object (for top-level objects only), e.g.
-for input:
-{
-    "applicantPartDCard": [
-        {
-            "name": "file1.png",
-            "attachmentId": "Front of Part D card",
-        }
-    ],
-    "applicantPartAPartBCard": [
-        {
-            "name": "file2.png",
-            "attachmentId": "Back of Parts A or B card",
-        }
-    ],
-    "someOtherKey": "other",
-}
-
-it would produce output:
-
-[
-  {
-      "name": "file1.png",
-      "attachmentId": "Front of Medicare Part D card",
-  },
-  {
-      "name": "file2.png",
-      "attachmentId": "Front of Medicare Parts A or B card",
-  },
-]
-*/
+/**
+ * Retrieves an array of objects containing the property 'attachmentId'
+ * from the given object.
+ *
+ * @param {Object} obj - The input object to search for objects with 'attachmentId'.
+ * @returns {Array} - An array containing objects with the 'attachmentId' property.
+ */
 export function getObjectsWithAttachmentId(obj) {
   const objectsWithAttachmentId = [];
   _.forEach(obj, value => {

--- a/src/applications/ivc-champva/10-7959C/helpers/utilities.js
+++ b/src/applications/ivc-champva/10-7959C/helpers/utilities.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+
 export function isRequiredFile(formContext, requiredFiles) {
   return Object.keys(formContext?.schema?.properties || {}).filter(v =>
     Object.keys(requiredFiles).includes(v),
@@ -21,4 +23,52 @@ export function nameWording(formData, isPosessive = true, cap = true) {
 
   // Optionally capitalize first letter and return
   return cap ? retVal.charAt(0).toUpperCase() + retVal.slice(1) : retVal;
+}
+
+/*
+For identifying all files the user has uploaded. Returns a list with
+each uploaded file object (for top-level objects only), e.g.
+for input:
+{
+    "applicantPartDCard": [
+        {
+            "name": "file1.png",
+            "attachmentId": "Front of Part D card",
+        }
+    ],
+    "applicantPartAPartBCard": [
+        {
+            "name": "file2.png",
+            "attachmentId": "Back of Parts A or B card",
+        }
+    ],
+    "someOtherKey": "other",
+}
+
+it would produce output:
+
+[
+  {
+      "name": "file1.png",
+      "attachmentId": "Front of Medicare Part D card",
+  },
+  {
+      "name": "file2.png",
+      "attachmentId": "Front of Medicare Parts A or B card",
+  },
+]
+*/
+export function getObjectsWithAttachmentId(obj) {
+  const objectsWithAttachmentId = [];
+  _.forEach(obj, value => {
+    if (_.isArray(value)) {
+      _.forEach(value, item => {
+        if (_.isObject(item) && _.has(item, 'attachmentId')) {
+          objectsWithAttachmentId.push(item);
+        }
+      });
+    }
+  });
+
+  return objectsWithAttachmentId;
 }


### PR DESCRIPTION
## Summary

This PR adds a function to the 10-7959c submit transformer to pull all file uploads into a single top-level array property `supportingDocs`. This is to simplify the process of adding attachments to the PDF on the backend.

- Adds function that corrals file uploads into a single top-level object
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- NA

## Testing done

- Manual

## What areas of the site does it impact?

Form 10-7959c only 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA