### PR TITLE
Login for travel pay cypress tests

### DIFF
--- a/src/applications/travel-pay/tests/travel-pay.cypress.spec.js
+++ b/src/applications/travel-pay/tests/travel-pay.cypress.spec.js
@@ -27,7 +27,7 @@ const testConfig = createTestConfig(
 
     setupPerTest: () => {
       // Log in if the form requires an authenticated session.
-      // cy.login();
+      cy.login();
 
       cy.route('POST', formConfig.submitUrl, { status: 200 });
     },


### PR DESCRIPTION
We're getting some 401 errors for the travel pay API claims endpoint - and we suspect it's because during testing, the cypress test does not log in before accessing the page.


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82677

