### PR TITLE
VACMS-18120 Re-roll injected header for cem.va.gov

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -41,11 +41,15 @@
       "cookieOnly": false
     },
     {
+      "hostname": "cem.va.gov",
+      "pathnameBeginning": "/",
+      "cookieOnly": false
+    },
+    {
       "hostname": "www.cem.va.gov",
       "pathnameBeginning": "/",
       "cookieOnly": false
     },
-
     {
       "hostname": "www.choose.va.gov",
       "pathnameBeginning": "/",


### PR DESCRIPTION
~# DO NOT MERGE until after Memorial Day, and after Platform S3 bucket policy is confirmed~ platform made this change [today 5/28/24](https://dsva.slack.com/archives/CBU0KDSB1/p1716914951410939?thread_ts=1716398255.107869&cid=CBU0KDSB1).

Relates to https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18120

Before this change: 
https://www.cem.va.gov shows the injected header 
https://cem.va.gov shows the old TeamSite header. 

After this change: https://cem.va.gov should show the injected header as well. We can only test locally and in prod. 🙃 

1. We rolled forward: https://github.com/department-of-veterans-affairs/vets-website/pull/29756
2. We rolled back: https://github.com/department-of-veterans-affairs/vets-website/pull/29782
3. We got Platform help to fix an S3 bucket policy to resolve the CORS issue: https://dsva.slack.com/archives/CBU0KDSB1/p1716398255107869
4. We are rolling forward again here. 
