### PR TITLE
[Health Care Supply Reordering] send source app name header

### DIFF
--- a/src/applications/health-care-supply-reordering/README.md
+++ b/src/applications/health-care-supply-reordering/README.md
@@ -19,7 +19,7 @@ Before you get started check [this page](https://depo-platform-documentation.scr
 
 ## Running tests
 
-Unit tests for can be run using this command: `yarn test:unit --app-folder health-care-supply-reordering`. To get detailed errors, run this command with `--log-level=error`. To get coverage reports run this command `yarn test:unit --app-folder health-care-supply-reordering --coverage --coverage-html`. View the report at `/coverage/index.html`
+Unit tests can be run using this command: `yarn test:unit --app-folder health-care-supply-reordering`. To get detailed errors, run this command with `--log-level=error`. To get coverage reports run this command `yarn test:unit --app-folder health-care-supply-reordering --coverage --coverage-html`. View the report at `/coverage/index.html`
 
 Cypress tests can be run with the GUI using this command: `yarn cy:open`. From there you can filter by `health-care-supply-reordering` to run end to end tests for this app.
 

--- a/src/applications/health-care-supply-reordering/app-entry.jsx
+++ b/src/applications/health-care-supply-reordering/app-entry.jsx
@@ -6,8 +6,9 @@ import routes from './routes';
 import './sass/health-care-supply-reordering.scss';
 
 startApp({
-  url: manifest.rootUrl,
+  analyticsEvents: [],
+  entryName: manifest.entryName,
   reducer,
   routes,
-  analyticsEvents: [],
+  url: manifest.rootUrl,
 });


### PR DESCRIPTION
## Summary

- adds `entryName` argument to `startApp` so that the source app header will be sent and usable in Datadog
- minor fix to README


## What areas of the site does it impact?

- Supply reordering app only 
