### PR TITLE
MHV-55962: fix for confirmation alert not visible when all medications have been refilled

### DIFF
--- a/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
+++ b/src/applications/mhv-medications/containers/RefillPrescriptions.jsx
@@ -194,9 +194,9 @@ const RefillPrescriptions = ({ refillList = [], isLoadingList = true }) => {
           <ApiErrorNotification errorType="access" content="medications" />
         ) : (
           <>
+            <RefillNotification refillResult={refillResult} />
             {fullRefillList?.length > 0 ? (
               <div>
-                <RefillNotification refillResult={refillResult} />
                 <h2
                   className="vads-u-margin-top--3"
                   data-testid="refill-page-subtitle"


### PR DESCRIPTION
This is a follow up fix for #29048 

## Summary

<img width="881" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/2671fc0b-76c8-4389-b4a6-71ab4972a44e">

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-55962

<img width="924" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/b9ef4cf5-333e-4079-8484-6ecdf1b9ca20">

## Testing done

- Manual testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: whether one, some, or all of the refills are requested a confirmation of refill should display.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
