### PR TITLE
VACMS-18364 Remove unneeded styles for benefit hub icons

### DIFF
--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -155,19 +155,6 @@ $medium-phone-screen: 375px;
     }
   }
 
-  .hub-main-title {
-    width: 90%;
-  }
-
-  .usa-grid {
-    .usa-width-two-thirds {
-      .hub-main-icon {
-        vertical-align: top;
-        margin-top: 8px;
-      }
-    }
-  }
-
   .vet-toolbar {
     .va-dropdown {
       span {


### PR DESCRIPTION
## Summary
Related PR: https://github.com/department-of-veterans-affairs/content-build/pull/2140/

We refactored the code for the Benefit Hub landing page icons (in content-build) to not use styles from vets-website. This removes the styles that will not be used anymore once the above PR is merged.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18364

## Testing done
Tested locally with content-build running. Screenshots and test URLs in this PR: https://github.com/department-of-veterans-affairs/content-build/pull/2140/

Also verified that these styles are only used in the files in the above PR (where they are being removed).

- https://github.com/search?q=org%3Adepartment-of-veterans-affairs%20hub-main-icon&type=code
- https://github.com/search?q=org%3Adepartment-of-veterans-affairs+hub-main-title&type=code