### PR TITLE
30907 Allow debts to be sourced from mockdata instead of hardcoding on local

### DIFF
--- a/src/applications/combined-debt-portal/combined/actions/debts.js
+++ b/src/applications/combined-debt-portal/combined/actions/debts.js
@@ -1,5 +1,3 @@
-import { isVAProfileServiceConfigured } from '@@vap-svc/util/local-vapsvc';
-
 export const DEBTS_FETCH_INITIATED = 'DEBTS_FETCH_INITIATED';
 export const DEBTS_FETCH_SUCCESS = 'DEBTS_FETCH_SUCCESS';
 export const DEBTS_FETCH_FAILURE = 'DEBTS_FETCH_FAILURE';
@@ -15,9 +13,8 @@ export const MCP_STATEMENTS_FETCH_FAILURE = 'MCP_STATEMENTS_FETCH_FAILURE';
 import * as Sentry from '@sentry/browser';
 import environment from '~/platform/utilities/environment';
 import { apiRequest } from '~/platform/utilities/api';
-import { deductionCodes } from '../../debt-letters/const/deduction-codes';
 import recordEvent from '~/platform/monitoring/record-event';
-import { debtMockResponse } from '../utils/mocks/mockResponses';
+import { deductionCodes } from '../../debt-letters/const/deduction-codes';
 
 const fetchDebtsInitiated = () => ({ type: DEBTS_FETCH_INITIATED });
 const fetchDebtLettersInitiated = () => ({
@@ -60,9 +57,10 @@ export const fetchDebtLettersVBMS = () => async dispatch => {
         'Source-App-Name': window.appName,
       },
     };
-    const response = isVAProfileServiceConfigured()
-      ? await apiRequest(`${environment.API_URL}/v0/debt_letters`, options)
-      : await debtMockResponse();
+    const response = await apiRequest(
+      `${environment.API_URL}/v0/debt_letters`,
+      options,
+    );
 
     // Remove DMC prefixing added by VBMS
     const filteredResponse = response.map(debtLetter => {
@@ -100,9 +98,10 @@ export const fetchDebtLetters = async (dispatch, debtLettersActive) => {
         'Source-App-Name': window.appName,
       },
     };
-    const response = isVAProfileServiceConfigured()
-      ? await apiRequest(`${environment.API_URL}/v0/debts`, options)
-      : await debtMockResponse();
+    const response = await apiRequest(
+      `${environment.API_URL}/v0/debts`,
+      options,
+    );
 
     if (Object.keys(response).includes('errors')) {
       recordEvent({ event: 'bam-get-veteran-dmc-info-failed' });

--- a/src/applications/financial-status-report/actions/index.js
+++ b/src/applications/financial-status-report/actions/index.js
@@ -1,5 +1,4 @@
 import moment from 'moment';
-import { isVAProfileServiceConfigured } from '@@vap-svc/util/local-vapsvc';
 import environment from 'platform/utilities/environment';
 import localStorage from 'platform/utilities/storage/localStorage';
 import {
@@ -8,7 +7,6 @@ import {
 } from 'platform/utilities/api';
 import * as Sentry from '@sentry/browser';
 import { deductionCodes } from '../constants/deduction-codes';
-import { debtMockResponse } from '../utils/debtMockResponses';
 import {
   FSR_API_ERROR,
   FSR_RESET_ERRORS,
@@ -73,9 +71,7 @@ export const fetchDebts = async dispatch => {
       },
     };
 
-    return isVAProfileServiceConfigured()
-      ? apiRequest(`${environment.API_URL}/v0/debts`, options)
-      : debtMockResponse();
+    return apiRequest(`${environment.API_URL}/v0/debts`, options);
   };
 
   try {


### PR DESCRIPTION
## Summary
Currently, when accessing the debt portal on a local env, all users are given a set of hardcoded debts. This goes counter to the vast majority of vets api services which pull local data from the user's local mockdata repo.

## Related issue(s)
[30907](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/30907)

## Testing done
- existing debts specs green


## What areas of the site does it impact?
[local debt balances](http://localhost:3001/manage-va-debt/summary/debt-balances)

## Acceptance criteria
A local debt portal user should have the debts defined in [their mockdata response](https://github.com/department-of-veterans-affairs/vets-api-mockdata/blob/master/debts/index/796330625.yml), unless they do not have debts defined, (like user 0) in which case they should see the default response.

### Quality Assurance & Testing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated