### PR TITLE
Add flipper for form upload flow

### DIFF
--- a/src/applications/static-pages/simple-forms/form-upload/entry.js
+++ b/src/applications/static-pages/simple-forms/form-upload/entry.js
@@ -2,23 +2,28 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import { Provider } from 'react-redux';
-import environment from 'platform/utilities/environment';
+import { Toggler } from 'platform/utilities/feature-toggles';
 
 export default function createFormUploadAccess(store, widgetType) {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   const { hasOnlineTool, formNumber } = root.dataset;
 
-  // TODO: Remove `environment.isStaging()` when we want to release this to production
-  if (root && environment.isStaging()) {
+  if (root) {
     import(/* webpackChunkName: "form-upload" */ './App.js').then(module => {
       const App = module.default;
       ReactDOM.render(
-        <Provider store={store}>
-          <App
-            hasOnlineTool={hasOnlineTool === 'true'}
-            formNumber={formNumber}
-          />
-        </Provider>,
+        <Toggler toggleName={Toggler.TOGGLE_NAMES.formUploadFlow}>
+          <Toggler.Enabled>
+            <Provider store={store}>
+              <App
+                hasOnlineTool={hasOnlineTool === 'true'}
+                formNumber={formNumber}
+              />
+            </Provider>
+          </Toggler.Enabled>
+
+          <Toggler.Disabled>{null}</Toggler.Disabled>
+        </Toggler>,
         root,
       );
     });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -89,6 +89,7 @@
   "form21P0847": "form21p0847",
   "form264555": "form264555",
   "form400247": "form400247",
+  "formUploadFlow": "form_upload_flow",
   "fsrConfirmationEmail": "fsr_confirmation_email",
   "gibctEybBottomSheet": "gibct_eyb_bottom_sheet",
   "gibctSchoolRatings": "gibct_school_ratings",


### PR DESCRIPTION
## Summary
This PR changes my older, clumsier boolean into a Flipper toggle instead. It will let us display or not display the Form Upload Flow widget on the Find-a-Form detail page more easily.

[BE PR here.](https://github.com/department-of-veterans-affairs/vets-api/pull/16997)
