### PR TITLE
update icon-found workflow for va-icon and font awesome

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -192,7 +192,7 @@ jobs:
 
             ## Note:
 
-            Font Awesome is deprecated. Please use va-icon instead. For more information, visit the migration documentation: [https://design.va.gov/about/developers/using-web-components#how-to-migrate-from-font-awesome-to-va-icon]
+            Font Awesome is deprecated. Please use va-icon instead. For more information, visit the migration documentation: [Migrate from font awesome to va-icon](https://design.va.gov/about/developers/using-web-components#how-to-migrate-from-font-awesome-to-va-icon)
 
   sentry-check:
     name: Sentry Check

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Run PR check script
         run: yarn pr-check
         env:
-          CODE_PATTERN: (<i )|(<i$)
+          CODE_PATTERN: (<i )|(<i$)|(<va-icon)
           LINE_COMMENT: icon found
           OVERALL_REVIEW_COMMENT: >
             # Icon found
@@ -189,6 +189,10 @@ jobs:
 
             Review the markup and see if the icon provides information that isn't
             represented textually, or wait for a VSP review.
+
+            ## Note:
+
+            Font Awesome is deprecated. Please use va-icon instead. For more information, visit the migration documentation: [https://design.va.gov/about/developers/using-web-components#how-to-migrate-from-font-awesome-to-va-icon]
 
   sentry-check:
     name: Sentry Check


### PR DESCRIPTION
## Summary
Update Icon Check Workflows to Include `va-icon` and Deprecate Font Awesome


## Related issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2626

## Testing done
N/A

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria
- [x]  both icon workflows are updated to check for va-icon
- [x] both icon workflows have a message that Font Awesome is deprecated and to use va-icon
- [x] the workflow still display the message about semantic meaning