### PR TITLE
Scale veteran status card to 3.5 x 2

### DIFF
--- a/src/platform/pdf/templates/veteran_status.js
+++ b/src/platform/pdf/templates/veteran_status.js
@@ -13,26 +13,26 @@ import { createAccessibleDoc, registerVaGovFonts } from './utils';
 
 const config = {
   margins: {
-    top: 40,
-    bottom: 40,
-    left: 20,
-    right: 20,
+    top: 30,
+    bottom: 30,
+    left: 15,
+    right: 15,
   },
   headings: {
     H1: {
       font: 'Bitter-Bold',
-      size: 14,
+      size: 10.5,
     },
     H2: {
       font: 'SourceSansPro-Bold',
-      size: 10,
+      size: 7.5,
     },
   },
   text: {
     boldFont: 'SourceSansPro-Bold',
     font: 'SourceSansPro-Regular',
-    size: 10,
-    disclaimerTextSize: 9,
+    size: 7.5,
+    disclaimerTextSize: 6.75,
   },
 };
 
@@ -60,7 +60,7 @@ const generate = async data => {
   // Add a dotted line to indicate where the card should be cut out
   const cardWrapper = doc.struct('Artifact', () => {
     doc
-      .roundedRect(100, 100, 336, 192, 5)
+      .roundedRect(75, 75, 252, 144, 5) // roughly results in a 2 x 3.5 inch rectangle
       .dash(5, { space: 5 })
       .stroke();
   });
@@ -79,9 +79,9 @@ const generate = async data => {
       `data:${contentType};base64,${Buffer.from(
         await fetchedImage.arrayBuffer(),
       ).toString('base64')}`,
-      275,
-      105,
-      { width: 150, alt: data.details.image.title },
+      206,
+      79,
+      { width: 112, alt: data.details.image.title },
     );
 
     const logo = doc.struct('Figure', { alt: data.details.image.title }, [
@@ -96,7 +96,7 @@ const generate = async data => {
     doc
       .font(config.headings.H1.font)
       .fontSize(config.headings.H1.size)
-      .text(data.details.fullName, 110, 115, { width: 150 });
+      .text(data.details.fullName, 82, 86, { width: 112 });
   });
 
   wrapper.add(name);
@@ -107,7 +107,7 @@ const generate = async data => {
       doc
         .font(config.headings.H2.font)
         .fontSize(config.headings.H2.size)
-        .text('Date of birth: ', 110, 160);
+        .text('Date of birth: ', 82, 120);
     });
     const dateOfBirth = doc.struct('P', () => {
       doc
@@ -148,7 +148,7 @@ const generate = async data => {
     doc
       .font(config.headings.H2.font)
       .fontSize(config.headings.H2.size)
-      .text('Period of service', 260, 160)
+      .text('Period of service', 195, 120)
       .moveDown(0.5);
   });
 
@@ -195,10 +195,10 @@ const generate = async data => {
       .fontSize(config.text.disclaimerTextSize)
       .text(
         "You can use this Veteran status to prove you served in the United States Uniformed Services. This status doesn't entitle you to any VA benefits.",
-        110,
-        250,
+        82,
+        187,
         {
-          width: 330,
+          width: 247,
         },
       );
   });

--- a/src/platform/pdf/test/templates/veteran_status/veteran_status.unit.spec.js
+++ b/src/platform/pdf/test/templates/veteran_status/veteran_status.unit.spec.js
@@ -43,7 +43,7 @@ describe('Veteran Status PDF template', () => {
       expect(content.items.filter(item => item.tag === 'H1').length).to.eq(1);
       expect(content.items[3].str).to.eq(data.details.fullName);
       // H1 in this case is set to 14 px
-      expect(content.items[3].height).to.eq(14);
+      expect(content.items[3].height).to.eq(10.5);
     });
 
     it('All sections are contained by a root level Document element', async () => {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- Scales the Proof of Veteran Status card to 3.5 x 2
- Solution: I found the card aspect ratio to be correct, but the size too large. So I calculated the difference between the current and desired size, and scaled down all the numbers by that amount (25%)
- I work for VA IIR.

## Related issue(s)

- [Ticket 743](https://app.zenhub.com/workspaces/va-iir-6508c0bd79e64e0fb5855caf/issues/gh/department-of-veterans-affairs/va-iir/743)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

New printout compared to 3.5 x 2 business card:
![IMG_8971 copy](https://github.com/department-of-veterans-affairs/vets-website/assets/1807967/086519fa-530e-4f6e-9622-03480c64af00)

## What areas of the site does it impact?

This change only impacts the Proof of Veteran Status page (https://www.va.gov/profile/military-information)

## Acceptance criteria
- [ ] Printed card measures 3.5 x 2
- [ ] Card content is scaled to fit the new size

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
