### PR TITLE
add trash-kb-nav-filter-sort test

### DIFF
--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-trash-kb-nav-filter-sort.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-trash-kb-nav-filter-sort.cypress.spec.js
@@ -1,0 +1,62 @@
+import SecureMessagingSite from '../sm_site/SecureMessagingSite';
+import PatientInboxPage from '../pages/PatientInboxPage';
+import PatientMessageTrashPage from '../pages/PatientMessageTrashPage';
+import inboxFilterResponse from '../fixtures/inboxResponse/sorted-inbox-messages-response.json';
+import { AXE_CONTEXT } from '../utils/constants';
+import mockTrashMessages from '../fixtures/trashResponse/trash-messages-response.json';
+import FolderLoadPage from '../pages/FolderLoadPage';
+// import below have to be deleted after merge with MHV-57520
+import mockMessages from '../fixtures/messages-response.json';
+
+describe('Keyboard Navigation for Filter & Sort functionalities', () => {
+  const site = new SecureMessagingSite();
+  const filteredData = {
+    data: inboxFilterResponse.data.filter(item =>
+      item.attributes.subject.toLowerCase().includes('test'),
+    ),
+  };
+
+  beforeEach(() => {
+    site.login();
+    PatientInboxPage.loadInboxMessages(mockTrashMessages);
+    FolderLoadPage.loadDeletedMessages(mockTrashMessages);
+  });
+
+  it('Verify filter works correctly', () => {
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+
+    PatientMessageTrashPage.inputFilterDataByKeyboard('test');
+    PatientMessageTrashPage.submitFilterByKeyboard(filteredData, -3);
+    PatientMessageTrashPage.verifyFilterResults('test', filteredData);
+  });
+
+  it('Verify clear filter btn works correctly', () => {
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+
+    PatientMessageTrashPage.inputFilterDataByKeyboard('test');
+    PatientMessageTrashPage.submitFilterByKeyboard(filteredData, -3);
+    PatientMessageTrashPage.clearFilterByKeyboard();
+    PatientMessageTrashPage.verifyFilterFieldCleared();
+  });
+
+  it('verify sorting works properly', () => {
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+
+    // mockMessages.data shuld be replaced by mockTrashMessages.data after merge with MHV-57520
+    const testData = {
+      data: Array.from(mockMessages.data).sort(
+        (a, b) =>
+          new Date(a.attributes.sentDate) - new Date(b.attributes.sentDate),
+      ),
+    };
+
+    PatientMessageTrashPage.verifySortingByKeyboard(
+      'Oldest to newest',
+      testData,
+      -3,
+    );
+  });
+});

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageTrashPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageTrashPage.js
@@ -5,6 +5,7 @@ import mockSingleMessageResponse from '../fixtures/trashResponse/trash-single-me
 import trashSearchResponse from '../fixtures/trashResponse/trash-search-response.json';
 import mockSortedMessages from '../fixtures/trashResponse/sorted-trash-message-response.json';
 import { Locators, Paths } from '../utils/constants';
+import sentSearchResponse from '../fixtures/sentResponse/sent-search-response.json';
 
 class PatientMessageTrashPage {
   loadMessages = (mockMessagesResponse = mockTrashMessages) => {
@@ -117,6 +118,22 @@ class PatientMessageTrashPage {
     );
   };
 
+  verifyFilterResults = (filterValue, responseData = sentSearchResponse) => {
+    cy.get(Locators.MESSAGES).should(
+      'have.length',
+      `${responseData.data.length}`,
+    );
+
+    cy.get(Locators.ALERTS.HIGHLIGHTED).each(element => {
+      cy.wrap(element)
+        .invoke('text')
+        .then(text => {
+          const lowerCaseText = text.toLowerCase();
+          expect(lowerCaseText).to.contain(`${filterValue}`);
+        });
+    });
+  };
+
   verifyFilterResultsText = (
     filterValue,
     responseData = trashSearchResponse,
@@ -141,6 +158,69 @@ class PatientMessageTrashPage {
       .shadow()
       .find('#inputField')
       .should('be.empty');
+  };
+
+  inputFilterDataByKeyboard = text => {
+    cy.tabToElement('#inputField')
+      .first()
+      .type(`${text}`, { force: true });
+  };
+
+  submitFilterByKeyboard = (mockFilterResponse, folderId) => {
+    cy.intercept(
+      'POST',
+      `${Paths.SM_API_BASE + Paths.FOLDERS}/${folderId}/search`,
+      mockFilterResponse,
+    ).as('filterResult');
+
+    cy.realPress('Enter');
+  };
+
+  clearFilterByKeyboard = () => {
+    // next line required to start tab navigation from the header of the page
+    cy.get('[data-testid="folder-header"]').click();
+    cy.contains('Clear Filters').then(el => {
+      cy.tabToElement(el)
+        .first()
+        .click();
+    });
+  };
+
+  sortMessagesByKeyboard = (text, data, folderId) => {
+    cy.get(Locators.DROPDOWN)
+      .shadow()
+      .find('select')
+      .select(`${text}`, { force: true });
+
+    cy.intercept(
+      'GET',
+      `${Paths.INTERCEPT.MESSAGE_FOLDERS}/${folderId}/threads**`,
+      data,
+    ).as('sortResponse');
+    cy.tabToElement('[data-testid="sort-button"]');
+    cy.realPress('Enter');
+  };
+
+  verifySortingByKeyboard = (text, data, folderId) => {
+    let listBefore;
+    let listAfter;
+    cy.get(Locators.THREAD_LIST)
+      .find(Locators.DATE_RECEIVED)
+      .then(list => {
+        listBefore = Cypress._.map(list, el => el.innerText);
+        cy.log(`List before sorting${JSON.stringify(listBefore)}`);
+      })
+      .then(() => {
+        this.sortMessagesByKeyboard(`${text}`, data, folderId);
+        cy.get(Locators.THREAD_LIST)
+          .find(Locators.DATE_RECEIVED)
+          .then(list2 => {
+            listAfter = Cypress._.map(list2, el => el.innerText);
+            cy.log(`List after sorting${JSON.stringify(listAfter)}`);
+            expect(listBefore[0]).to.eq(listAfter[listAfter.length - 1]);
+            expect(listBefore[listBefore.length - 1]).to.eq(listAfter[0]);
+          });
+      });
   };
 }
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- This PR adds E2E test scenario for keyboard navigation of filter and sort features for SM trash page

## Related issue(s)

- https://jira.devops.va.gov/browse/MHV-57753

## Testing done

- Relevant tests have been executed in headed mode with a 200x pattern.
- All tests have been successfully conducted in headless mode without any failures.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
