### PR TITLE
removed timestamp and related tests from pre-check-in.

### DIFF
--- a/src/applications/check-in/components/AppointmentBlock.jsx
+++ b/src/applications/check-in/components/AppointmentBlock.jsx
@@ -9,7 +9,6 @@ import { createAnalyticsSlug } from '../utils/analytics';
 import AppointmentListItem from './AppointmentDisplay/AppointmentListItem';
 import { makeSelectApp } from '../selectors';
 import { useFormRouting } from '../hooks/useFormRouting';
-import { APP_NAMES } from '../utils/appConstants';
 import {
   getAppointmentId,
   sortAppointmentsByStartTime,
@@ -20,7 +19,6 @@ const AppointmentBlock = props => {
   const selectApp = useMemo(makeSelectApp, []);
   const { app } = useSelector(selectApp);
   const { t } = useTranslation();
-  const appointmentsDateTime = new Date(appointments[0].startTime);
 
   const { jumpToPage } = useFormRouting(router);
 
@@ -36,22 +34,9 @@ const AppointmentBlock = props => {
 
   return (
     <div>
-      {app === APP_NAMES.PRE_CHECK_IN ? (
-        <p
-          className="vads-u-font-family--serif"
-          data-testid="appointment-day-location"
-        >
-          {t('your-appointments-on-day', {
-            count: appointments.length,
-            day: appointmentsDateTime,
-          })}
-        </p>
-      ) : (
-        <p className="vads-u-font-family--serif" data-testid="date-text">
-          {t('here-are-your-appointments-for-today', { date: new Date() })}
-        </p>
-      )}
-
+      <p className="vads-u-font-family--serif" data-testid="date-text">
+        {t('here-are-your-appointments-for-today', { date: new Date() })}
+      </p>
       <ul
         className="vads-u-border-top--1px vads-u-margin-bottom--4 check-in--appointment-list appointment-list"
         data-testid="appointment-list"

--- a/src/applications/check-in/components/AppointmentBlock.jsx
+++ b/src/applications/check-in/components/AppointmentBlock.jsx
@@ -9,6 +9,7 @@ import { createAnalyticsSlug } from '../utils/analytics';
 import AppointmentListItem from './AppointmentDisplay/AppointmentListItem';
 import { makeSelectApp } from '../selectors';
 import { useFormRouting } from '../hooks/useFormRouting';
+import { APP_NAMES } from '../utils/appConstants';
 import {
   getAppointmentId,
   sortAppointmentsByStartTime,
@@ -34,9 +35,11 @@ const AppointmentBlock = props => {
 
   return (
     <div>
-      <p className="vads-u-font-family--serif" data-testid="date-text">
-        {t('here-are-your-appointments-for-today', { date: new Date() })}
-      </p>
+      {app === APP_NAMES.CHECK_IN && (
+        <p className="vads-u-font-family--serif" data-testid="date-text">
+          {t('here-are-your-appointments-for-today', { date: new Date() })}
+        </p>
+      )}
       <ul
         className="vads-u-border-top--1px vads-u-margin-bottom--4 check-in--appointment-list appointment-list"
         data-testid="appointment-list"

--- a/src/applications/check-in/components/tests/AppointmentBlock.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/AppointmentBlock.unit.spec.jsx
@@ -45,9 +45,6 @@ describe('AppointmentBlock', () => {
             <AppointmentBlock appointments={appointments} page="intro" />
           </CheckInProvider>,
         );
-        expect(screen.getByTestId('appointment-day-location')).to.have.text(
-          'Your appointments are on November 16, 2021.',
-        );
         expect(screen.getAllByTestId('appointment-list-item').length).to.equal(
           2,
         );
@@ -62,31 +59,9 @@ describe('AppointmentBlock', () => {
             />
           </CheckInProvider>,
         );
-        expect(screen.getByTestId('appointment-day-location')).to.have.text(
-          'Your appointment is on November 16, 2021.',
-        );
 
         expect(screen.getAllByTestId('appointment-list-item').length).to.equal(
           1,
-        );
-      });
-    });
-    describe('Phone appointment context', () => {
-      const phoneAppointments = JSON.parse(JSON.stringify(appointments));
-      phoneAppointments[0].kind = 'phone';
-      phoneAppointments[1].kind = 'phone';
-
-      it('Renders appointment time with no clinic for phone appointments', () => {
-        const screen = render(
-          <CheckInProvider store={{ app: 'preCheckIn' }}>
-            <AppointmentBlock
-              appointments={phoneAppointments}
-              page="confirmation"
-            />
-          </CheckInProvider>,
-        );
-        expect(screen.getByTestId('appointment-day-location')).to.have.text(
-          'Your appointments are on November 16, 2021.',
         );
       });
     });

--- a/src/applications/check-in/pre-check-in/tests/e2e/pages/Confirmation.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/pages/Confirmation.js
@@ -10,7 +10,6 @@ class Confirmation {
       .should('be.visible')
       .and('have.text', 'You’ve completed pre-check-in');
     cy.get("[data-testid='confirmation-wrapper']");
-    cy.get("p[data-testid='appointment-day-location']");
     cy.get("[data-testid='appointment-list']");
     cy.get("[header='What if I have questions about my appointment?']")
       .shadow()


### PR DESCRIPTION
## Summary

Removes the timestamp on pre-check-in confirmation page

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#83222

## Testing done

Updates unit and e2e tests

## Screenshots

![localhost_3001_health-care_appointment-pre-check-in_complete (1)](https://github.com/department-of-veterans-affairs/vets-website/assets/13967174/56435c2b-f26b-4954-ac31-3af81509791b)

## What areas of the site does it impact?

pre-check-in application

## Acceptance criteria
 - [ ] timestamp is removed from pre-check-in confirmation page
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

