### PR TITLE
83939 Update copy in beneficiary section - form 10-7959c

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/applicantInformation.js
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash';
 import {
   addressUI,
   addressSchema,
@@ -16,10 +17,13 @@ import { nameWording } from '../helpers/utilities';
 
 export const blankSchema = { type: 'object', properties: {} };
 
+const fullNameMiddleInitialUI = cloneDeep(fullNameUI());
+fullNameMiddleInitialUI.middle['ui:title'] = 'Middle initial';
+
 export const applicantNameDobSchema = {
   uiSchema: {
-    ...titleUI('Applicant name and date of birth'),
-    applicantName: fullNameUI(),
+    ...titleUI('Beneficiary’s name and date of birth'),
+    applicantName: fullNameMiddleInitialUI,
     applicantDOB: dateOfBirthUI({ required: true }),
   },
   schema: {
@@ -36,8 +40,13 @@ export const applicantNameDobSchema = {
 export const applicantSsnSchema = {
   uiSchema: {
     ...titleUI(
-      ({ formData }) => `${nameWording(formData)} identification information`,
-      `You must enter a Social Security number`,
+      ({ formData }) =>
+        `${nameWording(
+          formData,
+          undefined,
+          undefined,
+          true,
+        )} identification information`,
     ),
     applicantSsn: ssnUI(),
   },
@@ -54,16 +63,12 @@ export const applicantSsnSchema = {
 export const applicantAddressInfoSchema = {
   uiSchema: {
     ...titleUI(
-      ({ formData }) => `${nameWording(formData)} mailing address`,
-      'We’ll send any important information about your application to this address.',
+      ({ formData }) =>
+        `${nameWording(formData, undefined, undefined, true)} mailing address`,
+      'We’ll send any important information about this form to this address.',
     ),
     applicantAddress: {
-      ...addressUI({
-        labels: {
-          militaryCheckbox:
-            'Address is on a United States military base outside the country.',
-        },
-      }),
+      ...addressUI({ labels: { street3: 'Apartment or unit number' } }),
     },
   },
   schema: {
@@ -78,13 +83,9 @@ export const applicantAddressInfoSchema = {
 export const applicantContactInfoSchema = {
   uiSchema: {
     ...titleUI(
-      ({ formData }) => `${nameWording(formData)} phone number`,
       ({ formData }) =>
-        `This information helps us contact ${nameWording(
-          formData,
-          false,
-          false,
-        )} faster if we need to follow up with you about the application.`,
+        `${nameWording(formData, undefined, undefined, true)} phone number`,
+      'We’ll contact this phone number if we need to follow up about this form.',
     ),
     applicantPhone: phoneUI(),
   },

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -110,7 +110,7 @@ const formConfig = {
       pages: {
         applicantNameDob: {
           path: 'applicant-info',
-          title: 'Applicant name and date of birth',
+          title: 'Beneficiary’s name and date of birth',
           ...applicantNameDobSchema,
         },
         applicantIdentity: {

--- a/src/applications/ivc-champva/10-7959C/helpers/utilities.js
+++ b/src/applications/ivc-champva/10-7959C/helpers/utilities.js
@@ -9,7 +9,12 @@ export function isRequiredFile(formContext, requiredFiles) {
 }
 
 // Return either 'your' or the applicant's name depending
-export function nameWording(formData, isPosessive = true, cap = true) {
+export function nameWording(
+  formData,
+  isPosessive = true,
+  cap = true,
+  firstNameOnly = false,
+) {
   let retVal = '';
   // NOTE: certifierRole isn't used in this form anymore so this will always
   // skip to else clause
@@ -17,9 +22,11 @@ export function nameWording(formData, isPosessive = true, cap = true) {
     retVal = isPosessive ? 'your' : 'you';
   } else {
     // Concatenate all parts of applicant's name (first, middle, etc...)
-    retVal = Object.values(formData?.applicantName || {})
-      .filter(el => el)
-      .join(' ');
+    retVal = firstNameOnly
+      ? formData?.applicantName?.first
+      : Object.values(formData?.applicantName || {})
+          .filter(el => el)
+          .join(' ');
     retVal = isPosessive ? `${retVal}’s` : retVal;
   }
 


### PR DESCRIPTION
## Summary

This PR updates some copy in the beneficiary section of form 10-7959c.

- Changes wording to use beneficiary language
- Adds middle initial title on full name
- Updated label on `Street 3` in address
- Updates nameWording func to support first-name only

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83939

## Testing done

- Manual
- Unit

## Screenshots

|         | Desktop |
| ------- | ------ | 
| Name |![Screenshot 2024-05-29 at 15 34 52](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/614f81fa-d0a0-4d20-be05-54b31ecbbe78)| 
| SSN |![Screenshot 2024-05-29 at 15 34 22](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/9566a6f1-1803-4413-8cfc-f5aa2cc18a19)| 
| Address |![Screenshot 2024-05-29 at 15 34 14](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/b080accf-8e1e-4424-8159-be430231ff37)| 
| Phone |![Screenshot 2024-05-29 at 15 34 04](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/9f5d7901-230a-42c0-849f-71adb965638f)| 

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA