### PR TITLE
HLR & NOD | Fix review page edit label for area of disagreement

### DIFF
--- a/src/applications/appeals/shared/pages/areaOfDisagreement.js
+++ b/src/applications/appeals/shared/pages/areaOfDisagreement.js
@@ -1,5 +1,6 @@
 import {
   issueTitle,
+  getIssueTitle,
   content,
   errorMessages,
   AreaOfDisagreementReviewField,
@@ -26,6 +27,9 @@ export default {
         'ui:validations': [areaOfDisagreementRequired],
         'ui:errorMessages': {
           required: errorMessages.missingDisagreement,
+        },
+        'ui:options': {
+          itemAriaLabel: data => getIssueTitle(data, { plainText: true }),
         },
         // Not used by CustomPage, kept here for review & submit page render
         disagreementOptions: {


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > The edit button on the review & submit page for every area of disagreement currently has an `aria-label` of "Edit [object Object]". The pages all have a dynamic page title and need an `itemAriaLabel` function to return the appropriate page title as plain text because the `va-button` label property only accepts plain text. This PR adds this `ui:option` to fix the problem.
- _(If bug, how to reproduce)_
  > - Get to the HLR or NOD review & submit page
  > - Expand the "Issues for review" accordion
  > - Inspect (dev tools) the area of disagreement edit button to see the un-helpful `va-button` label
- _(What is the solution, why is this the solution)_
  > `itemAriaLabel` is built into the platform review object field component to allow customizing the edit label
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#83691](https://github.com/department-of-veterans-affairs/va.gov-team/issues/83691)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         |  | 
| ------- | ----- |
| Before  | <img width="500" alt="Screenshot 2024-05-29 at 1 33 11 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/bd4b184f-70f6-4603-a19e-78a51bc461e6"> |
| After | <img width="500" alt="Screenshot 2024-05-29 at 1 13 05 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/136959/aee7823e-a4fd-4ea4-8e0d-eafac2e273d1"> |

## What areas of the site does it impact?

HLR & NOD

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
