### PR TITLE
Changed the way abbreviations are presented in MHV Secondary Nav

### DIFF
--- a/src/platform/mhv/secondary-nav/components/MhvSecondaryNavItem.jsx
+++ b/src/platform/mhv/secondary-nav/components/MhvSecondaryNavItem.jsx
@@ -49,7 +49,7 @@ const MhvSecondaryNavItem = ({
         href={href}
         data-dd-action-name={actionName}
         className="vads-u-text-decoration--none"
-        aria-label={ariaLabel}
+        aria-label={abbreviation && ariaLabel}
         onClick={() => {
           recordEvent({
             event: 'nav-mhv-secondary',

--- a/src/platform/mhv/secondary-nav/components/MhvSecondaryNavItem.jsx
+++ b/src/platform/mhv/secondary-nav/components/MhvSecondaryNavItem.jsx
@@ -10,6 +10,7 @@ import { default as recordEventFn } from '~/platform/monitoring/record-event';
  * @property {string} href the link for the navigation item
  * @property {string} title the title for the navigation item
  * @property {string} abbreviation the abbreviation for the navigation item shown instead of the title when the width is less than 400px
+ * @property {string} ariaLabel aria label for a given abbreviation
  * @property {string} actionName the name of the action to be provided for DD monitoring purposes
  * @property {string} isActive true if the nav item is to be shown as active
  * @property {string} isHeader true if the nav item is to be shown as the header
@@ -20,18 +21,13 @@ const MhvSecondaryNavItem = ({
   href,
   title,
   abbreviation,
+  ariaLabel,
   actionName,
   isActive = false,
   isHeader = false,
   recordEvent = recordEventFn,
 }) => {
   const key = title.toLowerCase().replaceAll(' ', '_');
-  const mobileTitle = abbreviation ? (
-    <abbr title={title}>{abbreviation}</abbr>
-  ) : (
-    title
-  );
-
   const itemClass = classNames(
     'mhv-c-sec-nav-item',
     'vads-u-text-align--left',
@@ -42,7 +38,6 @@ const MhvSecondaryNavItem = ({
       'mhv-u-sec-nav-item-style': !isHeader,
     },
   );
-
   const titleClass = classNames({
     'vads-u-font-weight--bold': isActive,
     'vads-u-font-size--lg': isHeader,
@@ -54,6 +49,7 @@ const MhvSecondaryNavItem = ({
         href={href}
         data-dd-action-name={actionName}
         className="vads-u-text-decoration--none"
+        aria-label={ariaLabel}
         onClick={() => {
           recordEvent({
             event: 'nav-mhv-secondary',
@@ -69,7 +65,7 @@ const MhvSecondaryNavItem = ({
           {title}
         </span>
         <span className={`mhv-u-sec-nav-short-title ${titleClass}`}>
-          {mobileTitle}
+          {abbreviation || title}
         </span>
       </a>
     </div>
@@ -82,6 +78,7 @@ MhvSecondaryNavItem.propTypes = {
   title: PropTypes.string.isRequired,
   abbreviation: PropTypes.string,
   actionName: PropTypes.string,
+  ariaLabel: PropTypes.string,
   isActive: PropTypes.bool,
   isHeader: PropTypes.bool,
   recordEvent: PropTypes.func,

--- a/src/platform/mhv/secondary-nav/components/MhvSecondaryNavMenu.jsx
+++ b/src/platform/mhv/secondary-nav/components/MhvSecondaryNavMenu.jsx
@@ -88,6 +88,7 @@ MhvSecondaryNavMenu.propTypes = {
       title: PropTypes.string.isRequired,
       abbreviation: PropTypes.string,
       actionName: PropTypes.string,
+      ariaLabel: PropTypes.string,
       appRootUrl: PropTypes.string,
     }),
   ),

--- a/src/platform/mhv/secondary-nav/containers/MhvSecondaryNav.jsx
+++ b/src/platform/mhv/secondary-nav/containers/MhvSecondaryNav.jsx
@@ -30,6 +30,7 @@ export const mhvSecNavItems = [
     title: 'Appointments',
     actionName: `${actionPrefix} - Appointments`,
     abbreviation: 'Appts',
+    ariaLabel: 'Appointments',
     icon: 'calendar_today',
     href: `/my-health/appointments`,
   },

--- a/src/platform/mhv/secondary-nav/tests/MhvSecondaryNavItem.unit.spec.jsx
+++ b/src/platform/mhv/secondary-nav/tests/MhvSecondaryNavItem.unit.spec.jsx
@@ -25,7 +25,7 @@ describe('MHV Secondary Navigation Item Component', () => {
   });
 
   describe('handle abbreviations', () => {
-    it('when provided', () => {
+    it('when provided without arial label', () => {
       const title = 'a title';
       const abbr = 'an abbr';
       const { getAllByText } = render(
@@ -38,6 +38,28 @@ describe('MHV Secondary Navigation Item Component', () => {
       );
       expect(getAllByText(title).length).to.eql(1);
       expect(getAllByText(abbr).length).to.eql(1);
+      expect(getAllByText(title)[0].parentNode.getAttribute('aria-label')).to.be
+        .null;
+    });
+
+    it('when provided with aria label', () => {
+      const title = 'a title';
+      const abbr = 'an abbr';
+      const ariaLabel = 'a label';
+      const { getAllByText } = render(
+        <MhvSecondaryNavItem
+          title={title}
+          abbreviation={abbr}
+          ariaLabel={ariaLabel}
+          icon="home"
+          href="/my-health"
+        />,
+      );
+      expect(getAllByText(title).length).to.eql(1);
+      expect(getAllByText(abbr).length).to.eql(1);
+      expect(
+        getAllByText(title)[0].parentNode.getAttribute('aria-label'),
+      ).to.eql(ariaLabel);
     });
 
     it('when not provided', () => {
@@ -98,7 +120,7 @@ describe('MHV Secondary Navigation Item Component', () => {
 
   describe('reports custom events to GA', async () => {
     it('when a link is clicked', async () => {
-      const href = '/my-health/unit-test';
+      const href = '#/my-health/unit-test';
       const title = 'MhvSecondaryNavItem GA Event test';
 
       const event = {

--- a/src/platform/mhv/secondary-nav/tests/MhvSecondaryNavItem.unit.spec.jsx
+++ b/src/platform/mhv/secondary-nav/tests/MhvSecondaryNavItem.unit.spec.jsx
@@ -28,7 +28,7 @@ describe('MHV Secondary Navigation Item Component', () => {
     it('when provided without arial label', () => {
       const title = 'a title';
       const abbr = 'an abbr';
-      const { getAllByText } = render(
+      const { getAllByText, getByRole } = render(
         <MhvSecondaryNavItem
           title={title}
           abbreviation={abbr}
@@ -38,15 +38,14 @@ describe('MHV Secondary Navigation Item Component', () => {
       );
       expect(getAllByText(title).length).to.eql(1);
       expect(getAllByText(abbr).length).to.eql(1);
-      expect(getAllByText(title)[0].parentNode.getAttribute('aria-label')).to.be
-        .null;
+      expect(getByRole('link').getAttribute('aria-label')).to.be.null;
     });
 
     it('when provided with aria label', () => {
       const title = 'a title';
       const abbr = 'an abbr';
       const ariaLabel = 'a label';
-      const { getAllByText } = render(
+      const { getAllByText, getByLabelText } = render(
         <MhvSecondaryNavItem
           title={title}
           abbreviation={abbr}
@@ -57,25 +56,23 @@ describe('MHV Secondary Navigation Item Component', () => {
       );
       expect(getAllByText(title).length).to.eql(1);
       expect(getAllByText(abbr).length).to.eql(1);
-      expect(
-        getAllByText(title)[0].parentNode.getAttribute('aria-label'),
-      ).to.eql(ariaLabel);
+      expect(getByLabelText(ariaLabel)).to.exist;
     });
 
     it('when not provided', () => {
       const title = 'a title';
-      const { getAllByText } = render(
+      const ariaLabel = 'a label';
+      const { getAllByText, getByRole } = render(
         <MhvSecondaryNavItem
           title={title}
           icon="home"
           href="/my-health"
-          ariaLabel="some label"
+          ariaLabel={ariaLabel}
         />,
       );
       // The title and abbreviation are the same
       expect(getAllByText(title).length).to.eql(2);
-      expect(getAllByText(title)[0].parentNode.getAttribute('aria-label')).to.be
-        .null;
+      expect(getByRole('link').getAttribute('aria-label')).to.be.null;
     });
   });
 

--- a/src/platform/mhv/secondary-nav/tests/MhvSecondaryNavItem.unit.spec.jsx
+++ b/src/platform/mhv/secondary-nav/tests/MhvSecondaryNavItem.unit.spec.jsx
@@ -65,10 +65,17 @@ describe('MHV Secondary Navigation Item Component', () => {
     it('when not provided', () => {
       const title = 'a title';
       const { getAllByText } = render(
-        <MhvSecondaryNavItem title={title} icon="home" href="/my-health" />,
+        <MhvSecondaryNavItem
+          title={title}
+          icon="home"
+          href="/my-health"
+          ariaLabel="some label"
+        />,
       );
       // The title and abbreviation are the same
       expect(getAllByText(title).length).to.eql(2);
+      expect(getAllByText(title)[0].parentNode.getAttribute('aria-label')).to.be
+        .null;
     });
   });
 


### PR DESCRIPTION
## Summary
See related issue for a more in-depth explanation of the changes. This PR removes the use of the `abbr` element and replaces it with the use of `aria-label`.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/84242

## Testing done
- Added unit tests
- Manual testing:
  - Load the MHV Landing page with the secondary nav enabled.
  - Use a screen reader to navigate the secondary nav items in mobile view and verify that `Appts` reads `Appointments` when using the screen reader.

## Screenshots
There were no changes to the UI.

## What areas of the site does it impact?
- MHV Secondary Navigation

## Acceptance criteria
- Remove the use of `abbr` which has inconsistent implementations in screen readers and voice control.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

