### PR TITLE
Remove unused CSS for Font Awesome

### DIFF
--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -344,29 +344,6 @@ $facility-locator-shadow: rgba(0, 0, 0, 0.5);
       margin-left: 1.5em;
     }
 
-    li.show-more {
-      list-style-type: none;
-    }
-
-    button.seeMore {
-      text-decoration: underline;
-
-      &:after {
-        font: normal normal normal 1em "Font Awesome 5 Free";
-        content: "\F078";
-        text-decoration: none;
-        display: inline-block;
-        padding: 0 0.5em;
-        font-weight: 900;
-      }
-
-      &.expanded {
-        &:after {
-          content: "\F077";
-        }
-      }
-    }
-
     h5 {
       padding-bottom: 0;
     }

--- a/src/applications/find-forms/sass/find-va-forms.scss
+++ b/src/applications/find-forms/sass/find-va-forms.scss
@@ -30,21 +30,6 @@
       }
     }
   }
-
-  .find-forms-alert-message {
-    i {
-      font-family: "Font Awesome 5 Free";
-      font-style: normal;
-      font-weight: 900;
-    }
-
-    i::before {
-      content: "\F05A";
-      display: flex;
-      margin-right: 1rem;
-      font-size: 1.25rem;
-    }
-  }
 }
 
 @media (min-width: $medium-screen) {

--- a/src/platform/site-wide/sass/modules/_m-crisis-line.scss
+++ b/src/platform/site-wide/sass/modules/_m-crisis-line.scss
@@ -158,11 +158,6 @@ button.va-crisis-line {
     align-self: center;
     flex-shrink: 0;
     font-family: "Font Awesome 5 Free";
-
-    &.fa-mobile {
-      font-size: 38px;
-      padding: 0.15em 0.3em;
-    }
   }
 
   &-close.va-modal-close {

--- a/src/platform/site-wide/sass/modules/facilities/_m-facilities.scss
+++ b/src/platform/site-wide/sass/modules/facilities/_m-facilities.scss
@@ -23,15 +23,6 @@
   background-color: var(--vads-color-primary-alt-lightest);
   border-radius: 50%;
   padding: 6px;
-
-  &.fa-calendar-check,
-  &.fa-comments {
-    padding: 8px;
-  }
-
-  &.fa-file-medical {
-    padding: 8px 11px;
-  }
 }
 
 .vads-facility-hub-cta-arrow {


### PR DESCRIPTION
## Summary
No ticket; quick audit of unused CSS after we converted to Font Awesome.

**No visual or behavioral changes. These styles are not used.** I also checked content-build for all of these and there were no results.

<img width="653" alt="Screenshot 2024-06-18 at 9 54 36 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/b4a2232f-7ffd-4761-90f0-ebefeec9bd9e">
<img width="653" alt="Screenshot 2024-06-18 at 9 54 23 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/5a2fb534-aab1-4a17-b0f1-fbd5377b112c">
<img width="652" alt="Screenshot 2024-06-18 at 9 54 16 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/1f411382-9a62-4faa-90ad-2aa75f80f227">


<img width="552" alt="Screenshot 2024-06-18 at 9 47 06 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/e67bf469-3d28-4d97-82bd-2c04bbd89466">
<img width="551" alt="Screenshot 2024-06-18 at 9 46 57 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/a57d027d-6306-48f9-9a9f-fb83c7d1ab12">

<img width="550" alt="Screenshot 2024-06-18 at 9 47 38 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/6765be6b-0f73-4857-8490-9716206be4f8">
<img width="551" alt="Screenshot 2024-06-18 at 9 47 18 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/180b43af-d8d8-448b-9c82-6923463cdc6f">
