### PR TITLE
DataDog RUM PII remediation, and improved staging logging

### DIFF
--- a/src/applications/claims-status/components/AddFilesFormOld.jsx
+++ b/src/applications/claims-status/components/AddFilesFormOld.jsx
@@ -222,7 +222,11 @@ class AddFilesFormOld extends React.Component {
                 <div className="document-title-row">
                   <div className="document-title-text-container">
                     <div>
-                      <span className="document-title" data-dd-privacy="mask">
+                      <span
+                        className="document-title"
+                        data-dd-privacy="mask"
+                        data-dd-action-name="document title"
+                      >
                         {file.name}
                       </span>
                     </div>

--- a/src/applications/claims-status/components/AdditionalEvidenceItem.jsx
+++ b/src/applications/claims-status/components/AdditionalEvidenceItem.jsx
@@ -12,7 +12,11 @@ export default function AdditionalEvidenceItem({ item }) {
       </h3>
       <p className="submission-description">
         <span className="claim-item-label">File:</span>{' '}
-        <span className="filename" data-dd-privacy="mask">
+        <span
+          className="filename"
+          data-dd-privacy="mask"
+          data-dd-action-name="filename"
+        >
           {originalFileName}
         </span>
         <br />

--- a/src/applications/claims-status/components/ClaimContentionList.jsx
+++ b/src/applications/claims-status/components/ClaimContentionList.jsx
@@ -8,7 +8,7 @@ const renderContentions = (contentions, limit = MAX_CONTENTIONS) => {
 
   return list.map((contention, index) => {
     return (
-      <li key={index} data-dd-privacy="mask">
+      <li key={index} data-dd-privacy="mask" data-dd-action-name="contention">
         {contention.name}
       </li>
     );

--- a/src/applications/claims-status/components/ClaimPhase.jsx
+++ b/src/applications/claims-status/components/ClaimPhase.jsx
@@ -94,7 +94,11 @@ export default class ClaimPhase extends React.Component {
 
       case 'supporting_document':
         return (
-          <div className="claims-evidence-item" data-dd-privacy="mask">
+          <div
+            className="claims-evidence-item"
+            data-dd-privacy="mask"
+            data-dd-action-name="supporting document submission"
+          >
             You or someone else submitted {file ? `"${file}"` : 'a file'}.
           </div>
         );

--- a/src/applications/claims-status/components/SubmittedTrackedItem.jsx
+++ b/src/applications/claims-status/components/SubmittedTrackedItem.jsx
@@ -18,7 +18,11 @@ export default function SubmittedTrackedItem({ item }) {
     <div className="submitted-file-list-item">
       <h3 className="submission-file-type">{displayName}</h3>
       {description && (
-        <p className="submission-description" data-dd-privacy="mask">
+        <p
+          className="submission-description"
+          data-dd-privacy="mask"
+          data-dd-action-name="submission description"
+        >
           {truncateDescription(description)}
         </p>
       )}
@@ -29,6 +33,7 @@ export default function SubmittedTrackedItem({ item }) {
             <span
               className="submission-description-filename"
               data-dd-privacy="mask"
+              data-dd-action-name="submission description filename"
             >
               {doc.originalFileName}
             </span>

--- a/src/applications/claims-status/components/appeals-v2/AppealListItem.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItem.jsx
@@ -77,14 +77,22 @@ export default function AppealListItem({ appeal, name }) {
           <p>
             {appeal.attributes.issues.length === 1 ? 'Issue' : 'Issues'} on
             {isAppeal ? ' appeal' : ' review'}:{' '}
-            <span className="masked-issue" data-dd-privacy="mask">
+            <span
+              className="masked-issue"
+              data-dd-privacy="mask"
+              data-dd-action-name="appeal issue"
+            >
               {appeal.attributes.description}
             </span>
           </p>
         )}
         <p>
           Status:{' '}
-          <span className="masked-issue" data-dd-privacy="mask">
+          <span
+            className="masked-issue"
+            data-dd-privacy="mask"
+            data-dd-action-name="appeal issue"
+          >
             {getStatusContents(appeal, name).title}
           </span>
         </p>

--- a/src/applications/claims-status/components/appeals-v2/CurrentStatus.jsx
+++ b/src/applications/claims-status/components/appeals-v2/CurrentStatus.jsx
@@ -18,8 +18,8 @@ const CurrentStatus = ({ title, description, isClosed }) => (
 );
 
 CurrentStatus.propTypes = {
-  title: PropTypes.string.isRequired,
   description: PropTypes.element.isRequired,
+  title: PropTypes.string.isRequired,
   isClosed: PropTypes.bool,
 };
 

--- a/src/applications/claims-status/components/appeals-v2/CurrentStatus.jsx
+++ b/src/applications/claims-status/components/appeals-v2/CurrentStatus.jsx
@@ -6,7 +6,12 @@ const CurrentStatus = ({ title, description, isClosed }) => (
     <h2>Current status</h2>
     <div className="current-status-content">
       <h3>{title}</h3>
-      <div data-dd-privacy="mask">{description}</div>
+      <div
+        data-dd-privacy="mask"
+        data-dd-action-name="current status description"
+      >
+        {description}
+      </div>
     </div>
     {!isClosed && <div className="down-arrow" />}
   </div>

--- a/src/applications/claims-status/components/appeals-v2/Decision.jsx
+++ b/src/applications/claims-status/components/appeals-v2/Decision.jsx
@@ -100,8 +100,8 @@ const Decision = ({ issues, aoj, ama = true, boardDecision = false }) => {
 };
 
 Decision.propTypes = {
-  issues: PropTypes.array.isRequired,
   aoj: PropTypes.string.isRequired,
+  issues: PropTypes.array.isRequired,
   ama: PropTypes.bool,
   boardDecision: PropTypes.bool,
 };

--- a/src/applications/claims-status/components/appeals-v2/Decision.jsx
+++ b/src/applications/claims-status/components/appeals-v2/Decision.jsx
@@ -33,7 +33,9 @@ const Decision = ({ issues, aoj, ama = true, boardDecision = false }) => {
           The {boardDecision ? 'judge' : 'reviewer'} granted the following{' '}
           {pluralize.allowed}:
         </p>
-        <ul data-dd-privacy="mask">{allowedIssues}</ul>
+        <ul data-dd-privacy="mask" data-dd-action-name="allowed issue">
+          {allowedIssues}
+        </ul>
       </div>
     );
   }
@@ -45,7 +47,9 @@ const Decision = ({ issues, aoj, ama = true, boardDecision = false }) => {
           The {boardDecision ? 'judge' : 'reviewer'} denied the following{' '}
           {pluralize.denied}:
         </p>
-        <ul data-dd-privacy="mask">{deniedIssues}</ul>
+        <ul data-dd-privacy="mask" data-dd-action-name="denied issue">
+          {deniedIssues}
+        </ul>
       </div>
     );
   }
@@ -61,7 +65,9 @@ const Decision = ({ issues, aoj, ama = true, boardDecision = false }) => {
             : 'gather more evidence or to fix a mistake before deciding whether to grant or deny'}
           :
         </p>
-        <ul data-dd-privacy="mask">{remandIssues}</ul>
+        <ul data-dd-privacy="mask" data-dd-action-name="remanded issue">
+          {remandIssues}
+        </ul>
       </div>
     );
   }

--- a/src/applications/claims-status/components/appeals-v2/Issues.jsx
+++ b/src/applications/claims-status/components/appeals-v2/Issues.jsx
@@ -13,6 +13,7 @@ const Issues = ({ issues, isAppeal }) => {
       className="issue-item"
       key={`${item.status}-${i}`}
       data-dd-privacy="mask"
+      data-dd-action-name="appeal issues"
     >
       {item.description}
     </li>

--- a/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
@@ -212,7 +212,11 @@ class AddFilesForm extends React.Component {
                 <div className="document-title-row">
                   <div className="document-title-text-container">
                     <div>
-                      <span className="document-title" data-dd-privacy="mask">
+                      <span
+                        className="document-title"
+                        data-dd-privacy="mask"
+                        data-dd-action-name="document title"
+                      >
                         {file.name}
                       </span>
                     </div>

--- a/src/applications/claims-status/components/claim-files-tab/DocumentsFiled.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/DocumentsFiled.jsx
@@ -144,6 +144,7 @@ function DocumentsFiled({ claim }) {
                         <h4
                           className="filename-title vads-u-margin-y--0"
                           data-dd-privacy="mask"
+                          data-dd-action-name="document filename"
                         >
                           {doc.originalFileName
                             ? doc.originalFileName

--- a/src/applications/claims-status/components/claim-files-tab/RemoveFileModal.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/RemoveFileModal.jsx
@@ -38,10 +38,10 @@ function RemoveFileModal({
 }
 
 RemoveFileModal.propTypes = {
-  removeFileName: PropTypes.string,
-  showRemoveFileModal: PropTypes.bool.isRequired,
   closeModal: PropTypes.func.isRequired,
   removeFile: PropTypes.func.isRequired,
+  showRemoveFileModal: PropTypes.bool.isRequired,
+  removeFileName: PropTypes.string,
 };
 
 export default RemoveFileModal;

--- a/src/applications/claims-status/components/claim-files-tab/RemoveFileModal.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/RemoveFileModal.jsx
@@ -28,7 +28,10 @@ function RemoveFileModal({
       status="warning"
     >
       <p>
-        We’ll remove <strong data-dd-privacy="mask">{removeFileName}</strong>
+        We’ll remove{' '}
+        <strong data-dd-privacy="mask" data-dd-action-name="file to be removed">
+          {removeFileName}
+        </strong>
       </p>
     </VaModal>
   );

--- a/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
+++ b/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
@@ -126,6 +126,7 @@ export default function RecentActivity({ claim }) {
                   <p
                     className="item-description vads-u-margin-top--0 vads-u-margin-bottom--1"
                     data-dd-privacy="mask"
+                    data-dd-action-name="item description"
                   >
                     {item.description}
                   </p>
@@ -135,6 +136,7 @@ export default function RecentActivity({ claim }) {
                   <p
                     className="item-description vads-u-margin-top--0p5 vads-u-margin-bottom--1"
                     data-dd-privacy="mask"
+                    data-dd-action-name="item description"
                   >
                     {item.description}
                   </p>

--- a/src/applications/claims-status/containers/DetailsPage.jsx
+++ b/src/applications/claims-status/containers/DetailsPage.jsx
@@ -87,6 +87,7 @@ class DetailsPage extends React.Component {
                     key={index}
                     className="claim-detail-list-item"
                     data-dd-privacy="mask"
+                    data-dd-action-name="contention name"
                   >
                     {contention.name}
                   </li>

--- a/src/applications/claims-status/utils/datadog-rum/initializeRealUserMonitoring.js
+++ b/src/applications/claims-status/utils/datadog-rum/initializeRealUserMonitoring.js
@@ -14,8 +14,9 @@ const defaultRumSettings = {
   site: 'ddog-gov.com',
   // see src/site/constants/vsp-environments.js for defaults
   env: environment.vspEnvironment(), // 'production'
-  sessionSampleRate: 5,
-  sessionReplaySampleRate: 20,
+  sessionSampleRate: environment.vspEnvironment() === 'staging' ? 100 : 5,
+  sessionReplaySampleRate:
+    environment.vspEnvironment() === 'staging' ? 100 : 20,
   trackInteractions: true,
   trackUserInteractions: true,
   trackFrustrations: true,
@@ -24,10 +25,7 @@ const defaultRumSettings = {
   defaultPrivacyLevel: 'mask-user-input',
   beforeSend: event => {
     // Prevent PII from being sent to Datadog with click actions.
-    if (
-      event.action?.type === 'click' &&
-      event.action?.target.getAttribute('data-dd-privacy') === 'mask'
-    ) {
+    if (event.action?.type === 'click') {
       // eslint-disable-next-line no-param-reassign
       event.action.target.name = 'Clicked item';
     }

--- a/src/applications/claims-status/utils/datadog-rum/initializeRealUserMonitoring.js
+++ b/src/applications/claims-status/utils/datadog-rum/initializeRealUserMonitoring.js
@@ -23,14 +23,6 @@ const defaultRumSettings = {
   trackResources: true,
   trackLongTasks: true,
   defaultPrivacyLevel: 'mask-user-input',
-  beforeSend: event => {
-    // Prevent PII from being sent to Datadog with click actions.
-    if (event.action?.type === 'click') {
-      // eslint-disable-next-line no-param-reassign
-      event.action.target.name = 'Clicked item';
-    }
-    return true;
-  },
 };
 
 import { isProductionEnv } from '../../constants';

--- a/src/applications/claims-status/utils/datadog-rum/useBrowserMonitoring.js
+++ b/src/applications/claims-status/utils/datadog-rum/useBrowserMonitoring.js
@@ -17,11 +17,11 @@ const defaultLogSettings = {
   site: 'ddog-gov.com',
   // see src/site/constants/vsp-environments.js for defaults
   env: environment.vspEnvironment(), // 'production'
-  sessionSampleRate: 5,
+  sessionSampleRate: environment.vspEnvironment() === 'staging' ? 100 : 5,
   forwardErrorsToLogs: true,
   forwardConsoleLogs: ['error'],
   forwardReports: [],
-  telemetrySampleRate: 20, // default 20
+  telemetrySampleRate: environment.vspEnvironment() === 'staging' ? 100 : 20, // default 20
 };
 
 const initializeBrowserLogging = customLogSettings => {


### PR DESCRIPTION
## Summary

- Turned DD RUM sampling rates to 100% for staging environment
- Specified masked but descriptive click event descriptions for all masked elements in DD RUM
- removed generic JS masking for click events
- fixed some linting issues where some prop validations weren't listed alphabetically or in order of required first

## Related issue(s)

- [[CST] [DataDog RUM] Confirm that RUM logging looks correct on staging](https://github.com/department-of-veterans-affairs/va.gov-team/issues/83751)
