### PR TITLE
MHV Landing Page cards can handle external links

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,21 +7,6 @@
             "name": "Launch Chrome Debugger",
             "url": "http://localhost:3001",
             "webRoot": "${workspaceFolder}"
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "Mocha Tests specific",
-            "env": {"BABEL_ENV": "test"},
-            "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
-            "runtimeArgs": [
-                "--inspect",
-                "--config",
-                "${workspaceFolder}/config/mocha.json",
-                "--recursive",
-                "${workspaceFolder}/src/applications/mhv-landing-page/tests/components/NavCard.unit.spec.jsx"
-            ],
-            "port": 9229
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,21 @@
             "name": "Launch Chrome Debugger",
             "url": "http://localhost:3001",
             "webRoot": "${workspaceFolder}"
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Mocha Tests specific",
+            "env": {"BABEL_ENV": "test"},
+            "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/mocha",
+            "runtimeArgs": [
+                "--inspect",
+                "--config",
+                "${workspaceFolder}/config/mocha.json",
+                "--recursive",
+                "${workspaceFolder}/src/applications/mhv-landing-page/tests/components/NavCard.unit.spec.jsx"
+            ],
+            "port": 9229
         }
     ]
 }

--- a/src/applications/mhv-landing-page/components/NavCard.jsx
+++ b/src/applications/mhv-landing-page/components/NavCard.jsx
@@ -2,13 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import recordEvent from '~/platform/monitoring/record-event';
 
