### PR TITLE
67014 Toxic Exposure: Herbicide Locations 15C

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ToxicExposureSummary.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ToxicExposureSummary.jsx
@@ -6,7 +6,7 @@ import {
   datesDescription,
   getOtherFieldDescription,
   goBackLink,
-} from './toxicExposure';
+} from '../content/toxicExposure';
 
 /**
  * Summary list used for the end of a Checkbox and Loop flow of the various Toxic Exposure pages

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -367,10 +367,6 @@ export const GULF_WAR_1990_LOCATIONS = Object.freeze({
   none: 'None of these locations',
 });
 
-// used to save feature flag in form in util function for 'depends' keyword of form config
-export const SHOW_REVISED_ADD_DISABILITIES_PAGE =
-  'showRevisedNewDisabilitiesPage';
-
 export const GULF_WAR_2001_LOCATIONS = Object.freeze({
   djibouti: 'Djibouti',
   lebanon: 'Lebanon',
@@ -379,3 +375,19 @@ export const GULF_WAR_2001_LOCATIONS = Object.freeze({
   airspace: 'The airspace above any of these locations',
   none: 'None of these locations',
 });
+
+export const HERBICIDE_LOCATIONS = Object.freeze({
+  cambodia: 'Cambodia at Mimot or Krek, Kampong Cham Province',
+  guam: 'Guam, American Samoa, or their territorial waters',
+  koreandemilitarizedzone: 'In or near the Korean demilitarized zone',
+  johnston: 'Johnston Atoll or on a ship that called at Johnston Atoll',
+  laos: 'Laos',
+  c123:
+    'Somewhere you had contact with C-123 airplanes while serving in the Air Force or the Air Force Reserves',
+  thailand: 'A U.S. or Royal Thai military base in Thailand',
+  vietnam: 'Vietnam or the waters in or off of Vietnam',
+});
+
+// used to save feature flag in form in util function for 'depends' keyword of form config
+export const SHOW_REVISED_ADD_DISABILITIES_PAGE =
+  'showRevisedNewDisabilitiesPage';

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -386,6 +386,7 @@ export const HERBICIDE_LOCATIONS = Object.freeze({
     'Somewhere you had contact with C-123 airplanes while serving in the Air Force or the Air Force Reserves',
   thailand: 'A U.S. or Royal Thai military base in Thailand',
   vietnam: 'Vietnam or the waters in or off of Vietnam',
+  none: 'None of these locations',
 });
 
 // used to save feature flag in form in util function for 'depends' keyword of form config

--- a/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
@@ -379,20 +379,23 @@ export function showCheckboxLoopDetailsPage(
  * Checks if the a checkbox and loop's summary page should display. It should display if all the following
  * are true
  * 1. TE pages should be showing at all
- * 2. at least one checkbox item was selected
+ * 2. at least one checkbox item was selected OR an 'other' item input was populated
  * 3. the 'none' location checkbox is not true
  *
  * @param {object} formData - full form data
+ * @param {string} checkboxObjectName - name of the object containing the checkboxes
+ * @param {string} otherObjectName - name of the object containing an 'other' input
  * @returns {boolean} true if the page should display, false otherwise
  */
-export function showSummaryPage(formData, checkboxObjectName) {
+export function showSummaryPage(formData, checkboxObjectName, otherObjectName) {
   return (
     isClaimingTECondition(formData) &&
     formData?.toxicExposure[checkboxObjectName] &&
     formData?.toxicExposure[checkboxObjectName].none !== true &&
-    Object.values(formData.toxicExposure[checkboxObjectName]).filter(
+    (Object.values(formData.toxicExposure[checkboxObjectName]).filter(
       value => value === true,
-    ).length > 0
+    ).length > 0 ||
+      getOtherFieldDescription(formData, otherObjectName))
   );
 }
 

--- a/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
@@ -247,19 +247,37 @@ export function validateTEConditions(errors, formData) {
 }
 
 /**
+ * Get the value for the 'other' field's description
+ * @param {object} formData - full form data
+ * @param {string} objectName - name of the object containing the 'other' field
+ * @returns {string} sanitized description value if present
+ */
+export function getOtherFieldDescription(formData, objectName) {
+  const description = formData?.toxicExposure?.[objectName]?.description;
+
+  return typeof description === 'string' ? description.trim() : '';
+}
+
+/**
  * Validates selected locations (e.g. gulfWar1990Locations, gulfWar2001Locations, etc.).
  * If the 'none' checkbox is selected along with another location, adds an error.
  *
  * @param {object} errors - Errors object from rjsf
  * @param {object} formData
  * @param {string} objectName - Name of the object to look at in the form data
+ * @param {string} otherObjectName - Name of the object containing other location or other hazard data
  */
-export function validateLocations(errors, formData, objectName) {
+export function validateLocations(
+  errors,
+  formData,
+  objectName,
+  otherObjectName,
+) {
   const { [objectName]: locations = {} } = formData?.toxicExposure;
-
   if (
     locations?.none === true &&
-    Object.values(locations).filter(value => value === true).length > 1
+    (Object.values(locations).filter(value => value === true).length > 1 ||
+      getOtherFieldDescription(formData, otherObjectName))
   ) {
     errors.toxicExposure[objectName].addError(noneAndLocationError);
   }
@@ -303,18 +321,6 @@ export function getKeyIndex(key, objectName, formData) {
     }
   }
   return 0;
-}
-
-/**
- * Get the value for the 'other' field's description
- * @param {object} formData - full form data
- * @param {string} objectName - name of the object containing the 'other' field
- * @returns {string} sanitized description value if present
- */
-export function getOtherFieldDescription(formData, objectName) {
-  const description = formData?.toxicExposure?.[objectName]?.description;
-
-  return typeof description === 'string' ? description.trim() : '';
 }
 
 /**

--- a/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
@@ -395,7 +395,7 @@ export function showSummaryPage(formData, checkboxObjectName, otherObjectName) {
     (Object.values(formData.toxicExposure[checkboxObjectName]).filter(
       value => value === true,
     ).length > 0 ||
-      getOtherFieldDescription(formData, otherObjectName))
+      !!getOtherFieldDescription(formData, otherObjectName))
   );
 }
 

--- a/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
@@ -391,3 +391,15 @@ export function datesDescription(dates) {
   const endDate = formatMonthYearDate(dates?.endDate) || 'No end date entered';
   return `${startDate} - ${endDate}`;
 }
+
+/**
+ * Get the value for the other field's description
+ * @param {object} formData
+ * @param {*} objectName
+ * @returns {string} sanitized description value if present
+ */
+export function getOtherFieldDescription(formData, objectName) {
+  const description = formData?.toxicExposure?.[objectName]?.description;
+
+  return typeof description === 'string' ? description.trim() : '';
+}

--- a/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
@@ -111,6 +111,10 @@ export function dateRangePageDescription(
   );
 }
 
+export const herbicidePageTitle = 'Agent Orange locations';
+export const herbicideQuestion =
+  'Did you serve in any of these locations where the military used the herbicide Agent Orange? Check any locations where you served.';
+
 /* ---------- utils ---------- */
 /**
  * Checks if the toxic exposure pages should be displayed using the following criteria

--- a/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
@@ -283,7 +283,7 @@ export function validateLocations(errors, formData, objectName) {
  * @param {object} formData - full formData for the form
  * @returns {number} - index of the key within the list of selected items if found, 0 otherwise
  */
