### PR TITLE
Remove mhv route guard from AVS

### DIFF
--- a/src/applications/avs/routes.jsx
+++ b/src/applications/avs/routes.jsx
@@ -1,20 +1,15 @@
 import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 import PageNotFound from '@department-of-veterans-affairs/platform-site-wide/PageNotFound';
-import { useMyHealthAccessGuard } from '~/platform/mhv/hooks/useMyHealthAccessGuard';
 import ErrorBoundary from './components/ErrorBoundary';
 
 import Avs from './containers/Avs';
 
-const ErrorBoundaryWrapper = props => {
-  useMyHealthAccessGuard();
-
-  return (
-    <ErrorBoundary>
-      <Avs {...props} />
-    </ErrorBoundary>
-  );
-};
+const ErrorBoundaryWrapper = props => (
+  <ErrorBoundary>
+    <Avs {...props} />
+  </ErrorBoundary>
+);
 
 const routes = (
   <Switch>


### PR DESCRIPTION
This PR removes the `useMyHealthAccessGuard` route guard from AVS. The `useMyHealthAccessGuard` route guard relies on the property `mhvAccountState` from the vets-api but AVS depends on data from the AVS-API instead. 

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

