### PR TITLE
10 7959f 1 mask ssn prefill

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -2,8 +2,7 @@ import environment from '@department-of-veterans-affairs/platform-utilities/envi
 import { cloneDeep } from 'lodash';
 
 import {
-  ssnOrVaFileNumberSchema,
-  ssnOrVaFileNumberNoHintUI,
+  ssnOrVaFileNumberNoHintSchema,
   fullNameUI,
   fullNameSchema,
   titleUI,
@@ -26,6 +25,7 @@ import ConfirmationPage from '../containers/ConfirmationPage';
 import GetFormHelp from '../../shared/components/GetFormHelp';
 
 // import mockdata from '../tests/e2e/fixtures/data/test-data.json';
+import { ssnOrVaFileNumberCustomUI } from '../helpers/CustomSSN';
 
 const veteranFullNameUI = cloneDeep(fullNameUI());
 veteranFullNameUI.middle['ui:title'] = 'Middle initial';
@@ -118,14 +118,14 @@ const formConfig = {
             ),
             messageAriaDescribedby:
               'You must enter either a Social Security number or VA file number.',
-            veteranSocialSecurityNumber: ssnOrVaFileNumberNoHintUI(),
+            veteranSocialSecurityNumber: ssnOrVaFileNumberCustomUI(),
           },
           schema: {
             type: 'object',
             required: ['veteranSocialSecurityNumber'],
             properties: {
               titleSchema,
-              veteranSocialSecurityNumber: ssnOrVaFileNumberSchema,
+              veteranSocialSecurityNumber: ssnOrVaFileNumberNoHintSchema,
             },
           },
         },

--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -25,7 +25,10 @@ import ConfirmationPage from '../containers/ConfirmationPage';
 import GetFormHelp from '../../shared/components/GetFormHelp';
 
 // import mockdata from '../tests/e2e/fixtures/data/test-data.json';
-import { ssnOrVaFileNumberCustomUI } from '../helpers/CustomSSN';
+import {
+  ssnOrVaFileNumberCustomUI,
+  CustomSSNReviewPage,
+} from '../helpers/CustomSSN';
 
 const veteranFullNameUI = cloneDeep(fullNameUI());
 veteranFullNameUI.middle['ui:title'] = 'Middle initial';
@@ -128,6 +131,7 @@ const formConfig = {
               veteranSocialSecurityNumber: ssnOrVaFileNumberNoHintSchema,
             },
           },
+          CustomPageReview: CustomSSNReviewPage,
         },
       },
     },

