### PR TITLE
10-7959f-1 Prefill copy link

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/helpers/prefilledAddress.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/helpers/prefilledAddress.jsx
@@ -9,7 +9,10 @@ const PrefilledAddress = props => {
       <p>
         Any updates you make here to the contact information will only apply to
         this form. If you want to update your contact information for all your
-        VA accounts, please go to your profile page.
+        VA accounts,{' '}
+        <a href="https://va.gov/profile/contact-information">
+          please go to your profile page.
+        </a>
       </p>
     </div>
   ) : (


### PR DESCRIPTION
## Summary
This is a small PR that adds a link to the text "please go to your profile page". That page goes to: https://va.gov/profile/contact-information

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/84445

## Testing done
Unit tests
Manually tested to be sure it goes to the right page

## Scre
![Screenshot 2024-06-12 at 9 54 21 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/617c87e8-0e57-44ad-9a42-89cb460970ba)
enshots
![Screenshot 2024-06-12 at 9 54 38 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/94866bc1-bcbe-4aab-9d66-e13650319d08)

## What areas of the site does it impact?
Only this form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA
