### PR TITLE
VACMS-18206 Add feature flipper and maintenance banner for Search.gov outages not occurring during planned maintenance windows

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -39,6 +39,7 @@ class SearchApp extends React.Component {
       results: PropTypes.array,
     }).isRequired,
     fetchSearchResults: PropTypes.func.isRequired,
+    searchGovMaintenance: PropTypes.bool,
   };
 
   constructor(props) {
@@ -351,6 +352,7 @@ class SearchApp extends React.Component {
   };
 
   renderResults() {
+    const { searchGovMaintenance } = this.props;
     const {
       loading,
       errors,
@@ -480,6 +482,22 @@ class SearchApp extends React.Component {
       };
     }
 
+    if (searchGovMaintenance) {
+      return (
+        <div className="columns vads-u-margin-bottom--4">
+          <va-banner
+            data-label="Error banner"
+            headline="Search Maintenance"
+            type="error"
+          >
+            We’re working on Search VA.gov right now. If you have trouble using
+            the search tool, check back later. Thank you for your patience.
+          </va-banner>
+          {searchInput}
+        </div>
+      );
+    }
+
     if (
       isWithinMaintenanceWindow() &&
       results &&
@@ -488,6 +506,7 @@ class SearchApp extends React.Component {
       !loading
     ) {
       const { start, end } = calculateCurrentMaintenanceWindow(); // Use this for the next scheduled maintenance window
+
       return (
         <div className="columns vads-u-margin-bottom--4">
           <va-maintenance-banner
@@ -844,6 +863,9 @@ const mapStateToProps = state => ({
   search: state.search,
   searchDropdownComponentEnabled: toggleValues(state)[
     FEATURE_FLAG_NAMES.searchDropdownComponentEnabled
+  ],
+  searchGovMaintenance: toggleValues(state)[
+    FEATURE_FLAG_NAMES.searchGovMaintenance
   ],
 });
 

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -165,6 +165,7 @@
   "scBrowserMonitoringEnabled": "sc_browser_monitoring_enabled",
   "searchRepresentative": "search_representative",
   "searchDropdownComponentEnabled": "search_dropdown_component_enabled",
+  "searchGovMaintenance": "search_gov_maintenance",
   "show526Wizard": "show526_wizard",
   "showPaymentAndDebtSection": "show_payment_and_debt_section",
   "showContactChatbot": "show_contact_chatbot",


### PR DESCRIPTION
## Summary
Search.gov normally conducts maintenance on their service Tuesdays & Thursdays from 3-6pm ET. During the week of 5/20, they have been doing significant maintenance on their Elasticsearch as well as other dependencies causing heavy outages on the VA.gov sitewide search.

We've added a feature flipper [here](https://github.com/department-of-veterans-affairs/vets-api/pull/16858) called "search_gov_maintenance" to control a separate banner that notifies users about possible (probable) service outages without stopping their use of the search completely.

A va-maintenance-banner is usually used for these purposes, but it requires a calculated duration of a certain number of hours. When we go through highly unusual heavy maintenance periods such as the one we're experiencing now, we don't know the end time/date, and don't want to put a very long maintenance duration on a va-maintenance banner.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18206
- Flipper added in vets-api: https://github.com/department-of-veterans-affairs/vets-api/pull/16858

## Testing done
Tested locally with the banner forced to true. Can't test with the toggle yet as it hasn't been merged.

<img width="1058" alt="Screenshot 2024-05-23 at 11 53 49 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/603099b6-65e5-491a-aa5e-48129d286360">