### PR TITLE
[SIMPLE_FORMS] fix: 20-10207 - remove requirement for otherHousingRisks

### DIFF
--- a/src/applications/simple-forms/20-10207/pages/otherHousingRisks.js
+++ b/src/applications/simple-forms/20-10207/pages/otherHousingRisks.js
@@ -10,9 +10,6 @@ export default {
     otherHousingRisks: {
       'ui:title': 'Tell us about other housing risks you are experiencing',
       'ui:webComponentField': VaTextareaField,
-      'ui:errorMessages': {
-        required: 'List other housing risks you are experiencing',
-      },
       'ui:options': {
         charcount: true,
       },
@@ -33,6 +30,5 @@ export default {
         properties: {},
       },
     },
-    required: ['otherHousingRisks'],
   },
 };

--- a/src/applications/simple-forms/20-10207/pages/otherHousingRisksThirdPartyNonVeteran.js
+++ b/src/applications/simple-forms/20-10207/pages/otherHousingRisksThirdPartyNonVeteran.js
@@ -11,9 +11,6 @@ export default {
       'ui:title':
         'Tell us about other housing risks the claimant is experiencing',
       'ui:webComponentField': VaTextareaField,
-      'ui:errorMessages': {
-        required: 'List other housing risks the claimant is experiencing',
-      },
       'ui:options': {
         charcount: true,
       },
@@ -34,6 +31,5 @@ export default {
         properties: {},
       },
     },
-    required: ['otherHousingRisks'],
   },
 };

--- a/src/applications/simple-forms/20-10207/pages/otherHousingRisksThirdPartyVeteran.js
+++ b/src/applications/simple-forms/20-10207/pages/otherHousingRisksThirdPartyVeteran.js
@@ -11,9 +11,6 @@ export default {
       'ui:title':
         'Tell us about other housing risks the Veteran is experiencing',
       'ui:webComponentField': VaTextareaField,
-      'ui:errorMessages': {
-        required: 'List other housing risks the Veteran is experiencing',
-      },
       'ui:options': {
         charcount: true,
       },
@@ -34,6 +31,5 @@ export default {
         properties: {},
       },
     },
-    required: ['otherHousingRisks'],
   },
 };


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- This work removes the required parameter for all instances of the `otherHousingRisks` for form 20-10207.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team-forms#1332

## Testing done

- Browser testing successful

## Requested Feedback

Any
