### PR TITLE
83952 Update signature block behavior - form 10-7959c

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/formSignature.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/formSignature.js
@@ -33,7 +33,7 @@ export const formSignatureSchema = {
   },
   schema: {
     type: 'object',
-    required: ['applicantMedicareClass'],
+    required: ['certifierRole'],
     properties: {
       certifierRole: radioSchema([
         'applicant',

--- a/src/applications/ivc-champva/10-7959C/chapters/formSignature.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/formSignature.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import {
+  titleUI,
+  radioUI,
+  radioSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+export const formSignatureSchema = {
+  uiSchema: {
+    ...titleUI('Form signature'),
+    certifierRole: {
+      ...radioUI({
+        title: 'Select who will sign for the beneficiary today.',
+        required: () => true,
+        labels: {
+          applicant: 'The beneficiary',
+          spouse: 'The spouse of the beneficiary',
+          parentOrGuardian: 'The parent or legal guardian of the beneficiary',
+          other:
+            'A representative with legal authority to make decisions for the beneficiary who is not also the parent, legal guardian or spouse',
+        },
+      }),
+    },
+    'view:additionalInfo': {
+      'ui:description': (
+        <p className="vads-u-font-size--sm vads-u-padding-left--4">
+          Not having a legal document on file with us that proves you have
+          authority to make decisions for the beneficiary may cause delays with
+          processing this form.
+        </p>
+      ),
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['applicantMedicareClass'],
+    properties: {
+      certifierRole: radioSchema([
+        'applicant',
+        'spouse',
+        'parentOrGuardian',
+        'other',
+      ]),
+      'view:additionalInfo': {
+        type: 'object',
+        properties: {},
+      },
+    },
+  },
+};

--- a/src/applications/ivc-champva/10-7959C/components/CustomAttestation.jsx
+++ b/src/applications/ivc-champva/10-7959C/components/CustomAttestation.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import FormSignature from 'platform/forms-system/src/js/components/FormSignature';
+import get from 'platform/utilities/data/get';
+import { nameWording } from '../helpers/utilities';
+
+/*
+Custom attestation/signature/statement of truth component.
+Had to make this because we want to collect a signature that either:
+1. Matches the beneficiary name provided
+OR
+2. Does not match existing string, but has extra messaging indicating
+   the third party is signing on behalf of the beneficiary. (This
+   case is triggered when user selects that they are not the beneficiary)
+
+Couldn't use the default because that provided no way to have the
+signature field and NOT check that it matched a previously entered string.
+*/
+
+/**
+ * Checks that the provided signature string matches the existing
+ * applicantName in the formData.
+ *
+ * @param {string} signatureName string we want to check
+ * @param {object} formData standard formData object
+ * @returns Either a string representing an error, or undefined (representing a match)
+ */
+function signatureValidator(signatureName, formData) {
+  const name = Object.values(formData?.applicantName || { empty: '' })
+    .filter(el => el)
+    .join('')
+    .toLowerCase();
+  if (signatureName.replaceAll(' ', '').toLowerCase() !== name) {
+    return `Please enter your name exactly as entered on the form: ${nameWording(
+      { ...formData, certifierRole: '' },
+      false,
+    )}`;
+  }
+  return undefined;
+}
+
+export default function CustomAttestation(signatureProps) {
+  const { formData } = signatureProps;
+  const isBeneficiary = get('certifierRole', formData) === 'applicant';
+
+  const pp = (
+    <span>
+      I have read and accept the{' '}
+      <a target="_blank" href="/privacy-policy/">
+        privacy policy
+      </a>
+    </span>
+  );
+
+  const isCorrect = (
+    <p>
+      I confirm that the identifying information in this form is accurate and
+      has been represented correctly.
+    </p>
+  );
+
+  const content = isBeneficiary ? (
+    <>
+      {isCorrect}
+      {pp}
+    </>
+  ) : (
+    <>
+      <p>
+        Signed by the beneficiary’s spouse, parent, legal guardian or legal
+        representative on behalf of the beneficiary.
+      </p>
+      {isCorrect}
+      {pp}
+      <p>
+        On behalf of:
+        <br />
+        <b>{nameWording(formData, false)}</b>
+      </p>
+    </>
+  );
+
+  const sigLabel = isBeneficiary
+    ? 'Your name'
+    : 'Enter your full name to sign as the beneficiary’s representative';
+
+  const validators = isBeneficiary ? [signatureValidator] : [];
+
+  return (
+    <>
+      <p className="vads-u-padding-x--3 vads-u-margin-y--1">
+        <strong>Note:</strong> According to federal law, there are criminal
+        penalties, including a fine and/or imprisonment for up to 5 years, for
+        withholding information or for providing incorrect information
+        (Reference: 18 U.S.C. 1001).
+      </p>
+      <section className="box vads-u-background-color--gray-lightest vads-u-padding-bottom--6 vads-u-padding-x--3 vads-u-padding-top--1px vads-u-margin-bottom--7">
+        <h3>Statement of truth</h3>
+        {content}
+        <FormSignature
+          {...signatureProps}
+          signatureLabel={sigLabel}
+          validations={validators}
+        />
+      </section>
+    </>
+  );
+}

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -42,7 +42,8 @@ import {
   applicantInsuranceCardSchema,
 } from '../chapters/healthInsuranceInformation';
 
-// import mockdata from '../tests/e2e/fixtures/data/test-data.json';
+import { formSignatureSchema } from '../chapters/formSignature';
+
 import GetFormHelp from '../../shared/components/GetFormHelp';
 import { hasReq } from '../../shared/components/fileUploads/MissingFileOverview';
 import SupportingDocumentsPage from '../components/SupportingDocumentsPage';
@@ -449,6 +450,16 @@ const formConfig = {
             },
           },
           schema: blankSchema,
+        },
+      },
+    },
+    formSignature: {
+      title: 'Form signature',
+      pages: {
+        supportingFIlesReview: {
+          path: 'form-signature',
+          title: 'Form signature',
+          ...formSignatureSchema,
         },
       },
     },

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -451,7 +451,7 @@ const formConfig = {
     formSignature: {
       title: 'Form signature',
       pages: {
-        supportingFIlesReview: {
+        supportingFilesReview: {
           path: 'form-signature',
           title: 'Form signature',
           ...formSignatureSchema,

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -43,6 +43,7 @@ import {
 } from '../chapters/healthInsuranceInformation';
 
 import { formSignatureSchema } from '../chapters/formSignature';
+import CustomAttestation from '../components/CustomAttestation';
 
 import GetFormHelp from '../../shared/components/GetFormHelp';
 import { hasReq } from '../../shared/components/fileUploads/MissingFileOverview';
@@ -84,14 +85,8 @@ const formConfig = {
     collapsibleNavLinks: true,
   },
   preSubmitInfo: {
-    statementOfTruth: {
-      body:
-        'I confirm that the identifying information in this form is accurate and has been represented correctly.',
-      messageAriaDescribedby:
-        'I confirm that the identifying information in this form is accurate and has been represented correctly.',
-      fullNamePath: formData =>
-        formData?.certifierRole ? 'certifierName' : 'applicantName',
-    },
+    required: true,
+    CustomComponent: signatureProps => CustomAttestation(signatureProps),
   },
   saveInProgress: {
     messages: {

--- a/src/applications/ivc-champva/10-7959C/tests/10-7959C.cypress.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/10-7959C.cypress.spec.js
@@ -7,7 +7,6 @@ import formConfig from '../config/form';
 import manifest from '../manifest.json';
 
 import {
-  reviewAndSubmitPageFlow,
   fillAddressWebComponentPattern,
   getAllPages,
   verifyAllDataWasSubmitted,
@@ -77,8 +76,17 @@ const testConfig = createTestConfig(
       'review-and-submit': ({ afterHook }) => {
         afterHook(() => {
           cy.get('@testData').then(data => {
-            const name = data.applicantName;
-            reviewAndSubmitPageFlow(name);
+            cy.get('va-text-input')
+              .shadow()
+              .get('#inputField')
+              .type(data.signature);
+            cy.get(`va-checkbox`)
+              .shadow()
+              .find('input')
+              .click({ force: true });
+            cy.findByText('Submit application', {
+              selector: 'button',
+            }).click();
           });
         });
       },

--- a/src/applications/ivc-champva/10-7959C/tests/config/form.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-7959C/tests/config/form.unit.spec.jsx
@@ -334,13 +334,6 @@ testNumberOfWebComponentFields(
   { ...mockData.data },
 );
 
-describe('fullNamePath', () => {
-  it('should be "applicantName"', () => {
-    const v = formConfig.preSubmitInfo.statementOfTruth.fullNamePath({});
-    expect(v).to.equal('applicantName');
-  });
-});
-
 describe('FileFieldWrapped', () => {
   it('should be called', () => {
     const ffw = FileFieldWrapped({});

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/maximal-test.json
@@ -71,7 +71,7 @@
       }
     ],
     "consentToMailMissingRequiredFiles": true,
-    "statementOfTruthSignature": "Applicant Jones",
-    "statementOfTruthCertified": true
+    "certifierRole": "other",
+    "signature": "Certifier Jones"
   }
 }

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/minimal-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/minimal-test.json
@@ -18,7 +18,7 @@
       "suffix": "III"
     },
     "applicantDOB": "2000-02-01",
-    "statementOfTruthSignature": "Applicant Jones",
-    "statementOfTruthCertified": true
+    "certifierRole": "other",
+    "signature": "Certifier Jones"
   }
 }

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/no-medicare-no-ohi.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/no-medicare-no-ohi.json
@@ -18,7 +18,7 @@
       "suffix": "IV"
     },
     "applicantDOB": "2009-01-02",
-    "statementOfTruthSignature": "Applicant Jones",
-    "statementOfTruthCertified": true
+    "certifierRole": "other",
+    "signature": "Certifier Jones"
   }
 }

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/no-medicare-yes-ohi.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/no-medicare-yes-ohi.json
@@ -58,7 +58,7 @@
       }
     ],
     "consentToMailMissingRequiredFiles": true,
-    "statementOfTruthSignature": "Applicant Jones",
-    "statementOfTruthCertified": true
+    "certifierRole": "other",
+    "signature": "Certifier Jones"
   }
 }

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/no-medicare-yes-primary.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/no-medicare-yes-primary.json
@@ -36,7 +36,7 @@
       }
     ],
     "consentToMailMissingRequiredFiles": true,
