### PR TITLE
Form and forms-library updates to remove font awesome references

### DIFF
--- a/src/applications/simple-forms/21-0845/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-0845/containers/ConfirmationPage.jsx
@@ -18,15 +18,7 @@ const content = {
           1-800-827-1000
         </a>{' '}
         or contact VA online at{' '}
-        <a href="https://ask.va.gov" target="_blank" rel="noopener noreferrer">
-          Ask VA
-          <i
-            className="fas fa-arrow-up-right-from-square"
-            aria-hidden="true"
-            role="img"
-          />
-        </a>
-        .
+        <va-link href="https://ask.va.gov" text="Ask VA" />.
       </p>
       <p>
         Upon notification from you VA will no longer give out benefit or claim

--- a/src/applications/simple-forms/21-0845/pages/authorizerType.js
+++ b/src/applications/simple-forms/21-0845/pages/authorizerType.js
@@ -35,19 +35,11 @@ export default {
           You can authorize the release of only your own information with this
           online form. If you’re a court-ordered or VA-appointed fiduciary
           representing a beneficiary, you’ll need to{' '}
-          <a
+          <va-link
+            download
             href="http://www.vba.va.gov/pubs/forms/VBA-21-0845-ARE.pdf"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            download the PDF version of this form
-            <i
-              className="fas fa-arrow-up-right-from-square"
-              aria-hidden="true"
-              role="img"
-            />
-            <span className="sr-only">[ opens in a new browser-tab ]</span>
-          </a>
+            text="download the PDF version of this form"
+          />
           . Then submit it in person or by mail.
         </p>
       ),

--- a/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomHeader.jsx
+++ b/src/applications/simple-forms/mock-alternate-header-21-0845/components/CustomHeader.jsx
@@ -55,9 +55,9 @@ const CustomHeader = ({ formData, formConfig, currentLocation }) => {
           </div>
           <div className="rjsf-form-custom-header vads-u-display--flex vads-u-justify-content--space-between small-screen:vads-u-justify-content--flex-start">
             <span>
-              <i
-                aria-hidden="true"
-                className="fas fa-arrow-left va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--0p5 vads-u-color--gray-medium"
+              <va-icon
+                icon="arrow_back"
+                class="va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--0p5 vads-u-color--gray-medium"
               />
               <Link
                 to={previousPage}

--- a/src/platform/forms-system/src/js/components/ProgressButton.jsx
+++ b/src/platform/forms-system/src/js/components/ProgressButton.jsx
@@ -16,7 +16,9 @@ class ProgressButton extends React.Component {
     let beforeText = '';
 
     if (this.props.beforeText && this.props.beforeText === '«') {
-      beforeText = <i aria-hidden="true" className="fa fa-angles-left" />;
+      beforeText = (
+        <va-icon icon="navigate_far_before" class="vads-u-padding-right--1" />
+      );
     } else if (this.props.beforeText) {
       beforeText = (
         <span className="button-icon" aria-hidden="true">
@@ -29,7 +31,9 @@ class ProgressButton extends React.Component {
     let afterText = '';
 
     if (this.props.afterText && this.props.afterText === '»') {
-      afterText = <i aria-hidden="true" className="fa fa-angles-right" />;
+      afterText = (
+        <va-icon icon="navigate_far_next" class="vads-u-padding-left--1" />
+      );
     } else if (this.props.afterText) {
       afterText = (
         <span className="button-icon" aria-hidden="true">

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -482,11 +482,7 @@ class ReviewCollapsibleChapter extends React.Component {
           uswds
         >
           {this.props.hasUnviewedPages && (
-            <i
-              aria-hidden="true"
-              className="fas fa-exclamation-circle vads-u-color--secondary"
-              slot="subheader-icon"
-            />
+            <va-icon icon="error" class="vads-u-color--secondary" />
           )}
           {this.getChapterContent(this.props)}
         </va-accordion-item>

--- a/src/platform/forms-system/test/js/components/ProgressButton.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/ProgressButton.unit.spec.jsx
@@ -116,22 +116,6 @@ describe('<ProgressButton>', () => {
     wrapper.unmount();
   });
 
-  it('should add aria-hidden button icons', () => {
-    const tree = shallow(
-      <ProgressButton
-        buttonText="Button text"
-        buttonClass="usa-button-primary"
-        disabled={false}
-        beforeText="«"
-        afterText="»"
-      />,
-    );
-    expect(tree.text()).to.equal('Button text');
-    const icons = tree.find('i[aria-hidden="true"]');
-    expect(icons).to.have.length.of(2);
-    tree.unmount();
-  });
-
   it('should pass aXe check when enabled', () =>
     axeCheck(
       <ProgressButton

--- a/src/platform/forms/components/review/PreSubmitSection.jsx
+++ b/src/platform/forms/components/review/PreSubmitSection.jsx
@@ -141,20 +141,7 @@ export function PreSubmitSection(props) {
             {statementOfTruthBodyElement(form?.data, statementOfTruth.body)}
             <p>
               I have read and accept the{' '}
-              <a
-                href="/privacy-policy/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                privacy policy
-                <span className="sr-only">opens in a new window</span>
-                <i
-                  className="fas fa-arrow-up-right-from-square"
-                  aria-hidden="true"
-                  role="img"
-                />
-              </a>
-              .
+              <va-link href="/privacy-policy/" text="privacy policy" />.
             </p>
             <VaTextInput
               id="veteran-signature"

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -133,10 +133,7 @@ const SipsDevModal = props => {
                 ))}
             </VaSelect>
             <p />
-            <a href={docsPage}>
-              <i aria-hidden="true" className="fas fa-info-circle" role="img" />{' '}
-              How to use this menu
-            </a>
+            <va-link href={docsPage} text="How to use this menu" />
             <p />
             <div className="row">
               <div className="small-6 columns">
@@ -171,8 +168,7 @@ const SipsDevModal = props => {
         className="va-button-link vads-u-margin-left--2"
         onClick={handlers.openSipsModal}
       >
-        <i aria-hidden="true" className="fas fa-cog" role="img" /> Open
-        save-in-progress menu
+        <va-icon icon="settings" /> Open save-in-progress menu
       </button>
     </>
   );


### PR DESCRIPTION
## Summary
This pull request updates the locations in our forms and in the forms library that use font awesome icons to instead use design system web components.

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#1330