### PR TITLE
Update intro page component and form header - 10-7959c

### DIFF
--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -106,7 +106,8 @@ const formConfig = {
     noAuth:
       'Please sign in again to continue your application for CHAMPVA other health insurance certification.',
   },
-  title: '10-7959C CHAMPVA Other Health Insurance Certification form',
+  title: 'File for CHAMPVA Other Health Insurance Certification',
+  subTitle: 'CHAMPVA Other Health Insurance Certification (VA Form 10-7959c)',
   defaultDefinitions: {},
   chapters: {
     applicantInformation: {

--- a/src/applications/ivc-champva/10-7959C/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959C/containers/IntroductionPage.jsx
@@ -1,133 +1,119 @@
-import React from 'react';
-// import { Link } from 'react-router';
+import React, { useEffect } from 'react';
+import { Link } from 'react-router';
 import { connect } from 'react-redux';
-
+import recordEvent from 'platform/monitoring/record-event';
 import { focusElement } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import FormTitle from '@department-of-veterans-affairs/platform-forms-system/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import GetFormHelp from '../../shared/components/GetFormHelp';
 
-class IntroductionPage extends React.Component {
-  componentDidMount() {
-    focusElement('.va-nav-breadcrumbs-list');
-  }
+const IntroductionPage = props => {
+  const { route, isLoggedIn } = props;
+  const { formConfig, pageList } = route;
 
-  render() {
-    const { route, loggedIn } = this.props;
-    const { formConfig, pageList } = route;
+  const handleClick = () => {
+    recordEvent({ event: 'no-login-start-form' });
+  };
 
-    return (
-      <article className="schemaform-intro">
-        <FormTitle
-          title="File for CHAMPVA Other Health Insurance Certification"
-          subTitle="CHAMPVA Other Health Insurance Certification (VA Form 10-7959c)"
-        />
+  useEffect(
+    () => {
+      focusElement('.va-nav-breadcrumbs-list');
+    },
+    [props],
+  );
 
-        <p>
-          Use this form if you're applying for Civilian Health and Medical
-          Program of the Department of Veterans Affairs (CHAMPVA) benefits and
-          have other non-VA health insurance. You can also use this form to
-          report changes in your non-VA health insurance or your personal
-          information, like your address or phone number.
-        </p>
+  return (
+    <article className="schemaform-intro">
+      <FormTitle title={formConfig.title} subTitle={formConfig.subTitle} />
 
-        <h2>What to know before you fill out this form</h2>
+      <p>
+        Use this form if you’re applying for Civilian Health and Medical Program
+        of the Department of Veterans Affairs (CHAMPVA) benefits and have other
+        non-VA health insurance. You can also use this form to report changes in
+        your non-VA health insurance or your personal information, like your
+        address or phone number.
+      </p>
 
-        <p>
-          If you're applying for CHAMPVA benefits for the first time, here's
-          what you'll need to provide:
-        </p>
-        <ul>
-          <li>
-            <b>Personal information.</b> This includes your phone number and
-            address.
-          </li>
-          <li>
-            <b>Insurance information.</b> This includes any non-VA health
-            insurance companies that cover you. And you may need to upload
-            supporting documents, like copies of your Medicare cards, other
-            health insurance cards, schedule of benefits and co-payment
-            documents. Be sure to include any secondary or supplemental
-            insurance such as vision, dental or accidental insurance.
-          </li>
-        </ul>
+      <h2>What to know before you fill out this form</h2>
 
-        <p>
-          <b>If you're already receiving CHAMPVA benefits,</b> you can provide
-          updated personal information, like your phone number and address.
-          <br />
-          <br />
-          And you can also provide your updated non-VA health insurance
-          information and copies of your Medicare or other health insurance
-          cards.
-        </p>
+      <p>
+        If you’re applying for CHAMPVA benefits for the first time, here’s what
+        you’ll need to provide:
+      </p>
+      <ul>
+        <li>
+          <b>Personal information.</b> This includes your phone number and
+          address.
+        </li>
+        <li>
+          <b>Insurance information.</b> This includes any non-VA health
+          insurance companies that cover you. And you may need to upload
+          supporting documents, like copies of your Medicare cards, other health
+          insurance cards, schedule of benefits and co-payment documents. Be
+          sure to include any secondary or supplemental insurance such as
+          vision, dental or accidental insurance.
+        </li>
+      </ul>
 
-        {!loggedIn && (
-          <VaAlert status="info" visible uswds>
-            <h2>Sign in now to save time and save your work in progress</h2>
-            <p>Here’s how signing in now helps you:</p>
-            <ul>
-              <li>
-                We can fill in some of your information for you to save you
-                time.
-              </li>
-              <li>
-                You can save your work in progress. You’ll have 60 days from
-                when you start or make updates to your application to come back
-                and finish it.
-              </li>
-            </ul>
-            <p>
-              <strong>Note:</strong> You can sign in after you start your
-              application. But you’ll lose any information you already filled
-              in.
-            </p>
-            <SaveInProgressIntro
-              buttonOnly
-              headingLevel={2}
-              prefillEnabled={formConfig.prefillEnabled}
-              messages={formConfig.savedFormMessages}
-              pageList={pageList}
-              startText="Start the Application"
-            />
-          </VaAlert>
-        )}
-        {loggedIn && (
-          <div className="signed-in-sip">
-            {/* <Link
-              to="/your-information/description"
-              className="auth-start-link vads-c-action-link--green"
-            >
-              Start your application
-            </Link> */}
-            <SaveInProgressIntro
-              testActionLink
-              prefillEnabled={route.formConfig.prefillEnabled}
-              messages={route.formConfig.savedFormMessages}
-              formConfig={route.formConfig}
-              pageList={route.pageList}
-              startText="Start the application"
-              headingLevel={2}
-            />
-          </div>
-        )}
+      <p>
+        <b>If you’re already receiving CHAMPVA benefits,</b> you can provide
+        updated personal information, like your phone number and address.
         <br />
-
-        <va-omb-info
-          res-burden={10}
-          omb-number="2900-0219"
-          exp-date="10/31/2024"
+        <br />
+        And you can also provide your updated non-VA health insurance
+        information and copies of your Medicare or other health insurance cards.
+      </p>
+      {!isLoggedIn ? (
+        <VaAlert status="info" visible uswds>
+          <h2>Sign in now to save time and save your work in progress</h2>
+          <p>Here’s how signing in now helps you:</p>
+          <ul>
+            <li>
+              We can fill in some of your information for you to save you time.
+            </li>
+            <li>
+              You can save your work in progress. You’ll have 60 days from when
+              you start or make updates to your application to come back and
+              finish it.
+            </li>
+          </ul>
+          <p>
+            <strong>Note:</strong> You can sign in after you start your
+            application. But you’ll lose any information you already filled in.
+          </p>
+          <p className="vads-u-margin-top--2">
+            <Link onClick={handleClick} to={pageList[1]?.path}>
+              Start your form without signing in
+            </Link>
+          </p>
+        </VaAlert>
+      ) : (
+        <SaveInProgressIntro
+          formId={formConfig.formId}
+          headingLevel={2}
+          prefillEnabled={formConfig.prefillEnabled}
+          messages={formConfig.savedFormMessages}
+          pageList={pageList}
+          startText="Start"
         />
+      )}
 
-        <GetFormHelp />
-      </article>
-    );
-  }
-}
+      <va-omb-info
+        res-burden={10}
+        omb-number="2900-0219"
+        exp-date="10/31/2024"
+      />
 
-const mapStateToProps = state => ({
-  loggedIn: state.user.login.currentlyLoggedIn,
-});
+      <GetFormHelp />
+    </article>
+  );
+};
+
+const mapStateToProps = state => {
+  return {
+    isLoggedIn: state.user.login.currentlyLoggedIn,
+  };
+};
 
 export default connect(mapStateToProps)(IntroductionPage);

--- a/src/applications/ivc-champva/10-7959C/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959C/containers/IntroductionPage.jsx
@@ -95,7 +95,7 @@ const IntroductionPage = props => {
           prefillEnabled={formConfig.prefillEnabled}
           messages={formConfig.savedFormMessages}
           pageList={pageList}
-          startText="Start"
+          startText="Start the application"
         />
       )}
 

--- a/src/applications/ivc-champva/10-7959C/tests/containers/IntroductionPage.unit.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/containers/IntroductionPage.unit.spec.js
@@ -58,6 +58,6 @@ describe('IntroductionPage', () => {
         <IntroductionPage {...props} />
       </Provider>,
     );
-    expect(container.querySelector('.signed-in-sip')).to.exist;
+    expect(container.querySelector('.vads-c-action-link--green')).to.exist;
   });
 });


### PR DESCRIPTION
## Summary

This PR updates the intro page slightly by adjusting the authenticated link to automatically take the user to the first page of the form. Additionally the form title and subtitle has been updated to show the same value on every page of the form.

The intro page has also been refactored to be a functional component instead of a class-based one.

- Updated intro page authenticated start link (under the hood change, not visual)
- Updated intro page to be functional instead of class-based
- Updated title/subtitle on all form pages (in `form.js`)
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- 

## Testing done

- Manual

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Title/Subtitle |![Screenshot 2024-06-04 at 10 58 24](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/fe5b266a-440b-47ee-858e-577943e5c612)|![Screenshot 2024-06-04 at 10 55 51](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/232dc9be-33f1-44a0-8022-81ffc42705aa)|

## What areas of the site does it impact?

Form 10-7959c only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA