### PR TITLE
83409 Increase E2E testing for form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -1039,7 +1039,7 @@ const formConfig = {
         },
         // Applicant separated from sponsor before sponsor's death
         page18f6: {
-          path: 'applicant-information/:index/married-separated-dates',
+          path: 'applicant-information/married-separated-dates/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} marriage dates`,

--- a/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
@@ -38,12 +38,12 @@ const testConfig = createTestConfig(
     // Each dataset contains a `description` property that elaborates on what
     // is contained within.
     dataSets: [
-      // 'test-data',
       'maximal-test',
       'app-sa-cs-medab',
       'app-sd-cb-ohi',
-      // 'cert-sd-spoused',
+      'cert-sd-spoused',
       'vet-2a-spouse-child-medabd-ohi',
+      'test-data',
     ],
     arrayPages: [{ arrayPath: 'applicants', regex: /.*applicant.*/g }],
     pageHooks: {
@@ -266,6 +266,22 @@ const testConfig = createTestConfig(
           });
         });
       },
+      [ALL_PAGES.page18f1.path]: ({ afterHook }) => {
+        cy.injectAxeThenAxeCheck();
+        afterHook(() => {
+          cy.get('@testData').then(data => {
+            cy.url().then(url => {
+              selectRadioWebComponent(
+                'applicantSponsorMarriageDetails',
+                data.applicants[getIdx(url)].applicantSponsorMarriageDetails
+                  .relationshipToVeteran,
+              );
+            });
+            cy.axeCheck();
+            cy.findByText(/continue/i, { selector: 'button' }).click();
+          });
+        });
+      },
       [ALL_PAGES.page18f3.path]: ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
