### PR TITLE
Convert remaining font awesome icon

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/AppointmentColumn.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/AppointmentColumn.jsx
@@ -36,7 +36,6 @@ export default function AppointmentColumn({
   children,
   className,
   first,
-  icon,
   last,
   padding,
   size,
@@ -56,13 +55,6 @@ export default function AppointmentColumn({
       {...props}
       role="cell"
     >
-      {icon && (
-        <i
-          aria-hidden="true"
-          className={classNames('fas', 'vads-u-margin-right--1', icon)}
-        />
-      )}
-
       {children}
     </div>
   );
@@ -80,9 +72,6 @@ AppointmentColumn.propTypes = {
 
   /** First appointment flag */
   first: PropTypes.bool,
-
-  /** Modality icon to display */
-  icon: PropTypes.string,
 
   /** Last appointment flag */
   last: PropTypes.bool,

--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/AppointmentListItemGroup.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/AppointmentListItemGroup.jsx
@@ -68,7 +68,7 @@ function getGridData(appointment) {
     return {
       appointmentDetails: 'VA Appointment',
       appointmentType: 'Phone call',
-      icon: 'fas fa-phone vads-u-margin-right--1',
+      icon: '',
     };
   }
   if (isInPersonVAAppointment()) {
@@ -131,7 +131,6 @@ export default function AppointmentListItemGroup({ data }) {
       },
     };
     const { appointmentDetails, appointmentType } = getGridData(appointment);
-    const { isCommunityCare, isVideo } = appointment.vaos;
 
     return (
       <ListItem
@@ -214,19 +213,7 @@ export default function AppointmentListItemGroup({ data }) {
                 'vads-u-border-color--gray-medium': isBorderBottom,
               })}
             >
-              <div style={styles.canceled}>
-                <i
-                  aria-hidden="true"
-                  className={classNames('fas', 'vads-u-margin-right--1', {
-                    'fa-phone': isVAPhoneAppointment(appointment),
-                    'fa-video': isVideo,
-                    'fa-building': isInPersonVAAppointment() || isCommunityCare,
-                    'fa-blank': isCommunityCare,
-                  })}
-                />
-
-                {appointmentType}
-              </div>
+              <div style={styles.canceled}>{appointmentType}</div>
             </div>
             <div
               className={classNames(

--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/RequestListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/RequestListItem.jsx
@@ -90,10 +90,9 @@ export default function RequestListItem({ appointment, facility }) {
             text="Details"
             data-testid="appointment-detail-link"
           />
-          <i
-            aria-hidden="true"
-            className="fas fa-chevron-right vads-u-color--link-default vads-u-margin-left--1"
-          />
+          <span className="vads-u-color--link-default vads-u-margin-left--1">
+            <va-icon icon="navigate_next" size="3" aria-hidden="true" />
+          </span>
         </div>
       </div>
     </li>

--- a/src/applications/vaos/components/calendar/CalendarCell.jsx
+++ b/src/applications/vaos/components/calendar/CalendarCell.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
 import moment from 'moment';
 import classNames from 'classnames';
 import debounce from 'platform/utilities/data/debounce';
@@ -151,3 +152,22 @@ const CalendarCell = ({
 };
 
 export default CalendarCell;
+
+CalendarCell.propTypes = {
+  availableSlots: PropTypes.array,
+  currentlySelectedDate: PropTypes.string,
+  date: PropTypes.string,
+  disabled: PropTypes.bool,
+  handleSelectOption: PropTypes.func,
+  hasError: PropTypes.bool,
+  id: PropTypes.string,
+  index: PropTypes.number,
+  maxSelections: PropTypes.number,
+  renderIndicator: PropTypes.func,
+  renderOptions: PropTypes.func,
+  renderSelectedLabel: PropTypes.func,
+  selectedDates: PropTypes.array,
+  showWeekends: PropTypes.bool,
+  timezone: PropTypes.string,
+  onClick: PropTypes.func,
+};

--- a/src/applications/vaos/components/calendar/CalendarCell.jsx
+++ b/src/applications/vaos/components/calendar/CalendarCell.jsx
@@ -121,7 +121,9 @@ const CalendarCell = ({
           renderIndicator({ date, id, selectedDates })}
         {inSelectedArray &&
           !renderIndicator && (
-            <i className="fas fa-check vads-u-color--white vaos-calendar__fa-check-position" />
+            <span className="vads-u-color--white vaos-calendar__fa-check-position">
+              <va-icon icon="check" size="3" aria-hidden="true" />
+            </span>
           )}
         {dateDay}
         {isCurrentlySelected && (

--- a/src/applications/vaos/covid-19-vaccine/components/ConfirmationPage.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/ConfirmationPage.jsx
@@ -58,7 +58,10 @@ export default function ConfirmationPage() {
           {appointmentDateString}
         </h2>
         <strong>
-          <i className="fa fa-check-circle vads-u-color--green" />
+          <span className="vads-u-color--green">
+            <va-icon icon="check_circle" size="3" aria-hidden="true" />
+          </span>
+
           <span className="vads-u-font-weight--bold vads-u-margin-left--1 vads-u-display--inline-block">
             Confirmed
           </span>

--- a/src/applications/vaos/covid-19-vaccine/components/ConfirmationPageV2.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/ConfirmationPageV2.jsx
@@ -139,7 +139,7 @@ function ConfirmationPageV2({
       </div>
 
       <div className="vads-u-margin-top--2 vaos-appts__block-label vaos-hide-for-print">
-        <i aria-hidden="true" className="fas fa-print vads-u-margin-right--1" />
+        <va-icon icon="print" size="3" aria-hidden="true" />
         <button
           type="button"
           className="va-button-link"

--- a/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationDirectScheduleInfoV2.jsx
+++ b/src/applications/vaos/new-appointment/components/ConfirmationPage/ConfirmationDirectScheduleInfoV2.jsx
@@ -130,7 +130,7 @@ export default function ConfirmationDirectScheduleInfoV2({
       </div>
 
       <div className="vads-u-margin-top--2 vaos-appts__block-label vaos-hide-for-print">
-        <i aria-hidden="true" className="fas fa-print vads-u-margin-right--1" />
+        <va-icon icon="print" size="3" aria-hidden="true" />
         <va-button
           className="va-button-link"
           onClick={() => window.print()}

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -148,7 +148,7 @@
         "start": "2024-10-13T15:00:00Z",
         "status": "booked",
         "created": "2024-11-01T00:00:00Z",
-        "cancellable": true,
+        "cancellable": false,
         "localStartTime": "2024-10-13T09:00:00.000-06:00",
         "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988663350853",
         "telehealth": null


### PR DESCRIPTION


## Summary
There are files that may be obsolete and not utilized by the vaos app but does call on the use of font awesome icon. On 6/20/2024, the design platform team will have eslint error out on instances where font awesome is detected and will be blockers for CI deployment.

This PR converts remaining files that call on font awesome icon to `va-icon`


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#86378


## Testing done

visual inspection

## Screenshots

n/a

## What areas of the site does it impact?

vaos

## Acceptance criteria

- [ ] Convert remaining files that call on font awesome icon to use `va-icon` web component

