### PR TITLE
MHV-58111 Fix-Role-In-Print-Download-Alert-Code

### DIFF
--- a/src/applications/mhv-medical-records/components/shared/DownloadSuccessAlert.jsx
+++ b/src/applications/mhv-medical-records/components/shared/DownloadSuccessAlert.jsx
@@ -19,7 +19,7 @@ const DownloadSuccessAlert = props => {
       status={ALERT_TYPE_SUCCESS}
       visible
       class={`vads-u-margin-top--4 no-print ${className}`}
-      aria-live="polite"
+      role="alert"
     >
       <h2 slot="headline" data-testid="download-success-alert-message">
         Download started


### PR DESCRIPTION
## Summary
In DownloadSuccessAlert.jsx, I replaced aria-live= "polite" with role= "alert. 

## Related issue(s)
[MHV-58111]([MHV-58111](https://jira.devops.va.gov/browse/MHV-58111)) - Fix "role" in Print/Download alert code

Proper resolution (see [https://dsva.slack.com/archives/C044WNQT4P9/p1715266125405519](https://dsva.slack.com/archives/C044WNQT4P9/p1715266125405519):))

Note:  Set role=alert, and do not change focus

The decision moving forward on downloading. Due to browsers automatically prioritizing download notifications as assertive, folks will miss the announcement of the on-page alert. For each MHV product that has these download buttons, we must do the following:

Replace aria-live="polite" with aria-live="assertive" or role="alert".
Please verify the implementation with Bobby.

For history and context only, here's the original comment from [Bobby Bailey](https://jira.devops.va.gov/secure/ViewProfile.jspa?name=robert.bailey1%40va.gov):
It seems that our alerts for downloading PDFs on Medical Records has the following code
<div class="usa-alert__body" role="presentation"><slot name="headline"></slot><slot></slot></div>
Note, the role="presentation" means that screen readers will never hear this alert. It is a must and requirement to have role=”alert”.
We will need to remove role="presentation" and add the role="alert"
We can replace the aria-live="polite" with role="alert" in the parent element.

User Story: As a Medical Records User, I want to   * , so that I can    

GIVEN

WHEN

THEN

Feature Flag Y/N ?

DataDog/Analytics Y/N ?

Manual Testing Y/N ? 

Automated Testing Y/N ?

Accessibility Testing Y/N ?

UCD Validation Y/N

Acceptance Criteria:

AC1  

AC2

AC3
AC4
AC5

Links to UCD:

Figma Link:

User Flow:

Mobile:

Desktop:

Other Design Notes:

Architectural Notes: Always check for the latest designs in Figma

## Testing done
Conducted UI testing to ensure the expected behavior. I updated existing unit test for new components.

## Screenshots
A screenshot is not available because this behavior affects screen reader devices.

## What areas of the site does it impact?
The modification affects the DownloadSuccessAlert of the Medical Records pages.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