@@ -274,6 +290,25 @@ const testConfig = createTestConfig(
               fillDateWebComponentPattern(
                 'dateOfMarriageToSponsor',
                 data.applicants[getIdx(url)].dateOfMarriageToSponsor,
+              );
+            });
+            cy.axeCheck();
+            cy.findByText(/continue/i, { selector: 'button' }).click();
+          });
+        });
+      },
+      [ALL_PAGES.page18f6.path]: ({ afterHook }) => {
+        cy.injectAxeThenAxeCheck();
+        afterHook(() => {
+          cy.get('@testData').then(data => {
+            cy.url().then(url => {
+              fillDateWebComponentPattern(
+                'dateOfMarriageToSponsor',
+                data.applicants[getIdx(url)].dateOfMarriageToSponsor,
+              );
+              fillDateWebComponentPattern(
+                'dateOfSeparationFromSponsor',
+                data.applicants[getIdx(url)].dateOfSeparationFromSponsor,
               );
             });
             cy.axeCheck();

--- a/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
@@ -40,7 +40,7 @@ const testConfig = createTestConfig(
     dataSets: [
       // 'test-data',
       'maximal-test',
-      // 'app-sa-cs-medab',
+      'app-sa-cs-medab',
       // 'app-sd-cb-ohi',
       // 'cert-sd-spoused',
       'vet-2a-spouse-child-medabd-ohi',

--- a/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
@@ -43,7 +43,7 @@ const testConfig = createTestConfig(
       // 'app-sa-cs-medab',
       // 'app-sd-cb-ohi',
       // 'cert-sd-spoused',
-      // 'vet-2a-spouse-child-medabd-ohi',
+      'vet-2a-spouse-child-medabd-ohi',
     ],
     arrayPages: [{ arrayPath: 'applicants', regex: /.*applicant.*/g }],
     pageHooks: {

--- a/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
@@ -41,7 +41,7 @@ const testConfig = createTestConfig(
       // 'test-data',
       'maximal-test',
       'app-sa-cs-medab',
-      // 'app-sd-cb-ohi',
+      'app-sd-cb-ohi',
       // 'cert-sd-spoused',
       'vet-2a-spouse-child-medabd-ohi',
     ],

--- a/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/app-sa-cs-medab.json
+++ b/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/app-sa-cs-medab.json
@@ -1,0 +1,92 @@
+{
+  "description": "Is applicant, sponsor alive, child (step), has Medicare A/B",
+  "data": {
+    "applicants": [
+      {
+        "applicantPhone": "2341232345",
+        "applicantEmailAddress": "applicant@email.gov",
+        "applicantAddress": {
+          "country": "USA",
+          "street": "321 Street Av",
+          "city": "Cityburg",
+          "state": "AS",
+          "postalCode": "12312"
+        },
+        "applicantSSN": {
+          "ssn": "123123123"
+        },
+        "applicantName": {
+          "first": "Applicant",
+          "last": "Jones"
+        },
+        "applicantDOB": "2000-02-02",
+        "applicantGender": {
+          "gender": "male"
+        },
+        "applicantRelationshipToSponsor": {
+          "relationshipToVeteran": "child"
+        },
+        "applicantRelationshipOrigin": {
+          "relationshipToVeteran": "step"
+        },
+        "missingUploads": [
+          {
+            "name": "applicantBirthCertOrSocialSecCard",
+            "path": "applicant-child-file/:index",
+            "required": false,
+            "uploaded": false
+          },
+          {
+            "name": "applicantStepMarriageCert",
+            "path": "applicant-child-marriage-file/:index",
+            "required": true,
+            "uploaded": false
+          },
+          {
+            "name": "applicantMedicarePartAPartBCard",
+            "path": "applicant-medicare-ab-file/:index",
+            "required": true,
+            "uploaded": false
+          },
+          {
+            "name": "applicantOtherInsuranceCertification",
+            "path": "applicant-other-insurance-10-7959c-file/:index",
+            "required": true,
+            "uploaded": false
+          }
+        ],
+        "applicantMedicareStatus": {
+          "eligibility": "enrolled"
+        },
+        "applicantMedicarePartD": {
+          "enrollment": "notEnrolled"
+        },
+        "applicantHasOhi": {
+          "hasOhi": "no"
+        }
+      }
+    ],
+    "sponsorPhone": "2342342342",
+    "sponsorAddress": {
+      "country": "USA",
+      "street": "123 Street Circle",
+      "city": "Citytown",
+      "state": "AL",
+      "postalCode": "12312"
+    },
+    "sponsorIsDeceased": false,
+    "ssn": {
+      "ssn": "123123123"
+    },
+    "veteransFullName": {
+      "first": "Sponsor",
+      "last": "Jones",
+      "suffix": "Sr."
+    },
+    "sponsorDOB": "1999-01-01",
+    "certifierRole": "applicant",
+    "consentToMailMissingRequiredFiles": true,
+    "statementOfTruthSignature": "applicant jones",
+    "statementOfTruthCertified": true
+  }
+}

--- a/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/app-sd-cb-ohi.json
+++ b/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/app-sd-cb-ohi.json
@@ -1,0 +1,78 @@
+{
+  "description": "Is applicant, sponsor deceased, child (biological), has OHI",
+  "data": {
+    "applicants": [
+      {
+        "applicantPhone": "1231231234",
+        "applicantEmailAddress": "email@applicant.gov",
+        "applicantAddress": {
+          "country": "USA",
+          "street": "123 Street Lane",
+          "city": "Citytown",
+          "state": "AL",
+          "postalCode": "12312"
+        },
+        "applicantSSN": {
+          "ssn": "234234234"
+        },
+        "applicantName": {
+          "first": "Applicant",
+          "last": "Jones",
+          "suffix": "II"
+        },
+        "applicantDOB": "2000-02-02",
+        "applicantGender": {
+          "gender": "male"
+        },
+        "applicantRelationshipToSponsor": {
+          "relationshipToVeteran": "child"
+        },
+        "applicantRelationshipOrigin": {
+          "relationshipToVeteran": "blood"
+        },
+        "missingUploads": [
+          {
+            "name": "applicantBirthCertOrSocialSecCard",
+            "path": "applicant-child-file/:index",
+            "required": false,
+            "uploaded": false
+          },
+          {
+            "name": "applicantOhiCard",
+            "path": "applicant-other-insurance-file/:index",
+            "required": true,
+            "uploaded": false
+          },
+          {
+            "name": "applicantOtherInsuranceCertification",
+            "path": "applicant-other-insurance-10-7959c-file/:index",
+            "required": true,
+            "uploaded": false
+          }
+        ],
+        "applicantMedicareStatus": {
+          "eligibility": "ineligible"
+        },
+        "applicantHasOhi": {
+          "hasOhi": "yes"
+        }
+      }
+    ],
+    "veteransFullName": {
+      "first": "Sponsor",
+      "last": "Jones",
+      "suffix": "Jr."
+    },
+    "sponsorDOB": "1999-01-01",
+    "sponsorDOD": "2000-01-01",
+    "sponsorDeathConditions": true,
+    "sponsorIsDeceased": true,
+    "ssn": {
+      "ssn": "123123123"
+    },
+    "certifierRole": "applicant",
+    "consentToMailMissingRequiredFiles": true,
+    "statementOfTruthSignature": "applicant jones",
+    "statementOfTruthCertified": true
+  }
+}

--- a/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/cert-sd-spoused.json
+++ b/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/cert-sd-spoused.json
@@ -1,0 +1,77 @@
+{
+  "description": "Is 3rd party certifier, sponsor deceased, applicant was spouse but divorced before death",
+  "data": {
+    "applicants": [
+      {
+        "dateOfMarriageToSponsor": "2001-01-01",
+        "dateOfSeparationFromSponsor": "2004-04-02",
+        "applicantPhone": "1231231234",
+        "applicantEmailAddress": "app@email.gov",
+        "applicantAddress": {
+          "country": "USA",
+          "street": "123 App Street",
+          "city": "Cityburg",
+          "state": "CO",
+          "postalCode": "12312"
+        },
+        "applicantSSN": {
+          "ssn": "123123123"
+        },
+        "applicantName": {
+          "first": "Applicant",
+          "last": "Jones"
+        },
+        "applicantDOB": "2001-02-02",
+        "applicantGender": {
+          "gender": "female"
+        },
+        "applicantRelationshipToSponsor": {
+          "relationshipToVeteran": "spouse"
+        },
+        "applicantSponsorMarriageDetails": {
+          "relationshipToVeteran": "marriageDissolved"
+        },
+        "applicantMedicareStatus": {
+          "eligibility": "ineligible"
+        },
+        "applicantHasOhi": {
+          "hasOhi": "no"
+        }
+      }
+    ],
+    "sponsorDOD": "2000-04-05",
+    "sponsorDeathConditions": true,
+    "sponsorIsDeceased": true,
+    "ssn": {
+      "ssn": "123123123"
+    },
+    "veteransFullName": {
+      "first": "Sponsor",
+      "last": "Jones"
+    },
+    "sponsorDOB": "1950-01-01",
+    "certifierRelationship": {
+      "relationshipToVeteran": {
+        "spouse": false,
+        "thirdParty": true
+      }
+    },
+    "certifierPhone": "1231231234",
+    "certifierAddress": {
+      "country": "USA",
+      "street": "123 Certifier Street",
+      "city": "CertTown",
+      "state": "AK",
+      "postalCode": "12312"
+    },
+    "certifierName": {
+      "first": "Certifier",
+      "last": "Jones",
+      "suffix": "Jr."
+    },
+    "certifierRole": "other",
+    "consentToMailMissingRequiredFiles": false,
+    "statementOfTruthSignature": "certifier jones",
+    "statementOfTruthCertified": true
+  }
+}

--- a/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/maximal-test.json
@@ -1,0 +1,218 @@
+{
+  "description": "Is 3rd party certifier, sponsor alive, 3 applicants, spouse, child, other relationship, over 65 no Medicare no OHI, Medicare ABD and OHI",
+  "data": {
+    "applicants": [
+      {
+        "applicantPhone": "1231231234",
+        "applicantEmailAddress": "app1@email.gov",
+        "applicantAddress": {
+          "country": "USA",
+          "street": "123 App1 St",
+          "city": "Cityland",
+          "state": "MD",
+          "postalCode": "12312"
+        },
+        "applicantSSN": {
+          "ssn": "123123123"
+        },
+        "applicantName": {
+          "first": "Applicant1",
+          "last": "Jones"
+        },
+        "applicantDOB": "2004-04-03",
+        "applicantGender": {
+          "gender": "male"
+        },
+        "applicantRelationshipToSponsor": {
+          "relationshipToVeteran": "child"
+        },
+        "applicantRelationshipOrigin": {
+          "relationshipToVeteran": "blood"
+        },
+        "missingUploads": [
+          {
+            "name": "applicantBirthCertOrSocialSecCard",
+            "path": "applicant-child-file/:index",
+            "required": false,
+            "uploaded": false
+          },
+          {
+            "name": "applicantSchoolCert",
+            "path": "applicant-child-school-file/:index",
+            "required": true,
+            "uploaded": false
+          }
+        ],
+        "applicantDependentStatus": {
+          "status": "enrolled"
+        },
+        "applicantMedicareStatus": {
+          "eligibility": "ineligible"
+        },
+        "applicantHasOhi": {
+          "hasOhi": "no"
+        }
+      },
+      {
+        "dateOfMarriageToSponsor": "1980-02-03",
+        "applicantPhone": "2342342345",
+        "applicantAddress": {
+          "country": "USA",
+          "street": "123 Sponsor Street",
+          "city": "Citytown",
+          "state": "AL",
+          "postalCode": "12312"
+        },
+        "applicantSSN": {
+          "ssn": "123234123"
+        },
+        "applicantName": {
+          "first": "Applicant2",
+          "last": "Jones"
+        },
+        "applicantDOB": "1955-04-02",
+        "missingUploads": [
+          {
+            "name": "applicantMedicareIneligibleProof",
+            "path": "applicant-medicare-ineligible/:index",
+            "required": true,
+            "uploaded": false
+          },
+          {
+            "name": "applicantMarriageCert",
+            "path": "applicant-marriage-file/:index",
+            "required": false,
+            "uploaded": false
+          },
+          {
+            "name": "applicantOhiCard",
+            "path": "applicant-other-insurance-file/:index",
+            "required": true,
+            "uploaded": false
+          },
+          {
+            "name": "applicantOtherInsuranceCertification",
+            "path": "applicant-other-insurance-10-7959c-file/:index",
+            "required": true,
+            "uploaded": false
+          }
+        ],
+        "sharesAddressWith": "{\"originatorName\":\"Sponsor  Jones \",\"originatorAddress\":{\"view:militaryBaseDescription\":{},\"country\":\"USA\",\"street\":\"123 Sponsor Street\",\"city\":\"Citytown\",\"state\":\"AL\",\"postalCode\":\"12312\"},\"displayText\":\"123 Sponsor Street\"}",
+        "applicantGender": {
+          "gender": "female"
+        },
+        "applicantRelationshipToSponsor": {
+          "relationshipToVeteran": "spouse"
+        },
+        "applicantMedicareStatus": {
+          "eligibility": "ineligible"
+        },
+        "applicantHasOhi": {
+          "hasOhi": "yes"
+        }
+      },
+      {
+        "applicantPhone": "1231232345",
+        "applicantEmailAddress": "app3@email.gov",
+        "applicantAddress": {
+          "country": "USA",
+          "street": "123 Certifier Street",
+          "city": "Citytown",
+          "state": "AL",
+          "postalCode": "12312"
+        },
+        "applicantSSN": {
+          "ssn": "876123876"
+        },
+        "applicantName": {
+          "first": "Applicant3",
+          "last": "Jones"
+        },
+        "applicantDOB": "2000-01-02",
+        "missingUploads": [
+          {
+            "name": "applicantMedicarePartAPartBCard",
+            "path": "applicant-medicare-ab-file/:index",
+            "required": true,
+            "uploaded": false
+          },
+          {
+            "name": "applicantMedicarePartDCard",
+            "path": "applicant-medicare-d-file/:index",
+            "required": true,
+            "uploaded": false
+          },
+          {
+            "name": "applicantOtherInsuranceCertification",
+            "path": "applicant-other-insurance-10-7959c-file/:index",
+            "required": true,
+            "uploaded": false
+          },
+          {
+            "name": "applicantOhiCard",
+            "path": "applicant-other-insurance-file/:index",
+            "required": true,
+            "uploaded": false
+          }
+        ],
+        "sharesAddressWith": "{\"originatorName\":\"Certifier  Jones \",\"originatorAddress\":{\"view:militaryBaseDescription\":{},\"country\":\"USA\",\"street\":\"123 Certifier Street\",\"city\":\"Citytown\",\"state\":\"AL\",\"postalCode\":\"12312\"},\"displayText\":\"123 Certifier Street\"}",
+        "applicantGender": {
+          "gender": "male"
+        },
+        "applicantRelationshipToSponsor": {
+          "relationshipToVeteran": "other",
+          "otherRelationshipToVeteran": "Something else"
+        },
+        "applicantMedicareStatus": {
+          "eligibility": "enrolled"
+        },
+        "applicantMedicarePartD": {
+          "enrollment": "enrolled"
+        },
+        "applicantHasOhi": {
+          "hasOhi": "yes"
+        }
+      }
+    ],
+    "sponsorPhone": "1231232345",
+    "sponsorAddress": {
+      "country": "USA",
+      "street": "123 Sponsor Street",
+      "city": "Citytown",
+      "state": "AL",
+      "postalCode": "12312"
+    },
+    "sponsorIsDeceased": false,
+    "ssn": {
+      "ssn": "123123123"
+    },
+    "veteransFullName": {
+      "first": "Sponsor",
+      "last": "Jones"
+    },
+    "sponsorDOB": "1950-01-01",
+    "certifierRelationship": {
+      "relationshipToVeteran": {
+        "spouse": true,
+        "child": true,
+        "thirdParty": true
+      }
+    },
+    "certifierPhone": "1231231234",
+    "certifierAddress": {
+      "country": "USA",
+      "street": "123 Certifier Street",
+      "city": "Citytown",
+      "state": "AL",
+      "postalCode": "12312"
+    },
+    "certifierName": {
+      "first": "Certifier",
+      "last": "Jones"
+    },
+    "certifierRole": "other",
+    "consentToMailMissingRequiredFiles": true,
+    "statementOfTruthSignature": "certifier jones",
+    "statementOfTruthCertified": true
+  }
+}

--- a/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/vet-2a-spouse-child-medabd-ohi.json
+++ b/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/vet-2a-spouse-child-medabd-ohi.json
@@ -1,0 +1,137 @@
+{
+  "description": "Is veteran, 2 applicants, 1st applicant is spouse, 2nd applicant is child (bio), 1st applicant has Medicare A/B/D and OHI.",
+  "data": {
+    "applicants": [
+      {
+        "dateOfMarriageToSponsor": "2001-01-01",
+        "applicantPhone": "1232343456",
+        "applicantEmailAddress": "app1@email.gov",
+        "applicantAddress": {
+          "country": "USA",
+          "street": "123 App1 Street",
+          "city": "App1 Town",
+          "state": "MD",
+          "postalCode": "12312"
+        },
+        "applicantSSN": {
+          "ssn": "345345345"
+        },
+        "applicantName": {
+          "first": "Applicant",
+          "last": "Jones"
+        },
+        "applicantDOB": "2001-01-01",
+        "applicantGender": {
+          "gender": "female"
+        },
+        "applicantRelationshipToSponsor": {
+          "relationshipToVeteran": "spouse"
+        },
+        "missingUploads": [
+          {
+            "name": "applicantMarriageCert",
+            "path": "applicant-marriage-file/:index",
+            "required": false,
+            "uploaded": false
+          },
+          {
+            "name": "applicantMedicarePartAPartBCard",
+            "path": "applicant-medicare-ab-file/:index",
+            "required": true,
+            "uploaded": false
+          },
+          {
+            "name": "applicantMedicarePartDCard",
+            "path": "applicant-medicare-d-file/:index",
+            "required": true,
+            "uploaded": false
+          },
+          {
+            "name": "applicantOtherInsuranceCertification",
+            "path": "applicant-other-insurance-10-7959c-file/:index",
+            "required": true,
+            "uploaded": false
+          },
+          {
+            "name": "applicantOhiCard",
+            "path": "applicant-other-insurance-file/:index",
+            "required": true,
+            "uploaded": false
+          }
+        ],
+        "applicantMedicareStatus": {
+          "eligibility": "enrolled"
+        },
+        "applicantMedicarePartD": {
+          "enrollment": "enrolled"
+        },
+        "applicantHasOhi": {
+          "hasOhi": "yes"
+        }
+      },
+      {
+        "applicantPhone": "1231231234",
+        "applicantEmailAddress": "app2@email.gov",
+        "applicantAddress": {
+          "country": "USA",
+          "street": "123 App1 Street",
+          "city": "App1 Town",
+          "state": "MD",
+          "postalCode": "12312"
+        },
+        "applicantSSN": {
+          "ssn": "234123234"
+        },
+        "applicantName": {
+          "first": "Applicant2",
+          "last": "Jones2"
+        },
+        "applicantDOB": "2000-04-03",
+        "missingUploads": [
+          {
+            "name": "applicantBirthCertOrSocialSecCard",
+            "path": "applicant-child-file/:index",
+            "required": false,
+            "uploaded": false
+          }
+        ],
+        "sharesAddressWith": "{\"originatorName\":\"Applicant  Jones \",\"originatorAddress\":{\"view:militaryBaseDescription\":{},\"country\":\"USA\",\"street\":\"123 App1 Street\",\"city\":\"App1 Town\",\"state\":\"MD\",\"postalCode\":\"12312\"},\"displayText\":\"123 App1 Street\"}",
+        "applicantGender": {
+          "gender": "male"
+        },
+        "applicantRelationshipToSponsor": {
+          "relationshipToVeteran": "child"
+        },
+        "applicantRelationshipOrigin": {
+          "relationshipToVeteran": "blood"
+        },
+        "applicantMedicareStatus": {
+          "eligibility": "ineligible"
+        },
+        "applicantHasOhi": {
+          "hasOhi": "no"
+        }
+      }
+    ],
+    "sponsorPhone": "1231231234",
+    "sponsorAddress": {
+      "country": "USA",
+      "street": "123 Veteran Lane",
+      "city": "Citytown",
+      "state": "AZ",
+      "postalCode": "12312"
+    },
+    "ssn": {
+      "ssn": "234234234"
+    },
+    "veteransFullName": {
+      "first": "Sponsor",
+      "last": "Jones"
+    },
+    "sponsorDOB": "1950-04-01",
+    "certifierRole": "sponsor",
+    "consentToMailMissingRequiredFiles": true,
+    "statementOfTruthSignature": "Sponsor Jones",
+    "statementOfTruthCertified": true
+  }
+}

--- a/src/applications/ivc-champva/10-7959C/tests/10-7959C.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/10-7959C.cypress.spec.js
@@ -9,16 +9,12 @@ import manifest from '../manifest.json';
 import {
   reviewAndSubmitPageFlow,
   fillAddressWebComponentPattern,
+  getAllPages,
 } from '../../shared/tests/helpers';
 
 // Put all page objects into an object where pagename maps to page data
 // E.g., {page1: {path: '/blah'}}
-const ALL_PAGES = {};
-Object.values(formConfig.chapters).forEach(ch =>
-  Object.keys(ch.pages).forEach(p => {
-    ALL_PAGES[p] = ch.pages[p];
-  }),
-);
+const ALL_PAGES = getAllPages(formConfig);
 
 const testConfig = createTestConfig(
   {
@@ -128,9 +124,13 @@ const testConfig = createTestConfig(
               // format of dates (goes from YYYY-MM-DD to MM-DD-YYYY).
               // TODO: Address discrepancy at some point.
               expect(data[k]?.length).to.equal(req.body[k]?.length);
+            } else {
+              expect(data[k] === req.body[k]);
             }
           });
         });
+        // Mock the backend response on form submit:
+        req.reply({ status: 200 });
       });
       cy.config('includeShadowDom', true);
     },

--- a/src/applications/ivc-champva/shared/components/applicantLists/ApplicantRelationshipPage.jsx
+++ b/src/applications/ivc-champva/shared/components/applicantLists/ApplicantRelationshipPage.jsx
@@ -306,6 +306,7 @@ export default function ApplicantRelationshipPage({
                     customOtherDescription ||
                     `Since ${relativePossessive} relationship with the ${personTitle} was not listed, please describe it here`
                   }
+                  name="other-relationship-description"
                   onInput={handlers.inputUpdate}
                   required={checkValue[primary] === 'other'}
                   error={inputError}

--- a/src/applications/ivc-champva/shared/tests/helpers.js
+++ b/src/applications/ivc-champva/shared/tests/helpers.js
@@ -118,3 +118,19 @@ export const reviewAndSubmitPageFlow = (
     selector: 'button',
   }).click();
 };
+
+/**
+ * Puts all page objects into an object where pagename maps to page data
+ * E.g., {page1: {path: '/blah'}}*
+ * @param {object} formConfig A standard config representing a form
+ * @returns object mapping page name to the matching page object: {page1: {path: '/blah'}}
+ */
+export function getAllPages(formConfig) {
+  const allPages = {};
+  Object.values(formConfig.chapters).forEach(ch =>
+    Object.keys(ch.pages).forEach(p => {
+      allPages[p] = ch.pages[p];
+    }),
+  );
+  return allPages;
+}

--- a/src/applications/ivc-champva/shared/tests/helpers.js
+++ b/src/applications/ivc-champva/shared/tests/helpers.js
@@ -41,7 +41,14 @@ export const fillAddressWebComponentPattern = (fieldName, addressObject) => {
   fillTextWebComponent(`${fieldName}_street`, addressObject.street);
   fillTextWebComponent(`${fieldName}_street2`, addressObject.street2);
   fillTextWebComponent(`${fieldName}_street3`, addressObject.street3);
-  selectDropdownWebComponent(`${fieldName}_state`, addressObject.state);
+  // List loop fields sometimes fail on this because the state <select> renders as a text input
+  // TODO: look into that bug. For now, set the test to check which field type we have
+  cy.get('body').then(body => {
+    if (body.find(`va-select[name="root_${fieldName}_state"]`).length > 0)
+      selectDropdownWebComponent(`${fieldName}_state`, addressObject.state);
+    if (body.find(`va-text-input[name="root_${fieldName}_state"]`).length > 0)
+      fillTextWebComponent(`${fieldName}_state`, addressObject.state);
+  });
   fillTextWebComponent(`${fieldName}_postalCode`, addressObject.postalCode);
 };
 


### PR DESCRIPTION
## Summary

This PR adds several new E2E tests. Tests were run in loops to verify they are not flaky. They cover the following courses:

Test 1
- The user is an applicant
- The sponsor is alive
- The applicant is the sponsor's step child
- The applicant has Medicare A/B
- The applicant does not have Medicare D or OHI

Test 2
- The user is an applicant
- The sponsor is deceased
- The applicant is the sponsor's biological child
- The applicant has OHI
- The applicant does not have any form of Medicare

Test 3
- The user is a 3rd party certifying on behalf of an applicant
- The sponsor is deceased
- the applicant was married to the sponsor but divorced

Test 4
- This is a maximal test that includes a 3rd party certifier, a living sponsor, and three applicants with most conditional paths included

Test 5
- The user is the sponsor
- Two applicants are included
- Applicant 1 is the sponsor's spouse, has Medicare A/B/D, and OHI
- Applicant 2 is the sponsor's biological child and does not have Medicare or OHI

Summary
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83409

## Testing done

- E2E, unit 

## What areas of the site does it impact?

IVC form 10-10d

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA