### PR TITLE
Only display the form upload access widget in staging

### DIFF
--- a/src/applications/static-pages/simple-forms/form-upload/entry.js
+++ b/src/applications/static-pages/simple-forms/form-upload/entry.js
@@ -2,12 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import { Provider } from 'react-redux';
+import environment from 'platform/utilities/environment';
 
 export default function createFormUploadAccess(store, widgetType) {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   const { hasOnlineTool, formNumber } = root.dataset;
 
-  if (root) {
+  // TODO: Remove `environment.isStaging()` when we want to release this to production
+  if (root && environment.isStaging()) {
     import(/* webpackChunkName: "form-upload" */ './App.js').then(module => {
       const App = module.default;
       ReactDOM.render(


### PR DESCRIPTION
## Summary
This PR will make it so that the form upload access widget is only shown in staging. We want to do this because flipping on the feature will turn it on in both staging and prod but we don't want to release yet.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1242
