### PR TITLE
NOD | Show "Not selected" for empty boolean values

### DIFF
--- a/src/applications/appeals/10182/components/ConfirmationPageV2.jsx
+++ b/src/applications/appeals/10182/components/ConfirmationPageV2.jsx
@@ -151,22 +151,23 @@ export const ConfirmationPageV2 = () => {
             {boardReviewLabels[data.boardReviewOption] || ''}
           </div>
         </li>
-        {data.boardReviewOption === 'evidence_submission' && (
-          <li>
-            <div className="page-title vads-u-color--gray">
-              Uploaded evidence
-            </div>
-            {data.evidence.map((file, index) => (
-              <div
-                key={index}
-                className="page-value dd-privacy-hidden"
-                data-dd-action-name="evidence file name"
-              >
-                {file.name}
+        {data.boardReviewOption === 'evidence_submission' &&
+          data.evidence.length && (
+            <li>
+              <div className="page-title vads-u-color--gray">
+                Uploaded evidence
               </div>
-            ))}
-          </li>
-        )}
+              {data.evidence?.map((file, index) => (
+                <div
+                  key={index}
+                  className="page-value dd-privacy-hidden"
+                  data-dd-action-name="evidence file name"
+                >
+                  {file.name}
+                </div>
+              ))}
+            </li>
+          )}
         {data.boardReviewOption === 'hearing' && (
           <>
             <li>

--- a/src/applications/appeals/10182/tests/components/ConfirmationPagev2.unit.spec.jsx
+++ b/src/applications/appeals/10182/tests/components/ConfirmationPagev2.unit.spec.jsx
@@ -50,6 +50,22 @@ describe('ConfirmationPageV2', () => {
       </Provider>,
     );
     expect($('va-alert[status="success"]', container)).to.exist;
+
+    const items = $$('.dd-privacy-hidden[data-dd-action-name]', container);
+    expect(items.length).to.eq(9);
+    expect(
+      items.map((el, index) => el[index === 4 ? 'innerHTML' : 'textContent']),
+    ).to.deep.equal([
+      '●●●–●●–V A file number ending with ',
+      '',
+      'Not selected',
+      '',
+      '',
+      ',  ',
+      'Not selected',
+      'Not selected',
+      '',
+    ]);
   });
 
   it('should render the confirmation page with evidence', () => {

--- a/src/applications/appeals/shared/components/ConfirmationIssues.jsx
+++ b/src/applications/appeals/shared/components/ConfirmationIssues.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { getReadableDate } from '../utils/dates';
 import { getIssueName, getIssueDate } from '../utils/issues';
-import { showBooleanValue } from '../utils/confirmation';
+import { showValueOrNotSelected } from '../utils/confirmation';
 import { disagreeWith } from '../utils/areaOfDisagreement';
 
 const ConfirmationIssues = ({ data }) => (
@@ -22,7 +22,7 @@ const ConfirmationIssues = ({ data }) => (
           className="page-value dd-privacy-hidden"
           data-dd-action-name="requesting an extension"
         >
-          {showBooleanValue(data.requestingExtension)}
+          {showValueOrNotSelected(data.requestingExtension)}
         </div>
       </li>
       {data.requestingExtension && (
@@ -46,7 +46,7 @@ const ConfirmationIssues = ({ data }) => (
           className="page-value dd-privacy-hidden"
           data-dd-action-name="is appealing VHA benefits"
         >
-          {showBooleanValue(data.appealingVHADenial)}
+          {showValueOrNotSelected(data.appealingVHADenial)}
         </div>
       </li>
       {/* List item that is common for all Decision Review forms */}

--- a/src/applications/appeals/shared/components/ConfirmationIssues.jsx
+++ b/src/applications/appeals/shared/components/ConfirmationIssues.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { getReadableDate } from '../utils/dates';
 import { getIssueName, getIssueDate } from '../utils/issues';
+import { showBooleanValue } from '../utils/confirmation';
 import { disagreeWith } from '../utils/areaOfDisagreement';
 
 const ConfirmationIssues = ({ data }) => (
@@ -21,7 +22,7 @@ const ConfirmationIssues = ({ data }) => (
           className="page-value dd-privacy-hidden"
           data-dd-action-name="requesting an extension"
         >
-          {data.requestingExtension ? 'Yes' : 'No'}
+          {showBooleanValue(data.requestingExtension)}
         </div>
       </li>
       {data.requestingExtension && (
@@ -45,7 +46,7 @@ const ConfirmationIssues = ({ data }) => (
           className="page-value dd-privacy-hidden"
           data-dd-action-name="is appealing VHA benefits"
         >
-          {data.appealingVHADenial ? 'Yes' : 'No'}
+          {showBooleanValue(data.appealingVHADenial)}
         </div>
       </li>
       {/* List item that is common for all Decision Review forms */}

--- a/src/applications/appeals/shared/components/ConfirmationPersonalInfo.jsx
+++ b/src/applications/appeals/shared/components/ConfirmationPersonalInfo.jsx
@@ -5,7 +5,7 @@ import { getPhoneString } from '~/platform/forms-system/src/js/utilities/data/pr
 
 import { renderFullName, maskVafn } from '../utils/data';
 import { getReadableDate } from '../utils/dates';
-import { showBooleanValue } from '../utils/confirmation';
+import { showValueOrNotSelected } from '../utils/confirmation';
 
 const ConfirmationPersonalInfo = ({
   dob = '',
@@ -51,7 +51,7 @@ const ConfirmationPersonalInfo = ({
             className="page-value dd-privacy-hidden"
             data-dd-action-name="homeless"
           >
-            {showBooleanValue(homeless)}
+            {showValueOrNotSelected(homeless)}
           </div>
         </li>
         <li>

--- a/src/applications/appeals/shared/components/ConfirmationPersonalInfo.jsx
+++ b/src/applications/appeals/shared/components/ConfirmationPersonalInfo.jsx
@@ -5,6 +5,7 @@ import { getPhoneString } from '~/platform/forms-system/src/js/utilities/data/pr
 
 import { renderFullName, maskVafn } from '../utils/data';
 import { getReadableDate } from '../utils/dates';
+import { showBooleanValue } from '../utils/confirmation';
 
 const ConfirmationPersonalInfo = ({
   dob = '',
@@ -50,7 +51,7 @@ const ConfirmationPersonalInfo = ({
             className="page-value dd-privacy-hidden"
             data-dd-action-name="homeless"
           >
-            {homeless ? 'Yes' : 'No'}
+            {showBooleanValue(homeless)}
           </div>
         </li>
         <li>

--- a/src/applications/appeals/shared/tests/components/ConfirmationPersonalInfo.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/ConfirmationPersonalInfo.unit.spec.jsx
@@ -116,7 +116,7 @@ describe('ConfirmationPersonalInfo', () => {
     ).to.deep.equal([
       '●●●–●●–V A file number ending with ',
       '',
-      'No',
+      'Not selected',
       '',
       '',
       ',  ',

--- a/src/applications/appeals/shared/tests/utils/confirmation.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/confirmation.unit.spec.js
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+
+import { showValueOrNotSelected } from '../../utils/confirmation';
+
+describe('showValueOrNotSelected', () => {
+  it('should return "Yes" for truthy values', () => {
+    expect(showValueOrNotSelected(true)).to.eq('Yes');
+    expect(showValueOrNotSelected(1)).to.eq('Yes');
+    expect(showValueOrNotSelected('foo')).to.eq('Yes');
+  });
+  it('should return "No" for falsy values', () => {
+    expect(showValueOrNotSelected(false)).to.eq('No');
+    expect(showValueOrNotSelected(0)).to.eq('No');
+    expect(showValueOrNotSelected('')).to.eq('No');
+  });
+  it('should return "Not selected" for undefined & null values', () => {
+    expect(showValueOrNotSelected(null)).to.eq('Not selected');
+    expect(showValueOrNotSelected()).to.eq('Not selected');
+  });
+
+  it('should return "Yep" for truthy values', () => {
+    expect(showValueOrNotSelected(true, 'Yep', 'Nope')).to.eq('Yep');
+    expect(showValueOrNotSelected(1, 'Yep', 'Nope')).to.eq('Yep');
+    expect(showValueOrNotSelected('foo', 'Yep', 'Nope')).to.eq('Yep');
+  });
+  it('should return "No" for falsy values', () => {
+    expect(showValueOrNotSelected(false, 'Yep', 'Nope')).to.eq('Nope');
+    expect(showValueOrNotSelected(0, 'Yep', 'Nope')).to.eq('Nope');
+    expect(showValueOrNotSelected('', 'Yep', 'Nope')).to.eq('Nope');
+  });
+});

--- a/src/applications/appeals/shared/utils/confirmation.js
+++ b/src/applications/appeals/shared/utils/confirmation.js
@@ -1,5 +1,12 @@
-export const showBooleanValue = (value, [yes = 'Yes', no = 'No'] = []) => {
-  if (typeof value === 'boolean') {
+/**
+ * Return "Yes", "No" or "Not selected" from value; the value will be
+ * @param {boolean|undefined} value - Boolean value or undefined
+ * @param {string} yes = 'Yes' - text to show for truthy values
+ * @param {string} no = 'No' - text to show for falsy values
+ * @returns {string}
+ */
+export const showValueOrNotSelected = (value, yes = 'Yes', no = 'No') => {
+  if (typeof value !== 'undefined' && value !== null) {
     return value ? yes : no;
   }
   return 'Not selected';

--- a/src/applications/appeals/shared/utils/confirmation.js
+++ b/src/applications/appeals/shared/utils/confirmation.js
@@ -1,0 +1,6 @@
+export const showBooleanValue = (value, [yes = 'Yes', no = 'No'] = []) => {
+  if (typeof value === 'boolean') {
+    return value ? yes : no;
+  }
+  return 'Not selected';
+};


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Defaulting a boolean value to `false` does not truly indicate the (non-) selection made by the Veteran, so we're updating our confirmation page data to check if the boolean value and show "Not selected"
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Add common function for reuse
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#81564](https://github.com/department-of-veterans-affairs/va.gov-team/issues/81564)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Confirmation data | <img width="680" alt="Screenshot 2024-05-21 at 2 32 08 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/b9b81963-fb14-4513-a274-f34faaa8ed48"> | <img width="684" alt="Screenshot 2024-05-21 at 3 10 41 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/4874a6e2-8b16-47b1-bb30-5ccdbbc35380"> |


## What areas of the site does it impact?

NOD

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
