### PR TITLE
vfep-1465 & vfep-1433 remove nonVaAssistance from schema and add ui:title back to newSchoolUpdate.

### DIFF
--- a/src/applications/edu-benefits/1995/pages/newSchoolUpdate.js
+++ b/src/applications/edu-benefits/1995/pages/newSchoolUpdate.js
@@ -5,11 +5,12 @@ import fullSchema1995 from 'vets-json-schema/dist/22-1995-schema.json';
 import { showSchoolAddress } from '../../utils/helpers';
 import educationTypeUpdateUISchema from '../../definitions/educationTypeUpdate';
 
-const { educationObjective, nonVaAssistance } = fullSchema1995.properties;
+const { educationObjective } = fullSchema1995.properties;
 
 const { educationTypeUpdate } = fullSchema1995.definitions;
 
 export const uiSchema = {
+  'ui:title': 'School or training facility you want to attend',
   // Broken up because we need to fit educationTypeUpdate between name and address
   // Put back together again in transform()
   newSchoolName: {
@@ -42,6 +43,5 @@ export const schema = {
     educationTypeUpdate,
     newSchoolAddress: address.schema(fullSchema1995),
     educationObjective,
-    nonVaAssistance,
   },
 };


### PR DESCRIPTION
## Summary
- VFEP-1465 & VFEP-1433 remove nonVaAssistance from schema and add ui:title back to newSchoolUpdate.


## Related issue(s)

- [VFEP-1433](https://github.com/department-of-veterans-affairs/vets-website/pull/29851)
- [VFEP-1465](https://github.com/department-of-veterans-affairs/vets-website/pull/29800)


## Testing done

- Verify changes on local machine.

## Before Image

<img width="693" alt="Screenshot 2024-05-22 at 5 26 25 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/95312667/260bcfa2-5b30-4b41-8570-2ad91493de3d">


## After Image

![Screenshot 2024-05-22 at 4 16 25 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/95312667/47e4c641-cf27-4773-9ced-020f99b784eb)


