### PR TITLE
HCA facilities API integration for EZ

### DIFF
--- a/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
+++ b/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
@@ -174,7 +174,15 @@ const VaMedicalCenter = props => {
     );
   }
 
-  return !error ? (
+  if (error) {
+    return (
+      <div className="server-error-message vads-u-margin-top--4">
+        <ServerErrorAlert />
+      </div>
+    );
+  }
+
+  return (
     <fieldset className="rjsf-object-field vads-u-margin-y--2">
       <legend
         id="root_view:preferredFacility__title"
@@ -221,10 +229,6 @@ const VaMedicalCenter = props => {
         ))}
       </VaSelect>
     </fieldset>
-  ) : (
-    <div className="server-error-message vads-u-margin-top--4">
-      <ServerErrorAlert />
-    </div>
   );
 };
 

--- a/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
+++ b/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
@@ -47,20 +47,22 @@ const VaMedicalCenter = props => {
     [dirtyFields],
   );
 
+  const getFieldNameSuffix = fieldName => fieldName.split('_').pop();
+
   // define our non-checkbox input change event
   const handleChange = useCallback(
     event => {
-      const fieldName = event.target.name.split('_').pop();
+      const fieldName = getFieldNameSuffix(event.target.name);
       setLocalData({ ...localData, [fieldName]: event.target.value });
       addDirtyField(fieldName);
     },
-    [addDirtyField, localData, onChange],
+    [addDirtyField, localData],
   );
 
   // define our non-checkbox input blur event
   const handleBlur = useCallback(
     event => {
-      const fieldName = event.target.name.split('_').pop();
+      const fieldName = getFieldNameSuffix(event.target.name);
       addDirtyField(fieldName);
     },
     [addDirtyField],
@@ -83,7 +85,7 @@ const VaMedicalCenter = props => {
   // grab the facility name based upon the selected value
   const getFacilityName = useCallback(
     val => {
-      const facility = facilities.find(f => f.id.split('_').pop() === val);
+      const facility = facilities.find(f => getFieldNameSuffix(f.id) === val);
       return facility?.name || '\u2014';
     },
     [facilities],
@@ -104,9 +106,10 @@ const VaMedicalCenter = props => {
         vaMedicalFacility: localData.vaMedicalFacility || undefined,
       });
     },
-    [localData],
+    [localData, onChange],
   );
 
+  const localDataFacilityState = localData['view:facilityState'];
   const previousFacilityState = usePrevious(localData['view:facilityState']);
 
   // fetch, map and set our list of facilities based on the state selection
@@ -147,7 +150,7 @@ const VaMedicalCenter = props => {
         isLoading(false);
       }
     },
-    [localData['view:facilityState']],
+    [localDataFacilityState, previousFacilityState],
   );
 
   // render the static facility name on review page
@@ -212,7 +215,7 @@ const VaMedicalCenter = props => {
         uswds
       >
         {facilities.map(f => (
-          <option key={f.id} value={f.id.split('_').pop()}>
+          <option key={f.id} value={getFieldNameSuffix(f.id)}>
             {f.name}
           </option>
         ))}

--- a/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
+++ b/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
@@ -145,7 +145,14 @@ const VaMedicalCenter = props => {
   }
 
   return !error ? (
-    <>
+    <fieldset className="rjsf-object-field vads-u-margin-y--2">
+      <legend
+        id="root_view:preferredFacility__title"
+        className="schemaform-block-title"
+      >
+        Select your preferred VA medical facility
+      </legend>
+
       <VaSelect
         id={idSchema['view:facilityState'].$id}
         name={idSchema['view:facilityState'].$id}
@@ -183,7 +190,7 @@ const VaMedicalCenter = props => {
           </option>
         ))}
       </VaSelect>
-    </>
+    </fieldset>
   ) : (
     <div className="server-error-message vads-u-margin-top--4">
       <ServerErrorAlert />

--- a/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
+++ b/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
@@ -68,7 +68,7 @@ const VaMedicalCenter = props => {
 
   // check field for validation errors
   const showError = field => {
-    const errorList = errorSchema[field].__errors;
+    const errorList = errorSchema[field].__errors || [];
     const fieldIsDirty = dirtyFields.includes(field);
     const shouldValidate = (submitted || fieldIsDirty) && errorList.length;
 
@@ -96,8 +96,13 @@ const VaMedicalCenter = props => {
       //   submission if the value is null or undefined. Without this, the form allows
       //   Continuing with both values set, going Back, unsetting the Facility, and then
       //   Continuing again, resulting in a State but no Facility.
-      const vaMedicalFacility = localData.vaMedicalFacility || undefined;
-      onChange({ ...localData, vaMedicalFacility });
+      //   Similarly, selecting a State and Facility and then unselecting the State
+      //   allows Continuing without a State set, causing the entire Review Form
+      //   view to collapse to nothing.
+      onChange({
+        'view:facilityState': localData['view:facilityState'] || undefined,
+        vaMedicalFacility: localData.vaMedicalFacility || undefined,
+      });
     },
     [localData],
   );

--- a/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
+++ b/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
@@ -155,10 +155,13 @@ const VaMedicalCenter = props => {
 
   // render the static facility name on review page
   if (reviewMode) {
+    const stateLabel = constants.states.USA.find(
+      state => state.value === localData['view:facilityState'],
+    )?.label;
     return (
       <VaMedicalCenterReviewField
         facilityName={getFacilityName(localData.vaMedicalFacility)}
-        stateCode={localData['view:facilityState']}
+        stateLabel={stateLabel}
       />
     );
   }

--- a/src/applications/hca/components/FormReview/VaMedicalCenterReviewField.jsx
+++ b/src/applications/hca/components/FormReview/VaMedicalCenterReviewField.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import constants from 'vets-json-schema/dist/constants.json';
+
+const VaMedicalCenterReviewField = ({ state, facilityName }) => {
+  const stateLabel = constants.states.USA.find(s => s.value === state).label;
+  return (
+    <>
+      <div className="review-row">
+        <dt>State</dt>
+        <dd data-testid="hca-facility-state">{stateLabel}</dd>
+      </div>
+      <div className="review-row">
+        <dt>Center or clinic</dt>
+        <dd data-testid="hca-facility-name">{facilityName}</dd>
+      </div>
+    </>
+  );
+};
+
+VaMedicalCenterReviewField.propTypes = {
+  facilityName: PropTypes.string,
+  state: PropTypes.string,
+};
+
+export { VaMedicalCenterReviewField };

--- a/src/applications/hca/components/FormReview/VaMedicalCenterReviewField.jsx
+++ b/src/applications/hca/components/FormReview/VaMedicalCenterReviewField.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import constants from 'vets-json-schema/dist/constants.json';
 
-const VaMedicalCenterReviewField = ({ state, facilityName }) => {
-  const stateLabel = constants.states.USA.find(s => s.value === state).label;
+const VaMedicalCenterReviewField = ({ stateCode, facilityName }) => {
+  const stateLabel = constants.states.USA.find(s => s.value === stateCode)
+    .label;
   return (
     <>
       <div className="review-row">
@@ -20,7 +21,7 @@ const VaMedicalCenterReviewField = ({ state, facilityName }) => {
 
 VaMedicalCenterReviewField.propTypes = {
   facilityName: PropTypes.string,
-  state: PropTypes.string,
+  stateCode: PropTypes.string,
 };
 
 export { VaMedicalCenterReviewField };

--- a/src/applications/hca/components/FormReview/VaMedicalCenterReviewField.jsx
+++ b/src/applications/hca/components/FormReview/VaMedicalCenterReviewField.jsx
@@ -1,27 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import constants from 'vets-json-schema/dist/constants.json';
 
-const VaMedicalCenterReviewField = ({ stateCode, facilityName }) => {
-  const stateLabel = constants.states.USA.find(s => s.value === stateCode)
-    .label;
-  return (
-    <>
-      <div className="review-row">
-        <dt>State</dt>
-        <dd data-testid="hca-facility-state">{stateLabel}</dd>
-      </div>
-      <div className="review-row">
-        <dt>Center or clinic</dt>
-        <dd data-testid="hca-facility-name">{facilityName}</dd>
-      </div>
-    </>
-  );
-};
+const VaMedicalCenterReviewField = ({ facilityName, stateLabel }) => (
+  <>
+    <div className="review-row">
+      <dt>State</dt>
+      <dd data-testid="hca-facility-state">{stateLabel}</dd>
+    </div>
+    <div className="review-row">
+      <dt>Center or clinic</dt>
+      <dd data-testid="hca-facility-name">{facilityName}</dd>
+    </div>
+  </>
+);
 
 VaMedicalCenterReviewField.propTypes = {
   facilityName: PropTypes.string,
-  stateCode: PropTypes.string,
+  stateLabel: PropTypes.string,
 };
 
 export { VaMedicalCenterReviewField };

--- a/src/applications/hca/config/chapters/insuranceInformation/vaFacility_api.js
+++ b/src/applications/hca/config/chapters/insuranceInformation/vaFacility_api.js
@@ -1,6 +1,4 @@
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
-import constants from 'vets-json-schema/dist/constants.json';
-import { STATES_WITHOUT_MEDICAL } from '../../../utils/constants';
 import {
   EssentialCoverageDescription,
   FacilityLocatorDescription,
@@ -15,11 +13,6 @@ const {
   isEssentialAcaCoverage,
   wantsInitialVaContact,
 } = fullSchemaHca.properties;
-
-// define states/territories with health care facilities
-const healthcareStates = constants.states.USA.filter(state => {
-  return !STATES_WITHOUT_MEDICAL.includes(state.value);
-});
 
 export default {
   uiSchema: {
@@ -41,16 +34,7 @@ export default {
     },
     'view:preferredFacility': {
       'ui:title': 'Select your preferred VA medical facility',
-      'view:facilityState': {
-        'ui:title': 'State',
-      },
-      vaMedicalFacility: {
-        'ui:title': 'Center or clinic',
-        'ui:widget': VaMedicalCenter,
-        'ui:options': {
-          hideLabelText: true,
-        },
-      },
+      'ui:field': VaMedicalCenter,
     },
     'view:locator': {
       'ui:description': FacilityLocatorDescription,
@@ -74,8 +58,6 @@ export default {
         properties: {
           'view:facilityState': {
             type: 'string',
-            enum: healthcareStates.map(object => object.value),
-            enumNames: healthcareStates.map(object => object.label),
           },
           vaMedicalFacility: {
             type: 'string',

--- a/src/applications/hca/config/chapters/insuranceInformation/vaFacility_api.js
+++ b/src/applications/hca/config/chapters/insuranceInformation/vaFacility_api.js
@@ -33,7 +33,6 @@ export default {
       'ui:description': EssentialCoverageDescription,
     },
     'view:preferredFacility': {
-      'ui:title': 'Select your preferred VA medical facility',
       'ui:field': VaMedicalCenter,
     },
     'view:locator': {

--- a/src/applications/hca/tests/unit/components/FormFields/VaMedicalCenter.unit.spec.js
+++ b/src/applications/hca/tests/unit/components/FormFields/VaMedicalCenter.unit.spec.js
@@ -15,18 +15,17 @@ describe('hca <VaMedicalCenter>', () => {
     {
       id: 'vha_528A4',
       uniqueId: '528A4',
-      attributes: { name: 'Batavia VA Medical Center' },
+      name: 'Batavia VA Medical Center',
     },
     {
       id: 'vha_528A5',
       uniqueId: '528A5',
-      attributes: { name: 'Canandaigua VA Medical Center' },
+      name: 'Canandaigua VA Medical Center',
     },
   ];
   const getData = ({
     reviewMode = false,
-    submitted = undefined,
-    value = undefined,
+    submitted = false,
     formData = {},
   }) => ({
     mockStore: {
@@ -42,57 +41,87 @@ describe('hca <VaMedicalCenter>', () => {
     },
     props: {
       formContext: { reviewMode, submitted },
-      id: 'preferredFacility_vaMedicalFacility',
+      idSchema: {
+        'view:facilityState': { $id: 'preferredFacility_facilityState' },
+        vaMedicalFacility: { $id: 'preferredFacility_vaMedicalFacility' },
+      },
       onChange: sinon.spy(),
-      required: true,
-      value,
+      formData,
+      schema: {
+        required: ['view:facilityState', 'vaMedicalFacility'],
+      },
+      errorSchema: {
+        'view:facilityState': { __errors: 'state required' },
+        vaMedicalFacility: { __errors: 'facility required' },
+      },
     },
   });
 
   context('when the component renders on form page', () => {
     const { mockStore, props } = getData({});
 
-    it('should render `va-select`', () => {
+    it('should render both `va-select` fields', () => {
       const { container } = render(
         <Provider store={mockStore}>
           <VaMedicalCenter {...props} />
         </Provider>,
       );
-      const selector = container.querySelector(`#${props.id}`);
-      expect(selector).to.exist;
+      const stateSelector = container.querySelector(
+        `#${props.idSchema['view:facilityState'].$id}`,
+      );
+      expect(stateSelector).to.exist;
+      const facilitySelector = container.querySelector(
+        `#${props.idSchema.vaMedicalFacility.$id}`,
+      );
+      expect(facilitySelector).to.exist;
     });
 
-    it('should not render the facility name container', () => {
+    it('should not render the containers from review mode', () => {
       const { container } = render(
         <Provider store={mockStore}>
           <VaMedicalCenter {...props} />
         </Provider>,
       );
-      const selector = container.querySelector(
+      const stateSelector = container.querySelector(
+        '[data-testid="hca-facility-state"]',
+      );
+      expect(stateSelector).to.not.exist;
+      const facilitySelector = container.querySelector(
         '[data-testid="hca-facility-name"]',
       );
-      expect(selector).to.not.exist;
+      expect(facilitySelector).to.not.exist;
     });
   });
 
   context('when the component renders in review mode', () => {
     const { mockStore, props } = getData({
-      formData: { 'view:facilityState': 'NY' },
+      formData: {
+        'view:facilityState': 'NY',
+        vaMedicalFacility: mockData[1].uniqueId,
+      },
       reviewMode: true,
-      value: mockData[1].uniqueId,
     });
 
-    it('should render the correct facility name', async () => {
+    it('should render the correct state and facility name', async () => {
+      mockApiRequest(mockData);
       const { container } = render(
         <Provider store={mockStore}>
           <VaMedicalCenter {...props} />
         </Provider>,
       );
-      const selector = container.querySelector(
+
+      const stateSelector = container.querySelector(
+        '[data-testid="hca-facility-state"]',
+      );
+      await waitFor(() => {
+        expect(stateSelector).to.contain.text('New York');
+      });
+
+      const facilitySelector = container.querySelector(
         '[data-testid="hca-facility-name"]',
       );
-      waitFor(() => {
-        expect(selector).to.contain.text(mockData[1].attributes.name);
+      await waitFor(() => {
+        expect(facilitySelector).to.contain.text(mockData[1].name);
       });
     });
 
@@ -103,7 +132,7 @@ describe('hca <VaMedicalCenter>', () => {
         </Provider>,
       );
       const selector = container.querySelector('va-loading-indicator');
-      waitFor(() => {
+      await waitFor(() => {
         expect(selector).to.not.exist;
       });
     });
@@ -115,19 +144,20 @@ describe('hca <VaMedicalCenter>', () => {
         </Provider>,
       );
       const selector = container.querySelector('va-select');
-      waitFor(() => {
+      await waitFor(() => {
         expect(selector).to.not.exist;
       });
     });
 
     it('should not render the server error alert', async () => {
+      mockApiRequest(mockData);
       const { container } = render(
         <Provider store={mockStore}>
           <VaMedicalCenter {...props} />
         </Provider>,
       );
       const selector = container.querySelector('va-alert');
-      waitFor(() => {
+      await waitFor(() => {
         expect(selector).to.not.exist;
       });
     });
@@ -144,17 +174,16 @@ describe('hca <VaMedicalCenter>', () => {
           <VaMedicalCenter {...props} />
         </Provider>,
       );
-      const selectors = {
-        options: container.querySelectorAll('option'),
-        alert: container.querySelector('va-alert'),
-      };
-      waitFor(() => {
-        expect(selectors.options).to.have.lengthOf(mockData.length + 1);
-        expect(selectors.options[1]).to.have.attr(
-          'value',
-          mockData[0].uniqueId,
+
+      await waitFor(() => {
+        const options = container.querySelectorAll(
+          `#${props.idSchema.vaMedicalFacility.$id} option`,
         );
-        expect(selectors.alert).to.not.exist;
+        const alert = container.querySelector('va-alert');
+
+        expect(options).to.have.lengthOf(mockData.length);
+        expect(options[0]).to.have.attr('value', mockData[0].uniqueId);
+        expect(alert).to.not.exist;
       });
     });
 
@@ -173,13 +202,18 @@ describe('hca <VaMedicalCenter>', () => {
           <VaMedicalCenter {...props} />
         </Provider>,
       );
-      const selectors = {
-        vaSelect: container.querySelector(`#${props.id}`),
-        alert: container.querySelector('va-alert'),
-      };
-      waitFor(() => {
-        expect(selectors.vaSelect).to.not.exist;
-        expect(selectors.alert).to.exist;
+      await waitFor(() => {
+        const vaSelectState = container.querySelector(
+          `#${props.idSchema['view:facilityState'].$id}`,
+        );
+        const vaSelectFacility = container.querySelector(
+          `#${props.idSchema.vaMedicalFacility.$id}`,
+        );
+        const alert = container.querySelector('va-alert');
+
+        expect(vaSelectState).to.not.exist;
+        expect(vaSelectFacility).to.not.exist;
+        expect(alert).to.exist;
       });
     });
   });
@@ -195,11 +229,17 @@ describe('hca <VaMedicalCenter>', () => {
           <VaMedicalCenter {...props} />
         </Provider>,
       );
-      const selector = container.querySelector(`#${props.id}`);
 
-      waitFor(() => {
+      await waitFor(() => {
+        const selector = container.querySelector(
+          `#${props.idSchema.vaMedicalFacility.$id}`,
+        );
+
         selector.__events.vaSelect({
-          detail: { value: mockData[1].id },
+          target: {
+            name: props.idSchema.vaMedicalFacility.$id,
+            value: mockData[1].id,
+          },
         });
 
         expect(props.onChange.called).to.be.true;
@@ -210,9 +250,9 @@ describe('hca <VaMedicalCenter>', () => {
   context(
     'when the form is submitted without a selected facility',
     async () => {
-      it('should render an error message', () => {
+      it('should render an error message on the facility field', async () => {
         const { mockStore, props } = getData({
-          formData: { 'view:facilityState': 'NY' },
+          formData: {},
           submitted: true,
         });
         const { container } = render(
@@ -220,9 +260,75 @@ describe('hca <VaMedicalCenter>', () => {
             <VaMedicalCenter {...props} />
           </Provider>,
         );
-        const selector = container.querySelector(`#${props.id}`);
-        waitFor(() => {
+        await waitFor(() => {
+          const selector = container.querySelector(
+            `#${props.idSchema.vaMedicalFacility.$id}`,
+          );
           expect(selector).to.have.attr('error', 'Please provide a response');
+        });
+      });
+    },
+  );
+
+  context('when submitted without a selected state or facility', async () => {
+    it('should render error messages for both fields', async () => {
+      const { mockStore, props } = getData({
+        formData: {},
+        submitted: true,
+      });
+      const { container } = render(
+        <Provider store={mockStore}>
+          <VaMedicalCenter {...props} />
+        </Provider>,
+      );
+      await waitFor(() => {
+        const vaSelectState = container.querySelector(
+          `#${props.idSchema['view:facilityState'].$id}`,
+        );
+        const vaSelectFacility = container.querySelector(
+          `#${props.idSchema.vaMedicalFacility.$id}`,
+        );
+        expect(vaSelectState).to.have.attr(
+          'error',
+          'Please provide a response',
+        );
+        expect(vaSelectFacility).to.have.attr(
+          'error',
+          'Please provide a response',
+        );
+      });
+    });
+  });
+
+  context(
+    'when the form is submitted with both state and facility selected',
+    async () => {
+      it('should not render error messages', async () => {
+        mockApiRequest(mockData);
+        const { mockStore, props } = getData({
+          formData: {
+            'view:facilityState': 'NY',
+            vaMedicalFacility: mockData[0].uniqueId,
+          },
+          submitted: true,
+        });
+        const { container } = render(
+          <Provider store={mockStore}>
+            <VaMedicalCenter {...props} />
+          </Provider>,
+        );
+        await waitFor(() => {
+          const vaSelectState = container.querySelector(
+            `#${props.idSchema['view:facilityState'].$id}`,
+          );
+          const vaSelectFacility = container.querySelector(
+            `#${props.idSchema.vaMedicalFacility.$id}`,
+          );
+          const alert = container.querySelector('va-alert');
+
+          expect(alert).to.not.exist;
+          expect(vaSelectState).to.not.have.attr('error');
+          expect(vaSelectFacility).to.not.have.attr('error');
         });
       });
     },

--- a/src/applications/hca/tests/unit/components/FormReview/VaMedicalCenterReviewField.unit.spec.js
+++ b/src/applications/hca/tests/unit/components/FormReview/VaMedicalCenterReviewField.unit.spec.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import { VaMedicalCenterReviewField } from '../../../../components/FormReview/VaMedicalCenterReviewField';
+
+describe('hca <VaMedicalCenterReviewField>', () => {
+  context('when the component renders', () => {
+    it('should render the correct state and facility name', async () => {
+      const props = {
+        stateLabel: 'New York',
+        facilityName: 'Batavia VA Medical Center',
+      };
+      const { container } = render(<VaMedicalCenterReviewField {...props} />);
+
+      const stateSelector = container.querySelector(
+        '[data-testid="hca-facility-state"]',
+      );
+      expect(stateSelector.textContent).to.eq(props.stateLabel);
+
+      const facilitySelector = container.querySelector(
+        '[data-testid="hca-facility-name"]',
+      );
+      expect(facilitySelector.textContent).to.eq(props.facilityName);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fix EZ Medical Center component to consistently handle both state and facility dropdowns
- Rather than having an isolated component for the Facility, validation requirements made it cleaner to move the State dropdown into the component, too.
- 10-10 Health Apps - EZ/CG team
- Feature switch `hca_use_facilities_API` to be enabled after release, no timeline for full enabling yet.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/79440
- earlier PR: https://github.com/department-of-veterans-affairs/vets-website/pull/29412

## Testing done

- Old behavior: proceed through EZ form to section 5/6: Insurance Information, and select a State. Facilities information showed up instantly, but was stale, pulled from a static JSON file.
- Verification: see the new list of facilities, as in the preceding PR linked above. No longer able to proceed to the Review form with any unpopulated dropdowns.

## Screenshots

Original form:
<img width="785" alt="Screenshot 2024-04-25 at 3 26 25 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/153661030/593e137b-949d-4b87-9fdf-fcf7f41a95a9">

Updated version, with current facilities list and modern VaSelect components:
<img width="709" alt="Screenshot 2024-05-22 at 4 11 15 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/153661030/3841b154-91ba-4255-a65a-933ec5b9a470">



## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

- We ran in to some bugs with going back and forth between this page and the Review page. The ones we found are patched now, but it was a surprising error point. 
