### PR TITLE
#82393: Mock wellHive Referral endpoint

### DIFF
--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -46,6 +46,7 @@ const WHNetworks = require('./wellHive/networks.json');
 const specialties = require('./wellHive/specialties.json');
 const specialtyGroups = require('./wellHive/specialtyGroups.json');
 const providerOrgs = require('./wellHive/providerOrganizations.json');
+const referrals = require('./wellHive/referrals.json');
 
 // Returns the meta object without any backend service errors
 const meta = require('./v2/meta.json');
@@ -575,6 +576,16 @@ const responses = {
   },
   'GET /vaos/v2/wellhive/provider-organization': (req, res) => {
     return res.json({ data: providerOrgs });
+  },
+  'GET /vaos/v2/wellhive/referrals': (req, res) => {
+    return res.json({ data: referrals });
+  },
+  'GET /vaos/v2/wellhive/referrals/:referralId': (req, res) => {
+    return res.json({
+      data: referrals.referrals.find(
+        referral => referral?.id === req.params.referralId,
+      ),
+    });
   },
   'GET /v0/user': {
     data: {


### PR DESCRIPTION
## Summary
Mock wellHive Referral endpoint #82393



## Related issue(s)

- https://app.zenhub.com/workspaces/appointments-cc-direct-scheduling-660abc13699bfa00195d685a/issues/gh/department-of-veterans-affairs/va.gov-team/82393
- 
## Testing done
Tested mocks with postman.

`GET /vaos/v2/wellhive/referrals`

<img width="897" alt="Screenshot 2024-05-20 at 6 09 16 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/47654119/8322a3ef-2804-4c17-81af-8ba3bae81ccd">


`GET /vaos/v2/wellhive/referrals/:referralId`

<img width="869" alt="Screenshot 2024-05-20 at 6 09 42 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/47654119/58ab1274-0e01-452a-b3db-0746ceadc507">




WH API DOC:

<img width="811" alt="Screenshot 2024-05-20 at 6 08 42 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/47654119/b3e4e444-b989-4b8d-9ac1-9d2dd5e866f7">



Postman Collection:



## Acceptance criteria
- [x] Mock wellHive ProviderOrganization endpoints.