### PR TITLE
Fix VAOS vaccine flow: SelectDate1Page test reliability

### DIFF
--- a/src/applications/vaos/tests/covid-19-vaccine/components/SelectDate1Page.unit.spec.js
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/SelectDate1Page.unit.spec.js
@@ -323,16 +323,16 @@ describe('VAOS vaccine flow: SelectDate1Page', () => {
     expect(screen.history.push.called).not.to.be.true;
   });
 
-  // Test failure: https://github.com/department-of-veterans-affairs/va.gov-team/issues/84370
-  it.skip('should fetch slots when moving between months', async () => {
+  it('should fetch slots when moving between months', async () => {
     mockEligibilityFetches({
       facilityId: '983',
       typeOfCareId: TYPE_OF_CARE_ID,
       clinics,
     });
 
-    const preferredDate = moment();
-    const slot308Date = moment()
+    const preferredDate = moment().day(15);
+    const slot308Date = preferredDate
+      .clone()
       .add(1, 'day')
       .hour(9)
       .minute(0)


### PR DESCRIPTION
## Summary

- "VAOS vaccine flow: SelectDate1Page should fetch slots when moving between months" was failing on the last day of each month and had to be disabled.
- This PR modifies the test so it can pass reliably and re-enables it

## Related issue(s)

- Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/84370

## Testing done

- Ran the affected test repeatedly and for different dates to ensure it passes reliably.

## Acceptance criteria

- [ ] Root cause for test failure is found
- [ ] Test is updated or fixed

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
