### PR TITLE
Add more tests for form upload flow

### DIFF
--- a/src/applications/simple-forms/form-upload/tests/helpers/index.unit.spec.js
+++ b/src/applications/simple-forms/form-upload/tests/helpers/index.unit.spec.js
@@ -1,8 +1,25 @@
 import sinon from 'sinon';
 import { expect } from 'chai';
-import { getFileSize, handleRouteChange } from '../../helpers';
+import * as actions from 'platform/forms-system/src/js/actions';
+import * as api from '@department-of-veterans-affairs/platform-utilities/api';
+import { shallow } from 'enzyme';
+import {
+  createPayload,
+  getFileSize,
+  getFormUploadContent,
+  handleRouteChange,
+  mask,
+  submitForm,
+  uploadScannedForm,
+} from '../../helpers';
 
 describe('Helpers', () => {
+  describe('getFormUploadContent', () => {
+    it('returns the empty string when formNumber does not match', () => {
+      expect(getFormUploadContent('fake-form')).to.eq('');
+    });
+  });
+
   describe('handleRouteChange', () => {
     it('pushes the href to history', () => {
       const fakeHref = 'fake-href';
@@ -27,6 +44,60 @@ describe('Helpers', () => {
     });
     it('should be in MB for values greater than a million', () => {
       expect(getFileSize(2000000)).to.equal('2.0 MB');
+    });
+  });
+
+  describe('createPayload', () => {
+    it('should return the appropriate payload', () => {
+      const formId = '21-0779';
+      const file = {};
+
+      const payload = createPayload(file, formId);
+
+      expect(payload.get('form_id')).to.eq(formId);
+    });
+  });
+
+  describe('uploadScannedForm', () => {
+    it('should call uploadFile', () => {
+      const uploadFileStub = sinon
+        .stub(actions, 'uploadFile')
+        .returns(() => {});
+      const formNumber = '21-0779';
+      const fileToUpload = {};
+      const onFileUploaded = () => {};
+      const dispatch = uploadScannedForm(
+        formNumber,
+        fileToUpload,
+        onFileUploaded,
+      );
+
+      dispatch();
+
+      expect(uploadFileStub.called).to.be.true;
+    });
+  });
+
+  describe('submitForm', () => {
+    it('should make an api request', () => {
+      const apiRequestStub = sinon.stub(api, 'apiRequest').resolves({});
+      const formNumber = '21-0779';
+      const confirmationCode = 'some-confirmation-code';
+      const history = [];
+
+      submitForm(formNumber, confirmationCode, history);
+
+      expect(apiRequestStub.called).to.be.true;
+    });
+  });
+
+  describe('mask', () => {
+    it('should return a masked string', () => {
+      const node = shallow(mask('secret-stuf'));
+
+      expect(node.text()).to.contain('●●●–●●–stuf');
+
+      node.unmount();
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR adds more tests to the form upload flow helpers.

## Screenshots
Before:
<img width="1723" alt="Screenshot 2024-05-22 at 3 18 01 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/10481391/8d193709-6e56-4569-a480-6ca0405ef2e8">

After:
<img width="1722" alt="Screenshot 2024-05-22 at 3 17 32 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/10481391/6a98f996-671f-4375-aee6-e24828bff6ed">
