### PR TITLE
10-7959f-1 Same as address page

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -16,6 +16,8 @@ import {
   phoneSchema,
   emailUI,
   emailSchema,
+  yesNoUI,
+  yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import transformForSubmit from './submitTransformer';
 import manifest from '../manifest.json';
@@ -164,6 +166,30 @@ const formConfig = {
                 type: 'object',
                 properties: {},
               },
+            },
+          },
+        },
+      },
+    },
+    sameAsMailingAddress: {
+      title: 'Mailing address',
+      pages: {
+        page3a: {
+          path: 'same-as-mailing-address',
+          uiSchema: {
+            sameMailingAddress: yesNoUI({
+              title: 'Is your mailing address the same as your home address?',
+              labels: {
+                Y: 'Yes',
+                N: 'No',
+              },
+            }),
+          },
+          schema: {
+            type: 'object',
+            required: ['sameMailingAddress'],
+            properties: {
+              sameMailingAddress: yesNoSchema,
             },
           },
         },

--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -177,6 +177,7 @@ const formConfig = {
         page3a: {
           path: 'same-as-mailing-address',
           uiSchema: {
+            ...titleUI('Mailing address'),
             sameMailingAddress: yesNoUI({
               title: 'Is your mailing address the same as your home address?',
               labels: {
@@ -189,6 +190,7 @@ const formConfig = {
             type: 'object',
             required: ['sameMailingAddress'],
             properties: {
+              titleSchema,
               sameMailingAddress: yesNoSchema,
             },
           },
@@ -201,6 +203,7 @@ const formConfig = {
         page4: {
           path: 'home-address',
           title: "Veteran's Home address",
+          depends: formData => formData.sameMailingAddress === false,
           uiSchema: {
             ...titleUI(
               'Home Address',


### PR DESCRIPTION
## Summary
This PR adds a page after mailing address asking if the user has the same address for home. If yes, we skip the home address page. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/83695

## Testing done
Manual testing
unit testing

## Screens
![Screenshot 2024-06-14 at 11 02 29 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/15307f25-2eef-4938-ad99-8a8830ad20dc)
hots
![Screenshot 2024-06-14 at 11 04 25 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/4834e599-946c-4116-8cc5-fefda5ed8f8f)
![Screenshot 2024-06-14 at 11 04 33 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/5b5e4973-8d54-4f94-9652-c9352c0f545f)

## What areas of the site does it impact?
Just this form

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA