### PR TITLE
83660c small copy changes to medicare and insurance sections - form 10-7959c

### DIFF
--- a/src/applications/ivc-champva/10-10D/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/IntroductionPage.jsx
@@ -148,7 +148,7 @@ const IntroductionPage = props => {
 };
 
 IntroductionPage.propTypes = {
-  isLoggedIn: PropTypes.func,
+  isLoggedIn: PropTypes.bool,
   route: PropTypes.object,
 };
 

--- a/src/applications/ivc-champva/10-7959C/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/applicantInformation.js
@@ -26,7 +26,10 @@ export const applicantNameDobSchema = {
   uiSchema: {
     ...titleUI('Beneficiary’s name and date of birth'),
     applicantName: fullNameMiddleInitialUI,
-    applicantDOB: dateOfBirthUI({ required: true }),
+    applicantDOB: dateOfBirthUI({
+      required: true,
+      hint: 'For example: January 19 2000',
+    }),
   },
   schema: {
     type: 'object',

--- a/src/applications/ivc-champva/10-7959C/chapters/healthInsuranceInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/healthInsuranceInformation.js
@@ -12,8 +12,7 @@ import {
   yesNoUI,
   yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { requiredFiles } from '../config/constants';
-import { isRequiredFile, nameWording } from '../helpers/utilities';
+import { nameWording } from '../helpers/utilities';
 import {
   fileWithMetadataSchema,
   fileUploadBlurb,
@@ -445,15 +444,12 @@ export function applicantInsuranceCardSchema(isPrimary) {
   return {
     uiSchema: {
       ...titleUI(
-        ({ formData, formContext }) =>
+        ({ formData }) =>
           `Upload ${
             isPrimary
               ? formData?.applicantPrimaryProvider
               : formData?.applicantSecondaryProvider
-          } ${val} health insurance cards ${isRequiredFile(
-            formContext,
-            requiredFiles,
-          )}`,
+          } ${val} health insurance card`,
         () => {
           return (
             <>

--- a/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
@@ -349,7 +349,7 @@ export const applicantMedicareDUploadSchema = {
     }),
     ...fileUploadBlurb,
     applicantMedicarePartDCard: fileUploadUI({
-      label: 'Upload Medicare card',
+      label: 'Upload Medicare Part D card',
     }),
   },
   schema: {

--- a/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
@@ -127,7 +127,7 @@ export const applicantMedicarePharmacySchema = {
             )} Medicare plan provide pharmacy benefits?`,
             'ui:options': {
               hint:
-                'You can find this information ont he front of your Medicare card.',
+                'You can find this information on the front of your Medicare card.',
             },
           };
         },
@@ -235,7 +235,6 @@ export const applicantMedicareABUploadSchema = {
               </li>
               <li>Medicare PACE card</li>
             </ul>
-            <br />
             You can also upload any other supporting documents you may have for
             this Medicare plan.
             <br />

--- a/src/applications/ivc-champva/10-7959C/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959C/containers/App.jsx
@@ -23,17 +23,14 @@ const breadcrumbList = [
 ];
 
 export default function App({ location, children }) {
-  // Insert CSS to hide 'For example: January 19 2000' hint on memorable dates
-  // (can't be overridden by passing 'hint' to uiOptions):
-  const urls = [
-    formConfig.chapters.healthcareInformation.pages.primaryProvider.path,
-    formConfig.chapters.healthcareInformation.pages.secondaryProvider.path,
-  ];
-  const targets = ['va-memorable-date'];
-  const css = '#dateHint {display: none}';
-
   useEffect(() => {
-    addStyleToShadowDomOnPages(urls, targets, css);
+    // Insert CSS to hide 'For example: January 19 2000' hint on memorable dates
+    // (can't be overridden by passing 'hint' to uiOptions):
+    addStyleToShadowDomOnPages(
+      [''],
+      ['va-memorable-date'],
+      '#dateHint {display: none}',
+    );
   });
 
   return (

--- a/src/applications/ivc-champva/10-7959C/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959C/containers/IntroductionPage.jsx
@@ -112,7 +112,7 @@ const IntroductionPage = props => {
 };
 
 IntroductionPage.propTypes = {
-  isLoggedIn: PropTypes.func,
+  isLoggedIn: PropTypes.bool,
   route: PropTypes.object,
 };
 

--- a/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
@@ -93,7 +93,7 @@ const IntroductionPage = props => {
 };
 
 IntroductionPage.propTypes = {
-  isLoggedIn: PropTypes.func,
+  isLoggedIn: PropTypes.bool,
   route: PropTypes.object,
 };
 

--- a/src/applications/ivc-champva/10-7959f-2/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-2/containers/IntroductionPage.jsx
@@ -89,7 +89,7 @@ const IntroductionPage = props => {
 };
 
 IntroductionPage.propTypes = {
-  isLoggedIn: PropTypes.func,
+  isLoggedIn: PropTypes.bool,
   route: PropTypes.object,
 };
 

--- a/src/applications/ivc-champva/shared/utilities.js
+++ b/src/applications/ivc-champva/shared/utilities.js
@@ -78,7 +78,7 @@ export function getAgeInYears(date) {
  * )
  * ```
  *
- * @param {Array} urlArray Array of page URLs where these styles should be applied
+ * @param {Array} urlArray Array of page URLs where these styles should be applied - to target all URLs, use value: ['']
  * @param {Array} targetElements Array of HTML elements we want to inject styles into, e.g.: ['va-select', 'va-radio']
  * @param {String} style String of CSS to inject into the specified elements on the specified pages
  */


### PR DESCRIPTION
## Summary

This PR makes the following copy changes

### Medicare
- medicare-pharmacy screen: Fix typo "ont he front" to "on the front"
- Remove all "for example: january" text everywhere except applicant DOB
- Remove extra space below "Medicare PACE card" on upload screen
- Update label above upload button on medicare part D upload screen
### Healthcare
- Update insurance-upload header to read "...health insurance card" singular     and drop "(required)"
### Misc
- Fixed proptype warning when using `isLoggedIn`


## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83660
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83658

## Testing done

- Manual

## Screenshots

|         |  After |
| ------- |  ----- |
| Date hints gone |![Screenshot 2024-06-10 at 11 17 30](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/a2ba8b22-6d28-42aa-8f77-b9a9444dd4eb)|
| Removed extra space under "PACE card" |![Screenshot 2024-06-10 at 11 18 30](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/907c4b02-7f63-4f09-b526-c14fa64461b0)|
| Part D upload label |![Screenshot 2024-06-10 at 11 31 12](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/caeb51f2-ef58-4dd1-9e7e-491411df5470)
| Health card header |![Screenshot 2024-06-10 at 11 20 54](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/a5fa5b02-654f-47af-a50d-113873b6cbb3)|

## What areas of the site does it impact?

IVC forms only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA