### PR TITLE
VFEP-1507  The Sponsor information step should be renamed to be DEA, Chapter 35 sponsor information

### DIFF
--- a/src/applications/edu-benefits/1995/config/chapters.js
+++ b/src/applications/edu-benefits/1995/config/chapters.js
@@ -18,7 +18,7 @@ import {
   sponsorInfo,
 } from '../pages';
 
-import { isProductionOfTestProdEnv } from '../helpers';
+import { isProductionOfTestProdEnv, sponsorInformationTitle } from '../helpers';
 import guardianInformation from '../pages/guardianInformation';
 
 export const applicantInformationField = (automatedTest = false) => {
@@ -131,7 +131,7 @@ export const chapters = {
     },
   },
   sponsorInformation: {
-    title: 'Sponsor information',
+    title: sponsorInformationTitle(),
     pages: {
       sponsorInformation: sponsorInfo(fullSchema1995),
     },

--- a/src/applications/edu-benefits/1995/helpers.jsx
+++ b/src/applications/edu-benefits/1995/helpers.jsx
@@ -10,6 +10,13 @@ export const isProductionOfTestProdEnv = automatedTest => {
   );
 };
 
+export const sponsorInformationTitle = (automatedTest = false) => {
+  if (isProductionOfTestProdEnv(automatedTest)) {
+    return 'Sponsor information';
+  }
+  return 'DEA, Chapter 35 sponsor information';
+};
+
 export const directDepositMethod = (formData, automatedTest = false) => {
   return isProductionOfTestProdEnv(automatedTest)
     ? formData.bankAccountChange

--- a/src/applications/edu-benefits/1995/pages/sponsorInfomartion.js
+++ b/src/applications/edu-benefits/1995/pages/sponsorInfomartion.js
@@ -1,6 +1,6 @@
 import { pick } from 'lodash';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
-import { isProductionOfTestProdEnv } from '../helpers';
+import { isProductionOfTestProdEnv, sponsorInformationTitle } from '../helpers';
 
 /**
  * Returns a Sponsor page based on the options passed.
@@ -46,7 +46,7 @@ export function sponsorInfo(schema) {
   };
   return {
     path: 'sponsor/information',
-    title: 'Sponsor information',
+    title: sponsorInformationTitle(),
     depends: formData => showSponsorInfo(formData),
     uiSchema: {
       sponsorFullName: {


### PR DESCRIPTION
## Summary

    *As a...*
    VFEP Business user
    *I want...*
     To understand what I am entering for sponsor information
    *So that...*
    I enter the correct information
    *Acceptance Criteria:*
     * The Sponsor information step should be renamed to be DEA, Chapter 35 sponsor information



## Testing done

- Verify Changes on my local machine

## Screenshots

_Note: Before

![Screenshot 2024-05-30 at 10 49 43 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/95312667/60632053-2d58-4e24-bc4c-e1d703602a4e)

_Note:  After

![Screenshot 2024-05-30 at 10 24 27 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/95312667/1a4c5628-1ca5-4710-af1f-9303cf9a9802)