+export const externalLinkText = '(opens in new tab)';
+
 const NavCard = ({ icon = null, title, links }) => {
-  const listItems = links.map(({ ariaLabel, href, text }) => (
+  const listItems = links.map(({ ariaLabel, href, text, isExternal }) => (
     <li className="mhv-c-navlistitem" key={href}>
       <a
-        className="mhv-c-navlink"
+        className={isExternal ? 'mhv-c-navlink-external' : 'mhv-c-navlink'}
         href={href}
         aria-label={ariaLabel}
+        target={isExternal ? '_blank' : ''}
         onClick={() => {
           recordEvent({
             event: 'nav-linkslist',
@@ -16,13 +19,14 @@ const NavCard = ({ icon = null, title, links }) => {
             'links-list-section-header': title,
           });
         }}
+        rel="noreferrer"
       >
         <span
           className={ariaLabel?.includes('unread') ? 'mhv-c-indicator' : ''}
         >
-          {text}
+          {text} {isExternal && externalLinkText}
         </span>
-        <i aria-hidden="true" />
+        {!isExternal && <i aria-hidden="true" />}
       </a>
     </li>
   ));
@@ -64,6 +68,7 @@ NavCard.propTypes = {
     PropTypes.shape({
       text: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
       href: PropTypes.string,
+      isExternal: PropTypes.bool,
     }),
   ),
   title: PropTypes.string,

--- a/src/applications/mhv-landing-page/constants.js
+++ b/src/applications/mhv-landing-page/constants.js
@@ -62,12 +62,14 @@ export const HEALTH_TOOL_LINKS = freeze({
   ]),
   PAYMENTS: freeze([
     {
-      href: 'https://dvagov-btsss.dynamics365portals.us/signin',
-      text: 'File a claim for travel reimbursement',
-    },
-    {
       href: '/manage-va-debt/summary/copay-balances',
       text: 'Pay copay bills',
+    },
+    {
+      href: 'https://dvagov-btsss.dynamics365portals.us/signin',
+      text:
+        'File a claim for travel reimbursement on the Beneficiary Travel Self-Service System website',
+      isExternal: true,
     },
   ]),
   MEDICAL_SUPPLIES: freeze([

--- a/src/applications/mhv-landing-page/containers/App.jsx
+++ b/src/applications/mhv-landing-page/containers/App.jsx
@@ -38,18 +38,11 @@ const App = () => {
       return resolveLandingPageLinks(
         ssoe,
         featureToggles,
-        unreadMessageCount,
         unreadMessageAriaLabel,
         userHasHealthData,
       );
     },
-    [
-      featureToggles,
-      ssoe,
-      unreadMessageCount,
-      unreadMessageAriaLabel,
-      userHasHealthData,
-    ],
+    [featureToggles, ssoe, unreadMessageAriaLabel, userHasHealthData],
   );
 
   const datadogRumConfig = {

--- a/src/applications/mhv-landing-page/sass/mhv-landing-page.scss
+++ b/src/applications/mhv-landing-page/sass/mhv-landing-page.scss
@@ -112,6 +112,18 @@ $anchor-font-size: 1.1875rem;
   }
 }
 
+.mhv-c-navlink-external {
+  display: inline-block;
+  align-items: center;
+  text-decoration: none;
+
+  &:active,
+  &:hover,
+  &:visited {
+    text-decoration: none;
+  }
+}
+
 .visibility\:hidden {
   visibility: hidden;
 }

--- a/src/applications/mhv-landing-page/tests/components/NavCard.unit.spec.jsx
+++ b/src/applications/mhv-landing-page/tests/components/NavCard.unit.spec.jsx
@@ -5,72 +5,95 @@ import {
   resolveLandingPageLinks,
   resolveUnreadMessageAriaLabel,
 } from '../../utilities/data';
-import NavCard from '../../components/NavCard';
+import NavCard, { externalLinkText } from '../../components/NavCard';
 
-describe('unread message indicator', () => {
-  function renderCards(unreadMessageCount) {
-    const unreadMessageAriaLabel = resolveUnreadMessageAriaLabel(
-      unreadMessageCount,
-    );
-    const { cards } = resolveLandingPageLinks(
-      undefined,
-      { featureToggles: {} },
-      unreadMessageCount,
-      unreadMessageAriaLabel,
-    );
+describe('NavCard component', () => {
+  describe('unread message indicator', () => {
+    function renderCards(unreadMessageCount) {
+      const unreadMessageAriaLabel = resolveUnreadMessageAriaLabel(
+        unreadMessageCount,
+      );
+      const { cards } = resolveLandingPageLinks(
+        undefined,
+        { featureToggles: {} },
+        unreadMessageAriaLabel,
+      );
 
-    return render(
-      cards.map(c => (
-        <NavCard
-          key={c.title}
-          icon={c.icon}
-          title={c.title}
-          links={c.links}
-          aria-label={c.ariaLabel}
-        />
-      )),
-    );
-  }
+      return render(
+        cards.map(c => (
+          <NavCard
+            key={c.title}
+            icon={c.icon}
+            title={c.title}
+            links={c.links}
+            aria-label={c.ariaLabel}
+          />
+        )),
+      );
+    }
 
-  const messagesMessage = 'You have unread messages. Go to your inbox.';
+    const messagesMessage = 'You have unread messages. Go to your inbox.';
 
-  it('includes unread messages message when greater than 0', () => {
-    const unreadMessageCount = 4;
-    const { getByText } = renderCards(unreadMessageCount);
+    it('includes unread messages message when greater than 0', () => {
+      const unreadMessageCount = 4;
+      const { getByText } = renderCards(unreadMessageCount);
 
-    const inboxSpan = getByText('Go to inbox');
-    const message = inboxSpan.parentNode.getAttribute('aria-label');
+      const inboxSpan = getByText('Go to inbox');
+      const message = inboxSpan.parentNode.getAttribute('aria-label');
 
-    expect(inboxSpan).to.exist;
-    expect(message).to.equal(messagesMessage);
+      expect(inboxSpan).to.exist;
+      expect(message).to.equal(messagesMessage);
+    });
+
+    it('does not include unread messages message when message count is 0', () => {
+      const unreadMessageCount = 0;
+      const { queryByRole, getByText } = renderCards(unreadMessageCount);
+      const indicator = queryByRole('status');
+
+      expect(indicator).not.to.exist;
+
+      const inboxSpan = getByText('Go to inbox');
+      const message = inboxSpan.parentNode.getAttribute('aria-label');
+
+      expect(message).to.not.exist;
+    });
+
+    it('renders if message count is undefined', () => {
+      const { getByRole } = renderCards(undefined);
+
+      const link = getByRole('link', { name: /inbox/i });
+
+      expect(link).to.exist;
+    });
+
+    it('does not include unread messages message when message count is undefined', () => {
+      const { queryByRole } = renderCards(undefined);
+
+      const indicator = queryByRole('status');
+
+      expect(indicator).not.to.exist;
+    });
   });
 
-  it('does not include unread messages message when message count is 0', () => {
-    const unreadMessageCount = 0;
-    const { queryByRole, getByText } = renderCards(unreadMessageCount);
-    const indicator = queryByRole('status');
+  describe('link rendering', () => {
+    it('internal links', () => {
+      const links = [{ text: 'some text', href: 'https://www.va.gov' }];
+      const { getByRole } = render(
+        <NavCard title="Card title" links={links} />,
+      );
+      const linkElement = getByRole('link');
+      expect(linkElement.text).to.not.include(externalLinkText);
+    });
 
-    expect(indicator).not.to.exist;
-
-    const inboxSpan = getByText('Go to inbox');
-    const message = inboxSpan.parentNode.getAttribute('aria-label');
-
-    expect(message).to.not.exist;
-  });
-
-  it('renders if message count is undefined', () => {
-    const { getByRole } = renderCards(undefined);
-
-    const link = getByRole('link', { name: /inbox/i });
-
-    expect(link).to.exist;
-  });
-
-  it('does not include unread messages message when message count is undefined', () => {
-    const { queryByRole } = renderCards(undefined);
-
-    const indicator = queryByRole('status');
-
-    expect(indicator).not.to.exist;
+    it('external links', () => {
+      const links = [
+        { text: 'some text', href: 'https://www.google.com', isExternal: true },
+      ];
+      const { getByRole } = render(
+        <NavCard title="Card title" links={links} />,
+      );
+      const linkElement = getByRole('link');
+      expect(linkElement.text).to.include(externalLinkText);
+    });
   });
 });

--- a/src/applications/mhv-landing-page/tests/e2e/restrict-by-facilities-list/facilities.content.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/restrict-by-facilities-list/facilities.content.cypress.spec.js
@@ -19,7 +19,6 @@ describe(appName, () => {
         const pageLinks = resolveLandingPageLinks(
           false,
           [],
-          0,
           'arialLabel',
           false,
         );
@@ -52,7 +51,6 @@ describe(appName, () => {
         const pageLinks = resolveLandingPageLinks(
           false,
           [],
-          0,
           'arialLabel',
           true,
         );

--- a/src/applications/mhv-landing-page/tests/e2e/restrict-by-identity-verification/loa1.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/restrict-by-identity-verification/loa1.cypress.spec.js
@@ -22,7 +22,6 @@ describe(appName, () => {
         const pageLinks = resolveLandingPageLinks(
           false,
           [],
-          0,
           'arialLabel',
           true,
         );
@@ -61,7 +60,6 @@ describe(appName, () => {
         const pageLinks = resolveLandingPageLinks(
           false,
           [],
-          0,
           'arialLabel',
           true,
         );

--- a/src/applications/mhv-landing-page/tests/e2e/va-gov-health-tools/va-gov-health-tools.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/va-gov-health-tools/va-gov-health-tools.cypress.spec.js
@@ -32,7 +32,8 @@ describe(`${appName} -- VA.gov Health Tools feature`, () => {
         };
         cy.findByRole('heading', heading).should.exist;
         links.forEach(({ text, href }) => {
-          cy.findByRole('link', { name: text }).should(
+          const linkNameRegex = new RegExp(text, 'i');
+          cy.findByRole('link', { name: linkNameRegex }).should(
             'have.attr',
             'href',
             href,

--- a/src/applications/mhv-landing-page/tests/e2e/va-gov-health-tools/va-gov-health-tools.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/va-gov-health-tools/va-gov-health-tools.cypress.spec.js
@@ -32,7 +32,7 @@ describe(`${appName} -- VA.gov Health Tools feature`, () => {
         };
         cy.findByRole('heading', heading).should.exist;
         links.forEach(({ text, href }) => {
-          const linkNameRegex = new RegExp(text, 'i');
+          const linkNameRegex = new RegExp(text);
           cy.findByRole('link', { name: linkNameRegex }).should(
             'have.attr',
             'href',

--- a/src/applications/mhv-landing-page/utilities/data/index.js
+++ b/src/applications/mhv-landing-page/utilities/data/index.js
@@ -29,7 +29,6 @@ const resolveUnreadMessageAriaLabel = unreadMessageCount => {
 const resolveLandingPageLinks = (
   authdWithSSOe = false,
   featureToggles,
-  unreadMessageCount,
   unreadMessageAriaLabel,
   userHasHealthData = false,
 ) => {


### PR DESCRIPTION
## Summary
- Updated link order per [Figma file](https://www.figma.com/design/CAChU51fWYMZsgDR5RXeSc/MHV-Landing-Page?node-id=2404-21524&t=Dw0sSkjjnj5kXr3G-0)
  - Swap order of two links in payments box so that "Copays" link is on top and the "travel reimbursement link" is below
  - Update link text of travel reimbursement link to read "File a claim for travel reimbursement on the Beneficiary Travel Self-Service System website (opens in new tab)"
  - Visual treatment: do not bold the link text; remove the caret symbol at the end of the line for this link
- NavCards can handle external links by setting a property
- Removed unused 'unreadMessageCount' argument

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/82707

## Testing done
- Updated unit tests

## Screenshots
|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |     ![localhost_3001_my-health_(iPhone 14 Pro Max) (3)](https://github.com/department-of-veterans-affairs/vets-website/assets/63804190/385a4848-d7c5-4918-9ab9-375ed65d58a2)   |     ![localhost_3001_my-health_(iPhone 14 Pro Max) (5)](https://github.com/department-of-veterans-affairs/vets-website/assets/63804190/a506c3de-34e0-44e8-bdd9-3111ed0ff73f)  |
| Desktop |    ![localhost_3001_my-health_ (8)](https://github.com/department-of-veterans-affairs/vets-website/assets/63804190/5f03b8be-edbd-43e2-afd5-55f7356f1896)    |    ![localhost_3001_my-health_ (10)](https://github.com/department-of-veterans-affairs/vets-website/assets/63804190/25d99bd2-61bb-4cf1-b1ed-18f264f81fc5)   |

## What areas of the site does it impact?
- MHV Landing Page

## Acceptance criteria
- Swap order of two links in payments box so that "Copays" link is on top and the "travel reimbursement link" is below
- Update link text of travel reimbursement link to read "File a claim for travel reimbursement on the Beneficiary Travel Self-Service System website (opens in new tab)"
- Visual treatment: do not bold the link text; remove the caret symbol at the end of the line for this link

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
