### PR TITLE
[CST] - Update font awesome icons to va-icons

### DIFF
--- a/src/applications/claims-status/components/ClaimCard/ClaimCardLink.jsx
+++ b/src/applications/claims-status/components/ClaimCard/ClaimCardLink.jsx
@@ -16,7 +16,7 @@ export default function ClaimCardLink({
       onClick={onClick}
     >
       {text}
-      <i aria-hidden="true" />
+      <va-icon icon="chevron_right" size={3} aria-hidden="true" />
     </Link>
   );
 }

--- a/src/applications/claims-status/components/ClaimsListItem.jsx
+++ b/src/applications/claims-status/components/ClaimsListItem.jsx
@@ -33,8 +33,10 @@ const isClaimComplete = claim => claim.attributes.status === 'COMPLETE';
 const CommunicationsItem = ({ children, icon }) => {
   return (
     <li className="vads-u-margin--0">
-      <i
-        className={`fa fa-${icon} vads-u-margin-right--1`}
+      <va-icon
+        icon={icon}
+        size={3}
+        class="vads-u-margin-right--1"
         aria-hidden="true"
       />
       {children}
@@ -72,12 +74,12 @@ export default function ClaimsListItem({ claim }) {
     >
       <ul className="communications">
         {showPrecomms && developmentLetterSent ? (
-          <CommunicationsItem icon="envelope">
+          <CommunicationsItem icon="mail">
             We sent you a development letter
           </CommunicationsItem>
         ) : null}
         {decisionLetterSent && (
-          <CommunicationsItem icon="envelope">
+          <CommunicationsItem icon="mail">
             You have a decision letter ready
           </CommunicationsItem>
         )}

--- a/src/applications/claims-status/components/DueDateOld.jsx
+++ b/src/applications/claims-status/components/DueDateOld.jsx
@@ -9,8 +9,8 @@ export default function DueDateOld({ date }) {
   return (
     <div className="tracked-item-due">
       <strong className={className}>
-        <i className="fa fa-exclamation-triangle past-due-icon" /> Needed from
-        you
+        <va-icon icon="warning" size={3} class="past-due-icon" />
+        Needed from you
       </strong>
       <span className={className}> - due {dueDate.fromNow()}</span>
     </div>

--- a/src/applications/claims-status/components/SubmittedTrackedItem.jsx
+++ b/src/applications/claims-status/components/SubmittedTrackedItem.jsx
@@ -41,7 +41,7 @@ export default function SubmittedTrackedItem({ item }) {
         reviewed && (
           <div>
             <span className="submission-status reviewed-file">
-              <i className="fa fa-check-circle submission-icon" />
+              <va-icon icon="check_circle" size={3} class="submission-icon" />
               Reviewed by VA
             </span>
             <span className="submission-date reviewed-file">

--- a/src/applications/claims-status/components/claim-files-tab/DocumentsFiled.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/DocumentsFiled.jsx
@@ -174,7 +174,11 @@ function DocumentsFiled({ claim }) {
                   {item.text && (
                     <div className="vads-u-margin-top--0 vads-u-margin-bottom--1">
                       {reviewed(item.text) && (
-                        <i className="fa fa-check-circle docs-filed-icon" />
+                        <va-icon
+                          icon="check_circle"
+                          size={3}
+                          class="docs-filed-icon"
+                        />
                       )}
                       <span className="docs-filed-text">{item.text}</span>
                     </div>

--- a/src/applications/claims-status/components/claim-letters/ClaimLetterSection.jsx
+++ b/src/applications/claims-status/components/claim-letters/ClaimLetterSection.jsx
@@ -16,7 +16,7 @@ export default function ClaimLetterSection() {
       <h2 id="your-claim-letters">Your claim letters</h2>
       <Link className="active-va-link" to="/your-claim-letters">
         Download your VA claim letters
-        <i aria-hidden="true" />
+        <va-icon icon="chevron_right" size={3} aria-hidden="true" />
       </Link>
       <p className="vads-u-margin-y--0p5">{claimLetterSubText}</p>
     </div>

--- a/src/applications/claims-status/components/claim-status-tab/WhatWeAreDoing.jsx
+++ b/src/applications/claims-status/components/claim-status-tab/WhatWeAreDoing.jsx
@@ -27,7 +27,7 @@ export default function WhatWeAreDoing({ status }) {
           to="../overview"
         >
           Overview of the process
-          <i aria-hidden="true" />
+          <va-icon icon="chevron_right" size={3} aria-hidden="true" />
         </Link>
       </va-card>
     </div>

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -1136,31 +1136,12 @@ $marker-text-width: 5.625rem;
   font-weight: bold;
   margin-top: 16px;
 
-  &:focus i::before,
-  &:hover i::before {
+  &:focus va-icon,
+  &:hover va-icon {
     margin-left: 0.75rem;
     transition-duration: 0.3s;
     transition-timing-function: ease-in-out;
     transition-property: margin;
-  }
-
-  i::before {
-    -moz-osx-font-smoothing: grayscale;
-    -webkit-font-smoothing: antialiased;
-    display: inline-block;
-    font-family: "Font Awesome 5 Free";
-    font-size: 1rem;
-    font-style: normal;
-    font-variant: normal;
-    font-weight: 900;
-    line-height: 1;
-    margin-right: 0.5rem;
-    text-rendering: auto;
-    content: "\f105"; /* fa-angle-right */
-    margin-bottom: 0.0625rem;
-    margin-left: 0.5rem;
-    margin-right: 0;
-    vertical-align: middle;
   }
 }
 

--- a/src/applications/rated-disabilities/components/OnThisPageLink.jsx
+++ b/src/applications/rated-disabilities/components/OnThisPageLink.jsx
@@ -6,8 +6,10 @@ export const OnThisPageLink = ({ link, text }) => {
     <a className="arrow-down-link" href={link}>
       <p>
         <span className="icon-with-info">
-          <i
-            className="fa fa-arrow-down vads-u-padding-right--1"
+          <va-icon
+            icon="arrow_downward"
+            size={3}
+            class="vads-u-padding-right--1"
             aria-hidden="true"
           />
           {text}


### PR DESCRIPTION
## Summary

- Updated `ClaimsListItem.jsx` so the font awesome `envelope` icon that displays on the ClaimCard is replaced with the va-icon called `mail` 
- Updated `DueDateOld.jsx` so the font awesome `exclamation-triangle` icon that displays on an alert; when the feature flag cstUseClaimDetailsV2 is disabled on the files tab, is replaced with the va-icon called `warning`
- Updated `SubmittedTrackedItem.jsx` so the font awesome `fa-check-circle` icon that displays under Documents Filed; when a document has been reviewed by the VA and the feature flag cstUseClaimDetailsV2 is disabled on the files tab, is replaced with the va-icon called `check_circle`
- Updated `DocumentsFiled.jsx` so the font awesome `fa-check-circle` icon that displays under Documents Filed; when a document has been reviewed by the VA and the feature flag cstUseClaimDetailsV2 is enabled on the files tab, is replaced with the va-icon called `check_circle`
- Updated `ClaimLetterSection.jsx` so the font awesome `chevron right` icon that displays on the main CST page under the 'Your claim letters' header is replaced with the va-icon called `chevron_right`
- Updated `WhatWeAreDoing.jsx` so the font awesome `chevron right` icon that displays on the status tav under the 'What we're doing' header is replaced with the va-icon called `chevron_right`
- Updated `ClaimCardLink.jsx` so the font awesome `chevron right` icon that displays on the cst home page on the claim card, next to the details link is replaced with the va-icon called `chevron_right` 
- Updated OnThisPageLink.jsx so the font awesome `fa-arrow-down` icon that displays on the rated disabilities page under the 'On this page' header is replaced with the va-icon called `arrow_downward`
- Updated `claim-status.scss` so that the active-va-link css occurs on the `va-icon` instead of the font awesome icon


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#82180

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| ClaimsListItem.jsx  | ![Screenshot 2024-05-22 at 11 00 26 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/d7085d5c-4ade-403f-8da0-dc6dee5aa826) | ![Screenshot 2024-05-22 at 12 00 49 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/0234334b-e964-4e3e-aa44-ee6d89efd133) |
| DueDateOld.jsx | ![Screenshot 2024-05-22 at 11 57 39 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/6627adb2-786d-489b-95e3-7389c36b46c1) | ![Screenshot 2024-05-22 at 12 28 14 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/d818943b-fd91-49ca-bad8-507d76275049) |
| SubmittedTrackedItem.jsx | ![Screenshot 2024-05-22 at 12 32 04 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/b70d7086-6f51-4ee1-8a29-f43adc5c46c0) | ![Screenshot 2024-05-22 at 12 37 08 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/4313e034-95f8-4882-8355-d5e921adebc1) |
| DocumnetsFiled.jsx | ![Screenshot 2024-05-22 at 1 43 21 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/1286aa6d-4873-46ce-8677-9a7ebf57b7ca) | ![Screenshot 2024-05-22 at 1 44 43 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/2c5b5927-a712-4cdc-b063-195506fea228) |
| ClaimLetterSection.jsx | ![Screenshot 2024-05-22 at 2 07 08 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/f40a333d-d501-44a7-b756-1c2d26e48132) | ![Screenshot 2024-05-22 at 2 07 44 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/77ffda49-48c7-4d51-8db2-765d60c837bd) |
|WhatWeAreDoing.jsx | ![Screenshot 2024-05-22 at 2 13 59 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/6c817b34-1f86-4ba6-bfed-2663b409a914) | ![Screenshot 2024-05-22 at 2 14 30 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/a3d93d1d-1886-455c-9713-aa2786003555) |
|ClaimCardLink.jsx | ![Screenshot 2024-05-22 at 2 20 48 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/951a09b5-f2c6-47bc-a12f-32989894a82b) | ![Screenshot 2024-05-22 at 2 21 19 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/44f44563-2721-414d-9bff-f783c9e5ea13) |
| Hover on a chevron link - showing it moves the chevron to the right | ![Screenshot 2024-05-23 at 9 53 01 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/822b1eea-7b71-4462-878e-bd64fdfb8d27) | ![Screenshot 2024-05-23 at 9 49 57 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/cd9f692e-aef8-42a2-9a04-576cf1222d42) |
| OnThisPageLink.jsx| ![Screenshot 2024-05-22 at 2 47 32 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/fc872b5b-3347-4be0-b118-f49bc8f82a06) | ![Screenshot 2024-05-22 at 3 54 47 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/8ebebeee-40e3-421d-92c6-b6de154acca0) |



## What areas of the site does it impact?

Claim Status Tool and Rated Disabilities

## Acceptance criteria

- [x] claims-status to no longer uses font awesome icons 
- [x] rated-disabilities to no longer use font awesome icons
- [x] Claim status tool shows the appropriate icons.
- [x] Rated Disabilities shows the appropriate icons.
- [x] Icons use the existing design system

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
