### PR TITLE
removed chevron

### DIFF
--- a/src/applications/check-in/pre-check-in/pages/Error/index.jsx
+++ b/src/applications/check-in/pre-check-in/pages/Error/index.jsx
@@ -52,13 +52,9 @@ const Error = () => {
       </p>
     </div>
   );
-  const chevRight = (
-    <span className="fas fa-chevron-right vads-u-margin-left--neg0p5" />
-  );
   const mixedModalityMessage = (
     <div data-testid="mixed-modality-message">
       <div>
-        {chevRight}
         <span className="appointment-type-label vads-u-margin-left--0p5 vads-u-font-weight--bold">
           {t('in-person-appointment')}
         </span>
@@ -69,7 +65,6 @@ const Error = () => {
         )}
       </div>
       <div className="vads-u-margin-top--2">
-        {chevRight}
         <span className="appointment-type-label vads-u-margin-left--0p5 vads-u-font-weight--bold">
           {t('video-appointment--title')}
         </span>
@@ -86,7 +81,6 @@ const Error = () => {
         </ExternalLink>
       </div>
       <div className="vads-u-margin-top--2">
-        {chevRight}
         <span className="appointment-type-label vads-u-margin-left--0p5 vads-u-font-weight--bold">
           {t('phone-appointment')}
         </span>


### PR DESCRIPTION
## Summary

removes the right chevron in the mixed modality message

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#83224

## Testing done

Visual

## Screenshots
![localhost_3001_health-care_appointment-pre-check-in__id=000](https://github.com/department-of-veterans-affairs/vets-website/assets/13967174/80707aa8-dba8-4f24-ae21-706d55ea5cba)



## What areas of the site does it impact?

day-of and pre-check-in error pages

## Acceptance criteria
 - [ ] chevron gone
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

