### PR TITLE
[CST] - Update Status Tab for the What We're Doing Section when feature flag cst_claim_phases is enabled 

### DIFF
--- a/src/applications/claims-status/components/claim-status-tab/WhatWeAreDoing.jsx
+++ b/src/applications/claims-status/components/claim-status-tab/WhatWeAreDoing.jsx
@@ -1,15 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom-v5-compat';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 
 import {
   getStatusDescription,
   getClaimStatusDescription,
+  getClaimPhaseTypeHeaderText,
+  getClaimPhaseTypeDescription,
 } from '../../utils/helpers';
 
-export default function WhatWeAreDoing({ status }) {
-  const humanStatus = getStatusDescription(status);
-  const description = getClaimStatusDescription(status);
+export default function WhatWeAreDoing({ claimPhaseType, status }) {
+  const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
+  const cstClaimPhasesEnabled = useToggleValue(TOGGLE_NAMES.cstClaimPhases);
+  const humanStatus = cstClaimPhasesEnabled
+    ? getClaimPhaseTypeHeaderText(claimPhaseType)
+    : getStatusDescription(status);
+  const description = cstClaimPhasesEnabled
+    ? getClaimPhaseTypeDescription(claimPhaseType)
+    : getClaimStatusDescription(status);
+  const linkText = cstClaimPhasesEnabled
+    ? 'Learn more about this step'
+    : 'Overview of the process';
 
   return (
     <div className="what-were-doing-container vads-u-margin-bottom--4">
@@ -22,11 +34,11 @@ export default function WhatWeAreDoing({ status }) {
           {description}
         </p>
         <Link
-          aria-label="Overview of the process"
+          aria-label={linkText}
           className="vads-u-margin-top--1 active-va-link"
           to="../overview"
         >
-          Overview of the process
+          {linkText}
           <va-icon icon="chevron_right" size={3} aria-hidden="true" />
         </Link>
       </va-card>
@@ -35,5 +47,6 @@ export default function WhatWeAreDoing({ status }) {
 }
 
 WhatWeAreDoing.propTypes = {
+  claimPhaseType: PropTypes.string,
   status: PropTypes.string,
 };

--- a/src/applications/claims-status/components/claim-status-tab/WhatWeAreDoing.jsx
+++ b/src/applications/claims-status/components/claim-status-tab/WhatWeAreDoing.jsx
@@ -8,9 +8,20 @@ import {
   getClaimStatusDescription,
   getClaimPhaseTypeHeaderText,
   getClaimPhaseTypeDescription,
+  buildDateFormatter,
 } from '../../utils/helpers';
 
-export default function WhatWeAreDoing({ claimPhaseType, status }) {
+const getPhaseChangeDateText = phaseChangeDate => {
+  const formattedDate = buildDateFormatter()(phaseChangeDate);
+
+  return `Moved to this step on ${formattedDate}`;
+};
+
+export default function WhatWeAreDoing({
+  claimPhaseType,
+  phaseChangeDate,
+  status,
+}) {
   const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
   const cstClaimPhasesEnabled = useToggleValue(TOGGLE_NAMES.cstClaimPhases);
   const humanStatus = cstClaimPhasesEnabled
@@ -33,6 +44,9 @@ export default function WhatWeAreDoing({ claimPhaseType, status }) {
         <p className="vads-u-margin-top--0p5 vads-u-margin-bottom--0p5">
           {description}
         </p>
+        {cstClaimPhasesEnabled && (
+          <p>{getPhaseChangeDateText(phaseChangeDate)}</p>
+        )}
         <Link
           aria-label={linkText}
           className="vads-u-margin-top--1 active-va-link"
@@ -48,5 +62,6 @@ export default function WhatWeAreDoing({ claimPhaseType, status }) {
 
 WhatWeAreDoing.propTypes = {
   claimPhaseType: PropTypes.string,
+  phaseChangeDate: PropTypes.string,
   status: PropTypes.string,
 };

--- a/src/applications/claims-status/containers/ClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/ClaimStatusPage.jsx
@@ -225,6 +225,7 @@ class ClaimStatusPage extends React.Component {
                 <WhatYouNeedToDo claim={claim} useLighthouse />
                 <WhatWeAreDoing
                   claimPhaseType={claimPhaseType}
+                  phaseChangeDate={claimPhaseDates.phaseChangeDate}
                   status={status}
                 />
               </>
@@ -246,7 +247,7 @@ class ClaimStatusPage extends React.Component {
               isOpen && (
                 <ClaimTimeline
                   id={claim.id}
-                  phase={getPhaseFromStatus(claimPhaseDates.latestPhaseType)}
+                  phase={getPhaseFromStatus(claimPhaseType)}
                   currentPhaseBack={claimPhaseDates.currentPhaseBack}
                   events={generateEventTimeline(claim)}
                 />

--- a/src/applications/claims-status/containers/ClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/ClaimStatusPage.jsx
@@ -209,6 +209,7 @@ class ClaimStatusPage extends React.Component {
       status,
       trackedItems,
     } = claim.attributes;
+    const claimPhaseType = claimPhaseDates.latestPhaseType;
     const isOpen = isClaimOpen(status, closeDate);
     const filesNeeded = itemsNeedingAttentionFromVet(trackedItems);
     const showDocsNeeded =
@@ -222,7 +223,10 @@ class ClaimStatusPage extends React.Component {
             {isOpen ? (
               <>
                 <WhatYouNeedToDo claim={claim} useLighthouse />
-                <WhatWeAreDoing status={status} />
+                <WhatWeAreDoing
+                  claimPhaseType={claimPhaseType}
+                  status={status}
+                />
               </>
             ) : (
               <>

--- a/src/applications/claims-status/tests/components/ClaimStatusPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimStatusPage.unit.spec.jsx
@@ -74,7 +74,7 @@ describe('<ClaimStatusPage>', () => {
                 claimPhaseDates: {
                   currentPhaseBack: false,
                   phaseChangeDate: '2015-01-01',
-                  latestPhaseType: 'INITIAL_REVIEW',
+                  latestPhaseType: 'UNDER_REVIEW',
                   previousPhases: {
                     phase1CompleteDate: '2023-02-08',
                     phase2CompleteDate: '2023-02-08',

--- a/src/applications/claims-status/tests/components/OverviewPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/OverviewPage.unit.spec.jsx
@@ -166,7 +166,7 @@ describe('<OverviewPage>', () => {
     });
   });
 
-  context('cstClaimPhases feature flag enabled', () => {
+  context('cstClaimPhases feature flag disabled', () => {
     context('when claim is closed', () => {
       const claim = {
         id: '1',

--- a/src/applications/claims-status/tests/components/claim-status-tab/WhatWeAreDoing.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-status-tab/WhatWeAreDoing.unit.spec.jsx
@@ -13,7 +13,25 @@ import { renderWithRouter } from '../../utils';
 
 import WhatWeAreDoing from '../../../components/claim-status-tab/WhatWeAreDoing';
 
-const claim = {
+const claimPhase1 = {
+  id: '1',
+  attributes: {
+    claimDate: '2023-01-01',
+    claimPhaseDates: {
+      currentPhaseBack: false,
+      phaseChangeDate: '2023-02-08',
+      latestPhaseType: 'CLAIM_RECEIVED',
+      previousPhases: {},
+    },
+    closeDate: null,
+    documentsNeeded: true,
+    decisionLetterSent: false,
+    status: 'CLAIM_RECEIVED',
+    supportingDocuments: [],
+  },
+};
+
+const claimPhase2 = {
   id: '1',
   attributes: {
     claimDate: '2023-01-01',
@@ -33,6 +51,121 @@ const claim = {
   },
 };
 
+const claimPhase3 = {
+  id: '1',
+  attributes: {
+    claimDate: '2023-01-01',
+    claimPhaseDates: {
+      currentPhaseBack: false,
+      phaseChangeDate: '2023-02-08',
+      latestPhaseType: 'GATHERING_OF_EVIDENCE',
+      previousPhases: {
+        phase1CompleteDate: '2023-02-08',
+        phase2CompleteDate: '2023-02-08',
+      },
+    },
+    closeDate: null,
+    documentsNeeded: true,
+    decisionLetterSent: false,
+    status: 'EVIDENCE_GATHERING_REVIEW_DECISION',
+    supportingDocuments: [],
+  },
+};
+
+const claimPhase4 = {
+  id: '1',
+  attributes: {
+    claimDate: '2023-01-01',
+    claimPhaseDates: {
+      currentPhaseBack: false,
+      phaseChangeDate: '2023-02-08',
+      latestPhaseType: 'REVIEW_OF_EVIDENCE',
+      previousPhases: {
+        phase1CompleteDate: '2023-02-08',
+        phase2CompleteDate: '2023-02-08',
+        phase3CompleteDate: '2023-02-08',
+      },
+    },
+    closeDate: null,
+    documentsNeeded: true,
+    decisionLetterSent: false,
+    status: 'EVIDENCE_GATHERING_REVIEW_DECISION',
+    supportingDocuments: [],
+  },
+};
+
+const claimPhase5 = {
+  id: '1',
+  attributes: {
+    claimDate: '2023-01-01',
+    claimPhaseDates: {
+      currentPhaseBack: false,
+      phaseChangeDate: '2023-02-08',
+      latestPhaseType: 'PREPARATION_FOR_DECISION',
+      previousPhases: {
+        phase1CompleteDate: '2023-02-08',
+        phase2CompleteDate: '2023-02-08',
+        phase3CompleteDate: '2023-02-08',
+        phase4CompleteDate: '2023-02-08',
+      },
+    },
+    closeDate: null,
+    documentsNeeded: true,
+    decisionLetterSent: false,
+    status: 'EVIDENCE_GATHERING_REVIEW_DECISION',
+    supportingDocuments: [],
+  },
+};
+
+const claimPhase6 = {
+  id: '1',
+  attributes: {
+    claimDate: '2023-01-01',
+    claimPhaseDates: {
+      currentPhaseBack: false,
+      phaseChangeDate: '2023-02-08',
+      latestPhaseType: 'PENDING_DECISION_APPROVAL',
+      previousPhases: {
+        phase1CompleteDate: '2023-02-08',
+        phase2CompleteDate: '2023-02-08',
+        phase3CompleteDate: '2023-02-08',
+        phase4CompleteDate: '2023-02-08',
+        phase5CompleteDate: '2023-02-08',
+      },
+    },
+    closeDate: null,
+    documentsNeeded: true,
+    decisionLetterSent: false,
+    status: 'EVIDENCE_GATHERING_REVIEW_DECISION',
+    supportingDocuments: [],
+  },
+};
+
+const claimPhase7 = {
+  id: '1',
+  attributes: {
+    claimDate: '2023-01-01',
+    claimPhaseDates: {
+      currentPhaseBack: false,
+      phaseChangeDate: '2023-02-08',
+      latestPhaseType: 'PREPARATION_FOR_NOTIFICATION',
+      previousPhases: {
+        phase1CompleteDate: '2023-02-08',
+        phase2CompleteDate: '2023-02-08',
+        phase3CompleteDate: '2023-02-08',
+        phase4CompleteDate: '2023-02-08',
+        phase5CompleteDate: '2023-02-08',
+        phase6CompleteDate: '2023-02-08',
+      },
+    },
+    closeDate: null,
+    documentsNeeded: true,
+    decisionLetterSent: false,
+    status: 'PREPARATION_FOR_NOTIFICATION',
+    supportingDocuments: [],
+  },
+};
+
 describe('<WhatWeAreDoing>', () => {
   const getStore = (cstClaimPhasesEnabled = true) =>
     createStore(() => ({
@@ -42,33 +175,267 @@ describe('<WhatWeAreDoing>', () => {
       },
     }));
 
-  const { status, claimPhaseDates } = claim.attributes;
-  const claimPhaseType = claimPhaseDates.latestPhaseType;
-
   context('cstClaimPhases feature flag enabled', () => {
-    it('should render a WhatWereDoing section', () => {
+    it('should render a WhatWereDoing section when claim phase 1', () => {
+      const { status, claimPhaseDates } = claimPhase1.attributes;
+      const claimPhaseType = claimPhaseDates.latestPhaseType;
       const { getByText, getByRole } = renderWithRouter(
         <Provider store={getStore()}>
-          <WhatWeAreDoing status={status} claimPhaseType={claimPhaseType} />
+          <WhatWeAreDoing
+            status={status}
+            claimPhaseType={claimPhaseDates.latestPhaseType}
+            phaseChangeDate={claimPhaseDates.phaseChangeDate}
+          />
         </Provider>,
       );
 
       getByText(getClaimPhaseTypeHeaderText(claimPhaseType));
       getByText(getClaimPhaseTypeDescription(claimPhaseType));
+      getByText('Moved to this step on February 8, 2023');
+      expect(getByRole('link')).to.have.text('Learn more about this step');
+    });
+    it('should render a WhatWereDoing section when claim phase 2', () => {
+      const { status, claimPhaseDates } = claimPhase2.attributes;
+      const claimPhaseType = claimPhaseDates.latestPhaseType;
+      const { getByText, getByRole } = renderWithRouter(
+        <Provider store={getStore()}>
+          <WhatWeAreDoing
+            status={status}
+            claimPhaseType={claimPhaseType}
+            phaseChangeDate={claimPhaseDates.phaseChangeDate}
+          />
+        </Provider>,
+      );
+
+      getByText(getClaimPhaseTypeHeaderText(claimPhaseType));
+      getByText(getClaimPhaseTypeDescription(claimPhaseType));
+      getByText('Moved to this step on February 8, 2023');
+      expect(getByRole('link')).to.have.text('Learn more about this step');
+    });
+    it('should render a WhatWereDoing section when claim phase 3', () => {
+      const { status, claimPhaseDates } = claimPhase3.attributes;
+      const claimPhaseType = claimPhaseDates.latestPhaseType;
+      const { getByText, getByRole } = renderWithRouter(
+        <Provider store={getStore()}>
+          <WhatWeAreDoing
+            status={status}
+            claimPhaseType={claimPhaseType}
+            phaseChangeDate={claimPhaseDates.phaseChangeDate}
+          />
+        </Provider>,
+      );
+
+      getByText(getClaimPhaseTypeHeaderText(claimPhaseType));
+      getByText(getClaimPhaseTypeDescription(claimPhaseType));
+      getByText('Moved to this step on February 8, 2023');
+      expect(getByRole('link')).to.have.text('Learn more about this step');
+    });
+    it('should render a WhatWereDoing section when claim phase 4', () => {
+      const { status, claimPhaseDates } = claimPhase4.attributes;
+      const claimPhaseType = claimPhaseDates.latestPhaseType;
+      const { getByText, getByRole } = renderWithRouter(
+        <Provider store={getStore()}>
+          <WhatWeAreDoing
+            status={status}
+            claimPhaseType={claimPhaseType}
+            phaseChangeDate={claimPhaseDates.phaseChangeDate}
+          />
+        </Provider>,
+      );
+
+      getByText(getClaimPhaseTypeHeaderText(claimPhaseType));
+      getByText(getClaimPhaseTypeDescription(claimPhaseType));
+      getByText('Moved to this step on February 8, 2023');
+      expect(getByRole('link')).to.have.text('Learn more about this step');
+    });
+    it('should render a WhatWereDoing section when claim phase 5', () => {
+      const { status, claimPhaseDates } = claimPhase5.attributes;
+      const claimPhaseType = claimPhaseDates.latestPhaseType;
+      const { getByText, getByRole } = renderWithRouter(
+        <Provider store={getStore()}>
+          <WhatWeAreDoing
+            status={status}
+            claimPhaseType={claimPhaseType}
+            phaseChangeDate={claimPhaseDates.phaseChangeDate}
+          />
+        </Provider>,
+      );
+
+      getByText(getClaimPhaseTypeHeaderText(claimPhaseType));
+      getByText(getClaimPhaseTypeDescription(claimPhaseType));
+      getByText('Moved to this step on February 8, 2023');
+      expect(getByRole('link')).to.have.text('Learn more about this step');
+    });
+    it('should render a WhatWereDoing section when claim phase 6', () => {
+      const { status, claimPhaseDates } = claimPhase6.attributes;
+      const claimPhaseType = claimPhaseDates.latestPhaseType;
+      const { getByText, getByRole } = renderWithRouter(
+        <Provider store={getStore()}>
+          <WhatWeAreDoing
+            status={status}
+            claimPhaseType={claimPhaseType}
+            phaseChangeDate={claimPhaseDates.phaseChangeDate}
+          />
+        </Provider>,
+      );
+
+      getByText(getClaimPhaseTypeHeaderText(claimPhaseType));
+      getByText(getClaimPhaseTypeDescription(claimPhaseType));
+      getByText('Moved to this step on February 8, 2023');
+      expect(getByRole('link')).to.have.text('Learn more about this step');
+    });
+    it('should render a WhatWereDoing section when claim phase 7', () => {
+      const { status, claimPhaseDates } = claimPhase7.attributes;
+      const claimPhaseType = claimPhaseDates.latestPhaseType;
+      const { getByText, getByRole } = renderWithRouter(
+        <Provider store={getStore()}>
+          <WhatWeAreDoing
+            status={status}
+            claimPhaseType={claimPhaseType}
+            phaseChangeDate={claimPhaseDates.phaseChangeDate}
+          />
+        </Provider>,
+      );
+
+      getByText(getClaimPhaseTypeHeaderText(claimPhaseType));
+      getByText(getClaimPhaseTypeDescription(claimPhaseType));
+      getByText('Moved to this step on February 8, 2023');
       expect(getByRole('link')).to.have.text('Learn more about this step');
     });
   });
 
   context('cstClaimPhases feature flag disabled', () => {
-    it('should render a WhatWereDoing section', () => {
-      const { getByText, getByRole } = renderWithRouter(
+    it('should render a WhatWereDoing section when claim phase 2', () => {
+      const { status, claimPhaseDates } = claimPhase1.attributes;
+      const claimPhaseType = claimPhaseDates.latestPhaseType;
+      const { getByText, getByRole, queryByText } = renderWithRouter(
         <Provider store={getStore(false)}>
-          <WhatWeAreDoing status={status} claimPhaseType={claimPhaseType} />
+          <WhatWeAreDoing
+            status={status}
+            claimPhaseType={claimPhaseType}
+            phaseChangeDate={claimPhaseDates.phaseChangeDate}
+          />
         </Provider>,
       );
 
       getByText(getStatusDescription(status));
       getByText(getClaimStatusDescription(status));
+      expect(queryByText('Moved to this step on February 8, 2023')).to.not
+        .exist;
+      expect(getByRole('link')).to.have.text('Overview of the process');
+    });
+    it('should render a WhatWereDoing section when claim phase 2', () => {
+      const { status, claimPhaseDates } = claimPhase2.attributes;
+      const claimPhaseType = claimPhaseDates.latestPhaseType;
+      const { getByText, getByRole, queryByText } = renderWithRouter(
+        <Provider store={getStore(false)}>
+          <WhatWeAreDoing
+            status={status}
+            claimPhaseType={claimPhaseType}
+            phaseChangeDate={claimPhaseDates.phaseChangeDate}
+          />
+        </Provider>,
+      );
+
+      getByText(getStatusDescription(status));
+      getByText(getClaimStatusDescription(status));
+      expect(queryByText('Moved to this step on February 8, 2023')).to.not
+        .exist;
+      expect(getByRole('link')).to.have.text('Overview of the process');
+    });
+    it('should render a WhatWereDoing section when claim phase 3', () => {
+      const { status, claimPhaseDates } = claimPhase3.attributes;
+      const claimPhaseType = claimPhaseDates.latestPhaseType;
+      const { getByText, getByRole, queryByText } = renderWithRouter(
+        <Provider store={getStore(false)}>
+          <WhatWeAreDoing
+            status={status}
+            claimPhaseType={claimPhaseType}
+            phaseChangeDate={claimPhaseDates.phaseChangeDate}
+          />
+        </Provider>,
+      );
+
+      getByText(getStatusDescription(status));
+      getByText(getClaimStatusDescription(status));
+      expect(queryByText('Moved to this step on February 8, 2023')).to.not
+        .exist;
+      expect(getByRole('link')).to.have.text('Overview of the process');
+    });
+    it('should render a WhatWereDoing section when claim phase 4', () => {
+      const { status, claimPhaseDates } = claimPhase4.attributes;
+      const claimPhaseType = claimPhaseDates.latestPhaseType;
+      const { getByText, getByRole, queryByText } = renderWithRouter(
+        <Provider store={getStore(false)}>
+          <WhatWeAreDoing
+            status={status}
+            claimPhaseType={claimPhaseType}
+            phaseChangeDate={claimPhaseDates.phaseChangeDate}
+          />
+        </Provider>,
+      );
+
+      getByText(getStatusDescription(status));
+      getByText(getClaimStatusDescription(status));
+      expect(queryByText('Moved to this step on February 8, 2023')).to.not
+        .exist;
+      expect(getByRole('link')).to.have.text('Overview of the process');
+    });
+    it('should render a WhatWereDoing section when claim phase 5', () => {
+      const { status, claimPhaseDates } = claimPhase5.attributes;
+      const claimPhaseType = claimPhaseDates.latestPhaseType;
+      const { getByText, getByRole, queryByText } = renderWithRouter(
+        <Provider store={getStore(false)}>
+          <WhatWeAreDoing
+            status={status}
+            claimPhaseType={claimPhaseType}
+            phaseChangeDate={claimPhaseDates.phaseChangeDate}
+          />
+        </Provider>,
+      );
+
+      getByText(getStatusDescription(status));
+      getByText(getClaimStatusDescription(status));
+      expect(queryByText('Moved to this step on February 8, 2023')).to.not
+        .exist;
+      expect(getByRole('link')).to.have.text('Overview of the process');
+    });
+    it('should render a WhatWereDoing section when claim phase 6', () => {
+      const { status, claimPhaseDates } = claimPhase6.attributes;
+      const claimPhaseType = claimPhaseDates.latestPhaseType;
+      const { getByText, getByRole, queryByText } = renderWithRouter(
+        <Provider store={getStore(false)}>
+          <WhatWeAreDoing
+            status={status}
+            claimPhaseType={claimPhaseType}
+            phaseChangeDate={claimPhaseDates.phaseChangeDate}
+          />
+        </Provider>,
+      );
+
+      getByText(getStatusDescription(status));
+      getByText(getClaimStatusDescription(status));
+      expect(queryByText('Moved to this step on February 8, 2023')).to.not
+        .exist;
+      expect(getByRole('link')).to.have.text('Overview of the process');
+    });
+    it('should render a WhatWereDoing section when claim phase 7', () => {
+      const { status, claimPhaseDates } = claimPhase7.attributes;
+      const claimPhaseType = claimPhaseDates.latestPhaseType;
+      const { getByText, getByRole, queryByText } = renderWithRouter(
+        <Provider store={getStore(false)}>
+          <WhatWeAreDoing
+            status={status}
+            claimPhaseType={claimPhaseType}
+            phaseChangeDate={claimPhaseDates.phaseChangeDate}
+          />
+        </Provider>,
+      );
+
+      getByText(getStatusDescription(status));
+      getByText(getClaimStatusDescription(status));
+      expect(queryByText('Moved to this step on February 8, 2023')).to.not
+        .exist;
       expect(getByRole('link')).to.have.text('Overview of the process');
     });
   });

--- a/src/applications/claims-status/tests/utils/helpers.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/helpers.unit.spec.js
@@ -29,6 +29,8 @@ import {
   roundToNearest,
   groupClaimsByDocsNeeded,
   claimAvailable,
+  getClaimPhaseTypeHeaderText,
+  getClaimPhaseTypeDescription,
 } from '../../utils/helpers';
 
 import {
@@ -1027,6 +1029,22 @@ describe('Disability benefits helpers: ', () => {
       const isClaimAvaliable = claimAvailable(claim);
 
       expect(isClaimAvaliable).to.be.true;
+    });
+  });
+
+  describe('getClaimPhaseTypeHeaderText', () => {
+    it('should display claim phase type header text from map', () => {
+      const desc = getClaimPhaseTypeHeaderText('CLAIM_RECEIVED');
+
+      expect(desc).to.equal('Step 1 of 8: Claim received');
+    });
+  });
+
+  describe('getClaimPhaseTypeDescription', () => {
+    it('should display claim phase type description from map', () => {
+      const desc = getClaimPhaseTypeDescription('CLAIM_RECEIVED');
+
+      expect(desc).to.equal('We received your claim in our system.');
     });
   });
 });

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -43,6 +43,43 @@ export function getStatusDescription(status) {
   return statusStepMap[status];
 }
 
+const claimPhaseTypeStepMap = {
+  CLAIM_RECEIVED: 'Step 1 of 8: Claim received',
+  UNDER_REVIEW: 'Step 2 of 8: Initial review',
+  GATHERING_OF_EVIDENCE: 'Step 3 of 8: Evidence gathering',
+  REVIEW_OF_EVIDENCE: 'Step 4 of 8: Evidence review',
+  PREPARATION_FOR_DECISION: 'Step 5 of 8: Rating',
+  PENDING_DECISION_APPROVAL: 'Step 6 of 8: Preparing decision letter',
+  PREPARATION_FOR_NOTIFICATION: 'Step 7 of 8: Final review',
+  COMPLETE: 'Step 8 of 8: Claim decided',
+};
+
+export function getClaimPhaseTypeHeaderText(claimPhaseType) {
+  return claimPhaseTypeStepMap[claimPhaseType];
+}
+
+const claimPhaseTypeDescriptionMap = {
+  CLAIM_RECEIVED: 'We received your claim in our system.',
+  UNDER_REVIEW:
+    'We’re checking your claim for basic information, like your name and Social Security number. If information is missing, we’ll contact you.',
+  GATHERING_OF_EVIDENCE:
+    'We’re reviewing your claim to make sure we have all the evidence and information we need. If we need anything else, we’ll contact you.',
+  REVIEW_OF_EVIDENCE:
+    'We’re reviewing all the evidence for your claim. If we need more evidence or you submit more evidence, your claim will go back to Step 3: Evidence gathering.',
+  PREPARATION_FOR_DECISION:
+    'We’re deciding your claim and determining your disability rating. If we need more evidence or you submit more evidence, your claim will go back to Step 3: Evidence gathering.',
+  PENDING_DECISION_APPROVAL:
+    'We’re preparing your decision letter. If we need more evidence or you submit more evidence, your claim will go back to Step 3: Evidence gathering.',
+  PREPARATION_FOR_NOTIFICATION:
+    'A senior reviewer is doing a final review of your claim and the decision letter. If we need more evidence or you submit more evidence, your claim will go back to Step 3: Evidence gathering.',
+  COMPLETE:
+    'You can view and download your decision letter. We also sent you a copy by mail.',
+};
+
+export function getClaimPhaseTypeDescription(claimPhaseType) {
+  return claimPhaseTypeDescriptionMap[claimPhaseType];
+}
+
 const statusDescriptionMap = {
   CLAIM_RECEIVED:
     'We received your claim. We haven’t assigned the claim to a reviewer yet.',


### PR DESCRIPTION
## Summary

Updated `src/applications/claims-status/components/claim-status-tab/WhatWeAreDoing.jsx` so that when the feature flag `cst_claim_phases` is enabled the following occurs:
- The header text reads 'Step <CURRENT_STEP> of 8'  and the corresponding text from [this](https://docs.google.com/document/d/1WfWCfoQgKoMBg835VP7j_ptXmqb2o3RVme2u5dMOEr8/edit) doc 
- The description is the description listed for the given step in [this](https://docs.google.com/document/d/1WfWCfoQgKoMBg835VP7j_ptXmqb2o3RVme2u5dMOEr8/edit) doc 
- There is a new field that says 'Moved to this step on <PhaseChangeDate>
- The link text is 'Learn more about this step'

Added tests to `src/applications/claims-status/tests/components/claim-status-tab/WhatWeAreDoing.unit.spec.jsx`

Added new props for WhatWeAreDoing and updated `src/applications/claims-status/containers/ClaimStatusPage.jsx` with these new props

Added new helper functions to `helpers.js` to account for these new phases called `getClaimPhaseTypeHeaderText`, `getClaimPhaseTypeDescription`

Updated `src/applications/claims-status/tests/components/ClaimStatusPage.unit.spec.jsx` so that its referencing an actual phaseType

Added tests to `src/applications/claims-status/tests/utils/helpers.unit.spec.js`


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#82375

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

**Step 1**
![Screenshot 2024-05-30 at 2 16 36 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/14f134d9-4654-4e01-a7d1-264530c1ae8d)

**Step 2**
![Screenshot 2024-05-30 at 1 29 26 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/7e3127cc-1eaa-484e-8e08-a26ab45e8b84)

**Step 3**
![Screenshot 2024-05-30 at 1 30 11 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/355c5217-2bc0-4940-a4bf-f06e9e9696eb)

**Step 4**
![Screenshot 2024-05-30 at 1 30 39 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/9220c3c2-8a78-40af-8551-b01ba2e73728)

**Step 5** 
![Screenshot 2024-05-30 at 1 31 18 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/677b7093-a225-4790-9ea0-b1df0cb3edd0)

**Step 6**
![Screenshot 2024-05-30 at 1 31 41 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/0f46329c-2dba-49fc-acae-558ece8e5f5d)

**Step 7**
![Screenshot 2024-05-30 at 1 32 22 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/716fcbf0-555c-4c31-897d-fb3bf1e149d4)

**Step 8**
We dont show the `What we're doing` section when a claim is closed so this what it will look like
![Screenshot 2024-05-30 at 12 25 58 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/b202f100-130f-43ff-afb7-2c25af514f51)

## What areas of the site does it impact?

Claim Status Tool

## Acceptance criteria

- [x] There is header text for claim phases 1-7 in the "What We're Doing" component and the number and step description matches exactly what is used as headers on the Overview page.
- [x] The part of the header that mentions the claim "step" matches exactly the name of the step on the Overview page for the new timeline; When a user is on step 1 of 8 the header shows and the description shows
- [x] The description for each phase matches the "What We're Doing" text from [this doc](https://docs.google.com/document/d/1WfWCfoQgKoMBg835VP7j_ptXmqb2o3RVme2u5dMOEr8/edit#heading=h.55axkr7jidx0) consistent with the phase steps.
- [x] There is a link to the overview section of CST that says "Learn more about this step
- [x]  There is "moved to" text that clearly calls out the date the claim moved to this step.
- [x] Behind cst_claim_phases feature flag

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
