### PR TITLE
Pensions- change alert to info

### DIFF
--- a/src/applications/pensions/components/FormAlerts/index.jsx
+++ b/src/applications/pensions/components/FormAlerts/index.jsx
@@ -60,13 +60,13 @@ export const IncomeAssetStatementFormAlert = () => (
 );
 
 export const IncomeInformationAlert = () => (
-  <va-alert-expandable status="info" trigger="What is income?">
+  <va-additional-info trigger="What is income?">
     <p>
       Your income is how much you earn. It includes your Social Security
       benefits, investment and retirement payments, and any income your spouse
       and dependents receive.
     </p>
-  </va-alert-expandable>
+  </va-additional-info>
 );
 
 export const LandMarketableAlert = () => (

--- a/src/applications/pensions/tests/unit/chapters/05-financial-information/incomeSources.unit.spec.jsx
+++ b/src/applications/pensions/tests/unit/chapters/05-financial-information/incomeSources.unit.spec.jsx
@@ -1,3 +1,9 @@
+import React from 'react';
+import { $$ } from '@department-of-veterans-affairs/platform-forms-system/ui';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+
+import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfErrorsOnSubmit,
@@ -5,6 +11,7 @@ import {
   testNumberOfFields,
   testSubmitsWithoutErrors,
   testNumberOfFieldsByType,
+  FakeProvider,
 } from '../pageTests.spec';
 import formConfig from '../../../../config/form';
 import incomeSources from '../../../../config/chapters/05-financial-information/incomeSources';
@@ -149,4 +156,21 @@ describe('Pension: Financial information, income sources page', () => {
     },
     pageTitle,
   );
+
+  it('shows additional info instead of alert', () => {
+    const data = { incomeSources: [{}] };
+    const { container } = render(
+      <FakeProvider>
+        <DefinitionTester
+          schema={schema}
+          data={data}
+          definitions={formConfig.defaultDefinitions}
+          uiSchema={uiSchema}
+        />
+      </FakeProvider>,
+    );
+
+    expect($$('va-alert', container).length).to.equal(0);
+    expect($$('va-additional-info', container).length).to.equal(1);
+  });
 });


### PR DESCRIPTION
## Summary

The Gross monthly income page had an expandable alert for the definition of "What is income?". To avoid alert fatigue on VA.gov, we only want to use alerts when absolutely necessary, and replaced it with the additional info component.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/82851

## Testing done

- Viewed the page http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/financial/income-sources and confirmed that the alert was now an additional info component.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Gross Monthly Income  |    <img width="562" alt="Screenshot 2024-05-22 at 10 26 42 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/21046714/74a68c14-a8c6-4d7c-9e3a-008a7b56244c">   |    <img width="566" alt="Screenshot 2024-05-22 at 10 10 16 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/21046714/822a939c-90d3-41f3-8ac4-f6eadde273c3">   |

## What areas of the site does it impact?

Pension Benefits

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

