### PR TITLE
My VA - add new feature flag to FE for Forms status work

### DIFF
--- a/src/applications/personalization/dashboard/mocks/server.js
+++ b/src/applications/personalization/dashboard/mocks/server.js
@@ -24,6 +24,7 @@ const responses = {
     {
       authExpVbaDowntimeMessage: false,
       myVaUseExperimental: false,
+      myVaEnableNewSipConfig: false,
     },
     true,
   ),

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -132,6 +132,7 @@
   "myVaUseExperimentalFrontend": "my_va_experimental_frontend",
   "myVaUseExperimentalFullstack": "my_va_experimental_fullstack",
   "myVaHideNotificationsSection": "my_va_hide_notifications_section",
+  "myVaLighthouseUploadsReport": "my_va_lighthouse_uploads_report",
   "myVaNotificationDotIndicator": "my_va_notification_dot_indicator",
   "myVaEnableMhvLink": "my_va_enable_mhv_link",
   "myVaEnableNewSipConfig": "my_va_enable_new_sip_config",


### PR DESCRIPTION
## Summary

This PR 
- adds the `my_va_lighthouse_uploads_report` feature flag to the frontend in preparation for upcoming Forms status work (after usability studies)
- sets the `my_va_enable_new_sip_config` feature flag to false on the My VA mock server until this [bug gets resolved](https://github.com/department-of-veterans-affairs/va.gov-team/issues/83536) ([PR awaiting review](https://github.com/department-of-veterans-affairs/vets-website/pull/29910))

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/81598

## Testing done
- locally, visually
- all unit and e2e tests still pass

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
