### PR TITLE
[SIMPLE_FORMS] fix: 21-4138 - reduce the character limit of the statement to align with backend

### DIFF
--- a/src/applications/simple-forms/21-4138/pages/statement.js
+++ b/src/applications/simple-forms/21-4138/pages/statement.js
@@ -20,7 +20,7 @@ export const statementPage = {
     properties: {
       statement: {
         type: 'string',
-        maxLength: 5000,
+        maxLength: 3650,
       },
     },
   },


### PR DESCRIPTION
## Summary

- This work reduces the character limit of the statement field for form 21-4138 in order to align it with the capabilities of the backend.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team-forms#1389

## Testing done

- Browser Testing.


## What areas of the site does it impact?

- Only form 21-4138

## Requested Feedback

Any