### PR TITLE
Add step labels to va-segmented-progress-bar

### DIFF
--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -143,6 +143,7 @@ export default function FormNav(props) {
   );
 
   const v3SegmentedProgressBar = formConfig?.v3SegmentedProgressBar;
+  const stepLabels = formConfig?.stepLabels;
   // show progress-bar and stepText only if hideFormNavProgress is falsy.
   return (
     <div>
@@ -153,6 +154,7 @@ export default function FormNav(props) {
           uswds={v3SegmentedProgressBar}
           heading-text={chapterName ?? ''} // functionality only available for v3
           name="v3SegmentedProgressBar"
+          labels={v3SegmentedProgressBar && stepLabels ? stepLabels : ''}
           {...(v3SegmentedProgressBar ? { 'header-level': '2' } : {})}
         />
       )}

--- a/src/platform/forms/tests/forms.unit.spec.js
+++ b/src/platform/forms/tests/forms.unit.spec.js
@@ -91,6 +91,7 @@ const formConfigKeys = [
   'useTopBackLink',
   'v3SegmentedProgressBar',
   'formOptions',
+  'stepLabels',
 ];
 
 const validProperty = (


### PR DESCRIPTION
## Summary

This PR allows the va-segmented-progress-bar in FormNav to accept step labels provided by a new formConfig item.

Team: VES Transition

## Related issue(s)

[PTEMSVT-63](https://jira.devops.va.gov/browse/PTEMSVT-63)

## Testing done

The old behavior was no labels could be added to the progress bar even though it is supported in the va-segmented-progress-bar component. 

[uswds-va-segmented-progress-bar](https://design.va.gov/storybook/?path=/docs/uswds-va-segmented-progress-bar--docs )

The new behavior is that label property can be supplied by adding stepLabels to the formConfig.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |![image](https://github.com/department-of-veterans-affairs/vets-website/assets/159946297/69cd19b1-2b1a-456c-9883-3738eeae8771)|![image](https://github.com/department-of-veterans-affairs/vets-website/assets/159946297/c620c6d5-2544-41cb-82dc-2d6c03d7c583)|
| Desktop |![image](https://github.com/department-of-veterans-affairs/vets-website/assets/159946297/9025c4bc-2594-4764-8dcc-03c2c8bd0083)|![image](https://github.com/department-of-veterans-affairs/vets-website/assets/159946297/911fa055-9f62-41a4-a197-71cc31300935)|

## What areas of the site does it impact?

Forms that use FormNav component can now use step labels. Step labels are not shown in mobile.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
