### PR TITLE
Check in/81831/upcoming feature flag

### DIFF
--- a/src/applications/check-in/README.md
+++ b/src/applications/check-in/README.md
@@ -158,7 +158,38 @@ Current and errors Travel-claim: `yarn cy:run --env with_screenshots=true --spec
 ### Adding additional screenshots
 There is a cypress command that gets imported in our local commands named `createScreenshots`. It is best used after an axe check on the page you wish to capture. Add cy.createScreenshots([filename]) and also make sure that the test is imported in one of the screenshot scripts listed above. Filename syntax should be `application--page-name` example: `Pre-check-in--Validate-with-DOB`. The command will automatically get screenshots for translated versions of the page.
 
-## Adding Feature Toggles
+## Feature toggles
+
+We are currently using an HOC located at `src/applications/pre-check-in/containers/withFeatureFlip.jsx` to control the feature flips. The whole app is wrapped around one, and each new feature should have its own toggle.
+
+Though we have the HOC, its now considered best practice to query redux using the useSelector hook.
+
+### Current toggles
+
+- `check_in_experience_enabled` : Enables or disabled the whole day-of check-in app on va.gov
+  - when to sunset: never.
+- `check_in_experience_pre_check_in_enabled` : Enables or disabled the whole pre-check-in app on va.gov
+  - when to sunset: never.
+- `check_in_experience_pre_check_in_action_link_top_placement`: Changes pre-check-in action link placement to the top of the page.
+  - when to sunset: now.
+- `check_in_experience_translation_disclaimer_spanish_enabled` : Enables or disables the mixed language disclaimer (there may be some untranslated content) for spanish pages of the site
+  - when to sunset: when we are in a situation where new content is not added to the site until it is translated into spanish.
+- `check_in_experience_travel_reimbursement`: Enables or disables travel reimbursement workflow for day-of check-in.
+  - when to sunset: never.
+- `check_in_experience_travel_logic`: Enables logic that allows the veteran to submit a travel claim to more than one appointment in a day if they are at separate facilities.
+  - when to sunset: now.
+- `check_in_experience_browser_monitoring`: Enables browser monitoring for check-in applications.
+  - when to sunset: never.
+- `check_in_experience_upcoming_appointments_enabled`: Enables the upcoming appointments block.
+  - when to sunset: After it is confirmed that upcoming appointments consistently works and adds value to the veterans.
+
+### How to test this?
+
+Each feature should have unit tests and e2e tests.
+
+For testing in staging, use the instructions at [https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/checkin/engineering/qa/test-data-setup.md](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/checkin/engineering/qa/test-data-setup.md).
+
+### Adding Feature Toggles
 
 To add a feature toggle follow the steps oulined in the VA Platform Documentation on [Feature Toggles](https://depo-platform-documentation.scrollhelp.site/developer-docs/feature-toggles-guide). Additionally add the feature toggle to selectors, mocks and the readme for Pre-check-in and/or Check-in apps.
 

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
@@ -8,7 +8,7 @@ const generateFeatureToggles = (toggles = {}) => {
     checkInExperienceTravelLogic = true,
     checkInExperienceBrowserMonitoring = false,
     checkInExperiencePreCheckInActionLinkTopPlacement = true,
-    checkInExperienceUnifiedLandingPage = false,
+    checkInExperienceUpcomingAppointmentsEnabled = false,
   } = toggles;
 
   return {
@@ -48,8 +48,8 @@ const generateFeatureToggles = (toggles = {}) => {
           value: checkInExperiencePreCheckInActionLinkTopPlacement,
         },
         {
-          name: 'check_in_experience_unified_landing_page',
-          value: checkInExperienceUnifiedLandingPage,
+          name: 'check_in_experience_upcoming_appointments_enabled',
+          value: checkInExperienceUpcomingAppointmentsEnabled,
         },
       ],
     },

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
@@ -8,7 +8,7 @@ const generateFeatureToggles = (toggles = {}) => {
     checkInExperienceTravelLogic = true,
     checkInExperienceBrowserMonitoring = false,
     checkInExperiencePreCheckInActionLinkTopPlacement = true,
-    checkInExperienceUpcomingAppointmentsEnabled = false,
+    checkInExperienceUpcomingAppointmentsEnabled = true,
   } = toggles;
 
   return {

--- a/src/applications/check-in/components/pages/Appointments/AppointmentsPage.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/Appointments/AppointmentsPage.unit.spec.jsx
@@ -17,6 +17,12 @@ describe('unified check-in experience', () => {
     teardownI18n();
   });
   describe('AppointmentsPage', () => {
+    const appointmentsOn = {
+      check_in_experience_upcoming_appointments_enabled: true,
+    };
+    const appointmentsOff = {
+      check_in_experience_upcoming_appointments_enabled: false,
+    };
     it('renders regions', () => {
       // Mock the return value for the useGetCheckInData hook
       const useGetCheckInDataStub = sinon
@@ -26,7 +32,7 @@ describe('unified check-in experience', () => {
         });
 
       const { getByTestId } = render(
-        <CheckInProvider>
+        <CheckInProvider store={{ features: appointmentsOn }}>
           <AppointmentsPage />
         </CheckInProvider>,
       );
@@ -47,7 +53,7 @@ describe('unified check-in experience', () => {
           isLoading: true,
         });
       const screen = render(
-        <CheckInProvider store={{ appointments: [] }}>
+        <CheckInProvider store={{ appointments: [], features: appointmentsOn }}>
           <AppointmentsPage />
         </CheckInProvider>,
       );
@@ -58,7 +64,7 @@ describe('unified check-in experience', () => {
     });
     it('shows the date & time the appointments were loaded & a refresh link', () => {
       const checkIn = render(
-        <CheckInProvider>
+        <CheckInProvider store={{ features: appointmentsOn }}>
           <AppointmentsPage />
         </CheckInProvider>,
       );
@@ -69,6 +75,15 @@ describe('unified check-in experience', () => {
         'refresh-appointments-button',
       );
       expect(refreshButton).to.exist;
+    });
+    it('does not show upcoming appointments or accordions with the feature off', () => {
+      const checkIn = render(
+        <CheckInProvider store={{ features: appointmentsOff }}>
+          <AppointmentsPage />
+        </CheckInProvider>,
+      );
+      expect(checkIn.queryByTestId('upcoming-appointments')).to.not.exist;
+      expect(checkIn.queryByTestId('appointments-accordions')).to.not.exist;
     });
   });
 });

--- a/src/applications/check-in/components/pages/Appointments/index.jsx
+++ b/src/applications/check-in/components/pages/Appointments/index.jsx
@@ -7,6 +7,7 @@ import { useGetCheckInData } from '../../../hooks/useGetCheckInData';
 import Wrapper from '../../layout/Wrapper';
 import { APP_NAMES } from '../../../utils/appConstants';
 import { makeSelectApp, makeSelectVeteranData } from '../../../selectors';
+import { makeSelectFeatureToggles } from '../../../utils/selectors/feature-toggles';
 import { useUpdateError } from '../../../hooks/useUpdateError';
 import UpcomingAppointments from '../../UpcomingAppointments';
 import ActionItemDisplay from '../../ActionItemDisplay';
@@ -16,6 +17,8 @@ import { intervalUntilNextAppointmentIneligibleForCheckin } from '../../../utils
 
 const AppointmentsPage = props => {
   const { router } = props;
+  const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
+  const { isUpcomingAppointmentsEnabled } = useSelector(selectFeatureToggles);
   const selectApp = useMemo(makeSelectApp, []);
   const { app } = useSelector(selectApp);
   const { t } = useTranslation();
@@ -172,7 +175,9 @@ const AppointmentsPage = props => {
       withBackButton
     >
       <ActionItemDisplay router={router} />
-      <UpcomingAppointments router={router} refresh={refresh} />
+      {isUpcomingAppointmentsEnabled && (
+        <UpcomingAppointments router={router} refresh={refresh} />
+      )}
       <div className="vads-u-display--flex vads-u-align-itmes--stretch vads-u-flex-direction--column vads-u-padding-top--1p5 vads-u-padding-bottom--5">
         <p data-testid="update-text">
           <Trans
@@ -190,19 +195,21 @@ const AppointmentsPage = props => {
           data-testid="refresh-appointments-button"
         />
       </div>
-      <va-accordion uswds bordered data-testid="appointments-accordions">
-        {accordionContent.map((accordion, index) => (
-          <va-accordion-item
-            key={index}
-            header={accordion.header}
-            open={accordion.open}
-            uswds
-            bordered
-          >
-            {accordion.body}
-          </va-accordion-item>
-        ))}
-      </va-accordion>
+      {isUpcomingAppointmentsEnabled && (
+        <va-accordion uswds bordered data-testid="appointments-accordions">
+          {accordionContent.map((accordion, index) => (
+            <va-accordion-item
+              key={index}
+              header={accordion.header}
+              open={accordion.open}
+              uswds
+              bordered
+            >
+              {accordion.body}
+            </va-accordion-item>
+          ))}
+        </va-accordion>
+      )}
     </Wrapper>
   );
 };

--- a/src/applications/check-in/day-of/README.md
+++ b/src/applications/check-in/day-of/README.md
@@ -127,30 +127,6 @@ Even though this my look like a form, the first iteration of the VA form system 
 
 We are currently using the endpoints that are mocked in `src/applications/check-in/api/local-mock-api`.
 
-### Feature toggles
-
-We are currently using an HOC located at `src/applications/check-in/containers/withFeatureFlip.jsx` to control the feature flips. The whole app is wrapped around one, and each new feature should have its own toggle.
-
-Though we have the HOC, its now considered best practice to query redux using the useSelector hook.
-
-#### Current toggles
-
-- `check_in_experience_enabled` : Enables or disabled the whole app on va.gov
-  - when to sunset: never;
-- `check_in_experience_translation_disclaimer_spanish_enabled` : Enables or disables the mixed language disclaimer (there may be some untranslated content) for spanish pages of the site
-  - when to sunset: when we are in a situation where new content is not added to the site until it is translated into spanish
-- `check_in_experience_travel_reimbursement`: Enables travel reimbursement workflow for day-of check-in.
-- `check_in_experience_travel_logic`: Enables logic that allows the veteran to submit a travel claim to more than one appointment in a day if they are at separate facilities.
-- `check_in_experience_browser_monitoring`: Enables browser monitoring for check-in applications.
-- `check_in_experience_upcoming_appointments_enabled`: Enables the upcoming appointments block.
-- `check_in_experience_45_minute_reminder`: Enables the 45 minute reminder
-
-### How to test this?
-
-Each feature should have unit tests and e2e tests.
-
-For testing in staging, use the instructions at [https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/checkin/engineering/qa/test-data-setup.md](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/checkin/engineering/qa/test-data-setup.md).
-
 ### Useful acronym and terms
 
 - CHIP - New API that is a central point for all the health data access. Bascially a wrapper around VistA and other internal nasty APIs.

--- a/src/applications/check-in/day-of/README.md
+++ b/src/applications/check-in/day-of/README.md
@@ -142,7 +142,7 @@ Though we have the HOC, its now considered best practice to query redux using th
 - `check_in_experience_travel_reimbursement`: Enables travel reimbursement workflow for day-of check-in.
 - `check_in_experience_travel_logic`: Enables logic that allows the veteran to submit a travel claim to more than one appointment in a day if they are at separate facilities.
 - `check_in_experience_browser_monitoring`: Enables browser monitoring for check-in applications.
-- `check_in_experience_unified_landing_page`: Enabled the unified check in landing page
+- `check_in_experience_upcoming_appointments_enabled`: Enables the upcoming appointments block.
 - `check_in_experience_45_minute_reminder`: Enables the 45 minute reminder
 
 ### How to test this?

--- a/src/applications/check-in/pre-check-in/README.md
+++ b/src/applications/check-in/pre-check-in/README.md
@@ -81,27 +81,6 @@ To share an app instance using the mock API running on Codespaces publicly, use 
 
 // TODO: fill this doc in with ticket number<https://github.com/department-of-veterans-affairs/va.gov-team/issues/32743>
 
-### Feature toggles
-
-We are currently using an HOC located at `src/applications/pre-check-in/containers/withFeatureFlip.jsx` to control the feature flips. The whole app is wrapped around one, and each new feature should have its own toggle.
-
-Though we have the HOC, its now considered best practice to query redux using the useSelector hook.
-
-#### Current toggles
-
-- `check_in_experience_pre_check_in_enabled` : Enables or disabled the whole app on va.gov
-  - when to sunset: never;
-- `check_in_experience_translation_disclaimer_spanish_enabled` : Enables or disables the mixed language disclaimer (there may be some untranslated content) for spanish pages of the site
-  - when to sunset: when we are in a situation where new content is not added to the site until it is translated into spanish
-- `check_in_experience_browser_monitoring`: Enables browser monitoring for check-in applications.
-- `check_in_experience_pre_check_in_action_link_top_placement`: Changes pre-check-in action link placement to the top of the page.
-
-### How to test this?
-
-Each feature should have unit tests and e2e tests.
-
-For testing in staging, use the instructions at [https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/checkin/engineering/qa/test-data-setup.md](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/checkin/engineering/qa/test-data-setup.md).
-
 ### Useful acronym and terms
 
 - CHIP - New API that is a central point for all the health data access. Bascially a wrapper around VistA and other internal nasty APIs.

--- a/src/applications/check-in/utils/selectors/feature-toggles.js
+++ b/src/applications/check-in/utils/selectors/feature-toggles.js
@@ -30,8 +30,8 @@ const selectFeatureToggles = createSelector(
     isPreCheckInActionLinkTopPlacementEnabled: toggleValues(state)[
       FEATURE_FLAG_NAMES.checkInExperiencePreCheckInActionLinkTopPlacement
     ],
-    isUnifiedLandingPageEnabled: toggleValues(state)[
-      FEATURE_FLAG_NAMES.checkInExperienceUnifiedLandingPage
+    isUpcomingAppointmentsEnabled: toggleValues(state)[
+      FEATURE_FLAG_NAMES.checkInExperienceUpcomingAppointmentsEnabled
     ],
   }),
   toggles => toggles,

--- a/src/applications/check-in/utils/selectors/tests/feature-toggles.unit.spec.js
+++ b/src/applications/check-in/utils/selectors/tests/feature-toggles.unit.spec.js
@@ -18,7 +18,7 @@ describe('check-in', () => {
         check_in_experience_travel_logic: false,
         check_in_experience_browser_monitoring: false,
         check_in_experience_pre_check_in_action_link_top_placement: true,
-        check_in_experience_unified_landing_page: false,
+        check_in_experience_upcoming_appointments_enabled: true,
         loading: false,
       },
     };
@@ -36,7 +36,7 @@ describe('check-in', () => {
           isTravelLogicEnabled: false,
           isBrowserMonitoringEnabled: false,
           isPreCheckInActionLinkTopPlacementEnabled: true,
-          isUnifiedLandingPageEnabled: false,
+          isUpcomingAppointmentsEnabled: true,
         });
       });
     });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -30,6 +30,7 @@
   "checkInExperienceBrowserMonitoring": "check_in_experience_browser_monitoring",
   "checkInExperienceUpdatedApptPresentation": "check_in_experience_updated_appt_presentation",
   "checkInExperienceUnifiedLandingPage": "check_in_experience_unified_landing_page",
+  "checkInExperienceUpcomingAppointmentsEnabled": "check_in_experience_upcoming_appointments_enabled",
   "checkVAInboxEnabled": "check_va_inbox_enabled",
   "claimLettersAccess": "claim_letters_access",
   "coeAccess": "coe_access",


### PR DESCRIPTION
## Summary

Wraps the upcoming appointments portion of the new landing page in a feature flag.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#81831

## Testing done

- Added unit test

## Screenshots
<img src="https://github.com/department-of-veterans-affairs/vets-website/assets/13967174/c4964d1f-d380-4555-9a0c-c53e275baa6d" width="419" />
<img src="https://github.com/department-of-veterans-affairs/vets-website/assets/13967174/cb6e8b69-273d-46b6-8dcd-e3f7a83d33b5" width="419" />

## What areas of the site does it impact?

pre-check-in and day-of check-in

## Acceptance criteria
 - [ ] upcoming appointments and accordions do not show with the feature off.
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)