### PR TITLE
Expenses checkbox for users still behind the SIP

### DIFF
--- a/src/applications/financial-status-report/components/householdExpenses/HouseholdExpensesChecklist.jsx
+++ b/src/applications/financial-status-report/components/householdExpenses/HouseholdExpensesChecklist.jsx
@@ -11,34 +11,24 @@ const HouseholdExpensesChecklist = () => {
   const { expenses } = formData;
   const { expenseRecords = [] } = expenses;
 
-  const onChange = ({ target }) => {
-    const { value } = target;
-    return expenseRecords.some(source => source.name === value)
-      ? dispatch(
-          setData({
-            ...formData,
-            expenses: {
-              ...expenses,
-              expenseRecords: expenseRecords.filter(
-                source => source.name !== value,
-              ),
-            },
-          }),
-        )
-      : dispatch(
-          setData({
-            ...formData,
-            expenses: {
-              ...expenses,
-              expenseRecords: [...expenseRecords, { name: value, amount: '' }],
-            },
-          }),
-        );
+  const onChange = ({ name, checked }) => {
+    dispatch(
+      setData({
+        ...formData,
+        expenses: {
+          ...expenses,
+          expenseRecords: checked
+            ? [...expenseRecords, { name, amount: '' }]
+            : expenseRecords.filter(source => source.name !== name),
+        },
+      }),
+    );
   };
 
   const isBoxChecked = option => {
     return expenseRecords.some(incomeValue => incomeValue.name === option);
   };
+
   const title = 'Monthly housing expenses';
   const prompt = 'Which of these expenses do you pay for?';
 


### PR DESCRIPTION
## Summary

During the checkbox refactor, the expenses checklist was replaced by a new expenses experience. The checklist is now behind a feature flag. This pull request updates the checklist to use the new refactored v3 component. Our SIP users who have not switched to the new experience will be able to enter values for their various expenses

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#86084

## Testing done

- Cypress 
- Manual


## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._



![image](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/2ad586f4-7757-4f27-b51b-c118adf7760d)

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/ac4ab22a-de2d-46dc-ac8f-3a39ecb4545b)

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/0fe19324-b131-44d1-819c-88d3cb35f432)

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/ee7fc2f6-55b8-4f5f-ad9a-612c6f667977)

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/25a9bc98-e537-4363-9f86-6d7afc0172f3)


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
