### PR TITLE
add console.log messages to focus calls used on revisedAddDisabilities

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -18,6 +18,7 @@ import {
 } from 'platform/forms-system/src/js/utilities/ui';
 import { setArrayRecordTouched } from 'platform/forms-system/src/js/helpers';
 import { errorSchemaIsValid } from 'platform/forms-system/src/js/validation';
+import { showRevisedNewDisabilitiesPage } from '../content/addDisabilities';
 
 import findDuplicateIndexes from 'platform/forms-system/src/js/utilities/data/findDuplicateIndexes';
 
@@ -142,6 +143,9 @@ export default class ArrayField extends React.Component {
 
   focusOnEditButton = index => {
     const editButton = this.findElementsFromIndex(-1, '.edit');
+    if (showRevisedNewDisabilitiesPage()) {
+      console.log('focusing on edit button ', editButton[index]);
+    }
     focusElement(editButton[index]);
   };
 
@@ -149,6 +153,9 @@ export default class ArrayField extends React.Component {
     this.scrollToRow(`${this.props.idSchema.$id}_${index}`);
     // Focus on first label
     const labels = this.findElementsFromIndex(index, 'label, legend');
+    if (showRevisedNewDisabilitiesPage()) {
+      console.log('focusing on label', labels[0]);
+    }
     focusElement(labels[0]);
   };
 
@@ -158,6 +165,9 @@ export default class ArrayField extends React.Component {
       index,
       '.usa-input-error-message',
     );
+    if (showRevisedNewDisabilitiesPage()) {
+      console.log('focusing on error msg', errorMessage[0]);
+    }
     focusElement(errorMessage[0]);
   };
 

--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -18,9 +18,8 @@ import {
 } from 'platform/forms-system/src/js/utilities/ui';
 import { setArrayRecordTouched } from 'platform/forms-system/src/js/helpers';
 import { errorSchemaIsValid } from 'platform/forms-system/src/js/validation';
-import { showRevisedNewDisabilitiesPage } from '../content/addDisabilities';
-
 import findDuplicateIndexes from 'platform/forms-system/src/js/utilities/data/findDuplicateIndexes';
+import { showRevisedNewDisabilitiesPage } from '../content/addDisabilities';
 
 import { NULL_CONDITION_STRING } from '../constants';
 
@@ -144,6 +143,7 @@ export default class ArrayField extends React.Component {
   focusOnEditButton = index => {
     const editButton = this.findElementsFromIndex(-1, '.edit');
     if (showRevisedNewDisabilitiesPage()) {
+      // eslint-disable-next-line no-console
       console.log('focusing on edit button ', editButton[index]);
     }
     focusElement(editButton[index]);
@@ -154,6 +154,7 @@ export default class ArrayField extends React.Component {
     // Focus on first label
     const labels = this.findElementsFromIndex(index, 'label, legend');
     if (showRevisedNewDisabilitiesPage()) {
+      // eslint-disable-next-line no-console
       console.log('focusing on label', labels[0]);
     }
     focusElement(labels[0]);
@@ -166,6 +167,7 @@ export default class ArrayField extends React.Component {
       '.usa-input-error-message',
     );
     if (showRevisedNewDisabilitiesPage()) {
+      // eslint-disable-next-line no-console
       console.log('focusing on error msg', errorMessage[0]);
     }
     focusElement(errorMessage[0]);
@@ -182,6 +184,10 @@ export default class ArrayField extends React.Component {
   handleCancelEdit = index => {
     this.props.onChange(this.state.oldData);
     this.setState(set(['editing', index], false, this.state), () => {
+      if (showRevisedNewDisabilitiesPage()) {
+        // eslint-disable-next-line no-console
+        console.log('calling focusOnEditButton from handleCancelEdit()', index);
+      }
       this.focusOnEditButton(index);
     });
   };
@@ -213,6 +219,10 @@ export default class ArrayField extends React.Component {
     if (errorSchemaIsValid(this.props.errorSchema[index])) {
       this.setState(set(['editing', index], false, this.state), () => {
         this.scrollToTop();
+        if (showRevisedNewDisabilitiesPage()) {
+          // eslint-disable-next-line no-console
+          console.log('calling focusOnEditButton from handleUpdate()', index);
+        }
         this.focusOnEditButton(index);
       });
     } else {
@@ -241,6 +251,13 @@ export default class ArrayField extends React.Component {
         },
         () => {
           // Focus on edit button after saving
+          if (showRevisedNewDisabilitiesPage()) {
+            // eslint-disable-next-line no-console
+            console.log(
+              'calling focusOnEditButton from handleSave()',
+              lastIndex,
+            );
+          }
           this.focusOnEditButton(lastIndex);
         },
       );

--- a/src/applications/disability-benefits/all-claims/components/ComboBox.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ComboBox.jsx
@@ -65,6 +65,7 @@ export class ComboBox extends React.Component {
         value: searchTerm,
         filteredOptions: [],
       });
+      console.log('sending focus to input from handleClickOutsideList');
       this.sendFocusToInput(this.inputRef);
     }
   };
@@ -80,6 +81,7 @@ export class ComboBox extends React.Component {
     });
     this.props.onChange(newTextValue);
     // send focus back to input after selection in case user wants to append something else
+    console.log('sending focus to input from handleSearchChange');
     this.sendFocusToInput(this.inputRef);
   };
 
