### PR TITLE
[CST] - Added accessibility text to the Overview Page when cst_claim_phases toggle is enabled

### DIFF
--- a/src/applications/claims-status/components/claim-overview-tab/ClaimPhaseStepper.jsx
+++ b/src/applications/claims-status/components/claim-overview-tab/ClaimPhaseStepper.jsx
@@ -181,6 +181,18 @@ export default function ClaimPhaseStepper({
     return '';
   };
 
+  const headerIconText = phase => {
+    if (isCurrentPhase(phase) && phase !== 8) {
+      return 'Current';
+    }
+
+    if (phase < currentPhase || (isCurrentPhase(phase) && phase === 8)) {
+      return 'Completed';
+    }
+
+    return '';
+  };
+
   const headerIconColor = phase => {
     if (isCurrentPhase(phase) && phase !== 8) {
       return 'phase-current';
@@ -206,6 +218,7 @@ export default function ClaimPhaseStepper({
             <va-icon
               icon={headerIcon(claimPhase.phase)}
               class={headerIconColor(claimPhase.phase)}
+              srtext={headerIconText(claimPhase.phase)}
               slot="icon"
             />
             {isCurrentPhase(claimPhase.phase) && (

--- a/src/applications/claims-status/components/claim-overview-tab/DesktopClaimPhaseDiagram.jsx
+++ b/src/applications/claims-status/components/claim-overview-tab/DesktopClaimPhaseDiagram.jsx
@@ -22,6 +22,8 @@ export default function DesktopClaimPhaseDiagram({ currentPhase }) {
     return <circle cx={x} cy={y} r="23.5" fill="#DFE1E2" stroke="#1B1B1B" />;
   };
 
+  const accessibilityTitle = `Your current step is ${currentPhase} of 8 in the claims process. Steps 3 through 6 can be repeated.`;
+
   return (
     <div className="desktop vads-u-margin-bottom--4">
       <svg
@@ -31,6 +33,7 @@ export default function DesktopClaimPhaseDiagram({ currentPhase }) {
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
       >
+        <title>{accessibilityTitle}</title>
         <rect
           x="178.279"
           y="33.9127"

--- a/src/applications/claims-status/components/claim-overview-tab/MobileClaimPhaseDiagram.jsx
+++ b/src/applications/claims-status/components/claim-overview-tab/MobileClaimPhaseDiagram.jsx
@@ -22,6 +22,8 @@ export default function MobileClaimPhaseDiagram({ currentPhase }) {
     return <circle cx={x} cy={y} r="16.5" fill="#DFE1E2" stroke="#1B1B1B" />;
   };
 
+  const accessibilityTitle = `Your current step is ${currentPhase} of 8 in the claims process. Steps 3 through 6 can be repeated.`;
+
   return (
     <div className="mobile vads-u-margin-bottom--4">
       <svg
@@ -31,6 +33,7 @@ export default function MobileClaimPhaseDiagram({ currentPhase }) {
         fill="none"
         xmlns="http://www.w3.org/2000/svg"
       >
+        <title>{accessibilityTitle}</title>
         <rect
           width="352"
           height="114"

--- a/src/applications/claims-status/tests/components/claim-overview-tab/ClaimPhaseStepper.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-overview-tab/ClaimPhaseStepper.unit.spec.jsx
@@ -10,6 +10,23 @@ describe('<ClaimPhaseStepper>', () => {
   const claimDate = '2024-01-16';
   const currentClaimPhaseDate = '2024-03-07';
 
+  it('should render a ClaimPhaseStepper section where there is accessibility text', () => {
+    const { container } = renderWithRouter(
+      <ClaimPhaseStepper
+        claimDate={claimDate}
+        currentClaimPhaseDate={currentClaimPhaseDate}
+        currentPhase={3}
+      />,
+    );
+    expect($('.claim-phase-stepper', container)).to.exist;
+
+    const phaseCurrent = $('#phase3 va-icon.phase-current', container);
+    expect(phaseCurrent).to.have.attr('srtext', 'Current');
+
+    const phase2Complete = $('#phase2 va-icon.phase-complete', container);
+    expect(phase2Complete).to.have.attr('srtext', 'Completed');
+  });
+
   it('should render a ClaimPhaseStepper section where step 1 is the current step', () => {
     const { container, getByText } = renderWithRouter(
       <ClaimPhaseStepper

--- a/src/applications/claims-status/tests/components/claim-overview-tab/DesktopClaimPhaseDiagram.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-overview-tab/DesktopClaimPhaseDiagram.unit.spec.jsx
@@ -7,7 +7,14 @@ import DesktopClaimPhaseDiagram from '../../../components/claim-overview-tab/Des
 
 describe('<DesktopClaimPhaseDiagram>', () => {
   it('should render a DesktopClaimPhaseDiagram section', () => {
-    const { container } = render(<DesktopClaimPhaseDiagram currentPhase={1} />);
+    const { container, getByTitle } = render(
+      <DesktopClaimPhaseDiagram currentPhase={1} />,
+    );
     expect($('.desktop', container)).to.exist;
+    expect(
+      getByTitle(
+        'Your current step is 1 of 8 in the claims process. Steps 3 through 6 can be repeated.',
+      ),
+    );
   });
 });

--- a/src/applications/claims-status/tests/components/claim-overview-tab/MobileClaimPhaseDiagram.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-overview-tab/MobileClaimPhaseDiagram.unit.spec.jsx
@@ -7,7 +7,14 @@ import MobileClaimPhaseDiagram from '../../../components/claim-overview-tab/Mobi
 
 describe('<MobileClaimPhaseDiagram>', () => {
   it('should render a MobileClaimPhaseDiagram section', () => {
-    const { container } = render(<MobileClaimPhaseDiagram currentPhase={1} />);
+    const { container, getByTitle } = render(
+      <MobileClaimPhaseDiagram currentPhase={1} />,
+    );
     expect($('.mobile', container)).to.exist;
+    expect(
+      getByTitle(
+        'Your current step is 1 of 8 in the claims process. Steps 3 through 6 can be repeated.',
+      ),
+    );
   });
 });


### PR DESCRIPTION
## Summary

When `cst_claim_phases` toggle/ feature flag is enabled we will show the following accessibility text...
- `ClaimPhaseStepper.jsx` now shows `srtext` on the check mark icon and the flag icon
- `DesktopClaimPhaseDiagram.jsx` now shows title text on the diagram that says `Your current step is [currentPhase#] of 8 in the claims process. Steps 3 through 6 can be repeated.`
- `MobileClaimPhaseDiagram.jsx` now shows title text on the diagram `Your current step is [currentPhase#] of 8 in the claims process. Steps 3 through 6 can be repeated.`

Added tests for all files


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#82952

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

**Added title text of `Your current step is [currentPhase#] of 8 in the claims process. Steps 3 through 6 can be repeated.` to the desktop claim phase diagram** 
![Screenshot 2024-06-04 at 12 38 39 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/786506a6-fd23-4bce-8f13-1ce7a8e945f2)

**Added title text of `Your current step is [currentPhase#] of 8 in the claims process. Steps 3 through 6 can be repeated.` to the mobile claim phase diagram** 
![Screenshot 2024-06-04 at 12 38 15 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/5dc046bd-e518-40e6-ae68-c0a69c2ad980)

**Added srtext of `Current` to the flag icon that occurs in the claim phase stepper on the current step** 
![Screenshot 2024-06-04 at 12 30 22 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/01b56b6f-87cb-4b8e-a980-4e0de459dd6a)

**Added srtext of `Completed` to the checkmark icon that occurs in the claim phase stepper on steps that have been completed** 
![Screenshot 2024-06-04 at 12 30 45 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/3f447dcd-f927-4f0a-8e62-db12f583595c)

## What areas of the site does it impact?

Claims Status Tool

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions