### PR TITLE
Screenreader Announce suggested terms

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ComboBox.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ComboBox.jsx
@@ -94,12 +94,17 @@ export class ComboBox extends React.Component {
     input.focus();
   };
 
+  optionFocus(index) {
+    const focusOption = document.getElementById(`option-${index}`);
+    focusOption.focus();
+  }
+
   // Keyboard handling for combobox list options
   handleKeyPress = e => {
     const { highlightedIndex, searchTerm } = this.state;
     const list = this.listRef.current;
     let index = highlightedIndex;
-    let focusOption;
+
     switch (e.key) {
       // On Tab, user input should remain as-is, list should close, focus goes to save button.
       case 'Tab':
@@ -117,20 +122,14 @@ export class ComboBox extends React.Component {
         index = this.decrementIndex(index);
         this.scrollIntoView(index);
         this.setState({ highlightedIndex: index });
-        if (index >= 0 && index < list.children.length) {
-          focusOption = document.getElementById(`option-${index}`);
-          focusOption.focus();
-        }
+        this.optionFocus(index);
         e.preventDefault();
         break;
       case 'ArrowDown':
         index = this.incrementIndex(index);
         this.scrollIntoView(index);
         this.setState({ highlightedIndex: index });
-        if (index >= 0 && index < list.children.length) {
-          focusOption = document.getElementById(`option-${index}`);
-          focusOption.focus();
-        }
+        this.optionFocus(index);
         e.preventDefault();
         break;
       // On Enter, select the highlighted option and close the list. Focus on text input.

--- a/src/applications/disability-benefits/all-claims/components/ComboBox.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ComboBox.jsx
@@ -94,11 +94,6 @@ export class ComboBox extends React.Component {
     input.focus();
   };
 
-  optionFocus(index) {
-    const focusOption = document.getElementById(`option-${index}`);
-    focusOption.focus();
-  }
-
   // Keyboard handling for combobox list options
   handleKeyPress = e => {
     const { highlightedIndex, searchTerm } = this.state;
@@ -221,6 +216,11 @@ export class ComboBox extends React.Component {
     return index;
   };
 
+  optionFocus(index) {
+    const focusOption = document.getElementById(`option-${index}`);
+    focusOption.focus();
+  }
+
   // Click handler for a list item
   selectOption(option) {
     this.setState({
@@ -297,7 +297,6 @@ export class ComboBox extends React.Component {
         role="combobox"
         aria-expanded={filteredOptions.length > 0}
         className="cc-combobox"
-        aria-activedescendant={`option-${this.state.highlightedIndex}`}
         aria-haspopup="listbox"
         aria-controls="combobox-list"
         aria-owns="combobox-list"
@@ -328,6 +327,12 @@ export class ComboBox extends React.Component {
           ref={this.listRef}
           aria-label="List of matching conditions"
           id="combobox-list"
+          aria-activedescendant={
+            filteredOptions.length > 0
+              ? `option-${this.state.highlightedIndex}`
+              : null
+          }
+          tabIndex={0}
         >
           {this.drawFreeTextOption(searchTerm)}
           {filteredOptions &&

--- a/src/applications/disability-benefits/all-claims/components/ComboBox.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ComboBox.jsx
@@ -35,7 +35,7 @@ export class ComboBox extends React.Component {
       searchTerm: props.formData,
       input: props.formData,
       value: props.formData,
-      highlightedIndex: 0,
+      highlightedIndex: null,
       ariaLive1: '',
       ariaLive2: '',
       filteredOptions: [],
@@ -99,7 +99,7 @@ export class ComboBox extends React.Component {
     const { highlightedIndex, searchTerm } = this.state;
     const list = this.listRef.current;
     let index = highlightedIndex;
-
+    let focusOption;
     switch (e.key) {
       // On Tab, user input should remain as-is, list should close, focus goes to save button.
       case 'Tab':
@@ -117,12 +117,26 @@ export class ComboBox extends React.Component {
         index = this.decrementIndex(index);
         this.scrollIntoView(index);
         this.setState({ highlightedIndex: index });
+        if (index >= 0 && index <= list.children.length) {
+          focusOption = document.getElementById(`option-${index}`);
+          focusOption.focus();
+        } else {
+          this.sendFocusToInput(this.inputRef);
+          this.setState({ highlightedIndex: 0 });
+        }
         e.preventDefault();
         break;
       case 'ArrowDown':
         index = this.incrementIndex(index);
         this.scrollIntoView(index);
         this.setState({ highlightedIndex: index });
+        if (index >= 0 && index <= list.children.length) {
+          focusOption = document.getElementById(`option-${index}`);
+          focusOption.focus();
+        } else {
+          this.sendFocusToInput(this.inputRef);
+          this.setState({ highlightedIndex: 0 });
+        }
         e.preventDefault();
         break;
       // On Enter, select the highlighted option and close the list. Focus on text input.
@@ -266,6 +280,7 @@ export class ComboBox extends React.Component {
         onClick={() => {
           this.selectOption(option);
         }}
+        id={`option-${this.state.highlightedIndex}`}
         style={{ cursor: 'pointer' }}
         tabIndex={0}
         onMouseEnter={e => {
@@ -285,7 +300,17 @@ export class ComboBox extends React.Component {
   render() {
     const { searchTerm, ariaLive1, ariaLive2, filteredOptions } = this.state;
     return (
-      <div className="cc-combobox">
+      <div
+        role="combobox"
+        aria-expanded={filteredOptions.length > 0}
+        className="cc-combobox"
+        aria-activedescendant={`option-${this.state.highlightedIndex}`}
+        aria-haspopup="listbox"
+        aria-controls="combobox-list"
+        aria-owns="combobox-list"
+        aria-autocomplete="list"
+        tabIndex={0}
+      >
         <VaTextInput
           label={this.props.uiSchema['ui:title']}
           required
@@ -307,6 +332,9 @@ export class ComboBox extends React.Component {
           role="listbox"
           ref={this.listRef}
           aria-label="List of matching conditions"
+          id="combobox-list"
+          // aria-live='polite'
+          aria-labelledby={this.props.idSchema.$id}
         >
           {this.drawFreeTextOption(searchTerm)}
           {filteredOptions &&
@@ -332,6 +360,7 @@ export class ComboBox extends React.Component {
                   label={option}
                   role="option"
                   aria-selected={this.state.input === option}
+                  id={`option-${optionIndex}`}
                 >
                   {option}
                 </li>

--- a/src/applications/disability-benefits/all-claims/components/ComboBox.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ComboBox.jsx
@@ -35,7 +35,7 @@ export class ComboBox extends React.Component {
       searchTerm: props.formData,
       input: props.formData,
       value: props.formData,
-      highlightedIndex: null,
+      highlightedIndex: 0,
       ariaLive1: '',
       ariaLive2: '',
       filteredOptions: [],
@@ -117,12 +117,9 @@ export class ComboBox extends React.Component {
         index = this.decrementIndex(index);
         this.scrollIntoView(index);
         this.setState({ highlightedIndex: index });
-        if (index >= 0 && index <= list.children.length) {
+        if (index >= 0 && index < list.children.length) {
           focusOption = document.getElementById(`option-${index}`);
           focusOption.focus();
-        } else {
-          this.sendFocusToInput(this.inputRef);
-          this.setState({ highlightedIndex: 0 });
         }
         e.preventDefault();
         break;
@@ -130,12 +127,9 @@ export class ComboBox extends React.Component {
         index = this.incrementIndex(index);
         this.scrollIntoView(index);
         this.setState({ highlightedIndex: index });
-        if (index >= 0 && index <= list.children.length) {
+        if (index >= 0 && index < list.children.length) {
           focusOption = document.getElementById(`option-${index}`);
           focusOption.focus();
-        } else {
-          this.sendFocusToInput(this.inputRef);
-          this.setState({ highlightedIndex: 0 });
         }
         e.preventDefault();
         break;
@@ -263,7 +257,7 @@ export class ComboBox extends React.Component {
 
   // Creates the dynamic element for free text user entry.
   drawFreeTextOption(option) {
-    const { highlightedIndex, searchTerm, value } = this.state;
+    const { highlightedIndex, value } = this.state;
 
     if (option === value || option.length < 1) {
       return null;
@@ -280,16 +274,16 @@ export class ComboBox extends React.Component {
         onClick={() => {
           this.selectOption(option);
         }}
-        id={`option-${this.state.highlightedIndex}`}
+        id="option-0"
         style={{ cursor: 'pointer' }}
         tabIndex={0}
         onMouseEnter={e => {
           this.handleMouseEnter(e, 0);
         }}
-        onKeyDown={() => null}
+        onKeyDown={this.handleKeyPress}
         label="new-condition-option"
         role="option"
-        aria-selected={searchTerm === option}
+        aria-selected="false"
       >
         Enter your condition as "
         <span style={{ fontWeight: 'bold' }}>{option}</span>"
@@ -310,6 +304,8 @@ export class ComboBox extends React.Component {
         aria-owns="combobox-list"
         aria-autocomplete="list"
         tabIndex={0}
+        aria-labelledby={this.props.idSchema.$id}
+        aria-label="Enter you condition"
       >
         <VaTextInput
           label={this.props.uiSchema['ui:title']}
@@ -333,8 +329,6 @@ export class ComboBox extends React.Component {
           ref={this.listRef}
           aria-label="List of matching conditions"
           id="combobox-list"
-          // aria-live='polite'
-          aria-labelledby={this.props.idSchema.$id}
         >
           {this.drawFreeTextOption(searchTerm)}
           {filteredOptions &&
@@ -356,10 +350,10 @@ export class ComboBox extends React.Component {
                   onMouseEnter={e => {
                     this.handleMouseEnter(e, optionIndex);
                   }}
-                  onKeyDown={() => null}
+                  onKeyDown={this.handleKeyPress}
                   label={option}
                   role="option"
-                  aria-selected={this.state.input === option}
+                  aria-selected="false"
                   id={`option-${optionIndex}`}
                 >
                   {option}


### PR DESCRIPTION
## Summary

- During the Staging Review for the Contention Classification team, it was identified that the suggested terms were not announced by the screen reader.  This ticket corrects this and enables the screen reader to announce results.  The below screen shot shows what the screen reader announces. 

## Related issue(s)

-  [Staging Review Ticket #84584](https://github.com/department-of-veterans-affairs/va.gov-team/issues/84584) 


## Testing done

- Manually testing completed and shown in screen shot above. 

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/142833783/3f87337f-1eb4-4d3c-9a17-92ce2e0115fe)
_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
