### PR TITLE
Appoint a Rep - Address Authorization Screen

### DIFF
--- a/src/applications/representative-appoint/components/Breadcrumbs.jsx
+++ b/src/applications/representative-appoint/components/Breadcrumbs.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+export const wrapWithBreadcrumb = component => (
+  <>
+    <div className="row">
+      <VaBreadcrumbs
+        uswds
+        label="Breadcrumb"
+        breadcrumbList={[
+          { href: '/', label: 'Home' },
+          {
+            label: 'Get Help From An Accredited Representative',
+            href: '/get-help-from-accredited-representative',
+          },
+          {
+            label: 'Appoint An Accredited Representative',
+            href: '/get-help-from-accredited-representative/appoint',
+          },
+        ]}
+      />
+    </div>
+    {component}
+  </>
+);

--- a/src/applications/representative-appoint/config/form.js
+++ b/src/applications/representative-appoint/config/form.js
@@ -7,7 +7,11 @@ import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 
-import { authorizeMedical, authorizeMedicalSelect } from '../pages';
+import {
+  authorizeMedical,
+  authorizeMedicalSelect,
+  authorizeAddress,
+} from '../pages';
 
 const { fullName, ssn, date, dateRange, usaPhone } = commonDefinitions;
 
@@ -72,6 +76,12 @@ const formConfig = {
           title: 'Authorization for Certain Medical Records - Select',
           uiSchema: authorizeMedicalSelect.uiSchema,
           schema: authorizeMedicalSelect.schema,
+        },
+        authorizeAddress: {
+          path: 'authorize-address',
+          title: 'Authorization to change your address',
+          uiSchema: authorizeAddress.uiSchema,
+          schema: authorizeAddress.schema,
         },
       },
     },

--- a/src/applications/representative-appoint/containers/App.jsx
+++ b/src/applications/representative-appoint/containers/App.jsx
@@ -1,11 +1,15 @@
 import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
 import { connect, useSelector } from 'react-redux';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import { wrapWithBreadcrumb } from '../components/Breadcrumbs';
