### PR TITLE
[SIMPLE_FORMS] fix: form-upload - update segmented steppers to use h2 instead of h4

### DIFF
--- a/src/applications/simple-forms/form-upload/containers/ReviewPage.jsx
+++ b/src/applications/simple-forms/form-upload/containers/ReviewPage.jsx
@@ -62,6 +62,7 @@ const ReviewPage = () => {
         <VaSegmentedProgressBar
           current={2}
           total={3}
+          headerLevel={2}
           labels="Upload your file;Review your information;Submit your form"
         />
       </div>

--- a/src/applications/simple-forms/form-upload/containers/SubmitPage.jsx
+++ b/src/applications/simple-forms/form-upload/containers/SubmitPage.jsx
@@ -69,6 +69,7 @@ const SubmitPage = () => {
         <VaSegmentedProgressBar
           current={3}
           total={3}
+          headerLevel={2}
           labels="Upload your file;Review your information;Submit your form"
         />
       </div>

--- a/src/applications/simple-forms/form-upload/containers/UploadPage.jsx
+++ b/src/applications/simple-forms/form-upload/containers/UploadPage.jsx
@@ -56,6 +56,7 @@ const UploadPage = () => {
         <VaSegmentedProgressBar
           current={1}
           total={3}
+          headerLevel={2}
           labels="Upload your file;Review your information;Submit your form"
         />
       </div>


### PR DESCRIPTION
## Summary

- This PR updates form upload segmented stepper to use H2's instead of H4's.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team-forms#1374

## Testing done

- Browser testing successful

## What areas of the site does it impact?

- Only form uploads

## Requested Feedback

Any