### PR TITLE
Fix: Unit Test Stability running with no tests actually set to run

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -243,7 +243,7 @@ jobs:
           name: e2e-tests-to-test
           path: e2e_tests_to_test.json
 
-      - name: Set output of e2e_tests_to_STRESS_TEST
+      - name: Set output of CYPRESS_TESTS_TO_STRESS_TEST
         id: cypress-tests-to-stress-test
         run: echo tests=$CYPRESS_TESTS_TO_STRESS_TEST >> $GITHUB_OUTPUT
 

--- a/script/github-actions/run-unit-tests-gha.js
+++ b/script/github-actions/run-unit-tests-gha.js
@@ -140,6 +140,8 @@ if (testsToVerify === null) {
           test.includes(`src/platform`),
       )
       .join(' ');
+    console.log('testsToVerify: ', testsToVerify);
+    console.log('testsToRun: ', testsToRun);
     if (testsToRun !== '') {
       const command = `LOG_LEVEL=${options[
         'log-level'

--- a/script/github-actions/run-unit-tests-gha.js
+++ b/script/github-actions/run-unit-tests-gha.js
@@ -131,7 +131,14 @@ if (testsToVerify === null) {
   // Stress test
   const appsToVerify = JSON.parse(process.env.APPS_TO_VERIFY)
     .filter(app => app.startsWith('src/applications'))
-    .map(app => app.split('/')[2]);
+    .map(app => app.split('/')[2])
+    .concat(
+      JSON.parse(
+        process.env.APPS_TO_VERIFY.filter(app =>
+          app.startsWith('src/platform'),
+        ),
+      ),
+    );
   console.log(appsToVerify);
   for (const app of appsToVerify) {
     const testsToRun = testsToVerify

--- a/script/github-actions/run-unit-tests-gha.js
+++ b/script/github-actions/run-unit-tests-gha.js
@@ -132,6 +132,7 @@ if (testsToVerify === null) {
   const appsToVerify = JSON.parse(process.env.APPS_TO_VERIFY)
     .filter(app => app.startsWith('src/applications'))
     .map(app => app.split('/')[2]);
+  console.log(appsToVerify);
   for (const app of appsToVerify) {
     const testsToRun = testsToVerify
       .filter(

--- a/script/github-actions/run-unit-tests-gha.js
+++ b/script/github-actions/run-unit-tests-gha.js
@@ -133,10 +133,8 @@ if (testsToVerify === null) {
     .filter(app => app.startsWith('src/applications'))
     .map(app => app.split('/')[2])
     .concat(
-      JSON.parse(
-        process.env.APPS_TO_VERIFY.filter(app =>
-          app.startsWith('src/platform'),
-        ),
+      JSON.parse(process.env.APPS_TO_VERIFY).filter(app =>
+        app.startsWith('src/platform'),
       ),
     );
   console.log(appsToVerify);

--- a/script/github-actions/run-unit-tests-gha.js
+++ b/script/github-actions/run-unit-tests-gha.js
@@ -137,7 +137,6 @@ if (testsToVerify === null) {
         app.startsWith('src/platform'),
       ),
     );
-  console.log(appsToVerify);
   for (const app of appsToVerify) {
     const testsToRun = testsToVerify
       .filter(
@@ -146,8 +145,6 @@ if (testsToVerify === null) {
           test.includes(`src/platform`),
       )
       .join(' ');
-    console.log('testsToVerify: ', testsToVerify);
-    console.log('testsToRun: ', testsToRun);
     if (testsToRun !== '') {
       const command = `LOG_LEVEL=${options[
         'log-level'

--- a/script/github-actions/run-unit-tests-gha.js
+++ b/script/github-actions/run-unit-tests-gha.js
@@ -134,7 +134,11 @@ if (testsToVerify === null) {
     .map(app => app.split('/')[2]);
   for (const app of appsToVerify) {
     const testsToRun = testsToVerify
-      .filter(test => test.includes(`src/applications/${app}`))
+      .filter(
+        test =>
+          test.includes(`src/applications/${app}`) ||
+          test.includes(`src/platform`),
+      )
       .join(' ');
     if (testsToRun !== '') {
       const command = `LOG_LEVEL=${options[

--- a/script/github-actions/select-unit-tests.js
+++ b/script/github-actions/select-unit-tests.js
@@ -14,7 +14,7 @@ const IS_STRESS_TEST = process.env.IS_STRESS_TEST || 'false';
 const DISALLOWED_SPECS = ALLOW_LIST.filter(spec => spec.allowed === false).map(
   spec => spec.spec_path.substring(spec.spec_path.indexOf('src')),
 );
-
+console.log('ALL_SPECS: ', ALL_SPECS);
 const ALL_APPS = [
   ...new Set(
     ALL_SPECS.map(filePath =>
@@ -45,7 +45,7 @@ const TESTS_TO_STRESS_TEST = ALL_SPECS.filter(
 );
 
 core.exportVariable('DISALLOWED_TESTS', DISALLOWED_SPECS);
-
+console.log('TESTS_TO_STRESS_TEST:', TESTS_TO_STRESS_TEST);
 if (TESTS_TO_STRESS_TEST.length > 0 && IS_STRESS_TEST === 'false') {
   core.exportVariable('UNIT_TESTS_TO_STRESS_TEST', 'true');
   core.exportVariable('APPS_TO_STRESS_TEST', CHANGED_APPS_UNIQUE);

--- a/script/github-actions/select-unit-tests.js
+++ b/script/github-actions/select-unit-tests.js
@@ -26,6 +26,8 @@ const ALL_APPS = [
   ),
 ];
 
+console.log('ALL_APPS', ALL_APPS);
+
 const CHANGED_APPS =
   CHANGED_FILES.length > 0
     ? CHANGED_FILES.split(' ').map(filePath =>

--- a/script/github-actions/select-unit-tests.js
+++ b/script/github-actions/select-unit-tests.js
@@ -14,7 +14,6 @@ const IS_STRESS_TEST = process.env.IS_STRESS_TEST || 'false';
 const DISALLOWED_SPECS = ALLOW_LIST.filter(spec => spec.allowed === false).map(
   spec => spec.spec_path.substring(spec.spec_path.indexOf('src')),
 );
-console.log('ALL_SPECS: ', ALL_SPECS);
 const ALL_APPS = [
   ...new Set(
     ALL_SPECS.map(filePath =>
@@ -25,8 +24,6 @@ const ALL_APPS = [
     ),
   ),
 ];
-
-console.log('ALL_APPS', ALL_APPS);
 
 const CHANGED_APPS =
   CHANGED_FILES.length > 0
@@ -47,7 +44,6 @@ const TESTS_TO_STRESS_TEST = ALL_SPECS.filter(
 );
 
 core.exportVariable('DISALLOWED_TESTS', DISALLOWED_SPECS);
-console.log('TESTS_TO_STRESS_TEST:', TESTS_TO_STRESS_TEST);
 if (TESTS_TO_STRESS_TEST.length > 0 && IS_STRESS_TEST === 'false') {
   core.exportVariable('UNIT_TESTS_TO_STRESS_TEST', 'true');
   core.exportVariable('APPS_TO_STRESS_TEST', CHANGED_APPS_UNIQUE);

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -27,7 +27,7 @@
 
 /* "Very Dissatisfied" label below "1 of 5" rating element */
 .ng-scope #leftEdge {
-  padding-right: 25px;
+  padding-right: 24px;
   text-align: left;
   width: 75px;
 }
@@ -57,7 +57,10 @@
 
 /* Very specific override that fixes an issue where the modal is unreadable because it is constrained to the width of col-sm-1 on tablet screens */
 @media (min-width: 576px) {
-  #liveForm>div>div.row.neb-form-close-btn-container.ng-hide>div.col-sm-offset-11.col-sm-1 {
+  #liveForm
+    > div
+    > div.row.neb-form-close-btn-container.ng-hide
+    > div.col-sm-offset-11.col-sm-1 {
     max-width: 100% !important;
   }
 }
@@ -153,7 +156,7 @@
 }
 
 #liveForm .kpl_builder .panel-footer .btn.submit-btn {
- margin-right: 10px;
+  margin-right: 10px;
 }
 
 #liveForm .kpl_builder .panel-footer .btn.cancel-btn {
@@ -161,20 +164,51 @@
 }
 
 /* Very specific selectors to move 'do not inclide PII'helper text before the textarea */
-#liveForm>div>div>div>div>div>div>.neb-component.neb-web-component.neb-textArea.kplFormHolder {
+#liveForm
+  > div
+  > div
+  > div
+  > div
+  > div
+  > div
+  > .neb-component.neb-web-component.neb-textArea.kplFormHolder {
   display: flex;
   flex-direction: column;
 }
 
-#liveForm>div>div>div>div>div>div>.neb-component.neb-web-component.neb-textArea.kplFormHolder>label {
+#liveForm
+  > div
+  > div
+  > div
+  > div
+  > div
+  > div
+  > .neb-component.neb-web-component.neb-textArea.kplFormHolder
+  > label {
   order: 1;
 }
 
-#liveForm>div>div>div>div>div>div>.neb-component.neb-web-component.neb-textArea.kplFormHolder>p {
+#liveForm
+  > div
+  > div
+  > div
+  > div
+  > div
+  > div
+  > .neb-component.neb-web-component.neb-textArea.kplFormHolder
+  > p {
   order: 2;
 }
 
-#liveForm>div>div>div>div>div>div>div.neb-component.neb-web-component.neb-textArea.kplFormHolder>.neb-content.neb-wcag {
+#liveForm
+  > div
+  > div
+  > div
+  > div
+  > div
+  > div
+  > div.neb-component.neb-web-component.neb-textArea.kplFormHolder
+  > .neb-content.neb-wcag {
   order: 3;
 }
 
@@ -183,13 +217,13 @@
   text-align: left !important;
 }
 
-.thankYouPageLogoPreviewText>div>p>span>span>span[style] {
+.thankYouPageLogoPreviewText > div > p > span > span > span[style] {
   text-align: left !important;
   font-size: 20px;
   font-weight: 400;
 }
 
-.thankYouPageLogoPreviewText>div>p {
+.thankYouPageLogoPreviewText > div > p {
   text-align: left !important;
   font-size: 20px;
   font-weight: 400;
@@ -214,12 +248,12 @@
 /*  next button on VAMC muli-page surveys in-line style override*/
 .form-next-btn[style] {
   background-color: var(--vads-color-primary) !important;
-  margin-right: 10px !important
+  margin-right: 10px !important;
 }
 
 .modal-live-form a {
   cursor: pointer;
-  color: var(--vads-color-link)!important;
+  color: var(--vads-color-link) !important;
   text-decoration: underline !important;
   transition-duration: 0.3s;
   transition-timing-function: ease-in-out;
@@ -236,12 +270,12 @@
 }
 
 /* Unordered list styling for crisis header */
-.omb_crises>div>p>ul {
+.omb_crises > div > p > ul {
   padding: 0 0 0 1.5em !important;
   list-style: square !important;
 }
 
-.omb_crises>div>p>ul>li {
+.omb_crises > div > p > ul > li {
   line-height: 1.5 !important;
   margin-bottom: 0.5em !important;
 }
@@ -251,15 +285,15 @@
 }
 
 /* temp styles until VSignals team can change */
-.omb_crises>div>p>ul>li:nth-child(1)>span>strong:nth-child(3) {
+.omb_crises > div > p > ul > li:nth-child(1) > span > strong:nth-child(3) {
   font-weight: 400 !important;
 }
 
-.omb_crises>div>p>ul>li:nth-child(1)>span>strong:nth-child(2)>a {
+.omb_crises > div > p > ul > li:nth-child(1) > span > strong:nth-child(2) > a {
   font-weight: 400 !important;
 }
 
-.omb_crises>div>p>ul>li:nth-child(2)>span>strong:nth-child(2) > a {
+.omb_crises > div > p > ul > li:nth-child(2) > span > strong:nth-child(2) > a {
   font-weight: 400 !important;
 }
 /* end temp styles */
@@ -290,7 +324,11 @@
   padding-right: 20px !important;
 }
 
-.TKB4VqaXyyt6uMNVvoLdN input:not([disabled]):focus, select:not([disabled]):focus, textarea:not([disabled]):focus, button:not([disabled]):focus, a:focus {
+.TKB4VqaXyyt6uMNVvoLdN input:not([disabled]):focus,
+select:not([disabled]):focus,
+textarea:not([disabled]):focus,
+button:not([disabled]):focus,
+a:focus {
   outline: 2px solid var(--vads-color-action-focus-on-light) !important;
   outline-offset: 2px;
   box-shadow: 0 0 0 0 !important;
@@ -315,12 +353,12 @@
 /* omb_crisis */
 ._1BI5B2xY6xMD9hHPCMgWgM > div > ul {
   padding: 0 0 0 1.5em !important;
-  list-style: square !important
+  list-style: square !important;
 }
 
 ._1BI5B2xY6xMD9hHPCMgWgM > div > ul > li {
   line-height: 1.5 !important;
-  margin-bottom: 0.5em !important
+  margin-bottom: 0.5em !important;
 }
 
 /*** form main body ***/
@@ -340,32 +378,34 @@
 
 /* Specific Styles for question h2s*/
 ._3qavF1mE7wQGkoUgHE1D75 {
-    display: inline-block;
-    font-weight: bold !important;
-    margin-bottom: 5px;
-    text-align: left !important;
+  display: inline-block;
+  font-weight: bold !important;
+  margin-bottom: 5px;
+  text-align: left !important;
 }
 
 /* empty header & close button */
 ._1SPV2GZjz0ekDKiu5qBJ16 {
-    padding: 8px 0px !important;
-    display: flex;
-    justify-content: flex-end;
+  padding: 8px 0px !important;
+  display: flex;
+  justify-content: flex-end;
 }
 
-._1wOydBgObqX6N_H4ZxO4E5, ._1BI5B2xY6xMD9hHPCMgWgM {
+._1wOydBgObqX6N_H4ZxO4E5,
+._1BI5B2xY6xMD9hHPCMgWgM {
   padding-bottom: 0 !important;
 }
 
 /* div above each component*/
 ._1BI5B2xY6xMD9hHPCMgWgM {
-    margin-bottom: 25px !important;
-    padding-left: 30px !important;
-    padding-right: 30px !important;
+  margin-bottom: 25px !important;
+  padding-left: 30px !important;
+  padding-right: 30px !important;
 }
 
 /* textbox, text area */
-._3VgxUzppbTclqye69HSxig, ._3LJt9oCN0ZNp9W7qDxV4Pb {
+._3VgxUzppbTclqye69HSxig,
+._3LJt9oCN0ZNp9W7qDxV4Pb {
   border-radius: 0px !important;
 }
 
@@ -375,14 +415,17 @@
 }
 
 /* Base styles for interactive elements */
-._2BCbSBZTAy3NNEkchW4JAl, .d2_RCwrIYw0j7I65dMyHx {
+._2BCbSBZTAy3NNEkchW4JAl,
+.d2_RCwrIYw0j7I65dMyHx {
   cursor: pointer !important;
   position: relative;
 }
 
 /* Hover styles */
-._2BCbSBZTAy3NNEkchW4JAl:hover, .d2_RCwrIYw0j7I65dMyHx:hover,
-._2BCbSBZTAy3NNEkchW4JAl:focus, .d2_RCwrIYw0j7I65dMyHx {
+._2BCbSBZTAy3NNEkchW4JAl:hover,
+.d2_RCwrIYw0j7I65dMyHx:hover,
+._2BCbSBZTAy3NNEkchW4JAl:focus,
+.d2_RCwrIYw0j7I65dMyHx {
   z-index: 1;
   box-shadow: 0 0 0 0 !important;
   outline: 2px solid var(--vads-color-action-focus-on-light) !important;
@@ -396,12 +439,14 @@ textarea:not([disabled]):focus,
 button:not([disabled]):focus {
   outline: 2px solid var(--vads-color-action-focus-on-light) !important;
   outline-offset: 2px !important;
-  box-shadow: 0 0 0 2px var(--vads-color-white), 0 0 0 4px var(--vads-color-primary) !important;
+  box-shadow: 0 0 0 2px var(--vads-color-white),
+    0 0 0 4px var(--vads-color-primary) !important;
 }
 /* coloring input checkboxes*/
 ._2BCbSBZTAy3NNEkchW4JAl input:checked + label ._3gm0DTvejOVCp2Ui6X30hr:before {
   background-color: var(--vads-color-primary);
-  box-shadow: 0 0 0 2px  var(--vads-color-white), 0 0 0 4px var(--vads-color-primary);
+  box-shadow: 0 0 0 2px var(--vads-color-white),
+    0 0 0 4px var(--vads-color-primary);
 }
 
 ._2BCbSBZTAy3NNEkchW4JAl input:checked + label ._3vIIqCsHxivLQpx8AfcIkO:after {
@@ -418,13 +463,14 @@ button:not([disabled]):focus {
   color: var(--vads-color-base-darker) !important;
 }
 
-._1_7PScJ_jiqe-TBSrlCh24 ._1YsDAuTgzg-TJThBFYa0LN:focus, ._1_7PScJ_jiqe-TBSrlCh24 ._1YsDAuTgzg-TJThBFYa0LN:hover {
+._1_7PScJ_jiqe-TBSrlCh24 ._1YsDAuTgzg-TJThBFYa0LN:focus,
+._1_7PScJ_jiqe-TBSrlCh24 ._1YsDAuTgzg-TJThBFYa0LN:hover {
   outline: 2px solid var(--vads-color-action-focus-on-light) !important;
   outline-offset: 2px;
   box-shadow: 0 0 0 0 !important;
 }
 
-._1_7PScJ_jiqe-TBSrlCh24 ._3_foUkwcSeMY2vBraukrvR:hover{
+._1_7PScJ_jiqe-TBSrlCh24 ._3_foUkwcSeMY2vBraukrvR:hover {
   outline: 2px solid var(--vads-color-action-focus-on-light) !important;
   border-color: transparent;
 }
@@ -434,7 +480,8 @@ button:not([disabled]):focus {
 }
 
 /* Rating Label */
-.ratingMinLabel, .ratingMaxLabel {
+.ratingMinLabel,
+.ratingMaxLabel {
   text-align: left;
   width: 75px;
 }
@@ -453,7 +500,12 @@ button:not([disabled]):focus {
 /*** footer ***/
 
 /*omb legal*/
-#survey-wrapper > form > main > div._1BI5B2xY6xMD9hHPCMgWgM.pra_footer > div._2x6S50Ozibu2fOMgF5qDzt > p:nth-child(2) {
+#survey-wrapper
+  > form
+  > main
+  > div._1BI5B2xY6xMD9hHPCMgWgM.pra_footer
+  > div._2x6S50Ozibu2fOMgF5qDzt
+  > p:nth-child(2) {
   padding-top: 20px;
 }
 
@@ -465,10 +517,10 @@ button:not([disabled]):focus {
 
 /* swap button positioning */
 ._207sw0FPxzBQQBPqaDdUpd._1wsMeNP_TDIxNDJlja6xcv > div:nth-child(2) {
-    order: 1;
+  order: 1;
 }
 ._207sw0FPxzBQQBPqaDdUpd._1wsMeNP_TDIxNDJlja6xcv > div:nth-child(1) {
-    order: 2;
+  order: 2;
 }
 
 ._207sw0FPxzBQQBPqaDdUpd button {
@@ -527,18 +579,28 @@ button:not([disabled]):focus {
   width: 139px !important;
 }
 
-#survey-wrapper > form > footer > div._207sw0FPxzBQQBPqaDdUpd._1wsMeNP_TDIxNDJlja6xcv > div:nth-child(2) > button {
+#survey-wrapper
+  > form
+  > footer
+  > div._207sw0FPxzBQQBPqaDdUpd._1wsMeNP_TDIxNDJlja6xcv
+  > div:nth-child(2)
+  > button {
   width: 150px !important;
   height: 48px !important;
-  font-size: 16px
+  font-size: 16px;
 }
-#survey-wrapper > form > footer > div._207sw0FPxzBQQBPqaDdUpd._1wsMeNP_TDIxNDJlja6xcv > div._1RyEnl1pfp8YClxLIzLFFu > button {
+#survey-wrapper
+  > form
+  > footer
+  > div._207sw0FPxzBQQBPqaDdUpd._1wsMeNP_TDIxNDJlja6xcv
+  > div._1RyEnl1pfp8YClxLIzLFFu
+  > button {
   width: 70px !important;
   height: 48px !important;
-  font-size: 16px
+  font-size: 16px;
 }
 
 /* powered by div */
 ._10o3Ogtkx0b1R7N7tOe-dr {
-  padding-top: 80px !important
+  padding-top: 80px !important;
 }

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -27,7 +27,7 @@
 
 /* "Very Dissatisfied" label below "1 of 5" rating element */
 .ng-scope #leftEdge {
-  padding-right: 24px;
+  padding-right: 25px;
   text-align: left;
   width: 75px;
 }

--- a/src/platform/site-wide/sass/modules/_m-medallia.scss
+++ b/src/platform/site-wide/sass/modules/_m-medallia.scss
@@ -57,10 +57,7 @@
 
 /* Very specific override that fixes an issue where the modal is unreadable because it is constrained to the width of col-sm-1 on tablet screens */
 @media (min-width: 576px) {
-  #liveForm
-    > div
-    > div.row.neb-form-close-btn-container.ng-hide
-    > div.col-sm-offset-11.col-sm-1 {
+  #liveForm>div>div.row.neb-form-close-btn-container.ng-hide>div.col-sm-offset-11.col-sm-1 {
     max-width: 100% !important;
   }
 }
@@ -156,7 +153,7 @@
 }
 
 #liveForm .kpl_builder .panel-footer .btn.submit-btn {
-  margin-right: 10px;
+ margin-right: 10px;
 }
 
 #liveForm .kpl_builder .panel-footer .btn.cancel-btn {
@@ -164,51 +161,20 @@
 }
 
 /* Very specific selectors to move 'do not inclide PII'helper text before the textarea */
-#liveForm
-  > div
-  > div
-  > div
-  > div
-  > div
-  > div
-  > .neb-component.neb-web-component.neb-textArea.kplFormHolder {
+#liveForm>div>div>div>div>div>div>.neb-component.neb-web-component.neb-textArea.kplFormHolder {
   display: flex;
   flex-direction: column;
 }
 
-#liveForm
-  > div
-  > div
-  > div
-  > div
-  > div
-  > div
-  > .neb-component.neb-web-component.neb-textArea.kplFormHolder
-  > label {
+#liveForm>div>div>div>div>div>div>.neb-component.neb-web-component.neb-textArea.kplFormHolder>label {
   order: 1;
 }
 
-#liveForm
-  > div
-  > div
-  > div
-  > div
-  > div
-  > div
-  > .neb-component.neb-web-component.neb-textArea.kplFormHolder
-  > p {
+#liveForm>div>div>div>div>div>div>.neb-component.neb-web-component.neb-textArea.kplFormHolder>p {
   order: 2;
 }
 
-#liveForm
-  > div
-  > div
-  > div
-  > div
-  > div
-  > div
-  > div.neb-component.neb-web-component.neb-textArea.kplFormHolder
-  > .neb-content.neb-wcag {
+#liveForm>div>div>div>div>div>div>div.neb-component.neb-web-component.neb-textArea.kplFormHolder>.neb-content.neb-wcag {
   order: 3;
 }
 
@@ -217,13 +183,13 @@
   text-align: left !important;
 }
 
-.thankYouPageLogoPreviewText > div > p > span > span > span[style] {
+.thankYouPageLogoPreviewText>div>p>span>span>span[style] {
   text-align: left !important;
   font-size: 20px;
   font-weight: 400;
 }
 
-.thankYouPageLogoPreviewText > div > p {
+.thankYouPageLogoPreviewText>div>p {
   text-align: left !important;
   font-size: 20px;
   font-weight: 400;
@@ -248,12 +214,12 @@
 /*  next button on VAMC muli-page surveys in-line style override*/
 .form-next-btn[style] {
   background-color: var(--vads-color-primary) !important;
-  margin-right: 10px !important;
+  margin-right: 10px !important
 }
 
 .modal-live-form a {
   cursor: pointer;
-  color: var(--vads-color-link) !important;
+  color: var(--vads-color-link)!important;
   text-decoration: underline !important;
   transition-duration: 0.3s;
   transition-timing-function: ease-in-out;
@@ -270,12 +236,12 @@
 }
 
 /* Unordered list styling for crisis header */
-.omb_crises > div > p > ul {
+.omb_crises>div>p>ul {
   padding: 0 0 0 1.5em !important;
   list-style: square !important;
 }
 
-.omb_crises > div > p > ul > li {
+.omb_crises>div>p>ul>li {
   line-height: 1.5 !important;
   margin-bottom: 0.5em !important;
 }
@@ -285,15 +251,15 @@
 }
 
 /* temp styles until VSignals team can change */
-.omb_crises > div > p > ul > li:nth-child(1) > span > strong:nth-child(3) {
+.omb_crises>div>p>ul>li:nth-child(1)>span>strong:nth-child(3) {
   font-weight: 400 !important;
 }
 
-.omb_crises > div > p > ul > li:nth-child(1) > span > strong:nth-child(2) > a {
+.omb_crises>div>p>ul>li:nth-child(1)>span>strong:nth-child(2)>a {
   font-weight: 400 !important;
 }
 
-.omb_crises > div > p > ul > li:nth-child(2) > span > strong:nth-child(2) > a {
+.omb_crises>div>p>ul>li:nth-child(2)>span>strong:nth-child(2) > a {
   font-weight: 400 !important;
 }
 /* end temp styles */
@@ -324,11 +290,7 @@
   padding-right: 20px !important;
 }
 
-.TKB4VqaXyyt6uMNVvoLdN input:not([disabled]):focus,
-select:not([disabled]):focus,
-textarea:not([disabled]):focus,
-button:not([disabled]):focus,
-a:focus {
+.TKB4VqaXyyt6uMNVvoLdN input:not([disabled]):focus, select:not([disabled]):focus, textarea:not([disabled]):focus, button:not([disabled]):focus, a:focus {
   outline: 2px solid var(--vads-color-action-focus-on-light) !important;
   outline-offset: 2px;
   box-shadow: 0 0 0 0 !important;
@@ -353,12 +315,12 @@ a:focus {
 /* omb_crisis */
 ._1BI5B2xY6xMD9hHPCMgWgM > div > ul {
   padding: 0 0 0 1.5em !important;
-  list-style: square !important;
+  list-style: square !important
 }
 
 ._1BI5B2xY6xMD9hHPCMgWgM > div > ul > li {
   line-height: 1.5 !important;
-  margin-bottom: 0.5em !important;
+  margin-bottom: 0.5em !important
 }
 
 /*** form main body ***/
@@ -378,34 +340,32 @@ a:focus {
 
 /* Specific Styles for question h2s*/
 ._3qavF1mE7wQGkoUgHE1D75 {
-  display: inline-block;
-  font-weight: bold !important;
-  margin-bottom: 5px;
-  text-align: left !important;
+    display: inline-block;
+    font-weight: bold !important;
+    margin-bottom: 5px;
+    text-align: left !important;
 }
 
 /* empty header & close button */
 ._1SPV2GZjz0ekDKiu5qBJ16 {
-  padding: 8px 0px !important;
-  display: flex;
-  justify-content: flex-end;
+    padding: 8px 0px !important;
+    display: flex;
+    justify-content: flex-end;
 }
 
-._1wOydBgObqX6N_H4ZxO4E5,
-._1BI5B2xY6xMD9hHPCMgWgM {
+._1wOydBgObqX6N_H4ZxO4E5, ._1BI5B2xY6xMD9hHPCMgWgM {
   padding-bottom: 0 !important;
 }
 
 /* div above each component*/
 ._1BI5B2xY6xMD9hHPCMgWgM {
-  margin-bottom: 25px !important;
-  padding-left: 30px !important;
-  padding-right: 30px !important;
+    margin-bottom: 25px !important;
+    padding-left: 30px !important;
+    padding-right: 30px !important;
 }
 
 /* textbox, text area */
-._3VgxUzppbTclqye69HSxig,
-._3LJt9oCN0ZNp9W7qDxV4Pb {
+._3VgxUzppbTclqye69HSxig, ._3LJt9oCN0ZNp9W7qDxV4Pb {
   border-radius: 0px !important;
 }
 
@@ -415,17 +375,14 @@ a:focus {
 }
 
 /* Base styles for interactive elements */
-._2BCbSBZTAy3NNEkchW4JAl,
-.d2_RCwrIYw0j7I65dMyHx {
+._2BCbSBZTAy3NNEkchW4JAl, .d2_RCwrIYw0j7I65dMyHx {
   cursor: pointer !important;
   position: relative;
 }
 
 /* Hover styles */
-._2BCbSBZTAy3NNEkchW4JAl:hover,
-.d2_RCwrIYw0j7I65dMyHx:hover,
-._2BCbSBZTAy3NNEkchW4JAl:focus,
-.d2_RCwrIYw0j7I65dMyHx {
+._2BCbSBZTAy3NNEkchW4JAl:hover, .d2_RCwrIYw0j7I65dMyHx:hover,
+._2BCbSBZTAy3NNEkchW4JAl:focus, .d2_RCwrIYw0j7I65dMyHx {
   z-index: 1;
   box-shadow: 0 0 0 0 !important;
   outline: 2px solid var(--vads-color-action-focus-on-light) !important;
@@ -439,14 +396,12 @@ textarea:not([disabled]):focus,
 button:not([disabled]):focus {
   outline: 2px solid var(--vads-color-action-focus-on-light) !important;
   outline-offset: 2px !important;
-  box-shadow: 0 0 0 2px var(--vads-color-white),
-    0 0 0 4px var(--vads-color-primary) !important;
+  box-shadow: 0 0 0 2px var(--vads-color-white), 0 0 0 4px var(--vads-color-primary) !important;
 }
 /* coloring input checkboxes*/
 ._2BCbSBZTAy3NNEkchW4JAl input:checked + label ._3gm0DTvejOVCp2Ui6X30hr:before {
   background-color: var(--vads-color-primary);
-  box-shadow: 0 0 0 2px var(--vads-color-white),
-    0 0 0 4px var(--vads-color-primary);
+  box-shadow: 0 0 0 2px  var(--vads-color-white), 0 0 0 4px var(--vads-color-primary);
 }
 
 ._2BCbSBZTAy3NNEkchW4JAl input:checked + label ._3vIIqCsHxivLQpx8AfcIkO:after {
@@ -463,14 +418,13 @@ button:not([disabled]):focus {
   color: var(--vads-color-base-darker) !important;
 }
 
-._1_7PScJ_jiqe-TBSrlCh24 ._1YsDAuTgzg-TJThBFYa0LN:focus,
-._1_7PScJ_jiqe-TBSrlCh24 ._1YsDAuTgzg-TJThBFYa0LN:hover {
+._1_7PScJ_jiqe-TBSrlCh24 ._1YsDAuTgzg-TJThBFYa0LN:focus, ._1_7PScJ_jiqe-TBSrlCh24 ._1YsDAuTgzg-TJThBFYa0LN:hover {
   outline: 2px solid var(--vads-color-action-focus-on-light) !important;
   outline-offset: 2px;
   box-shadow: 0 0 0 0 !important;
 }
 
-._1_7PScJ_jiqe-TBSrlCh24 ._3_foUkwcSeMY2vBraukrvR:hover {
+._1_7PScJ_jiqe-TBSrlCh24 ._3_foUkwcSeMY2vBraukrvR:hover{
   outline: 2px solid var(--vads-color-action-focus-on-light) !important;
   border-color: transparent;
 }
@@ -480,8 +434,7 @@ button:not([disabled]):focus {
 }
 
 /* Rating Label */
-.ratingMinLabel,
-.ratingMaxLabel {
+.ratingMinLabel, .ratingMaxLabel {
   text-align: left;
   width: 75px;
 }
@@ -500,12 +453,7 @@ button:not([disabled]):focus {
 /*** footer ***/
 
 /*omb legal*/
-#survey-wrapper
-  > form
-  > main
-  > div._1BI5B2xY6xMD9hHPCMgWgM.pra_footer
-  > div._2x6S50Ozibu2fOMgF5qDzt
-  > p:nth-child(2) {
+#survey-wrapper > form > main > div._1BI5B2xY6xMD9hHPCMgWgM.pra_footer > div._2x6S50Ozibu2fOMgF5qDzt > p:nth-child(2) {
   padding-top: 20px;
 }
 
@@ -517,10 +465,10 @@ button:not([disabled]):focus {
 
 /* swap button positioning */
 ._207sw0FPxzBQQBPqaDdUpd._1wsMeNP_TDIxNDJlja6xcv > div:nth-child(2) {
-  order: 1;
+    order: 1;
 }
 ._207sw0FPxzBQQBPqaDdUpd._1wsMeNP_TDIxNDJlja6xcv > div:nth-child(1) {
-  order: 2;
+    order: 2;
 }
 
 ._207sw0FPxzBQQBPqaDdUpd button {
@@ -579,28 +527,18 @@ button:not([disabled]):focus {
   width: 139px !important;
 }
 
-#survey-wrapper
-  > form
-  > footer
-  > div._207sw0FPxzBQQBPqaDdUpd._1wsMeNP_TDIxNDJlja6xcv
-  > div:nth-child(2)
-  > button {
+#survey-wrapper > form > footer > div._207sw0FPxzBQQBPqaDdUpd._1wsMeNP_TDIxNDJlja6xcv > div:nth-child(2) > button {
   width: 150px !important;
   height: 48px !important;
-  font-size: 16px;
+  font-size: 16px
 }
-#survey-wrapper
-  > form
-  > footer
-  > div._207sw0FPxzBQQBPqaDdUpd._1wsMeNP_TDIxNDJlja6xcv
-  > div._1RyEnl1pfp8YClxLIzLFFu
-  > button {
+#survey-wrapper > form > footer > div._207sw0FPxzBQQBPqaDdUpd._1wsMeNP_TDIxNDJlja6xcv > div._1RyEnl1pfp8YClxLIzLFFu > button {
   width: 70px !important;
   height: 48px !important;
-  font-size: 16px;
+  font-size: 16px
 }
 
 /* powered by div */
 ._10o3Ogtkx0b1R7N7tOe-dr {
-  padding-top: 80px !important;
+  padding-top: 80px !important
 }


### PR DESCRIPTION
## Summary

- Issue was caused by a condition in test selection that was causing only `src/applications` tests to run and skipping all platform unit tests in the stress test. This resulted in platform tests being selected to run, therefore triggering the unit test stability review, but then those tests not actually running causing it to run with empty tests. This was in turn causing all unit test reporting steps to error, as there were no results files to generate reports with.
- The script has been altered to include any paths that are set to stress test from the platform folder.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/83408

## Testing done

- Forced a change in a platform scss file and watched the platform tests run to a successful conclusion.
- Removed the change and observed the test check skipping still as expected. 