+
 import formConfig from '../config/form';
 import configService from '../utilities/configService';
 
 function App({ location, children }) {
   const subTitle = useSelector(state => state.flow.subTitle);
+  const { pathname } = location || {};
   const [formUseState, setFormUseState] = useState({ ...formConfig });
 
   useEffect(
@@ -16,12 +20,25 @@ function App({ location, children }) {
     [subTitle],
   );
 
-  return (
+  const content = (
     <RoutedSavableApp formConfig={formUseState} currentLocation={location}>
       {children}
     </RoutedSavableApp>
   );
+
+  return wrapWithBreadcrumb(
+    <article id="form-21-22" data-location={`${pathname?.slice(1)}`}>
+      {content}
+    </article>,
+  );
 }
+
+App.propTypes = {
+  children: PropTypes.object,
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+  }),
+};
 
 function mapStateToProps(state) {
   return {

--- a/src/applications/representative-appoint/pages/authorizeAddress.js
+++ b/src/applications/representative-appoint/pages/authorizeAddress.js
@@ -1,0 +1,99 @@
+import React from 'react';
+import { authorizationNote } from '../content/authorizeMedical';
+import { saveYourApplication } from '../content/saveYourApplication';
+
+export const uiSchema = {
+  'view:saveYourApplication': {
+    'ui:description': saveYourApplication,
+  },
+  'view:authorizeAddress': {
+    'ui:description': formData => {
+      return (
+        <>
+          <h3>Authorization to change your address</h3>
+          <p>
+            This accredited{' '}
+            {formData.repType || `Veterans Service Organization (VSO)`} can help
+            you change the address on your VA records. If the address on your VA
+            records is incorrect or outdated, it may take us longer to contact
+            you and process your benefit claims.
+          </p>
+        </>
+      );
+    },
+  },
+  'view:addressAuthorizationPolicy': {
+    'ui:description': () => {
+      return (
+        <div className="vads-u-margin-y--3">
+          <va-accordion uswds bordered open-single>
+            <va-accordion-item
+              bordered
+              header="Our address authorization policy"
+            >
+              <p>
+                <strong>I authorize</strong> any official representative of the
+                organization named in Item 15 to act on my behalf to change my
+                address in my VA records. This authorization does not extend to
+                any other organization without my further written consent. This
+                authorization will remain in effect until the earlier of the
+                following events: (1) I revoke this authorization by filing a
+                written revocation with VA; or (2) I appoint another
+                representative, or (3) I have been determined unable to manage
+                my financial affairs and the individual or organization named in
+                Item 16A is not my appointed fiduciary.
+              </p>
+            </va-accordion-item>
+          </va-accordion>
+        </div>
+      );
+    },
+  },
+  authorizeAddressRadio: {
+    'ui:title': `Do you authorize this accredited VSO to change your address on VA records?`,
+    'ui:widget': 'radio',
+    'ui:options': {
+      widgetProps: {
+        'Yes address change': { 'data-info': 'yes_address_change' },
+        'No address change': { 'data-info': 'no_address_change' },
+      },
+      selectedProps: {
+        'Yes address change': { 'aria-describedby': 'yes_address_change' },
+        'No address change': { 'aria-describedby': 'no_address_change' },
+      },
+    },
+  },
+
+  'view:authorizationNote': {
+    'ui:description': authorizationNote,
+  },
+};
+
+export const schema = {
+  type: 'object',
+  properties: {
+    'view:saveYourApplication': {
+      type: 'object',
+      properties: {},
+    },
+    'view:authorizeAddress': {
+      type: 'object',
+      properties: {},
+    },
+    'view:addressAuthorizationPolicy': {
+      type: 'object',
+      properties: {},
+    },
+    authorizeAddressRadio: {
+      type: 'string',
+      enum: [
+        `Yes, they can change my address if it's incorrect or outdated`,
+        `No, they can't change my address`,
+      ],
+    },
+    'view:authorizationNote': {
+      type: 'object',
+      properties: {},
+    },
+  },
+};

--- a/src/applications/representative-appoint/pages/authorizeMedical.js
+++ b/src/applications/representative-appoint/pages/authorizeMedical.js
@@ -30,7 +30,7 @@ export const uiSchema = {
   'view:authorizationPolicy': {
     'ui:description': () => {
       return (
-        <>
+        <div className="vads-u-margin-y--3">
           <va-accordion uswds bordered open-single>
             <va-accordion-item
               bordered
@@ -54,7 +54,7 @@ export const uiSchema = {
               </p>
             </va-accordion-item>
           </va-accordion>
-        </>
+        </div>
       );
     },
   },

--- a/src/applications/representative-appoint/pages/index.js
+++ b/src/applications/representative-appoint/pages/index.js
@@ -1,4 +1,5 @@
 import * as authorizeMedical from './authorizeMedical';
 import * as authorizeMedicalSelect from './authorizeMedicalSelect';
+import * as authorizeAddress from './authorizeAddress';
 
-export { authorizeMedical, authorizeMedicalSelect };
+export { authorizeMedical, authorizeMedicalSelect, authorizeAddress };

--- a/src/applications/representative-search/components/results/ReportModal.jsx
+++ b/src/applications/representative-search/components/results/ReportModal.jsx
@@ -160,7 +160,6 @@ const ReportModal = ({
               error={reportIsBlankError ? 'Please select an item' : null}
               hint={null}
               onVaChange={handleCheckboxChange}
-              required
               label="Select the information we need to update"
               label-header-level=""
               uswds


### PR DESCRIPTION

## Summary

- Built address authorization screen for Appoint a Rep
- Styling adjustments
- Removed "required" from report modal in Find a Rep
- Added breadcrumbs to Appoint a Rep


## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83966
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85516
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83964

## Screenshots
<img width="640" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/143013011/199fd93b-348e-4eb5-abbd-b8049ee0cb45">
