### PR TITLE
Entry point widgets for supply re-ordering [fix/content update]

### DIFF
--- a/src/applications/static-pages/cta-widget/ctaWidgets.js
+++ b/src/applications/static-pages/cta-widget/ctaWidgets.js
@@ -152,9 +152,8 @@ export const ctaWidgetsLookup = {
     isHealthTool: false,
     mhvToolName: null,
     requiredServices: null,
-    serviceDescription: 'order hearing aid batteries and accessories online',
+    serviceDescription: 'order hearing aid and CPAP supplies',
     featureToggle: featureFlagNames.haCpapSuppliesCta,
-    headerLevel: '4',
   },
   [CTA_WIDGET_TYPES.HEALTH_RECORDS]: {
     id: CTA_WIDGET_TYPES.HEALTH_RECORDS,

--- a/src/applications/static-pages/cta-widget/tests/index.unit.spec.js
+++ b/src/applications/static-pages/cta-widget/tests/index.unit.spec.js
@@ -836,13 +836,13 @@ describe('<CallToActionWidget>', () => {
     describe('enabled', () => {
       it('promps to sign in w/ h4 when enabled and user signed out', () => {
         const tree = setup({ haCpapSuppliesCta: true });
-        expect(tree.find('h4').exists()).to.be.true;
+        expect(tree.find('h3').exists()).to.be.true;
         expect(tree.find('SignIn').exists()).to.be.true;
       });
 
       it('promps to verify w/ h4 when enabled and user is unverified', () => {
         const tree = setup({ haCpapSuppliesCta: true, isLoggedIn: true });
-        expect(tree.find('h4').exists()).to.be.true;
+        expect(tree.find('h3').exists()).to.be.true;
         expect(tree.find('Verify').exists()).to.be.true;
       });
 


### PR DESCRIPTION
## Summary

**This PR is a fix/content change.** See previous changes in the Related issues section, below.

- Use an h3, not an h4 for the headline
- Content: "Sign in to order hearing aid and CPAP supplies"
- Use the "simple" Sign in flow

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#79823
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#29702
department-of-veterans-affairs/vets-website#29499

## Testing done

- unit specs
- see previous changes for instructions to verify locally


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
