### PR TITLE
Add entryName for all apps missing it

### DIFF
--- a/src/applications/_mock-form/app-entry.jsx
+++ b/src/applications/_mock-form/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/accredited-representative-portal/app-entry.jsx
+++ b/src/applications/accredited-representative-portal/app-entry.jsx
@@ -7,6 +7,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/appeals/testing/app-entry.jsx
+++ b/src/applications/appeals/testing/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/ask-a-question/app-entry.jsx
+++ b/src/applications/ask-a-question/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/avs/app-entry.jsx
+++ b/src/applications/avs/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/burial-poc-v6/app-entry.jsx
+++ b/src/applications/burial-poc-v6/app-entry.jsx
@@ -7,6 +7,7 @@ import routes from './routes';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   routes,
 });

--- a/src/applications/check-in/day-of/app-entry.jsx
+++ b/src/applications/check-in/day-of/app-entry.jsx
@@ -12,6 +12,7 @@ import { setupI18n } from '../utils/i18n/i18n';
 setupI18n();
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   createRoutesWithStore,

--- a/src/applications/check-in/pre-check-in/app-entry.jsx
+++ b/src/applications/check-in/pre-check-in/app-entry.jsx
@@ -12,6 +12,7 @@ import { setupI18n } from '../utils/i18n/i18n';
 setupI18n();
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   createRoutesWithStore,

--- a/src/applications/check-in/travel-claim/app-entry.jsx
+++ b/src/applications/check-in/travel-claim/app-entry.jsx
@@ -12,6 +12,7 @@ import { setupI18n } from '../utils/i18n/i18n';
 setupI18n();
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   createRoutesWithStore,

--- a/src/applications/coronavirus-research/sign-up/app-entry.jsx
+++ b/src/applications/coronavirus-research/sign-up/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/coronavirus-research/update/app-entry.jsx
+++ b/src/applications/coronavirus-research/update/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/coronavirus-screener/app-entry.jsx
+++ b/src/applications/coronavirus-screener/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/dhp-connected-devices/app-entry.jsx
+++ b/src/applications/dhp-connected-devices/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/disability-benefits/2346/app-entry.jsx
+++ b/src/applications/disability-benefits/2346/app-entry.jsx
@@ -6,6 +6,7 @@ import routes from './routes';
 import './sass/form-2346.scss';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/edu-benefits/0994/edu-benefits-entry.jsx
+++ b/src/applications/edu-benefits/0994/edu-benefits-entry.jsx
@@ -9,6 +9,7 @@ import manifest from './manifest.json';
 import analyticsEvents from './analytics-events';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/education-letters/app-entry.jsx
+++ b/src/applications/education-letters/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/enrollment-verification/app-entry.jsx
+++ b/src/applications/enrollment-verification/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/financial-status-report/app-entry.jsx
+++ b/src/applications/financial-status-report/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/fry-dea/fry-dea-app-entry.jsx
+++ b/src/applications/fry-dea/fry-dea-app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/ivc-champva/10-10D/app-entry.jsx
+++ b/src/applications/ivc-champva/10-10D/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/ivc-champva/10-7959C/app-entry.jsx
+++ b/src/applications/ivc-champva/10-7959C/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/ivc-champva/10-7959a/app-entry.jsx
+++ b/src/applications/ivc-champva/10-7959a/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/ivc-champva/10-7959f-1/app-entry.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/ivc-champva/10-7959f-2/app-entry.jsx
+++ b/src/applications/ivc-champva/10-7959f-2/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/lgy/coe/form/app-entry.jsx
+++ b/src/applications/lgy/coe/form/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from '../shared/reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/lgy/coe/status/app-entry.jsx
+++ b/src/applications/lgy/coe/status/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from '../shared/reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/login/app-entry.jsx
+++ b/src/applications/login/app-entry.jsx
@@ -6,6 +6,7 @@ import routes from './routes';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   routes,
 });

--- a/src/applications/messages/app-entry.jsx
+++ b/src/applications/messages/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/mock-sip-form/app-entry.jsx
+++ b/src/applications/mock-sip-form/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/my-education-benefits/app-entry.jsx
+++ b/src/applications/my-education-benefits/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/office-directory/app-entry.jsx
+++ b/src/applications/office-directory/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/personalization/search-representative/app-entry.jsx
+++ b/src/applications/personalization/search-representative/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/personalization/view-representative/app-entry.jsx
+++ b/src/applications/personalization/view-representative/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/representative-appoint/app-entry.jsx
+++ b/src/applications/representative-appoint/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/representative-search/app-entry.jsx
+++ b/src/applications/representative-search/app-entry.jsx
@@ -7,6 +7,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/sah/sahg/app-entry.jsx
+++ b/src/applications/sah/sahg/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/simple-forms/20-10206/app-entry.jsx
+++ b/src/applications/simple-forms/20-10206/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/simple-forms/20-10207/app-entry.jsx
+++ b/src/applications/simple-forms/20-10207/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/simple-forms/21-0845/app-entry.jsx
+++ b/src/applications/simple-forms/21-0845/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/simple-forms/21-0966/app-entry.jsx
+++ b/src/applications/simple-forms/21-0966/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/simple-forms/21-0972/app-entry.jsx
+++ b/src/applications/simple-forms/21-0972/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/simple-forms/21-10210/app-entry.jsx
+++ b/src/applications/simple-forms/21-10210/app-entry.jsx
@@ -7,6 +7,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/simple-forms/21-4138/app-entry.jsx
+++ b/src/applications/simple-forms/21-4138/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/simple-forms/21-4142/app-entry.jsx
+++ b/src/applications/simple-forms/21-4142/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/simple-forms/21P-0847/app-entry.jsx
+++ b/src/applications/simple-forms/21P-0847/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/simple-forms/26-4555/app-entry.jsx
+++ b/src/applications/simple-forms/26-4555/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/simple-forms/40-0247/app-entry.jsx
+++ b/src/applications/simple-forms/40-0247/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/simple-forms/form-upload/form-upload-entry.jsx
+++ b/src/applications/simple-forms/form-upload/form-upload-entry.jsx
@@ -7,6 +7,7 @@ import routes from './routes';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   routes,
 });

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/app-entry.jsx
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/simple-forms/mock-simple-forms-patterns-v3/app-entry.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns-v3/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/simple-forms/mock-simple-forms-patterns/app-entry.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/toe/app-entry.jsx
+++ b/src/applications/toe/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/travel-pay/app-entry.jsx
+++ b/src/applications/travel-pay/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './redux/reducer';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/verify-your-enrollment/app-entry.jsx
+++ b/src/applications/verify-your-enrollment/app-entry.jsx
@@ -10,6 +10,7 @@ import manifest from './manifest.json';
 // eslint-disable-next-line no-unused-expressions
 (!environment.isProduction() || window.isProduction) &&
   startApp({
+    entryName: manifest.entryName,
     url: manifest.rootUrl,
     reducer,
     routes,

--- a/src/applications/virtual-agent/app-entry.jsx
+++ b/src/applications/virtual-agent/app-entry.jsx
@@ -19,6 +19,7 @@ script.text =
 document.body.appendChild(script);
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/vre/25-8832/app-entry.jsx
+++ b/src/applications/vre/25-8832/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,

--- a/src/applications/vre/28-1900/app-entry.jsx
+++ b/src/applications/vre/28-1900/app-entry.jsx
@@ -8,6 +8,7 @@ import reducer from './reducers';
 import manifest from './manifest.json';
 
 startApp({
+  entryName: manifest.entryName,
   url: manifest.rootUrl,
   reducer,
   routes,


### PR DESCRIPTION
## Summary

- adds `entryName` parameter to all applications that don't have it

This should improve reporting in Datadog and eliminate `unknown` values for `source_app`. ([cf](https://vagov.ddog-gov.com/metric/explorer?fromUser=false&start=1717605042950&end=1717608642950&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGniqyABuiBpOGPIQAHQaCJ4aUM2NEE7aGJkA1n0mZm3AcCLVyHCDGgC08to4UBQABOl4WXAN8vLIeCKDIjhgIjzd9Zn4IggAFACUIDwAulSu7niYoeEfql8YGKleLPN4gNpYNA5UDyDBQhAIHJJHAwJyZb4aCCZRJoUQ7OSKco4XFQHF4pz0JjKE7uOHPfgQeyYLBOAlIgBGGG0llePD44PkuIQAGEpMIYCgRF80DwgA))
 
## Related issue(s)

- https://github.com/department-of-veterans-affairs/generator-vets-website/pull/410