-    "statementOfTruthSignature": "Applicant Jones",
-    "statementOfTruthCertified": true
+    "certifierRole": "other",
+    "signature": "Certifier Jones"
   }
 }

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/test-data.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/test-data.json
@@ -45,6 +45,8 @@
     "applicantSecondaryInsuranceType": "medigap",
     "secondaryMedigapPlan": "M",
     "secondaryAdditionalComments": "Additional secondary comment",
+    "certifierRole": "other",
+    "signature": "Certifier Jones",
     "consentToMailMissingRequiredFiles": true
   }
 }

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/yes-medicare-no-ohi.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/yes-medicare-no-ohi.json
@@ -18,7 +18,7 @@
       "suffix": "II"
     },
     "applicantDOB": "1950-08-02",
-    "statementOfTruthSignature": "Applicant Jones",
-    "statementOfTruthCertified": true
+    "certifierRole": "other",
+    "signature": "Certifier Jones"
   }
 }

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/yes-medicare-yes-primary.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/yes-medicare-yes-primary.json
@@ -37,7 +37,7 @@
     "primaryMedigapPlan": "A",
     "primaryAdditionalComments": "Additional primary comment",
     "consentToMailMissingRequiredFiles": true,
-    "statementOfTruthCertified": true,
-    "statementOfTruthSignature": "Jimmy Alvin"
+    "certifierRole": "other",
+    "signature": "Certifier Jones"
   }
 }


### PR DESCRIPTION
## Summary

This PR adds a new `certifierRole` form page and a customized signature/statement of truth block. The new signature block allows us to either verify that a beneficiary has typed their own name, or allow an arbitrary name to be typed if the user has specified they are a third party.

- Added screen to collect what type of signature we need
- Added custom signature block that checks either beneficiary name or collects arbitrary string
- Updated unit tests
- Updated end to end tests
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83952

## Testing done

- Manual
- Unit
- E2E

## Screenshots

|         | Third Party | Beneficiary |
| ------- | ------ | ----- |
| Signature type screen  |        |![Screenshot 2024-06-13 at 17 51 03](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/b9934bce-807b-4f17-89bb-d7b6fb5c71a0)|
| Signature block |![Screenshot 2024-06-13 at 17 08 44](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/5a16513f-3836-474a-b55f-e04465c03131)|![Screenshot 2024-06-13 at 17 08 40](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/23995652-7b6a-442c-ac90-17ba22af776e)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA