### PR TITLE
83158 remove redundant medicare status screens

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
@@ -5,8 +5,6 @@ import {
   titleSchema,
   currentOrPastDateUI,
   currentOrPastDateSchema,
-  radioUI,
-  radioSchema,
   yesNoUI,
   yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
@@ -54,51 +52,6 @@ export const applicantHasMedicareABSchema = {
   },
 };
 
-export const applicantMedicareABContextSchema = {
-  uiSchema: {
-    ...titleUI(({ formData }) => `${nameWording(formData)} Medicare status`),
-    applicantMedicareStatusContinued: {
-      ...radioUI({
-        updateUiSchema: formData => {
-          const useFirstPerson = formData?.certifierRole === 'applicant';
-          let title = 'Which of these best describes you?';
-          if (formData?.certifierRole !== 'applicant') {
-            title = `${title.slice(0, -4)} ${nameWording(formData, false)}?`;
-          }
-          const labels = {
-            ineligible: `${
-              useFirstPerson ? 'I’m' : nameWording(formData, false)
-            } not eligible for Medicare`,
-            enrolledNoUpdates: `${
-              useFirstPerson ? 'I have' : `${nameWording(formData, false)} has`
-            } Medicare but no updates to add at this time`,
-            eligibleNotEnrolled: `No, ${
-              useFirstPerson ? 'I’m' : `${nameWording(formData, false)} is`
-            } eligible for Medicare but ${
-              useFirstPerson ? 'have' : 'has'
-            } not signed up for it yet`,
-          };
-          return {
-            'ui:title': title,
-            'ui:options': { labels, hint: additionalFilesHint },
-          };
-        },
-      }),
-    },
-  },
-  schema: {
-    type: 'object',
-    required: ['applicantMedicareStatusContinued'],
-    properties: {
-      applicantMedicareStatusContinued: radioSchema([
-        'ineligible',
-        'enrolledNoUpdates',
-        'eligibleNotEnrolled',
-      ]),
-    },
-  },
-};
-
 export const applicantMedicarePartACarrierSchema = {
   uiSchema: {
     ...titleUI(
@@ -122,53 +75,6 @@ export const applicantMedicarePartACarrierSchema = {
       titleSchema,
       applicantMedicarePartACarrier: { type: 'string' },
       applicantMedicarePartAEffectiveDate: currentOrPastDateSchema,
-    },
-  },
-};
-
-export const appMedicareOver65IneligibleUploadSchema = {
-  uiSchema: {
-    ...titleUI(
-      ({ _formData, formContext }) =>
-        `Upload proof of Medicare ineligibility ${isRequiredFile(
-          formContext,
-          requiredFiles,
-        )}`,
-      ({ formData }) => {
-        const appName = nameWording(formData, false, true);
-        const nameWithBeingVerb =
-          appName === 'You' ? 'You are' : `${appName} is`;
-        return (
-          <>
-            {nameWithBeingVerb} 65 years or older and you selected that{' '}
-            {nameWithBeingVerb === 'You' ? 'you' : nameWithBeingVerb} not
-            eligible for Medicare.
-            <br />
-            <br />
-            You’ll need to submit a copy of a letter from the Social Security
-            Administration that confirms that{' '}
-            {appName === 'You' ? 'you don’t' : `${appName} doesn’t`} qualify for
-            Medicare benefits under anyone’s Social Security number.
-            <br />
-            If you don’t have a copy to upload now, you can send one by mail or
-            fax
-          </>
-        );
-      },
-    ),
-    ...fileUploadBlurb,
-    applicantMedicareIneligibleProof: fileUploadUI({
-      label: 'Upload proof of Medicare ineligibility',
-    }),
-  },
-  schema: {
-    type: 'object',
-    properties: {
-      titleSchema,
-      'view:fileUploadBlurb': blankSchema,
-      applicantMedicareIneligibleProof: fileWithMetadataSchema([
-        'Letter from the SSA',
-      ]),
     },
   },
 };

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -4,7 +4,6 @@ import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import transformForSubmit from './submitTransformer';
-import { getAgeInYears } from '../../shared/utilities';
 import { nameWording } from '../helpers/utilities';
 import FileFieldWrapped from '../components/FileUploadWrapper';
 import { prefillTransformer } from './prefillTransformer';
@@ -27,14 +26,12 @@ import {
 
 import {
   applicantHasMedicareABSchema,
-  applicantMedicareABContextSchema,
   applicantMedicarePartACarrierSchema,
   applicantMedicarePartBCarrierSchema,
   applicantMedicarePharmacySchema,
   applicantMedicareAdvantageSchema,
   applicantHasMedicareDSchema,
   applicantMedicarePartDCarrierSchema,
-  appMedicareOver65IneligibleUploadSchema,
   applicantMedicareABUploadSchema,
   applicantMedicareDUploadSchema,
 } from '../chapters/medicareInformation';
@@ -187,34 +184,12 @@ const formConfig = {
           title: formData => `${nameWording(formData)} Medicare status`,
           ...applicantHasMedicareABSchema,
         },
-        // If 'no' to previous question:
-        medicareABContext: {
-          path: 'medicare-ab-status-type',
-          title: formData => `${nameWording(formData)} Medicare status`,
-          depends: formData =>
-            get('applicantMedicareStatus', formData) === false,
-          ...applicantMedicareABContextSchema,
-        },
         // If 'yes' to previous question:
         partACarrier: {
           path: 'medicare-a-carrier',
           title: formData => `${nameWording(formData)} Medicare Part A carrier`,
           depends: formData => get('applicantMedicareStatus', formData),
           ...applicantMedicarePartACarrierSchema,
-        },
-        // If ineligible and over 65, require user to upload proof of ineligibility
-        medicareIneligible: {
-          path: 'medicare-ineligible-upload',
-          title: 'Over 65 and ineligible for Medicare',
-          depends: formData => {
-            return (
-              get('applicantMedicareStatusContinued', formData) ===
-                'ineligible' && getAgeInYears(formData?.applicantDOB) >= 65
-            );
-          },
-          CustomPage: FileFieldWrapped,
-          CustomPageReview: null,
-          ...appMedicareOver65IneligibleUploadSchema,
         },
         partBCarrier: {
           path: 'medicare-b-carrier',

--- a/src/applications/ivc-champva/10-7959C/tests/config/form.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-7959C/tests/config/form.unit.spec.jsx
@@ -176,37 +176,10 @@ testNumberOfWebComponentFields(
 
 testNumberOfWebComponentFields(
   formConfig,
-  formConfig.chapters.medicareInformation.pages.medicareABContext.schema,
-  formConfig.chapters.medicareInformation.pages.medicareABContext.uiSchema,
-  1,
-  'Applicant medicare AB context (certifier role: applicant)',
-  { ...mockData.data, certifierRole: 'applicant' },
-);
-
-testNumberOfWebComponentFields(
-  formConfig,
-  formConfig.chapters.medicareInformation.pages.medicareABContext.schema,
-  formConfig.chapters.medicareInformation.pages.medicareABContext.uiSchema,
-  1,
-  'Applicant medicare AB context',
-  { ...mockData.data },
-);
-
-testNumberOfWebComponentFields(
-  formConfig,
   formConfig.chapters.medicareInformation.pages.partACarrier.schema,
   formConfig.chapters.medicareInformation.pages.partACarrier.uiSchema,
   2,
   'Applicant medicare A carrier',
-  { ...mockData.data },
-);
-
-testNumberOfWebComponentFields(
-  formConfig,
-  formConfig.chapters.medicareInformation.pages.medicareIneligible.schema,
-  formConfig.chapters.medicareInformation.pages.medicareIneligible.uiSchema,
-  0,
-  'Applicant medicare ineligible',
   { ...mockData.data },
 );
 
@@ -292,23 +265,6 @@ testNumberOfWebComponentFields(
   'Applicant medicare D cards',
   { ...mockData.data },
 );
-
-describe('Medicare ineligibility screen depends function', () => {
-  // Get date 65 yrs ago in format MM-DD-YYYY (to match what form would produce)
-  const date65YrAgo = new Date();
-  date65YrAgo.setFullYear(date65YrAgo.getFullYear() - 65);
-
-  it('should return true if applicant is ineligible and over 65', () => {
-    const depRes = formConfig.chapters.medicareInformation.pages.medicareIneligible.depends(
-      {
-        applicantMedicareStatusContinued: 'ineligible',
-        applicantDOB: date65YrAgo,
-      },
-    );
-
-    expect(depRes).to.be.true;
-  });
-});
 
 describe('Medicare part D screen depends function', () => {
   it('should return true if applicant has Medicare parts A, B, and D', () => {

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-no-medicare-no-primary-no-secondary-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-no-medicare-no-primary-no-secondary-test.json
@@ -2,7 +2,6 @@
   "data": {
     "applicantHasSecondary": false,
     "applicantHasPrimary": false,
-    "applicantMedicareStatusContinued": "eligibleNotEnrolled",
     "applicantMedicareStatus": false,
     "applicantPhone": "1112221212",
     "applicantEmailAddress": "email@email.ca",

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-no-medicare-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-no-medicare-test.json
@@ -29,7 +29,6 @@
     "applicantPrimaryEffectiveDate": "2001-01-02",
     "applicantPrimaryExpirationDate": "2020-03-03",
     "applicantHasPrimary": true,
-    "applicantMedicareStatusContinued": "ineligible",
     "applicantMedicareStatus": false,
     "applicantPhone": "5551112222",
     "applicantEmailAddress": "email@email.gov",
@@ -51,12 +50,6 @@
     "certifierRole": "applicant",
     "preparerType": "sponsor",
     "missingUploads": [
-      {
-        "name": "applicantMedicareIneligibleProof",
-        "path": "medicare-ineligible-upload",
-        "required": true,
-        "uploaded": false
-      },
       {
         "name": "primaryInsuranceCard",
         "path": "insurance-upload",

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-no-primary-yes-secondary-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-no-primary-yes-secondary-test.json
@@ -14,7 +14,6 @@
     "applicantSecondaryExpirationDate": "2010-09-03",
     "applicantHasSecondary": true,
     "applicantHasPrimary": false,
-    "applicantMedicareStatusContinued": "enrolledNoUpdates",
     "applicantMedicareStatus": false,
     "applicantPhone": "7771231234",
     "applicantEmailAddress": "email@email.edu",

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-no-secondary-yes-primary-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/applicant-no-secondary-yes-primary-test.json
@@ -15,7 +15,6 @@
     "applicantPrimaryEffectiveDate": "2000-01-01",
     "applicantPrimaryExpirationDate": "2024-01-01",
     "applicantHasPrimary": true,
-    "applicantMedicareStatusContinued": "eligibleNotEnrolled",
     "applicantMedicareStatus": false,
     "applicantPhone": "6661231234",
     "applicantEmailAddress": "email@email.net",

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/thirdparty-no-medicare-no-primary-yes-secondary-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/thirdparty-no-medicare-no-primary-yes-secondary-test.json
@@ -13,7 +13,6 @@
     "applicantSecondaryExpirationDate": "2023-05-02",
     "applicantHasSecondary": true,
     "applicantHasPrimary": false,
-    "applicantMedicareStatusContinued": "ineligible",
     "applicantMedicareStatus": false,
     "applicantPhone": "1231231234",
     "applicantEmailAddress": "applicant@email.gov",

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/veteran-child-no-medicare-yes-primary-no-secondary-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/veteran-child-no-medicare-yes-primary-no-secondary-test.json
@@ -14,7 +14,6 @@
     "applicantPrimaryEffectiveDate": "1999-01-01",
     "applicantPrimaryExpirationDate": "2001-05-02",
     "applicantHasPrimary": true,
-    "applicantMedicareStatusContinued": "eligibleNotEnrolled",
     "applicantMedicareStatus": false,
     "applicantPhone": "1231231234",
     "applicantEmailAddress": "email@email.com",


### PR DESCRIPTION
## Summary

This PR removes two conditional screens that collected additional information about an applicant who selected `false` when asked if they wanted to add Medicare details to their application.

- Removed the contextual medicare question screen
- Removed the over 65 + ineligible for Medicare upload screen
- Removed unit tests that tested these pages
- Updated E2E test data to exclude data related to these pages
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83158

## Testing done

- Unit
- E2E
- Manual

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA