### PR TITLE
83660a Medicare section copy updates - form 10-7959c

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import VaTextInputField from 'platform/forms-system/src/js/web-component-fields/VaTextInputField';
 import VaTextareaField from 'platform/forms-system/src/js/web-component-fields/VaTextareaField';
 import {
   titleUI,
@@ -307,11 +306,10 @@ export const applicantMedicarePartDCarrierSchema = {
     ...titleUI(
       ({ formData }) => `${nameWording(formData)} Medicare Part D carrier`,
     ),
-    applicantMedicarePartDCarrier: {
-      'ui:title': 'Name of insurance carrier',
-      'ui:description': 'Your insurance carrier is your insurance company.',
-      'ui:webComponentField': VaTextInputField,
-    },
+    applicantMedicarePartDCarrier: textUI({
+      title: 'Name of insurance carrier',
+      hint: 'Your insurance carrier is your insurance company.',
+    }),
     applicantMedicarePartDEffectiveDate: currentOrPastDateUI({
       title: 'Medicare Part D effective date',
       hint: effectiveDateHint,
@@ -325,7 +323,7 @@ export const applicantMedicarePartDCarrierSchema = {
     ],
     properties: {
       titleSchema,
-      applicantMedicarePartDCarrier: { type: 'string' },
+      applicantMedicarePartDCarrier: textSchema,
       applicantMedicarePartDEffectiveDate: currentOrPastDateSchema,
     },
   },

--- a/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
@@ -4,6 +4,8 @@ import VaTextareaField from 'platform/forms-system/src/js/web-component-fields/V
 import {
   titleUI,
   titleSchema,
+  textUI,
+  textSchema,
   currentOrPastDateUI,
   currentOrPastDateSchema,
   yesNoUI,
@@ -73,7 +75,7 @@ export const applicantMedicareClassSchema = {
       ...radioUI({
         required: () => true,
         labels: {
-          ab: 'Original Medicare Parts A and B (hospital and medical coverage',
+          ab: 'Original Medicare Parts A and B (hospital and medical coverage)',
           advantage: 'Medicare Advantage Plan (Part C)',
           other: 'Other Medicare plan',
         },
@@ -153,12 +155,11 @@ export const applicantMedicarePartACarrierSchema = {
           true,
         )} Medicare Part A carrier`,
     ),
-    applicantMedicarePartACarrier: {
-      'ui:title': 'Name of insurance carrier',
-      'ui:hint':
-        'Your insurance is "Medicare Health Insurance" or your insurance company',
-      'ui:webComponentField': VaTextInputField,
-    },
+    applicantMedicarePartACarrier: textUI({
+      title: 'Name of insurance carrier',
+      hint:
+        'Your insurance is "Medicare Health Insurance" or your insurance company.',
+    }),
     applicantMedicarePartAEffectiveDate: currentOrPastDateUI({
       title: 'Medicare Part A effective date',
       hint: effectiveDateHint,
@@ -172,7 +173,7 @@ export const applicantMedicarePartACarrierSchema = {
     ],
     properties: {
       titleSchema,
-      applicantMedicarePartACarrier: { type: 'string' },
+      applicantMedicarePartACarrier: textSchema,
       applicantMedicarePartAEffectiveDate: currentOrPastDateSchema,
     },
   },
@@ -181,14 +182,19 @@ export const applicantMedicarePartACarrierSchema = {
 export const applicantMedicarePartBCarrierSchema = {
   uiSchema: {
     ...titleUI(
-      ({ formData }) => `${nameWording(formData)} Medicare Part B carrier`,
+      ({ formData }) =>
+        `${nameWording(
+          formData,
+          undefined,
+          undefined,
+          true,
+        )} Medicare Part B carrier`,
     ),
-    applicantMedicarePartBCarrier: {
-      'ui:title': 'Name of insurance carrier',
-      'ui:hint':
-        'Your insurance is "Medicare Health Insurance" or your insurance company',
-      'ui:webComponentField': VaTextInputField,
-    },
+    applicantMedicarePartBCarrier: textUI({
+      title: 'Name of insurance carrier',
+      hint:
+        'Your insurance is "Medicare Health Insurance" or your insurance company.',
+    }),
     applicantMedicarePartBEffectiveDate: currentOrPastDateUI({
       title: 'Medicare Part B effective date',
       hint: effectiveDateHint,
@@ -202,7 +208,7 @@ export const applicantMedicarePartBCarrierSchema = {
     ],
     properties: {
       titleSchema,
-      applicantMedicarePartBCarrier: { type: 'string' },
+      applicantMedicarePartBCarrier: textSchema,
       applicantMedicarePartBEffectiveDate: currentOrPastDateSchema,
     },
   },
@@ -219,6 +225,7 @@ export const applicantMedicareABUploadSchema = {
             You’ll need to submit a copy of the front and back of {appName}{' '}
             Medicare card for hospital and medical coverage.
             <br />
+            <br />
             Upload a copy of one of these documents:
             <ul>
               <li>
@@ -232,6 +239,7 @@ export const applicantMedicareABUploadSchema = {
             <br />
             You can also upload any other supporting documents you may have for
             this Medicare plan.
+            <br />
             <br />
             If you don’t have a copy to upload now, you can send it by mail or
             fax
@@ -301,7 +309,7 @@ export const applicantMedicarePartDCarrierSchema = {
     ),
     applicantMedicarePartDCarrier: {
       'ui:title': 'Name of insurance carrier',
-      'ui:hint': 'Your insurance carrier is your insurance company.',
+      'ui:description': 'Your insurance carrier is your insurance company.',
       'ui:webComponentField': VaTextInputField,
     },
     applicantMedicarePartDEffectiveDate: currentOrPastDateUI({

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -115,6 +115,7 @@ const formConfig = {
       title: 'Beneficiary information',
       pages: {
         applicantNameDob: {
+          // initialData: mockdata.data,
           path: 'applicant-info',
           title: 'Beneficiary’s name and date of birth',
           ...applicantNameDobSchema,


### PR DESCRIPTION
## Summary

This PR fixes a couple small typos and switches the textInput field to the `textUI` component in a couple places.

- Updates medicare part A, B, and D screens to use textUI element
- Adds proper hints above text inputs
- Fixes line spacing on file upload screen
- Fixed a typo or two

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83660

## Testing done

- Manual
- Unit
- E2E

## Screenshots

|         | Text area | File upload |
| ------- | ------ | ----- |
| Desktop |![Screenshot 2024-06-05 at 12 58 33](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/3fe1031a-e922-4c8d-bda6-15a7eb6ca9a7)|![Screenshot 2024-06-05 at 12 58 39](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/3ec7f99d-e566-4628-a2f3-1736f9999e2a)|

## What areas of the site does it impact?

This form only


## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA