### PR TITLE
Add top margin to errors

### DIFF
--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -753,3 +753,8 @@ va-checkbox.statement-of-truth-va-checkbox::part(checkbox) {
   border-bottom: 24px solid transparent;
   border-left: 24px solid var(--vads-color-primary);
 }
+
+/* Add space above */
+.rjsf-web-component-field[error]:not([error=""]) {
+  margin-top: 1.5rem;
+}


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > Add top margin to errored web components. When web components are stacked, the vertical margin between fields appears to be removed, but the overall height of the web component is maintained and the label plus error message fill the previous margin (see screenshot) 
- _(If bug, how to reproduce)_
  > - Log into staging with any user
  > - Go to [Request a Board Appeal introduction page](https://staging.va.gov/decision-reviews/board-appeal/request-board-appeal-form-10182/)
  > - Navigate to the contact information page
  > - Use the Mailing address edit link
  > - Clear all fields and save the changes
- _(What is the solution, why is this the solution)_
  > Global change to add a top margin of 1.5rem when a web component added via a web component field has an error
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#81600](https://github.com/department-of-veterans-affairs/va.gov-team/issues/81600)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Within the web component markup, the label includes a top margin of 1.5rem. When an error is added, that top margin is set to zero to account for the addition of the error message
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Edit mailing address errors  | <img width="560" alt="Screenshot 2024-05-22 at 8 26 34 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/d29b2802-f0e3-4413-9e61-3a2212e202f3"> | <img width="560" alt="Screenshot 2024-05-22 at 8 29 21 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/6c08fe45-4590-4ca1-bcb5-e613f718205a"> |
| Edit email errors | <img width="596" alt="Screenshot 2024-05-22 at 8 34 57 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/704258b2-f4c7-4eec-a026-a5a1094ed1e5"> | <img width="563" alt="Screenshot 2024-05-22 at 8 35 11 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/cf9d0eca-fed4-4ad3-abe7-ac4ba82e9711"> |
| Edit all | ![edit-error-before](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/a8509185-c8d1-4bcd-97b8-b021bf66188a) | ![edit-error-after](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/55ffa3dc-46b4-4ac7-91ea-3bb97de685ff) |

## What areas of the site does it impact?

All forms that use web component fields 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
