### PR TITLE
Move help text in travel pay

### DIFF
--- a/src/applications/travel-pay/components/HelpText.jsx
+++ b/src/applications/travel-pay/components/HelpText.jsx
@@ -4,24 +4,22 @@ export default function HelpText() {
   const BTSSS_PORTAL_URL = 'https://dvagov-btsss.dynamics365portals.us/';
 
   return (
-    <va-need-help>
-      <div slot="content">
-        <p>
-          If you need to manage a claim, log into the{' '}
-          <a className="btsss-portal-link" href={BTSSS_PORTAL_URL}>
-            BTSSS portal
-            <va-icon
-              aria-hidden="true"
-              className="vads-u-margin-left--2p5"
-              icon="launch"
-              size={2}
-            />
-          </a>{' '}
-          or call <va-telephone contact="8555747292" /> from 7 a.m. to 7 p.m.
-          Monday through Friday. Have your claim number ready to share when you
-          call.
-        </p>
-      </div>
-    </va-need-help>
+    <div slot="content">
+      <p>
+        If you need to manage a claim, log into the{' '}
+        <a className="btsss-portal-link" href={BTSSS_PORTAL_URL}>
+          BTSSS portal
+          <va-icon
+            aria-hidden="true"
+            className="vads-u-margin-left--2p5"
+            icon="launch"
+            size={2}
+          />
+        </a>{' '}
+        or call <va-telephone contact="8555747292" /> from 7 a.m. to 7 p.m.
+        Monday through Friday. Have your claim number ready to share when you
+        call.
+      </p>
+    </div>
   );
 }

--- a/src/applications/travel-pay/containers/TravelPayStatusApp.jsx
+++ b/src/applications/travel-pay/containers/TravelPayStatusApp.jsx
@@ -92,6 +92,7 @@ export default function App({ children }) {
               </h1>
             </div>
             <div className="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--8">
+              <HelpText />
               {isLoading && (
                 <va-loading-indicator
                   label="Loading"
@@ -142,8 +143,6 @@ export default function App({ children }) {
                     {travelClaims.map(travelClaim =>
                       TravelClaimCard(travelClaim),
                     )}
-
-                    <HelpText />
                   </>
                 )}
               {userLoggedIn &&


### PR DESCRIPTION
Moves help text section to top of the travel pay page. Removes "Need Help?" title.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83838

## Screenshots

![Screenshot 2024-06-04 at 2 26 26 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/7432170/33a8ff99-ad26-496f-bc4b-2260ded8e17e)

