### PR TITLE
Fix Ineligibility Screen Depends Function in Form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -1272,7 +1272,7 @@ const formConfig = {
               get(
                 'applicantMedicareStatus.eligibility',
                 formData?.applicants?.[index],
-              ) !== 'enrolled' &&
+              ) === 'ineligible' &&
               getAgeInYears(formData.applicants[index]?.applicantDOB) >= 65
             );
           },


### PR DESCRIPTION
## Summary

This PR fixes a `depends` function that was too broad. The medicare ineligibility file upload screen should only be shown if user is over 65 years and has chosen that they're ineligible for Medicare. However, the form was displaying this page to users who also selected that they were eligible for Medicare but had not enrolled yet. This has been corrected.

- Fixed `depends` function to only show page under proper circumstances
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- 

## Testing done

- Manual, unit

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Mockup |
| ------- | ------ |
| Desktop | ![Screenshot 2024-05-21 at 12 34 36](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/adee0f68-2fa7-479a-bf0a-3c3e57c8c7ae)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA