### PR TITLE
#vfep-1529 #comment Replaced award icon and removed asterisk icon in …

### DIFF
--- a/src/applications/gi/components/CompareGrid.jsx
+++ b/src/applications/gi/components/CompareGrid.jsx
@@ -67,12 +67,12 @@ export function CompareGrid({
             first: index === 0,
             'has-diff': displayDiff,
           })}
+          aria-label={
+            displayDiff
+              ? 'This row displays information that is different between your selected institutions'
+              : null
+          }
         >
-          {displayDiff && (
-            <div className="label-diff">
-              <i className="fas fa-asterisk" aria-hidden="true" />
-            </div>
-          )}
           {field.label}
         </div>
       </div>

--- a/src/applications/gi/components/CompareHeader.jsx
+++ b/src/applications/gi/components/CompareHeader.jsx
@@ -72,11 +72,7 @@ export default function({
             <Checkbox
               checked={showDifferences}
               label={
-                <span>
-                  <i
-                    className="fas fa-asterisk"
-                    aria-label="An * indicates the information is different between your selected institutions."
-                  />{' '}
+                <span aria-label="A highlighted row indicates the information is different between your selected institutions.">
                   Highlight differences
                 </span>
               }

--- a/src/applications/gi/components/IconWithInfo.jsx
+++ b/src/applications/gi/components/IconWithInfo.jsx
@@ -1,27 +1,13 @@
 import React from 'react';
 
-export default function IconWithInfo({ icon, children, present, variant }) {
+export default function IconWithInfo({ icon, children, present }) {
   if (!present) return null;
 
   return (
-    <>
-      {variant === 'fontawesome' ? (
-        <p className="icon-with-info">
-          <i
-            className={`fa fa-${icon}`}
-            style={{ marginLeft: '5px' }}
-            aria-hidden="true"
-          />
-          &nbsp;
-          {children}
-        </p>
-      ) : (
-        <p className="icon-with-info">
-          <va-icon icon={icon} size={3} aria-hidden="true" />
-          &nbsp;
-          {children}
-        </p>
-      )}
-    </>
+    <p className="icon-with-info">
+      <va-icon icon={icon} size={3} aria-hidden="true" />
+      &nbsp;
+      {children}
+    </p>
   );
 }

--- a/src/applications/gi/containers/ProfilePageHeader.jsx
+++ b/src/applications/gi/containers/ProfilePageHeader.jsx
@@ -188,11 +188,7 @@ const ProfilePageHeader = ({
               {'   '}
               {_.capitalize(lowerType)} school
             </IconWithInfo>
-            <IconWithInfo
-              icon="award"
-              present={accreditationType}
-              variant="fontawesome"
-            >
+            <IconWithInfo icon="bookmark" present={accreditationType}>
               {'   '}
               <LearnMoreLabel
                 text={<>{_.capitalize(accreditationType)} Accreditation</>}

--- a/src/applications/gi/sass/partials/_gi-compare-page.scss
+++ b/src/applications/gi/sass/partials/_gi-compare-page.scss
@@ -259,12 +259,6 @@
   .field-label {
     vertical-align: middle;
 
-    .label-diff {
-      display: inline-block;
-      padding-right: .75em;
-      font-size: 14px;
-    }
-
     .label-cell {
       background-color: var(--vads-color-gray-light-alt);
       margin-right: 1.5em;
@@ -290,7 +284,6 @@
     .label-cell.has-diff {
       font-weight: bold;
       border-width: 2px;
-      padding-left: .8em;
     }
 
     @media (max-width: $small-screen) {


### PR DESCRIPTION
## Summary

### - _(Summarize the changes that have been made to the platform)_
- Updated the GI Bill Comparison Tool. 
- Converted the fontawesome award icon into the uswds bookmark icon. 
- Removed the asterisk icon.
- Added aria labels to the compare grid
### - _(If bug, how to reproduce)_ N/A
### - _(What is the solution, why is this the solution)_
- Converted the fontawesome icon into an uswds icon.
### - _(Which team do you work for, does your team own the maintenance of this component?)_
- GovCIO, we are the code owners 
### - _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_ N/A

## Related issue(s)

Jira -> https://jira.devops.va.gov/browse/VFEP-1529

## Testing done

### - _Describe what the old behavior was prior to the change_
- Institution profile header shows fontawesome award icon for accreditation type. Fontawesome asterisk icons appear in the compare grid when there are differences between the institutions
### - _Describe the steps required to verify your changes are working as expected_
- Award icon now appears as a bookmark uswds icon. Asterisk icons are removed.
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

Before:
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/162637891/ce25fced-3957-4abe-a63d-ac2fff61a391)

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/162637891/c19fbcaa-8cbc-4b5d-8c0a-84038172b0e1)

After:
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/162637891/182baf96-4176-4124-a77a-219b21a6bda3)

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/162637891/8e553d36-cab8-4586-ab2d-c029e4358e38)


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
