### PR TITLE
Remove va_online_scheduling_GA4_migration feature toggle

### DIFF
--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -88,9 +88,6 @@ export const selectFeatureBreadcrumbUrlUpdate = state =>
 export const selectFeatureStaticLandingPage = state =>
   toggleValues(state).vaOnlineSchedulingStaticLandingPage;
 
-export const selectFeatureGA4Migration = state =>
-  toggleValues(state).vaOnlineSchedulingGA4Migration;
-
 export const selectFeatureAfterVisitSummary = state =>
   toggleValues(state).vaOnlineSchedulingAfterVisitSummary;
 

--- a/src/applications/vaos/utils/featureFlags.js
+++ b/src/applications/vaos/utils/featureFlags.js
@@ -22,7 +22,6 @@ module.exports = [
   { name: 'vaOnlineSchedulingBreadcrumbUrlUpdate', value: true },
   { name: 'vaOnlineSchedulingBookingExclusion', value: false },
   { name: 'vaOnlineSchedulingStaticLandingPage', value: true },
-  { name: 'vaOnlineSchedulingGA4Migration', value: true },
   { name: 'vaOnlineSchedulingAfterVisitSummary', value: true },
   { name: 'vaOnlineSchedulingStartSchedulingLink', value: true },
   { name: 'vaOnlineSchedulingDatadogRum', value: true },


### PR DESCRIPTION
## Summary

- Removing va_online_scheduling_GA4_migration feature toggle which is now obsolete.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82973

## Testing done

- Ensure existing test suite passes

## Acceptance criteria

- [ ] Remove any references of the feature toggle va_online_scheduling_GA4_migration
- [ ] Changes have been updated in vets-website

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

