### PR TITLE
Remove va_online_scheduling_request_flow_update feature toggle

### DIFF
--- a/src/applications/mhv-secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
+++ b/src/applications/mhv-secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
@@ -1711,14 +1711,6 @@
         "value": true
       },
       {
-        "name": "vaOnlineSchedulingRequestFlowUpdate",
-        "value": false
-      },
-      {
-        "name": "va_online_scheduling_request_flow_update",
-        "value": false
-      },
-      {
         "name": "vaOnlineSchedulingPocTypeOfCare",
         "value": false
       },

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -76,9 +76,6 @@ export const selectFeatureVaosV2Next = state =>
 export const selectFeatureClinicFilter = state =>
   toggleValues(state).vaOnlineSchedulingClinicFilter;
 
-export const selectFeatureRequestFlowUpdate = state =>
-  toggleValues(state).vaOnlineSchedulingRequestFlowUpdate;
-
 export const selectFeaturePocTypeOfCare = state =>
   toggleValues(state).vaOnlineSchedulingPocTypeOfCare;
 

--- a/src/applications/vaos/utils/featureFlags.js
+++ b/src/applications/vaos/utils/featureFlags.js
@@ -18,7 +18,6 @@ module.exports = [
   { name: 'vaOnlineSchedulingVAOSV2Next', value: true },
   { name: 'vaOnlineSchedulingClinicFilter', value: true },
   { name: 'vaOnlineSchedulingUseDsot', value: true },
-  { name: 'vaOnlineSchedulingRequestFlowUpdate', value: true },
   { name: 'vaOnlineSchedulingConvertUtcToLocal', value: false },
   { name: 'vaOnlineSchedulingBreadcrumbUrlUpdate', value: true },
   { name: 'vaOnlineSchedulingBookingExclusion', value: false },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -233,7 +233,6 @@
   "vaOnlineSchedulingClinicLocation": "va_online_scheduling_clinic_location",
   "vaOnlineSchedulingVaosV2Next": "va_online_scheduling_vaos_v2_next",
   "vaOnlineSchedulingClinicFilter": "va_online_scheduling_clinic_filter",
-  "vaOnlineSchedulingRequestFlowUpdate": "va_online_scheduling_request_flow_update",
   "vaOnlineSchedulingPocTypeOfCare": "va_online_scheduling_poc_type_of_care",
   "vaOnlineSchedulingConvertUtcToLocal": "va_online_scheduling_convert_utc_to_local",
   "vaOnlineSchedulingBreadcrumbUrlUpdate": "va_online_scheduling_breadcrumb_url_update",


### PR DESCRIPTION
## Summary

- Removing the deprecated va_online_scheduling_request_flow_update feature toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/64029

## Testing done

- Ensured existing test suite passes.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

