### PR TITLE
Add hyphen to Winston-Salem

### DIFF
--- a/src/applications/simple-forms/26-4555/definitions/constants.js
+++ b/src/applications/simple-forms/26-4555/definitions/constants.js
@@ -83,5 +83,5 @@ export const VA_REGIONAL_OFFICE_CITIES = [
   'Waco',
   'Washington',
   'Wichita',
-  'Winston Salem',
+  'Winston-Salem',
 ];


### PR DESCRIPTION
## Summary
SAHSHA needs `Winston-Salem` instead of `Winston Salem`.