### PR TITLE
Profile/aw/85603/show privacy statements

### DIFF
--- a/src/applications/personalization/profile/components/ProfilePrivacyPolicy.jsx
+++ b/src/applications/personalization/profile/components/ProfilePrivacyPolicy.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
+
+export const ProfilePrivacyPolicy = () => {
+  const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
+
+  const showProfilePrivacyPolicy = useToggleValue(
+    TOGGLE_NAMES.profileShowPrivacyPolicy,
+  );
+
+  return showProfilePrivacyPolicy ? (
+    <>
+      <h2 className="vads-u-font-size--h3">Privacy policy</h2>
+      <p>
+        To learn how we collect, store, and use your profile information, read
+        our privacy policy.
+      </p>
+      <va-link href="/privacy-policy" text="Go to our privacy policy" />
+    </>
+  ) : null;
+};

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -4,9 +4,10 @@ import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
 
 import { useLocation } from 'react-router-dom';
+import NameTag from '~/applications/personalization/components/NameTag';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 import { hasTotalDisabilityServerError } from '../../common/selectors/ratedDisabilities';
 
-import NameTag from '~/applications/personalization/components/NameTag';
 import ProfileSubNav from './ProfileSubNav';
 import ProfileMobileSubNav from './ProfileMobileSubNav';
 import { PROFILE_PATHS } from '../constants';
@@ -14,7 +15,7 @@ import { ProfileFullWidthContainer } from './ProfileFullWidthContainer';
 import { getRoutesForNav } from '../routesForNav';
 import { normalizePath } from '../../common/helpers';
 import { ProfileBreadcrumbs } from './ProfileBreadcrumbs';
-import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
+import { ProfilePrivacyPolicy } from './ProfilePrivacyPolicy';
 
 const LAYOUTS = {
   SIDEBAR: 'sidebar',
@@ -103,6 +104,7 @@ const ProfileWrapper = ({
               <div className="vads-l-col--12 vads-u-padding-bottom--4 vads-u-padding-x--1 medium-screen:vads-l-col--9 medium-screen:vads-u-padding-x--2 medium-screen:vads-u-padding-bottom--6 small-desktop-screen:vads-l-col--8">
                 {/* children will be passed in from React Router one level up */}
                 {children}
+                <ProfilePrivacyPolicy />
               </div>
             </div>
           </div>
@@ -110,7 +112,12 @@ const ProfileWrapper = ({
       )}
 
       {layout === LAYOUTS.FULL_WIDTH && (
-        <ProfileFullWidthContainer>{children}</ProfileFullWidthContainer>
+        <ProfileFullWidthContainer>
+          <>
+            {children}
+            <ProfilePrivacyPolicy />
+          </>
+        </ProfileFullWidthContainer>
       )}
     </>
   );

--- a/src/applications/personalization/profile/mocks/endpoints/feature-toggles/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/feature-toggles/index.js
@@ -17,6 +17,7 @@ const profileToggles = {
   profileShowDirectDepositSingleFormAlert: false,
   profileShowDirectDepositSingleFormEduDowntime: false,
   profileShowEmailNotificationSettings: false,
+  profileShowPrivacyPolicy: false,
 };
 
 const makeAllTogglesTrue = toggles => {

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -104,6 +104,7 @@ const responses = {
             profileShowDirectDepositSingleFormUAT: false,
             profileShowDirectDepositSingleFormAlert: true,
             profileShowDirectDepositSingleFormEduDowntime: true,
+            profileShowPrivacyPolicy: true,
           }),
         ),
       secondsOfDelay,

--- a/src/applications/personalization/profile/tests/components/ProfilePrivacyPolicy.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/ProfilePrivacyPolicy.unit.spec.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { expect } from 'chai';
+import { renderInReduxProvider } from '~/platform/testing/unit/react-testing-library-helpers';
+import FEATURE_FLAGS from '~/platform/utilities/feature-toggles/featureFlagNames';
+import { ProfilePrivacyPolicy } from '../../components/ProfilePrivacyPolicy';
+
+describe('<ProfilePrivacyPolicy />', () => {
+  it('should render when profileShowPrivacyPolicy feature toggle is true', () => {
+    const view = renderInReduxProvider(<ProfilePrivacyPolicy />, {
+      initialState: {
+        featureToggles: {
+          loading: false,
+          [FEATURE_FLAGS.profileShowPrivacyPolicy]: true,
+        },
+      },
+    });
+
+    // renders heading
+    expect(view.queryByText('Privacy policy')).to.exist;
+
+    // renders link
+    expect(
+      view.container.querySelector('va-link').getAttribute('href') ===
+        '/privacy-policy',
+    ).to.be.true;
+  });
+
+  it('should not render when profileShowPrivacyPolicy feature toggle is false', async () => {
+    const view = renderInReduxProvider(<ProfilePrivacyPolicy />, {
+      initialState: {
+        featureToggles: {
+          loading: false,
+          [FEATURE_FLAGS.profileShowPrivacyPolicy]: false,
+        },
+      },
+    });
+
+    // does not render heading
+    expect(view.queryByText('Privacy policy')).to.be.null;
+  });
+});

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -160,6 +160,7 @@
   "profileShowPronounsAndSexualOrientation": "profile_show_pronouns_and_sexual_orientation",
   "profileShowPaymentsNotificationSetting": "profile_show_payments_notification_setting",
   "profileShowQuickSubmitNotificationSetting": "profile_show_quick_submit_notification_setting",
+  "profileShowPrivacyPolicy": "profile_show_privacy_policy",
   "profileUseExperimental": "profile_use_experimental",
   "pwEhrCtaUseSlo": "pw_ehr_cta_use_slo",
   "ratedDisabilitiesSortAbTest": "rated_disabilities_sort_ab_test",


### PR DESCRIPTION
## Summary

- Adds a feature toggle for `profile_show_privacy_policy` and builds the content for the privacy policy being shown at the bottom of each page of profile when the toggle is active.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85603

## Testing done

- Added basic unit test for conditional rendering based on toggle

## Screenshots

All pages look the same, but here is what the contact info page will look like with the toggle on.

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | ![Screenshot 2024-06-17 at 9 15 21 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/4af66a93-c2a6-4c43-982d-f3317383e488) | ![Screenshot 2024-06-17 at 9 01 55 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/1de95296-7162-4af1-a3d0-fbd323871996) |
| Desktop | ![Screenshot 2024-06-17 at 9 15 08 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/af159559-2308-4e20-a1d1-1f29463c8c6c) | ![Screenshot 2024-06-17 at 9 02 26 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/8332986/a85ac5fb-caa5-4108-8fef-c62d7156c1d2) |

## What areas of the site does it impact?

Profile

## Acceptance criteria

- [x] Toggle Added
- [x] Content shown based on toggle

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
