### PR TITLE
Update yes/no review fields for Caregiver Application

### DIFF
--- a/src/applications/caregivers/components/FormDescriptions/index.jsx
+++ b/src/applications/caregivers/components/FormDescriptions/index.jsx
@@ -202,6 +202,7 @@ export const VeteranFullNameDescription = (
     </span>
   </>
 );
+
 export const CaregiverFullNameDescription = (
   <>
     <span className="vads-u-display--block vads-u-color--gray-medium">

--- a/src/applications/caregivers/components/FormReview/CustomYesNoReviewField.jsx
+++ b/src/applications/caregivers/components/FormReview/CustomYesNoReviewField.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const CustomYesNoReviewField = ({
+  children: {
+    props: { uiSchema, formData },
+  },
+}) => (
+  <div className="review-row">
+    <dt>{uiSchema['ui:title']}</dt>
+    <dd className="dd-privacy-hidden" data-dd-action-name="data value">
+      {formData ? 'Yes' : 'No'}
+    </dd>
+  </div>
+);
+
+CustomYesNoReviewField.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.object, PropTypes.node]),
+};
+
+export default CustomYesNoReviewField;

--- a/src/applications/caregivers/config/chapters/primary/hasPrimaryCaregiver.js
+++ b/src/applications/caregivers/config/chapters/primary/hasPrimaryCaregiver.js
@@ -1,4 +1,5 @@
 import { primaryCaregiverFields } from '../../../definitions/constants';
