### PR TITLE
Fix wording on marriage upload

### DIFF
--- a/src/applications/ivc-champva/10-10D/components/Applicant/applicantFileUpload.js
+++ b/src/applications/ivc-champva/10-10D/components/Applicant/applicantFileUpload.js
@@ -489,6 +489,15 @@ export const applicantMarriageCertConfig = uploadWithInfoComponent(
   true,
 );
 
+// When in list loop, formData is just the list element's data, but when editing
+// a list item's data on review-and-submit `formData` may be the complete form
+// data object. This provides a consistent interface via formContext.
+export function getTopLevelFormData(formContext) {
+  return formContext.contentAfterButtons === undefined
+    ? formContext.data
+    : formContext.contentAfterButtons.props.form.data;
+}
+
 export const applicantMarriageCertUploadUiSchema = {
   applicants: {
     'ui:options': { viewField: ApplicantField },
@@ -506,15 +515,17 @@ export const applicantMarriageCertUploadUiSchema = {
             false,
             formContext.pagePerItemIndex,
           );
+          // Inside list loop this lets us grab form data outside the scope of
+          // current list element:
+          const vetName = getTopLevelFormData(formContext)?.veteransFullName;
           return (
             <>
               You’ll need to submit a document showing proof of the marriage or
-              legal union between <b>{nonPosessive}</b> sponsor and{' '}
+              legal union between <b>{nonPosessive}</b> and{' '}
               <b>
-                {formData.veteransFullName?.first}{' '}
-                {formData.veteransFullName?.last}.
+                {vetName?.first ?? ''} {vetName?.last ?? ''}
               </b>
-              <br />
+              .<br />
               <br />
               {marriageDocumentList}
               {mailOrFaxLaterMsg}

--- a/src/applications/ivc-champva/10-10D/tests/unit/helpers/helpers.unit.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/unit/helpers/helpers.unit.spec.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { applicantWording, getAgeInYears } from '../../../../shared/utilities';
 import { sponsorWording } from '../../../helpers/wordingCustomization';
 import { isInRange } from '../../../helpers/utilities';
+import { getTopLevelFormData } from '../../../components/Applicant/applicantFileUpload';
 import ApplicantField from '../../../../shared/components/applicantLists/ApplicantField';
 import { testComponentRender } from '../../../../shared/tests/pages/pageTests.spec';
 import mockData from '../../e2e/fixtures/data/test-data.json';
@@ -60,3 +61,30 @@ testComponentRender(
   'ApplicantField',
   <ApplicantField formData={mockData.data.applicants[0]} />,
 );
+
+describe('getTopLevelFormData helper', () => {
+  it('should return data if `contentAfterButtons` is present in formContext', () => {
+    expect(
+      getTopLevelFormData({
+        contentAfterButtons: {
+          props: {
+            form: {
+              data: {
+                veteransFullName: { first: 'firstname', last: 'lastname' },
+              },
+            },
+          },
+        },
+      }),
+    ).to.not.be.undefined;
+  });
+  it('should return data if `contentAfterButtons` is not present in formContext', () => {
+    expect(
+      getTopLevelFormData({
+        data: {
+          veteransFullName: { first: 'firstname', last: 'lastname' },
+        },
+      }),
+    ).to.not.be.undefined;
+  });
+});


### PR DESCRIPTION
## Summary

Fixes wording on marriage file upload screen so it properly pulls in sponsor name for dynamic text.

- Previously, sponsor name would not render
- Now, sponsor name does render
- Added a helper to access the proper top level form data (this was missing previously, resulting in sponsor name being undefined)
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83906

## Testing done

- Manual
- Unit

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![Screenshot 2024-05-30 at 16 08 24](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/74d59b9f-9068-4fbd-b0ce-e4518bddc689)|![Screenshot 2024-05-30 at 15 43 36](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/8e47aaae-44a2-4b0c-9f16-ac8a7e99b000)|

## What areas of the site does it impact?

IVC form 10-10d

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA