### PR TITLE
Remove anchor class that provided the "secondary action" style for the

### DIFF
--- a/src/applications/mhv-landing-page/components/NewsletterSignup.jsx
+++ b/src/applications/mhv-landing-page/components/NewsletterSignup.jsx
@@ -16,12 +16,7 @@ const NewsletterSignup = () => {
         </p>
       </div>
       <div className="vads-l-row">
-        <a
-          className="vads-c-action-link--blue"
-          href={mhvNewsletterURL}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
+        <a href={mhvNewsletterURL} rel="noopener noreferrer" target="_blank">
           Subscribe to the My HealtheVet newsletter on GovDelivery.com (opens in
           new tab)
         </a>


### PR DESCRIPTION
link

## Summary

- Remove "secondary call to action" style on newsletter link


## Related issue(s)

- department-of-veterans-affairs/va.gov-team/issues/82904

## Testing done

- The link was bold and an icon appeared to the left of it. Now it looks like a normal link
- Visual inspection, click link

## Screenshots


|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | ![Screen Shot 2024-05-23 at 15 50 29-fullpage](https://github.com/department-of-veterans-affairs/vets-website/assets/279327/296ca999-0dc4-42c1-a1b2-99c726ac1a6b)     |    ![Screen Shot 2024-05-23 at 15 48 22-fullpage](https://github.com/department-of-veterans-affairs/vets-website/assets/279327/484e75ed-e7a1-49b0-a9ca-7141cb99b765)   |
| Desktop |   ![Screen Shot 2024-05-23 at 16 00 47-fullpage](https://github.com/department-of-veterans-affairs/vets-website/assets/279327/d81c79dd-ccb7-4cff-90ea-34f846dcbdbd)     |   ![Screen Shot 2024-05-23 at 15 47 48-fullpage](https://github.com/department-of-veterans-affairs/vets-website/assets/279327/a6270761-8c07-4342-a2f5-eeaaf21aed48)  |

## What areas of the site does it impact?

N/A


## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
