### PR TITLE
MHV-58535: VA.gov Details page content updates

### DIFF
--- a/src/applications/mhv-medications/components/shared/BeforeYouDownloadDropdown.jsx
+++ b/src/applications/mhv-medications/components/shared/BeforeYouDownloadDropdown.jsx
@@ -9,8 +9,8 @@ const BeforeYouDownloadDropdown = ({ page }) => {
         return (
           <ul>
             <li>
-              <strong>If you download this page,</strong> we’ll include a list
-              of allergies and reactions in your VA medical records.
+              <strong>If you print or download this page,</strong> we’ll include
+              a list of allergies and reactions in your VA medical records.
             </li>
             <li>
               <strong>If you’re on a public or shared computer,</strong>{' '}

--- a/src/applications/mhv-medications/containers/RxBreadcrumbs.jsx
+++ b/src/applications/mhv-medications/containers/RxBreadcrumbs.jsx
@@ -42,7 +42,7 @@ const RxBreadcrumbs = () => {
             href={`${
               medicationsUrls.MEDICATIONS_URL
             }?page=${pagination?.currentPage || 1}`}
-            text="Back to Medications"
+            text="Back to medications"
             data-testid="rx-breadcrumb-link"
           />
         </div>

--- a/src/applications/mhv-medications/tests/components/shared/BeforeYouDownloadDropdown.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/shared/BeforeYouDownloadDropdown.unit.spec.jsx
@@ -16,7 +16,9 @@ describe('What do know before you download dropdown component', () => {
 
   it('displays text inside of drop down on Details page', async () => {
     const screen = setup(DD_ACTIONS_PAGE_TYPE.DETAILS);
-    const firstItem = await screen.findByText('If you download this page,');
+    const firstItem = await screen.findByText(
+      'If you print or download this page,',
+    );
     expect(firstItem).to.exist;
   });
 


### PR DESCRIPTION
## Summary

Medications Details page: breadcrumb + "before you download" verbiage update

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-58535

<img width="835" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/1ca57799-c2f3-4bc0-9905-398e534ffa7a">

## Screenshots

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/2d4eb122-8683-4e3a-911f-fb2a50ca3b80)

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/336ea4fd-c94d-4049-8d64-28e5c3325ccd)

## Testing done

- Manual testing
- Unit test updated

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

Update content on the details page according to the following figma files:
[Figma design 1](https://www.figma.com/design/UGHasFKuKENvKz8AgSmxtI/Medications?node-id=6146-39714)

AC1: Make the "M" in the "Back to Medications" breadcrumb lower case.

[Figma design 2](https://www.figma.com/design/UGHasFKuKENvKz8AgSmxtI/Medications?node-id=6146-40537&t=aqadYgQv44OSX4kR-4)

AC2: Update the content in this first bullet point. Added "print or".
Note: Use the square bullet points, not the round ones, we just don't have that option in Figma.

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
