### PR TITLE
Remove 10-10 ezr link for unregistered users

### DIFF
--- a/src/applications/mhv-landing-page/mocks/api/index.js
+++ b/src/applications/mhv-landing-page/mocks/api/index.js
@@ -18,7 +18,7 @@ const responses = (selectedMockType = MOCK_TYPES.VERIFIED_USER) => {
   const getUser = () => {
     switch (selectedMockType) {
       case MOCK_TYPES.UNVERIFIED_USER:
-        return generateUser({ loa: 1 });
+        return generateUser({ loa: 1, vaPatient: false });
       case MOCK_TYPES.UNREGISTERED_USER:
         return generateUser({ vaPatient: false });
       default:

--- a/src/applications/mhv-landing-page/utilities/data/index.js
+++ b/src/applications/mhv-landing-page/utilities/data/index.js
@@ -117,7 +117,7 @@ const resolveLandingPageLinks = (
         href: '/COMMUNITYCARE/programs/veterans/index.asp',
         text: 'Community care',
       },
-      {
+      registered && {
         href:
           '/my-health/update-benefits-information-form-10-10ezr/introduction',
         text: 'Update health benefits info (10-10EZR)',


### PR DESCRIPTION
## Summary
Remove 10-10 ezr link for unregistered users. Note that only LOA3 users can be registered.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/82174

## Testing done
N/A

## Screenshots
UI changes only affect unregistered users

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   ![localhost_3001_my-health_(iPhone 14 Pro Max) (6)](https://github.com/department-of-veterans-affairs/vets-website/assets/63804190/d0e759f1-6dc1-4722-8930-5e219c4c9e0f)     |    ![localhost_3001_my-health_(iPhone 14 Pro Max) (5)](https://github.com/department-of-veterans-affairs/vets-website/assets/63804190/905432fd-573c-4ff5-ae79-cc1653a68ba4)   |
| Desktop |   ![localhost_3001_my-health_ (11)](https://github.com/department-of-veterans-affairs/vets-website/assets/63804190/5e137de0-e347-491f-ba45-618b9a82aaa1)     |   ![localhost_3001_my-health_ (10)](https://github.com/department-of-veterans-affairs/vets-website/assets/63804190/4f728103-4faf-4dbe-82d4-3031f740b0ef)    |

## What areas of the site does it impact?
- MHV Landing Page

## Acceptance criteria
- 10-10EZR link is hidden on the MHV landing page when a user is unregistered

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
