### PR TITLE
Fix typo in aws_region holding up deploy

### DIFF
--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -181,7 +181,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
+          aws_region: us-gov-west-1
           role-to-assume: ${{ env.AWS_FRONTEND_PROD_ROLE }}
           role-duration-seconds: 900
           role-session-name: vsp-frontendteam-githubaction

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -168,7 +168,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-gov-west-1
+          aws_region: us-gov-west-1
 
       - name: Get AWS IAM role
         uses: ./.github/workflows/inject-secrets

--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -166,8 +166,8 @@ jobs:
       - name: Configure AWS credentials (1)
         uses: ./.github/workflows/configure-aws-credentials
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-gov-west-1
 
       - name: Get AWS IAM role
@@ -179,12 +179,12 @@ jobs:
       - name: Configure AWS Credentials (2)
         uses: ./.github/workflows/configure-aws-credentials
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-gov-west-1
-          role-to-assume: ${{ env.AWS_FRONTEND_PROD_ROLE }}
-          role-duration-seconds: 900
-          role-session-name: vsp-frontendteam-githubaction
+          role: ${{ env.AWS_FRONTEND_PROD_ROLE }}
+          role_duration: 900
+          session_name: vsp-frontendteam-githubaction
 
       - name: Deploy
         run: ./script/github-actions/deploy.sh -s $SRC -d $DEST -a $ASSET_DEST -v


### PR DESCRIPTION
Per [failed deploy](https://github.com/department-of-veterans-affairs/vets-website/actions/runs/9321730274/job/25661438586):

`Warning: Unexpected input(s) 'aws-access-key-id', 'aws-secret-access-key', 'aws-region', valid inputs are ['aws_id', 'aws_key', 'aws_region', 'role', 'session_name', 'role_duration']`

Replacing aws-region with aws_region