### PR TITLE
26-4555: Modify Confirmation page for duplicate submission

### DIFF
--- a/src/applications/simple-forms/26-4555/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/26-4555/containers/ConfirmationPage.jsx
@@ -25,7 +25,7 @@ export const ConfirmationPage = props => {
   } else if (status === 'DUPLICATE') {
     content = {
       headlineText: 'Thank you for completing your benefit application',
-      nextStepsText: `We received your application, but we already have an existing housing grant application from you on file. We're still processing your existing application. If you have any questions, contact us at 877-827-3702, select the Specially Adapted Housing grant option, and give them your confirmation number ${referenceNumber}.`,
+      nextStepsText: `We received your application, but we already have an existing housing grant application from you on file. We're still processing your existing application. If you have any questions, contact us at 877-827-3702, select the Specially Adapted Housing grant option.`,
     };
   }
 


### PR DESCRIPTION
## Summary
This PR modifies the Confirmation Page for 26-4555 (Simple Forms) such that if the submission is a duplicate (and we have no confirmation number), we don't try to display the confirmation number.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1335
