### PR TITLE
Changed root url per department-of-veterans-affairs/va.gov-team#81927

### DIFF
--- a/src/applications/travel-pay/components/Breadcrumbs.jsx
+++ b/src/applications/travel-pay/components/Breadcrumbs.jsx
@@ -16,7 +16,7 @@ export default function BreadCrumbs() {
           label: 'My HealtheVet',
         },
         {
-          href: '/health-care/file-travel-claim',
+          href: '/my-health/travel-claim-status',
           label: 'Check your travel reimbursement claim status',
         },
       ]}

--- a/src/applications/travel-pay/manifest.json
+++ b/src/applications/travel-pay/manifest.json
@@ -2,6 +2,6 @@
   "appName": "Beneficiary Travel",
   "entryFile": "./app-entry.jsx",
   "entryName": "travel-pay",
-  "rootUrl": "/health-care/file-travel-claim",
+  "rootUrl": "/my-health/travel-claim-status",
   "productId": "1e585463-5625-4868-b5f5-58ee0490ea28"
 }


### PR DESCRIPTION
## Summary

- Makes our feature (BTSSS Travel Claim Status Page) URL consistent with other MHV pages
- BTSSS Travel Pay VA.gov Migration

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#81927

## Testing done

- Previously: Navigate to https://<FE_ENV_URL>/health-care/file-travel-claim
- Now: Navigate to https://<FE_ENV_URL>/my-heath/travel-claim-status

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)

### Error Handling

- [x] Browser console contains no warnings or errors.

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
