### PR TITLE
MHV Landing Page updated link text for travel pay link

### DIFF
--- a/src/applications/mhv-landing-page/constants.js
+++ b/src/applications/mhv-landing-page/constants.js
@@ -63,7 +63,7 @@ export const HEALTH_TOOL_LINKS = freeze({
   PAYMENTS: freeze([
     {
       href: 'https://dvagov-btsss.dynamics365portals.us/signin',
-      text: 'File a claim for travel reimbursement (opens in new tab)',
+      text: 'File a claim for travel reimbursement',
     },
     {
       href: '/manage-va-debt/summary/copay-balances',


### PR DESCRIPTION
## Summary
BTSSS link reads simply "File a claim for travel reimbursement" and opens in the current tab.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/83213

## Testing done
N/A

## Screenshots
|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   ![localhost_3001_my-health_(iPhone 14 Pro Max) (3)](https://github.com/department-of-veterans-affairs/vets-website/assets/63804190/442d31f1-c491-41b9-9ad5-dfe12fe8fae1)     |  ![localhost_3001_my-health_(iPhone 14 Pro Max) (5)](https://github.com/department-of-veterans-affairs/vets-website/assets/63804190/55a54da0-3d88-44bf-a5c8-bf6da321133b)     |
| Desktop |   ![localhost_3001_my-health_ (8)](https://github.com/department-of-veterans-affairs/vets-website/assets/63804190/22e9bc69-c5ab-4857-a044-6978f8d128b8)     |     ![localhost_3001_my-health_ (10)](https://github.com/department-of-veterans-affairs/vets-website/assets/63804190/a8083463-13aa-4553-bd80-636bf8b57fce)  |

## What areas of the site does it impact?
- MHV Landing Page

## Acceptance criteria
- BTSSS link reads simply "File a claim for travel reimbursement" and opens in the current tab.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