-export function getKeyIndex(key, objectName, { formData }) {
+export function getKeyIndex(key, objectName, formData) {
   if (
     !formData ||
     !formData?.toxicExposure ||
@@ -313,7 +313,7 @@ export function getKeyIndex(key, objectName, { formData }) {
  * @param {object} formData - full formData for the form
  * @returns {number} count of checkboxes with a value of true
  */
-export function getSelectedCount(objectName, { formData } = {}) {
+export function getSelectedCount(objectName, formData) {
   if (
     !formData ||
     !formData?.toxicExposure ||

--- a/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
@@ -306,24 +306,43 @@ export function getKeyIndex(key, objectName, formData) {
 }
 
 /**
+ * Get the value for the 'other' field's description
+ * @param {object} formData - full form data
+ * @param {string} objectName - name of the object containing the 'other' field
+ * @returns {string} sanitized description value if present
+ */
+export function getOtherFieldDescription(formData, objectName) {
+  const description = formData?.toxicExposure?.[objectName]?.description;
+
+  return typeof description === 'string' ? description.trim() : '';
+}
+
+/**
  * Given an object storing checkbox values, get a count of how many values have been selected
  * by the Veteran
  *
- * @param {string} objectName - name of the object to look at in the form data
+ * @param {string} checkboxObjectName - name of the checkbox object to look at in the form data
+ * @param {string} otherFieldName - name of the 'other' field to look at in the form data
  * @param {object} formData - full formData for the form
  * @returns {number} count of checkboxes with a value of true
  */
-export function getSelectedCount(objectName, formData) {
-  if (
-    !formData ||
-    !formData?.toxicExposure ||
-    !formData?.toxicExposure[objectName]
-  )
+export function getSelectedCount(
+  checkboxObjectName,
+  formData,
+  otherFieldName = '',
+) {
+  const otherFieldDescription = getOtherFieldDescription(
+    formData,
+    otherFieldName,
+  );
+  if (!formData?.toxicExposure?.[checkboxObjectName] && !otherFieldDescription)
     return 0;
 
-  return Object.values(formData.toxicExposure[objectName]).filter(
-    value => value === true,
-  ).length;
+  return (
+    Object.values(formData.toxicExposure[checkboxObjectName]).filter(
+      value => value === true,
+    ).length + (otherFieldDescription ? 1 : 0)
+  );
 }
 
 /**
@@ -390,16 +409,4 @@ export function datesDescription(dates) {
     formatMonthYearDate(dates?.startDate) || 'No start date entered';
   const endDate = formatMonthYearDate(dates?.endDate) || 'No end date entered';
   return `${startDate} - ${endDate}`;
-}
-
-/**
- * Get the value for the other field's description
- * @param {object} formData
- * @param {*} objectName
- * @returns {string} sanitized description value if present
- */
-export function getOtherFieldDescription(formData, objectName) {
-  const description = formData?.toxicExposure?.[objectName]?.description;
-
-  return typeof description === 'string' ? description.trim() : '';
 }

--- a/src/applications/disability-benefits/all-claims/content/toxicExposureSummary.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposureSummary.jsx
@@ -1,29 +1,31 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import { formSubtitle } from '../utils';
-import { datesDescription, goBackLink } from './toxicExposure';
+import {
+  datesDescription,
+  getOtherFieldDescription,
+  goBackLink,
+} from './toxicExposure';
 
 /**
  * Summary list used for the end of a Checkbox and Loop flow of the various Toxic Exposure pages
- * @param {object} formData - data for the form
- * @param {string} checkboxObjectName - name of the object containing the checkboxes
- * @param {object} checkboxDefinitions - constant providing the mapping of checkbox keys to display values
- * @param {string} datesObjectName - name of the object containing the locations and date ranges
- * @param {string} goBackDescription - aria label for the go back link
- * @param {string} goBackUrlPath - path to the first page of this Checkbox and Loop flow
- * @returns component for toxic exposure summary
  */
-export function toxicExposureSummary(
-  { formData },
+export function ToxicExposureSummary({
+  formData,
   checkboxObjectName,
   checkboxDefinitions,
   datesObjectName,
+  otherObjectName = '',
   goBackDescription,
   goBackUrlPath,
-) {
+}) {
   const { toxicExposure } = formData;
   const checkboxes = toxicExposure[checkboxObjectName];
-
+  const otherFieldDescription = getOtherFieldDescription(
+    formData,
+    otherObjectName,
+  );
   return (
     <>
       {formSubtitle('Summary')}
@@ -32,9 +34,9 @@ export function toxicExposureSummary(
           return (
             checkboxes[item] === true && (
               <li key={item}>
-                <h5 className="vads-u-font-size--h6">
+                <strong className="vads-u-font-size--h6">
                   {checkboxDefinitions[item]}
-                </h5>
+                </strong>
                 <p className="vads-u-margin-y--1">
                   {datesDescription(toxicExposure[datesObjectName][item])}
                 </p>
@@ -42,6 +44,16 @@ export function toxicExposureSummary(
             )
           );
         })}
+        {otherFieldDescription && (
+          <li key="other">
+            <strong className="vads-u-font-size--h6">
+              {toxicExposure[otherObjectName].description}
+            </strong>
+            <p className="vads-u-margin-y--1">
+              {datesDescription(toxicExposure[otherObjectName])}
+            </p>
+          </li>
+        )}
       </ul>
       <p>
         <Link
@@ -57,3 +69,36 @@ export function toxicExposureSummary(
     </>
   );
 }
+
+ToxicExposureSummary.propTypes = {
+  /**
+   * Data for the form
+   */
+  formData: PropTypes.shape({
+    toxicExposure: PropTypes.any,
+  }).isRequired,
+  /**
+   * Constant providing the mapping of checkbox keys to display values
+   */
+  checkboxDefinitions: PropTypes.any,
+  /**
+   * Name of the object containing the checkboxes
+   */
+  checkboxObjectName: PropTypes.any,
+  /**
+   * Name of the object containing the locations and date ranges
+   */
+  datesObjectName: PropTypes.string,
+  /**
+   * Aria label for the go back link
+   */
+  goBackDescription: PropTypes.string,
+  /**
+   * Path to the first page of this Checkbox and Loop flow
+   */
+  goBackUrlPath: PropTypes.any,
+  /**
+   * Name of the object containg an 'other' field info
+   */
+  otherObjectName: PropTypes.string,
+};

--- a/src/applications/disability-benefits/all-claims/content/toxicExposureSummary.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposureSummary.jsx
@@ -26,6 +26,7 @@ export function ToxicExposureSummary({
     formData,
     otherObjectName,
   );
+
   return (
     <>
       {formSubtitle('Summary')}
@@ -72,31 +73,31 @@ export function ToxicExposureSummary({
 
 ToxicExposureSummary.propTypes = {
   /**
+   * Constant providing the mapping of checkbox keys to display values
+   */
+  checkboxDefinitions: PropTypes.object.isRequired,
+  /**
+   * Name of the object containing the checkboxes
+   */
+  checkboxObjectName: PropTypes.string.isRequired,
+  /**
+   * Name of the object containing the locations and date ranges
+   */
+  datesObjectName: PropTypes.string.isRequired,
+  /**
    * Data for the form
    */
   formData: PropTypes.shape({
     toxicExposure: PropTypes.any,
   }).isRequired,
   /**
-   * Constant providing the mapping of checkbox keys to display values
+   * Path to the first page of this Checkbox and Loop flow
    */
-  checkboxDefinitions: PropTypes.any,
-  /**
-   * Name of the object containing the checkboxes
-   */
-  checkboxObjectName: PropTypes.any,
-  /**
-   * Name of the object containing the locations and date ranges
-   */
-  datesObjectName: PropTypes.string,
+  goBackUrlPath: PropTypes.string.isRequired,
   /**
    * Aria label for the go back link
    */
   goBackDescription: PropTypes.string,
-  /**
-   * Path to the first page of this Checkbox and Loop flow
-   */
-  goBackUrlPath: PropTypes.any,
   /**
    * Name of the object containg an 'other' field info
    */

--- a/src/applications/disability-benefits/all-claims/pages/index.js
+++ b/src/applications/disability-benefits/all-claims/pages/index.js
@@ -22,6 +22,8 @@ import * as gulfWar1990Summary from './toxicExposure/gulfWar1990Summary';
 import * as gulfWar2001Locations from './toxicExposure/gulfWar2001Locations';
 import * as gulfWar2001Details from './toxicExposure/gulfWar2001Details';
 import * as gulfWar2001Summary from './toxicExposure/gulfWar2001Summary';
+import * as herbicideLocations from './toxicExposure/herbicideLocations';
+import * as herbicideDetails from './toxicExposure/herbicideDetails';
 import * as homelessOrAtRisk from './homelessOrAtRisk';
 import * as hospitalizationHistory from './hospitalizationHistory';
 import * as incidentDate from './incidentDate';
@@ -133,6 +135,8 @@ export {
   gulfWar2001Locations,
   gulfWar2001Details,
   gulfWar2001Summary,
+  herbicideLocations,
+  herbicideDetails,
   homelessOrAtRisk,
   hospitalizationHistory,
   incidentDate,

--- a/src/applications/disability-benefits/all-claims/pages/index.js
+++ b/src/applications/disability-benefits/all-claims/pages/index.js
@@ -24,6 +24,7 @@ import * as gulfWar2001Details from './toxicExposure/gulfWar2001Details';
 import * as gulfWar2001Summary from './toxicExposure/gulfWar2001Summary';
 import * as herbicideLocations from './toxicExposure/herbicideLocations';
 import * as herbicideDetails from './toxicExposure/herbicideDetails';
+import * as herbicideOtherLocations from './toxicExposure/herbicideOtherLocations';
 import * as homelessOrAtRisk from './homelessOrAtRisk';
 import * as hospitalizationHistory from './hospitalizationHistory';
 import * as incidentDate from './incidentDate';
@@ -137,6 +138,7 @@ export {
   gulfWar2001Summary,
   herbicideLocations,
   herbicideDetails,
+  herbicideOtherLocations,
   homelessOrAtRisk,
   hospitalizationHistory,
   incidentDate,

--- a/src/applications/disability-benefits/all-claims/pages/index.js
+++ b/src/applications/disability-benefits/all-claims/pages/index.js
@@ -25,6 +25,7 @@ import * as gulfWar2001Summary from './toxicExposure/gulfWar2001Summary';
 import * as herbicideLocations from './toxicExposure/herbicideLocations';
 import * as herbicideDetails from './toxicExposure/herbicideDetails';
 import * as herbicideOtherLocations from './toxicExposure/herbicideOtherLocations';
+import * as herbicideSummary from './toxicExposure/herbicideSummary';
 import * as homelessOrAtRisk from './homelessOrAtRisk';
 import * as hospitalizationHistory from './hospitalizationHistory';
 import * as incidentDate from './incidentDate';
@@ -139,6 +140,7 @@ export {
   herbicideLocations,
   herbicideDetails,
   herbicideOtherLocations,
+  herbicideSummary,
   homelessOrAtRisk,
   hospitalizationHistory,
   incidentDate,

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
@@ -24,7 +24,7 @@ import { GULF_WAR_1990_LOCATIONS, TE_URL_PREFIX } from '../../constants';
 function makeUiSchema(locationId) {
   return {
     'ui:title': formTitle(gulfWar1990PageTitle),
-    'ui:description': formData =>
+    'ui:description': ({ formData }) =>
       dateRangePageDescription(
         getKeyIndex(locationId, 'gulfWar1990', formData),
         getSelectedCount('gulfWar1990', formData),
@@ -110,8 +110,8 @@ export function makePages() {
         [pageName]: {
           title: formData =>
             teSubtitle(
-              getKeyIndex(locationId, 'gulfWar1990', { formData }),
-              getSelectedCount('gulfWar1990', { formData }),
+              getKeyIndex(locationId, 'gulfWar1990', formData),
+              getSelectedCount('gulfWar1990', formData),
               GULF_WAR_1990_LOCATIONS[locationId],
             ),
           path: `${TE_URL_PREFIX}/${pageName}`,

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
@@ -35,11 +35,9 @@ function makeUiSchema(locationId) {
         [locationId]: {
           startDate: currentOrPastDateUI({
             title: startDateApproximate,
-            monthYearOnly: true,
           }),
           endDate: currentOrPastDateUI({
             title: endDateApproximate,
-            monthYearOnly: true,
           }),
         },
       },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Summary.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Summary.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { GULF_WAR_1990_LOCATIONS, TE_URL_PREFIX } from '../../constants';
-import { ToxicExposureSummary } from '../../content/toxicExposureSummary';
+import { ToxicExposureSummary } from '../../components/ToxicExposureSummary';
 import { gulfWar1990PageTitle } from '../../content/toxicExposure';
 import { formTitle } from '../../utils';
 

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Summary.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Summary.js
@@ -1,19 +1,21 @@
+import React from 'react';
 import { GULF_WAR_1990_LOCATIONS, TE_URL_PREFIX } from '../../constants';
-import { toxicExposureSummary } from '../../content/toxicExposureSummary';
+import { ToxicExposureSummary } from '../../content/toxicExposureSummary';
 import { gulfWar1990PageTitle } from '../../content/toxicExposure';
 import { formTitle } from '../../utils';
 
 export const uiSchema = {
   'ui:title': formTitle(gulfWar1990PageTitle),
-  'ui:description': formData =>
-    toxicExposureSummary(
-      formData,
-      'gulfWar1990',
-      GULF_WAR_1990_LOCATIONS,
-      'gulfWar1990Details',
-      'go back and edit locations and dates for service after August 2, 1990',
-      `${TE_URL_PREFIX}/gulf-war-1990`,
-    ),
+  'ui:description': ({ formData }) => (
+    <ToxicExposureSummary
+      formData={formData}
+      checkboxObjectName="gulfWar1990"
+      checkboxDefinitions={GULF_WAR_1990_LOCATIONS}
+      datesObjectName="gulfWar1990Details"
+      goBackDescription="go back and edit locations and dates for service after August 2, 1990"
+      goBackUrlPath={`${TE_URL_PREFIX}/gulf-war-1990`}
+    />
+  ),
 };
 
 export const schema = {

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
@@ -24,7 +24,7 @@ import { GULF_WAR_2001_LOCATIONS, TE_URL_PREFIX } from '../../constants';
 function makeUiSchema(locationId) {
   return {
     'ui:title': formTitle(gulfWar2001PageTitle),
-    'ui:description': formData =>
+    'ui:description': ({ formData }) =>
       dateRangePageDescription(
         getKeyIndex(locationId, 'gulfWar2001', formData),
         getSelectedCount('gulfWar2001', formData),
@@ -111,8 +111,8 @@ export function makePages() {
         [pageName]: {
           title: formData =>
             teSubtitle(
-              getKeyIndex(locationId, 'gulfWar2001', { formData }),
-              getSelectedCount('gulfWar2001', { formData }),
+              getKeyIndex(locationId, 'gulfWar2001', formData),
+              getSelectedCount('gulfWar2001', formData),
               GULF_WAR_2001_LOCATIONS[locationId],
             ),
           path: `${TE_URL_PREFIX}/${pageName}`,

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
@@ -35,11 +35,9 @@ function makeUiSchema(locationId) {
         [locationId]: {
           startDate: currentOrPastDateUI({
             title: startDateApproximate,
-            monthYearOnly: true,
           }),
           endDate: currentOrPastDateUI({
             title: endDateApproximate,
-            monthYearOnly: true,
           }),
         },
       },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Summary.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Summary.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { GULF_WAR_2001_LOCATIONS, TE_URL_PREFIX } from '../../constants';
 import { gulfWar2001PageTitle } from '../../content/toxicExposure';
-import { ToxicExposureSummary } from '../../content/toxicExposureSummary';
+import { ToxicExposureSummary } from '../../components/ToxicExposureSummary';
 import { formTitle } from '../../utils';
 
 export const uiSchema = {

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Summary.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Summary.js
@@ -1,19 +1,21 @@
+import React from 'react';
 import { GULF_WAR_2001_LOCATIONS, TE_URL_PREFIX } from '../../constants';
 import { gulfWar2001PageTitle } from '../../content/toxicExposure';
-import { toxicExposureSummary } from '../../content/toxicExposureSummary';
+import { ToxicExposureSummary } from '../../content/toxicExposureSummary';
 import { formTitle } from '../../utils';
 
 export const uiSchema = {
   'ui:title': formTitle(gulfWar2001PageTitle),
-  'ui:description': formData =>
-    toxicExposureSummary(
-      formData,
-      'gulfWar2001',
-      GULF_WAR_2001_LOCATIONS,
-      'gulfWar2001Details',
-      'go back and edit locations and dates for service post-9/11',
-      `${TE_URL_PREFIX}/gulf-war-2001`,
-    ),
+  'ui:description': ({ formData }) => (
+    <ToxicExposureSummary
+      formData={formData}
+      checkboxObjectName="gulfWar2001"
+      checkboxDefinitions={GULF_WAR_2001_LOCATIONS}
+      datesObjectName="gulfWar2001Details"
+      goBackDescription="go back and edit locations and dates for service post-9/11"
+      goBackUrlPath={`${TE_URL_PREFIX}/gulf-war-2001`}
+    />
+  ),
 };
 
 export const schema = {

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
@@ -1,0 +1,105 @@
+import {
+  currentOrPastDateUI,
+  currentOrPastDateSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { formTitle } from '../../utils';
+import {
+  dateRangePageDescription,
+  endDateApproximate,
+  getKeyIndex,
+  getSelectedCount,
+  herbicidePageTitle,
+  showCheckboxLoopDetailsPage,
+  startDateApproximate,
+  teSubtitle,
+} from '../../content/toxicExposure';
+import { HERBICIDE_LOCATIONS, TE_URL_PREFIX } from '../../constants';
+
+/**
+ * Make the uiSchema for each herbicide details page
+ * @param {string} locationId - unique id for the location
+ * @returns {object} uiSchema object
+ */
+function makeUiSchema(locationId) {
+  return {
+    'ui:title': formTitle(herbicidePageTitle),
+    'ui:description': ({ formData }) => {
+      return dateRangePageDescription(
+        getKeyIndex(locationId, 'herbicide', formData),
+        getSelectedCount('herbicide', formData) +
+          (formData.toxicExposure?.otherHerbicideLocation ? 1 : 0),
+        HERBICIDE_LOCATIONS[locationId],
+      );
+    },
+    herbicideDetails: {
+      [locationId]: {
+        startDate: currentOrPastDateUI({
+          title: startDateApproximate,
+          monthYearOnly: true,
+        }),
+        endDate: currentOrPastDateUI({
+          title: endDateApproximate,
+          monthYearOnly: true,
+        }),
+      },
+    },
+    'view:herbicideAdditionalInfo': {
+      'ui:description': 'additional info',
+    },
+  };
+}
+
+/**
+ * Make the schema for each herbicide details page
+ * @param {string} locationId - unique id for the location
+ * @returns {object} - schema object
+ */
+function makeSchema(locationId) {
+  return {
+    type: 'object',
+    properties: {
+      herbicideDetails: {
+        type: 'object',
+        properties: {
+          [locationId]: {
+            type: 'object',
+            properties: {
+              startDate: currentOrPastDateSchema,
+              endDate: currentOrPastDateSchema,
+            },
+          },
+        },
+      },
+      'view:herbicideAdditionalInfo': {
+        type: 'object',
+        properties: {},
+      },
+    },
+  };
+}
+
+export function makePages() {
+  const herbicideLocationPagesList = Object.keys(HERBICIDE_LOCATIONS)
+    .filter(locationId => locationId !== 'none')
+    .map(locationId => {
+      const pageName = `herbicide-location-${locationId}`;
+      return {
+        [pageName]: {
+          title: formData =>
+            teSubtitle(
+              getKeyIndex(locationId, 'herbicide', formData),
+              getSelectedCount('herbicide', formData) +
+                (formData.toxicExposure?.otherHerbicideLocation ? 1 : 0),
+              HERBICIDE_LOCATIONS[locationId],
+            ),
+          path: `${TE_URL_PREFIX}/${pageName}`,
+          uiSchema: makeUiSchema(locationId),
+          schema: makeSchema(locationId),
+          depends: formData =>
+            showCheckboxLoopDetailsPage(formData, 'herbicide', locationId),
+        },
+      };
+    });
+
+  return Object.assign({}, ...herbicideLocationPagesList);
+}

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
@@ -8,7 +8,6 @@ import {
   dateRangePageDescription,
   endDateApproximate,
   getKeyIndex,
-  getOtherFieldDescription,
   getSelectedCount,
   herbicidePageTitle,
   showCheckboxLoopDetailsPage,
@@ -28,10 +27,7 @@ function makeUiSchema(locationId) {
     'ui:description': ({ formData }) =>
       dateRangePageDescription(
         getKeyIndex(locationId, 'herbicide', formData),
-        getSelectedCount('herbicide', formData) +
-          (getOtherFieldDescription(formData, 'otherHerbicideLocations')
-            ? 1
-            : 0),
+        getSelectedCount('herbicide', formData, 'otherHerbicideLocations'),
         HERBICIDE_LOCATIONS[locationId],
       ),
     toxicExposure: {
@@ -76,10 +72,10 @@ function makeSchema(locationId) {
               },
             },
           },
-        },
-        'view:herbicideAdditionalInfo': {
-          type: 'object',
-          properties: {},
+          'view:herbicideAdditionalInfo': {
+            type: 'object',
+            properties: {},
+          },
         },
       },
     },
@@ -96,10 +92,11 @@ export function makePages() {
           title: formData =>
             teSubtitle(
               getKeyIndex(locationId, 'herbicide', formData),
-              getSelectedCount('herbicide', formData) +
-                (getOtherFieldDescription(formData, 'otherHerbicideLocations')
-                  ? 1
-                  : 0),
+              getSelectedCount(
+                'herbicide',
+                formData,
+                'otherHerbicideLocations',
+              ),
               HERBICIDE_LOCATIONS[locationId],
             ),
           path: `${TE_URL_PREFIX}/${pageName}`,

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
@@ -4,9 +4,11 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import { formTitle } from '../../utils';
 import {
+  dateRangeAdditionalInfo,
   dateRangePageDescription,
   endDateApproximate,
   getKeyIndex,
+  getOtherFieldDescription,
   getSelectedCount,
   herbicidePageTitle,
   showCheckboxLoopDetailsPage,
@@ -23,28 +25,29 @@ import { HERBICIDE_LOCATIONS, TE_URL_PREFIX } from '../../constants';
 function makeUiSchema(locationId) {
   return {
     'ui:title': formTitle(herbicidePageTitle),
-    'ui:description': ({ formData }) => {
-      return dateRangePageDescription(
+    'ui:description': ({ formData }) =>
+      dateRangePageDescription(
         getKeyIndex(locationId, 'herbicide', formData),
         getSelectedCount('herbicide', formData) +
-          (formData.toxicExposure?.otherHerbicideLocation ? 1 : 0),
+          (getOtherFieldDescription(formData, 'otherHerbicideLocations')
+            ? 1
+            : 0),
         HERBICIDE_LOCATIONS[locationId],
-      );
-    },
-    herbicideDetails: {
-      [locationId]: {
-        startDate: currentOrPastDateUI({
-          title: startDateApproximate,
-          monthYearOnly: true,
-        }),
-        endDate: currentOrPastDateUI({
-          title: endDateApproximate,
-          monthYearOnly: true,
-        }),
+      ),
+    toxicExposure: {
+      herbicideDetails: {
+        [locationId]: {
+          startDate: currentOrPastDateUI({
+            title: startDateApproximate,
+          }),
+          endDate: currentOrPastDateUI({
+            title: endDateApproximate,
+          }),
+        },
       },
-    },
-    'view:herbicideAdditionalInfo': {
-      'ui:description': 'additional info',
+      'view:herbicideAdditionalInfo': {
+        'ui:description': dateRangeAdditionalInfo,
+      },
     },
   };
 }
@@ -58,21 +61,26 @@ function makeSchema(locationId) {
   return {
     type: 'object',
     properties: {
-      herbicideDetails: {
+      toxicExposure: {
         type: 'object',
         properties: {
-          [locationId]: {
+          herbicideDetails: {
             type: 'object',
             properties: {
-              startDate: currentOrPastDateSchema,
-              endDate: currentOrPastDateSchema,
+              [locationId]: {
+                type: 'object',
+                properties: {
+                  startDate: currentOrPastDateSchema,
+                  endDate: currentOrPastDateSchema,
+                },
+              },
             },
           },
         },
-      },
-      'view:herbicideAdditionalInfo': {
-        type: 'object',
-        properties: {},
+        'view:herbicideAdditionalInfo': {
+          type: 'object',
+          properties: {},
+        },
       },
     },
   };
@@ -89,7 +97,9 @@ export function makePages() {
             teSubtitle(
               getKeyIndex(locationId, 'herbicide', formData),
               getSelectedCount('herbicide', formData) +
-                (formData.toxicExposure?.otherHerbicideLocation ? 1 : 0),
+                (getOtherFieldDescription(formData, 'otherHerbicideLocations')
+                  ? 1
+                  : 0),
               HERBICIDE_LOCATIONS[locationId],
             ),
           path: `${TE_URL_PREFIX}/${pageName}`,

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideLocations.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideLocations.js
@@ -6,6 +6,7 @@ import {
 import {
   herbicidePageTitle,
   herbicideQuestion,
+  validateLocations,
 } from '../../content/toxicExposure';
 import { formTitle } from '../../utils';
 import { HERBICIDE_LOCATIONS } from '../../constants';
@@ -21,10 +22,21 @@ export const uiSchema = {
     otherHerbicideLocations: {
       description: textareaUI({
         title: 'Other locations not listed here (250 characters maximum)',
-        // TODO: add LH regex
       }),
     },
   },
+  'ui:validations': [
+    {
+      validator: (errors, formData) => {
+        validateLocations(
+          errors,
+          formData,
+          'herbicide',
+          'otherHerbicideLocations',
+        );
+      },
+    },
+  ],
 };
 
 export const schema = {
@@ -39,6 +51,7 @@ export const schema = {
           properties: {
             description: {
               type: 'string',
+              pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
               maxLength: 250,
             },
           },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideLocations.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideLocations.js
@@ -1,0 +1,34 @@
+import {
+  checkboxGroupUI,
+  checkboxGroupSchema,
+  textareaUI,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import {
+  herbicidePageTitle,
+  herbicideQuestion,
+} from '../../content/toxicExposure';
+import { formTitle } from '../../utils';
+import { HERBICIDE_LOCATIONS } from '../../constants';
+
+export const uiSchema = {
+  'ui:title': formTitle(herbicidePageTitle),
+  herbicide: checkboxGroupUI({
+    title: herbicideQuestion,
+    labels: HERBICIDE_LOCATIONS,
+    required: false,
+  }),
+  otherHerbicideLocation: textareaUI({
+    title: 'Other locations not listed here',
+  }),
+};
+
+export const schema = {
+  type: 'object',
+  properties: {
+    herbicide: checkboxGroupSchema(Object.keys(HERBICIDE_LOCATIONS)),
+    otherHerbicideLocation: {
+      type: 'string',
+      maxLength: 250,
+    },
+  },
+};

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideLocations.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideLocations.js
@@ -18,10 +18,12 @@ export const uiSchema = {
       labels: HERBICIDE_LOCATIONS,
       required: false,
     }),
-    otherHerbicideLocation: textareaUI({
-      title: 'Other locations not listed here (250 characters maximum)',
-      // TODO: add LH regex
-    }),
+    otherHerbicideLocations: {
+      description: textareaUI({
+        title: 'Other locations not listed here (250 characters maximum)',
+        // TODO: add LH regex
+      }),
+    },
   },
 };
 
@@ -32,9 +34,14 @@ export const schema = {
       type: 'object',
       properties: {
         herbicide: checkboxGroupSchema(Object.keys(HERBICIDE_LOCATIONS)),
-        otherHerbicideLocation: {
-          type: 'string',
-          maxLength: 250,
+        otherHerbicideLocations: {
+          type: 'object',
+          properties: {
+            description: {
+              type: 'string',
+              maxLength: 250,
+            },
+          },
         },
       },
     },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideLocations.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideLocations.js
@@ -12,23 +12,31 @@ import { HERBICIDE_LOCATIONS } from '../../constants';
 
 export const uiSchema = {
   'ui:title': formTitle(herbicidePageTitle),
-  herbicide: checkboxGroupUI({
-    title: herbicideQuestion,
-    labels: HERBICIDE_LOCATIONS,
-    required: false,
-  }),
-  otherHerbicideLocation: textareaUI({
-    title: 'Other locations not listed here',
-  }),
+  toxicExposure: {
+    herbicide: checkboxGroupUI({
+      title: herbicideQuestion,
+      labels: HERBICIDE_LOCATIONS,
+      required: false,
+    }),
+    otherHerbicideLocation: textareaUI({
+      title: 'Other locations not listed here (250 characters maximum)',
+      // TODO: add LH regex
+    }),
+  },
 };
 
 export const schema = {
   type: 'object',
   properties: {
-    herbicide: checkboxGroupSchema(Object.keys(HERBICIDE_LOCATIONS)),
-    otherHerbicideLocation: {
-      type: 'string',
-      maxLength: 250,
+    toxicExposure: {
+      type: 'object',
+      properties: {
+        herbicide: checkboxGroupSchema(Object.keys(HERBICIDE_LOCATIONS)),
+        otherHerbicideLocation: {
+          type: 'string',
+          maxLength: 250,
+        },
+      },
     },
   },
 };

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
@@ -16,7 +16,11 @@ import { formTitle } from '../../utils';
 export const uiSchema = {
   'ui:title': formTitle(herbicidePageTitle),
   'ui:description': ({ formData }) => {
-    const indexAndSelectedCount = getSelectedCount('herbicide', formData) + 1;
+    const indexAndSelectedCount = getSelectedCount(
+      'herbicide',
+      formData,
+      'otherHerbicideLocations',
+    );
     return dateRangePageDescription(
       indexAndSelectedCount,
       indexAndSelectedCount,

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
@@ -1,0 +1,61 @@
+import {
+  currentOrPastDateUI,
+  currentOrPastDateSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import {
+  dateRangeAdditionalInfo,
+  dateRangePageDescription,
+  endDateApproximate,
+  getOtherFieldDescription,
+  getSelectedCount,
+  herbicidePageTitle,
+  startDateApproximate,
+} from '../../content/toxicExposure';
+import { formTitle } from '../../utils';
+
+export const uiSchema = {
+  'ui:title': formTitle(herbicidePageTitle),
+  'ui:description': ({ formData }) => {
+    const indexAndSelectedCount = getSelectedCount('herbicide', formData) + 1;
+    return dateRangePageDescription(
+      indexAndSelectedCount,
+      indexAndSelectedCount,
+      getOtherFieldDescription(formData, 'otherHerbicideLocations'),
+    );
+  },
+  toxicExposure: {
+    otherHerbicideLocations: {
+      startDate: currentOrPastDateUI({
+        title: startDateApproximate,
+      }),
+      endDate: currentOrPastDateUI({
+        title: endDateApproximate,
+      }),
+    },
+    'view:herbicideAdditionalInfo': {
+      'ui:description': dateRangeAdditionalInfo,
+    },
+  },
+};
+
+export const schema = {
+  type: 'object',
+  properties: {
+    toxicExposure: {
+      type: 'object',
+      properties: {
+        otherHerbicideLocations: {
+          type: 'object',
+          properties: {
+            startDate: currentOrPastDateSchema,
+            endDate: currentOrPastDateSchema,
+          },
+        },
+        'view:herbicideAdditionalInfo': {
+          type: 'object',
+          properties: {},
+        },
+      },
+    },
+  },
+};

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideSummary.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideSummary.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { HERBICIDE_LOCATIONS, TE_URL_PREFIX } from '../../constants';
-import { ToxicExposureSummary } from '../../content/toxicExposureSummary';
+import { ToxicExposureSummary } from '../../components/ToxicExposureSummary';
 import { herbicidePageTitle } from '../../content/toxicExposure';
 import { formTitle } from '../../utils';
 

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideSummary.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideSummary.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { HERBICIDE_LOCATIONS, TE_URL_PREFIX } from '../../constants';
+import { ToxicExposureSummary } from '../../content/toxicExposureSummary';
+import { herbicidePageTitle } from '../../content/toxicExposure';
+import { formTitle } from '../../utils';
+
+export const uiSchema = {
+  'ui:title': formTitle(herbicidePageTitle),
+  'ui:description': ({ formData }) => (
+    <ToxicExposureSummary
+      formData={formData}
+      checkboxObjectName="herbicide"
+      checkboxDefinitions={HERBICIDE_LOCATIONS}
+      datesObjectName="herbicideDetails"
+      goBackDescription="go back and edit locations and dates for Agent Orange locations"
+      goBackUrlPath={`${TE_URL_PREFIX}/herbicide`}
+      otherObjectName="otherHerbicideLocations"
+    />
+  ),
+};
+
+export const schema = {
+  type: 'object',
+  properties: {},
+};

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
@@ -14,12 +14,14 @@ import { TE_URL_PREFIX } from '../../constants';
 import {
   conditionsPageTitle,
   getOtherFieldDescription,
+  getSelectedCount,
   gulfWar1990PageTitle,
   gulfWar2001PageTitle,
   herbicidePageTitle,
   isClaimingTECondition,
   showSummaryPage,
   showToxicExposurePages,
+  teSubtitle,
 } from '../../content/toxicExposure';
 
 export const toxicExposurePages = {
@@ -69,7 +71,12 @@ export const toxicExposurePages = {
   },
   ...herbicideDetails.makePages(),
   herbicideOtherLocations: {
-    title: 'Hazard n of n: <fill in>', // TODO
+    title: formData =>
+      teSubtitle(
+        getSelectedCount('herbicide', formData, 'otherHerbicideLocations'),
+        getSelectedCount('herbicide', formData, 'otherHerbicideLocations'),
+        getOtherFieldDescription(formData, 'otherHerbicideLocations'),
+      ),
     path: `${TE_URL_PREFIX}/herbicide-location-other`,
     depends: formData =>
       getOtherFieldDescription(formData, 'otherHerbicideLocations'),

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
@@ -7,6 +7,7 @@ import {
   gulfWar2001Details,
   gulfWar2001Summary,
   herbicideLocations,
+  herbicideDetails,
 } from '..';
 import { TE_URL_PREFIX } from '../../constants';
 import {
@@ -64,4 +65,5 @@ export const toxicExposurePages = {
     uiSchema: herbicideLocations.uiSchema,
     schema: herbicideLocations.schema,
   },
+  ...herbicideDetails.makePages(),
 };

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
@@ -9,6 +9,7 @@ import {
   herbicideLocations,
   herbicideDetails,
   herbicideOtherLocations,
+  herbicideSummary,
 } from '..';
 import { TE_URL_PREFIX } from '../../constants';
 import {
@@ -64,7 +65,7 @@ export const toxicExposurePages = {
   },
   herbicideLocations: {
     title: herbicidePageTitle,
-    path: 'herbicide-locations',
+    path: 'herbicide',
     depends: formData => isClaimingTECondition(formData),
     uiSchema: herbicideLocations.uiSchema,
     schema: herbicideLocations.schema,
@@ -82,5 +83,12 @@ export const toxicExposurePages = {
       getOtherFieldDescription(formData, 'otherHerbicideLocations'),
     uiSchema: herbicideOtherLocations.uiSchema,
     schema: herbicideOtherLocations.schema,
+  },
+  herbicideSummary: {
+    title: 'Summary of Agent Orange locations',
+    path: `${TE_URL_PREFIX}/herbicide-summary`,
+    depends: formData => showSummaryPage(formData, 'herbicide'),
+    uiSchema: herbicideSummary.uiSchema,
+    schema: herbicideSummary.schema,
   },
 };

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
@@ -6,12 +6,14 @@ import {
   gulfWar2001Locations,
   gulfWar2001Details,
   gulfWar2001Summary,
+  herbicideLocations,
 } from '..';
 import { TE_URL_PREFIX } from '../../constants';
 import {
   conditionsPageTitle,
   gulfWar1990PageTitle,
   gulfWar2001PageTitle,
+  herbicidePageTitle,
   isClaimingTECondition,
   showSummaryPage,
   showToxicExposurePages,
@@ -54,5 +56,12 @@ export const toxicExposurePages = {
     depends: formData => showSummaryPage(formData, 'gulfWar2001'),
     uiSchema: gulfWar2001Summary.uiSchema,
     schema: gulfWar2001Summary.schema,
+  },
+  herbicideLocations: {
+    title: herbicidePageTitle,
+    path: 'herbicide-locations',
+    depends: formData => isClaimingTECondition(formData),
+    uiSchema: herbicideLocations.uiSchema,
+    schema: herbicideLocations.schema,
   },
 };

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
@@ -8,10 +8,12 @@ import {
   gulfWar2001Summary,
   herbicideLocations,
   herbicideDetails,
+  herbicideOtherLocations,
 } from '..';
 import { TE_URL_PREFIX } from '../../constants';
 import {
   conditionsPageTitle,
+  getOtherFieldDescription,
   gulfWar1990PageTitle,
   gulfWar2001PageTitle,
   herbicidePageTitle,
@@ -66,4 +68,12 @@ export const toxicExposurePages = {
     schema: herbicideLocations.schema,
   },
   ...herbicideDetails.makePages(),
+  herbicideOtherLocations: {
+    title: 'Hazard n of n: <fill in>', // TODO
+    path: `${TE_URL_PREFIX}/herbicide-location-other`,
+    depends: formData =>
+      getOtherFieldDescription(formData, 'otherHerbicideLocations'),
+    uiSchema: herbicideOtherLocations.uiSchema,
+    schema: herbicideOtherLocations.schema,
+  },
 };

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
@@ -65,7 +65,7 @@ export const toxicExposurePages = {
   },
   herbicideLocations: {
     title: herbicidePageTitle,
-    path: 'herbicide',
+    path: `${TE_URL_PREFIX}/herbicide`,
     depends: formData => isClaimingTECondition(formData),
     uiSchema: herbicideLocations.uiSchema,
     schema: herbicideLocations.schema,

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/toxicExposurePages.js
@@ -87,7 +87,8 @@ export const toxicExposurePages = {
   herbicideSummary: {
     title: 'Summary of Agent Orange locations',
     path: `${TE_URL_PREFIX}/herbicide-summary`,
-    depends: formData => showSummaryPage(formData, 'herbicide'),
+    depends: formData =>
+      showSummaryPage(formData, 'herbicide', 'otherHerbicideLocations'),
     uiSchema: herbicideSummary.uiSchema,
     schema: herbicideSummary.schema,
   },

--- a/src/applications/disability-benefits/all-claims/tests/components/ToxicExposureSummary.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ToxicExposureSummary.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
-import { ToxicExposureSummary } from '../../content/toxicExposureSummary';
+import { ToxicExposureSummary } from '../../components/ToxicExposureSummary';
 import { GULF_WAR_1990_LOCATIONS, TE_URL_PREFIX } from '../../constants';
 import { goBackLink, noDatesEntered } from '../../content/toxicExposure';
 

--- a/src/applications/disability-benefits/all-claims/tests/content/toxicExposure.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/toxicExposure.unit.spec.jsx
@@ -381,8 +381,8 @@ describe('toxicExposure', () => {
         },
       };
 
-      expect(getKeyIndex('bahrain', 'gulfWar1990', { formData })).to.equal(1);
-      expect(getKeyIndex('airspace', 'gulfWar1990', { formData })).to.equal(2);
+      expect(getKeyIndex('bahrain', 'gulfWar1990', formData)).to.equal(1);
+      expect(getKeyIndex('airspace', 'gulfWar1990', formData)).to.equal(2);
     });
 
     it('returns 0 when location data not available', () => {
@@ -403,8 +403,8 @@ describe('toxicExposure', () => {
         },
       };
 
-      expect(getKeyIndex('egypt', 'gulfWar1990', { formData })).to.equal(0);
-      expect(getKeyIndex('bahrain', 'gulfWar1990', { formData })).to.equal(0);
+      expect(getKeyIndex('egypt', 'gulfWar1990', formData)).to.equal(0);
+      expect(getKeyIndex('bahrain', 'gulfWar1990', formData)).to.equal(0);
     });
   });
 
@@ -420,7 +420,7 @@ describe('toxicExposure', () => {
         },
       };
 
-      expect(getSelectedCount('gulfWar1990', { formData })).to.be.equal(2);
+      expect(getSelectedCount('gulfWar1990', formData)).to.be.equal(2);
     });
 
     it('gets 0 count when no items selected', () => {
@@ -434,7 +434,7 @@ describe('toxicExposure', () => {
         },
       };
 
-      expect(getSelectedCount('gulfWar1990', { formData })).to.be.equal(0);
+      expect(getSelectedCount('gulfWar1990', formData)).to.be.equal(0);
     });
 
     it('gets 0 count when no checkbox values', () => {
@@ -444,13 +444,13 @@ describe('toxicExposure', () => {
         },
       };
 
-      expect(getSelectedCount('gulfWar1990', { formData })).to.be.equal(0);
+      expect(getSelectedCount('gulfWar1990', formData)).to.be.equal(0);
     });
 
     it('gets 0 count when no checkbox object not found', () => {
       const formData = {};
 
-      expect(getSelectedCount('gulfWar1990', { formData })).to.be.equal(0);
+      expect(getSelectedCount('gulfWar1990', formData)).to.be.equal(0);
     });
 
     it('gets 0 count when no form data', () => {

--- a/src/applications/disability-benefits/all-claims/tests/content/toxicExposure.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/toxicExposure.unit.spec.jsx
@@ -6,6 +6,7 @@ import {
   dateRangePageDescription,
   datesDescription,
   getKeyIndex,
+  getOtherFieldDescription,
   getSelectedCount,
   isClaimingTECondition,
   makeTEConditionsSchema,
@@ -456,6 +457,43 @@ describe('toxicExposure', () => {
     it('gets 0 count when no form data', () => {
       expect(getSelectedCount('gulfWar1990', undefined)).to.be.equal(0);
     });
+
+    it('gets the count with a mix of selected and deselected items and other description', () => {
+      const formData = {
+        toxicExposure: {
+          herbicide: {
+            cambodia: true,
+            koreandemilitarizedzone: true,
+            laos: true,
+            vietnam: false,
+          },
+          otherHerbicideLocations: {
+            startDate: '1968-01-01',
+            endDate: '1969-01-01',
+            description: 'location 1, location 2',
+          },
+        },
+      };
+
+      expect(
+        getSelectedCount('herbicide', formData, 'otherHerbicideLocations'),
+      ).to.be.equal(4);
+    });
+
+    it('gets the count with other description only', () => {
+      const formData = {
+        toxicExposure: {
+          herbicide: {},
+          otherHerbicideLocations: {
+            description: 'location 1, location 2',
+          },
+        },
+      };
+
+      expect(
+        getSelectedCount('herbicide', formData, 'otherHerbicideLocations'),
+      ).to.be.equal(1);
+    });
   });
 
   describe('showCheckboxLoopDetailsPage', () => {
@@ -807,6 +845,23 @@ describe('toxicExposure', () => {
       expect(datesDescription(dates)).to.equal(
         'January 2022 - No end date entered',
       );
+    });
+  });
+
+  describe('getOtherFieldDescription', () => {
+    it('gets the trimmed value', () => {
+      const formData = {
+        toxicExposure: {
+          otherHerbicideLocations: {
+            startDate: '1968-01-01',
+            endDate: '1969-01-01',
+            description: ' location 1, location 2   ',
+          },
+        },
+      };
+      expect(
+        getOtherFieldDescription(formData, 'otherHerbicideLocations'),
+      ).to.equal('location 1, location 2');
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/content/toxicExposureSummary.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/toxicExposureSummary.unit.spec.jsx
@@ -1,8 +1,18 @@
+import React from 'react';
 import { render } from '@testing-library/react';
 import { expect } from 'chai';
-import { toxicExposureSummary } from '../../content/toxicExposureSummary';
+import { ToxicExposureSummary } from '../../content/toxicExposureSummary';
 import { GULF_WAR_1990_LOCATIONS, TE_URL_PREFIX } from '../../constants';
 import { goBackLink, noDatesEntered } from '../../content/toxicExposure';
+
+const props = {
+  checkboxObjectName: 'gulfWar1990',
+  checkboxDefinitions: GULF_WAR_1990_LOCATIONS,
+  datesObjectName: 'gulfWar1990Details',
+  goBackDescription:
+    'go back and edit locations and dates for service after August 2, 1990',
+  goBackUrlPath: `${TE_URL_PREFIX}/gulf-war-1990`,
+};
 
 describe('toxicExposureSummary', () => {
   it('renders when a location has no dates', () => {
@@ -16,14 +26,7 @@ describe('toxicExposureSummary', () => {
     };
 
     const tree = render(
-      toxicExposureSummary(
-        { formData },
-        'gulfWar1990',
-        GULF_WAR_1990_LOCATIONS,
-        'gulfWar1990Details',
-        'go back and edit locations and dates for service after August 2, 1990',
-        `${TE_URL_PREFIX}/gulf-war-1990`,
-      ),
+      <ToxicExposureSummary formData={formData} {...props} />,
     );
 
     tree.getByText('Summary');
@@ -53,14 +56,7 @@ describe('toxicExposureSummary', () => {
     };
 
     const tree = render(
-      toxicExposureSummary(
-        { formData },
-        'gulfWar1990',
-        GULF_WAR_1990_LOCATIONS,
-        'gulfWar1990Details',
-        'go back and edit locations and dates for service after August 2, 1990',
-        `${TE_URL_PREFIX}/gulf-war-1990`,
-      ),
+      <ToxicExposureSummary formData={formData} {...props} />,
     );
 
     tree.getByText('Summary');
@@ -94,14 +90,7 @@ describe('toxicExposureSummary', () => {
     };
 
     const tree = render(
-      toxicExposureSummary(
-        { formData },
-        'gulfWar1990',
-        GULF_WAR_1990_LOCATIONS,
-        'gulfWar1990Details',
-        'go back and edit locations and dates for service after August 2, 1990',
-        `${TE_URL_PREFIX}/gulf-war-1990`,
-      ),
+      <ToxicExposureSummary formData={formData} {...props} />,
     );
 
     tree.getByText('Summary');
@@ -138,14 +127,7 @@ describe('toxicExposureSummary', () => {
     };
 
     const { queryByText } = render(
-      toxicExposureSummary(
-        { formData },
-        'gulfWar1990',
-        GULF_WAR_1990_LOCATIONS,
-        'gulfWar1990Details',
-        'go back and edit locations and dates for service after August 2, 1990',
-        `${TE_URL_PREFIX}/gulf-war-1990`,
-      ),
+      <ToxicExposureSummary formData={formData} {...props} />,
     );
 
     expect(queryByText(GULF_WAR_1990_LOCATIONS.waters)).to.exist;

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-toxic-exposure-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-toxic-exposure-test.json
@@ -165,6 +165,31 @@
           "startDate": "2002-01-01"
         },
         "airspace": {}
+      },
+      "herbicide": {
+        "guam": true,
+        "laos": true,
+        "c123": true
+      },
+      "herbicideDetails": {
+        "c123": {
+          "endDate": "1966-02-20"
+        },
+        "laos": {
+          "startDate": "1965-01-01"
+        },
+        "guam": {},
+        "cambodia": {},
+        "koreandemilitarizedzone": {},
+        "johnston": {},
+        "thailand": {},
+        "vietnam": {}
+      },
+      "view:herbicideAdditionalInfo": {},
+      "otherHerbicideLocations": {
+        "description": "Test location 1",
+        "startDate": "1968-01-01",
+        "endDate": "1969-01-01"
       }
     },
     "view:powStatus": true,

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-toxic-exposure-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-toxic-exposure-test.json
@@ -61,6 +61,24 @@
         "yemen": {
           "startDate": "2002-01-01"
         }
+      },
+      "herbicide": {
+        "c123": true,
+        "guam": true,
+        "laos": true
+      },
+      "herbicideDetails": {
+        "c123": {
+          "endDate": "1966-02-20"
+        },
+        "laos": {
+          "startDate": "1965-01-01"
+        }
+      },
+      "otherHerbicideLocations": {
+        "description": "Test location 1",
+        "endDate": "1969-01-01",
+        "startDate": "1968-01-01"
       }
     },
     "vaTreatmentFacilities": [

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideDetails.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideDetails.unit.spec.jsx
@@ -31,66 +31,69 @@ describe('herbicideDetails', () => {
     },
   };
 
-  Object.keys(HERBICIDE_LOCATIONS).forEach(locationId => {
-    const pageSchema = schemas[`herbicide-location-${locationId}`];
-    it(`should render for ${locationId}`, () => {
-      const { container, getByText } = render(
-        <DefinitionTester
-          schema={pageSchema.schema}
-          uiSchema={pageSchema.uiSchema}
-          data={formData}
-        />,
-      );
-
-      getByText(herbicidePageTitle);
-      getByText(dateRangeDescription);
-
-      const addlInfo = container.querySelector('va-additional-info');
-      expect(addlInfo).to.have.attribute(
-        'trigger',
-        'What if I have more than one date range?',
-      );
-
-      expect($(`va-memorable-date[label="${startDateApproximate}"]`, container))
-        .to.exist;
-      expect($(`va-memorable-date[label="${endDateApproximate}"]`, container))
-        .to.exist;
-
-      if (locationId === 'cambodia') {
-        getByText(`Location 1 of 2: ${HERBICIDE_LOCATIONS.cambodia}`, {
-          exact: false,
-        });
-        expect(pageSchema.title(formData)).to.equal(
-          `Location 1 of 2: ${HERBICIDE_LOCATIONS.cambodia}`,
+  Object.keys(HERBICIDE_LOCATIONS)
+    .filter(locationId => locationId !== 'none')
+    .forEach(locationId => {
+      const pageSchema = schemas[`herbicide-location-${locationId}`];
+      it(`should render for ${locationId}`, () => {
+        const { container, getByText } = render(
+          <DefinitionTester
+            schema={pageSchema.schema}
+            uiSchema={pageSchema.uiSchema}
+            data={formData}
+          />,
         );
-      } else if (locationId === 'laos') {
-        getByText(`Location 2 of 2: ${HERBICIDE_LOCATIONS.laos}`, {
-          exact: false,
-        });
-        expect(pageSchema.title(formData)).to.equal(
-          `Location 2 of 2: ${HERBICIDE_LOCATIONS.laos}`,
+
+        getByText(herbicidePageTitle);
+        getByText(dateRangeDescription);
+
+        const addlInfo = container.querySelector('va-additional-info');
+        expect(addlInfo).to.have.attribute(
+          'trigger',
+          'What if I have more than one date range?',
         );
-      } else {
-        getByText(HERBICIDE_LOCATIONS[locationId]);
-        expect(pageSchema.title(formData)).to.equal(
-          `${HERBICIDE_LOCATIONS[locationId]}`,
+
+        expect(
+          $(`va-memorable-date[label="${startDateApproximate}"]`, container),
+        ).to.exist;
+        expect($(`va-memorable-date[label="${endDateApproximate}"]`, container))
+          .to.exist;
+
+        if (locationId === 'cambodia') {
+          getByText(`Location 1 of 2: ${HERBICIDE_LOCATIONS.cambodia}`, {
+            exact: false,
+          });
+          expect(pageSchema.title(formData)).to.equal(
+            `Location 1 of 2: ${HERBICIDE_LOCATIONS.cambodia}`,
+          );
+        } else if (locationId === 'laos') {
+          getByText(`Location 2 of 2: ${HERBICIDE_LOCATIONS.laos}`, {
+            exact: false,
+          });
+          expect(pageSchema.title(formData)).to.equal(
+            `Location 2 of 2: ${HERBICIDE_LOCATIONS.laos}`,
+          );
+        } else {
+          getByText(HERBICIDE_LOCATIONS[locationId]);
+          expect(pageSchema.title(formData)).to.equal(
+            `${HERBICIDE_LOCATIONS[locationId]}`,
+          );
+        }
+      });
+
+      it(`should submit without dates for ${locationId}`, () => {
+        const onSubmit = sinon.spy();
+        const { getByText } = render(
+          <DefinitionTester
+            schema={pageSchema.schema}
+            uiSchema={pageSchema.uiSchema}
+            data={formData}
+            onSubmit={onSubmit}
+          />,
         );
-      }
+
+        userEvent.click(getByText('Submit'));
+        expect(onSubmit.calledOnce).to.be.true;
+      });
     });
-
-    it(`should submit without dates for ${locationId}`, () => {
-      const onSubmit = sinon.spy();
-      const { getByText } = render(
-        <DefinitionTester
-          schema={pageSchema.schema}
-          uiSchema={pageSchema.uiSchema}
-          data={formData}
-          onSubmit={onSubmit}
-        />,
-      );
-
-      userEvent.click(getByText('Submit'));
-      expect(onSubmit.calledOnce).to.be.true;
-    });
-  });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideDetails.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideDetails.unit.spec.jsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
+import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
+import { makePages } from '../../../pages/toxicExposure/herbicideDetails';
+import { HERBICIDE_LOCATIONS } from '../../../constants';
+import {
+  dateRangeDescription,
+  endDateApproximate,
+  herbicidePageTitle,
+  startDateApproximate,
+} from '../../../content/toxicExposure';
+
+/**
+ * Unit tests for the herbicide details pages. Verifies each page can render and submit with
+ * and without dates. Additionally, verifies the subtitles are built appropriately whether or not
+ * the location was selected.
+ */
+describe('herbicideDetails', () => {
+  const schemas = { ...makePages() };
+  const formData = {
+    toxicExposure: {
+      herbicide: {
+        cambodia: true,
+        koreandemilitarizedzone: false,
+        laos: true,
+      },
+    },
+  };
+
+  Object.keys(HERBICIDE_LOCATIONS).forEach(locationId => {
+    const pageSchema = schemas[`herbicide-location-${locationId}`];
+    it(`should render for ${locationId}`, () => {
+      const { container, getByText } = render(
+        <DefinitionTester
+          schema={pageSchema.schema}
+          uiSchema={pageSchema.uiSchema}
+          data={formData}
+        />,
+      );
+
+      getByText(herbicidePageTitle);
+      getByText(dateRangeDescription);
+
+      const addlInfo = container.querySelector('va-additional-info');
+      expect(addlInfo).to.have.attribute(
+        'trigger',
+        'What if I have more than one date range?',
+      );
+
+      expect($(`va-memorable-date[label="${startDateApproximate}"]`, container))
+        .to.exist;
+      expect($(`va-memorable-date[label="${endDateApproximate}"]`, container))
+        .to.exist;
+
+      if (locationId === 'cambodia') {
+        getByText(`Location 1 of 2: ${HERBICIDE_LOCATIONS.cambodia}`, {
+          exact: false,
+        });
+        expect(pageSchema.title(formData)).to.equal(
+          `Location 1 of 2: ${HERBICIDE_LOCATIONS.cambodia}`,
+        );
+      } else if (locationId === 'laos') {
+        getByText(`Location 2 of 2: ${HERBICIDE_LOCATIONS.laos}`, {
+          exact: false,
+        });
+        expect(pageSchema.title(formData)).to.equal(
+          `Location 2 of 2: ${HERBICIDE_LOCATIONS.laos}`,
+        );
+      } else {
+        getByText(HERBICIDE_LOCATIONS[locationId]);
+        expect(pageSchema.title(formData)).to.equal(
+          `${HERBICIDE_LOCATIONS[locationId]}`,
+        );
+      }
+    });
+
+    it(`should submit without dates for ${locationId}`, () => {
+      const onSubmit = sinon.spy();
+      const { getByText } = render(
+        <DefinitionTester
+          schema={pageSchema.schema}
+          uiSchema={pageSchema.uiSchema}
+          data={formData}
+          onSubmit={onSubmit}
+        />,
+      );
+
+      userEvent.click(getByText('Submit'));
+      expect(onSubmit.calledOnce).to.be.true;
+    });
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideLocations.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideLocations.unit.spec.jsx
@@ -13,8 +13,10 @@ import formConfig from '../../../config/form';
 import {
   herbicidePageTitle,
   herbicideQuestion,
+  noneAndLocationError,
 } from '../../../content/toxicExposure';
 import { HERBICIDE_LOCATIONS } from '../../../constants';
+import { checkVaCheckbox, inputVaTextInput } from '../../testUtils';
 
 describe('Herbicide Location', () => {
   const {
@@ -68,17 +70,57 @@ describe('Herbicide Location', () => {
     );
 
     const checkboxGroup = $('va-checkbox-group', container);
-    await checkboxGroup.__events.vaChange({
-      target: { checked: true, dataset: { key: 'cambodia' } },
-      detail: { checked: true },
-    });
-
-    await checkboxGroup.__events.vaChange({
-      target: { checked: true, dataset: { key: 'laos' } },
-      detail: { checked: true },
-    });
+    checkVaCheckbox(checkboxGroup, 'cambodia');
+    checkVaCheckbox(checkboxGroup, 'laos');
 
     userEvent.click(getByText('Submit'));
     expect(onSubmit.calledOnce).to.be.true;
+  });
+
+  it('should display error when location and "none"', () => {
+    const formData = {};
+    const { container, getByText } = render(
+      <DefinitionTester schema={schema} uiSchema={uiSchema} data={formData} />,
+    );
+    const checkboxGroup = $('va-checkbox-group', container);
+    checkVaCheckbox(checkboxGroup, 'guam');
+    checkVaCheckbox(checkboxGroup, 'none');
+
+    userEvent.click(getByText('Submit'));
+    expect($('va-checkbox-group').error).to.equal(noneAndLocationError);
+  });
+
+  it('should display error when other location and "none"', () => {
+    const formData = {};
+    const { container, getByText } = render(
+      <DefinitionTester schema={schema} uiSchema={uiSchema} data={formData} />,
+    );
+    const checkboxGroup = $('va-checkbox-group', container);
+
+    checkVaCheckbox(checkboxGroup, 'none');
+    inputVaTextInput(
+      container,
+      'Test location 1, Test location #2',
+      'va-textarea',
+    );
+
+    userEvent.click(getByText('Submit'));
+    expect($('va-checkbox-group').error).to.equal(noneAndLocationError);
+  });
+
+  it('should display error when other location does not match pattern', () => {
+    const formData = {};
+    const { container, getByText } = render(
+      <DefinitionTester schema={schema} uiSchema={uiSchema} data={formData} />,
+    );
+
+    inputVaTextInput(
+      container,
+      'Test location 1 + Test location 2',
+      'va-textarea',
+    );
+
+    userEvent.click(getByText('Submit'));
+    expect($('va-textarea').error.startsWith('does not match pattern'));
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideLocations.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideLocations.unit.spec.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
+import {
+  $,
+  $$,
+} from '@department-of-veterans-affairs/platform-forms-system/ui';
+import { expect } from 'chai';
+import userEvent from '@testing-library/user-event';
+import sinon from 'sinon';
+import formConfig from '../../../config/form';
+
+import {
+  herbicidePageTitle,
+  herbicideQuestion,
+} from '../../../content/toxicExposure';
+import { HERBICIDE_LOCATIONS } from '../../../constants';
+
+describe('Herbicide Location', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.disabilities.pages.herbicideLocations;
+
+  it('should render locations page with all checkboxes', () => {
+    const { container, getByText } = render(
+      <DefinitionTester schema={schema} uiSchema={uiSchema} data={{}} />,
+    );
+
+    getByText(herbicidePageTitle);
+
+    expect($$('va-checkbox-group', container).length).to.equal(1);
+    expect($('va-checkbox-group', container).getAttribute('label')).to.equal(
+      herbicideQuestion,
+    );
+
+    Object.values(HERBICIDE_LOCATIONS).forEach(option => {
+      expect($$(`va-checkbox[label="${option}"]`, container)).to.exist;
+    });
+  });
+
+  it('should submit without selecting any locations', () => {
+    const onSubmit = sinon.spy();
+
+    const { getByText } = render(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    userEvent.click(getByText('Submit'));
+    expect(onSubmit.calledOnce).to.be.true;
+  });
+
+  it('should submit with locations selected', async () => {
+    const onSubmit = sinon.spy();
+
+    const { container, getByText } = render(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const checkboxGroup = $('va-checkbox-group', container);
+    await checkboxGroup.__events.vaChange({
+      target: { checked: true, dataset: { key: 'cambodia' } },
+      detail: { checked: true },
+    });
+
+    await checkboxGroup.__events.vaChange({
+      target: { checked: true, dataset: { key: 'laos' } },
+      detail: { checked: true },
+    });
+
+    userEvent.click(getByText('Submit'));
+    expect(onSubmit.calledOnce).to.be.true;
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideOtherLocations.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideOtherLocations.unit.spec.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
+import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
+import formConfig from '../../../config/form';
+import {
+  dateRangeDescription,
+  endDateApproximate,
+  herbicidePageTitle,
+  startDateApproximate,
+} from '../../../content/toxicExposure';
+
+describe('Herbicide Other Locations', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.disabilities.pages.herbicideOtherLocations;
+
+  it('should render', () => {
+    const formData = {
+      toxicExposure: {
+        herbicide: {
+          cambodia: true,
+          koreandemilitarizedzone: false,
+          laos: true,
+        },
+        otherHerbicideLocations: {
+          description: 'Test Location 1',
+        },
+      },
+    };
+
+    const { container, getByText } = render(
+      <DefinitionTester schema={schema} uiSchema={uiSchema} data={formData} />,
+    );
+
+    getByText(herbicidePageTitle);
+    getByText(dateRangeDescription);
+
+    const addlInfo = container.querySelector('va-additional-info');
+    expect(addlInfo).to.have.attribute(
+      'trigger',
+      'What if I have more than one date range?',
+    );
+
+    expect($(`va-memorable-date[label="${startDateApproximate}"]`, container))
+      .to.exist;
+    expect($(`va-memorable-date[label="${endDateApproximate}"]`, container)).to
+      .exist;
+
+    getByText(`Location 3 of 3: Test location 1`, {
+      exact: false,
+    });
+    expect(
+      formConfig.chapters.disabilities.pages.herbicideOtherLocations.title(
+        formData,
+      ),
+    ).to.equal(`Location 3 of 3: Test Location 1`);
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideSummary.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideSummary.unit.spec.jsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
+import formConfig from '../../../config/form';
+import {
+  goBackLink,
+  herbicidePageTitle,
+  noDatesEntered,
+} from '../../../content/toxicExposure';
+import { HERBICIDE_LOCATIONS } from '../../../constants';
+
+describe('Herbicide Summary', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.disabilities.pages.herbicideSummary;
+
+  it('renders when multiple locations with various date range situations', () => {
+    const formData = {
+      toxicExposure: {
+        herbicide: {
+          guam: true,
+          laos: true,
+          c123: true,
+        },
+        herbicideDetails: {
+          c123: {
+            endDate: '1966-02-20',
+          },
+          laos: {
+            startDate: '1965-01-01',
+          },
+          guam: {},
+          cambodia: {},
+          koreandemilitarizedzone: {},
+          johnston: {},
+          thailand: {},
+          vietnam: {},
+        },
+        'view:herbicideAdditionalInfo': {},
+        otherHerbicideLocations: {
+          description: 'Test location 1',
+          startDate: '1968-01-01',
+          endDate: '1969-01-01',
+        },
+      },
+    };
+
+    const { getByText, getByLabelText } = render(
+      <DefinitionTester schema={schema} uiSchema={uiSchema} data={formData} />,
+    );
+
+    getByText(herbicidePageTitle);
+    getByText('Summary');
+
+    getByText(HERBICIDE_LOCATIONS.guam);
+    getByText(noDatesEntered);
+
+    getByText(HERBICIDE_LOCATIONS.laos);
+    getByText('January 1965 - No end date entered');
+
+    getByText(HERBICIDE_LOCATIONS.c123);
+    getByText('No start date entered - February 1966');
+
+    getByText('Test location 1');
+    getByText('January 1968 - January 1969');
+
+    getByText(goBackLink);
+    getByLabelText(
+      'go back and edit locations and dates for Agent Orange locations',
+    );
+  });
+
+  it('does not render a location if not checked', () => {
+    const formData = {
+      toxicExposure: {
+        herbicide: {
+          cambodia: false,
+          guam: true,
+          c123: false,
+        },
+        herbicideDetails: {
+          c123: {
+            startDate: '1967-07-01',
+            endDate: '1967-12-01',
+          },
+          guam: {
+            startDate: '1965-01-01',
+            endDate: '1966-06-01',
+          },
+          cambodia: {},
+          koreandemilitarizedzone: {},
+          johnston: {},
+          laos: {},
+          thailand: {},
+          vietnam: {},
+        },
+        otherHerbicideLocations: {
+          startDate: '1968-01-01',
+          endDate: '1969-01-01',
+          description: 'Test location 1',
+        },
+        'view:herbicideAdditionalInfo': {},
+      },
+    };
+
+    const { getByText, queryByText } = render(
+      <DefinitionTester schema={schema} uiSchema={uiSchema} data={formData} />,
+    );
+
+    expect(queryByText(HERBICIDE_LOCATIONS.cambodia)).to.not.exist;
+
+    expect(queryByText(HERBICIDE_LOCATIONS.c123)).to.not.exist;
+    expect(queryByText('July 1967 - December 1967')).to.not.exist;
+
+    getByText(HERBICIDE_LOCATIONS.guam);
+    getByText('January 1965 - June 1966');
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/property-names.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/property-names.unit.spec.js
@@ -26,6 +26,7 @@ const ignoreList = {
     'toxicExposureConditions',
     'gulfWar1990Locations',
     'gulfWar2001Locations',
+    'herbicideLocations',
   ],
   unemployability: [
     'medicalCare',

--- a/src/applications/disability-benefits/all-claims/tests/property-names.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/property-names.unit.spec.js
@@ -27,6 +27,7 @@ const ignoreList = {
     'gulfWar1990Locations',
     'gulfWar2001Locations',
     'herbicideLocations',
+    'herbicideOtherLocations',
   ],
   unemployability: [
     'medicalCare',

--- a/src/applications/disability-benefits/all-claims/tests/testUtils.js
+++ b/src/applications/disability-benefits/all-claims/tests/testUtils.js
@@ -1,0 +1,37 @@
+import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
+
+/**
+ * Input a string value into a va-text-input component.
+ * @param {any} container - React Testing Library container
+ * @param {string} value - String value to enter in the input field
+ * @param {string} selector - select or element
+ */
+export const inputVaTextInput = (
+  container,
+  value,
+  selector = 'va-text-input',
+) => {
+  const vaTextInput = $(selector, container);
+  vaTextInput.value = value;
+
+  const event = new CustomEvent('input', {
+    bubbles: true,
+    detail: { value },
+  });
+  vaTextInput.dispatchEvent(event);
+};
+
+/**
+ * Select a checkbox within a given group
+ * @param {object} checkboxGroup - element containing the group
+ * @param {string} keyName - unique key
+ */
+export const checkVaCheckbox = (checkboxGroup, keyName) => {
+  checkboxGroup.__events.vaChange({
+    target: {
+      checked: true,
+      dataset: { key: keyName },
+    },
+    detail: { checked: true },
+  });
+};


### PR DESCRIPTION
## Summary
- Create the location, details, and summary pages for the Herbicide question 15C
- Locations page contains all the checkboxes in the mock except for "I'm not sure" which will come in a subsequent story
- Other locations input field has 250 max characters and utilizes regex specified by Lighthouse.
- Details pages is similar to the Gulf War 1990 pages, with minor changes for content
- The other locations field is not a checkbox, but is still included in the loop 
- Add summary page with logic reused from the Gulf War 1990 summary page

team: @department-of-veterans-affairs/dbex-trex 
flipper: department-of-veterans-affairs/va.gov-team#65089

## Related issue(s)
department-of-veterans-affairs/va.gov-team#67014

## Testing done
Unit and e2e tests added/updated

### Manual tests
**Setup steps**

1. Enable toggle `disability_526_toxic_exposure`
2. Start a new claim with new conditions
3. On the toxic-exposure/conditions page, select at least one new condition
4. Continue until you get to the `toxic-exposure/herbicide` page

**No locations selected**
1. On the `herbicide` page, do not select any locations OR select 'None of these locations'
2. **Verify**: Make sure the details and summary pages do not display. (the next page in the flow is currently the `pow` page)

**Locations selected, happy path**
1. On the `herbicide` page, select 3 locations. For 'Other locations...', enter a valid string e.g. `Test location 1, Test location 2`. Click 'Continue' button.
2. **Verify**: Make sure a details page displays for the each of the 4 locations with appropriate title, e.g. `Location 1 of 4: <location-name>
3. Fill out details pages with the following, then continue to the summary page
page 1 of 4: enter both dates
page 2 of 4: enter start date only
page 3 of 4: enter end date only
page 4 of 4: empty dates
4. **Verify**: Make sure locations and dates entered on the previous details pages are displaying in the list as expected
For no dates: "No dates entered"
For start date only, e.g. "January 1990 - No end date entered"
For end date only, e.g. "No start date entered - December 1991"
For both dates, e.g. "February 1993 - June 1995"
5. **Verify**: Click on the 'Edit locations and dates' link. Make sure you are redirected to the `herbicide` page
6. Continue through the 526 form until you get to the Review and Submit page
7. **Verify**: Expand the 'Conditions' section. Make sure all the following is present on the Review and Submit page
-Agent Orange locations: 3 locations are marked 'Selected. The 'other' location is populated
-Each details page displays with appropriate title 'Location <n> of 4: <location-name>' and dates
-Summary page does not display
8. **Verify**: Submit the claim. Make sure you are able to submit the claim and nothing about the new TE data prevents submission, i.e. you arrive on the confirmation page with success message.

**Location(s) and None selected**
1. On the `herbicide` page, select one or more locations along with 'None of these locations'.
2. **Verify**: Make sure error displays "You selected a location, and you also selected "None of these locations." You’ll need to uncheck one of these options to continue." and clicking Continue button does not move to the next page

**Other Location and None selected**
1. On the `herbicide` page, enter a value for 'Other locations..' and select 'None of these locations'
2. **Verify**: Make sure error displays "You selected a location, and you also selected "None of these locations." You’ll need to uncheck one of these options to continue." and clicking Continue button does not move to the next page

**Invalid 'Other' Location**
1. On the `herbicide` page, enter an invalid value for 'Other locations..'. (Validation pattern is `^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$`), so for example`~` or `%` are invalid chars.
2. **Verify**: Make sure error displays "does not match pattern" and clicking Continue button does not move to the next page
 

## Screenshots
[67014 Herbicide.pdf](https://github.com/department-of-veterans-affairs/vets-website/files/15396613/67014.Herbicide.pdf)

## What areas of the site does it impact?
526ez

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