@@ -91,6 +93,7 @@ export class ComboBox extends React.Component {
   sendFocusToInput = ref => {
     const { shadowRoot } = ref.current;
     const input = shadowRoot.querySelector('input');
+    console.log('sendFocusToInput() called. Input: ', input);
     input.focus();
   };
 
@@ -138,12 +141,14 @@ export class ComboBox extends React.Component {
           filteredOptions: [],
           highlightedIndex: 0,
         });
+        console.log('sending focus to input from escape');
         this.sendFocusToInput(this.inputRef);
         e.preventDefault();
         break;
       // All other cases treat as regular user input into the text field.
       default:
         // focus goes to input box by default
+        console.log('sending focus to input from default');
         this.sendFocusToInput(this.inputRef);
         // highlight dynamic free text option
         this.setState({ highlightedIndex: 0 });
@@ -225,6 +230,7 @@ export class ComboBox extends React.Component {
     const { onChange } = this.props;
     onChange(option);
     // Send focus to input element for additional user input.
+    console.log('sending focus to input from selectOption');
     this.sendFocusToInput(this.inputRef);
   }
 

--- a/src/applications/disability-benefits/all-claims/components/ComboBox.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ComboBox.jsx
@@ -65,6 +65,7 @@ export class ComboBox extends React.Component {
         value: searchTerm,
         filteredOptions: [],
       });
+      // eslint-disable-next-line no-console
       console.log('sending focus to input from handleClickOutsideList');
       this.sendFocusToInput(this.inputRef);
     }
@@ -81,6 +82,7 @@ export class ComboBox extends React.Component {
     });
     this.props.onChange(newTextValue);
     // send focus back to input after selection in case user wants to append something else
+    // eslint-disable-next-line no-console
     console.log('sending focus to input from handleSearchChange');
     this.sendFocusToInput(this.inputRef);
   };
@@ -93,6 +95,7 @@ export class ComboBox extends React.Component {
   sendFocusToInput = ref => {
     const { shadowRoot } = ref.current;
     const input = shadowRoot.querySelector('input');
+    // eslint-disable-next-line no-console
     console.log('sendFocusToInput() called. Input: ', input);
     input.focus();
   };
@@ -141,6 +144,7 @@ export class ComboBox extends React.Component {
           filteredOptions: [],
           highlightedIndex: 0,
         });
+        // eslint-disable-next-line no-console
         console.log('sending focus to input from escape');
         this.sendFocusToInput(this.inputRef);
         e.preventDefault();
@@ -148,6 +152,7 @@ export class ComboBox extends React.Component {
       // All other cases treat as regular user input into the text field.
       default:
         // focus goes to input box by default
+        // eslint-disable-next-line no-console
         console.log('sending focus to input from default');
         this.sendFocusToInput(this.inputRef);
         // highlight dynamic free text option
@@ -230,6 +235,7 @@ export class ComboBox extends React.Component {
     const { onChange } = this.props;
     onChange(option);
     // Send focus to input element for additional user input.
+    // eslint-disable-next-line no-console
     console.log('sending focus to input from selectOption');
     this.sendFocusToInput(this.inputRef);
   }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- On mobile screenreaders, the incorrect element is focused after saving a conditon on the [revisedAddDisabilities](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/disability-benefits/all-claims/pages/addDisabilitiesRevised.js) page.
- I added several `console.log()` statements before `.focus()` is called in the javascript in order to debug what is happening when the wrong element is focused. (see slack thread [here](https://dsva.slack.com/archives/C04AZ8T7XN1/p1717784964430969?thread_ts=1716930732.421339&cid=C04AZ8T7XN1)).

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vagov-claim-classification/issues/493

## Testing done

- ran through the 526-ez locally, but need to access the page from a mobile device (not able to reproduce issue w/ mobile view from chrome dev tools on desktop)

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
