### PR TITLE
Sort facilities alphabetically by name

### DIFF
--- a/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
+++ b/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
@@ -132,7 +132,7 @@ const VaMedicalCenter = props => {
             ) {
               setLocalData({ ...localData, vaMedicalFacility: undefined });
             }
-            setFacilities(data);
+            setFacilities(data.sort((a, b) => a.name.localeCompare(b.name)));
             isLoading(false);
           })
           .catch(err => {

--- a/src/applications/hca/tests/unit/components/FormFields/VaMedicalCenter.unit.spec.js
+++ b/src/applications/hca/tests/unit/components/FormFields/VaMedicalCenter.unit.spec.js
@@ -166,7 +166,7 @@ describe('hca <VaMedicalCenter>', () => {
   });
 
   context('when the user selects a facility state', () => {
-    it('should render the correct number of options if API call succeeds', async () => {
+    it('should render the correct number of options, resorted in alphabetical order by name, if API call succeeds', async () => {
       mockApiRequest(mockData);
       const { mockStore, props } = getData({
         formData: { 'view:facilityState': 'NY' },

--- a/src/applications/hca/tests/unit/components/FormFields/VaMedicalCenter.unit.spec.js
+++ b/src/applications/hca/tests/unit/components/FormFields/VaMedicalCenter.unit.spec.js
@@ -15,7 +15,7 @@ describe('hca <VaMedicalCenter>', () => {
     {
       id: 'vha_528A4',
       uniqueId: '528A4',
-      name: 'Batavia VA Medical Center',
+      name: 'ZBatavia VA Medical Center',
     },
     {
       id: 'vha_528A5',
@@ -126,6 +126,7 @@ describe('hca <VaMedicalCenter>', () => {
     });
 
     it('should not render the loading indicator', async () => {
+      mockApiRequest(mockData);
       const { container } = render(
         <Provider store={mockStore}>
           <VaMedicalCenter {...props} />
@@ -138,6 +139,7 @@ describe('hca <VaMedicalCenter>', () => {
     });
 
     it('should not render the select input', async () => {
+      mockApiRequest(mockData);
       const { container } = render(
         <Provider store={mockStore}>
           <VaMedicalCenter {...props} />
@@ -182,7 +184,8 @@ describe('hca <VaMedicalCenter>', () => {
         const alert = container.querySelector('va-alert');
 
         expect(options).to.have.lengthOf(mockData.length);
-        expect(options[0]).to.have.attr('value', mockData[0].uniqueId);
+        expect(options[0]).to.have.attr('value', mockData[1].uniqueId);
+        expect(options[1]).to.have.attr('value', mockData[0].uniqueId);
         expect(alert).to.not.exist;
       });
     });


### PR DESCRIPTION
## Summary

- 10-10 EZ form: sort the Facilities list by name in alphabetical order instead of by Facility ID
- 10-10 Health Apps - EZ/CG team

## Related issue(s)

- https://app.zenhub.com/workspaces/10-10-health-apps-5fff0cfd1462b6000e320fc7/issues/gh/department-of-veterans-affairs/va.gov-team/85772

## Testing done

- Facilities were ordered by their (hidden) ID value, (e.g., `520GA`)
- We sort the Facilities list by the Name attribute of each entry prior to display (e.g., `Mobile VA Clinic`)
- Tested locally and in unit tests to confirm that the order is now alphabetical

## Screenshots
before: 
<img width="517" alt="Screenshot 2024-06-12 at 3 56 19 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/153661030/11ade75d-2d4e-4926-9b06-00c32553f698">

after:
<img width="505" alt="Screenshot 2024-06-12 at 4 01 07 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/153661030/695260c0-bd28-4bd0-a89d-fb10f0178ad2">


## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
