### PR TITLE
[#1267] Remove upgraded webchat feature toggle

### DIFF
--- a/src/applications/virtual-agent/hooks/useLoadWebChat.js
+++ b/src/applications/virtual-agent/hooks/useLoadWebChat.js
@@ -1,37 +1,22 @@
 import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom';
 
-import { useFeatureToggle } from '~/platform/utilities/feature-toggles/useFeatureToggle/';
-
-const loadWebChat = webchatUpdateEnabled => {
+function loadWebChat() {
   const script = document.createElement('script');
 
-  if (webchatUpdateEnabled) {
-    script.src =
-      'https://cdn.botframework.com/botframework-webchat/4.17.0/webchat.js';
-  } else {
-    script.src =
-      'https://cdn.botframework.com/botframework-webchat/4.15.8/webchat.js';
-  }
+  script.src =
+    'https://cdn.botframework.com/botframework-webchat/4.17.0/webchat.js';
 
   script.crossOrigin = 'anonymous';
   script.dataset.testid = 'webchat-framework-script';
 
   document.body.appendChild(script);
-};
+}
 
 export default function useLoadWebChat() {
-  const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
-  const webchatUpdateEnabled = useToggleValue(
-    TOGGLE_NAMES.virtualAgentUpgradeWebchat14158,
-  );
-
-  useEffect(
-    () => {
-      window.React = React;
-      window.ReactDOM = ReactDOM;
-      loadWebChat(webchatUpdateEnabled);
-    },
-    [webchatUpdateEnabled],
-  );
+  useEffect(() => {
+    window.React = React;
+    window.ReactDOM = ReactDOM;
+    loadWebChat();
+  }, []);
 }

--- a/src/applications/virtual-agent/tests/hooks/useLoadWebChat.unit.spec.js
+++ b/src/applications/virtual-agent/tests/hooks/useLoadWebChat.unit.spec.js
@@ -2,7 +2,6 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 
 import { renderHook } from '@testing-library/react-hooks';
-import * as UseFeatureToggleModule from '~/platform/utilities/feature-toggles/useFeatureToggle/';
 import useLoadWebChat from '../../hooks/useLoadWebChat';
 
 describe('useLoadWebChat', () => {
@@ -17,31 +16,7 @@ describe('useLoadWebChat', () => {
   });
 
   describe('useLoadWebChat', () => {
-    it('should load regular webchat if virtualAgentUpgradeWebchat14158 feature toggle is false', () => {
-      const useToggleValueStub = sandbox.stub().returns(false);
-      sandbox.stub(UseFeatureToggleModule, 'useFeatureToggle').returns({
-        useToggleValue: useToggleValueStub,
-        TOGGLE_NAMES: {
-          virtualAgentUpgradeWebchat14158: 'virtualAgentUpgradeWebchat14158',
-        },
-      });
-
-      renderHook(() => useLoadWebChat());
-
-      const script = document.querySelector('script');
-      expect(script.src).to.equal(
-        'https://cdn.botframework.com/botframework-webchat/4.15.8/webchat.js',
-      );
-    });
-    it('should load webchat v4.16.1 if virtualAgentUpgradeWebchat14158 feature toggle is false', () => {
-      const useToggleValueStub = sandbox.stub().returns(true);
-      sandbox.stub(UseFeatureToggleModule, 'useFeatureToggle').returns({
-        useToggleValue: useToggleValueStub,
-        TOGGLE_NAMES: {
-          virtualAgentUpgradeWebchat14158: 'virtualAgentUpgradeWebchat14158',
-        },
-      });
-
+    it('should load webchat v4.17.0', () => {
       renderHook(() => useLoadWebChat());
 
       const script = document.querySelector('script');

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -249,7 +249,6 @@
   "virtualAgentShowFloatingChatbot": "virtual_agent_show_floating_chatbot",
   "virtualAgentEnableParamErrorDetection": "virtual_agent_enable_param_error_detection",
   "virtualAgentVoice": "virtual_agent_voice",
-  "virtualAgentUpgradeWebchat14158": "virtual_agent_upgrade_webchat_14_15_8",
   "virtualAgentEnableMsftPvaTesting": "virtual_agent_enable_msft_pva_testing",
   "virtualAgentEnableNluPvaTesting": "virtual_agent_enable_nlu_pva_testing",
   "yellowRibbonAutomatedDateOnSchoolSearch": "yellow_ribbon_automated_date_on_school_search",


### PR DESCRIPTION
## Summary

Removing the feature toggle for upgrading the webchat. The feature toggle is currently flipped on for all users.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-virtual-agent/issues/1267
- https://github.com/department-of-veterans-affairs/vets-api/pull/16988

## Testing done

- vets-website unit testing completed
- Ran vets-website locally and verified behavior

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
