### PR TITLE
86099 update review page copy, hide file upload section - form 10-7959c

### DIFF
--- a/src/applications/ivc-champva/10-7959C/components/CustomAttestation.jsx
+++ b/src/applications/ivc-champva/10-7959C/components/CustomAttestation.jsx
@@ -47,6 +47,7 @@ export default function CustomAttestation(signatureProps) {
       I have read and accept the{' '}
       <a target="_blank" href="/privacy-policy/">
         privacy policy
+        <va-icon icon="launch" size={3} />
       </a>
     </span>
   );

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -229,7 +229,7 @@ const formConfig = {
       },
     },
     healthcareInformation: {
-      title: 'Healthcare information',
+      title: 'Health insurance information',
       pages: {
         hasPrimaryHealthInsurance: {
           path: 'insurance-status',

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -50,6 +50,8 @@ import { hasReq } from '../../shared/components/fileUploads/MissingFileOverview'
 import SupportingDocumentsPage from '../components/SupportingDocumentsPage';
 import { MissingFileConsentPage } from '../components/MissingFileConsentPage';
 
+// import mockdata from '../tests/e2e/fixtures/data/test-data.json';
+
 // Control whether we show the file overview page by calling `hasReq` to
 // determine if any files have not been uploaded. Defaults to false (hide the page)
 // if anything goes sideways.


### PR DESCRIPTION
## Summary

This PR updates a chapter heading on the review accordion and adds an icon to the privacy policy link. 
_(The referenced Git issue also mentions hiding the file upload section of the accordion - that was accomplished with [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/30382))_

- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86099

## Testing done

- Manual

## Screenshots
|         | Before | After |
| ------- | ------ | ----- |
| Privacy policy link |![Screenshot 2024-06-18 at 15 48 17](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/bb29f9d4-c091-4c14-a09f-68b1f2ad2897)|![Screenshot 2024-06-18 at 15 43 31](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/1cfccf01-fd5e-4a09-b92f-5fdbd57d26dc)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA