### PR TITLE
10-7959f-1 Same As Address edits

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -173,11 +173,6 @@ const formConfig = {
             },
           },
         },
-      },
-    },
-    sameAsMailingAddress: {
-      title: 'Mailing address',
-      pages: {
         page3a: {
           path: 'same-as-mailing-address',
           uiSchema: {


### PR DESCRIPTION
## Summary
This PR moved to the same as address page to the same chapter as mailing address. This way it doesn't appear as a different step in the progress bar, nor does it appear twice in the review page. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/83695

## Testing done
Unit tests
e2e tests
manual tests

## Screenshots

![Screenshot 2024-06-20 at 9 55 02 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/e766fa4f-815c-432f-b649-3b2e3ca294e6)
![Screenshot 2024-06-20 at 9 55 13 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/746a7a96-6a11-42e2-b0ba-45c4f0655cc8)
![Screenshot 2024-06-20 at 9 55 25 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/e47cd0b8-dd11-40ab-9f9c-273e90a58922)

## What areas of the site does it impact?
This form only

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA
