### PR TITLE
Removing "other" report option from report modal of Find a Representative

### DIFF
--- a/src/applications/representative-search/components/results/ReportModal.jsx
+++ b/src/applications/representative-search/components/results/ReportModal.jsx
@@ -17,18 +17,14 @@ const ReportModal = ({
   onCloseReportModal,
   submitRepresentativeReport,
   cancelRepresentativeReport,
-  handleOtherInputChangeTestId,
   testReportObject,
 }) => {
   const [reportObject, setReportObject] = useState({
     phone: null,
     email: null,
     address: null,
-    other: null,
   });
 
-  const [otherIsChecked, setOtherIsChecked] = useState(false);
-  const [otherIsBlankError, setOtherIsBlankError] = useState(false);
   const [reportIsBlankError, setReportIsBlankError] = useState(false);
 
   // render conditions
@@ -41,14 +37,6 @@ const ReportModal = ({
   const addressReportable = address && !existingReports?.address;
   const emailReportable = email && !existingReports?.email;
   const phoneReportable = phone && !existingReports?.phone;
-  const otherReportable = !existingReports?.other;
-
-  const handleOtherInputChange = event => {
-    setOtherIsBlankError(false);
-    const newState = { ...reportObject };
-    newState.other = event.target.value;
-    setReportObject(newState);
-  };
 
   const handleCheckboxChange = event => {
     setReportIsBlankError(false);
@@ -67,10 +55,6 @@ const ReportModal = ({
         break;
       case '3':
         newState.phone = checked ? phone : null;
-        break;
-      case '4':
-        setOtherIsBlankError(false);
-        setOtherIsChecked(checked);
         break;
       default:
         break;
@@ -92,10 +76,6 @@ const ReportModal = ({
       }
     });
 
-    if (otherIsChecked && !formattedReportObject.reports.other) {
-      setOtherIsBlankError(true);
-      return;
-    }
     if (!Object.keys(formattedReportObject.reports).length) {
       setReportIsBlankError(true);
       return;
@@ -108,7 +88,6 @@ const ReportModal = ({
         phone: null,
         email: null,
         address: null,
-        other: null,
       });
     }
 
@@ -131,33 +110,7 @@ const ReportModal = ({
         uswds
       >
         {/* These buttons trigger methods for unit testing - temporary workaround for shadow root issues with va checkboxes */}
-        {handleOtherInputChangeTestId ? (
-          <>
-            <button
-              label="unit test button"
-              id="handle-checkbox-change-test-button"
-              type="button"
-              onClick={() =>
-                handleCheckboxChange({
-                  target: { id: handleOtherInputChangeTestId, checked: 'true' },
-                })
-              }
-            />
-            <button
-              id="handle-other-input-change-test-button"
-              label="unit test button"
-              type="button"
-              onClick={() =>
-                handleOtherInputChange({
-                  target: {
-                    id: handleOtherInputChangeTestId,
-                    value: 'test comment',
-                  },
-                })
-              }
-            />
-          </>
-        ) : null}
+
         {testReportObject ? (
           <>
             <button
@@ -189,9 +142,6 @@ const ReportModal = ({
               {existingReports.address && <li>Outdated address</li>}
               {existingReports.email && <li>Outdated email</li>}
               {existingReports.phone && <li>Outdated phone number</li>}
-              {existingReports.other && (
-                <li>Other: "{existingReports.other}"</li>
-              )}
             </ul>
           </>
         )}
@@ -224,34 +174,8 @@ const ReportModal = ({
               {phoneReportable && (
                 <va-checkbox label="Phone number" name="phone" uswds id="3" />
               )}
-              {otherReportable && (
-                <va-checkbox label="Other" name="other" uswds id="4" />
-              )}
             </VaCheckboxGroup>
           </>
-        )}
-
-        {otherIsChecked && (
-          <div className="report-other-text-input">
-            <div
-              className={`${
-                !otherIsBlankError ? 'form-expanding-group-open' : null
-              } form-expanding-group-inner-enter-done`}
-            >
-              <va-textarea
-                hint={null}
-                label="Describe the other information we need to update"
-                required
-                error={otherIsBlankError ? 'This field is required' : null}
-                value={reportObject.other}
-                name="Other comment input"
-                maxlength={250}
-                onInput={e => handleOtherInputChange(e)}
-                uswds
-                charcount
-              />
-            </div>
-          </div>
         )}
       </VaModal>
     </>
@@ -267,10 +191,8 @@ ReportModal.propTypes = {
   existingReports: PropTypes.shape({
     address: PropTypes.string,
     email: PropTypes.string,
-    other: PropTypes.string,
     phone: PropTypes.string,
   }),
-  handleOtherInputChangeTestId: PropTypes.func,
   phone: PropTypes.string,
   representativeId: PropTypes.string,
   representativeName: PropTypes.string,

--- a/src/applications/representative-search/tests/components/ReportModal.unit.spec.jsx
+++ b/src/applications/representative-search/tests/components/ReportModal.unit.spec.jsx
@@ -25,25 +25,23 @@ describe('ReportModal component', () => {
     const phoneNumberCheckBox = container.querySelector(
       'va-checkbox[label="Phone number"]',
     );
-    const otherCheckBox = container.querySelector('va-checkbox[label="Other"]');
 
     expect(emailCheckBox).to.exist;
 
     expect(addressCheckBox).to.exist;
 
-    expect(otherCheckBox).to.exist;
     expect(phoneNumberCheckBox).to.exist;
   });
 
   it('should parse reports array', () => {
     localStorage.setItem(
       'vaReports',
-      '[{"representativeId":"28162","reports":{"address":"1521 Scottsdale Ave Columbus, OH 43235","otherComment":"test"}}]',
+      '[{"representativeId":"28162","reports":{"address":"1521 Scottsdale Ave Columbus, OH 43235"}}]',
     );
     const localReportsArray = localStorage.getItem('vaReports');
 
     expect(localReportsArray).to.equal(
-      '[{"representativeId":"28162","reports":{"address":"1521 Scottsdale Ave Columbus, OH 43235","otherComment":"test"}}]',
+      '[{"representativeId":"28162","reports":{"address":"1521 Scottsdale Ave Columbus, OH 43235"}}]',
     );
   });
 
@@ -52,7 +50,6 @@ describe('ReportModal component', () => {
       address: '123 Main St',
       email: 'rep@example.com',
       phone: '794-273-8433',
-      other: 'Some other information',
     };
 
     const wrapper = shallow(
@@ -73,127 +70,6 @@ describe('ReportModal component', () => {
     expect(wrapper.contains(<li>Outdated address</li>)).to.be.true;
     expect(wrapper.contains(<li>Outdated email</li>)).to.be.true;
     expect(wrapper.contains(<li>Outdated phone number</li>)).to.be.true;
-    expect(wrapper.contains(<li>Other: "Some other information"</li>)).to.be
-      .true;
-
-    wrapper.unmount();
-  });
-
-  it('does not cause text input to render when selecting "Address"', () => {
-    const wrapper = mount(
-      <ReportModal
-        representativeName="Bob law"
-        representativeId="123"
-        address="123 Main St"
-        phone="794-273-8433"
-        email="rep@example.com"
-        existingReports={{}}
-        submitRepresentativeReport={() => {}}
-        onCloseModal={() => {}}
-        handleOtherInputChangeTestId="1"
-      />,
-    );
-    wrapper.find('#handle-checkbox-change-test-button').simulate('click');
-
-    wrapper.update();
-
-    const vaTextInputExists = wrapper.find('va-text-input').exists();
-    expect(vaTextInputExists).to.be.false;
-    wrapper.unmount();
-  });
-
-  it('does not cause text input to render when selecting "Email"', () => {
-    const wrapper = mount(
-      <ReportModal
-        representativeName="Bob law"
-        representativeId="123"
-        address="123 Main St"
-        phone="794-273-8433"
-        email="rep@example.com"
-        existingReports={{}}
-        submitRepresentativeReport={() => {}}
-        onCloseModal={() => {}}
-        handleOtherInputChangeTestId="2"
-      />,
-    );
-    wrapper.find('#handle-checkbox-change-test-button').simulate('click');
-
-    wrapper.update();
-
-    const vaTextInputExists = wrapper.find('va-text-input').exists();
-    expect(vaTextInputExists).to.be.false;
-    wrapper.unmount();
-  });
-
-  it('does not cause text input to render when selecting "Phone"', () => {
-    const wrapper = mount(
-      <ReportModal
-        representativeName="Bob law"
-        representativeId="123"
-        address="123 Main St"
-        phone="794-273-8433"
-        email="rep@example.com"
-        existingReports={{}}
-        submitRepresentativeReport={() => {}}
-        onCloseModal={() => {}}
-        handleOtherInputChangeTestId="3"
-      />,
-    );
-    wrapper.find('#handle-checkbox-change-test-button').simulate('click');
-
-    wrapper.update();
-
-    const vaTextInputExists = wrapper.find('va-text-input').exists();
-    expect(vaTextInputExists).to.be.false;
-    wrapper.unmount();
-  });
-
-  it('causes text input to render when selecting "Other"', () => {
-    const wrapper = mount(
-      <ReportModal
-        representativeName="Bob law"
-        representativeId="123"
-        address="123 Main St"
-        phone="794-273-8433"
-        email="rep@example.com"
-        existingReports={{}}
-        submitRepresentativeReport={() => {}}
-        onCloseModal={() => {}}
-        handleOtherInputChangeTestId="4"
-      />,
-    );
-    wrapper.find('#handle-checkbox-change-test-button').simulate('click');
-
-    wrapper.update();
-
-    const vaTextAreaExists = wrapper.find('va-textarea').exists();
-    expect(vaTextAreaExists).to.be.true;
-    wrapper.unmount();
-  });
-
-  it('controls text input', () => {
-    const wrapper = mount(
-      <ReportModal
-        representativeName="Bob law"
-        representativeId="123"
-        address="123 Main St"
-        phone="794-273-8433"
-        email="rep@example.com"
-        existingReports={{}}
-        submitRepresentativeReport={() => {}}
-        onCloseModal={() => {}}
-        handleOtherInputChangeTestId="4"
-      />,
-    );
-    wrapper.find('#handle-checkbox-change-test-button').simulate('click');
-
-    wrapper.update();
-
-    wrapper.find('#handle-other-input-change-test-button').simulate('click');
-
-    wrapper.update();
-
-    expect(wrapper.find('va-textarea').prop('value')).equal('test comment');
 
     wrapper.unmount();
   });
@@ -213,7 +89,6 @@ describe('ReportModal component', () => {
           phone: '976-876-5432',
           email: null,
           address: null,
-          other: null,
         }}
       />,
     );


### PR DESCRIPTION
## Summary

- Removed "other" option from report modal component
- Removed unit tests testing "other" report option

## Related to 
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85516

## Testing done
- Mainly removed tests for a functionality that is no longer being supported

## Screenshots
<img width="841" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/143013011/78a4bf5b-6cde-4178-b9f4-bf7cc2925452">
