### PR TITLE
VFEP-1518 Service History section of the 22-1995 form should be renamed to Applicant service history.

### DIFF
--- a/src/applications/edu-benefits/1995/config/chapters.js
+++ b/src/applications/edu-benefits/1995/config/chapters.js
@@ -106,6 +106,13 @@ export const directDepositField = (automatedTest = false) => {
     : createDirectDepositChangePageUpdate(fullSchema1995);
 };
 
+export const serviceHistoryTitle = (automatedTest = false) => {
+  if (isProductionOfTestProdEnv(automatedTest)) {
+    return 'Service history';
+  }
+  return 'Applicant service history';
+};
+
 export const chapters = {
   applicantInformation: {
     title: 'Applicant information',
@@ -137,7 +144,7 @@ export const chapters = {
     },
   },
   militaryService: {
-    title: 'Service history',
+    title: serviceHistoryTitle(),
     pages: {
       servicePeriods: {
         path: 'military/service',


### PR DESCRIPTION
## Summary

- VFEP-1518 Service History section of the 22-1995 form should be renamed to Applicant service history.

## Description

22-1995 Add "Applicant" to Service history step title - Front-end
As a...
VFEP Business User
I want...
To understand the information requested for service history
So that...
I can enter the information correctly
Acceptance Criteria:
The Service History section of the 22-1995 form should be renamed to Applicant service history. 
The review section heading should also reflect the updated heading

## Testing done

- Verified Changes on my local machine

## Screenshots

![Screenshot 2024-05-30 at 11 29 16 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/95312667/0e2b156d-c786-43f1-a092-f170dffdc117)


