### PR TITLE
Removes vaos status improvement feature flag remnants 

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/UpcomingAppointmentLayout.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/UpcomingAppointmentLayout.jsx
@@ -137,6 +137,5 @@ export default function UpcomingAppointmentLayout({
 
 UpcomingAppointmentLayout.propTypes = {
   featureBreadcrumbUrlUpdate: PropTypes.bool,
-  featureStatusImprovement: PropTypes.bool,
   hashTable: PropTypes.object,
 };

--- a/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
+++ b/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
@@ -41,7 +41,7 @@ export default function UpcomingAppointmentsList() {
   useEffect(
     () => {
       if (futureStatus === FETCH_STATUS.notStarted) {
-        dispatch(fetchFutureAppointments({}));
+        dispatch(fetchFutureAppointments());
       } else if (hasTypeChanged && futureStatus === FETCH_STATUS.succeeded) {
         scrollAndFocus('#type-dropdown');
       } else if (hasTypeChanged && futureStatus === FETCH_STATUS.failed) {

--- a/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
+++ b/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
@@ -14,10 +14,7 @@ import {
   fetchFutureAppointments,
   startNewAppointmentFlow,
 } from '../redux/actions';
-import {
-  selectFeatureStatusImprovement,
-  selectFeatureBreadcrumbUrlUpdate,
-} from '../../redux/selectors';
+import { selectFeatureBreadcrumbUrlUpdate } from '../../redux/selectors';
 import UpcomingAppointmentLayout from './AppointmentsPage/UpcomingAppointmentLayout';
 import BackendAppointmentServiceAlert from './BackendAppointmentServiceAlert';
 
@@ -30,9 +27,7 @@ export default function UpcomingAppointmentsList() {
     futureStatus,
     hasTypeChanged,
   } = useSelector(state => getUpcomingAppointmentListInfo(state), shallowEqual);
-  const featureStatusImprovement = useSelector(state =>
-    selectFeatureStatusImprovement(state),
-  );
+
   const featureBreadcrumbUrlUpdate = useSelector(state =>
     selectFeatureBreadcrumbUrlUpdate(state),
   );
@@ -48,7 +43,7 @@ export default function UpcomingAppointmentsList() {
       if (futureStatus === FETCH_STATUS.notStarted) {
         dispatch(
           fetchFutureAppointments({
-            includeRequests: featureStatusImprovement,
+            includeRequests: false,
           }),
         );
       } else if (hasTypeChanged && futureStatus === FETCH_STATUS.succeeded) {
@@ -57,7 +52,7 @@ export default function UpcomingAppointmentsList() {
         scrollAndFocus('h3');
       }
     },
-    [dispatch, featureStatusImprovement, futureStatus, hasTypeChanged],
+    [dispatch, futureStatus, hasTypeChanged],
   );
 
   if (

--- a/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
+++ b/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
@@ -41,11 +41,7 @@ export default function UpcomingAppointmentsList() {
   useEffect(
     () => {
       if (futureStatus === FETCH_STATUS.notStarted) {
-        dispatch(
-          fetchFutureAppointments({
-            includeRequests: false,
-          }),
-        );
+        dispatch(fetchFutureAppointments({}));
       } else if (hasTypeChanged && futureStatus === FETCH_STATUS.succeeded) {
         scrollAndFocus('#type-dropdown');
       } else if (hasTypeChanged && futureStatus === FETCH_STATUS.failed) {

--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -64,9 +64,6 @@ export const selectFeatureVAOSServiceCCAppointments = state =>
 export const selectFeatureFacilitiesServiceV2 = state =>
   toggleValues(state).vaOnlineSchedulingFacilitiesServiceV2;
 
-export const selectFeatureStatusImprovement = state =>
-  toggleValues(state).vaOnlineSchedulingStatusImprovement;
-
 export const selectFeatureStatusImprovementCanceled = state =>
   toggleValues(state).vaOnlineSchedulingStatusImprovementCanceled;
 

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPage.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPage.unit.spec.js
@@ -304,7 +304,6 @@ describe('VAOS Page: AppointmentsPage', () => {
         ...initialState.featureToggles,
         vaOnlineSchedulingDirect: true,
         vaOnlineSchedulingCommunityCare: false,
-        vaOnlineSchedulingStatusImprovement: true,
       },
       user: userState,
     };
@@ -325,7 +324,6 @@ describe('VAOS Page: AppointmentsPage', () => {
         ...initialState.featureToggles,
         vaOnlineSchedulingDirect: true,
         vaOnlineSchedulingCommunityCare: false,
-        vaOnlineSchedulingStatusImprovement: true,
         vaOnlineSchedulingBreadcrumbUrlUpdate: true,
       },
       user: userState,

--- a/src/applications/vaos/tests/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.js
@@ -359,7 +359,6 @@ describe('VAOS Backend Service Alert', () => {
           ...initialState,
           featureToggles: {
             ...initialState.featureToggles,
-            vaOnlineSchedulingStatusImprovement: true,
             vaOnlineSchedulingVAOSServiceRequests: true,
           },
         },
@@ -452,7 +451,6 @@ describe('VAOS Backend Service Alert', () => {
           ...initialState,
           featureToggles: {
             ...initialState.featureToggles,
-            vaOnlineSchedulingStatusImprovement: true,
             vaOnlineSchedulingVAOSServiceRequests: true,
           },
         },

--- a/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.js
@@ -20,7 +20,6 @@ const initialState = {
     vaOnlineSchedulingPast: true,
     // eslint-disable-next-line camelcase
     show_new_schedule_view_appointments_page: true,
-    vaOnlineSchedulingStatusImprovement: false,
   },
 };
 

--- a/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/CommunityCareAppointmentDetailsPage.unit.spec.js
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import {
   mockSingleVAOSAppointmentFetch,
   mockVAOSAppointmentsFetch,
+  mockAppointmentsApi,
 } from '../../mocks/helpers';
 import { renderWithStoreAndRouter, getTestDate } from '../../mocks/setup';
 import { createMockAppointment } from '../../mocks/data';
@@ -70,6 +71,15 @@ describe('VAOS Page: CommunityCareAppointmentDetailsPage with VAOS service', () 
 
     const appointment = createMockAppointment({
       ...data,
+    });
+
+    mockAppointmentsApi({
+      start: moment()
+        .subtract(120, 'days')
+        .format('YYYY-MM-DD'),
+      end: moment().format('YYYY-MM-DD'),
+      statuses: ['proposed', 'cancelled'],
+      response: [],
     });
 
     mockVAOSAppointmentsFetch({

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.js
@@ -40,7 +40,6 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
       vaOnlineSchedulingCancel: true,
       vaOnlineSchedulingPast: true,
       vaOnlineSchedulingRequests: true,
-      vaOnlineSchedulingStatusImprovement: true,
       vaOnlineSchedulingVAOSServiceRequests: true,
       vaOnlineSchedulingVAOSServiceVAAppointments: true,
       vaOnlineSchedulingAppointmentDetailsRedesign: false,

--- a/src/applications/vaos/tests/appointment-list/components/PastAppointmentsListV2.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/PastAppointmentsListV2.unit.spec.js
@@ -20,7 +20,6 @@ const initialState = {
     vaOnlineSchedulingPast: true,
     vaOnlineSchedulingVAOSServiceVAAppointments: true,
     vaOnlineSchedulingVAOSServiceCCAppointments: true,
-    vaOnlineSchedulingStatusImprovement: true,
   },
 };
 

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.js
@@ -26,7 +26,6 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
   const initialState = {
     featureToggles: {
       vaOnlineSchedulingBreadcrumbUrlUpdate: true,
-      vaOnlineSchedulingStatusImprovement: true,
       vaOnlineSchedulingVAOSServiceCCAppointments: true,
       vaOnlineSchedulingVAOSServiceRequests: true,
       vaOnlineSchedulingBookingExclusion: false,

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentListGroup.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentListGroup.unit.spec.js
@@ -17,362 +17,342 @@ const initialStateVAOSService = {
 };
 
 describe('VAOS Component: RequestedAppointmentsList', () => {
-  describe('Given vaOnlineSchedulingStatusImprovement feature is on', () => {
-    beforeEach(() => {
-      mockFetch();
-      MockDate.set(getTestDate());
-    });
+  beforeEach(() => {
+    mockFetch();
+    MockDate.set(getTestDate());
+  });
 
-    afterEach(() => {
-      MockDate.reset();
-    });
+  afterEach(() => {
+    MockDate.reset();
+  });
 
-    it('should display pending and canceled appointments grouped', async () => {
-      // And a veteran has VA appointment request
-      const startDate = moment.utc();
-      const appointment = getVAOSRequestMock();
-      appointment.id = '1234';
-      appointment.attributes = {
-        comment: 'A message from the patient',
-        contact: {
-          telecom: [
-            { type: 'phone', value: '2125551212' },
-            { type: 'email', value: 'veteranemailtest@va.gov' },
-          ],
-        },
-        kind: 'clinic',
-        locationId: '983',
-        location: {
-          id: '983',
-          type: 'appointments',
-          attributes: {
-            id: '983',
-            vistaSite: '983',
-            name: 'Cheyenne VA Medical Center',
-            lat: 39.744507,
-            long: -104.830956,
-            phone: { main: '307-778-7550' },
-            physicalAddress: {
-              line: ['2360 East Pershing Boulevard'],
-              city: 'Cheyenne',
-              state: 'WY',
-              postalCode: '82001-5356',
-            },
-          },
-        },
-
-        id: '1234',
-        preferredTimesForPhoneCall: ['Morning'],
-        reasonCode: {
-          coding: [{ code: 'Routine Follow-up' }],
-          text: 'A message from the patient',
-        },
-        requestedPeriods: [
-          {
-            start: moment(startDate)
-              .add(3, 'days')
-              .format('YYYY-MM-DDTHH:mm:ss[Z]'),
-          },
-          {
-            start: moment(startDate)
-              .add(4, 'days')
-              .format('YYYY-MM-DDTHH:mm:ss[Z]'),
-          },
+  it('should display pending and canceled appointments grouped', async () => {
+    // And a veteran has VA appointment request
+    const startDate = moment.utc();
+    const appointment = getVAOSRequestMock();
+    appointment.id = '1234';
+    appointment.attributes = {
+      comment: 'A message from the patient',
+      contact: {
+        telecom: [
+          { type: 'phone', value: '2125551212' },
+          { type: 'email', value: 'veteranemailtest@va.gov' },
         ],
-        serviceType: '323',
-        start: null,
-        status: 'proposed',
-      };
-      const canceledAppointment = {
-        ...appointment,
+      },
+      kind: 'clinic',
+      locationId: '983',
+      location: {
+        id: '983',
+        type: 'appointments',
         attributes: {
-          ...appointment.attributes,
-          serviceType: '160',
-          status: 'cancelled',
-        },
-      };
-
-      // And developer is using the v2 API
-      mockVAOSAppointmentsFetch({
-        start: moment()
-          .subtract(120, 'days')
-          .format('YYYY-MM-DD'),
-        end: moment()
-          .add(1, 'days')
-          .format('YYYY-MM-DD'),
-        statuses: ['proposed', 'cancelled'],
-        requests: [appointment, canceledAppointment],
-      });
-
-      // When veteran selects requested appointments
-      const screen = renderWithStoreAndRouter(
-        <RequestedAppointmentsListGroup />,
-        {
-          initialState: {
-            ...initialStateVAOSService,
-            featureToggles: {
-              ...initialStateVAOSService.featureToggles,
-              vaOnlineSchedulingStatusImprovement: true,
-            },
-          },
-          reducers,
-        },
-      );
-
-      // Then it should display the requested appointments
-      expect(await screen.findByText('Primary care')).to.be.ok;
-
-      // And it hsould display the cancelled appointments
-      expect(
-        screen.getByRole('heading', { level: 2, name: 'Canceled requests' }),
-      ).to.be.ok;
-      expect(screen.getByText('These appointment requests have been canceled.'))
-        .to.be.ok;
-    });
-
-    it('should display pending appointments when there are no canceled appointments', async () => {
-      // And a veteran has VA appointment request
-      const startDate = moment.utc();
-      const appointment = getVAOSRequestMock();
-      appointment.id = '1234';
-      appointment.attributes = {
-        comment: 'A message from the patient',
-        contact: {
-          telecom: [
-            { type: 'phone', value: '2125551212' },
-            { type: 'email', value: 'veteranemailtest@va.gov' },
-          ],
-        },
-        kind: 'clinic',
-        locationId: '983',
-        location: {
           id: '983',
-          type: 'appointments',
-          attributes: {
-            id: '983',
-            vistaSite: '983',
-            name: 'Cheyenne VA Medical Center',
-            lat: 39.744507,
-            long: -104.830956,
-            phone: { main: '307-778-7550' },
-            physicalAddress: {
-              line: ['2360 East Pershing Boulevard'],
-              city: 'Cheyenne',
-              state: 'WY',
-              postalCode: '82001-5356',
-            },
+          vistaSite: '983',
+          name: 'Cheyenne VA Medical Center',
+          lat: 39.744507,
+          long: -104.830956,
+          phone: { main: '307-778-7550' },
+          physicalAddress: {
+            line: ['2360 East Pershing Boulevard'],
+            city: 'Cheyenne',
+            state: 'WY',
+            postalCode: '82001-5356',
           },
         },
+      },
 
-        id: '1234',
-        preferredTimesForPhoneCall: ['Morning'],
-        reasonCode: {
-          coding: [{ code: 'Routine Follow-up' }],
-          text: 'A message from the patient',
-        },
-        requestedPeriods: [
-          {
-            start: moment(startDate)
-              .add(3, 'days')
-              .format('YYYY-MM-DDTHH:mm:ss[Z]'),
-          },
-          {
-            start: moment(startDate)
-              .add(4, 'days')
-              .format('YYYY-MM-DDTHH:mm:ss[Z]'),
-          },
-        ],
-        serviceType: '323',
-        start: null,
-        status: 'proposed',
-      };
-
-      // And developer is using the v2 API
-      mockVAOSAppointmentsFetch({
-        start: moment()
-          .subtract(120, 'days')
-          .format('YYYY-MM-DD'),
-        end: moment()
-          .add(1, 'days')
-          .format('YYYY-MM-DD'),
-        statuses: ['proposed', 'cancelled'],
-        requests: [appointment],
-      });
-
-      // When veteran selects requested appointments
-      const screen = renderWithStoreAndRouter(
-        <RequestedAppointmentsListGroup />,
+      id: '1234',
+      preferredTimesForPhoneCall: ['Morning'],
+      reasonCode: {
+        coding: [{ code: 'Routine Follow-up' }],
+        text: 'A message from the patient',
+      },
+      requestedPeriods: [
         {
-          initialState: {
-            ...initialStateVAOSService,
-            featureToggles: {
-              ...initialStateVAOSService.featureToggles,
-              vaOnlineSchedulingStatusImprovement: true,
-            },
-          },
-          reducers,
+          start: moment(startDate)
+            .add(3, 'days')
+            .format('YYYY-MM-DDTHH:mm:ss[Z]'),
         },
-      );
-
-      // Then it should display the requested appointments
-      expect(await screen.findByText('Primary care')).to.be.ok;
-
-      // And cancelled appointments should not be displayed
-      expect(
-        screen.queryByRole('heading', { level: 2, name: 'Canceled requests' }),
-      ).not.to.be.ok;
-      expect(
-        screen.queryByText('These appointment requests have been canceled.'),
-      ).not.to.be.ok;
-
-      // And the no appointments alert message should not be displayed
-      expect(
-        screen.queryByRole('heading', {
-          level: 3,
-          name: /You don’t have any/,
-        }),
-      ).not.to.be.ok;
-    });
-
-    it('should dispaly no appointments alert when there are no pending or cancelled appointments', async () => {
-      // And a veteran has no pending or canceled appointment request
-      // And developer is using the v2 API
-      mockVAOSAppointmentsFetch({
-        start: moment()
-          .subtract(120, 'days')
-          .format('YYYY-MM-DD'),
-        end: moment()
-          .add(1, 'days')
-          .format('YYYY-MM-DD'),
-        statuses: ['proposed', 'cancelled'],
-        requests: [{}],
-      });
-
-      // When veteran selects requested appointments
-      const screen = renderWithStoreAndRouter(
-        <RequestedAppointmentsListGroup />,
         {
-          initialState: {
-            ...initialStateVAOSService,
-            featureToggles: {
-              ...initialStateVAOSService.featureToggles,
-              vaOnlineSchedulingStatusImprovement: true,
-            },
-          },
-          reducers,
+          start: moment(startDate)
+            .add(4, 'days')
+            .format('YYYY-MM-DDTHH:mm:ss[Z]'),
         },
-      );
-
-      // Then it should display the no appointments alert message
-      expect(
-        await screen.findByRole('heading', {
-          level: 2,
-          name: /You don’t have any/,
-        }),
-      ).to.be.ok;
-    });
-
-    it('should display no appointments alert when there are no pending but cancelled appointments', async () => {
-      // And a veteran has VA appointment request
-      const startDate = moment.utc();
-      const appointment = getVAOSRequestMock();
-      appointment.id = '1234';
-      appointment.attributes = {
-        comment: 'A message from the patient',
-        contact: {
-          telecom: [
-            { type: 'phone', value: '2125551212' },
-            { type: 'email', value: 'veteranemailtest@va.gov' },
-          ],
-        },
-        kind: 'clinic',
-        locationId: '983',
-        location: {
-          id: '983',
-          type: 'appointments',
-          attributes: {
-            id: '983',
-            vistaSite: '983',
-            name: 'Cheyenne VA Medical Center',
-            lat: 39.744507,
-            long: -104.830956,
-            phone: { main: '307-778-7550' },
-            physicalAddress: {
-              line: ['2360 East Pershing Boulevard'],
-              city: 'Cheyenne',
-              state: 'WY',
-              postalCode: '82001-5356',
-            },
-          },
-        },
-
-        id: '1234',
-        preferredTimesForPhoneCall: ['Morning'],
-        reasonCode: {
-          coding: [{ code: 'Routine Follow-up' }],
-          text: 'A message from the patient',
-        },
-        requestedPeriods: [
-          {
-            start: moment(startDate)
-              .add(3, 'days')
-              .format('YYYY-MM-DDTHH:mm:ss[Z]'),
-          },
-          {
-            start: moment(startDate)
-              .add(4, 'days')
-              .format('YYYY-MM-DDTHH:mm:ss[Z]'),
-          },
-        ],
-        serviceType: '323',
-        start: null,
+      ],
+      serviceType: '323',
+      start: null,
+      status: 'proposed',
+    };
+    const canceledAppointment = {
+      ...appointment,
+      attributes: {
+        ...appointment.attributes,
+        serviceType: '160',
         status: 'cancelled',
-      };
+      },
+    };
 
-      // And developer is using the v2 API
-      mockVAOSAppointmentsFetch({
-        start: moment()
-          .subtract(120, 'days')
-          .format('YYYY-MM-DD'),
-        end: moment()
-          .add(1, 'days')
-          .format('YYYY-MM-DD'),
-        statuses: ['proposed', 'cancelled'],
-        requests: [appointment],
-      });
-
-      // When veteran selects requested appointments
-      const screen = renderWithStoreAndRouter(
-        <RequestedAppointmentsListGroup />,
-        {
-          initialState: {
-            ...initialStateVAOSService,
-            featureToggles: {
-              ...initialStateVAOSService.featureToggles,
-              vaOnlineSchedulingStatusImprovement: true,
-            },
-          },
-          reducers,
-        },
-      );
-
-      // Then it should display the requested appointments
-      expect(
-        await screen.findByRole('heading', {
-          level: 2,
-          name: 'Canceled requests',
-        }),
-      ).to.be.ok;
-      expect(screen.getByText('These appointment requests have been canceled.'))
-        .to.be.ok;
-
-      // And it should display the no appointments alert message
-      expect(
-        screen.getByRole('heading', {
-          level: 2,
-          name: /You don’t have any/,
-        }),
-      ).to.be.ok;
+    // And developer is using the v2 API
+    mockVAOSAppointmentsFetch({
+      start: moment()
+        .subtract(120, 'days')
+        .format('YYYY-MM-DD'),
+      end: moment()
+        .add(1, 'days')
+        .format('YYYY-MM-DD'),
+      statuses: ['proposed', 'cancelled'],
+      requests: [appointment, canceledAppointment],
     });
+
+    // When veteran selects requested appointments
+    const screen = renderWithStoreAndRouter(
+      <RequestedAppointmentsListGroup />,
+      {
+        initialState: {
+          ...initialStateVAOSService,
+        },
+        reducers,
+      },
+    );
+
+    // Then it should display the requested appointments
+    expect(await screen.findByText('Primary care')).to.be.ok;
+
+    // And it hsould display the cancelled appointments
+    expect(screen.getByRole('heading', { level: 2, name: 'Canceled requests' }))
+      .to.be.ok;
+    expect(screen.getByText('These appointment requests have been canceled.'))
+      .to.be.ok;
+  });
+
+  it('should display pending appointments when there are no canceled appointments', async () => {
+    // And a veteran has VA appointment request
+    const startDate = moment.utc();
+    const appointment = getVAOSRequestMock();
+    appointment.id = '1234';
+    appointment.attributes = {
+      comment: 'A message from the patient',
+      contact: {
+        telecom: [
+          { type: 'phone', value: '2125551212' },
+          { type: 'email', value: 'veteranemailtest@va.gov' },
+        ],
+      },
+      kind: 'clinic',
+      locationId: '983',
+      location: {
+        id: '983',
+        type: 'appointments',
+        attributes: {
+          id: '983',
+          vistaSite: '983',
+          name: 'Cheyenne VA Medical Center',
+          lat: 39.744507,
+          long: -104.830956,
+          phone: { main: '307-778-7550' },
+          physicalAddress: {
+            line: ['2360 East Pershing Boulevard'],
+            city: 'Cheyenne',
+            state: 'WY',
+            postalCode: '82001-5356',
+          },
+        },
+      },
+
+      id: '1234',
+      preferredTimesForPhoneCall: ['Morning'],
+      reasonCode: {
+        coding: [{ code: 'Routine Follow-up' }],
+        text: 'A message from the patient',
+      },
+      requestedPeriods: [
+        {
+          start: moment(startDate)
+            .add(3, 'days')
+            .format('YYYY-MM-DDTHH:mm:ss[Z]'),
+        },
+        {
+          start: moment(startDate)
+            .add(4, 'days')
+            .format('YYYY-MM-DDTHH:mm:ss[Z]'),
+        },
+      ],
+      serviceType: '323',
+      start: null,
+      status: 'proposed',
+    };
+
+    // And developer is using the v2 API
+    mockVAOSAppointmentsFetch({
+      start: moment()
+        .subtract(120, 'days')
+        .format('YYYY-MM-DD'),
+      end: moment()
+        .add(1, 'days')
+        .format('YYYY-MM-DD'),
+      statuses: ['proposed', 'cancelled'],
+      requests: [appointment],
+    });
+
+    // When veteran selects requested appointments
+    const screen = renderWithStoreAndRouter(
+      <RequestedAppointmentsListGroup />,
+      {
+        initialState: {
+          ...initialStateVAOSService,
+        },
+        reducers,
+      },
+    );
+
+    // Then it should display the requested appointments
+    expect(await screen.findByText('Primary care')).to.be.ok;
+
+    // And cancelled appointments should not be displayed
+    expect(
+      screen.queryByRole('heading', { level: 2, name: 'Canceled requests' }),
+    ).not.to.be.ok;
+    expect(screen.queryByText('These appointment requests have been canceled.'))
+      .not.to.be.ok;
+
+    // And the no appointments alert message should not be displayed
+    expect(
+      screen.queryByRole('heading', {
+        level: 3,
+        name: /You don’t have any/,
+      }),
+    ).not.to.be.ok;
+  });
+
+  it('should dispaly no appointments alert when there are no pending or cancelled appointments', async () => {
+    // And a veteran has no pending or canceled appointment request
+    // And developer is using the v2 API
+    mockVAOSAppointmentsFetch({
+      start: moment()
+        .subtract(120, 'days')
+        .format('YYYY-MM-DD'),
+      end: moment()
+        .add(1, 'days')
+        .format('YYYY-MM-DD'),
+      statuses: ['proposed', 'cancelled'],
+      requests: [{}],
+    });
+
+    // When veteran selects requested appointments
+    const screen = renderWithStoreAndRouter(
+      <RequestedAppointmentsListGroup />,
+      {
+        initialState: {
+          ...initialStateVAOSService,
+        },
+        reducers,
+      },
+    );
+
+    // Then it should display the no appointments alert message
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: /You don’t have any/,
+      }),
+    ).to.be.ok;
+  });
+
+  it('should display no appointments alert when there are no pending but cancelled appointments', async () => {
+    // And a veteran has VA appointment request
+    const startDate = moment.utc();
+    const appointment = getVAOSRequestMock();
+    appointment.id = '1234';
+    appointment.attributes = {
+      comment: 'A message from the patient',
+      contact: {
+        telecom: [
+          { type: 'phone', value: '2125551212' },
+          { type: 'email', value: 'veteranemailtest@va.gov' },
+        ],
+      },
+      kind: 'clinic',
+      locationId: '983',
+      location: {
+        id: '983',
+        type: 'appointments',
+        attributes: {
+          id: '983',
+          vistaSite: '983',
+          name: 'Cheyenne VA Medical Center',
+          lat: 39.744507,
+          long: -104.830956,
+          phone: { main: '307-778-7550' },
+          physicalAddress: {
+            line: ['2360 East Pershing Boulevard'],
+            city: 'Cheyenne',
+            state: 'WY',
+            postalCode: '82001-5356',
+          },
+        },
+      },
+
+      id: '1234',
+      preferredTimesForPhoneCall: ['Morning'],
+      reasonCode: {
+        coding: [{ code: 'Routine Follow-up' }],
+        text: 'A message from the patient',
+      },
+      requestedPeriods: [
+        {
+          start: moment(startDate)
+            .add(3, 'days')
+            .format('YYYY-MM-DDTHH:mm:ss[Z]'),
+        },
+        {
+          start: moment(startDate)
+            .add(4, 'days')
+            .format('YYYY-MM-DDTHH:mm:ss[Z]'),
+        },
+      ],
+      serviceType: '323',
+      start: null,
+      status: 'cancelled',
+    };
+
+    // And developer is using the v2 API
+    mockVAOSAppointmentsFetch({
+      start: moment()
+        .subtract(120, 'days')
+        .format('YYYY-MM-DD'),
+      end: moment()
+        .add(1, 'days')
+        .format('YYYY-MM-DD'),
+      statuses: ['proposed', 'cancelled'],
+      requests: [appointment],
+    });
+
+    // When veteran selects requested appointments
+    const screen = renderWithStoreAndRouter(
+      <RequestedAppointmentsListGroup />,
+      {
+        initialState: {
+          ...initialStateVAOSService,
+        },
+        reducers,
+      },
+    );
+
+    // Then it should display the requested appointments
+    expect(
+      await screen.findByRole('heading', {
+        level: 2,
+        name: 'Canceled requests',
+      }),
+    ).to.be.ok;
+    expect(screen.getByText('These appointment requests have been canceled.'))
+      .to.be.ok;
+
+    // And it should display the no appointments alert message
+    expect(
+      screen.getByRole('heading', {
+        level: 2,
+        name: /You don’t have any/,
+      }),
+    ).to.be.ok;
   });
 });

--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentsList.unit.spec.js
@@ -20,7 +20,6 @@ const initialStateVAOSService = {
   featureToggles: {
     vaOnlineSchedulingCancel: true,
     vaOnlineSchedulingVAOSServiceRequests: true,
-    vaOnlineSchedulingStatusImprovement: true,
   },
 };
 

--- a/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.js
@@ -6,7 +6,10 @@ import { mockFetch } from '@department-of-veterans-affairs/platform-testing/help
 import reducers from '../../../redux/reducer';
 import { getTestDate, renderWithStoreAndRouter } from '../../mocks/setup';
 import UpcomingAppointmentsList from '../../../appointment-list/components/UpcomingAppointmentsList';
-import { mockVAOSAppointmentsFetch } from '../../mocks/helpers';
+import {
+  mockVAOSAppointmentsFetch,
+  mockAppointmentsApi,
+} from '../../mocks/helpers';
 import { getVAOSAppointmentMock } from '../../mocks/mock';
 
 const initialState = {
@@ -66,6 +69,15 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
       end: now.format('YYYY-MM-DDTHH:mm:ss'),
     };
 
+    mockAppointmentsApi({
+      start: moment()
+        .subtract(120, 'days')
+        .format('YYYY-MM-DD'),
+      end: moment().format('YYYY-MM-DD'),
+      statuses: ['proposed', 'cancelled'],
+      response: [],
+    });
+
     mockVAOSAppointmentsFetch({
       start: start.format('YYYY-MM-DD'),
       end: end.format('YYYY-MM-DD'),
@@ -107,6 +119,15 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
       start: now.format('YYYY-MM-DDTHH:mm:ss'),
       end: now.format('YYYY-MM-DDTHH:mm:ss'),
     };
+
+    mockAppointmentsApi({
+      start: moment()
+        .subtract(120, 'days')
+        .format('YYYY-MM-DD'),
+      end: moment().format('YYYY-MM-DD'),
+      statuses: ['proposed', 'cancelled'],
+      response: [],
+    });
 
     mockVAOSAppointmentsFetch({
       start: start.format('YYYY-MM-DD'),
@@ -151,6 +172,15 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
       telehealth: { vvsKind: 'MOBILE_ANY' },
     };
 
+    mockAppointmentsApi({
+      start: moment()
+        .subtract(120, 'days')
+        .format('YYYY-MM-DD'),
+      end: moment().format('YYYY-MM-DD'),
+      statuses: ['proposed', 'cancelled'],
+      response: [],
+    });
+
     mockVAOSAppointmentsFetch({
       start: start.format('YYYY-MM-DD'),
       end: end.format('YYYY-MM-DD'),
@@ -191,6 +221,15 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
       start: now.format('YYYY-MM-DDTHH:mm:ss'),
       end: now.format('YYYY-MM-DDTHH:mm:ss'),
     };
+
+    mockAppointmentsApi({
+      start: moment()
+        .subtract(120, 'days')
+        .format('YYYY-MM-DD'),
+      end: moment().format('YYYY-MM-DD'),
+      statuses: ['proposed', 'cancelled'],
+      response: [],
+    });
 
     mockVAOSAppointmentsFetch({
       start: start.format('YYYY-MM-DD'),
@@ -235,6 +274,15 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
       end: now.format('YYYY-MM-DDTHH:mm:ss'),
       name: { firstName: 'Jane', lastName: 'Doctor' },
     };
+
+    mockAppointmentsApi({
+      start: moment()
+        .subtract(120, 'days')
+        .format('YYYY-MM-DD'),
+      end: moment().format('YYYY-MM-DD'),
+      statuses: ['proposed', 'cancelled'],
+      response: [],
+    });
 
     mockVAOSAppointmentsFetch({
       start: start.format('YYYY-MM-DD'),

--- a/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/UpcomingAppointmentsList.unit.spec.js
@@ -31,7 +31,6 @@ describe('VAOS Component: UpcomingAppointmentsList', () => {
         ...initialState.featureToggles,
         vaOnlineSchedulingVAOSServiceVAAppointments: true,
         vaOnlineSchedulingVAOSServiceCCAppointments: true,
-        vaOnlineSchedulingStatusImprovement: false,
       },
     };
     const now = moment();


### PR DESCRIPTION
## Summary

- This removes the use of the unit tests within VA online scheduling. It is part of a set of PR's to address https://github.com/department-of-veterans-affairs/va.gov-team/issues/55085. We no longer use this feature flag, so code behind this flag can be removed.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/55085

## Testing done

- unit tests

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
