### PR TITLE
Minor adjustments to form flow and breadcrumbs - Form 10-7959c

### DIFF
--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -275,7 +275,9 @@ const formConfig = {
         },
         primaryEOB: {
           path: 'insurance-eob',
-          depends: formData => get('applicantHasPrimary', formData),
+          depends: formData =>
+            get('applicantHasPrimary', formData) &&
+            get('applicantPrimaryHasPrescription', formData),
           title: formData =>
             `${nameWording(formData, undefined, undefined, true)} ${
               formData.applicantPrimaryProvider
@@ -286,6 +288,7 @@ const formConfig = {
           path: 'insurance-sob',
           depends: formData =>
             get('applicantHasPrimary', formData) &&
+            get('applicantPrimaryHasPrescription', formData) &&
             !get('applicantPrimaryEOB', formData),
           title: formData =>
             `${nameWording(formData)} ${
@@ -366,7 +369,9 @@ const formConfig = {
         },
         secondaryEOB: {
           path: 'secondary-insurance-eob',
-          depends: formData => get('applicantHasSecondary', formData),
+          depends: formData =>
+            get('applicantHasSecondary', formData) &&
+            get('applicantSecondaryHasPrescription', formData),
           title: formData =>
             `${nameWording(formData, undefined, undefined, true)} ${
               formData.applicantSecondaryProvider
@@ -377,6 +382,7 @@ const formConfig = {
           path: 'secondary-insurance-sob',
           depends: formData =>
             get('applicantHasSecondary', formData) &&
+            get('applicantSecondaryHasPrescription', formData) &&
             !get('applicantSecondaryEOB', formData),
           title: formData =>
             `${nameWording(formData)} ${

--- a/src/applications/ivc-champva/10-7959C/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959C/containers/App.jsx
@@ -5,14 +5,14 @@ import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library
 import formConfig from '../config/form';
 
 const breadcrumbList = [
-  { href: '/', label: 'VA.gov home' },
+  { href: '/', label: 'Home' },
   {
     href: `/family-and-caregiver-benefits`,
-    label: `Family and Caregiver Benefits`,
+    label: `Family and caregiver benefits`,
   },
   {
     href: `/family-and-caregiver-benefits/health-and-disability/`,
-    label: `Health and Disability`,
+    label: `Health and disability`,
   },
   {
     href: `/family-and-caregiver-benefits/health-and-disability/champva`,

--- a/src/applications/ivc-champva/10-7959C/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959C/containers/App.jsx
@@ -23,10 +23,7 @@ const breadcrumbList = [
 export default function App({ location, children }) {
   return (
     <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
-      <VaBreadcrumbs
-        breadcrumbList={breadcrumbList}
-        homeVeteransAffairs={false}
-      />
+      <VaBreadcrumbs breadcrumbList={breadcrumbList} />
       <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
         {children}
       </RoutedSavableApp>

--- a/src/applications/ivc-champva/10-7959C/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959C/containers/App.jsx
@@ -23,7 +23,10 @@ const breadcrumbList = [
 export default function App({ location, children }) {
   return (
     <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
-      <VaBreadcrumbs breadcrumbList={breadcrumbList} />
+      <VaBreadcrumbs
+        breadcrumbList={breadcrumbList}
+        homeVeteransAffairs={false}
+      />
       <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
         {children}
       </RoutedSavableApp>


### PR DESCRIPTION
## Summary

This PR updates the casing of words in the breadcrumb and updates the `depends` function for the schedule of benefits (SOB) upload screen. Previously, the SOB screen was showing up when a user selected that their insurance had prescription coverage. However, it should really only show if they have prescription coverage AND don't have EOBs provided. This has been fixed.

- Updated a depends function to show the SOB upload screen properly
- Adjusted the word casing on breadcrumb to use sentence casing
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83201

## Testing done

- Manual

## Screenshots

|         | breadcrumb | SOB upload |
| ------- | ------ | ----- |
| Desktop |![Screenshot 2024-06-03 at 09 45 57](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/1b862fd3-6f2b-48ba-bf87-1c791a5c1d44)|![Screenshot 2024-06-03 at 09 58 23](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/5a32d389-d0c5-48ab-bf44-ae46b305b04f)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA