### PR TITLE
[CST] - Update Document Request page with new 5103 waiver submission experience

### DIFF
--- a/src/applications/claims-status/actions/index.js
+++ b/src/applications/claims-status/actions/index.js
@@ -257,7 +257,7 @@ export function submitRequest(id) {
   };
 }
 
-export const submit5103 = id => {
+export function submit5103(id, cstClaimPhasesEnabled = false) {
   return dispatch => {
     dispatch({
       type: SUBMIT_DECISION_REQUEST,
@@ -269,20 +269,30 @@ export const submit5103 = id => {
       dispatch,
       () => {
         dispatch({ type: SET_DECISION_REQUESTED });
-        dispatch(
-          setNotification({
-            title: 'Request received',
-            body:
-              'Thank you. We have your claim request and will make a decision.',
-          }),
-        );
+        if (cstClaimPhasesEnabled) {
+          dispatch(
+            setNotification({
+              title: 'We received your evidence waiver',
+              body:
+                'Thank you. We’ll move your claim to the next step as soon as possible.',
+            }),
+          );
+        } else {
+          dispatch(
+            setNotification({
+              title: 'Request received',
+              body:
+                'Thank you. We have your claim request and will make a decision.',
+            }),
+          );
+        }
       },
       error => {
         dispatch({ type: SET_DECISION_REQUEST_ERROR, error });
       },
     );
   };
-};
+}
 // END lighthouse_migration
 
 export function resetUploads() {

--- a/src/applications/claims-status/actions/index.js
+++ b/src/applications/claims-status/actions/index.js
@@ -218,7 +218,7 @@ export const getClaim = (id, navigate) => {
   };
 };
 
-export function submitRequest(id) {
+export function submitRequest(id, cstClaimPhasesEnabled = false) {
   return dispatch => {
     dispatch({
       type: SUBMIT_DECISION_REQUEST,
@@ -242,13 +242,23 @@ export function submitRequest(id) {
       dispatch,
       () => {
         dispatch({ type: SET_DECISION_REQUESTED });
-        dispatch(
-          setNotification({
-            title: 'Request received',
-            body:
-              'Thank you. We have your claim request and will make a decision.',
-          }),
-        );
+        if (cstClaimPhasesEnabled) {
+          dispatch(
+            setNotification({
+              title: 'We received your evidence waiver',
+              body:
+                'Thank you. We’ll move your claim to the next step as soon as possible.',
+            }),
+          );
+        } else {
+          dispatch(
+            setNotification({
+              title: 'Request received',
+              body:
+                'Thank you. We have your claim request and will make a decision.',
+            }),
+          );
+        }
       },
       error => {
         dispatch({ type: SET_DECISION_REQUEST_ERROR, error });

--- a/src/applications/claims-status/components/claim-document-request-pages/Automated5103Notice.jsx
+++ b/src/applications/claims-status/components/claim-document-request-pages/Automated5103Notice.jsx
@@ -1,90 +1,157 @@
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom-v5-compat';
+import React from 'react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom-v5-compat';
 import {
   VaCheckbox,
   VaButton,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { buildDateFormatter } from '../../utils/helpers';
-import { submit5103 } from '../../actions';
+import { buildDateFormatter, setDocumentTitle } from '../../utils/helpers';
+import {
+  // START ligthouse_migration
+  submit5103 as submit5103Action,
+  submitRequest as submitRequestAction,
+  // END lighthouse_migration
+} from '../../actions';
+// START lighthouse_migration
+import { cstUseLighthouse } from '../../selectors';
+// END lighthouse_migration
+import { setUpPage } from '../../utils/page';
 
-export default function Automated5103Notice({ claimId, item }) {
-  const [isChecked, setChecked] = useState(false);
-  const [checkboxErrorMessage, setCheckboxErrorMessage] = useState(undefined);
-  const navigate = useNavigate();
+import withRouter from '../../utils/withRouter';
 
-  const submit = () => {
-    if (isChecked) {
-      submit5103(claimId, true);
-      navigate('../files');
-    } else {
-      setCheckboxErrorMessage(
-        `You must confirm you’re done adding evidence before submitting the evidence waiver`,
-      );
-    }
-  };
-  const formattedDueDate = buildDateFormatter()(item.suspenseDate);
-  if (item.displayName !== 'Automated 5103 Notice Response') {
-    return null;
+class Automated5103Notice extends React.Component {
+  constructor() {
+    super();
+    this.state = { addedEvidence: false, checkboxErrorMessage: undefined };
   }
-  return (
-    <div id="automated-5103-notice-page">
-      <h1 className="vads-u-margin-top--0 vads-u-margin-bottom--2">
-        Review the list of evidence we need
-      </h1>
-      <p>
-        We sent you a “5103 notice” letter that lists the types of evidence we
-        may need to decide your claim.
-      </p>
-      <Link className="active-va-link" to="/your-claim-letters">
-        Go to claim letters
-        <va-icon icon="chevron_right" size={3} aria-hidden="true" />
-      </Link>
-      <p>
-        You don’t need to do anything on this page. We’ll wait until{' '}
-        <strong>{formattedDueDate}</strong>, to move your claim to the next
-        step.
-      </p>
-      <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--2">
-        If you have more evidence to submit
-      </h2>
-      <p>
-        <strong>Note:</strong> You can add evidence at any time. But if you add
-        evidence later in the process, your claim will move back to this step.
-        So we encourage you to add all your evidence now.
-      </p>
-      <Link data-testid="upload-evidence-link" to="../files">
-        Upload your evidence here
-      </Link>
-      <p>
-        If you finish adding evidence before that date,{' '}
-        <strong>
-          you can submit the 5103 notice response waiver attached to the letter.
-        </strong>{' '}
-        This might help speed up the claim process.
-      </p>
-      <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--2">
-        If you don’t have more evidence to submit
-      </h2>
-      <p>
-        If you’re finished adding evidence, submit the evidence waiver. We’ll
-        move your claim to the next step as soon as possible.
-      </p>
-      <VaCheckbox
-        label="I’m finished adding evidence to support my claim."
-        className="vads-u-margin-y--3"
-        checked={isChecked}
-        error={checkboxErrorMessage}
-        onVaChange={event => {
-          setChecked(event.detail.checked);
-        }}
-      />
-      <VaButton id="submit" text="Submit evidence waiver" onClick={submit} />
-    </div>
-  );
+
+  componentDidMount() {
+    setDocumentTitle('Automated 5103 Notice - Document Request Page');
+    setUpPage();
+  }
+
+  goToFilesPage() {
+    this.props.navigate('../files');
+  }
+
+  render() {
+    const {
+      params,
+      submit5103,
+      submitRequest,
+      useLighthouse5103,
+      item,
+    } = this.props;
+
+    const submit = () => {
+      if (this.state.addedEvidence) {
+        if (useLighthouse5103) {
+          submit5103(params.id, true);
+        } else {
+          submitRequest(params.id);
+        }
+        this.goToFilesPage();
+      } else {
+        this.setState({
+          checkboxErrorMessage: `You must confirm you’re done adding evidence before submitting the evidence waiver`,
+        });
+      }
+    };
+    const formattedDueDate = buildDateFormatter()(item.suspenseDate);
+    if (item.displayName !== 'Automated 5103 Notice Response') {
+      return null;
+    }
+    return (
+      <div id="automated-5103-notice-page">
+        <h1 className="vads-u-margin-top--0 vads-u-margin-bottom--2">
+          Review the list of evidence we need
+        </h1>
+        <p>
+          We sent you a “5103 notice” letter that lists the types of evidence we
+          may need to decide your claim.
+        </p>
+        <Link className="active-va-link" to="/your-claim-letters">
+          Go to claim letters
+          <va-icon icon="chevron_right" size={3} aria-hidden="true" />
+        </Link>
+        <p>
+          You don’t need to do anything on this page. We’ll wait until{' '}
+          <strong>{formattedDueDate}</strong>, to move your claim to the next
+          step.
+        </p>
+        <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--2">
+          If you have more evidence to submit
+        </h2>
+        <p>
+          <strong>Note:</strong> You can add evidence at any time. But if you
+          add evidence later in the process, your claim will move back to this
+          step. So we encourage you to add all your evidence now.
+        </p>
+        <Link data-testid="upload-evidence-link" to="../files">
+          Upload your evidence here
+        </Link>
+        <p>
+          If you finish adding evidence before that date,{' '}
+          <strong>
+            you can submit the 5103 notice response waiver attached to the
+            letter.
+          </strong>{' '}
+          This might help speed up the claim process.
+        </p>
+        <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--2">
+          If you don’t have more evidence to submit
+        </h2>
+        <p>
+          If you’re finished adding evidence, submit the evidence waiver. We’ll
+          move your claim to the next step as soon as possible.
+        </p>
+        <VaCheckbox
+          label="I’m finished adding evidence to support my claim."
+          className="vads-u-margin-y--3"
+          checked={this.state.addedEvidence}
+          error={this.state.checkboxErrorMessage}
+          onVaChange={event => {
+            this.setState({ addedEvidence: event.detail.checked });
+          }}
+        />
+        <VaButton id="submit" text="Submit evidence waiver" onClick={submit} />
+      </div>
+    );
+  }
 }
 
-Automated5103Notice.propTypes = {
-  claimId: PropTypes.string.isRequired,
-  item: PropTypes.object.isRequired,
+function mapStateToProps(state) {
+  return {
+    // START lighthouse_migration
+    useLighthouse5103: cstUseLighthouse(state, '5103'),
+    // END lighthouse_migration
+  };
+}
+
+const mapDispatchToProps = {
+  // START lighthouse_migration
+  submit5103: submit5103Action,
+  submitRequest: submitRequestAction,
+  // END lighthouse_migration
 };
+
+export default withRouter(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(Automated5103Notice),
+);
+
+Automated5103Notice.propTypes = {
+  item: PropTypes.object,
+  navigate: PropTypes.func,
+  params: PropTypes.object,
+  // START lighthouse_migration
+  submit5103: PropTypes.func,
+  submitRequest: PropTypes.func,
+  useLighthouse5103: PropTypes.bool,
+  // END lighthouse_migration
+};
+
+export { Automated5103Notice };

--- a/src/applications/claims-status/components/claim-document-request-pages/Automated5103Notice.jsx
+++ b/src/applications/claims-status/components/claim-document-request-pages/Automated5103Notice.jsx
@@ -49,7 +49,7 @@ class Automated5103Notice extends React.Component {
         if (useLighthouse5103) {
           submit5103(params.id, true);
         } else {
-          submitRequest(params.id);
+          submitRequest(params.id, true);
         }
         this.goToFilesPage();
       } else {

--- a/src/applications/claims-status/components/claim-document-request-pages/Automated5103Notice.jsx
+++ b/src/applications/claims-status/components/claim-document-request-pages/Automated5103Notice.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router-dom-v5-compat';
 import {
@@ -20,106 +20,101 @@ import { setUpPage } from '../../utils/page';
 
 import withRouter from '../../utils/withRouter';
 
-class Automated5103Notice extends React.Component {
-  constructor() {
-    super();
-    this.state = { addedEvidence: false, checkboxErrorMessage: undefined };
-  }
+function Automated5103Notice({
+  item,
+  navigate,
+  params,
+  submit5103,
+  submitRequest,
+  useLighthouse5103,
+}) {
+  const [addedEvidence, setAddedEvidence] = useState(false);
+  const [checkboxErrorMessage, setCheckboxErrorMessage] = useState(undefined);
 
-  componentDidMount() {
+  useEffect(() => {
     setDocumentTitle('Automated 5103 Notice - Document Request Page');
     setUpPage();
-  }
+  }, []);
 
-  goToFilesPage() {
-    this.props.navigate('../files');
-  }
+  const goToFilesPage = () => {
+    navigate('../files');
+  };
 
-  render() {
-    const {
-      params,
-      submit5103,
-      submitRequest,
-      useLighthouse5103,
-      item,
-    } = this.props;
-
-    const submit = () => {
-      if (this.state.addedEvidence) {
-        if (useLighthouse5103) {
-          submit5103(params.id, true);
-        } else {
-          submitRequest(params.id, true);
-        }
-        this.goToFilesPage();
+  const submit = () => {
+    if (addedEvidence) {
+      if (useLighthouse5103) {
+        submit5103(params.id, true);
       } else {
-        this.setState({
-          checkboxErrorMessage: `You must confirm you’re done adding evidence before submitting the evidence waiver`,
-        });
+        submitRequest(params.id, true);
       }
-    };
-    const formattedDueDate = buildDateFormatter()(item.suspenseDate);
-    if (item.displayName !== 'Automated 5103 Notice Response') {
-      return null;
+      goToFilesPage();
+    } else {
+      setCheckboxErrorMessage(
+        `You must confirm you’re done adding evidence before submitting the evidence waiver`,
+      );
     }
-    return (
-      <div id="automated-5103-notice-page">
-        <h1 className="vads-u-margin-top--0 vads-u-margin-bottom--2">
-          Review the list of evidence we need
-        </h1>
-        <p>
-          We sent you a “5103 notice” letter that lists the types of evidence we
-          may need to decide your claim.
-        </p>
-        <Link className="active-va-link" to="/your-claim-letters">
-          Go to claim letters
-          <va-icon icon="chevron_right" size={3} aria-hidden="true" />
-        </Link>
-        <p>
-          You don’t need to do anything on this page. We’ll wait until{' '}
-          <strong>{formattedDueDate}</strong>, to move your claim to the next
-          step.
-        </p>
-        <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--2">
-          If you have more evidence to submit
-        </h2>
-        <p>
-          <strong>Note:</strong> You can add evidence at any time. But if you
-          add evidence later in the process, your claim will move back to this
-          step. So we encourage you to add all your evidence now.
-        </p>
-        <Link data-testid="upload-evidence-link" to="../files">
-          Upload your evidence here
-        </Link>
-        <p>
-          If you finish adding evidence before that date,{' '}
-          <strong>
-            you can submit the 5103 notice response waiver attached to the
-            letter.
-          </strong>{' '}
-          This might help speed up the claim process.
-        </p>
-        <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--2">
-          If you don’t have more evidence to submit
-        </h2>
-        <p>
-          If you’re finished adding evidence, submit the evidence waiver. We’ll
-          move your claim to the next step as soon as possible.
-        </p>
-        <VaCheckbox
-          label="I’m finished adding evidence to support my claim."
-          className="vads-u-margin-y--3"
-          checked={this.state.addedEvidence}
-          error={this.state.checkboxErrorMessage}
-          onVaChange={event => {
-            this.setState({ addedEvidence: event.detail.checked });
-          }}
-        />
-        <VaButton id="submit" text="Submit evidence waiver" onClick={submit} />
-      </div>
-    );
+  };
+  const formattedDueDate = buildDateFormatter()(item.suspenseDate);
+  if (item.displayName !== 'Automated 5103 Notice Response') {
+    return null;
   }
+  return (
+    <div id="automated-5103-notice-page">
+      <h1 className="vads-u-margin-top--0 vads-u-margin-bottom--2">
+        Review the list of evidence we need
+      </h1>
+      <p>
+        We sent you a “5103 notice” letter that lists the types of evidence we
+        may need to decide your claim.
+      </p>
+      <Link className="active-va-link" to="/your-claim-letters">
+        Go to claim letters
+        <va-icon icon="chevron_right" size={3} aria-hidden="true" />
+      </Link>
+      <p>
+        You don’t need to do anything on this page. We’ll wait until{' '}
+        <strong>{formattedDueDate}</strong>, to move your claim to the next
+        step.
+      </p>
+      <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--2">
+        If you have more evidence to submit
+      </h2>
+      <p>
+        <strong>Note:</strong> You can add evidence at any time. But if you add
+        evidence later in the process, your claim will move back to this step.
+        So we encourage you to add all your evidence now.
+      </p>
+      <Link data-testid="upload-evidence-link" to="../files">
+        Upload your evidence here
+      </Link>
+      <p>
+        If you finish adding evidence before that date,{' '}
+        <strong>
+          you can submit the 5103 notice response waiver attached to the letter.
+        </strong>{' '}
+        This might help speed up the claim process.
+      </p>
+      <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--2">
+        If you don’t have more evidence to submit
+      </h2>
+      <p>
+        If you’re finished adding evidence, submit the evidence waiver. We’ll
+        move your claim to the next step as soon as possible.
+      </p>
+      <VaCheckbox
+        label="I’m finished adding evidence to support my claim."
+        className="vads-u-margin-y--3"
+        checked={addedEvidence}
+        error={checkboxErrorMessage}
+        onVaChange={event => {
+          setAddedEvidence(event.detail.checked);
+        }}
+      />
+      <VaButton id="submit" text="Submit evidence waiver" onClick={submit} />
+    </div>
+  );
 }
+// }
 
 function mapStateToProps(state) {
   return {

--- a/src/applications/claims-status/components/claim-document-request-pages/Automated5103Notice.jsx
+++ b/src/applications/claims-status/components/claim-document-request-pages/Automated5103Notice.jsx
@@ -85,6 +85,6 @@ export default function Automated5103Notice({ claimId, item }) {
 }
 
 Automated5103Notice.propTypes = {
-  claimId: PropTypes.number.isRequired,
+  claimId: PropTypes.string.isRequired,
   item: PropTypes.object.isRequired,
 };

--- a/src/applications/claims-status/components/claim-document-request-pages/Automated5103Notice.jsx
+++ b/src/applications/claims-status/components/claim-document-request-pages/Automated5103Notice.jsx
@@ -1,9 +1,28 @@
 import PropTypes from 'prop-types';
-import React from 'react';
-import { Link } from 'react-router-dom-v5-compat';
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom-v5-compat';
+import {
+  VaCheckbox,
+  VaButton,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { buildDateFormatter } from '../../utils/helpers';
+import { submit5103 } from '../../actions';
 
-export default function Automated5103Notice({ item }) {
+export default function Automated5103Notice({ claimId, item }) {
+  const [isChecked, setChecked] = useState(false);
+  const [checkboxErrorMessage, setCheckboxErrorMessage] = useState(undefined);
+  const navigate = useNavigate();
+
+  const submit = () => {
+    if (isChecked) {
+      submit5103(claimId, true);
+      navigate('../files');
+    } else {
+      setCheckboxErrorMessage(
+        `You must confirm you’re done adding evidence before submitting the evidence waiver`,
+      );
+    }
+  };
   const formattedDueDate = buildDateFormatter()(item.suspenseDate);
   if (item.displayName !== 'Automated 5103 Notice Response') {
     return null;
@@ -44,10 +63,28 @@ export default function Automated5103Notice({ item }) {
         </strong>{' '}
         This might help speed up the claim process.
       </p>
+      <h2 className="vads-u-margin-top--4 vads-u-margin-bottom--2">
+        If you don’t have more evidence to submit
+      </h2>
+      <p>
+        If you’re finished adding evidence, submit the evidence waiver. We’ll
+        move your claim to the next step as soon as possible.
+      </p>
+      <VaCheckbox
+        label="I’m finished adding evidence to support my claim."
+        className="vads-u-margin-y--3"
+        checked={isChecked}
+        error={checkboxErrorMessage}
+        onVaChange={event => {
+          setChecked(event.detail.checked);
+        }}
+      />
+      <VaButton id="submit" text="Submit evidence waiver" onClick={submit} />
     </div>
   );
 }
 
 Automated5103Notice.propTypes = {
+  claimId: PropTypes.number.isRequired,
   item: PropTypes.object.isRequired,
 };

--- a/src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx
@@ -120,7 +120,14 @@ class AdditionalEvidencePage extends React.Component {
           {isOpen ? (
             <>
               {this.props.filesNeeded.map(item => (
-                <FilesNeeded key={item.id} id={claim.id} item={item} />
+                <FilesNeeded
+                  key={item.id}
+                  id={claim.id}
+                  item={item}
+                  evidenceWaiverSubmitted5103={
+                    claim.attributes.evidenceWaiverSubmitted5103
+                  }
+                />
               ))}
               {this.props.filesOptional.map(item => (
                 <FilesOptional key={item.id} id={claim.id} item={item} />

--- a/src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx
@@ -43,7 +43,11 @@ function FilesNeeded({ item, evidenceWaiverSubmitted5103 = false }) {
   }
 
   return (
-    <va-alert class="primary-alert vads-u-margin-bottom--2" status="warning">
+    <va-alert
+      data-testid={`item-${item.id}`}
+      class="primary-alert vads-u-margin-bottom--2"
+      status="warning"
+    >
       <h4 slot="headline" className="alert-title">
         {item.displayName}
       </h4>

--- a/src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { truncateDescription } from '../../utils/helpers';
 import DueDate from '../DueDate';
 
-function FilesNeeded({ item }) {
+function FilesNeeded({ item, evidenceWaiverSubmitted5103 }) {
   // We will not use the truncateDescription() here as these descriptions are custom and specific to what we want
   // the user to see based on the given item type.
   const itemsWithNewDescriptions = [
@@ -36,14 +36,18 @@ function FilesNeeded({ item }) {
   };
 
   // Hide the due date when item type is Automated 5103 Notice Response
-  const hideDueDate = item.displayName === 'Automated 5103 Notice Response';
+  const is5103Notice = item.displayName === 'Automated 5103 Notice Response';
+  // When evidenceWaiverSubmitted5103 is true and is5103Notice is true FilesNeeded should show null
+  if (evidenceWaiverSubmitted5103 && is5103Notice) {
+    return null;
+  }
 
   return (
     <va-alert class="primary-alert vads-u-margin-bottom--2" status="warning">
       <h4 slot="headline" className="alert-title">
         {item.displayName}
       </h4>
-      {!hideDueDate && <DueDate date={item.suspenseDate} />}
+      {!is5103Notice && <DueDate date={item.suspenseDate} />}
       <span className="alert-description">{getItemDescription()}</span>
       <div className="link-action-container">
         <Link
@@ -61,6 +65,7 @@ function FilesNeeded({ item }) {
 
 FilesNeeded.propTypes = {
   item: PropTypes.object.isRequired,
+  evidenceWaiverSubmitted5103: PropTypes.bool,
 };
 
 export default FilesNeeded;

--- a/src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { truncateDescription } from '../../utils/helpers';
 import DueDate from '../DueDate';
 
-function FilesNeeded({ item, evidenceWaiverSubmitted5103 }) {
+function FilesNeeded({ item, evidenceWaiverSubmitted5103 = false }) {
   // We will not use the truncateDescription() here as these descriptions are custom and specific to what we want
   // the user to see based on the given item type.
   const itemsWithNewDescriptions = [

--- a/src/applications/claims-status/components/claim-status-tab/WhatYouNeedToDo.jsx
+++ b/src/applications/claims-status/components/claim-status-tab/WhatYouNeedToDo.jsx
@@ -22,7 +22,14 @@ function WhatYouNeedToDo({ claim }) {
         </div>
       )}
       {filesNeeded.map(item => (
-        <FilesNeeded key={item.id} id={claim.id} item={item} />
+        <FilesNeeded
+          key={item.id}
+          id={claim.id}
+          item={item}
+          evidenceWaiverSubmitted5103={
+            claim.attributes.evidenceWaiverSubmitted5103
+          }
+        />
       ))}
     </>
   );

--- a/src/applications/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/applications/claims-status/containers/DocumentRequestPage.jsx
@@ -140,7 +140,7 @@ class DocumentRequestPage extends React.Component {
         />
       );
     } else {
-      const { claim, message, trackedItem } = this.props;
+      const { message, trackedItem } = this.props;
       const is5103Notice =
         trackedItem.displayName === 'Automated 5103 Notice Response';
 
@@ -159,7 +159,7 @@ class DocumentRequestPage extends React.Component {
           <Toggler toggleName={Toggler.TOGGLE_NAMES.cst5103UpdateEnabled}>
             <Toggler.Enabled>
               {is5103Notice ? (
-                <Automated5103Notice claimId={claim.id} item={trackedItem} />
+                <Automated5103Notice item={trackedItem} />
               ) : (
                 <>{this.getDefaultPage()}</>
               )}

--- a/src/applications/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/applications/claims-status/containers/DocumentRequestPage.jsx
@@ -140,7 +140,7 @@ class DocumentRequestPage extends React.Component {
         />
       );
     } else {
-      const { message, trackedItem } = this.props;
+      const { claim, message, trackedItem } = this.props;
       const is5103Notice =
         trackedItem.displayName === 'Automated 5103 Notice Response';
 
@@ -159,7 +159,7 @@ class DocumentRequestPage extends React.Component {
           <Toggler toggleName={Toggler.TOGGLE_NAMES.cst5103UpdateEnabled}>
             <Toggler.Enabled>
               {is5103Notice ? (
-                <Automated5103Notice item={trackedItem} />
+                <Automated5103Notice claimId={claim.id} item={trackedItem} />
               ) : (
                 <>{this.getDefaultPage()}</>
               )}

--- a/src/applications/claims-status/tests/components/claim-document-request-pages/Automated5103Notice.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-document-request-pages/Automated5103Notice.unit.spec.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
+import sinon from 'sinon';
 import { expect } from 'chai';
+import { fireEvent } from '@testing-library/dom';
 import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
-import { renderWithRouter } from '../../utils';
+// import * as router from 'react-router-dom-v5-compat';
+import { renderWithRouter, rerenderWithRouter } from '../../utils';
+import * as actions from '../../../actions';
 
 import Automated5103Notice from '../../../components/claim-document-request-pages/Automated5103Notice';
+
+const claimId = 1;
 
 describe('<Automated5103Notice>', () => {
   it('should render component when item is a 5103 notice', () => {
@@ -23,7 +29,7 @@ describe('<Automated5103Notice>', () => {
     };
 
     const { getByText, getByTestId, container } = renderWithRouter(
-      <Automated5103Notice item={item} />,
+      <Automated5103Notice claimId={claimId} item={item} />,
     );
     expect($('#automated-5103-notice-page', container)).to.exist;
     getByText('Review the list of evidence we need');
@@ -32,7 +38,11 @@ describe('<Automated5103Notice>', () => {
     expect(getByTestId('upload-evidence-link').textContent).to.equal(
       'Upload your evidence here',
     );
+    getByText('If you don’t have more evidence to submit');
+    expect($('va-checkbox', container)).to.exist;
+    expect($('va-button', container)).to.exist;
   });
+
   it('should render null when item is NOT a 5103 notice', () => {
     const item = {
       closedDate: null,
@@ -49,7 +59,58 @@ describe('<Automated5103Notice>', () => {
       date: '2024-03-07',
     };
 
-    const { container } = renderWithRouter(<Automated5103Notice item={item} />);
+    const { container } = renderWithRouter(
+      <Automated5103Notice claimId={claimId} item={item} />,
+    );
     expect($('#automated-5103-notice-page', container)).to.not.exist;
+  });
+
+  context('when checkbox is checked and submit button clicked', () => {
+    it('should submit 5103 notice and redirect to files tab', () => {
+      const submit = sinon.spy(actions, 'submit5103');
+      // const stubNavigate = sinon.stub(router, 'useNavigate');
+      // const navigate = sinon.spy();
+      // stubNavigate.returns(navigate);
+
+      const item = {
+        closedDate: null,
+        description: 'Automated 5103 Notice Response',
+        displayName: 'Automated 5103 Notice Response',
+        id: 467558,
+        overdue: true,
+        receivedDate: null,
+        requestedDate: '2024-03-07',
+        status: 'NEEDED_FROM_YOU',
+        suspenseDate: '2024-04-07',
+        uploadsAllowed: true,
+        documents: '[]',
+        date: '2024-03-07',
+      };
+
+      const { container, rerender } = renderWithRouter(
+        <Automated5103Notice claimId={claimId} item={item} />,
+      );
+      expect($('#automated-5103-notice-page', container)).to.exist;
+      expect($('va-checkbox', container)).to.exist;
+      expect($('va-button', container)).to.exist;
+
+      // Check the checkbox
+      $('va-checkbox', container).__events.vaChange({
+        detail: { checked: true },
+      });
+
+      rerenderWithRouter(
+        rerender,
+        <Automated5103Notice claimId={claimId} item={item} />,
+      );
+
+      // Click submit button
+      fireEvent.click($('#submit', container));
+
+      expect(submit.calledOnce).to.be.true;
+      // expect(navigate.calledOnce).to.be.true;
+
+      // expect(navigate.calledWith('../files')).to.be.true;
+    });
   });
 });

--- a/src/applications/claims-status/tests/components/claim-document-request-pages/Automated5103Notice.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-document-request-pages/Automated5103Notice.unit.spec.jsx
@@ -113,4 +113,45 @@ describe('<Automated5103Notice>', () => {
       // expect(navigate.calledWith('../files')).to.be.true;
     });
   });
+
+  context('when checkbox is not checked and submit button clicked', () => {
+    it('should not submit 5103 notice and error message displayed', () => {
+      const submit = sinon.spy(actions, 'submit5103');
+
+      const item = {
+        closedDate: null,
+        description: 'Automated 5103 Notice Response',
+        displayName: 'Automated 5103 Notice Response',
+        id: 467558,
+        overdue: true,
+        receivedDate: null,
+        requestedDate: '2024-03-07',
+        status: 'NEEDED_FROM_YOU',
+        suspenseDate: '2024-04-07',
+        uploadsAllowed: true,
+        documents: '[]',
+        date: '2024-03-07',
+      };
+
+      const { container } = renderWithRouter(
+        <Automated5103Notice claimId={claimId} item={item} />,
+      );
+      expect($('#automated-5103-notice-page', container)).to.exist;
+      expect($('va-checkbox', container)).to.exist;
+      expect($('va-button', container)).to.exist;
+
+      expect($('va-checkbox', container).getAttribute('error')).to.be.null;
+
+      // Click submit button
+      fireEvent.click($('#submit', container));
+
+      expect($('va-checkbox', container).getAttribute('checked')).to.equal(
+        'false',
+      );
+      expect(submit.calledOnce).to.be.false;
+      expect($('va-checkbox', container).getAttribute('error')).to.equal(
+        'You must confirm you’re done adding evidence before submitting the evidence waiver',
+      );
+    });
+  });
 });

--- a/src/applications/claims-status/tests/components/claim-document-request-pages/Automated5103Notice.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-document-request-pages/Automated5103Notice.unit.spec.jsx
@@ -2,34 +2,41 @@ import React from 'react';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { fireEvent } from '@testing-library/dom';
-import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
-// import * as router from 'react-router-dom-v5-compat';
-import { renderWithRouter, rerenderWithRouter } from '../../utils';
-import * as actions from '../../../actions';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
 
-import Automated5103Notice from '../../../components/claim-document-request-pages/Automated5103Notice';
+import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
+
+import { renderWithRouter, rerenderWithRouter } from '../../utils';
+import { Automated5103Notice } from '../../../components/claim-document-request-pages/Automated5103Notice';
 
 const claimId = 1;
 
+const store = createStore(() => ({
+  featureToggles: {},
+}));
+
+const item5103 = {
+  closedDate: null,
+  description: 'Automated 5103 Notice Response',
+  displayName: 'Automated 5103 Notice Response',
+  id: 467558,
+  overdue: true,
+  receivedDate: null,
+  requestedDate: '2024-03-07',
+  status: 'NEEDED_FROM_YOU',
+  suspenseDate: '2024-04-07',
+  uploadsAllowed: true,
+  documents: '[]',
+  date: '2024-03-07',
+};
+
 describe('<Automated5103Notice>', () => {
   it('should render component when item is a 5103 notice', () => {
-    const item = {
-      closedDate: null,
-      description: 'Automated 5103 Notice Response',
-      displayName: 'Automated 5103 Notice Response',
-      id: 467558,
-      overdue: true,
-      receivedDate: null,
-      requestedDate: '2024-03-07',
-      status: 'NEEDED_FROM_YOU',
-      suspenseDate: '2024-04-07',
-      uploadsAllowed: true,
-      documents: '[]',
-      date: '2024-03-07',
-    };
-
     const { getByText, getByTestId, container } = renderWithRouter(
-      <Automated5103Notice claimId={claimId} item={item} />,
+      <Provider store={store}>
+        <Automated5103Notice item={item5103} params={{ id: claimId }} />,
+      </Provider>,
     );
     expect($('#automated-5103-notice-page', container)).to.exist;
     getByText('Review the list of evidence we need');
@@ -60,98 +67,188 @@ describe('<Automated5103Notice>', () => {
     };
 
     const { container } = renderWithRouter(
-      <Automated5103Notice claimId={claimId} item={item} />,
+      <Provider store={store}>
+        <Automated5103Notice item={item} params={{ id: claimId }} />,
+      </Provider>,
     );
     expect($('#automated-5103-notice-page', container)).to.not.exist;
   });
 
-  context('when checkbox is checked and submit button clicked', () => {
-    it('should submit 5103 notice and redirect to files tab', () => {
-      const submit = sinon.spy(actions, 'submit5103');
-      // const stubNavigate = sinon.stub(router, 'useNavigate');
-      // const navigate = sinon.spy();
-      // stubNavigate.returns(navigate);
+  context('when useLighthouse5103 false', () => {
+    const props = {
+      item: item5103,
+      params: { id: claimId },
+      useLighthouse5103: false,
+    };
 
-      const item = {
-        closedDate: null,
-        description: 'Automated 5103 Notice Response',
-        displayName: 'Automated 5103 Notice Response',
-        id: 467558,
-        overdue: true,
-        receivedDate: null,
-        requestedDate: '2024-03-07',
-        status: 'NEEDED_FROM_YOU',
-        suspenseDate: '2024-04-07',
-        uploadsAllowed: true,
-        documents: '[]',
-        date: '2024-03-07',
-      };
+    context('when checkbox is checked and submit button clicked', () => {
+      it('should submitRequest notice and redirect to files tab', () => {
+        const submitRequest = sinon.spy();
+        const submit5103 = sinon.spy();
+        const navigate = sinon.spy();
 
-      const { container, rerender } = renderWithRouter(
-        <Automated5103Notice claimId={claimId} item={item} />,
-      );
-      expect($('#automated-5103-notice-page', container)).to.exist;
-      expect($('va-checkbox', container)).to.exist;
-      expect($('va-button', container)).to.exist;
+        const { container, rerender } = renderWithRouter(
+          <Provider store={store}>
+            <Automated5103Notice
+              {...props}
+              submit5103={submit5103}
+              submitRequest={submitRequest}
+              navigate={navigate}
+            />
+          </Provider>,
+        );
+        expect($('#automated-5103-notice-page', container)).to.exist;
+        expect($('va-checkbox', container)).to.exist;
+        expect($('va-button', container)).to.exist;
 
-      // Check the checkbox
-      $('va-checkbox', container).__events.vaChange({
-        detail: { checked: true },
+        // Check the checkbox
+        $('va-checkbox', container).__events.vaChange({
+          detail: { checked: true },
+        });
+
+        rerenderWithRouter(
+          rerender,
+          <Provider store={store}>
+            <Automated5103Notice
+              {...props}
+              submit5103={submit5103}
+              submitRequest={submitRequest}
+              navigate={navigate}
+            />
+          </Provider>,
+        );
+
+        // Click submit button
+        fireEvent.click($('#submit', container));
+
+        expect(submitRequest.called).to.be.true;
+        expect(submit5103.called).to.be.false;
+        expect(navigate.calledWith('../files')).to.be.true;
       });
+    });
+    context('when checkbox is not checked and submit button clicked', () => {
+      it('should not submit 5103 notice and error message displayed', () => {
+        const submitRequest = sinon.spy();
+        const submit5103 = sinon.spy();
+        const navigate = sinon.spy();
 
-      rerenderWithRouter(
-        rerender,
-        <Automated5103Notice claimId={claimId} item={item} />,
-      );
+        const { container } = renderWithRouter(
+          <Provider store={store}>
+            <Automated5103Notice
+              {...props}
+              submit5103={submit5103}
+              submitRequest={submitRequest}
+              navigate={navigate}
+            />
+          </Provider>,
+        );
+        expect($('#automated-5103-notice-page', container)).to.exist;
+        expect($('va-checkbox', container)).to.exist;
+        expect($('va-button', container)).to.exist;
+        expect($('va-checkbox', container).getAttribute('error')).to.be.null;
 
-      // Click submit button
-      fireEvent.click($('#submit', container));
+        // Click submit button
+        fireEvent.click($('#submit', container));
 
-      expect(submit.calledOnce).to.be.true;
-      // expect(navigate.calledOnce).to.be.true;
-
-      // expect(navigate.calledWith('../files')).to.be.true;
+        expect($('va-checkbox', container).getAttribute('checked')).to.equal(
+          'false',
+        );
+        expect(submitRequest.called).to.be.false;
+        expect(submit5103.called).to.be.false;
+        expect(navigate.called).to.be.false;
+        expect($('va-checkbox', container).getAttribute('error')).to.equal(
+          'You must confirm you’re done adding evidence before submitting the evidence waiver',
+        );
+      });
     });
   });
 
-  context('when checkbox is not checked and submit button clicked', () => {
-    it('should not submit 5103 notice and error message displayed', () => {
-      const submit = sinon.spy(actions, 'submit5103');
+  context('when useLighthouse5103 false', () => {
+    const props = {
+      item: item5103,
+      params: { id: claimId },
+      useLighthouse5103: true,
+    };
 
-      const item = {
-        closedDate: null,
-        description: 'Automated 5103 Notice Response',
-        displayName: 'Automated 5103 Notice Response',
-        id: 467558,
-        overdue: true,
-        receivedDate: null,
-        requestedDate: '2024-03-07',
-        status: 'NEEDED_FROM_YOU',
-        suspenseDate: '2024-04-07',
-        uploadsAllowed: true,
-        documents: '[]',
-        date: '2024-03-07',
-      };
+    context('when checkbox is checked and submit button clicked', () => {
+      it('should submit5103 notice and redirect to files tab', () => {
+        const submitRequest = sinon.spy();
+        const submit5103 = sinon.spy();
+        const navigate = sinon.spy();
 
-      const { container } = renderWithRouter(
-        <Automated5103Notice claimId={claimId} item={item} />,
-      );
-      expect($('#automated-5103-notice-page', container)).to.exist;
-      expect($('va-checkbox', container)).to.exist;
-      expect($('va-button', container)).to.exist;
+        const { container, rerender } = renderWithRouter(
+          <Provider store={store}>
+            <Automated5103Notice
+              {...props}
+              submit5103={submit5103}
+              submitRequest={submitRequest}
+              navigate={navigate}
+            />
+          </Provider>,
+        );
+        expect($('#automated-5103-notice-page', container)).to.exist;
+        expect($('va-checkbox', container)).to.exist;
+        expect($('va-button', container)).to.exist;
 
-      expect($('va-checkbox', container).getAttribute('error')).to.be.null;
+        // Check the checkbox
+        $('va-checkbox', container).__events.vaChange({
+          detail: { checked: true },
+        });
 
-      // Click submit button
-      fireEvent.click($('#submit', container));
+        rerenderWithRouter(
+          rerender,
+          <Provider store={store}>
+            <Automated5103Notice
+              {...props}
+              submit5103={submit5103}
+              submitRequest={submitRequest}
+              navigate={navigate}
+            />
+          </Provider>,
+        );
 
-      expect($('va-checkbox', container).getAttribute('checked')).to.equal(
-        'false',
-      );
-      expect(submit.calledOnce).to.be.false;
-      expect($('va-checkbox', container).getAttribute('error')).to.equal(
-        'You must confirm you’re done adding evidence before submitting the evidence waiver',
-      );
+        // Click submit button
+        fireEvent.click($('#submit', container));
+
+        expect(submitRequest.called).to.be.false;
+        expect(submit5103.called).to.be.true;
+        expect(navigate.calledWith('../files')).to.be.true;
+      });
+    });
+    context('when checkbox is not checked and submit button clicked', () => {
+      it('should not submit 5103 notice and error message displayed', () => {
+        const submitRequest = sinon.spy();
+        const submit5103 = sinon.spy();
+        const navigate = sinon.spy();
+
+        const { container } = renderWithRouter(
+          <Provider store={store}>
+            <Automated5103Notice
+              {...props}
+              submit5103={submit5103}
+              submitRequest={submitRequest}
+              navigate={navigate}
+            />
+          </Provider>,
+        );
+        expect($('#automated-5103-notice-page', container)).to.exist;
+        expect($('va-checkbox', container)).to.exist;
+        expect($('va-button', container)).to.exist;
+        expect($('va-checkbox', container).getAttribute('error')).to.be.null;
+
+        // Click submit button
+        fireEvent.click($('#submit', container));
+
+        expect($('va-checkbox', container).getAttribute('checked')).to.equal(
+          'false',
+        );
+        expect(submitRequest.called).to.be.false;
+        expect(submit5103.called).to.be.false;
+        expect(navigate.called).to.be.false;
+        expect($('va-checkbox', container).getAttribute('error')).to.equal(
+          'You must confirm you’re done adding evidence before submitting the evidence waiver',
+        );
+      });
     });
   });
 });

--- a/src/applications/claims-status/tests/components/claim-files-tab/FilesNeeded.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab/FilesNeeded.unit.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 
+import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import FilesNeeded from '../../../components/claim-files-tab/FilesNeeded';
 import { renderWithRouter } from '../../utils';
 
@@ -25,21 +26,33 @@ describe('<FilesNeeded>', () => {
       description: 'This is a alert',
       suspenseDate: '2024-12-01',
     };
-    it('should render va-alert with item data and hide DueDate', () => {
-      const { queryByText, getByText } = renderWithRouter(
-        <FilesNeeded item={item5103} />,
-      );
+    context('when evidenceWaiverSubmitted5103 is false', () => {
+      it('should render va-alert with item data and hide DueDate', () => {
+        const { queryByText, getByText } = renderWithRouter(
+          <FilesNeeded item={item5103} />,
+        );
 
-      expect(queryByText('December 1, 2024')).to.not.exist;
-      expect(queryByText(item5103.description)).to.not.exist;
-      getByText(item5103.displayName);
-      getByText(
-        `We sent you a "5103 notice" letter that lists the types of evidence we may need to decide your claim.`,
-      );
-      getByText(
-        `Upload the waiver attached to the letter if you’re finished adding evidence.`,
-      );
-      getByText('Details');
+        expect(queryByText('December 1, 2024')).to.not.exist;
+        expect(queryByText(item5103.description)).to.not.exist;
+        getByText(item5103.displayName);
+        getByText(
+          `We sent you a "5103 notice" letter that lists the types of evidence we may need to decide your claim.`,
+        );
+        getByText(
+          `Upload the waiver attached to the letter if you’re finished adding evidence.`,
+        );
+        getByText('Details');
+      });
+    });
+
+    context('when evidenceWaiverSubmitted5103 is true', () => {
+      it('should not render va-alert', () => {
+        const { container } = renderWithRouter(
+          <FilesNeeded item={item5103} evidenceWaiverSubmitted5103 />,
+        );
+
+        expect($('va-alert', container)).to.not.exist;
+      });
     });
   });
 });

--- a/src/applications/claims-status/tests/e2e/02.claim-files.v2.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/02.claim-files.v2.cypress.spec.js
@@ -48,12 +48,8 @@ describe('Need To Mail Files Test', () => {
   });
 });
 
-//  On the Files tab, a user can upload a file and submit it for review
-// Skipping these since we are temporarily rolling the changes for va-file-input
-// back form V1 to V3. When this ticket -> https://github.com/department-of-veterans-affairs/va.gov-team/issues/79156
-//  is worked we will unskip these
 describe('Upload Files Test', () => {
-  it.skip('shows the user an error if no file is selected', () => {
+  it('shows the user an error if no file is selected', () => {
     const trackClaimsPage = new TrackClaimsPageV2();
     trackClaimsPage.loadPage(claimsList, claimDetailsOpen);
     trackClaimsPage.verifyInProgressClaim(true);
@@ -62,7 +58,7 @@ describe('Upload Files Test', () => {
     cy.axeCheck();
   });
 
-  it.skip('uploads a file', () => {
+  it('uploads a file', () => {
     const trackClaimsPage = new TrackClaimsPageV2();
     trackClaimsPage.loadPage(claimsList, claimDetailsOpen);
     trackClaimsPage.verifyInProgressClaim(true);

--- a/src/applications/claims-status/tests/e2e/09.claim-document-request.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/09.claim-document-request.cypress.spec.js
@@ -1,0 +1,71 @@
+import TrackClaimsPageV2 from './page-objects/TrackClaimsPageV2';
+import claimsList from './fixtures/mocks/lighthouse/claims-list.json';
+import claimDetailsOpen from './fixtures/mocks/lighthouse/claim-detail-open.json';
+
+describe('When feature toggle cst_claim_phases disabled', () => {
+  context('A user can view primary alert details from the status tab', () => {
+    context('when alert is a Submit Buddy Statement', () => {
+      it('Shows primary alert details', () => {
+        const trackClaimsPage = new TrackClaimsPageV2();
+        trackClaimsPage.loadPage(claimsList, claimDetailsOpen);
+        trackClaimsPage.verifyInProgressClaim(false);
+        trackClaimsPage.verifyPrimaryAlertforSubmitBuddyStatement();
+        trackClaimsPage.verifyDocRequestforDefaultPage();
+        trackClaimsPage.submitFilesForReview(true);
+        cy.axeCheck();
+      });
+    });
+
+    context('when alert is a 5103 Notice', () => {
+      it('Shows primary alert details', () => {
+        const trackClaimsPage = new TrackClaimsPageV2();
+        trackClaimsPage.loadPage(claimsList, claimDetailsOpen);
+        trackClaimsPage.verifyInProgressClaim(false);
+        trackClaimsPage.verifyPrimaryAlertfor5103Notice();
+        trackClaimsPage.verifyDocRequestforDefaultPage(true);
+        trackClaimsPage.submitFilesForReview(true);
+        cy.axeCheck();
+      });
+    });
+  });
+});
+
+describe('When feature toggle cst_claim_phases enabled and cst_5103_update enabled', () => {
+  context('A user can view primary alert details from the status tab', () => {
+    context('when alert is a Submit Buddy Statement', () => {
+      it('Shows primary alert details', () => {
+        const trackClaimsPage = new TrackClaimsPageV2();
+        trackClaimsPage.loadPage(
+          claimsList,
+          claimDetailsOpen,
+          false,
+          false,
+          true,
+        );
+        trackClaimsPage.verifyInProgressClaim(false);
+        trackClaimsPage.verifyPrimaryAlertforSubmitBuddyStatement();
+        trackClaimsPage.verifyDocRequestforDefaultPage();
+        trackClaimsPage.submitFilesForReview(true);
+        cy.axeCheck();
+      });
+    });
+
+    context('when alert is a 5103 Notice', () => {
+      it('Shows primary alert details', () => {
+        const trackClaimsPage = new TrackClaimsPageV2();
+        trackClaimsPage.loadPage(
+          claimsList,
+          claimDetailsOpen,
+          true,
+          false,
+          true,
+        );
+        trackClaimsPage.verifyInProgressClaim(false);
+        trackClaimsPage.verifyPrimaryAlertfor5103Notice();
+        trackClaimsPage.verifyDocRequestfor5103Notice();
+        trackClaimsPage.submitEvidenceWaiver();
+        cy.axeCheck();
+      });
+    });
+  });
+});

--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/lighthouse/claim-detail-open.json
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/lighthouse/claim-detail-open.json
@@ -166,7 +166,7 @@
           "receivedDate": "2022-01-04",
           "requestedDate": null,
           "suspenseDate": null,
-          "id": 4,
+          "id": 1,
           "status": "INITIAL_REVIEW_COMPLETE",
           "uploaded": true,
           "uploadsAllowed": false
@@ -179,7 +179,7 @@
           "receivedDate": "2022-01-04",
           "requestedDate": null,
           "suspenseDate": "2022-02-04",
-          "id": 5,
+          "id": 2,
           "status": "NEEDED_FROM_YOU",
           "uploaded": false,
           "uploadsAllowed": false
@@ -192,7 +192,7 @@
           "receivedDate": null,
           "requestedDate": null,
           "suspenseDate": "2010-03-25",
-          "id": 50,
+          "id": 3,
           "status": "NEEDED_FROM_YOU",
           "uploaded": false,
           "uploadsAllowed": true
@@ -205,7 +205,7 @@
           "receivedDate": "2021-01-04",
           "requestedDate": null,
           "suspenseDate": null,
-          "id": 51,
+          "id": 4,
           "status": "NEEDED_FROM_OTHERS",
           "uploaded": false,
           "uploadsAllowed": false
@@ -218,7 +218,7 @@
           "receivedDate": "2022-01-04",
           "requestedDate": null,
           "suspenseDate": null,
-          "id": 4,
+          "id": 5,
           "status": "INITIAL_REVIEW_COMPLETE",
           "uploaded": true,
           "uploadsAllowed": false
@@ -231,7 +231,7 @@
           "receivedDate": "2022-01-04",
           "requestedDate": null,
           "suspenseDate": "2022-02-04",
-          "id": 5,
+          "id": 6,
           "status": "NEEDED_FROM_YOU",
           "uploaded": false,
           "uploadsAllowed": false
@@ -244,7 +244,7 @@
           "receivedDate": null,
           "requestedDate": null,
           "suspenseDate": "2010-03-25",
-          "id": 50,
+          "id": 7,
           "status": "NEEDED_FROM_YOU",
           "uploaded": false,
           "uploadsAllowed": true
@@ -257,7 +257,7 @@
           "receivedDate": "2021-01-04",
           "requestedDate": null,
           "suspenseDate": null,
-          "id": 51,
+          "id": 8,
           "status": "NEEDED_FROM_OTHERS",
           "uploaded": false,
           "uploadsAllowed": false
@@ -270,7 +270,7 @@
           "receivedDate": "2022-01-04",
           "requestedDate": null,
           "suspenseDate": null,
-          "id": 4,
+          "id": 9,
           "status": "INITIAL_REVIEW_COMPLETE",
           "uploaded": true,
           "uploadsAllowed": false
@@ -283,7 +283,7 @@
           "receivedDate": "2022-01-04",
           "requestedDate": null,
           "suspenseDate": "2022-02-04",
-          "id": 5,
+          "id": 10,
           "status": "NEEDED_FROM_YOU",
           "uploaded": false,
           "uploadsAllowed": false
@@ -296,7 +296,7 @@
           "receivedDate": null,
           "requestedDate": null,
           "suspenseDate": "2010-03-25",
-          "id": 50,
+          "id": 11,
           "status": "NEEDED_FROM_YOU",
           "uploaded": false,
           "uploadsAllowed": true
@@ -309,10 +309,23 @@
           "receivedDate": "2021-01-04",
           "requestedDate": null,
           "suspenseDate": null,
-          "id": 51,
+          "id": 12,
           "status": "NEEDED_FROM_OTHERS",
           "uploaded": false,
           "uploadsAllowed": false
+        },
+        {
+          "closedDate": null,
+          "description": "Automated 5103 Notice Response",
+          "displayName": "Automated 5103 Notice Response",
+          "overdue": false,
+          "receivedDate": "2024-06-13",
+          "requestedDate": "2024-06-13",
+          "suspenseDate": "2024-07-14",
+          "id": 13,
+          "status": "NEEDED_FROM_YOU",
+          "uploaded": false,
+          "uploadsAllowed": true
         }
       ]
     }

--- a/src/applications/claims-status/tests/e2e/fixtures/mocks/lighthouse/feature-toggle-5103-update-enabled.json
+++ b/src/applications/claims-status/tests/e2e/fixtures/mocks/lighthouse/feature-toggle-5103-update-enabled.json
@@ -1,0 +1,32 @@
+{
+  "data": {
+    "type": "feature_toggles",
+    "features": [
+      {
+        "name": "cst_use_lighthouse_5103",
+        "value": false
+      },
+      {
+        "name": "cst_use_lighthouse_index",
+        "value": true
+      },
+      {
+        "name": "cst_use_lighthouse_show",
+        "value": true
+      },
+      {
+        "name": "cst_use_claim_details_v2",
+        "value": true
+      },
+      {
+        "name": "cst_claim_phases",
+        "value": true
+      },
+      {
+        "name": "cst_5103_update_enabled",
+        "value": true
+        
+      }
+    ]
+  }
+}

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
@@ -491,6 +491,8 @@ class TrackClaimsPageV2 {
       .should('contain', 'I’m finished adding evidence to support my claim.');
   }
 
+  x;
+
   submitEvidenceWaiver() {
     cy.get('va-checkbox')
       .shadow()


### PR DESCRIPTION
## Summary

Updated `src/applications/claims-status/actions/index.js `
- Changed `submit5103` to a function
- Added a new prop called `cstClaimPhasesEnabled` that is defaulted to false for `submit5103` and `submitRequest`.  
- When this new prop is true, the notification title and body will be different per our design specs.

Updated `src/applications/claims-status/components/claim-document-request-pages/Automated5103Notice.jsx`
- Includes a new props so we can navigate to the files tab, determine the correct submit function to call and determine if the feature flag useLighthouse5103 is enabled
- Added a new h2
- Added a new p
- Added a new checkbox with and error message that is displayed when the user doesnt select the checkbox and then selects the submit button
- Added a new button that calls the submit method and then navigates a user to the files tab

Updated `src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx`
- Has a new prop called `evidenceWaiverSubmitted5103`
- Renamed const `hideDueDate` to `is5103Notice`
- When `evidenceWaiverSubmitted5103` and `is5103Notice` are true the component returns null

Updated `src/applications/claims-status/components/claim-status-tab/WhatYouNeedToDo.jsx` to pass the prop `evidenceWaiverSubmitted5103` to `FilesNeeded.jsx`

Updated `src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx to pass the prop `evidenceWaiverSubmitted5103` to `FilesNeeded.jsx`

Added tests to the following:
- `src/applications/claims-status/tests/components/claim-document-request-pages/Automated5103Notice.unit.spec.jsx`
- `src/applications/claims-status/tests/actions/index.unit.spec.js`
-  `src/applications/claims-status/tests/components/claim-files-tab/FilesNeeded.unit.spec.jsx`
- `src/applications/claims-status/tests/e2e/09.claim-document-request.cypress.spec.js`

Unskipped the tests in `src/applications/claims-status/tests/e2e/02.claim-files.v2.cypress.spec.js` since this has been resolved and updated code so that it was referencing the correct class names

Updated the ids of the tracked items in `src/applications/claims-status/tests/e2e/fixtures/mocks/lighthouse/claim-detail-open.json` so that they were sequential and easier to follow. Also added a new tracked item for 5103 notice.

Created a new file `src/applications/claims-status/tests/e2e/fixtures/mocks/lighthouse/feature-toggle-5103-update-enabled.json` for the feature toggle `cst_5103_update_enabled` to be used in cypress tests

In `src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js` added the following changes:
- Added a new prop `cst5103UpdateEnabled` for when we want this feature toggle enabled and added logic around it
- Updated `submitFilesForReview()` to have the prop  `isOldVersion` for when we use the old component `AddFilesFormOld.jsx`. Also updated the logic here.
- Added new methods - `verifyPrimaryAlertforSubmitBuddyStatement()`, `verifyPrimaryAlertfor5103Notice()`, `verifyDocRequestforDefaultPage()`, `verifyDocRequestfor5103Notice()`, `submitEvidenceWaiver()`



## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#82575


## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

**When user clicks submit without checking the checkbox**
![Screenshot 2024-06-11 at 3 47 49 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/dfc45e6b-00cc-4647-85b2-65467ffc1c1f)

**Video of user on 5103 Notice - Document Request Page where they check the checkbox and click the submit button. The claim field `evidenceWaiverSubmitted5103` is set to true and upon refresh the FilesNeeded component is set to null and the 5103 alert is hidden.** 
https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/67f97827-80a9-4d3c-9fe0-71124ff5d4fc

**Confirmation message after user clicks the 'Submit evidence waiver' button**
![Screenshot 2024-06-14 at 2 01 04 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/2c19b894-c6ca-45d6-b927-5b656020dcda)

**Document Request Page for a 5103 Notice**
![Screenshot 2024-06-14 at 3 08 54 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/5845ff00-433b-46ec-800e-679db3a85ba4)


## What areas of the site does it impact?

Claim Status Tool

## Acceptance criteria
- [x] Behind 5103 feature flag.
- [x] There is a header for the waiver section distinguishing it from other sections on the page and making clear what the section is for.
- [x] There is a brief description under the header elaborating on the value proposition for submitting a waiver.
- [x] There is a checkbox that verifies the person is done adding evidence in support of their claim
- [x] The waiver cannot be submitted unless the box is checked. 
- [x] There is submit button and, when clicked, a fully filled out 5103 waiver is submitted to VA on the person's behalf. 
- [x] After submitting waiver, there is some kind of confirmation that the form was successfully sent. 
- [x] When the waiver gets submitted, we hide the associated tracked item alerts on the status and files tabs.


### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
