### PR TITLE
Require a confirmationCode before letting users continue on Form Upload Flow

### DIFF
--- a/src/applications/simple-forms/form-upload/containers/UploadPage.jsx
+++ b/src/applications/simple-forms/form-upload/containers/UploadPage.jsx
@@ -36,8 +36,10 @@ const UploadPage = () => {
   };
   const onRouteChange = ({ detail }) => handleRouteChange({ detail }, history);
   const onFileUploaded = uploadedFile => {
-    setFileInputError('');
-    setFile(uploadedFile);
+    if (uploadedFile.confirmationCode) {
+      setFileInputError('');
+      setFile(uploadedFile);
+    }
   };
   const onVaChange = e =>
     dispatch(uploadScannedForm(formNumber, e.detail.files[0], onFileUploaded));


### PR DESCRIPTION
## Summary
This PR changes the `onChange` behavior of the upload button on the Form Upload Flow so that it requires the file to be fully uploaded before it allows users to continue to the next screen. This should prevent the filesize from showing up as `undefined B`.

EDIT: For further context, the `onFileUploaded` function gets called twice: once when the upload is initiated but no `confirmationCode` exists yet and again once the upload is complete and the `confirmationCode` is in place. We don't want to run our code until the second call.