### PR TITLE
 remove old strings from vet360 transactions

### DIFF
--- a/src/applications/letters/containers/VAProfileWrapper.jsx
+++ b/src/applications/letters/containers/VAProfileWrapper.jsx
@@ -14,7 +14,7 @@ export default function VAProfileWrapper() {
     <div className="va-profile-wrapper">
       <InitializeVAPServiceID>
         <VAPServicePendingTransactionCategory
-          categoryType={TRANSACTION_CATEGORY_TYPES.VAP_ADDRESS}
+          categoryType={TRANSACTION_CATEGORY_TYPES.ADDRESS}
         >
           <AddressField
             fieldName={FIELD_NAMES.MAILING_ADDRESS}

--- a/src/platform/user/profile/vap-svc/constants/index.js
+++ b/src/platform/user/profile/vap-svc/constants/index.js
@@ -53,21 +53,10 @@ export const USA = {
   COUNTRY_ISO3_CODE: 'USA',
 };
 
-// TODO: After https://github.com/department-of-veterans-affairs/va.gov-team/issues/19858
-// is completed and is live on prod, we can update this object to remove the
-// `Vet360` instances:
-//
-// PHONE: 'AsyncTransaction::VAProfile::PhoneTransaction',
-// EMAIL: 'AsyncTransaction::VAProfile::EmailTransaction',
-// ADDRESS: 'AsyncTransaction::VAProfile::AddressTransaction',
-//
 export const TRANSACTION_CATEGORY_TYPES = {
-  PHONE: 'AsyncTransaction::Vet360::PhoneTransaction',
-  EMAIL: 'AsyncTransaction::Vet360::EmailTransaction',
-  ADDRESS: 'AsyncTransaction::Vet360::AddressTransaction',
-  VAP_PHONE: 'AsyncTransaction::VAProfile::PhoneTransaction',
-  VAP_EMAIL: 'AsyncTransaction::VAProfile::EmailTransaction',
-  VAP_ADDRESS: 'AsyncTransaction::VAProfile::AddressTransaction',
+  PHONE: 'AsyncTransaction::VAProfile::PhoneTransaction',
+  EMAIL: 'AsyncTransaction::VAProfile::EmailTransaction',
+  ADDRESS: 'AsyncTransaction::VAProfile::AddressTransaction',
 };
 
 export const TRANSACTION_STATUS = {

--- a/src/platform/user/profile/vap-svc/containers/VAPServicePendingTransactionCategory.jsx
+++ b/src/platform/user/profile/vap-svc/containers/VAPServicePendingTransactionCategory.jsx
@@ -18,18 +18,10 @@ function VAPServicePendingTransactionCategory({
   if (!hasPendingCategoryTransaction) return <div>{children}</div>;
 
   let plural = 'email';
-  // TODO: After https://github.com/department-of-veterans-affairs/va.gov-team/issues/19858
-  // is completed and is live on prod, we can remove the `.VAP_` types used
-  // below:
-  if (
-    categoryType === TRANSACTION_CATEGORY_TYPES.PHONE ||
-    categoryType === TRANSACTION_CATEGORY_TYPES.VAP_PHONE
-  ) {
+
+  if (categoryType === TRANSACTION_CATEGORY_TYPES.PHONE) {
     plural = 'phone numbers';
-  } else if (
-    categoryType === TRANSACTION_CATEGORY_TYPES.ADDRESS ||
-    categoryType === TRANSACTION_CATEGORY_TYPES.VAP_ADDRESS
-  ) {
+  } else if (categoryType === TRANSACTION_CATEGORY_TYPES.ADDRESS) {
     plural = 'addresses';
   }
 


### PR DESCRIPTION
## Summary

- This is some maintenance work that has been hanging around for a long time, and so just cleaning up some vet360 strings that are no longer used by BE or FE.
- Removed old string and renamed constants to align with overall code 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/21587

## Testing done

- all tests continue to pass. This shouldn't affect any application logic as these strings have not been in use for a long time.

## Screenshots

No UI changes

## What areas of the site does it impact?

Profile

## Acceptance criteria

- [x] strings removed

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed