### PR TITLE
2931 - Use ESLint rule prefer-icon-component 

### DIFF
--- a/.eslintrc.changed.js
+++ b/.eslintrc.changed.js
@@ -8,7 +8,7 @@ module.exports = {
     'jsx-a11y/no-static-element-interactions': 2,
     '@department-of-veterans-affairs/prefer-table-component': 1,
     '@department-of-veterans-affairs/prefer-button-component': 1,
-    '@department-of-veterans-affairs/prefer-icon-component-message': 1,
+    '@department-of-veterans-affairs/prefer-icon-component': 1,
     '@department-of-veterans-affairs/prefer-telephone-component': 2,
     '@department-of-veterans-affairs/telephone-contact-digits': 2,
     '@department-of-veterans-affairs/remove-expanding-group': 1,

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@babel/traverse": "^7.23.2",
     "@bahmutov/cypress-esbuild-preprocessor": "^2.2.0",
     "@cypress/code-coverage": "^3.11.0",
-    "@department-of-veterans-affairs/eslint-plugin": "^1.18.0",
+    "@department-of-veterans-affairs/eslint-plugin": "^1.18.1",
     "@department-of-veterans-affairs/generator-vets-website": "^3.8.0",
     "@octokit/rest": "^18.11.0",
     "@sentry/browser": "^6.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2891,10 +2891,10 @@
     "@divriots/style-dictionary-to-figma" "^0.4.0"
     rimraf "^5.0.5"
 
-"@department-of-veterans-affairs/eslint-plugin@^1.18.0":
-  version "1.18.0"
-  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/eslint-plugin/-/eslint-plugin-1.18.0.tgz#4a013cfc06f50ee6abddec2ba87244e3ea0c8dc0"
-  integrity sha512-91QoWawCGm7REpUjShx1I4xwwYdJehCyjccokafVg/YczNSvEf28VVHYWvovhmCF5eCRRTZic+9adwbqdi0fkg==
+"@department-of-veterans-affairs/eslint-plugin@^1.18.1":
+  version "1.18.1"
+  resolved "https://registry.npmjs.org/@department-of-veterans-affairs/eslint-plugin/-/eslint-plugin-1.18.1.tgz#daa2bc99ae8d0b991395f7a0f35ca98baf834e73"
+  integrity sha512-irdnEsZidSwCE020kNwRmrUPUP7LSNkJK1sn4gq0ta+zXdKAsuslBqovlZng+4HuAcPfbwFJMl06ahzaoIw6ow==
   dependencies:
     jsx-ast-utils "^3.3.3"
 


### PR DESCRIPTION
## Summary
- Update eslint rules to use prefer-icon-component instead of prefer-icon-component-message

## Related issue(s)
https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2931

## Testing done
- Manual testing locally with verdaccio

## Screenshots

![image (5)](https://github.com/department-of-veterans-affairs/vets-website/assets/15200011/71a79aa9-e957-4c6f-9a56-e0a9ce61e2dd)
![image (6)](https://github.com/department-of-veterans-affairs/vets-website/assets/15200011/ba26872a-6109-4f0d-b256-7193ff0603a9)


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria
- New ESLint rule is setup

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
