### PR TITLE
Adds extra linebreak on description list

### DIFF
--- a/src/applications/my-education-benefits/config/form.js
+++ b/src/applications/my-education-benefits/config/form.js
@@ -1604,6 +1604,7 @@ const formConfig = {
               'ui:description': (
                 <div>
                   <br />
+                  <br />
                   <ul>
                     <li>
                       You can select a date up to one year in the past. We may


### PR DESCRIPTION
## Summary
Fixes Spacing Issue on Relinquishment page description list

## Related issue(s)
![Screenshot 2024-06-14 at 2 25 12 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8945799/4d982093-7eb1-4fcc-8379-571e3c4fe264)


## Testing done
First bullet point in the description list was wrapping, added an extra line break to fix the spacing.

## Screenshots
### Before
![Screenshot 2024-06-14 at 2 23 45 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/8945799/8cfa2f7d-d92d-4c5b-943e-ca1cc8cd9cea)

### After

![ch1606_after](https://github.com/department-of-veterans-affairs/vets-website/assets/8945799/7fa7575d-d8ec-46d9-8909-f8a510888d07)
![ch30_after](https://github.com/department-of-veterans-affairs/vets-website/assets/8945799/f7803f41-1365-418f-9f1f-71ca0fdea710)

## What areas of the site does it impact?
Original Claims 1990 Application


## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
