### PR TITLE
[86014] FSR Feature Flag Removal (vets-website)

### DIFF
--- a/src/applications/financial-status-report/containers/App.jsx
+++ b/src/applications/financial-status-report/containers/App.jsx
@@ -24,7 +24,6 @@ import { WIZARD_STATUS } from '../wizard/constants';
 import {
   fsrWizardFeatureToggle,
   fsrFeatureToggle,
-  streamlinedWaiverAssetUpdateFeatureToggle,
   reviewPageNavigationFeatureToggle,
 } from '../utils/helpers';
 import user from '../mocks/user.json';
@@ -239,7 +238,6 @@ App.propTypes = {
   setFormData: PropTypes.func,
   showFSR: PropTypes.bool,
   showReviewPageNavigationFeature: PropTypes.bool,
-  showStreamlinedWaiverAssetUpdate: PropTypes.bool,
   showWizard: PropTypes.bool,
 };
 
@@ -251,9 +249,6 @@ const mapStateToProps = state => ({
   profile: selectProfile(state) || {},
   showWizard: fsrWizardFeatureToggle(state),
   showFSR: fsrFeatureToggle(state),
-  showStreamlinedWaiverAssetUpdate: streamlinedWaiverAssetUpdateFeatureToggle(
-    state,
-  ),
   showReviewPageNavigationFeature: reviewPageNavigationFeatureToggle(state),
   isLoadingFeatures: toggleValues(state).loading,
   isStartingOver: state.form.isStartingOver,

--- a/src/applications/financial-status-report/containers/App.jsx
+++ b/src/applications/financial-status-report/containers/App.jsx
@@ -24,7 +24,6 @@ import { WIZARD_STATUS } from '../wizard/constants';
 import {
   fsrWizardFeatureToggle,
   fsrFeatureToggle,
-  enhancedFSRFeatureToggle,
   streamlinedWaiverFeatureToggle,
   streamlinedWaiverAssetUpdateFeatureToggle,
   reviewPageNavigationFeatureToggle,
@@ -239,7 +238,6 @@ App.propTypes = {
   }),
   router: PropTypes.object,
   setFormData: PropTypes.func,
-  showEnhancedFSR: PropTypes.bool,
   showFSR: PropTypes.bool,
   showReviewPageNavigationFeature: PropTypes.bool,
   showStreamlinedWaiver: PropTypes.bool,
@@ -255,7 +253,6 @@ const mapStateToProps = state => ({
   profile: selectProfile(state) || {},
   showWizard: fsrWizardFeatureToggle(state),
   showFSR: fsrFeatureToggle(state),
-  showEnhancedFSR: enhancedFSRFeatureToggle(state),
   showStreamlinedWaiver: streamlinedWaiverFeatureToggle(state),
   showStreamlinedWaiverAssetUpdate: streamlinedWaiverAssetUpdateFeatureToggle(
     state,

--- a/src/applications/financial-status-report/containers/App.jsx
+++ b/src/applications/financial-status-report/containers/App.jsx
@@ -24,7 +24,6 @@ import { WIZARD_STATUS } from '../wizard/constants';
 import {
   fsrWizardFeatureToggle,
   fsrFeatureToggle,
-  streamlinedWaiverFeatureToggle,
   streamlinedWaiverAssetUpdateFeatureToggle,
   reviewPageNavigationFeatureToggle,
 } from '../utils/helpers';
@@ -240,7 +239,6 @@ App.propTypes = {
   setFormData: PropTypes.func,
   showFSR: PropTypes.bool,
   showReviewPageNavigationFeature: PropTypes.bool,
-  showStreamlinedWaiver: PropTypes.bool,
   showStreamlinedWaiverAssetUpdate: PropTypes.bool,
   showWizard: PropTypes.bool,
 };
@@ -253,7 +251,6 @@ const mapStateToProps = state => ({
   profile: selectProfile(state) || {},
   showWizard: fsrWizardFeatureToggle(state),
   showFSR: fsrFeatureToggle(state),
-  showStreamlinedWaiver: streamlinedWaiverFeatureToggle(state),
   showStreamlinedWaiverAssetUpdate: streamlinedWaiverAssetUpdateFeatureToggle(
     state,
   ),

--- a/src/applications/financial-status-report/mocks/responses.js
+++ b/src/applications/financial-status-report/mocks/responses.js
@@ -6,7 +6,6 @@ module.exports = {
     data: {
       type: 'feature_toggles',
       features: [
-        { name: 'combined_financial_status_report_enhancements', value: true },
         { name: 'show_financial_status_report', value: true },
         { name: 'show_financial_status_report_wizard', value: true },
       ],

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-alert-cards-combined.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-alert-cards-combined.cypress.spec.js
@@ -34,10 +34,6 @@ describe.skip('Enhanced FSR debt and copay alerts', () => {
         features: [
           { name: 'show_financial_status_report_wizard', value: true },
           { name: 'show_financial_status_report', value: true },
-          {
-            name: 'combined_financial_status_report_enhancements',
-            value: true,
-          },
         ],
       },
     }).as('features');

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-alert-cards.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-alert-cards.cypress.spec.js
@@ -31,10 +31,6 @@ describe('Enhanced FSR debt and copay alerts', () => {
         features: [
           { name: 'show_financial_status_report_wizard', value: true },
           { name: 'show_financial_status_report', value: true },
-          {
-            name: 'combined_financial_status_report_enhancements',
-            value: true,
-          },
         ],
       },
     }).as('features');

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-contact-loop.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-contact-loop.cypress.spec.js
@@ -26,10 +26,6 @@ describe.skip('fsr 5655 contact info loop', () => {
         features: [
           { name: 'show_financial_status_report_wizard', value: true },
           { name: 'show_financial_status_report', value: true },
-          {
-            name: 'combined_financial_status_report_enhancements',
-            value: true,
-          },
         ],
       },
     }).as('features');

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-long.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-long.cypress.spec.js
@@ -28,10 +28,6 @@ const testConfig = createTestConfig(
             { name: 'show_financial_status_report_wizard', value: true },
             { name: 'show_financial_status_report', value: true },
             {
-              name: 'combined_financial_status_report_enhancements',
-              value: true,
-            },
-            {
               name: 'financial_status_report_streamlined_waiver',
               value: true,
             },

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-long.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-long.cypress.spec.js
@@ -28,10 +28,6 @@ const testConfig = createTestConfig(
             { name: 'show_financial_status_report_wizard', value: true },
             { name: 'show_financial_status_report', value: true },
             {
-              name: 'financial_status_report_streamlined_waiver',
-              value: true,
-            },
-            {
               name: 'financial_status_report_streamlined_waiver_assets',
               value: true,
             },

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-long.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-long.cypress.spec.js
@@ -27,10 +27,6 @@ const testConfig = createTestConfig(
           features: [
             { name: 'show_financial_status_report_wizard', value: true },
             { name: 'show_financial_status_report', value: true },
-            {
-              name: 'financial_status_report_streamlined_waiver_assets',
-              value: true,
-            },
           ],
         },
       });

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-short.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-short.cypress.spec.js
@@ -28,10 +28,6 @@ const testConfig = createTestConfig(
             { name: 'show_financial_status_report_wizard', value: true },
             { name: 'show_financial_status_report', value: true },
             {
-              name: 'combined_financial_status_report_enhancements',
-              value: true,
-            },
-            {
               name: 'financial_status_report_streamlined_waiver',
               value: true,
             },

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-short.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-short.cypress.spec.js
@@ -28,10 +28,6 @@ const testConfig = createTestConfig(
             { name: 'show_financial_status_report_wizard', value: true },
             { name: 'show_financial_status_report', value: true },
             {
-              name: 'financial_status_report_streamlined_waiver',
-              value: true,
-            },
-            {
               name: 'financial_status_report_streamlined_waiver_assets',
               value: true,
             },

--- a/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-short.cypress.spec.js
+++ b/src/applications/financial-status-report/tests/e2e/fsr-5655-streamlined-waiver-short.cypress.spec.js
@@ -27,10 +27,6 @@ const testConfig = createTestConfig(
           features: [
             { name: 'show_financial_status_report_wizard', value: true },
             { name: 'show_financial_status_report', value: true },
-            {
-              name: 'financial_status_report_streamlined_waiver_assets',
-              value: true,
-            },
           ],
         },
       });

--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -15,12 +15,6 @@ export const fsrFeatureToggle = state => {
   return toggleValues(state)[FEATURE_FLAG_NAMES.showFinancialStatusReport];
 };
 
-export const enhancedFSRFeatureToggle = state => {
-  return toggleValues(state)[
-    FEATURE_FLAG_NAMES.combinedFinancialStatusReportEnhancements
-  ];
-};
-
 export const streamlinedWaiverFeatureToggle = state => {
   return toggleValues(state)[
     FEATURE_FLAG_NAMES.financialStatusReportStreamlinedWaiver

--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -15,12 +15,6 @@ export const fsrFeatureToggle = state => {
   return toggleValues(state)[FEATURE_FLAG_NAMES.showFinancialStatusReport];
 };
 
-export const streamlinedWaiverAssetUpdateFeatureToggle = state => {
-  return toggleValues(state)[
-    FEATURE_FLAG_NAMES.financialStatusReportStreamlinedWaiverAssets
-  ];
-};
-
 export const reviewPageNavigationFeatureToggle = state => {
   return toggleValues(state)[
     FEATURE_FLAG_NAMES.financialStatusReportReviewPageNavigation

--- a/src/applications/financial-status-report/utils/helpers.js
+++ b/src/applications/financial-status-report/utils/helpers.js
@@ -15,12 +15,6 @@ export const fsrFeatureToggle = state => {
   return toggleValues(state)[FEATURE_FLAG_NAMES.showFinancialStatusReport];
 };
 
-export const streamlinedWaiverFeatureToggle = state => {
-  return toggleValues(state)[
-    FEATURE_FLAG_NAMES.financialStatusReportStreamlinedWaiver
-  ];
-};
-
 export const streamlinedWaiverAssetUpdateFeatureToggle = state => {
   return toggleValues(state)[
     FEATURE_FLAG_NAMES.financialStatusReportStreamlinedWaiverAssets

--- a/src/applications/mhv-secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
+++ b/src/applications/mhv-secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
@@ -267,14 +267,6 @@
         "value": true
       },
       {
-        "name": "combinedFinancialStatusReport",
-        "value": true
-      },
-      {
-        "name": "combined_financial_status_report",
-        "value": true
-      },
-      {
         "name": "communicationPreferences",
         "value": true
       },

--- a/src/applications/mhv-secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
+++ b/src/applications/mhv-secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
@@ -275,14 +275,6 @@
         "value": true
       },
       {
-        "name": "combinedFinancialStatusReportEnhancements",
-        "value": true
-      },
-      {
-        "name": "combined_financial_status_report_enhancements",
-        "value": true
-      },
-      {
         "name": "communicationPreferences",
         "value": true
       },

--- a/src/applications/mhv-secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
+++ b/src/applications/mhv-secure-messaging/tests/e2e/fixtures/generalResponses/featureToggles.json
@@ -775,14 +775,6 @@
         "value": true
       },
       {
-        "name": "financialStatusReportStreamlinedWaiver",
-        "value": true
-      },
-      {
-        "name": "financial_status_report_streamlined_waiver",
-        "value": true
-      },
-      {
         "name": "form526Legacy",
         "value": true
       },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -33,7 +33,6 @@
   "claimLettersAccess": "claim_letters_access",
   "coeAccess": "coe_access",
   "combinedDebtPortalAccess": "combined_debt_portal_access",
-  "combinedFinancialStatusReport": "combined_financial_status_report",
   "covidVaccineUpdatesCTA": "covid_vaccine_registration_frontend_cta",
   "covidVaccineUpdatesDisableAuth": "covid_vaccine_registration_frontend_hide_auth",
   "covidVaccineUpdatesEnableExpandedEligibility": "covid_vaccine_registration_frontend_enable_expanded_eligibility",

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -76,7 +76,6 @@
   "fsrServerSideTransform": "fsr_5655_server_side_transform",
   "financialStatusReportDebtsApiModule": "financial_status_report_debts_api_module",
   "financialStatusReportExpensesUpdate": "financial_status_report_expenses_update",
-  "financialStatusReportStreamlinedWaiverAssets": "financial_status_report_streamlined_waiver_assets",
   "financialStatusReportReviewPageNavigation": "financial_status_report_review_page_navigation",
   "findARepresentativeEnableFrontend": "find_a_representative_enable_frontend",
   "form2010206": "form2010206",

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -34,7 +34,6 @@
   "coeAccess": "coe_access",
   "combinedDebtPortalAccess": "combined_debt_portal_access",
   "combinedFinancialStatusReport": "combined_financial_status_report",
-  "combinedFinancialStatusReportEnhancements": "combined_financial_status_report_enhancements",
   "covidVaccineUpdatesCTA": "covid_vaccine_registration_frontend_cta",
   "covidVaccineUpdatesDisableAuth": "covid_vaccine_registration_frontend_hide_auth",
   "covidVaccineUpdatesEnableExpandedEligibility": "covid_vaccine_registration_frontend_enable_expanded_eligibility",

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -76,7 +76,6 @@
   "fsrServerSideTransform": "fsr_5655_server_side_transform",
   "financialStatusReportDebtsApiModule": "financial_status_report_debts_api_module",
   "financialStatusReportExpensesUpdate": "financial_status_report_expenses_update",
-  "financialStatusReportStreamlinedWaiver": "financial_status_report_streamlined_waiver",
   "financialStatusReportStreamlinedWaiverAssets": "financial_status_report_streamlined_waiver_assets",
   "financialStatusReportReviewPageNavigation": "financial_status_report_review_page_navigation",
   "findARepresentativeEnableFrontend": "find_a_representative_enable_frontend",


### PR DESCRIPTION
## Summary

Three feature flags have been set to `true` by default and there are no longer any in-progress forms that have them set to `false`. This means the flags are safe to remove, and this pull request removes them on the `vets-website` side.

## Related issue(s)

- [Main ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/86014)
- [Initial ticket for the discovery](https://github.com/department-of-veterans-affairs/va.gov-team/issues/81813)

## Testing done

N/A. As long as all the existing tests pass, this is good.

## Screenshots

N/A

## What areas of the site does it impact?

FSR Forms, specifically in-progress

## Acceptance criteria

- [x]  I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x]  No error nor warning in the console.
- [x]  Events are being sent to the appropriate logging solution
- [x]  No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs