### PR TITLE
[FSR] 83576 Adding tests for new expense page functionality

### DIFF
--- a/src/applications/financial-status-report/tests/e2e/fixtures/data/fsr-maximal.json
+++ b/src/applications/financial-status-report/tests/e2e/fixtures/data/fsr-maximal.json
@@ -390,6 +390,7 @@
     "view:streamlinedWaiver": true,
     "view:streamlinedWaiverAssetUpdate": true,
     "view:reviewPageNavigationToggle": true,
+    "view:showUpdatedExpensePages": true,
     "income": [
     {
         "veteranOrSpouse":   "VETERAN"

--- a/src/applications/financial-status-report/tests/e2e/fixtures/data/initial-expenses.json
+++ b/src/applications/financial-status-report/tests/e2e/fixtures/data/initial-expenses.json
@@ -1,0 +1,116 @@
+{
+  "data": {
+    "view:components": {
+      "view:veteranInfo": {},
+      "view:maritalStatus": {},
+      "view:dependentsAdditionalInfo": {},
+      "view:vaBenefitsOnFile": {},
+      "view:realEstateAdditionalInfo": {},
+      "view:recVehicleInfo": {},
+      "view:contractsAdditionalInfo": {}
+    },
+    "personalData": {
+      "veteranFullName": {
+        "first": "Brendan",
+        "last": "Eich",
+        "middle": "JS"
+      },
+      "dateOfBirth": "1950-09-06",
+      "veteranContactInformation": {
+        "email": "test@user.com",
+        "mobilePhone": {
+          "areaCode": "505",
+          "countryCode": "1",
+          "createdAt": "2023-08-10T14:15:12.000+00:00",
+          "extension": null,
+          "effectiveEndDate": null,
+          "effectiveStartDate": "2023-08-14T16:56:53.000+00:00",
+          "id": 375052,
+          "isInternational": false,
+          "isTextable": null,
+          "isTextPermitted": null,
+          "isTty": null,
+          "isVoicemailable": null,
+          "phoneNumber": "2700638",
+          "phoneType": "MOBILE",
+          "sourceDate": "2023-08-14T16:56:53.000+00:00",
+          "sourceSystemUser": null,
+          "transactionId": "05f6f7a0-997b-40b0-8a02-ade3b7b1da39",
+          "updatedAt": "2023-08-14T16:56:56.000+00:00",
+          "vet360Id": "134281"
+        },
+        "address": {
+          "addressLine1": "1060 W Addison St",
+          "addressPou": "CORRESPONDENCE",
+          "addressType": "DOMESTIC",
+          "city": "Chicago",
+          "countryName": "United States",
+          "countryCodeIso2": "US",
+          "countryCodeIso3": "USA",
+          "countryCodeFips": null,
+          "countyCode": null,
+          "countyName": "Cook County",
+          "createdAt": "2024-03-19T15:34:10.000Z",
+          "effectiveEndDate": null,
+          "effectiveStartDate": "2024-03-19T15:34:10.000Z",
+          "geocodeDate": "2024-03-19T15:34:10.000Z",
+          "geocodePrecision": 32.0,
+          "id": 19652768,
+          "internationalPostalCode": null,
+          "latitude": 41.9475,
+          "longitude": -87.6547,
+          "province": null,
+          "sourceDate": "2024-03-19T15:34:10.000Z",
+          "sourceSystemUser": null,
+          "stateCode": "IL",
+          "transactionId": "a8f8153f-92dd-4ea5-93ae-5fe2a6ba8e2f",
+          "updatedAt": "2024-03-19T15:34:10.000Z",
+          "validationKey": null,
+          "vet360Id": "21306345",
+          "zipCode": "60613",
+          "zipCodeSuffix": null,
+          "badAddress": false
+        }
+      },
+      "spouseFullName": {},
+      "address": {
+        "street": "1060 W Addison St",
+        "city": "Chicago",
+        "state": "IL",
+        "country": "USA",
+        "postalCode": "60613"
+      },
+      "telephoneNumber": "6304825671",
+      "emailAddress": "test@user.com"
+    },
+    "personalIdentification": {
+      "ssn": "3018",
+      "fileNumber": "3018"
+    },
+    "selectedDebtsAndCopays": [],
+    "questions": {},
+    "additionalIncome": {
+      "spouse": {}
+    },
+    "benefits": {
+      "spouseBenefits": {}
+    },
+    "assets": {},
+    "expenses": {},
+    "additionalData": {
+      "bankruptcy": {}
+    },
+    "view:enhancedFinancialStatusReport": true,
+    "view:streamlinedWaiver": true,
+    "view:streamlinedWaiverAssetUpdate": true,
+    "view:reviewPageNavigationToggle": true,
+    "view:showUpdatedExpensePages": true,
+    "income": [
+      {
+        "veteranOrSpouse": "VETERAN",
+        "compensationAndPension": "3261.1",
+        "education": "50"
+      }
+    ]
+  }
+}

--- a/src/applications/financial-status-report/tests/e2e/fixtures/data/initial.json
+++ b/src/applications/financial-status-report/tests/e2e/fixtures/data/initial.json
@@ -103,7 +103,7 @@
     "view:enhancedFinancialStatusReport": true,
     "view:streamlinedWaiver": true,
     "view:streamlinedWaiverAssetUpdate": true,
-    "view:reviewPageNavigationToggle": false,
+    "view:reviewPageNavigationToggle": true,
     "income": [
       {
         "veteranOrSpouse": "VETERAN",

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-complete.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-complete.cypress.spec.js
@@ -34,7 +34,7 @@ const testConfig = createTestConfig(
   {
     dataPrefix: 'data',
     // starting with no data, so form is filled with navigation
-    dataSets: ['initial'],
+    dataSets: ['initial', 'initial-expenses'],
     fixtures: { data: path.join(__dirname, 'fixtures', 'data') },
 
     setupPerTest: () => {
@@ -483,6 +483,17 @@ const testConfig = createTestConfig(
             .shadow()
             .find('input')
             .type('123');
+          cy.get('.usa-button-primary').click();
+        });
+      },
+      // only shows if showUpdatedExpensePages is active
+      'monthly-housing-expenses': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('va-text-input')
+            .first()
+            .shadow()
+            .find('input')
+            .type('1200');
           cy.get('.usa-button-primary').click();
         });
       },

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-complete.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-complete.cypress.spec.js
@@ -18,6 +18,10 @@ import {
   verifyEditPage,
 } from './pages/ChecklistSummaryFlow';
 import { data } from './fixtures/data/fsr-maximal.json';
+import {
+  otherLivingExpensesOptions,
+  otherLivingExpensesList,
+} from '../../constants/checkboxSelections';
 
 Cypress.config('waitForAnimations', true);
 
@@ -638,6 +642,18 @@ const testConfig = createTestConfig(
       },
       'other-expenses-checklist': ({ afterHook }) => {
         afterHook(() => {
+          // check testData to see if assets feature flag is true to udpate the length the checkbox should be
+          cy.get('@testData').then(testData => {
+            const otherExpenseChecklistLength = testData[
+              'view:showUpdatedExpensePages'
+            ]
+              ? otherLivingExpensesList.length
+              : otherLivingExpensesOptions.length;
+
+            cy.get('[type=checkbox]')
+              .as('checklist')
+              .should('have.length', otherExpenseChecklistLength);
+          });
           fillChecklist(otherExpenses);
           cy.get('.usa-button-primary').click();
         });

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-complete.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-complete.cypress.spec.js
@@ -7,7 +7,6 @@ import formConfig from '../../config/form';
 import manifest from '../../manifest.json';
 import mockUser from './fixtures/mocks/mockUser.json';
 import mockStatus from './fixtures/mocks/profile-status.json';
-import saveInProgress from './fixtures/mocks/saveInProgress.json';
 import debts from './fixtures/mocks/debts.json';
 import copays from './fixtures/mocks/copays.json';
 import { customButtonGroupContinue } from './fixtures/helpers';
@@ -40,6 +39,7 @@ const testConfig = createTestConfig(
 
     setupPerTest: () => {
       sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);
+
       cy.intercept('GET', '/v0/feature_toggles*', {
         data: {
           features: [
@@ -58,7 +58,14 @@ const testConfig = createTestConfig(
 
       cy.get('@testData').then(testData => {
         cy.intercept('PUT', '/v0/in_progress_forms/5655', testData);
-        cy.intercept('GET', '/v0/in_progress_forms/5655', saveInProgress);
+        cy.intercept('GET', '/v0/in_progress_forms/5655', {
+          formData: testData,
+          metadata: {
+            version: 0,
+            prefill: true,
+            returnUrl: '/veteran-information',
+          },
+        });
       });
 
       cy.intercept('GET', '/v0/debts', debts);
@@ -299,9 +306,17 @@ const testConfig = createTestConfig(
       },
       'monetary-asset-checklist': ({ afterHook }) => {
         afterHook(() => {
-          cy.get('[type=checkbox]')
-            .as('checklist')
-            .should('have.length', 8);
+          // check testData to see if assets feature flag is true to udpate the length the checkbox should be
+          cy.get('@testData').then(testData => {
+            const monetaryAssetChecklistLength = testData[
+              'view:streamlinedWaiverAssetUpdate'
+            ]
+              ? 5
+              : 8;
+            cy.get('[type=checkbox]')
+              .as('checklist')
+              .should('have.length', monetaryAssetChecklistLength);
+          });
           cy.get('@checklist')
             .eq(0)
             .click();
@@ -317,16 +332,33 @@ const testConfig = createTestConfig(
           cy.get('va-number-input')
             .as('numberInputs')
             .should('have.length', 2);
-          cy.get('#Cash0')
-            .first()
-            .shadow()
-            .find('input')
-            .type('1000');
-          cy.get('[id="Checking accounts1"]')
-            .first()
-            .shadow()
-            .find('input')
-            .type('1500');
+
+          // check testData to see if assets feature flag is true to udpate the length the checkbox should be
+          cy.get('@testData').then(testData => {
+            if (testData['view:streamlinedWaiverAssetUpdate']) {
+              cy.get('[id="U.S. Savings Bonds0"]')
+                .first()
+                .shadow()
+                .find('input')
+                .type('1000');
+              cy.get('[id="Retirement accounts (401k, IRAs, 403b, TSP)1"]')
+                .first()
+                .shadow()
+                .find('input')
+                .type('1500');
+            } else {
+              cy.get('#Cash0')
+                .first()
+                .shadow()
+                .find('input')
+                .type('1000');
+              cy.get('[id="Checking accounts1"]')
+                .first()
+                .shadow()
+                .find('input')
+                .type('1500');
+            }
+          });
           cy.get('.usa-button-primary').click();
         });
       },
@@ -707,7 +739,7 @@ const testConfig = createTestConfig(
             .shadow()
             .find('input')
             .first()
-            .type('Mark Webb');
+            .type('Brendan JS Eich');
           cy.get(`va-checkbox[name="veteran-certify"]`)
             .shadow()
             .find('input')


### PR DESCRIPTION
## Summary
Adding e2e tests for expense page changes that include:
- Inputting value for new `monthly-housing-expenses` page
- Checking length of options for 'other expense' page
- **[FIX]** Updated test response for `/v0/in_progress_forms/5655` in the `complete` test
  - This update prevents the initial data from being overwritten immediately, and keeps consistent feature flag for testing

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#83576
- Previous change that implemented new page and checklist update
department-of-veterans-affairs/vets-website#29829

## Testing done
Tests are passing locally

## Screenshots
N / A

## What areas of the site does it impact?
FSR 
*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
