### PR TITLE
Remove web component from login modal and replace with plain link

### DIFF
--- a/src/applications/vre/tests/GetFormHelp.unit.spec.jsx
+++ b/src/applications/vre/tests/GetFormHelp.unit.spec.jsx
@@ -7,6 +7,6 @@ import GetFormHelp from '../components/GetFormHelp';
 describe('GetFormHelp', () => {
   it('should render', () => {
     const { container } = render(<GetFormHelp />);
-    expect($$('va-telephone', container).length).to.eql(2);
+    expect($$('a', container).length).to.eql(2);
   });
 });

--- a/src/platform/static-data/SubmitSignInForm.jsx
+++ b/src/platform/static-data/SubmitSignInForm.jsx
@@ -1,13 +1,45 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import {
+  createHref,
+  formatAriaLabel,
+  formatPhoneNumber,
+} from './utilities/sign-in-phone-utils';
 
+// NOTE: Do not convert these phone links to web components as they are
+// used in the injected header, which does not support web components
 export default function SubmitSignInForm({ startSentence }) {
+  const helpDeskNumber = CONTACTS.HELP_DESK;
+  const ttyNumber = CONTACTS['711'];
+
+  const helpDeskLink = (
+    <a
+      href={createHref(helpDeskNumber)}
+      aria-label={formatAriaLabel(helpDeskNumber)}
+    >
+      {formatPhoneNumber(helpDeskNumber)}
+    </a>
+  );
+
+  const ttyLink = (
+    <a
+      aria-label={formatAriaLabel(ttyNumber, true)}
+      href={createHref(ttyNumber)}
+    >
+      {formatPhoneNumber(ttyNumber, true)}
+    </a>
+  );
+
   return (
     <span>
       {startSentence ? 'Call' : 'call'} our MyVA411 main information line for
-      help at <va-telephone contact={CONTACTS.HELP_DESK} /> (
-      <va-telephone contact={CONTACTS['711']} tty />
+      help at {helpDeskLink} ({ttyLink}
       ).
     </span>
   );
 }
+
+SubmitSignInForm.propTypes = {
+  startSentence: PropTypes.bool,
+};

--- a/src/platform/static-data/utilities/sign-in-phone-utils.js
+++ b/src/platform/static-data/utilities/sign-in-phone-utils.js
@@ -1,0 +1,56 @@
+// Used for src/platform/static-data/SubmitSignInForm.jsx
+// Utilities taken (and shortened) from https://github.com/department-of-veterans-affairs/component-library/blob/1b83decc698f91f2c4d0ce10a1f91a3225ea22f7/packages/web-components/src/components/va-telephone/va-telephone.tsx#L134
+const cleanContact = contact => {
+  return (contact || '').replace(/[^\d]/g, '');
+};
+
+const splitContact = contact => {
+  const cleanedContact = cleanContact(contact);
+
+  if (cleanedContact.length === 10) {
+    const regex = /^(\d{3})(\d{3})(\d{4})$/g;
+    const result = [...regex.exec(cleanedContact)];
+
+    return result.length === 4 ? result.slice(-3) : [cleanedContact];
+  }
+
+  return [cleanedContact];
+};
+
+export const formatPhoneNumber = (num, tty = false) => {
+  const splitNumber = splitContact(num);
+  let formattedNum = splitNumber.join('');
+
+  if (formattedNum.length === 10) {
+    const [area, local, last4] = splitNumber;
+
+    formattedNum = `${area}-${local}-${last4}`;
+  }
+
+  if (tty) {
+    formattedNum = `TTY: ${formattedNum}`;
+  }
+
+  return formattedNum;
+};
+
+export const createHref = contact => {
+  const cleanedContact = cleanContact(contact);
+  const isN11 = cleanedContact.length === 3;
+
+  if (isN11) {
+    return `tel:${cleanedContact}`;
+  }
+  return `tel:+1${cleanedContact}`;
+};
+
+export const formatAriaLabel = (contact, tty = false) => {
+  const spaceCharsOut = chars => chars.split('').join(' ');
+  const labelPieces = splitContact(contact).map(spaceCharsOut);
+
+  if (tty) {
+    labelPieces.unshift('TTY');
+  }
+
+  return labelPieces.join('. ');
+};

--- a/src/platform/static-data/utilities/sign-in-phone-utils.unit.spec.js
+++ b/src/platform/static-data/utilities/sign-in-phone-utils.unit.spec.js
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+import {
+  createHref,
+  formatAriaLabel,
+  formatPhoneNumber,
+} from './sign-in-phone-utils';
+
+describe('utilities for SubmitSignInForm', () => {
+  describe('createHref', () => {
+    it('should correctly create the href for a regular phone number', () => {
+      expect(createHref('8006982411')).to.equal('tel:+18006982411');
+    });
+
+    it('should correctly create the href for a tty number', () => {
+      expect(createHref('711')).to.equal('tel:711');
+    });
+  });
+
+  describe('formatAriaLabel', () => {
+    it('should correctly create the aria label for a regular phone number', () => {
+      expect(formatAriaLabel('8006982411')).to.equal('8 0 0. 6 9 8. 2 4 1 1');
+    });
+
+    it('should correctly create the aria label for a tty number', () => {
+      expect(formatAriaLabel('711', true)).to.equal('TTY. 7 1 1');
+    });
+  });
+
+  describe('formatPhoneNumber', () => {
+    it('should correctly create the phone number label for a regular phone number', () => {
+      expect(formatPhoneNumber('8006982411')).to.equal('800-698-2411');
+    });
+
+    it('should correctly create the phone number label for a tty number', () => {
+      expect(formatPhoneNumber('711', true)).to.equal('TTY: 711');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
The injected (Teamsites) header and footer cannot support any web components. Last year the login modal's help desk text at the bottom was converted to use a `va-telephone` web component, so the phone number at the bottom of the injected header's login modal may have been broken since then. This change reverts the phone numbers to plain links. I pulled in utility functions that `component-library` uses for `va-telephone` so we still have consistent formatting / accessibility to the web component.

In prod at va.gov/health:
<img width="624" alt="Screenshot 2024-06-13 at 9 26 59 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/909a4756-cea0-4f4b-968a-7d235f5f723a">

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17291

## Testing done
Tested locally using the [proxy-rewrite application](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev)

## Screenshots

### Before
<img width="500" alt="Screenshot 2024-06-13 at 8 58 21 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/f9b6f6ae-56cc-45d1-8a6e-19488b701949">
<img width="350" alt="Screenshot 2024-06-13 at 9 33 26 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/37338bf4-bc1c-4381-845c-d983d7baadc2">


### After
<img width="600" alt="Screenshot 2024-06-13 at 9 32 10 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/2ecfac48-99c5-4b37-8e22-095ef7d7f5d3">
<img width="450" alt="Screenshot 2024-06-13 at 9 32 24 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/2765d2af-42f6-4e78-bea5-b839c9295f5d">

## What areas of the site does it impact?

VA.gov and Teamsites login modal

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [x] The vets-website header does not contain any web-components
- [x] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario