### PR TITLE
10-7959f-1 Staging Confirmation Updates

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/ConfirmationPage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { format, isValid } from 'date-fns';
 import { connect } from 'react-redux';
+import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
@@ -30,10 +31,12 @@ export class ConfirmationPage extends React.Component {
             Register for the Foreign Medical Program (FMP) with Form 10-7959f-1
           </h2>
         </div>
-        <h2 className="vads-u-font-size--h3">
-          You've submitted your registration for FMP (VA Form 10-7959f-1)
-        </h2>
-        <p>We may contact you for more information or documents.</p>
+        <VaAlert uswds status="success">
+          <h2 className="vads-u-font-size--h3">
+            You've submitted your registration for FMP (VA Form 10-7959f-1)
+          </h2>
+        </VaAlert>
+
         <div className="inset">
           <h3 className="vads-u-margin-top--0 vads-u-font-size--h4">
             Your submission information
@@ -45,13 +48,6 @@ export class ConfirmationPage extends React.Component {
               {data.statementOfTruthSignature}
               <br />
             </p>
-          )}
-          {data.statementOfTruthSignature && (
-            <span className="veterans-full-name">
-              <strong>Confirmation number</strong>
-              <br />
-              {form.submission?.response?.confirmationNumber || ''}
-            </span>
           )}
           {isValid(submitDate) && (
             <p>
@@ -71,12 +67,12 @@ export class ConfirmationPage extends React.Component {
             onClick={window.print}
           />
         </div>
-        <h2>What happpens now?</h2>
+        <h2>What happpens next</h2>
         <p>
-          If you're eligible to register for RMP, we'll send you a benefits
-          authorization letter. This letter will list your service-connected
-          conditions that we'll cover. Then you can file FMP claims for care
-          related to the covered conditions.{' '}
+          We'll review your eligibility for the FMP and send you a notification
+          letter. If your registration is approved, the letter will list all of
+          your covered service-connected conditions. In the meantime, you are
+          also able to file claims to the FMP for care received abroad.
         </p>
         <div>
           <a className="vads-c-action-link--green" href="https://www.va.gov/">


### PR DESCRIPTION
## Summary
This PR has a few updated to the f1 confirmation page:

- Removes confirmation number
- Updates text
- Adds green border

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/83894

## Testing done
Manual testing
Unit testing

## Screenshots
![Screenshot 2024-05-31 at 1 29 45 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/4ae39830-3297-4f5e-8622-922114103e62)

## What areas of the site does it impact?
This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
