### PR TITLE
Update employment message to include maximum

### DIFF
--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/currentEmploymentHistory.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/currentEmploymentHistory.js
@@ -7,7 +7,7 @@ export default {
   ...generateEmployersSchemas({
     employersKey: 'currentEmployers',
     employersTitle: 'Current employment',
-    employerMessage: 'Enter all your current jobs',
+    employerMessage: 'Enter up to two of your current jobs',
     jobTypeFieldLabel: 'What kind of work do you currently do?',
     jobHoursWeekFieldLabel: 'How many hours per week do you work on average?',
     employersReviewTitle: 'Current employers',

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/previousEmploymentHistory.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/previousEmploymentHistory.js
@@ -8,7 +8,7 @@ export default {
     employersKey: 'previousEmployers',
     employersTitle: 'Previous employment',
     employerMessage:
-      'Enter all the previous jobs you held the last time you worked',
+      'Enter up to four of the previous jobs you held the last time you worked',
     jobTypeFieldLabel: 'What kind of work did you do?',
     jobHoursWeekFieldLabel: 'How many hours per week did you work on average?',
     jobTitleFieldLabel: 'What was your job title?',


### PR DESCRIPTION
## Summary

On [/employment/current/history](https://staging.va.gov/pension/apply-for-veteran-pension-form-21p-527ez/employment/current/history) when the maximum number of jobs has been entered, the "You've entered the maximum number of items allowed" alert message is likely to be missed by screen reader users. Adds helper text to the legend telling users up front what the limit is, which makes the alert mostly duplicative.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/82854

## Testing done

- Visit http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/employment/current/history and confirm the helper text includes the correct maximum
- Visit http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/employment/previous/history and confirm the helper text includes the correct maximum

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Current Employment |    <img width="545" alt="Screenshot 2024-05-23 at 1 20 01 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/21046714/b4434b8e-887b-43d7-b978-b322cb18e022">    |   <img width="561" alt="Screenshot 2024-05-23 at 1 19 37 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/21046714/ed0a93ef-83ea-4ff2-aec1-ed9248ef2abb">    |
| Previous Employment |    <img width="566" alt="Screenshot 2024-05-23 at 1 19 50 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/21046714/70cf5459-8ad8-4fe7-8193-1ac48bc87605">    |   <img width="555" alt="Screenshot 2024-05-23 at 1 18 55 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/21046714/a3f7e7c8-3e87-41bf-a53a-b1f584dad8ed">    |

## What areas of the site does it impact?

Pension Benefits

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
