### PR TITLE
[CST] - Update AddFilesForm paragraph

### DIFF
--- a/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
@@ -177,15 +177,9 @@ class AddFilesForm extends React.Component {
     return (
       <>
         <div className="add-files-form">
-          <p className="files-form-information vads-u-margin-top--3 vads-u-margin-bottom--0">
-            Please only submit evidence that supports this claim. You’ll need to
-            scan your document onto the device you’re using to submit this
-            application, such as your computer, tablet, or mobile phone. You can
-            upload your document from there.
-          </p>
-          <p className="vads-u-margin-top--1 vads-u-margin-bottom--3">
-            To submit supporting documents for a new disability claim, please
-            visit our{' '}
+          <p className="files-form-information vads-u-margin-top--3 vads-u-margin-bottom--3">
+            Please only submit evidence that supports this claim. To submit
+            supporting documents for a new disability claim, please visit our{' '}
             <a id="how-to-file-claim" href="/disability/how-to-file-claim">
               How to File a Claim
             </a>{' '}


### PR DESCRIPTION
## Summary

- Updated the paragraph text in AddFilesForm.jsx so that the sentence no longer says "You’ll need to scan your document onto the device you’re using to submit this application, such as your computer, tablet, or mobile phone. You can upload your document from there." and instead says "Please only submit evidence that supports this claim. To submit supporting documents for a new disability claim, please visit our (Link)How to File a Claim page."

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#85738

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | ![](https://api.zenhub.com/attachedFiles/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBMk5WQlE9PSIsImV4cCI6bnVsbCwicHVyIjoiYmxvYl9pZCJ9fQ==--5e6aaf1d1371facd7e9a496e9649ff4293fccf5c/Screenshot%202024-06-11%20at%204.52.42%E2%80%AFPM.png) | ![Screenshot 2024-06-20 at 2 28 52 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/766371a1-315c-4c5e-b8d1-892c4fce8000) |

## What areas of the site does it impact?

Claim Status Tool

## Acceptance criteria

- [ ] _Remove the sentence "You’ll need to scan your document onto the device you’re using to submit this application, such as your computer, tablet, or mobile phone. You can upload your document from there." from AddFilesForm.jsx

- [ ] _Update the sentences so that they are combined to say "Please only submit evidence that supports this claim. To submit supporting documents for a new disability claim, please visit our (Link)How to File a Claim page." on the AddFilesForm.jsx

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
