### PR TITLE
Generalize Search maintenance messaging

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -492,7 +492,7 @@ class SearchApp extends React.Component {
         <div className="columns vads-u-margin-bottom--4">
           <va-maintenance-banner
             banner-id="search-gov-maintenance-banner"
-            maintenance-title="Search.gov Maintenance"
+            maintenance-title="Search Maintenance"
             maintenance-start-date-time={start}
             maintenance-end-date-time={end}
             isError


### PR DESCRIPTION
## Summary
When we have sitewide Search outages, we should not be pointing to Search.gov as the root cause from a Veteran-facing perspective. Relevant Slack thread with decision from DaveC: https://dsva.slack.com/archives/C52CL1PKQ/p1716485579404739?thread_ts=1716483268.997379&cid=C52CL1PKQ

This generalizes the maintenance window messaging.