### PR TITLE
Travel pay/add mhv landing page link

### DIFF
--- a/src/applications/mhv-landing-page/constants.js
+++ b/src/applications/mhv-landing-page/constants.js
@@ -66,6 +66,10 @@ const HEALTH_TOOL_LINKS = freeze({
       text: 'Pay copay bills',
     },
     {
+      href: '/my-health/travel-claim-status',
+      text: 'Check travel reimbursement claim status',
+    },
+    {
       href: 'https://dvagov-btsss.dynamics365portals.us/signin',
       text:
         'File a claim for travel reimbursement on the Beneficiary Travel Self-Service System website',

--- a/src/applications/mhv-landing-page/mocks/api/feature-toggles/index.js
+++ b/src/applications/mhv-landing-page/mocks/api/feature-toggles/index.js
@@ -8,6 +8,7 @@ const APPLICATION_FEATURE_TOGGLES = Object.freeze({
   mhvLandingPageEnableVaGovHealthToolsLinks: false,
   mhvTransitionalMedicalRecordsLandingPage: false,
   mhvHelpdeskInformationEnabled: false,
+  travelPayPowerSwitch: false,
 });
 
 const generateFeatureToggles = ({

--- a/src/applications/mhv-landing-page/utilities/data/index.js
+++ b/src/applications/mhv-landing-page/utilities/data/index.js
@@ -81,6 +81,19 @@ const resolveLandingPageLinks = (
     featureToggles,
   );
 
+  const paymentsLinks = resolveLinks(
+    [
+      { ...HEALTH_TOOL_LINKS.PAYMENTS[0] },
+      {
+        ...HEALTH_TOOL_LINKS.PAYMENTS[1],
+        toggle: FEATURE_FLAG_NAMES.travelPayPowerSwitch,
+        hardToggle: true,
+      },
+      { ...HEALTH_TOOL_LINKS.PAYMENTS[2] },
+    ],
+    featureToggles,
+  );
+
   const medicalRecordsLinks = resolveLinks(
     [
       {
@@ -217,7 +230,7 @@ const resolveLandingPageLinks = (
       title: HEALTH_TOOL_HEADINGS.PAYMENTS,
       icon: 'attach_money',
       iconClasses: 'vads-u-margin-right--0 vads-u-margin-left--neg0p5',
-      links: HEALTH_TOOL_LINKS.PAYMENTS,
+      links: paymentsLinks,
     },
     {
       title: HEALTH_TOOL_HEADINGS.MEDICAL_SUPPLIES,

--- a/src/applications/mhv-landing-page/utilities/data/resolveLinks.js
+++ b/src/applications/mhv-landing-page/utilities/data/resolveLinks.js
@@ -29,9 +29,10 @@ export const toggleLink = (link, featureToggles = {}) => {
 //     e.g. in the case of a brand-new link with no `oldText`
 //     or in the event the link should be removed quickly and completely
 const filterOutHideableLinks = (links, featureToggles) => {
-  const shouldHideFilter = link =>
-    !isToggled(link.toggle, featureToggles) && link.hardToggle;
-  return links.filter(l => !shouldHideFilter(l));
+  return links.filter(
+    ({ toggle, hardToggle }) =>
+      !(!isToggled(toggle, featureToggles) && hardToggle),
+  );
 };
 
 const resolveLinks = (links, featureToggles) => {

--- a/src/applications/mhv-landing-page/utilities/data/resolveLinks.unit.spec.js
+++ b/src/applications/mhv-landing-page/utilities/data/resolveLinks.unit.spec.js
@@ -122,6 +122,24 @@ describe(`${manifest.appName} -- utilities/data/resolveLinks.js`, () => {
         ];
         expect(resolveLinks(links, toggles).length).to.eq(0);
       });
+
+      it('shows link or text when a link should not be hidden', () => {
+        const toggles = initializeFeatureToggles({ mhvLinkOneEnabled: false });
+        const links = [
+          {
+            href: '/test',
+            text: 'test',
+            toggle: 'mhv_link_one_enabled',
+            hardToggle: false,
+          },
+          {
+            href: '/test2',
+            text: 'test2',
+            toggle: 'mhv_link_one_enabled',
+          },
+        ];
+        expect(resolveLinks(links, toggles).length).to.eq(2);
+      });
     });
   });
 });

--- a/src/applications/mhv-landing-page/utilities/data/resolveLinks.unit.spec.js
+++ b/src/applications/mhv-landing-page/utilities/data/resolveLinks.unit.spec.js
@@ -60,6 +60,17 @@ describe(`${manifest.appName} -- utilities/data/resolveLinks.js`, () => {
       expect(result.href).to.equal('/new');
       expect(result.text).to.equal('New text');
     });
+
+    it('preserves external link status if present and true', () => {
+      const toggles = initializeFeatureToggles({});
+      const result = toggleLink(
+        { href: '/new', text: 'New text', isExternal: true },
+        toggles,
+      );
+      expect(result.href).to.equal('/new');
+      expect(result.text).to.equal('New text');
+      expect(result.isExternal).to.equal(true);
+    });
   });
 
   describe('resolveLinks', () => {
@@ -96,6 +107,21 @@ describe(`${manifest.appName} -- utilities/data/resolveLinks.js`, () => {
         },
       ];
       expect(resolveLinks(links, toggles).length).to.eq(1);
+    });
+
+    describe('hideable links', () => {
+      it('does not show link or text when a link should be hidden', () => {
+        const toggles = initializeFeatureToggles({ mhvLinkOneEnabled: false });
+        const links = [
+          {
+            href: '/test',
+            text: 'test',
+            toggle: 'mhv_link_one_enabled',
+            hardToggle: true,
+          },
+        ];
+        expect(resolveLinks(links, toggles).length).to.eq(0);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
We're in the process of migrating the Travel Pay status page from the existing BTSSS to VA.gov. In order to make sure the user experience is consistent when factoring in feature flags, we're proposing the following changes:

- Addition of a link to the Payments card of the MHV landing page. This link will direct users to a VA.gov page showing their travel pay claims
- Additions to `resolveLinks.js` including:
   - the ability to preserve the `isExternal` status of a link
   - the ability to completely remove a link if the feature flag is off (new link attribute: `hardToggle: true|false`

Team proposing changes: [VA.gov Travel Pay (BTSSS) Migration Team](https://dsva.slack.com/archives/C05UTPZRZFY)

## Requested Feedback
- Is there a better way to toggle a brand new link (i.e. no `oldText`/`oldHref`) that doesn't involve so many changes?
- Would you like another (separate) feature flag that more consistently matches the feature flag names you have currently?
- Any questions/comments? Happy to discuss here, in Slack or on a quick call.

## Related issue & discussion

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/84282
- [Slack discussion](https://dsva.slack.com/archives/C04DRS3L9NV/p1717595149897789)

## Testing done

- Previously:
  - There was no link to the internal travel pay status page
  - Including calling `resolveLandingPageLinks` with the `isInternal` flag set resulted in internal-link formatting
  - A disabled feature flag would default to show the old text/href. If there was no old text/href, toggling the feature flag had no effect and showed the current href/text
- Now:
  - An internal travel pay status page link exists on the landing page
  - `isExternal` status is preserved for all links
  - An additional property allows a link to be hidden if the new property (`hardToggle`) is true and the feature flag is disabled.

## Screenshots

<img width="530" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/462039/68b800a6-36a3-4a1c-bb31-96f7a515f7b2">

## What areas of the site does it impact?

* MHV Landing page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
