### PR TITLE
Add subTitle function support

### DIFF
--- a/src/platform/forms-system/src/js/containers/FormApp.jsx
+++ b/src/platform/forms-system/src/js/containers/FormApp.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
+import PropTypes from 'prop-types';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 
 import { isLoggedIn } from 'platform/user/selectors';
@@ -42,6 +43,10 @@ class FormApp extends React.Component {
       typeof formConfig.title === 'function'
         ? formConfig.title(this.props)
         : formConfig.title;
+    const subTitle =
+      typeof formConfig.subTitle === 'function'
+        ? formConfig.subTitle(this.props)
+        : formConfig.subTitle;
     const { noTitle, noTopNav, fullWidth } = formConfig?.formOptions || {};
     const notProd = !environment.isProduction();
     const hasHiddenFormTitle = hideFormTitle(formConfig, trimmedPathname);
@@ -54,7 +59,7 @@ class FormApp extends React.Component {
     //    specified in the form config
     // 2. there is a title specified in the form config
     if (!isIntroductionPage && !isNonFormPage && !hasHiddenFormTitle && title) {
-      formTitle = <FormTitle title={title} subTitle={formConfig.subTitle} />;
+      formTitle = <FormTitle title={title} subTitle={subTitle} />;
     }
 
     // Show nav only if we're not on the intro, form-saved, error, confirmation
@@ -106,6 +111,23 @@ class FormApp extends React.Component {
     );
   }
 }
+
+FormApp.propTypes = {
+  children: PropTypes.any,
+  currentLocation: PropTypes.shape({
+    pathname: PropTypes.string,
+  }),
+  formConfig: PropTypes.shape({
+    additionalRoutes: PropTypes.array,
+    footerContent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
+    formOptions: PropTypes.shape({}),
+    subTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  }),
+  formData: PropTypes.shape({}),
+  inProgressFormId: PropTypes.string,
+  isLoggedIn: PropTypes.bool,
+};
 
 const mapStateToProps = state => ({
   formData: state.form.data,

--- a/src/platform/forms-system/test/js/containers/FormApp.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/containers/FormApp.unit.spec.jsx
@@ -63,6 +63,30 @@ describe('Schemaform <FormApp>', () => {
     expect(tree.everySubTree('FormTitle')[0].props.title).to.equal(titles[1]);
   });
 
+  it('should show dynamic subTitle', () => {
+    const subTitles = ['Main subTitle', 'Alternate subTitle'];
+    const formData = { test: false };
+    const formConfig = {
+      title: 'Test',
+      subTitle: props => subTitles[props.formData.test ? 1 : 0],
+    };
+    const currentLocation = {
+      pathname: '/veteran-information/personal-information',
+      search: '',
+    };
+
+    const tree = shallowFormApp({ formConfig, currentLocation, formData });
+
+    expect(tree.everySubTree('FormTitle')[0].props.subTitle).to.equal(
+      subTitles[0],
+    );
+    formData.test = true;
+    tree.reRender({ formData, currentLocation, formConfig });
+    expect(tree.everySubTree('FormTitle')[0].props.subTitle).to.equal(
+      subTitles[1],
+    );
+  });
+
   it('should hide title, nav and layout classes when formOptions are set', () => {
     const formConfig = {
       formOptions: { noTitle: true, noTopNav: true, fullWidth: true },


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > We have a design where we need to change the form title & subtitle to display the title and form number of an embedded form. The form title already supports passing in a function for dynamic titles. This PR adds support for a dynamic subtitle.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- [#83774](https://github.com/department-of-veterans-affairs/va.gov-team/issues/83774)
- [Design](https://www.figma.com/design/2LGebZcUuu5Iqh4QLPII6A/Supplemental-Claims-(VA-0995)?node-id=559-13368&t=OJidqvO1JGj6T4FY-0)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > - Added a unit test for the subtitle change
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Form 995 | ![before dynamic subtitle](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/520db4d7-f4b8-415b-9695-af6f83564602) | ![dynamic subtitle](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/b70401df-ab93-46d1-9827-ee0ea0a83e22) |

## What areas of the site does it impact?

All forms that initialize using a `config/form.js` file

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