--- a/src/applications/ivc-champva/10-7959f-1/helpers/CustomSSN.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/helpers/CustomSSN.jsx
@@ -9,7 +9,7 @@ const SSN_DEFAULT_TITLE = 'Social Security number';
 const customSSNUI = title => {
   return {
     'ui:title': title ?? SSN_DEFAULT_TITLE,
-    'ui:webComponentField': HandlePrefilledSSN(),
+    'ui:webComponentField': HandlePrefilledSSN,
     'ui:reviewWidget': SSNReviewWidget,
     'ui:validations': [validateSSN],
     'ui:errorMessages': {
@@ -20,7 +20,6 @@ const customSSNUI = title => {
   };
 };
 
-// Using different hint text from the standard ssnOrVaFileNumberUI
 export const ssnOrVaFileNumberCustomUI = () => {
   return {
     ssn: customSSNUI(),

--- a/src/applications/ivc-champva/10-7959f-1/helpers/CustomSSN.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/helpers/CustomSSN.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { validateSSN } from 'platform/forms-system/src/js/validation';
@@ -29,13 +28,9 @@ export const ssnOrVaFileNumberCustomUI = () => {
     ssn: customSSNUI(),
     vaFileNumber: {
       ...vaFileNumberUI(),
-      'ui:options': {
-        hint:
-          'Enter this number only if it’s different than the Social Security number',
-      },
     },
     'ui:options': {
-      updateSchema: (formData, _schema, _uiSchema, path) => {
+      updateSchema: (formData, _schema, _uiSchema, index, path) => {
         const { ssn, vaFileNumber } = get(path, formData) ?? {};
 
         let required = ['ssn'];
@@ -53,7 +48,6 @@ export const ssnOrVaFileNumberCustomUI = () => {
 };
 
 export function CustomSSNReviewPage(props) {
-  console.log('props', props);
   const maskedSSN = maskSSN(props?.data?.veteranSocialSecurityNumber?.ssn);
   return props.data ? (
     <div className="form-review-panel-page">

--- a/src/applications/ivc-champva/10-7959f-1/helpers/CustomSSN.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/helpers/CustomSSN.jsx
@@ -1,4 +1,6 @@
+import React from 'react';
 import { validateSSN } from 'platform/forms-system/src/js/validation';
+import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import SSNReviewWidget from 'platform/forms-system/src/js/review/SSNWidget';
 import get from 'platform/utilities/data/get';
 import { vaFileNumberUI } from 'platform/forms-system/src/js/web-component-patterns';
@@ -47,3 +49,24 @@ export const ssnOrVaFileNumberCustomUI = () => {
     },
   };
 };
+
+// TODO: Needs safety checks, prop validation, and maybe some work on the title
+export function CustomSSNReviewPage(props) {
+  return props.data ? (
+    <div className="form-review-panel-page">
+      <div className="form-review-panel-page-header-row">
+        <h4 className="form-review-panel-page-header vads-u-font-size--h5">
+          {props?.title}
+        </h4>
+        <VaButton secondary onClick={props?.editPage} text="Edit" uswds />
+      </div>
+      <dl className="review">
+        <div className="review-row">
+          <dt>SSN</dt>
+          {/* TODO: mask the SSN */}
+          <dd>{props?.data?.veteranSocialSecurityNumber?.ssn}</dd>
+        </div>
+      </dl>
+    </div>
+  ) : null;
+}

--- a/src/applications/ivc-champva/10-7959f-1/helpers/CustomSSN.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/helpers/CustomSSN.jsx
@@ -1,10 +1,12 @@
+/* eslint-disable no-console */
 import React from 'react';
+import PropTypes from 'prop-types';
 import { validateSSN } from 'platform/forms-system/src/js/validation';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import SSNReviewWidget from 'platform/forms-system/src/js/review/SSNWidget';
 import get from 'platform/utilities/data/get';
 import { vaFileNumberUI } from 'platform/forms-system/src/js/web-component-patterns';
-import HandlePrefilledSSN from './maskSSN';
+import HandlePrefilledSSN, { maskSSN } from './maskSSN';
 
 const SSN_DEFAULT_TITLE = 'Social Security number';
 
@@ -33,7 +35,7 @@ export const ssnOrVaFileNumberCustomUI = () => {
       },
     },
     'ui:options': {
-      updateSchema: (formData, _schema, _uiSchema, index, path) => {
+      updateSchema: (formData, _schema, _uiSchema, path) => {
         const { ssn, vaFileNumber } = get(path, formData) ?? {};
 
         let required = ['ssn'];
@@ -50,8 +52,9 @@ export const ssnOrVaFileNumberCustomUI = () => {
   };
 };
 
-// TODO: Needs safety checks, prop validation, and maybe some work on the title
 export function CustomSSNReviewPage(props) {
+  console.log('props', props);
+  const maskedSSN = maskSSN(props?.data?.veteranSocialSecurityNumber?.ssn);
   return props.data ? (
     <div className="form-review-panel-page">
       <div className="form-review-panel-page-header-row">
@@ -63,10 +66,19 @@ export function CustomSSNReviewPage(props) {
       <dl className="review">
         <div className="review-row">
           <dt>SSN</dt>
-          {/* TODO: mask the SSN */}
-          <dd>{props?.data?.veteranSocialSecurityNumber?.ssn}</dd>
+          <dd>{maskedSSN}</dd>
         </div>
       </dl>
     </div>
   ) : null;
 }
+
+CustomSSNReviewPage.propTypes = {
+  data: PropTypes.shape({
+    veteranSocialSecurityNumber: PropTypes.shape({
+      ssn: PropTypes.string,
+    }),
+  }),
+  editPage: PropTypes.func,
+  title: PropTypes.string,
+};

--- a/src/applications/ivc-champva/10-7959f-1/helpers/CustomSSN.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/helpers/CustomSSN.jsx
@@ -1,0 +1,50 @@
+import { validateSSN } from 'platform/forms-system/src/js/validation';
+import SSNReviewWidget from 'platform/forms-system/src/js/review/SSNWidget';
+import get from 'platform/utilities/data/get';
+import { vaFileNumberUI } from 'platform/forms-system/src/js/web-component-patterns';
+import HandlePrefilledSSN from './maskSSN';
+
+const SSN_DEFAULT_TITLE = 'Social Security number';
+
+const customSSNUI = title => {
+  return {
+    'ui:title': title ?? SSN_DEFAULT_TITLE,
+    'ui:webComponentField': HandlePrefilledSSN(),
+    'ui:reviewWidget': SSNReviewWidget,
+    'ui:validations': [validateSSN],
+    'ui:errorMessages': {
+      pattern:
+        'Please enter a valid 9 digit Social Security number (dashes allowed)',
+      required: 'Please enter a Social Security number',
+    },
+  };
+};
+
+// Using different hint text from the standard ssnOrVaFileNumberUI
+export const ssnOrVaFileNumberCustomUI = () => {
+  return {
+    ssn: customSSNUI(),
+    vaFileNumber: {
+      ...vaFileNumberUI(),
+      'ui:options': {
+        hint:
+          'Enter this number only if it’s different than the Social Security number',
+      },
+    },
+    'ui:options': {
+      updateSchema: (formData, _schema, _uiSchema, index, path) => {
+        const { ssn, vaFileNumber } = get(path, formData) ?? {};
+
+        let required = ['ssn'];
+        if (!ssn && vaFileNumber) {
+          required = ['vaFileNumber'];
+        }
+
+        return {
+          ..._schema,
+          required,
+        };
+      },
+    },
+  };
+};

--- a/src/applications/ivc-champva/10-7959f-1/helpers/maskSSN.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/helpers/maskSSN.jsx
@@ -35,6 +35,7 @@ export default function HandlePrefilledSSN(fieldProps) {
       setDisplayVal(val);
     }
     setVal(value);
+    setDisplayVal(value);
     props.onInput(event, strippedSSN);
   };
 

--- a/src/applications/ivc-champva/10-7959f-1/helpers/maskSSN.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/helpers/maskSSN.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import vaTextInputFieldMapping from 'platform/forms-system/src/js/web-component-fields/vaTextInputFieldMapping';
 import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
-function maskSSN(ssnString = '') {
+export function maskSSN(ssnString = '') {
   const strippedSSN = ssnString.replace(/[- ]/g, '');
   const maskedSSN = strippedSSN.replace(/^\d{1,5}/, digit =>
     digit.replace(/\d/g, '●'),

--- a/src/applications/ivc-champva/10-7959f-1/helpers/maskSSN.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/helpers/maskSSN.jsx
@@ -1,5 +1,7 @@
 import { formatSSN } from 'platform/utilities/ui';
-import { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import vaTextInputFieldMapping from 'platform/forms-system/src/js/web-component-fields/vaTextInputFieldMapping';
+import { VaTextInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 function maskSSN(ssnString = '') {
   const strippedSSN = ssnString.replace(/[- ]/g, '');
@@ -9,17 +11,47 @@ function maskSSN(ssnString = '') {
   return formatSSN(maskedSSN);
 }
 
-const HandlePrefilledSSN = props => {
+/**
+ * @param {WebComponentFieldProps} props */
+export default function HandlePrefilledSSN(fieldProps) {
+  const props = vaTextInputFieldMapping(fieldProps);
   const [val, setVal] = useState(props.value);
-  const [setDisplayVal] = useState(props.value);
+  const [displayVal, setDisplayVal] = useState(props.value);
+  const vaTextInput = useRef();
 
-  useEffect(
-    () => {
-      setVal(maskSSN(val));
-      setDisplayVal(maskSSN(val));
-    },
-    [setDisplayVal, val],
+  useEffect(() => {
+    setVal(maskSSN(val));
+    setDisplayVal(maskSSN(val));
+  }, []);
+  const handleChange = event => {
+    const { value } = event.target;
+    let strippedSSN;
+    if (value) {
+      strippedSSN = value.replace(/[- ]/g, '');
+    }
+
+    setVal(value);
+    setDisplayVal(value);
+    props.onInput(event, strippedSSN);
+  };
+
+  const handleBlur = () => {
+    setDisplayVal(maskSSN(val));
+    props.onBlur(props.id);
+  };
+
+  const handleFocus = () => {
+    setDisplayVal(val);
+  };
+
+  return (
+    <VaTextInput
+      {...props}
+      value={displayVal}
+      onInput={handleChange}
+      onBlur={handleBlur}
+      onFocus={handleFocus}
+      ref={vaTextInput}
+    />
   );
-};
-
-export default HandlePrefilledSSN;
+}

--- a/src/applications/ivc-champva/10-7959f-1/helpers/maskSSN.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/helpers/maskSSN.jsx
@@ -1,0 +1,25 @@
+import { formatSSN } from 'platform/utilities/ui';
+import { useState, useEffect } from 'react';
+
+function maskSSN(ssnString = '') {
+  const strippedSSN = ssnString.replace(/[- ]/g, '');
+  const maskedSSN = strippedSSN.replace(/^\d{1,5}/, digit =>
+    digit.replace(/\d/g, '●'),
+  );
+  return formatSSN(maskedSSN);
+}
+
+const HandlePrefilledSSN = props => {
+  const [val, setVal] = useState(props.value);
+  const [setDisplayVal] = useState(props.value);
+
+  useEffect(
+    () => {
+      setVal(maskSSN(val));
+      setDisplayVal(maskSSN(val));
+    },
+    [setDisplayVal, val],
+  );
+};
+
+export default HandlePrefilledSSN;

--- a/src/applications/ivc-champva/10-7959f-1/helpers/maskSSN.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/helpers/maskSSN.jsx
@@ -17,21 +17,24 @@ export default function HandlePrefilledSSN(fieldProps) {
   const props = vaTextInputFieldMapping(fieldProps);
   const [val, setVal] = useState(props.value);
   const [displayVal, setDisplayVal] = useState(props.value);
+  const [cleared, setCleared] = useState(false);
   const vaTextInput = useRef();
 
   useEffect(() => {
-    setVal(maskSSN(val));
     setDisplayVal(maskSSN(val));
   }, []);
+
   const handleChange = event => {
     const { value } = event.target;
     let strippedSSN;
     if (value) {
       strippedSSN = value.replace(/[- ]/g, '');
     }
-
+    if (val === '') {
+      setCleared(true);
+      setDisplayVal(val);
+    }
     setVal(value);
-    setDisplayVal(value);
     props.onInput(event, strippedSSN);
   };
 
@@ -41,7 +44,9 @@ export default function HandlePrefilledSSN(fieldProps) {
   };
 
   const handleFocus = () => {
-    setDisplayVal(val);
+    if (cleared) {
+      setDisplayVal(val);
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
This PR updates the ssn to mask the number if it is prefilled. If the user then wants to update the ssn, they will need to re-enter the number. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/83841

## Testing done
unit tests
manual testing
needs to be tested on staging to be sure it works correctly with prefill

## Screenshots
![Screenshot 2024-06-11 at 8 05 05 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/ab7ef6f5-cd90-4736-b613-dca90f0ddd25)

## What areas of the site does it impact?
This form only, though if needed, could be used for other forms

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA
