### PR TITLE
update evaluate workflow failures worklfow to bump from node 16

### DIFF
--- a/.github/workflows/daily-lighthouse-scan.yml
+++ b/.github/workflows/daily-lighthouse-scan.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Audit URLs using Lighthouse on ${{ matrix.registry }}
         id: lighthouse-checks
-        uses: treosh/lighthouse-ci-action@v11
+        uses: treosh/lighthouse-ci-action@v9
         with:
           urls: |
             https://www.va.gov${{ matrix.registry }}

--- a/.github/workflows/e2e-stress-test.yml
+++ b/.github/workflows/e2e-stress-test.yml
@@ -1,9 +1,10 @@
 name: E2E Test Stability Review
 
 on:
-  schedule:
-    - cron: '0 02 * * 1-5' # 10pm EST/2am UTC, weekdays
-
+  # schedule:
+  #   - cron: '0 02 * * 1-5' # 10pm EST/2am UTC, weekdays
+  push
+  
 env:
   BUILDTYPE: vagovprod
 

--- a/.github/workflows/e2e-stress-test.yml
+++ b/.github/workflows/e2e-stress-test.yml
@@ -1,9 +1,8 @@
 name: E2E Test Stability Review
 
 on:
-  # schedule:
-  #   - cron: '0 02 * * 1-5' # 10pm EST/2am UTC, weekdays
-  push
+  schedule:
+    - cron: '0 02 * * 1-5' # 10pm EST/2am UTC, weekdays
   
 env:
   BUILDTYPE: vagovprod

--- a/.github/workflows/evaluate-workflow-failures.yml
+++ b/.github/workflows/evaluate-workflow-failures.yml
@@ -28,7 +28,7 @@ jobs:
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
       - name: Init Dashboard Data Repo
-        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
+        uses: ./.github/workflows/init-data-repo
 
       - name: Set Up BigQuery Creds
         uses: ./.github/workflows/configure-bigquery

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,7 +30,7 @@ jobs:
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
       - name: Init Dashboard Data Repo
-        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
+        uses: ./.github/workflows/init-data-repo
 
       - name: Set Up BigQuery Creds
         uses: ./.github/workflows/configure-bigquery

--- a/.github/workflows/review-instance-metrics.yml
+++ b/.github/workflows/review-instance-metrics.yml
@@ -26,7 +26,7 @@ jobs:
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
       - name: Init Dashboard Data Repo
-        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
+        uses: ./.github/workflows/init-data-repo
 
       - name: Set Up BigQuery Creds
         uses: ./.github/workflows/configure-bigquery

--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -307,13 +307,13 @@ function main() {
   exportVariables(testsToRunNormally);
 
   if (RUN_FULL_SUITE) {
-    core.exportVariable('e2e_tests_to_STRESS_TEST', 'true');
+    core.exportVariable('CYPRESS_TESTS_TO_STRESS_TEST', 'true');
     fs.writeFileSync(
       `e2e_tests_to_stress_test.json`,
       JSON.stringify(allAllowListSpecs),
     );
   } else {
-    core.exportVariable('e2e_tests_to_STRESS_TEST', 'true');
+    core.exportVariable('CYPRESS_TESTS_TO_STRESS_TEST', 'true');
     fs.writeFileSync(
       `e2e_tests_to_stress_test.json`,
       JSON.stringify(testsToStressTest),

--- a/script/github-actions/select-cypress-tests.js
+++ b/script/github-actions/select-cypress-tests.js
@@ -312,12 +312,14 @@ function main() {
       `e2e_tests_to_stress_test.json`,
       JSON.stringify(allAllowListSpecs),
     );
-  } else {
+  } else if (testsToStressTest.length > 0) {
     core.exportVariable('CYPRESS_TESTS_TO_STRESS_TEST', 'true');
     fs.writeFileSync(
       `e2e_tests_to_stress_test.json`,
       JSON.stringify(testsToStressTest),
     );
+  } else {
+    core.exportVariable('CYPRESS_TESTS_TO_STRESS_TEST', 'false');
   }
 }
 if (RUN_FULL_SUITE || ALLOW_LIST.length > 0) {

--- a/src/applications/burials/components/IntroductionPage.jsx
+++ b/src/applications/burials/components/IntroductionPage.jsx
@@ -13,7 +13,7 @@ class IntroductionPage extends React.Component {
   render() {
     const { route } = this.props;
     return (
-      <div className="schemaform-intro">
+      <div className="schemaform-introo">
         <FormTitle title="Apply for burial benefits" />
         <p>Equal to VA Form 21P-530 (Application for Burial Benefits).</p>
         <SaveInProgressIntro

--- a/src/applications/burials/components/IntroductionPage.jsx
+++ b/src/applications/burials/components/IntroductionPage.jsx
@@ -13,7 +13,7 @@ class IntroductionPage extends React.Component {
   render() {
     const { route } = this.props;
     return (
-      <div className="schemaform-introo">
+      <div className="schemaform-intro">
         <FormTitle title="Apply for burial benefits" />
         <p>Equal to VA Form 21P-530 (Application for Burial Benefits).</p>
         <SaveInProgressIntro


### PR DESCRIPTION
## Summary

- The goal of this PR is to eliminate many of the warnings about actions that are using node v16 by updating them or pointing them to the correct sources.
- This PR also contains a fix for the E2E overnight stress test.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/74667

## Testing done

- Forced a change to a component to ensure the e2e stress test conditions all worked correctly.

