### PR TITLE
Keyboard focus on the heading for MHV pages

### DIFF
--- a/src/applications/mhv-landing-page/containers/App.jsx
+++ b/src/applications/mhv-landing-page/containers/App.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import backendServices from '@department-of-veterans-affairs/platform-user/profile/backendServices';
 import { RequiredLoginView } from '@department-of-veterans-affairs/platform-user/RequiredLoginView';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 
 import LandingPage from '../components/LandingPage';
 import {
@@ -74,6 +75,14 @@ const App = () => {
       }
     },
     [enabled, hasMHVAccount],
+  );
+
+  useEffect(
+    () => {
+      // For accessibility purposes.
+      focusElement('h1');
+    },
+    [loading],
   );
 
   if (loading)

--- a/src/applications/mhv-landing-page/containers/MedicalRecordsContainer.jsx
+++ b/src/applications/mhv-landing-page/containers/MedicalRecordsContainer.jsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import PageNotFound from '@department-of-veterans-affairs/platform-site-wide/PageNotFound';
 import titleCase from '@department-of-veterans-affairs/platform-utilities/titleCase';
 import { MhvSecondaryNav } from '@department-of-veterans-affairs/mhv/exports';
+import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
 import { isAuthenticatedWithSSOe, isProfileLoading } from '../selectors';
 import MedicalRecords from '../components/MedicalRecords';
@@ -12,15 +13,24 @@ const Placeholder = () => <div style={{ height: '555px' }} />;
 const pageHeading = 'Medical records';
 
 const MedicalRecordsContainer = () => {
-  useEffect(() => {
-    document.title = `${titleCase(pageHeading)} | Veterans Affairs`;
-  }, []);
-
   const {
     loading: featureTogglesLoading,
     mhvTransitionalMedicalRecordsLandingPage,
   } = useSelector(state => state.featureToggles);
   const profileLoading = useSelector(isProfileLoading);
+
+  useEffect(() => {
+    document.title = `${titleCase(pageHeading)} | Veterans Affairs`;
+  }, []);
+
+  useEffect(
+    () => {
+      // For accessibility purposes.
+      focusElement('h1');
+    },
+    [featureTogglesLoading, profileLoading],
+  );
+
   const ssoe = useSelector(isAuthenticatedWithSSOe);
   const blueButtonUrl = mhvUrl(ssoe, 'download-my-data');
 

--- a/src/applications/mhv-landing-page/tests/e2e/medical-records/temporary-landing-page.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/medical-records/temporary-landing-page.cypress.spec.js
@@ -14,7 +14,9 @@ describe(`${appName} -- transitional Medical Records page enabled`, () => {
 
   it('renders', () => {
     cy.findByTestId('mhvMedicalRecords');
-    cy.findByRole('heading', { level: 1, name: pageHeading });
+    cy.findByRole('heading', { level: 1, name: pageHeading }).should(
+      'have.focus',
+    );
     cy.title().should('match', new RegExp(pageHeading, 'i'));
     cy.injectAxeThenAxeCheck();
   });

--- a/src/applications/mhv-landing-page/tests/e2e/mhv-landing-page.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/mhv-landing-page.cypress.spec.js
@@ -21,7 +21,7 @@ describe(`${appName} -- landing page`, () => {
       level: 1,
       name: /^My HealtheVet$/,
     };
-    cy.findByRole('heading', heading).should.exist;
+    cy.findByRole('heading', heading).should('have.focus');
   });
 
   it('passes automated accessibility (a11y) checks', () => {


### PR DESCRIPTION
## Summary
Set the focus to the heading H1 for the MHV Landing and temporary Records page, so screen readers start at the proper place. Note that `tabIndex="-1"` on the heading does not work for these pages as we load the content dynamically.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/84240

## Testing done
- Updated e2e tests
- For manual testing:
  - Start your screen reader (e.g. NVDA) and visit both the `/my-health` and `/my-health/records` URLs.
  - Verify that the screen reader starts at the heading for the page.

## Screenshots
There are no updates to the UI.

## What areas of the site does it impact?
- MHV Landing Page
- Temporary Records page

## Acceptance criteria
- After navigating using the MHV Home link, focus lands on H1 of MHV Home page
- After navigating using the Records link, focus lands on H1 of temporary Records page

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