+import CustomYesNoReviewField from '../../../components/FormReview/CustomYesNoReviewField';
 import PrimaryCaregiverDescription from '../../../components/FormDescriptions/PrimaryCaregiverDescription';
 
 const hasPrimaryCaregiverPage = {
@@ -6,11 +7,12 @@ const hasPrimaryCaregiverPage = {
     [primaryCaregiverFields.hasPrimaryCaregiver]: {
       'ui:title':
         'Would you like to apply for benefits for a Primary Family Caregiver?',
-      'ui:required': () => true,
       'ui:description': PrimaryCaregiverDescription({
         additionalInfo: true,
       }),
+      'ui:reviewField': CustomYesNoReviewField,
       'ui:widget': 'yesNo',
+      'ui:required': () => true,
     },
   },
   schema: {

--- a/src/applications/caregivers/config/chapters/primary/primaryHealthCareCoverage.js
+++ b/src/applications/caregivers/config/chapters/primary/primaryHealthCareCoverage.js
@@ -1,7 +1,8 @@
 import fullSchema from 'vets-json-schema/dist/10-10CG-schema.json';
 import { primaryCaregiverFields } from '../../../definitions/constants';
-import { hasHealthInsurance } from '../../../definitions/UIDefinitions/caregiverUI';
+import { HeathCareCoverageDescription } from '../../../components/FormDescriptions';
 import PrimaryHealthCoverageDescription from '../../../components/FormDescriptions/PrimaryHealthCoverageDescription';
+import CustomYesNoReviewField from '../../../components/FormReview/CustomYesNoReviewField';
 
 const { primaryCaregiver } = fullSchema.properties;
 const primaryCaregiverProps = primaryCaregiver.properties;
@@ -11,7 +12,13 @@ const primaryMedicalPage = {
     'ui:description': PrimaryHealthCoverageDescription({
       pageTitle: 'Health care coverage',
     }),
-    [primaryCaregiverFields.hasHealthInsurance]: hasHealthInsurance,
+    [primaryCaregiverFields.hasHealthInsurance]: {
+      'ui:title':
+        'Does the Primary Family Caregiver applicant have health care coverage, such as Medicaid, Medicare, CHAMPVA, Tricare, or private insurance?',
+      'ui:description': HeathCareCoverageDescription,
+      'ui:reviewField': CustomYesNoReviewField,
+      'ui:widget': 'yesNo',
+    },
   },
   schema: {
     type: 'object',

--- a/src/applications/caregivers/config/chapters/secondaryOne/hasSecondaryCaregiver.js
+++ b/src/applications/caregivers/config/chapters/secondaryOne/hasSecondaryCaregiver.js
@@ -1,6 +1,7 @@
 import { shouldHideAlert } from '../../../utils/helpers';
 import { primaryCaregiverFields } from '../../../definitions/constants';
 import SecondaryRequiredAlert from '../../../components/FormAlerts/SecondaryRequiredAlert';
+import CustomYesNoReviewField from '../../../components/FormReview/CustomYesNoReviewField';
 import SecondaryCaregiverDescription from '../../../components/FormDescriptions/SecondaryCaregiverDescription';
 
 const hasSecondaryCaregiverPage = {
@@ -8,10 +9,11 @@ const hasSecondaryCaregiverPage = {
     [primaryCaregiverFields.hasSecondaryCaregiverOne]: {
       'ui:title':
         'Would you like to apply for benefits for a Secondary Family Caregiver?',
-      'ui:widget': 'yesNo',
       'ui:description': SecondaryCaregiverDescription({
         additionalInfo: true,
       }),
+      'ui:reviewField': CustomYesNoReviewField,
+      'ui:widget': 'yesNo',
       'ui:required': formData =>
         !formData[primaryCaregiverFields.hasPrimaryCaregiver],
       'ui:validations': [

--- a/src/applications/caregivers/config/chapters/secondaryOne/secondaryOneContactInfo.js
+++ b/src/applications/caregivers/config/chapters/secondaryOne/secondaryOneContactInfo.js
@@ -12,10 +12,9 @@ import {
   addressWithAutofillUI,
   emailEncouragementUI,
 } from '../../../definitions/UIDefinitions/sharedUI';
-import {
-  secondaryOneInputLabel,
-  hasSecondaryCaregiverTwoUI,
-} from '../../../definitions/UIDefinitions/caregiverUI';
+import { secondaryOneInputLabel } from '../../../definitions/UIDefinitions/caregiverUI';
+import { AdditionalCaregiverDescription } from '../../../components/FormDescriptions';
+import CustomYesNoReviewField from '../../../components/FormReview/CustomYesNoReviewField';
 import SecondaryCaregiverDescription from '../../../components/FormDescriptions/SecondaryCaregiverDescription';
 
 const { address } = fullSchema.definitions;
@@ -43,7 +42,16 @@ const secondaryCaregiverContactPage = {
     [secondaryOneFields.vetRelationship]: vetRelationshipUI(
       secondaryOneInputLabel,
     ),
-    [secondaryOneFields.hasSecondaryCaregiverTwo]: hasSecondaryCaregiverTwoUI,
+    [secondaryOneFields.hasSecondaryCaregiverTwo]: {
+      'ui:title':
+        'Would you like to apply for benefits for another Secondary Family Caregiver?',
+      'ui:description': AdditionalCaregiverDescription,
+      'ui:reviewField': CustomYesNoReviewField,
+      'ui:widget': 'yesNo',
+      'ui:options': {
+        hideLabelText: true,
+      },
+    },
   },
   schema: {
     type: 'object',

--- a/src/applications/caregivers/definitions/UIDefinitions/caregiverUI.js
+++ b/src/applications/caregivers/definitions/UIDefinitions/caregiverUI.js
@@ -1,26 +1,6 @@
-import {
-  AdditionalCaregiverDescription,
-  HeathCareCoverageDescription,
-} from '../../components/FormDescriptions';
-
 export const primaryInputLabel = 'Primary Family Caregiver\u2019s';
 export const secondaryOneInputLabel = 'Secondary Family Caregiver\u2019s';
 export const secondaryTwoInputLabel = 'Secondary Family Caregiver\u2019s (2)';
 
-export const hasHealthInsurance = {
-  'ui:title':
-    'Does the Primary Family Caregiver applicant have health care coverage, such as Medicaid, Medicare, CHAMPVA, Tricare, or private insurance?',
-  'ui:description': HeathCareCoverageDescription,
-  'ui:widget': 'yesNo',
-};
-
 export const secondaryTwoChapterTitle =
   'Secondary Family Caregiver (2) applicant information';
-
-export const hasSecondaryCaregiverTwoUI = {
-  'ui:description': AdditionalCaregiverDescription,
-  'ui:widget': 'yesNo',
-  'ui:options': {
-    hideLabelText: true,
-  },
-};

--- a/src/applications/caregivers/tests/components/FormReview/CustomYesNoReviewField.unit.spec.js
+++ b/src/applications/caregivers/tests/components/FormReview/CustomYesNoReviewField.unit.spec.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+
+import CustomYesNoReviewField from '../../../components/FormReview/CustomYesNoReviewField';
+
+describe('CG <CustomYesNoReviewField>', () => {
+  const getData = ({ formData }) => ({
+    props: {
+      uiSchema: { 'ui:title': 'Review Field Title' },
+      formData,
+    },
+  });
+
+  context('when the component renders with `Yes` value', () => {
+    it('should render the correct field title & value', () => {
+      const { props } = getData({ formData: true });
+      const { container } = render(
+        <CustomYesNoReviewField>
+          <div {...props} />
+        </CustomYesNoReviewField>,
+      );
+      const selectors = {
+        title: container.querySelector('dt', '.review-row'),
+        value: container.querySelector('dd', '.review-row'),
+      };
+      expect(selectors.title).to.contain.text(props.uiSchema['ui:title']);
+      expect(selectors.value).to.contain.text('Yes');
+    });
+  });
+
+  describe('when the component renders with `No` value', () => {
+    it('should render the correct field title & value', () => {
+      const { props } = getData({ formData: false });
+      const { container } = render(
+        <CustomYesNoReviewField>
+          <div {...props} />
+        </CustomYesNoReviewField>,
+      );
+      const selectors = {
+        title: container.querySelector('dt', '.review-row'),
+        value: container.querySelector('dd', '.review-row'),
+      };
+      expect(selectors.title).to.contain.text(props.uiSchema['ui:title']);
+      expect(selectors.value).to.contain.text('No');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

For the Yes/No questions that had description text or components in the Caregivers Application, these were causing an issue with render on the Review page. This PR creates a dedicated review component for the Yes/No questions to eliminate their render on the Review page and only render the "title".

## Related issue(s)

department-of-veterans-affairs/va.gov-team#83329

## Testing done

- Confirmed all behavior via Cypress testing

## Screenshots

| Before | After |
| ------ | ----- |
| <img width="644" alt="Screenshot 2024-05-28 at 12 52 57" src="https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/e180bc0b-a4ac-4b7a-94ac-b43eb3fc54f1"> | <img width="407" alt="Screenshot 2024-05-28 at 12 32 49" src="https://github.com/department-of-veterans-affairs/vets-website/assets/6738544/e7e89dbb-3324-483d-b524-cc5d8f57249f"> |

## Acceptance criteria

 - Yes/No questions successfully render without description text on Review page

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution