### PR TITLE
MHV-59238 Small fix to properly display Chem/Hem results

### DIFF
--- a/src/applications/mhv-medical-records/reducers/labsAndTests.js
+++ b/src/applications/mhv-medical-records/reducers/labsAndTests.js
@@ -73,7 +73,9 @@ const convertChemHemObservation = record => {
     }
     let standardRange;
     if (observationUnit) {
-      standardRange = `${result.referenceRange[0].text} ${observationUnit}`;
+      standardRange = isArrayAndHasItems(result.referenceRange)
+        ? `${result.referenceRange[0].text} ${observationUnit}`
+        : null;
     }
     return {
       name: result.code.text,
@@ -295,7 +297,7 @@ export const labsAndTestsReducer = (state = initialState, action) => {
         listState: loadStates.FETCHED,
         labsAndTestsList:
           recordList.entry
-            ?.map(record => convertLabsAndTestsRecord(record))
+            ?.map(record => convertLabsAndTestsRecord(record.resource))
             .filter(record => record.type !== labTypes.OTHER) || [],
       };
     }

--- a/src/applications/mhv-medical-records/tests/e2e/fixtures/labsAndTests.json
+++ b/src/applications/mhv-medical-records/tests/e2e/fixtures/labsAndTests.json
@@ -14,2181 +14,2265 @@
   ],
   "entry": [
     {
-      "resourceType" : "DiagnosticReport",
-      "id" : "ex-MHV-chReport-1",
-      "meta" : {
-        "profile" : [
-          "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chReport"
-        ]
-      },
-      "text" : {
-        "status" : "generated",
-        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: \">CH</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>, <span title=\"Codes: {http://loinc.org 2823-3}\">POTASSIUM:SCNC:PT:SER/PLAS:QN:</span>, <span title=\"Codes: {http://loinc.org 2951-2}\">SODIUM:SCNC:PT:SER/PLAS:QN:</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>L MHVSYSTEST </b> unknown, DoB: 1000-01-01 ( <code>urn:oid:2.16.840.1.113883.4.349</code>/942104\u00a0(use:\u00a0USUAL))</td></tr><tr><td>When For</td><td>2021-01-20 16:38:59-0500</td></tr><tr><td>Reported</td><td>2021-01-21 11:32:47-0500</td></tr><tr><td>Identifier:</td><td> <code>urn:fdc:TEST.SALT-LAKE.MED.VA.GOV:LR</code>/1110200002\u00a0(use:\u00a0USUAL)</td></tr></table><p><b>Report Details</b></p><table class=\"grid\"><tr><td><b>Code</b></td><td><b>Value</b></td><td><b>Reference Range</b></td><td><b>Flags</b></td><td><b>Note</b></td><td><b>When For</b></td></tr><tr><td colspan=\"6\"><i>This Observation could not be resolved</i></td></tr><tr><td colspan=\"6\"><i>This Observation could not be resolved</i></td></tr></table></div>"
-      },
-      "contained" : [
-        {
-          "resourceType" : "Organization",
-          "id" : "ex-MHV-organization-552",
-          "meta" : {
-            "profile" : [
-              "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.organization"
-            ]
-          },
-          "identifier" : [
-            {
-              "use" : "usual",
-              "type" : {
-                "text" : "L"
-              },
-              "system" : "urn:oid:2.16.840.1.113883.4.349",
-              "value" : "552"
-            }
-          ],
-          "active" : true,
-          "name" : "DAYTON, OH VAMC",
-          "address" : [
-            {
-              "line" : [
-                "4100 W. THIRD STREET"
-              ],
-              "city" : "DAYTON",
-              "state" : "OH",
-              "postalCode" : "45428",
-              "country" : "USA"
-            }
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/DiagnosticReport/8109",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "ex-MHV-chReport-1",
+        "meta": {
+          "profile": [
+            "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chReport"
           ]
         },
-        {
-          "resourceType" : "Practitioner",
-          "id" : "ex-MHV-practitioner-14934-VA552",
-          "identifier" : [
-            {
-              "system" : "http://va.gov/terminology/vistaDefinedTerms/4",
-              "value" : "14934-VA552"
-            }
-          ],
-          "name" : [
-            {
-              "family" : "DOE",
-              "given" : [
-                "JANE",
-                "A"
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: \">CH</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>, <span title=\"Codes: {http://loinc.org 2823-3}\">POTASSIUM:SCNC:PT:SER/PLAS:QN:</span>, <span title=\"Codes: {http://loinc.org 2951-2}\">SODIUM:SCNC:PT:SER/PLAS:QN:</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>L MHVSYSTEST </b> unknown, DoB: 1000-01-01 ( <code>urn:oid:2.16.840.1.113883.4.349</code>/942104 (use: USUAL))</td></tr><tr><td>When For</td><td>2021-01-20 16:38:59-0500</td></tr><tr><td>Reported</td><td>2021-01-21 11:32:47-0500</td></tr><tr><td>Identifier:</td><td> <code>urn:fdc:TEST.SALT-LAKE.MED.VA.GOV:LR</code>/1110200002 (use: USUAL)</td></tr></table><p><b>Report Details</b></p><table class=\"grid\"><tr><td><b>Code</b></td><td><b>Value</b></td><td><b>Reference Range</b></td><td><b>Flags</b></td><td><b>Note</b></td><td><b>When For</b></td></tr><tr><td colspan=\"6\"><i>This Observation could not be resolved</i></td></tr><tr><td colspan=\"6\"><i>This Observation could not be resolved</i></td></tr></table></div>"
+        },
+        "contained": [
+          {
+            "resourceType": "Organization",
+            "id": "ex-MHV-organization-552",
+            "meta": {
+              "profile": [
+                "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.organization"
               ]
-            }
-          ]
-        },
-        {
-          "resourceType" : "Organization",
-          "id" : "ex-MHV-organization-989",
-          "meta" : {
-            "profile" : [
-              "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.organization"
-            ]
-          },
-          "identifier" : [
-            {
-              "use" : "usual",
-              "system" : "urn:oid:2.16.840.1.113883.4.349",
-              "value" : "LabSiteTO.989"
             },
-            {
-              "system" : "http://hl7.org/fhir/sid/us-npi",
-              "value" : "1234"
-            }
-          ],
-          "active" : true,
-          "name" : "Lab Site 989"
-        },
-        {
-          "resourceType" : "ServiceRequest",
-          "id" : "ex-MHV-chOrder-1a",
-          "meta" : {
-            "profile" : [
-              "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chOrder"
+            "identifier": [
+              {
+                "use": "usual",
+                "type": {
+                  "text": "L"
+                },
+                "system": "urn:oid:2.16.840.1.113883.4.349",
+                "value": "552"
+              }
+            ],
+            "active": true,
+            "name": "DAYTON, OH VAMC",
+            "address": [
+              {
+                "line": [
+                  "4100 W. THIRD STREET"
+                ],
+                "city": "DAYTON",
+                "state": "OH",
+                "postalCode": "45428",
+                "country": "USA"
+              }
             ]
           },
-          "status" : "unknown",
-          "intent" : "order",
-          "category" : [
-            {
-              "coding" : [
-                {
-                  "system" : "http://snomed.info/sct",
-                  "code" : "108252007",
-                  "display" : "Laboratory procedure"
-                }
+          {
+            "resourceType": "Practitioner",
+            "id": "ex-MHV-practitioner-14934-VA552",
+            "identifier": [
+              {
+                "system": "http://va.gov/terminology/vistaDefinedTerms/4",
+                "value": "14934-VA552"
+              }
+            ],
+            "name": [
+              {
+                "family": "DOE",
+                "given": [
+                  "JANE",
+                  "A"
+                ]
+              }
+            ]
+          },
+          {
+            "resourceType": "Organization",
+            "id": "ex-MHV-organization-989",
+            "meta": {
+              "profile": [
+                "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.organization"
               ]
-            }
-          ],
-          "code" : {
-            "coding" : [
+            },
+            "identifier": [
               {
-                "system" : "http://va.gov/terminology/vistaDefinedTerms/64",
-                "code" : "84140.0000"
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349",
+                "value": "LabSiteTO.989"
               },
               {
-                "system" : "http://va.gov/terminology/vistaDefinedTerms/60",
-                "code" : "177",
-                "display" : "POTASSIUM"
+                "system": "http://hl7.org/fhir/sid/us-npi",
+                "value": "1234"
               }
             ],
-            "text" : "Potassium"
+            "active": true,
+            "name": "Lab Site 989"
           },
-          "subject" : {
-            "reference" : "Patient/ex-MHV-patient-942104"
-          },
-          "requester" : {
-            "reference" : "#ex-MHV-practitioner-14934-VA552"
-          },
-          "performer" : [
-            {
-              "reference" : "#ex-MHV-organization-552"
-            }
-          ]
-        },
-        {
-          "resourceType" : "Observation",
-          "id" : "ex-MHV-chTest-1a",
-          "meta" : {
-            "profile" : [
-              "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chTest"
-            ]
-          },
-          "basedOn" : [
-            {
-              "reference" : "#ex-MHV-chOrder-1a"
-            }
-          ],
-          "status" : "final",
-          "category" : [
-            {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/observation-category",
-                  "code" : "laboratory"
-                }
+          {
+            "resourceType": "ServiceRequest",
+            "id": "ex-MHV-chOrder-1a",
+            "meta": {
+              "profile": [
+                "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chOrder"
               ]
-            }
-          ],
-          "code" : {
-            "coding" : [
+            },
+            "status": "unknown",
+            "intent": "order",
+            "category": [
               {
-                "system" : "http://loinc.org",
-                "version" : "2.68",
-                "code" : "2823-3"
-              },
-              {
-                "system" : "http://va.gov/terminology/vistaDefinedTerms/95.3",
-                "code" : "4670505"
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "108252007",
+                    "display": "Laboratory procedure"
+                  }
+                ]
               }
             ],
-            "text" : "POTASSIUM"
-          },
-          "subject" : {
-            "reference" : "Patient/ex-MHV-patient-942104"
-          },
-          "effectiveDateTime" : "2021-01-20T16:38:59-05:00",
-          "performer" : [
-            {
-              "reference" : "#ex-MHV-organization-552"
-            }
-          ],
-          "valueQuantity" : {
-            "value" : 3.5,
-            "unit" : "mEq/L",
-            "system" : "http://unitsofmeasure.org"
-          },
-          "interpretation" : [
-            {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-                  "code" : "L"
-                }
-              ],
-              "text" : "L"
-            }
-          ],
-          "note" : [
-            {
-              "text" : "Normal Range Prior to 8-22-02 was: 3.6 - 5.0 mEq/L."
-            }
-          ],
-          "specimen" : {
-            "reference" : "#ex-MHV-chSpecimen-1"
-          },
-          "referenceRange" : [
-            {
-              "text" : "3.6-5.1"
-            }
-          ]
-        },
-        {
-          "resourceType" : "ServiceRequest",
-          "id" : "ex-MHV-chOrder-1b",
-          "meta" : {
-            "profile" : [
-              "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chOrder"
-            ]
-          },
-          "status" : "unknown",
-          "intent" : "order",
-          "category" : [
-            {
-              "coding" : [
-                {
-                  "system" : "http://snomed.info/sct",
-                  "code" : "108252007",
-                  "display" : "Laboratory procedure"
-                }
-              ]
-            }
-          ],
-          "code" : {
-            "coding" : [
-              {
-                "system" : "http://va.gov/terminology/vistaDefinedTerms/64",
-                "code" : "84295.0000"
-              },
-              {
-                "system" : "http://va.gov/terminology/vistaDefinedTerms/60",
-                "code" : "176",
-                "display" : "SODIUM"
-              }
-            ],
-            "text" : "Sodium"
-          },
-          "subject" : {
-            "reference" : "Patient/ex-MHV-patient-942104"
-          },
-          "requester" : {
-            "reference" : "#ex-MHV-practitioner-14934-VA552"
-          },
-          "performer" : [
-            {
-              "reference" : "#ex-MHV-organization-552"
-            }
-          ]
-        },
-        {
-          "resourceType" : "Observation",
-          "id" : "ex-MHV-chTest-1b",
-          "meta" : {
-            "profile" : [
-              "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chTest"
-            ]
-          },
-          "basedOn" : [
-            {
-              "reference" : "#ex-MHV-chOrder-1b"
-            }
-          ],
-          "status" : "final",
-          "category" : [
-            {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/observation-category",
-                  "code" : "laboratory"
-                }
-              ]
-            }
-          ],
-          "code" : {
-            "coding" : [
-              {
-                "system" : "http://loinc.org",
-                "version" : "2.68",
-                "code" : "2951-2"
-              },
-              {
-                "system" : "http://va.gov/terminology/vistaDefinedTerms/95.3",
-                "code" : "4671912"
-              }
-            ],
-            "text" : "SODIUM:SCNC:PT:SER/PLAS:QN:"
-          },
-          "subject" : {
-            "reference" : "Patient/ex-MHV-patient-942104"
-          },
-          "effectiveDateTime" : "2021-01-20T16:38:59-05:00",
-          "performer" : [
-            {
-              "reference" : "#ex-MHV-organization-552"
-            }
-          ],
-          "valueQuantity" : {
-            "value" : 138,
-            "unit" : "mEq/L",
-            "system" : "http://unitsofmeasure.org"
-          },
-          "interpretation" : [
-            {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-                  "code" : "L"
-                }
-              ],
-              "text" : "L"
-            }
-          ],
-          "specimen" : {
-            "reference" : "#ex-MHV-chSpecimen-1"
-          },
-          "referenceRange" : [
-            {
-              "text" : "136-145"
-            }
-          ]
-        },
-        {
-          "resourceType" : "Specimen",
-          "id" : "ex-MHV-chSpecimen-1",
-          "meta" : {
-            "profile" : [
-              "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chSpecimen"
-            ]
-          },
-          "status" : "available",
-          "type" : {
-            "coding" : [
-              {
-                "system" : "http://terminology.hl7.org/CodeSystem/v2-0487",
-                "code" : "SER",
-                "display" : "Serum"
-              },
-              {
-                "system" : "http://va.gov/terminology/vistaDefinedTerms/61",
-                "code" : "72",
-                "display" : "SERUM"
-              }
-            ],
-            "text" : "SERUM"
-          },
-          "request" : [
-            {
-              "reference" : "#ex-MHV-chOrder-1a"
-            }
-          ],
-          "collection" : {
-            "collectedDateTime" : "2021-01-20T16:38:59-05:00"
-          }
-        }
-      ],
-      "extension" : [
-        {
-          "url" : "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/Notes",
-          "valueString" : "Jane's Test 1/20/2021 - Second lab"
-        },
-        {
-          "url" : "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/Notes",
-          "valueString" : "Added Potassium test"
-        }
-      ],
-      "identifier" : [
-        {
-          "use" : "usual",
-          "system" : "urn:fdc:TEST.SALT-LAKE.MED.VA.GOV:LR",
-          "value" : "1110200002"
-        }
-      ],
-      "basedOn" : [
-        {
-          "reference" : "#ex-MHV-chOrder-1a"
-        },
-        {
-          "reference" : "#ex-MHV-chOrder-1b"
-        }
-      ],
-      "status" : "final",
-      "category" : [
-        {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/v2-0074",
-              "code" : "LAB"
-            }
-          ]
-        },
-        {
-          "coding" : [
-            {
-              "system" : "http://loinc.org",
-              "version" : "2.68",
-              "code" : "2823-3"
-            }
-          ],
-          "text" : "POTASSIUM:SCNC:PT:SER/PLAS:QN:"
-        },
-        {
-          "coding" : [
-            {
-              "system" : "http://loinc.org",
-              "version" : "2.68",
-              "code" : "2951-2"
-            }
-          ],
-          "text" : "SODIUM:SCNC:PT:SER/PLAS:QN:"
-        }
-      ],
-      "code" : {
-        "text" : "CH"
-      },
-      "subject" : {
-        "reference" : "Patient/ex-MHV-patient-942104"
-      },
-      "effectiveDateTime" : "2021-01-20T16:38:59-05:00",
-      "issued" : "2021-01-21T11:32:47-05:00",
-      "performer" : [
-        {
-          "reference" : "#ex-MHV-organization-989"
-        }
-      ],
-      "specimen" : [
-        {
-          "reference" : "#ex-MHV-chSpecimen-1"
-        }
-      ],
-      "result" : [
-        {
-          "reference" : "#ex-MHV-chTest-1a"
-        },
-        {
-          "reference" : "#ex-MHV-chTest-1b"
-        }
-      ]
-    },
-    {
-      "resourceType" : "DiagnosticReport",
-      "id" : "9953",
-      "meta" : {
-        "versionId" : "22",
-        "lastUpdated" : "2024-05-16T18:08:59.215-04:00",
-        "source" : "#reWo6V0WdeyFTR19",
-        "profile" : [
-          "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chReport"
-        ]
-      },
-      "text" : {
-        "status" : "generated",
-        "div" : "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: \">CH</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>, <span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 CH}\">Chemistry</span>, <span title=\"Codes: {http://loinc.org 2345-7}\">GLUCOSE:MCNC:PT:SER/PLAS:QN:</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>L MHVSYSTEST </b> unknown, DoB: 1000-01-01 ( <code>urn:oid:2.16.840.1.113883.4.349</code>/942104\u00a0(use:\u00a0usual))</td></tr><tr><td>When For</td><td>2017-08-02 09:50:57-0400</td></tr><tr><td>Reported</td><td>2017-08-02 09:52:27-0400</td></tr><tr><td>Identifier:</td><td> <code>urn:fdc:TEST.DAYTON.MED.VA.GOV:LR</code>/1172140001\u00a0(use:\u00a0usual)</td></tr></table><p><b>Report Details</b></p><table class=\"grid\"><tr><td><b>Code</b></td><td><b>Value</b></td><td><b>Reference Range</b></td><td><b>Flags</b></td><td><b>Note</b></td><td><b>When For</b></td></tr><tr><td colspan=\"6\"><i>This Observation could not be resolved</i></td></tr></table></div>"
-      },
-      "contained" : [
-        {
-          "resourceType" : "Specimen",
-          "id" : "Specimen-0",
-          "meta" : {
-            "profile" : [
-              "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chSpecimen"
-            ]
-          },
-          "status" : "available",
-          "type" : {
-            "coding" : [
-              {
-                "system" : "http://terminology.hl7.org/CodeSystem/v2-0487",
-                "code" : "SER",
-                "display" : "Serum"
-              },
-              {
-                "system" : "http://va.gov/terminology/vistaDefinedTerms/61",
-                "version" : "5.2",
-                "code" : "72",
-                "display" : "SERUM"
-              }
-            ],
-            "text" : "SERUM"
-          },
-          "request" : [
-            {
-              "reference" : "#ServiceRequest-1"
-            }
-          ],
-          "collection" : {
-            "collectedDateTime" : "2017-08-02T09:50:57-04:00"
-          }
-        },
-        {
-          "resourceType" : "Practitioner",
-          "id" : "Provider-1",
-          "identifier" : [
-            {
-              "system" : "http://va.gov/terminology/vistaDefinedTerms/4",
-              "value" : "14934-VA552"
-            }
-          ],
-          "name" : [
-            {
-              "family" : "DOE",
-              "given" : [
-                "JANE",
-                "A"
-              ]
-            }
-          ]
-        },
-        {
-          "resourceType" : "Organization",
-          "id" : "Organization-552",
-          "meta" : {
-            "profile" : [
-              "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.organization"
-            ]
-          },
-          "identifier" : [
-            {
-              "use" : "usual",
-              "type" : {
-                "text" : "FI"
-              },
-              "system" : "urn:oid:2.16.840.1.113883.4.349",
-              "value" : "552"
-            }
-          ],
-          "active" : true,
-          "name" : "DAYTON, OH VAMC",
-          "address" : [
-            {
-              "line" : [
-                "4100 W. THIRD STREET"
-              ],
-              "city" : "DAYTON",
-              "state" : "OH",
-              "postalCode" : "45428",
-              "country" : "USA"
-            }
-          ]
-        },
-        {
-          "resourceType" : "Organization",
-          "id" : "OrgPerformer-989",
-          "meta" : {
-            "profile" : [
-              "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.organization"
-            ]
-          },
-          "identifier" : [
-            {
-              "use" : "usual",
-              "system" : "urn:oid:2.16.840.1.113883.4.349",
-              "value" : "989"
-            }
-          ],
-          "active" : true,
-          "name" : "DAYT29.FO-BAYPINES.MED.VA.GOV"
-        },
-        {
-          "resourceType" : "ServiceRequest",
-          "id" : "ServiceRequest-1",
-          "meta" : {
-            "profile" : [
-              "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chOrder"
-            ]
-          },
-          "status" : "unknown",
-          "intent" : "order",
-          "category" : [
-            {
-              "coding" : [
-                {
-                  "system" : "http://snomed.info/sct",
-                  "code" : "108252007",
-                  "display" : "Laboratory procedure"
-                }
-              ]
-            }
-          ],
-          "code" : {
-            "coding" : [
-              {
-                "system" : "http://va.gov/terminology/vistaDefinedTerms/64",
-                "code" : "84330.0000"
-              },
-              {
-                "system" : "http://va.gov/terminology/vistaDefinedTerms/60",
-                "code" : "175",
-                "display" : "GLUCOSE"
-              }
-            ],
-            "text" : "Glucose Quant"
-          },
-          "subject" : {
-            "reference" : "Patient/ex-MHV-patient-942104"
-          },
-          "requester" : {
-            "reference" : "#Provider-1"
-          },
-          "performer" : [
-            {
-              "reference" : "#Organization-552"
-            }
-          ]
-        },
-        {
-          "resourceType" : "Observation",
-          "id" : "ChemistryResult-1.1",
-          "meta" : {
-            "profile" : [
-              "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chTest"
-            ]
-          },
-          "basedOn" : [
-            {
-              "reference" : "#ServiceRequest-1"
-            }
-          ],
-          "status" : "final",
-          "category" : [
-            {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/observation-category",
-                  "code" : "laboratory"
-                }
-              ]
-            }
-          ],
-          "code" : {
-            "coding" : [
-              {
-                "system" : "http://loinc.org",
-                "version" : "2.52",
-                "code" : "2345-7"
-              },
-              {
-                "system" : "http://va.gov/terminology/vistaDefinedTerms/95.3",
-                "version" : "2.52",
-                "code" : "4665460"
-              }
-            ],
-            "text" : "GLUCOSE"
-          },
-          "subject" : {
-            "reference" : "Patient/ex-MHV-patient-942104"
-          },
-          "effectiveDateTime" : "2017-08-02T09:50:57-04:00",
-          "performer" : [
-            {
-              "reference" : "#Organization-552"
-            }
-          ],
-          "valueQuantity" : {
-            "value" : 171,
-            "unit" : "mg/dl",
-            "system" : "http://unitsofmeasure.org",
-            "code" : "mg/dl"
-          },
-          "interpretation" : [
-            {
-              "coding" : [
-                {
-                  "system" : "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
-                  "code" : "H"
-                }
-              ],
-              "text" : "H"
-            }
-          ],
-          "note" : [
-            {
-              "text" : "***PLEASE NOTE NEW CRITICAL VALUE EFFECTIVE 2/2/98***"
-            }
-          ],
-          "specimen" : {
-            "reference" : "#Specimen-0"
-          },
-          "referenceRange" : [
-            {
-              "text" : "65-110"
-            }
-          ]
-        }
-      ],
-      "extension" : [
-        {
-          "url" : "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/Notes",
-          "valueString" : "Jane's 8/2  test"
-        }
-      ],
-      "identifier" : [
-        {
-          "use" : "usual",
-          "system" : "urn:fdc:TEST.DAYTON.MED.VA.GOV:LR",
-          "value" : "1172140001"
-        }
-      ],
-      "basedOn" : [
-        {
-          "reference" : "#ServiceRequest-1"
-        }
-      ],
-      "status" : "final",
-      "category" : [
-        {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/v2-0074",
-              "code" : "LAB"
-            }
-          ]
-        },
-        {
-          "coding" : [
-            {
-              "system" : "http://terminology.hl7.org/CodeSystem/v2-0074",
-              "code" : "CH"
-            }
-          ]
-        },
-        {
-          "coding" : [
-            {
-              "system" : "http://loinc.org",
-              "version" : "2.52",
-              "code" : "2345-7"
-            }
-          ],
-          "text" : "GLUCOSE:MCNC:PT:SER/PLAS:QN:"
-        }
-      ],
-      "code" : {
-        "text" : "CH"
-      },
-      "subject" : {
-        "reference" : "Patient/ex-MHV-patient-942104"
-      },
-      "effectiveDateTime" : "2017-08-02T09:50:57-04:00",
-      "issued" : "2017-08-02T09:52:27.000-04:00",
-      "performer" : [
-        {
-          "reference" : "#OrgPerformer-989"
-        }
-      ],
-      "specimen" : [
-        {
-          "reference" : "#Specimen-0"
-        }
-      ],
-      "result" : [
-        {
-          "reference" : "#ChemistryResult-1.1"
-        }
-      ]
-    },
-    {
-      "resourceType": "DiagnosticReport",
-      "id": "ex-MHV-labReport-1",
-      "meta": {
-        "profile": [
-          "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
-        ]
-      },
-      "text": {
-        "status": "generated",
-        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 79381-0}\">LR MICROBIOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id:\u00a01013699147\u00a0(use:\u00a0OFFICIAL))</td></tr><tr><td>When For</td><td>1995-08-03 14:49:00+0000</td></tr><tr><td>Reported</td><td>1995-08-03 14:49:00+0000</td></tr><tr><td>Identifier:</td><td> id:\u00a0LabReportTO.MI;7049269\u00a0(use:\u00a0USUAL)</td></tr></table><p><b>Report Details</b></p><table class=\"grid\"><tr><td><b>Code</b></td><td><b>Value</b></td><td><b>When For</b></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr></table><p>Accession [UID]: PARAS 95 264 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 30, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT =&gt; Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND</p></div>"
-      },
-      "contained": [
-        {
-          "resourceType": "Observation",
-          "id": "ex-MHV-labTest-1",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
-            ]
-          },
-          "identifier": [
-            {
-              "use": "usual",
-              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-              "value": "LabTestTO.MI;7049269;1"
-            }
-          ],
-          "status": "final",
-          "category": [
-            {
+            "code": {
               "coding": [
                 {
-                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                  "code": "laboratory"
+                  "system": "http://va.gov/terminology/vistaDefinedTerms/64",
+                  "code": "84140.0000"
+                },
+                {
+                  "system": "http://va.gov/terminology/vistaDefinedTerms/60",
+                  "code": "177",
+                  "display": "POTASSIUM"
                 }
-              ]
-            }
-          ],
-          "code": {
-            "text": "Parasitology Remark(s)"
-          },
-          "subject": {
-            "reference": "Patient/ex-MHV-patient-1"
-          },
-          "effectiveDateTime": "1995-08-03T14:49:00-0400",
-          "performer": [
-            {
-              "reference": "Organization/ex-MHV-organization-989"
-            }
-          ],
-          "valueString": "NO OVA OR PARASITES FOUND"
-        },
-        {
-          "resourceType": "Specimen",
-          "id": "ex-MHV-specimen-1",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
+              ],
+              "text": "Potassium"
+            },
+            "subject": {
+              "reference": "Patient/ex-MHV-patient-942104"
+            },
+            "requester": {
+              "reference": "#ex-MHV-practitioner-14934-VA552"
+            },
+            "performer": [
+              {
+                "reference": "#ex-MHV-organization-552"
+              }
             ]
           },
-          "identifier": [
-            {
-              "use": "usual",
-              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-              "value": "LabSpecimenTO.6Y100"
-            }
-          ],
-          "accessionIdentifier": {
-            "use": "usual",
-            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-            "value": "PARAS 95 264"
-          },
-          "status": "available",
-          "type": {
-            "text": "FECES"
-          },
-          "collection": {
-            "collectedDateTime": "1995-07-30"
-          }
-        }
-      ],
-      "identifier": [
-        {
-          "use": "usual",
-          "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-          "value": "LabReportTO.MI;7049269"
-        }
-      ],
-      "status": "final",
-      "category": [
-        {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
-              "code": "LAB"
-            }
-          ]
-        }
-      ],
-      "code": {
-        "coding": [
           {
-            "system": "http://loinc.org",
-            "code": "79381-0"
-          }
-        ],
-        "text": "LR MICROBIOLOGY REPORT"
-      },
-      "subject": {
-        "reference": "Patient/ex-MHV-patient-1"
-      },
-      "effectiveDateTime": "1995-08-03T14:49:00-0400",
-      "issued": "1995-08-03T14:49:00-0400",
-      "performer": [
-        {
-          "reference": "Organization/ex-MHV-organization-989"
-        }
-      ],
-      "specimen": [
-        {
-          "reference": "#ex-MHV-specimen-1"
-        }
-      ],
-      "result": [
-        {
-          "reference": "#ex-MHV-labTest-1"
-        }
-      ],
-      "conclusion": "Accession [UID]: PARAS 95 264 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 30, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT => Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND"
-    },
-    {
-      "resourceType": "DiagnosticReport",
-      "id": "ex-MHV-labReport-2",
-      "meta": {
-        "profile": [
-          "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
-        ]
-      },
-      "text": {
-        "status": "generated",
-        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 79381-0}\">LR MICROBIOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id:\u00a01013699147\u00a0(use:\u00a0OFFICIAL))</td></tr><tr><td>When For</td><td>1995-08-03 14:49:00+0000</td></tr><tr><td>Reported</td><td>1995-08-03 14:49:00+0000</td></tr><tr><td>Identifier:</td><td> id:\u00a0LabReportTO.MI;7049269\u00a0(use:\u00a0USUAL)</td></tr></table><p><b>Report Details</b></p><table class=\"grid\"><tr><td><b>Code</b></td><td><b>Value</b></td><td><b>When For</b></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr></table><p>Accession [UID]: PARAS 95 264 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 30, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT =&gt; Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND</p></div>"
-      },
-      "contained": [
-        {
-          "resourceType": "Observation",
-          "id": "ex-MHV-labTest-1",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
-            ]
-          },
-          "identifier": [
-            {
-              "use": "usual",
-              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-              "value": "LabTestTO.MI;7049269;1"
-            }
-          ],
-          "status": "final",
-          "category": [
-            {
+            "resourceType": "Observation",
+            "id": "ex-MHV-chTest-1a",
+            "meta": {
+              "profile": [
+                "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chTest"
+              ]
+            },
+            "basedOn": [
+              {
+                "reference": "#ex-MHV-chOrder-1a"
+              }
+            ],
+            "status": "final",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                    "code": "laboratory"
+                  }
+                ]
+              }
+            ],
+            "code": {
               "coding": [
                 {
-                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                  "code": "laboratory"
+                  "system": "http://loinc.org",
+                  "version": "2.68",
+                  "code": "2823-3"
+                },
+                {
+                  "system": "http://va.gov/terminology/vistaDefinedTerms/95.3",
+                  "code": "4670505"
                 }
-              ]
-            }
-          ],
-          "code": {
-            "text": "Parasitology Remark(s)"
-          },
-          "subject": {
-            "reference": "Patient/ex-MHV-patient-1"
-          },
-          "effectiveDateTime": "1995-08-03T14:49:00-0400",
-          "performer": [
-            {
-              "reference": "Organization/ex-MHV-organization-989"
-            }
-          ],
-          "valueString": "NO OVA OR PARASITES FOUND"
-        },
-        {
-          "resourceType": "Specimen",
-          "id": "ex-MHV-specimen-1",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
+              ],
+              "text": "POTASSIUM"
+            },
+            "subject": {
+              "reference": "Patient/ex-MHV-patient-942104"
+            },
+            "effectiveDateTime": "2021-01-20T16:38:59-05:00",
+            "performer": [
+              {
+                "reference": "#ex-MHV-organization-552"
+              }
+            ],
+            "valueQuantity": {
+              "value": 3.5,
+              "unit": "mEq/L",
+              "system": "http://unitsofmeasure.org"
+            },
+            "interpretation": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                    "code": "L"
+                  }
+                ],
+                "text": "L"
+              }
+            ],
+            "note": [
+              {
+                "text": "Normal Range Prior to 8-22-02 was: 3.6 - 5.0 mEq/L."
+              }
+            ],
+            "specimen": {
+              "reference": "#ex-MHV-chSpecimen-1"
+            },
+            "referenceRange": [
+              {
+                "text": "3.6-5.1"
+              }
             ]
           },
-          "identifier": [
-            {
-              "use": "usual",
-              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-              "value": "LabSpecimenTO.6Y100"
-            }
-          ],
-          "accessionIdentifier": {
-            "use": "usual",
-            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-            "value": "PARAS 95 264"
-          },
-          "status": "available",
-          "type": {
-            "text": "FECES"
-          },
-          "collection": {
-            "collectedDateTime": "1995-07-30"
-          }
-        }
-      ],
-      "identifier": [
-        {
-          "use": "usual",
-          "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-          "value": "LabReportTO.MI;7049269"
-        }
-      ],
-      "status": "final",
-      "category": [
-        {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
-              "code": "LAB"
-            }
-          ]
-        }
-      ],
-      "code": {
-        "coding": [
           {
-            "system": "http://loinc.org",
-            "code": "79381-0"
+            "resourceType": "ServiceRequest",
+            "id": "ex-MHV-chOrder-1b",
+            "meta": {
+              "profile": [
+                "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chOrder"
+              ]
+            },
+            "status": "unknown",
+            "intent": "order",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "108252007",
+                    "display": "Laboratory procedure"
+                  }
+                ]
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "system": "http://va.gov/terminology/vistaDefinedTerms/64",
+                  "code": "84295.0000"
+                },
+                {
+                  "system": "http://va.gov/terminology/vistaDefinedTerms/60",
+                  "code": "176",
+                  "display": "SODIUM"
+                }
+              ],
+              "text": "Sodium"
+            },
+            "subject": {
+              "reference": "Patient/ex-MHV-patient-942104"
+            },
+            "requester": {
+              "reference": "#ex-MHV-practitioner-14934-VA552"
+            },
+            "performer": [
+              {
+                "reference": "#ex-MHV-organization-552"
+              }
+            ]
+          },
+          {
+            "resourceType": "Observation",
+            "id": "ex-MHV-chTest-1b",
+            "meta": {
+              "profile": [
+                "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chTest"
+              ]
+            },
+            "basedOn": [
+              {
+                "reference": "#ex-MHV-chOrder-1b"
+              }
+            ],
+            "status": "final",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                    "code": "laboratory"
+                  }
+                ]
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "version": "2.68",
+                  "code": "2951-2"
+                },
+                {
+                  "system": "http://va.gov/terminology/vistaDefinedTerms/95.3",
+                  "code": "4671912"
+                }
+              ],
+              "text": "SODIUM:SCNC:PT:SER/PLAS:QN:"
+            },
+            "subject": {
+              "reference": "Patient/ex-MHV-patient-942104"
+            },
+            "effectiveDateTime": "2021-01-20T16:38:59-05:00",
+            "performer": [
+              {
+                "reference": "#ex-MHV-organization-552"
+              }
+            ],
+            "valueQuantity": {
+              "value": 138,
+              "unit": "mEq/L",
+              "system": "http://unitsofmeasure.org"
+            },
+            "interpretation": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                    "code": "L"
+                  }
+                ],
+                "text": "L"
+              }
+            ],
+            "specimen": {
+              "reference": "#ex-MHV-chSpecimen-1"
+            },
+            "referenceRange": [
+              {
+                "text": "136-145"
+              }
+            ]
+          },
+          {
+            "resourceType": "Specimen",
+            "id": "ex-MHV-chSpecimen-1",
+            "meta": {
+              "profile": [
+                "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chSpecimen"
+              ]
+            },
+            "status": "available",
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+                  "code": "SER",
+                  "display": "Serum"
+                },
+                {
+                  "system": "http://va.gov/terminology/vistaDefinedTerms/61",
+                  "code": "72",
+                  "display": "SERUM"
+                }
+              ],
+              "text": "SERUM"
+            },
+            "request": [
+              {
+                "reference": "#ex-MHV-chOrder-1a"
+              }
+            ],
+            "collection": {
+              "collectedDateTime": "2021-01-20T16:38:59-05:00"
+            }
           }
         ],
-        "text": "LR MICROBIOLOGY REPORT"
-      },
-      "subject": {
-        "reference": "Patient/ex-MHV-patient-1"
-      },
-      "effectiveDateTime": "1995-08-03T14:49:00-0400",
-      "issued": "1995-08-03T14:49:00-0400",
-      "performer": [
-        {
-          "reference": "Organization/ex-MHV-organization-989"
-        }
-      ],
-      "specimen": [
-        {
-          "reference": "#ex-MHV-specimen-1"
-        }
-      ],
-      "result": [
-        {
-          "reference": "#ex-MHV-labTest-1"
-        }
-      ],
-      "conclusion": "Accession [UID]: PARAS 95 264 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 30, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT => Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND"
-    },
-    {
-      "resourceType": "DocumentReference",
-      "id": "ex-MHV-ecg-0",
-      "meta": {
-        "profile": [
-          "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.ecg"
-        ]
-      },
-      "text": {
-        "status": "generated",
-        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: DocumentReference</b><a name=\"ex-MHV-ecg-0\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource DocumentReference &quot;ex-MHV-ecg-0&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-VA.MHV.PHR.ecg.html\">VA MHV PHR ECG</a></p></div><p><b>identifier</b>: id: ClinicalProcedureTO.41359 (use: USUAL)</p><p><b>status</b>: current</p><p><b>type</b>: EKG study <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#11524-6)</span></p><p><b>category</b>: Cardiology <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#LP29708-2)</span>, Clinical Note <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/core/STU5.0.1/CodeSystem-us-core-documentreference-category.html\">US Core DocumentReferences Category Codes</a>#clinical-note)</span></p><p><b>subject</b>: <a href=\"Patient-ex-MHV-patient-1.html\">Patient/ex-MHV-patient-1</a> &quot; DAYTSHR&quot;</p><p><b>date</b>: Dec 14, 2000, 5:35:00 AM</p><blockquote><p><b>content</b></p><h3>Attachments</h3><table class=\"grid\"><tr><td>-</td><td><b>ContentType</b></td><td><b>Data</b></td><td><b>Title</b></td></tr><tr><td>*</td><td>text/plain</td><td>UGcuIDEgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAwOS8xMi8yMiAxMDoxMQogICAgICAgICAgICAgICAgICAgICAgICAgICBDT05GSURFTlRJQUwgRUNHIFJFUE9SVCAgICAgICAgICAgICAgICAgICAgICAgICAgICAKTUhWTElTQU9ORSxST0JFUlQgTSAgICA2NjYtMTItMzQ1NiAgIE5PVCBJTlBBVElFTlQgICAgICAgICAgICAgIERPQjogQVVHIDksMTk2MgogICAgICAgICAgICAgICAgICAgICAgUFJPQ0VEVVJFIERBVEUvVElNRTogMTIvMTQvMDAgMTE6MzUKLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBXQVJEL0NMSU5JQzogQ0FSRElPTE9HWSBPVVRQQVRJRU5UIChMT0MpCiAgICBBR0U6IDM4ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgU0VYOiAgTUFMRQogICAgSFQgSU46IDA3MSAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIFdUIExCUzogMTU0CiAgICBCTE9PRCBQUkVTU1VSRTogICAgICAgICAgICAgICAgICAgICAgICAgVFlQRTogCgogICAgICAgICBWRU5UIFJBVEU6IDA4NiAgICAgICAgUFIgSU5URVJWQUw6IDEzMiAgICAgICBRUlMgRFVSQVRJT046IDEzMgogICAgICAgICBRVDogMzg4ICAgICAgICAgICAgICAgUVRDOiA0NjQKICAgICAgICAgUCBBWElTOiAxMTIgICAgICAgICAgIFIgQVhJUzogNzAgICAgICAgICAgICAgVCBBWElTOiAxNDgKCiAgICBJTlRFUlBSRVRBVElPTjogCgogICAgSU5TVFJVTUVOVCBEWDogIE5vcm1hbCBzaW51cyByaHl0aG0KICAgICAgICAgICAgICAgICAgICBSaWdodCBidW5kbGUgYnJhbmNoIGJsb2NrCiAgICAgICAgICAgICAgICAgICAgTGF0ZXJhbCBpbmZhcmN0ICwgYWdlIHVuZGV0ZXJtaW5lZAogICAgICAgICAgICAgICAgICAgIFBvc3NpYmxlIEluZmVyaW9yIGluZmFyY3QgKGNpdGVkIG9uIG9yIGJlZm9yZSAzMS1KVUwtMjAwMCkKICAgICAgICAgICAgICAgICAgICBBYm5vcm1hbCBFQ0cKICAgICAgICAgICAgICAgICAgICAuCiAgICAgICAgICAgICAgICAgICAgLgogICAgICAgICAgICAgICAgICAgIC4KCiAgICBDT05GSVJNQVRJT04gU1RBVFVTOiBDT05GSVJNRUQKCiAgICBDT01QQVJJU09OOiAKIAoKICAgIENPTU1FTlRTOiAKCiAgICBIRUFSVCBNRURTOgoKICAgIElOVEVSUFJFVEVEIEJZOiBHVVBUQSxTQVRZRU5EUkE=</td><td>ELECTROCARDIOGRAM</td></tr></table></blockquote><h3>Contexts</h3><table class=\"grid\"><tr><td>-</td><td><b>Related</b></td></tr><tr><td>*</td><td><a href=\"Location-ex-MHV-location-989.html\">Location/ex-MHV-location-989</a> &quot;DAYT29 TEST LAB&quot;</td></tr></table></div>"
-      },
-      "identifier": [
-        {
-          "use": "usual",
-          "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-          "value": "ClinicalProcedureTO.41359"
-        }
-      ],
-      "status": "current",
-      "type": {
-        "coding": [
+        "extension": [
           {
-            "system": "http://loinc.org",
-            "code": "11524-6"
+            "url": "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/Notes",
+            "valueString": "Jane's Test 1/20/2021 - Second lab"
+          },
+          {
+            "url": "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/Notes",
+            "valueString": "Added Potassium test"
+          }
+        ],
+        "identifier": [
+          {
+            "use": "usual",
+            "system": "urn:fdc:TEST.SALT-LAKE.MED.VA.GOV:LR",
+            "value": "1110200002"
+          }
+        ],
+        "basedOn": [
+          {
+            "reference": "#ex-MHV-chOrder-1a"
+          },
+          {
+            "reference": "#ex-MHV-chOrder-1b"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB"
+              }
+            ]
+          },
+          {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "version": "2.68",
+                "code": "2823-3"
+              }
+            ],
+            "text": "POTASSIUM:SCNC:PT:SER/PLAS:QN:"
+          },
+          {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "version": "2.68",
+                "code": "2951-2"
+              }
+            ],
+            "text": "SODIUM:SCNC:PT:SER/PLAS:QN:"
+          }
+        ],
+        "code": {
+          "text": "CH"
+        },
+        "subject": {
+          "reference": "Patient/ex-MHV-patient-942104"
+        },
+        "effectiveDateTime": "2021-01-20T16:38:59-05:00",
+        "issued": "2021-01-21T11:32:47-05:00",
+        "performer": [
+          {
+            "reference": "#ex-MHV-organization-989"
+          }
+        ],
+        "specimen": [
+          {
+            "reference": "#ex-MHV-chSpecimen-1"
+          }
+        ],
+        "result": [
+          {
+            "reference": "#ex-MHV-chTest-1a"
+          },
+          {
+            "reference": "#ex-MHV-chTest-1b"
           }
         ]
       },
-      "category": [
-        {
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/DiagnosticReport/8109",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "9953",
+        "meta": {
+          "versionId": "22",
+          "lastUpdated": "2024-05-16T18:08:59.215-04:00",
+          "source": "#reWo6V0WdeyFTR19",
+          "profile": [
+            "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chReport"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: \">CH</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>, <span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 CH}\">Chemistry</span>, <span title=\"Codes: {http://loinc.org 2345-7}\">GLUCOSE:MCNC:PT:SER/PLAS:QN:</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>L MHVSYSTEST </b> unknown, DoB: 1000-01-01 ( <code>urn:oid:2.16.840.1.113883.4.349</code>/942104 (use: usual))</td></tr><tr><td>When For</td><td>2017-08-02 09:50:57-0400</td></tr><tr><td>Reported</td><td>2017-08-02 09:52:27-0400</td></tr><tr><td>Identifier:</td><td> <code>urn:fdc:TEST.DAYTON.MED.VA.GOV:LR</code>/1172140001 (use: usual)</td></tr></table><p><b>Report Details</b></p><table class=\"grid\"><tr><td><b>Code</b></td><td><b>Value</b></td><td><b>Reference Range</b></td><td><b>Flags</b></td><td><b>Note</b></td><td><b>When For</b></td></tr><tr><td colspan=\"6\"><i>This Observation could not be resolved</i></td></tr></table></div>"
+        },
+        "contained": [
+          {
+            "resourceType": "Specimen",
+            "id": "Specimen-0",
+            "meta": {
+              "profile": [
+                "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chSpecimen"
+              ]
+            },
+            "status": "available",
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0487",
+                  "code": "SER",
+                  "display": "Serum"
+                },
+                {
+                  "system": "http://va.gov/terminology/vistaDefinedTerms/61",
+                  "version": "5.2",
+                  "code": "72",
+                  "display": "SERUM"
+                }
+              ],
+              "text": "SERUM"
+            },
+            "request": [
+              {
+                "reference": "#ServiceRequest-1"
+              }
+            ],
+            "collection": {
+              "collectedDateTime": "2017-08-02T09:50:57-04:00"
+            }
+          },
+          {
+            "resourceType": "Practitioner",
+            "id": "Provider-1",
+            "identifier": [
+              {
+                "system": "http://va.gov/terminology/vistaDefinedTerms/4",
+                "value": "14934-VA552"
+              }
+            ],
+            "name": [
+              {
+                "family": "DOE",
+                "given": [
+                  "JANE",
+                  "A"
+                ]
+              }
+            ]
+          },
+          {
+            "resourceType": "Organization",
+            "id": "Organization-552",
+            "meta": {
+              "profile": [
+                "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.organization"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual",
+                "type": {
+                  "text": "FI"
+                },
+                "system": "urn:oid:2.16.840.1.113883.4.349",
+                "value": "552"
+              }
+            ],
+            "active": true,
+            "name": "DAYTON, OH VAMC",
+            "address": [
+              {
+                "line": [
+                  "4100 W. THIRD STREET"
+                ],
+                "city": "DAYTON",
+                "state": "OH",
+                "postalCode": "45428",
+                "country": "USA"
+              }
+            ]
+          },
+          {
+            "resourceType": "Organization",
+            "id": "OrgPerformer-989",
+            "meta": {
+              "profile": [
+                "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.organization"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349",
+                "value": "989"
+              }
+            ],
+            "active": true,
+            "name": "DAYT29.FO-BAYPINES.MED.VA.GOV"
+          },
+          {
+            "resourceType": "ServiceRequest",
+            "id": "ServiceRequest-1",
+            "meta": {
+              "profile": [
+                "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chOrder"
+              ]
+            },
+            "status": "unknown",
+            "intent": "order",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "108252007",
+                    "display": "Laboratory procedure"
+                  }
+                ]
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "system": "http://va.gov/terminology/vistaDefinedTerms/64",
+                  "code": "84330.0000"
+                },
+                {
+                  "system": "http://va.gov/terminology/vistaDefinedTerms/60",
+                  "code": "175",
+                  "display": "GLUCOSE"
+                }
+              ],
+              "text": "Glucose Quant"
+            },
+            "subject": {
+              "reference": "Patient/ex-MHV-patient-942104"
+            },
+            "requester": {
+              "reference": "#Provider-1"
+            },
+            "performer": [
+              {
+                "reference": "#Organization-552"
+              }
+            ]
+          },
+          {
+            "resourceType": "Observation",
+            "id": "ChemistryResult-1.1",
+            "meta": {
+              "profile": [
+                "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.chTest"
+              ]
+            },
+            "basedOn": [
+              {
+                "reference": "#ServiceRequest-1"
+              }
+            ],
+            "status": "final",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                    "code": "laboratory"
+                  }
+                ]
+              }
+            ],
+            "code": {
+              "coding": [
+                {
+                  "system": "http://loinc.org",
+                  "version": "2.52",
+                  "code": "2345-7"
+                },
+                {
+                  "system": "http://va.gov/terminology/vistaDefinedTerms/95.3",
+                  "version": "2.52",
+                  "code": "4665460"
+                }
+              ],
+              "text": "GLUCOSE"
+            },
+            "subject": {
+              "reference": "Patient/ex-MHV-patient-942104"
+            },
+            "effectiveDateTime": "2017-08-02T09:50:57-04:00",
+            "performer": [
+              {
+                "reference": "#Organization-552"
+              }
+            ],
+            "valueQuantity": {
+              "value": 171,
+              "unit": "mg/dl",
+              "system": "http://unitsofmeasure.org",
+              "code": "mg/dl"
+            },
+            "interpretation": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation",
+                    "code": "H"
+                  }
+                ],
+                "text": "H"
+              }
+            ],
+            "note": [
+              {
+                "text": "***PLEASE NOTE NEW CRITICAL VALUE EFFECTIVE 2/2/98***"
+              }
+            ],
+            "specimen": {
+              "reference": "#Specimen-0"
+            },
+            "referenceRange": [
+              {
+                "text": "65-110"
+              }
+            ]
+          }
+        ],
+        "extension": [
+          {
+            "url": "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/Notes",
+            "valueString": "Jane's 8/2  test"
+          }
+        ],
+        "identifier": [
+          {
+            "use": "usual",
+            "system": "urn:fdc:TEST.DAYTON.MED.VA.GOV:LR",
+            "value": "1172140001"
+          }
+        ],
+        "basedOn": [
+          {
+            "reference": "#ServiceRequest-1"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB"
+              }
+            ]
+          },
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "CH"
+              }
+            ]
+          },
+          {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "version": "2.52",
+                "code": "2345-7"
+              }
+            ],
+            "text": "GLUCOSE:MCNC:PT:SER/PLAS:QN:"
+          }
+        ],
+        "code": {
+          "text": "CH"
+        },
+        "subject": {
+          "reference": "Patient/ex-MHV-patient-942104"
+        },
+        "effectiveDateTime": "2017-08-02T09:50:57-04:00",
+        "issued": "2017-08-02T09:52:27.000-04:00",
+        "performer": [
+          {
+            "reference": "#OrgPerformer-989"
+          }
+        ],
+        "specimen": [
+          {
+            "reference": "#Specimen-0"
+          }
+        ],
+        "result": [
+          {
+            "reference": "#ChemistryResult-1.1"
+          }
+        ]
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/DiagnosticReport/8109",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "ex-MHV-labReport-1",
+        "meta": {
+          "profile": [
+            "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 79381-0}\">LR MICROBIOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id: 1013699147 (use: OFFICIAL))</td></tr><tr><td>When For</td><td>1995-08-03 14:49:00+0000</td></tr><tr><td>Reported</td><td>1995-08-03 14:49:00+0000</td></tr><tr><td>Identifier:</td><td> id: LabReportTO.MI;7049269 (use: USUAL)</td></tr></table><p><b>Report Details</b></p><table class=\"grid\"><tr><td><b>Code</b></td><td><b>Value</b></td><td><b>When For</b></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr></table><p>Accession [UID]: PARAS 95 264 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 30, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT =&gt; Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND</p></div>"
+        },
+        "contained": [
+          {
+            "resourceType": "Observation",
+            "id": "ex-MHV-labTest-1",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+                "value": "LabTestTO.MI;7049269;1"
+              }
+            ],
+            "status": "final",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                    "code": "laboratory"
+                  }
+                ]
+              }
+            ],
+            "code": {
+              "text": "Parasitology Remark(s)"
+            },
+            "subject": {
+              "reference": "Patient/ex-MHV-patient-1"
+            },
+            "effectiveDateTime": "1995-08-03T14:49:00-0400",
+            "performer": [
+              {
+                "reference": "Organization/ex-MHV-organization-989"
+              }
+            ],
+            "valueString": "NO OVA OR PARASITES FOUND"
+          },
+          {
+            "resourceType": "Specimen",
+            "id": "ex-MHV-specimen-1",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+                "value": "LabSpecimenTO.6Y100"
+              }
+            ],
+            "accessionIdentifier": {
+              "use": "usual",
+              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+              "value": "PARAS 95 264"
+            },
+            "status": "available",
+            "type": {
+              "text": "FECES"
+            },
+            "collection": {
+              "collectedDateTime": "1995-07-30"
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "use": "usual",
+            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+            "value": "LabReportTO.MI;7049269"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB"
+              }
+            ]
+          }
+        ],
+        "code": {
           "coding": [
             {
               "system": "http://loinc.org",
-              "code": "LP29708-2"
+              "code": "79381-0"
             }
-          ]
+          ],
+          "text": "LR MICROBIOLOGY REPORT"
         },
-        {
-          "coding": [
-            {
-              "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category",
-              "code": "clinical-note"
-            }
-          ]
-        }
-      ],
-      "subject": {
-        "reference": "Patient/ex-MHV-patient-1"
-      },
-      "date": "2000-12-14T11:35:00-0400",
-      "content": [
-        {
-          "attachment": {
-            "contentType": "text/plain",
-            "data": "UGcuIDEgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAwOS8xMi8yMiAxMDoxMQogICAgICAgICAgICAgICAgICAgICAgICAgICBDT05GSURFTlRJQUwgRUNHIFJFUE9SVCAgICAgICAgICAgICAgICAgICAgICAgICAgICAKTUhWTElTQU9ORSxST0JFUlQgTSAgICA2NjYtMTItMzQ1NiAgIE5PVCBJTlBBVElFTlQgICAgICAgICAgICAgIERPQjogQVVHIDksMTk2MgogICAgICAgICAgICAgICAgICAgICAgUFJPQ0VEVVJFIERBVEUvVElNRTogMTIvMTQvMDAgMTE6MzUKLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBXQVJEL0NMSU5JQzogQ0FSRElPTE9HWSBPVVRQQVRJRU5UIChMT0MpCiAgICBBR0U6IDM4ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgU0VYOiAgTUFMRQogICAgSFQgSU46IDA3MSAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIFdUIExCUzogMTU0CiAgICBCTE9PRCBQUkVTU1VSRTogICAgICAgICAgICAgICAgICAgICAgICAgVFlQRTogCgogICAgICAgICBWRU5UIFJBVEU6IDA4NiAgICAgICAgUFIgSU5URVJWQUw6IDEzMiAgICAgICBRUlMgRFVSQVRJT046IDEzMgogICAgICAgICBRVDogMzg4ICAgICAgICAgICAgICAgUVRDOiA0NjQKICAgICAgICAgUCBBWElTOiAxMTIgICAgICAgICAgIFIgQVhJUzogNzAgICAgICAgICAgICAgVCBBWElTOiAxNDgKCiAgICBJTlRFUlBSRVRBVElPTjogCgogICAgSU5TVFJVTUVOVCBEWDogIE5vcm1hbCBzaW51cyByaHl0aG0KICAgICAgICAgICAgICAgICAgICBSaWdodCBidW5kbGUgYnJhbmNoIGJsb2NrCiAgICAgICAgICAgICAgICAgICAgTGF0ZXJhbCBpbmZhcmN0ICwgYWdlIHVuZGV0ZXJtaW5lZAogICAgICAgICAgICAgICAgICAgIFBvc3NpYmxlIEluZmVyaW9yIGluZmFyY3QgKGNpdGVkIG9uIG9yIGJlZm9yZSAzMS1KVUwtMjAwMCkKICAgICAgICAgICAgICAgICAgICBBYm5vcm1hbCBFQ0cKICAgICAgICAgICAgICAgICAgICAuCiAgICAgICAgICAgICAgICAgICAgLgogICAgICAgICAgICAgICAgICAgIC4KCiAgICBDT05GSVJNQVRJT04gU1RBVFVTOiBDT05GSVJNRUQKCiAgICBDT01QQVJJU09OOiAKIAoKICAgIENPTU1FTlRTOiAKCiAgICBIRUFSVCBNRURTOgoKICAgIElOVEVSUFJFVEVEIEJZOiBHVVBUQSxTQVRZRU5EUkE=",
-            "title": "ELECTROCARDIOGRAM"
-          }
-        }
-      ],
-      "context": {
-        "related": [
+        "subject": {
+          "reference": "Patient/ex-MHV-patient-1"
+        },
+        "effectiveDateTime": "1995-08-03T14:49:00-0400",
+        "issued": "1995-08-03T14:49:00-0400",
+        "performer": [
           {
-            "reference": "Location/ex-MHV-location-989"
+            "reference": "Organization/ex-MHV-organization-989"
           }
-        ]
+        ],
+        "specimen": [
+          {
+            "reference": "#ex-MHV-specimen-1"
+          }
+        ],
+        "result": [
+          {
+            "reference": "#ex-MHV-labTest-1"
+          }
+        ],
+        "conclusion": "Accession [UID]: PARAS 95 264 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 30, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT => Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND"
+      },
+      "search": {
+        "mode": "match"
       }
     },
     {
-      "resourceType": "DocumentReference",
-      "id": "ex-MHV-imaging-0",
-      "meta": {
-        "profile": [
-          "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.imaging"
-        ]
-      },
-      "text": {
-        "status": "generated",
-        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: DocumentReference</b><a name=\"ex-MHV-imaging-0\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource DocumentReference &quot;ex-MHV-imaging-0&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-VA.MHV.PHR.imaging.html\">VA MHV PHR Radiology</a></p></div><p><b>identifier</b>: id: ImagingExamTO.6959075.8874-1 (use: USUAL), id: Accession.092404-1582 (use: OFFICIAL), id: CaseNum.1582 (use: SECONDARY)</p><p><b>status</b>: current</p><p><b>type</b>: RADIOLOGIC EXAMINATION, SPINE, LUMBOSACRAL; 2 OR 3 VIEWS <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#18748-4; <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-CPT.html\">Current Procedural Terminology (CPT®)</a>#72100)</span></p><p><b>category</b>: Clinical Note <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/core/STU5.0.1/CodeSystem-us-core-documentreference-category.html\">US Core DocumentReferences Category Codes</a>#clinical-note)</span></p><p><b>subject</b>: <a href=\"Patient-ex-MHV-patient-0.html\">Patient/ex-MHV-patient-0</a> &quot; MHVLISAONE&quot;</p><p><b>date</b>: Sep 24, 2004, 6:25:00 AM</p><p><b>author</b>: </p><ul><li><span>: GARFUNKEL,FELIX</span></li><li><span>: DAYT29 TEST LAB</span></li></ul><p><b>custodian</b>: <span/></p><blockquote><p><b>content</b></p><h3>Attachments</h3><table class=\"grid\"><tr><td>-</td><td><b>ContentType</b></td><td><b>Data</b></td><td><b>Title</b></td><td><b>Creation</b></td></tr><tr><td>*</td><td>text/plain</td><td>U1BJTkUgTFVNQk9TQUNSQUwgTUlOIDIgVklFV1MKICAgCkV4bSBEYXRlOiBTRVAgMjQsIDIwMDRAMTE6MjUKUmVxIFBoeXM6IEZFTEtMRVksS0VOTkVUSCBFICAgICAgICAgICAgICBQYXQgTG9jOiBQQ1RfTyBQQVRJTCAoRi9VKSAoUmVxJ2cgTG9jKQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEltZyBMb2M6IFJBRElPTE9HWQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIFNlcnZpY2U6IFVua25vd24KCiAKCihDYXNlIDE1ODIgQ09NUExFVEUpIFNQSU5FIExVTUJPU0FDUkFMIE1JTiAyIFZJRVdTICAgIChSQUQgIERldGFpbGVkKSBDUFQ6NzIxMDAKICAgICBQcm9jIE1vZGlmaWVycyA6IEJJTEFURVJBTCBFWEFNCgogICAgQ2xpbmljYWwgSGlzdG9yeToKICAgICAgaGF2aW5nIDMgd2Vla3Mgb2YgYmFjayBwYWlucyBuZWVkIHRvIHJlLWV2YWwgZm9yIGFyaHJpdGlzIG9yIGFueSAKICAgICAgd29yc25laW5nIGRpc2Mgc3BhY2VzIGV0Yy4gCgogICAgUmVwb3J0IFN0YXR1czogVmVyaWZpZWQgICAgICAgICAgICAgICAgICAgRGF0ZSBSZXBvcnRlZDogU0VQIDI3LCAyMDA0CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBEYXRlIFZlcmlmaWVkOiBTRVAgMjgsIDIwMDQKICAgIFZlcmlmaWVyIEUtU2lnOi9FUy9UaG9uZyBELiBOZ3V5ZW4sIE0uRC4KCiAgICBSZXBvcnQ6CiAgICAgIFRocmVlIHZpZXdzIG9mIHRoZSBsdW1ib3NhY3JhbCBzcGluZSBhcmUgY29tcGFyZWQgd2l0aCBhIHByZXZpb3VzIAogICAgICBleGFtaW5hdGlvbiBvZiA5LzIzLzAyLiAgCiAgICAgICAKICAgICAgVGhlcmUgaGFzIGJlZW4gYSBwYXJ0aWFsIGNvbGxhcHNlIG9mIEwyIHdoaWNoIGlzIHNpbWlsYXIgaW4KICAgICAgYXBwZWFyYW5jZSBhbmQgZGVncmVlIHRvIHRoZSBwcmV2aW91cyBleGFtaW5hdGlvbiBvZiBTZXB0ZW1iZXIKICAgICAgMjAwMi4gIFRoZXJlIGlzIGFsc28gY29sbGFwc2Ugb2YgdGhlIGJvZHkgb2YgVDEyIHdoaWNoIGFwcGFyZW50bHkKICAgICAgaXMgbmV3IHNpbmNlIHRoZSBwcmV2aW91cyBleGFtIGFuZCB0aGUgY29sbGFwc2UgaGFzIGJlZW4KICAgICAgZXN0aW1hdGVkIGFib3ZlIDc1IHRvIDgwJSBvZiB0aGUgaGVpZ2h0IG9mIHRoZSB2ZXJ0ZWJyYWwgYm9keS4gIAogICAgICAgCiAgICAgIFRoZXJlIGlzIG1pbGQgbWFyZ2luYWwgc3B1cnJpbmcgb2YgdGhlIHVwcGVyIGFudGVyaW9yIGFzcGVjdCBvZgogICAgICBMNC4gIFRoZXJlIGFyZSBhcnRlcmlvc2NsZXJvdGljIGNhbGNpZmljYXRpb25zIGluIHRoZSBhYmRvbWluYWwKICAgICAgYW9ydGEgYW5kIGJyYW5jaGVzLiAgCiAgICAgICAKICAgICAgVGhlIGludGVydmVydGVicmFsIGRpc2Mgc3BhY2VzIGFyZSBwcmVzZXJ2ZWQuICAKCiAgICBJbXByZXNzaW9uOgogICAgICAxLiAgT2xkIGNvbXByZXNzaW9uIGZyYWN0dXJlIG9mIEwyIHdpdGggYW50ZXJpb3IgbWFyZ2luYWwKICAgICAgc3B1cnJpbmcgYW5kIGFwcGFyZW50IGFua3lsb3NpcyBMMS1MMi4gIAogICAgICAgCiAgICAgIDIuICBDb2xsYXBzZSBvciBjb21wcmVzc2lvbiBmcmFjdHVyZSBvZiB0aGUgYm9keSBvZiBUMTIgd2hpY2ggaXMKICAgICAgbmV3IHNpbmNlIHRoZSBwcmV2aW91cyBleGFtaW5hdGlvbiBpbiAyMDAyIGFuZCBpbnZvbHZlcyBsb3NzIG9mCiAgICAgIGhlaWdodCBvZiB0aGF0IHZlcnRlYnJhbCBib2R5IGJ5IGFib3V0IDcwJS4gIEFydGVyaW9zY2xlcm90aWMKICAgICAgY2FsY2lmaWNhdGlvbnMgb2YgdGhlIGFvcnRhLiAgCgogICAgUHJpbWFyeSBEaWFnbm9zdGljIENvZGU6IAoKUHJpbWFyeSBJbnRlcnByZXRpbmcgU3RhZmY6CiAgRkVMSVggR0FSRlVOS0VMLCBTdGFmZiBQaHlzaWNpYW4KVkVSSUZJRUQgQlk6CiAgVEhPTkcgTkdVWUVOLCBSYWRpb2xvZ2lzdC9DaGllZgoKL0dFRw==</td><td>SPINE LUMBOSACRAL MIN 2 VIEWS</td><td>2004-09-24 11:25:00+0000</td></tr></table></blockquote><h3>Contexts</h3><table class=\"grid\"><tr><td>-</td><td><b>Encounter</b></td><td><b>Related</b></td></tr><tr><td>*</td><td><span/></td><td><span/></td></tr></table></div>"
-      },
-      "identifier": [
-        {
-          "use": "usual",
-          "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-          "value": "ImagingExamTO.6959075.8874-1"
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/DiagnosticReport/8109",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "ex-MHV-labReport-2",
+        "meta": {
+          "profile": [
+            "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
+          ]
         },
-        {
-          "use": "official",
-          "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-          "value": "Accession.092404-1582"
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 79381-0}\">LR MICROBIOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id: 1013699147 (use: OFFICIAL))</td></tr><tr><td>When For</td><td>1995-08-03 14:49:00+0000</td></tr><tr><td>Reported</td><td>1995-08-03 14:49:00+0000</td></tr><tr><td>Identifier:</td><td> id: LabReportTO.MI;7049269 (use: USUAL)</td></tr></table><p><b>Report Details</b></p><table class=\"grid\"><tr><td><b>Code</b></td><td><b>Value</b></td><td><b>When For</b></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr></table><p>Accession [UID]: PARAS 95 264 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 30, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT =&gt; Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND</p></div>"
         },
-        {
-          "use": "secondary",
-          "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-          "value": "CaseNum.1582"
-        }
-      ],
-      "status": "current",
-      "type": {
-        "coding": [
+        "contained": [
           {
-            "system": "http://loinc.org",
-            "code": "18748-4"
+            "resourceType": "Observation",
+            "id": "ex-MHV-labTest-1",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+                "value": "LabTestTO.MI;7049269;1"
+              }
+            ],
+            "status": "final",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                    "code": "laboratory"
+                  }
+                ]
+              }
+            ],
+            "code": {
+              "text": "Parasitology Remark(s)"
+            },
+            "subject": {
+              "reference": "Patient/ex-MHV-patient-1"
+            },
+            "effectiveDateTime": "1995-08-03T14:49:00-0400",
+            "performer": [
+              {
+                "reference": "Organization/ex-MHV-organization-989"
+              }
+            ],
+            "valueString": "NO OVA OR PARASITES FOUND"
           },
           {
-            "system": "http://www.ama-assn.org/go/cpt",
-            "code": "72100",
-            "display": "RADIOLOGIC EXAMINATION, SPINE, LUMBOSACRAL; 2 OR 3 VIEWS"
+            "resourceType": "Specimen",
+            "id": "ex-MHV-specimen-1",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+                "value": "LabSpecimenTO.6Y100"
+              }
+            ],
+            "accessionIdentifier": {
+              "use": "usual",
+              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+              "value": "PARAS 95 264"
+            },
+            "status": "available",
+            "type": {
+              "text": "FECES"
+            },
+            "collection": {
+              "collectedDateTime": "1995-07-30"
+            }
           }
-        ]
-      },
-      "category": [
-        {
+        ],
+        "identifier": [
+          {
+            "use": "usual",
+            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+            "value": "LabReportTO.MI;7049269"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB"
+              }
+            ]
+          }
+        ],
+        "code": {
           "coding": [
             {
-              "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category",
-              "code": "clinical-note"
+              "system": "http://loinc.org",
+              "code": "79381-0"
+            }
+          ],
+          "text": "LR MICROBIOLOGY REPORT"
+        },
+        "subject": {
+          "reference": "Patient/ex-MHV-patient-1"
+        },
+        "effectiveDateTime": "1995-08-03T14:49:00-0400",
+        "issued": "1995-08-03T14:49:00-0400",
+        "performer": [
+          {
+            "reference": "Organization/ex-MHV-organization-989"
+          }
+        ],
+        "specimen": [
+          {
+            "reference": "#ex-MHV-specimen-1"
+          }
+        ],
+        "result": [
+          {
+            "reference": "#ex-MHV-labTest-1"
+          }
+        ],
+        "conclusion": "Accession [UID]: PARAS 95 264 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 30, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT => Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND"
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/DiagnosticReport/8109",
+      "resource": {
+        "resourceType": "DocumentReference",
+        "id": "ex-MHV-ecg-0",
+        "meta": {
+          "profile": [
+            "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.ecg"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: DocumentReference</b><a name=\"ex-MHV-ecg-0\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource DocumentReference &quot;ex-MHV-ecg-0&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-VA.MHV.PHR.ecg.html\">VA MHV PHR ECG</a></p></div><p><b>identifier</b>: id: ClinicalProcedureTO.41359 (use: USUAL)</p><p><b>status</b>: current</p><p><b>type</b>: EKG study <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#11524-6)</span></p><p><b>category</b>: Cardiology <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#LP29708-2)</span>, Clinical Note <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/core/STU5.0.1/CodeSystem-us-core-documentreference-category.html\">US Core DocumentReferences Category Codes</a>#clinical-note)</span></p><p><b>subject</b>: <a href=\"Patient-ex-MHV-patient-1.html\">Patient/ex-MHV-patient-1</a> &quot; DAYTSHR&quot;</p><p><b>date</b>: Dec 14, 2000, 5:35:00 AM</p><blockquote><p><b>content</b></p><h3>Attachments</h3><table class=\"grid\"><tr><td>-</td><td><b>ContentType</b></td><td><b>Data</b></td><td><b>Title</b></td></tr><tr><td>*</td><td>text/plain</td><td>UGcuIDEgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAwOS8xMi8yMiAxMDoxMQogICAgICAgICAgICAgICAgICAgICAgICAgICBDT05GSURFTlRJQUwgRUNHIFJFUE9SVCAgICAgICAgICAgICAgICAgICAgICAgICAgICAKTUhWTElTQU9ORSxST0JFUlQgTSAgICA2NjYtMTItMzQ1NiAgIE5PVCBJTlBBVElFTlQgICAgICAgICAgICAgIERPQjogQVVHIDksMTk2MgogICAgICAgICAgICAgICAgICAgICAgUFJPQ0VEVVJFIERBVEUvVElNRTogMTIvMTQvMDAgMTE6MzUKLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBXQVJEL0NMSU5JQzogQ0FSRElPTE9HWSBPVVRQQVRJRU5UIChMT0MpCiAgICBBR0U6IDM4ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgU0VYOiAgTUFMRQogICAgSFQgSU46IDA3MSAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIFdUIExCUzogMTU0CiAgICBCTE9PRCBQUkVTU1VSRTogICAgICAgICAgICAgICAgICAgICAgICAgVFlQRTogCgogICAgICAgICBWRU5UIFJBVEU6IDA4NiAgICAgICAgUFIgSU5URVJWQUw6IDEzMiAgICAgICBRUlMgRFVSQVRJT046IDEzMgogICAgICAgICBRVDogMzg4ICAgICAgICAgICAgICAgUVRDOiA0NjQKICAgICAgICAgUCBBWElTOiAxMTIgICAgICAgICAgIFIgQVhJUzogNzAgICAgICAgICAgICAgVCBBWElTOiAxNDgKCiAgICBJTlRFUlBSRVRBVElPTjogCgogICAgSU5TVFJVTUVOVCBEWDogIE5vcm1hbCBzaW51cyByaHl0aG0KICAgICAgICAgICAgICAgICAgICBSaWdodCBidW5kbGUgYnJhbmNoIGJsb2NrCiAgICAgICAgICAgICAgICAgICAgTGF0ZXJhbCBpbmZhcmN0ICwgYWdlIHVuZGV0ZXJtaW5lZAogICAgICAgICAgICAgICAgICAgIFBvc3NpYmxlIEluZmVyaW9yIGluZmFyY3QgKGNpdGVkIG9uIG9yIGJlZm9yZSAzMS1KVUwtMjAwMCkKICAgICAgICAgICAgICAgICAgICBBYm5vcm1hbCBFQ0cKICAgICAgICAgICAgICAgICAgICAuCiAgICAgICAgICAgICAgICAgICAgLgogICAgICAgICAgICAgICAgICAgIC4KCiAgICBDT05GSVJNQVRJT04gU1RBVFVTOiBDT05GSVJNRUQKCiAgICBDT01QQVJJU09OOiAKIAoKICAgIENPTU1FTlRTOiAKCiAgICBIRUFSVCBNRURTOgoKICAgIElOVEVSUFJFVEVEIEJZOiBHVVBUQSxTQVRZRU5EUkE=</td><td>ELECTROCARDIOGRAM</td></tr></table></blockquote><h3>Contexts</h3><table class=\"grid\"><tr><td>-</td><td><b>Related</b></td></tr><tr><td>*</td><td><a href=\"Location-ex-MHV-location-989.html\">Location/ex-MHV-location-989</a> &quot;DAYT29 TEST LAB&quot;</td></tr></table></div>"
+        },
+        "identifier": [
+          {
+            "use": "usual",
+            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+            "value": "ClinicalProcedureTO.41359"
+          }
+        ],
+        "status": "current",
+        "type": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "11524-6"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "LP29708-2"
+              }
+            ]
+          },
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category",
+                "code": "clinical-note"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/ex-MHV-patient-1"
+        },
+        "date": "2000-12-14T11:35:00-0400",
+        "content": [
+          {
+            "attachment": {
+              "contentType": "text/plain",
+              "data": "UGcuIDEgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAwOS8xMi8yMiAxMDoxMQogICAgICAgICAgICAgICAgICAgICAgICAgICBDT05GSURFTlRJQUwgRUNHIFJFUE9SVCAgICAgICAgICAgICAgICAgICAgICAgICAgICAKTUhWTElTQU9ORSxST0JFUlQgTSAgICA2NjYtMTItMzQ1NiAgIE5PVCBJTlBBVElFTlQgICAgICAgICAgICAgIERPQjogQVVHIDksMTk2MgogICAgICAgICAgICAgICAgICAgICAgUFJPQ0VEVVJFIERBVEUvVElNRTogMTIvMTQvMDAgMTE6MzUKLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAtIC0gLSAKICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBXQVJEL0NMSU5JQzogQ0FSRElPTE9HWSBPVVRQQVRJRU5UIChMT0MpCiAgICBBR0U6IDM4ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgU0VYOiAgTUFMRQogICAgSFQgSU46IDA3MSAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIFdUIExCUzogMTU0CiAgICBCTE9PRCBQUkVTU1VSRTogICAgICAgICAgICAgICAgICAgICAgICAgVFlQRTogCgogICAgICAgICBWRU5UIFJBVEU6IDA4NiAgICAgICAgUFIgSU5URVJWQUw6IDEzMiAgICAgICBRUlMgRFVSQVRJT046IDEzMgogICAgICAgICBRVDogMzg4ICAgICAgICAgICAgICAgUVRDOiA0NjQKICAgICAgICAgUCBBWElTOiAxMTIgICAgICAgICAgIFIgQVhJUzogNzAgICAgICAgICAgICAgVCBBWElTOiAxNDgKCiAgICBJTlRFUlBSRVRBVElPTjogCgogICAgSU5TVFJVTUVOVCBEWDogIE5vcm1hbCBzaW51cyByaHl0aG0KICAgICAgICAgICAgICAgICAgICBSaWdodCBidW5kbGUgYnJhbmNoIGJsb2NrCiAgICAgICAgICAgICAgICAgICAgTGF0ZXJhbCBpbmZhcmN0ICwgYWdlIHVuZGV0ZXJtaW5lZAogICAgICAgICAgICAgICAgICAgIFBvc3NpYmxlIEluZmVyaW9yIGluZmFyY3QgKGNpdGVkIG9uIG9yIGJlZm9yZSAzMS1KVUwtMjAwMCkKICAgICAgICAgICAgICAgICAgICBBYm5vcm1hbCBFQ0cKICAgICAgICAgICAgICAgICAgICAuCiAgICAgICAgICAgICAgICAgICAgLgogICAgICAgICAgICAgICAgICAgIC4KCiAgICBDT05GSVJNQVRJT04gU1RBVFVTOiBDT05GSVJNRUQKCiAgICBDT01QQVJJU09OOiAKIAoKICAgIENPTU1FTlRTOiAKCiAgICBIRUFSVCBNRURTOgoKICAgIElOVEVSUFJFVEVEIEJZOiBHVVBUQSxTQVRZRU5EUkE=",
+              "title": "ELECTROCARDIOGRAM"
+            }
+          }
+        ],
+        "context": {
+          "related": [
+            {
+              "reference": "Location/ex-MHV-location-989"
             }
           ]
         }
-      ],
-      "subject": {
-        "reference": "Patient/ex-MHV-patient-0"
       },
-      "date": "2004-09-24T11:25:00-0400",
-      "author": [
-        {
-          "display": "GARFUNKEL,FELIX"
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/DiagnosticReport/8109",
+      "resource": {
+        "resourceType": "DocumentReference",
+        "id": "ex-MHV-imaging-0",
+        "meta": {
+          "profile": [
+            "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.imaging"
+          ]
         },
-        {
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Generated Narrative: DocumentReference</b><a name=\"ex-MHV-imaging-0\"> </a></p><div style=\"display: inline-block; background-color: #d9e0e7; padding: 6px; margin: 4px; border: 1px solid #8da1b4; border-radius: 5px; line-height: 60%\"><p style=\"margin-bottom: 0px\">Resource DocumentReference &quot;ex-MHV-imaging-0&quot; </p><p style=\"margin-bottom: 0px\">Profile: <a href=\"StructureDefinition-VA.MHV.PHR.imaging.html\">VA MHV PHR Radiology</a></p></div><p><b>identifier</b>: id: ImagingExamTO.6959075.8874-1 (use: USUAL), id: Accession.092404-1582 (use: OFFICIAL), id: CaseNum.1582 (use: SECONDARY)</p><p><b>status</b>: current</p><p><b>type</b>: RADIOLOGIC EXAMINATION, SPINE, LUMBOSACRAL; 2 OR 3 VIEWS <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"https://loinc.org/\">LOINC</a>#18748-4; <a href=\"http://terminology.hl7.org/3.1.0/CodeSystem-CPT.html\">Current Procedural Terminology (CPT®)</a>#72100)</span></p><p><b>category</b>: Clinical Note <span style=\"background: LightGoldenRodYellow; margin: 4px; border: 1px solid khaki\"> (<a href=\"http://hl7.org/fhir/us/core/STU5.0.1/CodeSystem-us-core-documentreference-category.html\">US Core DocumentReferences Category Codes</a>#clinical-note)</span></p><p><b>subject</b>: <a href=\"Patient-ex-MHV-patient-0.html\">Patient/ex-MHV-patient-0</a> &quot; MHVLISAONE&quot;</p><p><b>date</b>: Sep 24, 2004, 6:25:00 AM</p><p><b>author</b>: </p><ul><li><span>: GARFUNKEL,FELIX</span></li><li><span>: DAYT29 TEST LAB</span></li></ul><p><b>custodian</b>: <span/></p><blockquote><p><b>content</b></p><h3>Attachments</h3><table class=\"grid\"><tr><td>-</td><td><b>ContentType</b></td><td><b>Data</b></td><td><b>Title</b></td><td><b>Creation</b></td></tr><tr><td>*</td><td>text/plain</td><td>U1BJTkUgTFVNQk9TQUNSQUwgTUlOIDIgVklFV1MKICAgCkV4bSBEYXRlOiBTRVAgMjQsIDIwMDRAMTE6MjUKUmVxIFBoeXM6IEZFTEtMRVksS0VOTkVUSCBFICAgICAgICAgICAgICBQYXQgTG9jOiBQQ1RfTyBQQVRJTCAoRi9VKSAoUmVxJ2cgTG9jKQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEltZyBMb2M6IFJBRElPTE9HWQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIFNlcnZpY2U6IFVua25vd24KCiAKCihDYXNlIDE1ODIgQ09NUExFVEUpIFNQSU5FIExVTUJPU0FDUkFMIE1JTiAyIFZJRVdTICAgIChSQUQgIERldGFpbGVkKSBDUFQ6NzIxMDAKICAgICBQcm9jIE1vZGlmaWVycyA6IEJJTEFURVJBTCBFWEFNCgogICAgQ2xpbmljYWwgSGlzdG9yeToKICAgICAgaGF2aW5nIDMgd2Vla3Mgb2YgYmFjayBwYWlucyBuZWVkIHRvIHJlLWV2YWwgZm9yIGFyaHJpdGlzIG9yIGFueSAKICAgICAgd29yc25laW5nIGRpc2Mgc3BhY2VzIGV0Yy4gCgogICAgUmVwb3J0IFN0YXR1czogVmVyaWZpZWQgICAgICAgICAgICAgICAgICAgRGF0ZSBSZXBvcnRlZDogU0VQIDI3LCAyMDA0CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBEYXRlIFZlcmlmaWVkOiBTRVAgMjgsIDIwMDQKICAgIFZlcmlmaWVyIEUtU2lnOi9FUy9UaG9uZyBELiBOZ3V5ZW4sIE0uRC4KCiAgICBSZXBvcnQ6CiAgICAgIFRocmVlIHZpZXdzIG9mIHRoZSBsdW1ib3NhY3JhbCBzcGluZSBhcmUgY29tcGFyZWQgd2l0aCBhIHByZXZpb3VzIAogICAgICBleGFtaW5hdGlvbiBvZiA5LzIzLzAyLiAgCiAgICAgICAKICAgICAgVGhlcmUgaGFzIGJlZW4gYSBwYXJ0aWFsIGNvbGxhcHNlIG9mIEwyIHdoaWNoIGlzIHNpbWlsYXIgaW4KICAgICAgYXBwZWFyYW5jZSBhbmQgZGVncmVlIHRvIHRoZSBwcmV2aW91cyBleGFtaW5hdGlvbiBvZiBTZXB0ZW1iZXIKICAgICAgMjAwMi4gIFRoZXJlIGlzIGFsc28gY29sbGFwc2Ugb2YgdGhlIGJvZHkgb2YgVDEyIHdoaWNoIGFwcGFyZW50bHkKICAgICAgaXMgbmV3IHNpbmNlIHRoZSBwcmV2aW91cyBleGFtIGFuZCB0aGUgY29sbGFwc2UgaGFzIGJlZW4KICAgICAgZXN0aW1hdGVkIGFib3ZlIDc1IHRvIDgwJSBvZiB0aGUgaGVpZ2h0IG9mIHRoZSB2ZXJ0ZWJyYWwgYm9keS4gIAogICAgICAgCiAgICAgIFRoZXJlIGlzIG1pbGQgbWFyZ2luYWwgc3B1cnJpbmcgb2YgdGhlIHVwcGVyIGFudGVyaW9yIGFzcGVjdCBvZgogICAgICBMNC4gIFRoZXJlIGFyZSBhcnRlcmlvc2NsZXJvdGljIGNhbGNpZmljYXRpb25zIGluIHRoZSBhYmRvbWluYWwKICAgICAgYW9ydGEgYW5kIGJyYW5jaGVzLiAgCiAgICAgICAKICAgICAgVGhlIGludGVydmVydGVicmFsIGRpc2Mgc3BhY2VzIGFyZSBwcmVzZXJ2ZWQuICAKCiAgICBJbXByZXNzaW9uOgogICAgICAxLiAgT2xkIGNvbXByZXNzaW9uIGZyYWN0dXJlIG9mIEwyIHdpdGggYW50ZXJpb3IgbWFyZ2luYWwKICAgICAgc3B1cnJpbmcgYW5kIGFwcGFyZW50IGFua3lsb3NpcyBMMS1MMi4gIAogICAgICAgCiAgICAgIDIuICBDb2xsYXBzZSBvciBjb21wcmVzc2lvbiBmcmFjdHVyZSBvZiB0aGUgYm9keSBvZiBUMTIgd2hpY2ggaXMKICAgICAgbmV3IHNpbmNlIHRoZSBwcmV2aW91cyBleGFtaW5hdGlvbiBpbiAyMDAyIGFuZCBpbnZvbHZlcyBsb3NzIG9mCiAgICAgIGhlaWdodCBvZiB0aGF0IHZlcnRlYnJhbCBib2R5IGJ5IGFib3V0IDcwJS4gIEFydGVyaW9zY2xlcm90aWMKICAgICAgY2FsY2lmaWNhdGlvbnMgb2YgdGhlIGFvcnRhLiAgCgogICAgUHJpbWFyeSBEaWFnbm9zdGljIENvZGU6IAoKUHJpbWFyeSBJbnRlcnByZXRpbmcgU3RhZmY6CiAgRkVMSVggR0FSRlVOS0VMLCBTdGFmZiBQaHlzaWNpYW4KVkVSSUZJRUQgQlk6CiAgVEhPTkcgTkdVWUVOLCBSYWRpb2xvZ2lzdC9DaGllZgoKL0dFRw==</td><td>SPINE LUMBOSACRAL MIN 2 VIEWS</td><td>2004-09-24 11:25:00+0000</td></tr></table></blockquote><h3>Contexts</h3><table class=\"grid\"><tr><td>-</td><td><b>Encounter</b></td><td><b>Related</b></td></tr><tr><td>*</td><td><span/></td><td><span/></td></tr></table></div>"
+        },
+        "identifier": [
+          {
+            "use": "usual",
+            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+            "value": "ImagingExamTO.6959075.8874-1"
+          },
+          {
+            "use": "official",
+            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+            "value": "Accession.092404-1582"
+          },
+          {
+            "use": "secondary",
+            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+            "value": "CaseNum.1582"
+          }
+        ],
+        "status": "current",
+        "type": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "18748-4"
+            },
+            {
+              "system": "http://www.ama-assn.org/go/cpt",
+              "code": "72100",
+              "display": "RADIOLOGIC EXAMINATION, SPINE, LUMBOSACRAL; 2 OR 3 VIEWS"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category",
+                "code": "clinical-note"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "Patient/ex-MHV-patient-0"
+        },
+        "date": "2004-09-24T11:25:00-0400",
+        "author": [
+          {
+            "display": "GARFUNKEL,FELIX"
+          },
+          {
+            "identifier": {
+              "value": "989"
+            },
+            "display": "DAYT29 TEST LAB"
+          }
+        ],
+        "custodian": {
           "identifier": {
-            "value": "989"
-          },
-          "display": "DAYT29 TEST LAB"
-        }
-      ],
-      "custodian": {
-        "identifier": {
-          "value": "2267"
-        }
-      },
-      "content": [
-        {
-          "attachment": {
-            "contentType": "text/plain",
-            "data": "U1BJTkUgTFVNQk9TQUNSQUwgTUlOIDIgVklFV1MKICAgCkV4bSBEYXRlOiBTRVAgMjQsIDIwMDRAMTE6MjUKUmVxIFBoeXM6IEZFTEtMRVksS0VOTkVUSCBFICAgICAgICAgICAgICBQYXQgTG9jOiBQQ1RfTyBQQVRJTCAoRi9VKSAoUmVxJ2cgTG9jKQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEltZyBMb2M6IFJBRElPTE9HWQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIFNlcnZpY2U6IFVua25vd24KCiAKCihDYXNlIDE1ODIgQ09NUExFVEUpIFNQSU5FIExVTUJPU0FDUkFMIE1JTiAyIFZJRVdTICAgIChSQUQgIERldGFpbGVkKSBDUFQ6NzIxMDAKICAgICBQcm9jIE1vZGlmaWVycyA6IEJJTEFURVJBTCBFWEFNCgogICAgQ2xpbmljYWwgSGlzdG9yeToKICAgICAgaGF2aW5nIDMgd2Vla3Mgb2YgYmFjayBwYWlucyBuZWVkIHRvIHJlLWV2YWwgZm9yIGFyaHJpdGlzIG9yIGFueSAKICAgICAgd29yc25laW5nIGRpc2Mgc3BhY2VzIGV0Yy4gCgogICAgUmVwb3J0IFN0YXR1czogVmVyaWZpZWQgICAgICAgICAgICAgICAgICAgRGF0ZSBSZXBvcnRlZDogU0VQIDI3LCAyMDA0CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBEYXRlIFZlcmlmaWVkOiBTRVAgMjgsIDIwMDQKICAgIFZlcmlmaWVyIEUtU2lnOi9FUy9UaG9uZyBELiBOZ3V5ZW4sIE0uRC4KCiAgICBSZXBvcnQ6CiAgICAgIFRocmVlIHZpZXdzIG9mIHRoZSBsdW1ib3NhY3JhbCBzcGluZSBhcmUgY29tcGFyZWQgd2l0aCBhIHByZXZpb3VzIAogICAgICBleGFtaW5hdGlvbiBvZiA5LzIzLzAyLiAgCiAgICAgICAKICAgICAgVGhlcmUgaGFzIGJlZW4gYSBwYXJ0aWFsIGNvbGxhcHNlIG9mIEwyIHdoaWNoIGlzIHNpbWlsYXIgaW4KICAgICAgYXBwZWFyYW5jZSBhbmQgZGVncmVlIHRvIHRoZSBwcmV2aW91cyBleGFtaW5hdGlvbiBvZiBTZXB0ZW1iZXIKICAgICAgMjAwMi4gIFRoZXJlIGlzIGFsc28gY29sbGFwc2Ugb2YgdGhlIGJvZHkgb2YgVDEyIHdoaWNoIGFwcGFyZW50bHkKICAgICAgaXMgbmV3IHNpbmNlIHRoZSBwcmV2aW91cyBleGFtIGFuZCB0aGUgY29sbGFwc2UgaGFzIGJlZW4KICAgICAgZXN0aW1hdGVkIGFib3ZlIDc1IHRvIDgwJSBvZiB0aGUgaGVpZ2h0IG9mIHRoZSB2ZXJ0ZWJyYWwgYm9keS4gIAogICAgICAgCiAgICAgIFRoZXJlIGlzIG1pbGQgbWFyZ2luYWwgc3B1cnJpbmcgb2YgdGhlIHVwcGVyIGFudGVyaW9yIGFzcGVjdCBvZgogICAgICBMNC4gIFRoZXJlIGFyZSBhcnRlcmlvc2NsZXJvdGljIGNhbGNpZmljYXRpb25zIGluIHRoZSBhYmRvbWluYWwKICAgICAgYW9ydGEgYW5kIGJyYW5jaGVzLiAgCiAgICAgICAKICAgICAgVGhlIGludGVydmVydGVicmFsIGRpc2Mgc3BhY2VzIGFyZSBwcmVzZXJ2ZWQuICAKCiAgICBJbXByZXNzaW9uOgogICAgICAxLiAgT2xkIGNvbXByZXNzaW9uIGZyYWN0dXJlIG9mIEwyIHdpdGggYW50ZXJpb3IgbWFyZ2luYWwKICAgICAgc3B1cnJpbmcgYW5kIGFwcGFyZW50IGFua3lsb3NpcyBMMS1MMi4gIAogICAgICAgCiAgICAgIDIuICBDb2xsYXBzZSBvciBjb21wcmVzc2lvbiBmcmFjdHVyZSBvZiB0aGUgYm9keSBvZiBUMTIgd2hpY2ggaXMKICAgICAgbmV3IHNpbmNlIHRoZSBwcmV2aW91cyBleGFtaW5hdGlvbiBpbiAyMDAyIGFuZCBpbnZvbHZlcyBsb3NzIG9mCiAgICAgIGhlaWdodCBvZiB0aGF0IHZlcnRlYnJhbCBib2R5IGJ5IGFib3V0IDcwJS4gIEFydGVyaW9zY2xlcm90aWMKICAgICAgY2FsY2lmaWNhdGlvbnMgb2YgdGhlIGFvcnRhLiAgCgogICAgUHJpbWFyeSBEaWFnbm9zdGljIENvZGU6IAoKUHJpbWFyeSBJbnRlcnByZXRpbmcgU3RhZmY6CiAgRkVMSVggR0FSRlVOS0VMLCBTdGFmZiBQaHlzaWNpYW4KVkVSSUZJRUQgQlk6CiAgVEhPTkcgTkdVWUVOLCBSYWRpb2xvZ2lzdC9DaGllZgoKL0dFRw==",
-            "title": "SPINE LUMBOSACRAL MIN 2 VIEWS",
-            "creation": "2004-09-24T11:25:00-0400"
+            "value": "2267"
           }
-        }
-      ],
-      "context": {
-        "encounter": [
+        },
+        "content": [
           {
-            "identifier": {
-              "value": "5886199"
+            "attachment": {
+              "contentType": "text/plain",
+              "data": "U1BJTkUgTFVNQk9TQUNSQUwgTUlOIDIgVklFV1MKICAgCkV4bSBEYXRlOiBTRVAgMjQsIDIwMDRAMTE6MjUKUmVxIFBoeXM6IEZFTEtMRVksS0VOTkVUSCBFICAgICAgICAgICAgICBQYXQgTG9jOiBQQ1RfTyBQQVRJTCAoRi9VKSAoUmVxJ2cgTG9jKQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIEltZyBMb2M6IFJBRElPTE9HWQogICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIFNlcnZpY2U6IFVua25vd24KCiAKCihDYXNlIDE1ODIgQ09NUExFVEUpIFNQSU5FIExVTUJPU0FDUkFMIE1JTiAyIFZJRVdTICAgIChSQUQgIERldGFpbGVkKSBDUFQ6NzIxMDAKICAgICBQcm9jIE1vZGlmaWVycyA6IEJJTEFURVJBTCBFWEFNCgogICAgQ2xpbmljYWwgSGlzdG9yeToKICAgICAgaGF2aW5nIDMgd2Vla3Mgb2YgYmFjayBwYWlucyBuZWVkIHRvIHJlLWV2YWwgZm9yIGFyaHJpdGlzIG9yIGFueSAKICAgICAgd29yc25laW5nIGRpc2Mgc3BhY2VzIGV0Yy4gCgogICAgUmVwb3J0IFN0YXR1czogVmVyaWZpZWQgICAgICAgICAgICAgICAgICAgRGF0ZSBSZXBvcnRlZDogU0VQIDI3LCAyMDA0CiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBEYXRlIFZlcmlmaWVkOiBTRVAgMjgsIDIwMDQKICAgIFZlcmlmaWVyIEUtU2lnOi9FUy9UaG9uZyBELiBOZ3V5ZW4sIE0uRC4KCiAgICBSZXBvcnQ6CiAgICAgIFRocmVlIHZpZXdzIG9mIHRoZSBsdW1ib3NhY3JhbCBzcGluZSBhcmUgY29tcGFyZWQgd2l0aCBhIHByZXZpb3VzIAogICAgICBleGFtaW5hdGlvbiBvZiA5LzIzLzAyLiAgCiAgICAgICAKICAgICAgVGhlcmUgaGFzIGJlZW4gYSBwYXJ0aWFsIGNvbGxhcHNlIG9mIEwyIHdoaWNoIGlzIHNpbWlsYXIgaW4KICAgICAgYXBwZWFyYW5jZSBhbmQgZGVncmVlIHRvIHRoZSBwcmV2aW91cyBleGFtaW5hdGlvbiBvZiBTZXB0ZW1iZXIKICAgICAgMjAwMi4gIFRoZXJlIGlzIGFsc28gY29sbGFwc2Ugb2YgdGhlIGJvZHkgb2YgVDEyIHdoaWNoIGFwcGFyZW50bHkKICAgICAgaXMgbmV3IHNpbmNlIHRoZSBwcmV2aW91cyBleGFtIGFuZCB0aGUgY29sbGFwc2UgaGFzIGJlZW4KICAgICAgZXN0aW1hdGVkIGFib3ZlIDc1IHRvIDgwJSBvZiB0aGUgaGVpZ2h0IG9mIHRoZSB2ZXJ0ZWJyYWwgYm9keS4gIAogICAgICAgCiAgICAgIFRoZXJlIGlzIG1pbGQgbWFyZ2luYWwgc3B1cnJpbmcgb2YgdGhlIHVwcGVyIGFudGVyaW9yIGFzcGVjdCBvZgogICAgICBMNC4gIFRoZXJlIGFyZSBhcnRlcmlvc2NsZXJvdGljIGNhbGNpZmljYXRpb25zIGluIHRoZSBhYmRvbWluYWwKICAgICAgYW9ydGEgYW5kIGJyYW5jaGVzLiAgCiAgICAgICAKICAgICAgVGhlIGludGVydmVydGVicmFsIGRpc2Mgc3BhY2VzIGFyZSBwcmVzZXJ2ZWQuICAKCiAgICBJbXByZXNzaW9uOgogICAgICAxLiAgT2xkIGNvbXByZXNzaW9uIGZyYWN0dXJlIG9mIEwyIHdpdGggYW50ZXJpb3IgbWFyZ2luYWwKICAgICAgc3B1cnJpbmcgYW5kIGFwcGFyZW50IGFua3lsb3NpcyBMMS1MMi4gIAogICAgICAgCiAgICAgIDIuICBDb2xsYXBzZSBvciBjb21wcmVzc2lvbiBmcmFjdHVyZSBvZiB0aGUgYm9keSBvZiBUMTIgd2hpY2ggaXMKICAgICAgbmV3IHNpbmNlIHRoZSBwcmV2aW91cyBleGFtaW5hdGlvbiBpbiAyMDAyIGFuZCBpbnZvbHZlcyBsb3NzIG9mCiAgICAgIGhlaWdodCBvZiB0aGF0IHZlcnRlYnJhbCBib2R5IGJ5IGFib3V0IDcwJS4gIEFydGVyaW9zY2xlcm90aWMKICAgICAgY2FsY2lmaWNhdGlvbnMgb2YgdGhlIGFvcnRhLiAgCgogICAgUHJpbWFyeSBEaWFnbm9zdGljIENvZGU6IAoKUHJpbWFyeSBJbnRlcnByZXRpbmcgU3RhZmY6CiAgRkVMSVggR0FSRlVOS0VMLCBTdGFmZiBQaHlzaWNpYW4KVkVSSUZJRUQgQlk6CiAgVEhPTkcgTkdVWUVOLCBSYWRpb2xvZ2lzdC9DaGllZgoKL0dFRw==",
+              "title": "SPINE LUMBOSACRAL MIN 2 VIEWS",
+              "creation": "2004-09-24T11:25:00-0400"
             }
           }
         ],
-        "related": [
-          {
-            "identifier": {
-              "value": "12248947"
+        "context": {
+          "encounter": [
+            {
+              "identifier": {
+                "value": "5886199"
+              }
             }
-          }
-        ]
+          ],
+          "related": [
+            {
+              "identifier": {
+                "value": "12248947"
+              }
+            }
+          ]
+        }
+      },
+      "search": {
+        "mode": "match"
       }
     },
     {
-      "resourceType": "DiagnosticReport",
-      "id": "ex-MHV-labReport-1",
-      "meta": {
-        "profile": [
-          "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
-        ]
-      },
-      "text": {
-        "status": "generated",
-        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 79381-0}\">LR MICROBIOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id:\u00a01013699147\u00a0(use:\u00a0OFFICIAL))</td></tr><tr><td>When For</td><td>1995-08-03 14:49:00+0000</td></tr><tr><td>Reported</td><td>1995-08-03 14:49:00+0000</td></tr><tr><td>Identifier:</td><td> id:\u00a0LabReportTO.MI;7049269\u00a0(use:\u00a0USUAL)</td></tr></table><p><b>Report Details</b></p><table class=\"grid\"><tr><td><b>Code</b></td><td><b>Value</b></td><td><b>When For</b></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr></table><p>Accession [UID]: PARAS 95 264 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 30, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT =&gt; Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND</p></div>"
-      },
-      "contained": [
-        {
-          "resourceType": "Observation",
-          "id": "ex-MHV-labTest-1",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
-            ]
-          },
-          "identifier": [
-            {
-              "use": "usual",
-              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-              "value": "LabTestTO.MI;7049269;1"
-            }
-          ],
-          "status": "final",
-          "category": [
-            {
-              "coding": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                  "code": "laboratory"
-                }
-              ]
-            }
-          ],
-          "code": {
-            "text": "Parasitology Remark(s)"
-          },
-          "subject": {
-            "reference": "Patient/ex-MHV-patient-1"
-          },
-          "effectiveDateTime": "1995-08-03T14:49:00-0400",
-          "performer": [
-            {
-              "reference": "Organization/ex-MHV-organization-989"
-            }
-          ],
-          "valueString": "NO OVA OR PARASITES FOUND"
-        },
-        {
-          "resourceType": "Specimen",
-          "id": "ex-MHV-specimen-1",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
-            ]
-          },
-          "identifier": [
-            {
-              "use": "usual",
-              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-              "value": "LabSpecimenTO.6Y100"
-            }
-          ],
-          "accessionIdentifier": {
-            "use": "usual",
-            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-            "value": "PARAS 95 264"
-          },
-          "status": "available",
-          "type": {
-            "text": "FECES"
-          },
-          "collection": {
-            "collectedDateTime": "1995-07-30"
-          }
-        }
-      ],
-      "identifier": [
-        {
-          "use": "usual",
-          "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-          "value": "LabReportTO.MI;7049269"
-        }
-      ],
-      "status": "final",
-      "category": [
-        {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
-              "code": "LAB"
-            }
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/DiagnosticReport/8109",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "ex-MHV-labReport-1",
+        "meta": {
+          "profile": [
+            "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
           ]
-        }
-      ],
-      "code": {
-        "coding": [
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 79381-0}\">LR MICROBIOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id: 1013699147 (use: OFFICIAL))</td></tr><tr><td>When For</td><td>1995-08-03 14:49:00+0000</td></tr><tr><td>Reported</td><td>1995-08-03 14:49:00+0000</td></tr><tr><td>Identifier:</td><td> id: LabReportTO.MI;7049269 (use: USUAL)</td></tr></table><p><b>Report Details</b></p><table class=\"grid\"><tr><td><b>Code</b></td><td><b>Value</b></td><td><b>When For</b></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr></table><p>Accession [UID]: PARAS 95 264 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 30, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT =&gt; Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND</p></div>"
+        },
+        "contained": [
           {
-            "system": "http://loinc.org",
-            "code": "79381-0"
+            "resourceType": "Observation",
+            "id": "ex-MHV-labTest-1",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+                "value": "LabTestTO.MI;7049269;1"
+              }
+            ],
+            "status": "final",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                    "code": "laboratory"
+                  }
+                ]
+              }
+            ],
+            "code": {
+              "text": "Parasitology Remark(s)"
+            },
+            "subject": {
+              "reference": "Patient/ex-MHV-patient-1"
+            },
+            "effectiveDateTime": "1995-08-03T14:49:00-0400",
+            "performer": [
+              {
+                "reference": "Organization/ex-MHV-organization-989"
+              }
+            ],
+            "valueString": "NO OVA OR PARASITES FOUND"
+          },
+          {
+            "resourceType": "Specimen",
+            "id": "ex-MHV-specimen-1",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+                "value": "LabSpecimenTO.6Y100"
+              }
+            ],
+            "accessionIdentifier": {
+              "use": "usual",
+              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+              "value": "PARAS 95 264"
+            },
+            "status": "available",
+            "type": {
+              "text": "FECES"
+            },
+            "collection": {
+              "collectedDateTime": "1995-07-30"
+            }
           }
         ],
-        "text": "LR MICROBIOLOGY REPORT"
+        "identifier": [
+          {
+            "use": "usual",
+            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+            "value": "LabReportTO.MI;7049269"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "79381-0"
+            }
+          ],
+          "text": "LR MICROBIOLOGY REPORT"
+        },
+        "subject": {
+          "reference": "Patient/ex-MHV-patient-1"
+        },
+        "effectiveDateTime": "1995-08-03T14:49:00-0400",
+        "issued": "1995-08-03T14:49:00-0400",
+        "performer": [
+          {
+            "reference": "Organization/ex-MHV-organization-989"
+          }
+        ],
+        "specimen": [
+          {
+            "reference": "#ex-MHV-specimen-1"
+          }
+        ],
+        "result": [
+          {
+            "reference": "#ex-MHV-labTest-1"
+          }
+        ],
+        "conclusion": "Accession [UID]: PARAS 95 264 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 30, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT => Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND"
       },
-      "subject": {
-        "reference": "Patient/ex-MHV-patient-1"
-      },
-      "effectiveDateTime": "1995-08-03T14:49:00-0400",
-      "issued": "1995-08-03T14:49:00-0400",
-      "performer": [
-        {
-          "reference": "Organization/ex-MHV-organization-989"
-        }
-      ],
-      "specimen": [
-        {
-          "reference": "#ex-MHV-specimen-1"
-        }
-      ],
-      "result": [
-        {
-          "reference": "#ex-MHV-labTest-1"
-        }
-      ],
-      "conclusion": "Accession [UID]: PARAS 95 264 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 30, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT => Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND"
+      "search": {
+        "mode": "match"
+      }
     },
     {
-      "resourceType": "DiagnosticReport",
-      "id": "ex-MHV-labReport-2",
-      "meta": {
-        "profile": [
-          "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
-        ]
-      },
-      "text": {
-        "status": "generated",
-        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 79381-0}\">LR MICROBIOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id:\u00a01013699147\u00a0(use:\u00a0OFFICIAL))</td></tr><tr><td>When For</td><td>1995-08-03 14:49:00+0000</td></tr><tr><td>Reported</td><td>1995-08-03 14:49:00+0000</td></tr><tr><td>Identifier:</td><td> id:\u00a0LabReportTO.MI;7049269.93\u00a0(use:\u00a0USUAL)</td></tr></table><p><b>Report Details</b></p><table class=\"grid\"><tr><td><b>Code</b></td><td><b>Value</b></td><td><b>When For</b></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr></table><p>Accession [UID]: PARAS 95 263 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 29, 1995 07:00\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT =&gt; Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND \nMODERATE WBC'S SEEN \nMODERATE YEAST</p></div>"
-      },
-      "contained": [
-        {
-          "resourceType": "Observation",
-          "id": "ex-MHV-labTest-2",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
-            ]
-          },
-          "identifier": [
-            {
-              "use": "usual",
-              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-              "value": "LabTestTO.MI;7049269.93;1"
-            }
-          ],
-          "status": "final",
-          "category": [
-            {
-              "coding": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                  "code": "laboratory"
-                }
-              ]
-            }
-          ],
-          "code": {
-            "text": "Parasitology Remark(s)"
-          },
-          "subject": {
-            "reference": "Patient/ex-MHV-patient-1"
-          },
-          "effectiveDateTime": "1995-08-03T14:49:00-0400",
-          "performer": [
-            {
-              "reference": "Organization/ex-MHV-organization-989"
-            }
-          ],
-          "valueString": "NO OVA OR PARASITES FOUND"
-        },
-        {
-          "resourceType": "Observation",
-          "id": "ex-MHV-labTest-3",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
-            ]
-          },
-          "identifier": [
-            {
-              "use": "usual",
-              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-              "value": "LabTestTO.MI;7049269.93;2"
-            }
-          ],
-          "status": "final",
-          "category": [
-            {
-              "coding": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                  "code": "laboratory"
-                }
-              ]
-            }
-          ],
-          "code": {
-            "text": "Parasitology Remark(s)"
-          },
-          "subject": {
-            "reference": "Patient/ex-MHV-patient-1"
-          },
-          "effectiveDateTime": "1995-08-03T14:49:00-0400",
-          "performer": [
-            {
-              "reference": "Organization/ex-MHV-organization-989"
-            }
-          ],
-          "valueString": "MODERATE WBC'S SEEN"
-        },
-        {
-          "resourceType": "Observation",
-          "id": "ex-MHV-labTest-4",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
-            ]
-          },
-          "identifier": [
-            {
-              "use": "usual",
-              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-              "value": "LabTestTO.MI;7049269.93;3"
-            }
-          ],
-          "status": "final",
-          "category": [
-            {
-              "coding": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                  "code": "laboratory"
-                }
-              ]
-            }
-          ],
-          "code": {
-            "text": "Parasitology Remark(s)"
-          },
-          "subject": {
-            "reference": "Patient/ex-MHV-patient-1"
-          },
-          "effectiveDateTime": "1995-08-03T14:49:00-0400",
-          "performer": [
-            {
-              "reference": "Organization/ex-MHV-organization-989"
-            }
-          ],
-          "valueString": "MODERATE YEAST"
-        },
-        {
-          "resourceType": "Specimen",
-          "id": "ex-MHV-specimen-2",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
-            ]
-          },
-          "identifier": [
-            {
-              "use": "usual",
-              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-              "value": "LabSpecimenTO.6Y100"
-            }
-          ],
-          "accessionIdentifier": {
-            "use": "usual",
-            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-            "value": "PARAS 95 263"
-          },
-          "status": "available",
-          "type": {
-            "text": "FECES"
-          },
-          "collection": {
-            "collectedDateTime": "1995-07-29T07:00:00-0400"
-          }
-        }
-      ],
-      "identifier": [
-        {
-          "use": "usual",
-          "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-          "value": "LabReportTO.MI;7049269.93"
-        }
-      ],
-      "status": "final",
-      "category": [
-        {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
-              "code": "LAB"
-            }
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/DiagnosticReport/8109",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "ex-MHV-labReport-2",
+        "meta": {
+          "profile": [
+            "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
           ]
-        }
-      ],
-      "code": {
-        "coding": [
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 79381-0}\">LR MICROBIOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id: 1013699147 (use: OFFICIAL))</td></tr><tr><td>When For</td><td>1995-08-03 14:49:00+0000</td></tr><tr><td>Reported</td><td>1995-08-03 14:49:00+0000</td></tr><tr><td>Identifier:</td><td> id: LabReportTO.MI;7049269.93 (use: USUAL)</td></tr></table><p><b>Report Details</b></p><table class=\"grid\"><tr><td><b>Code</b></td><td><b>Value</b></td><td><b>When For</b></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr></table><p>Accession [UID]: PARAS 95 263 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 29, 1995 07:00\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT =&gt; Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND \nMODERATE WBC'S SEEN \nMODERATE YEAST</p></div>"
+        },
+        "contained": [
           {
-            "system": "http://loinc.org",
-            "code": "79381-0"
+            "resourceType": "Observation",
+            "id": "ex-MHV-labTest-2",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+                "value": "LabTestTO.MI;7049269.93;1"
+              }
+            ],
+            "status": "final",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                    "code": "laboratory"
+                  }
+                ]
+              }
+            ],
+            "code": {
+              "text": "Parasitology Remark(s)"
+            },
+            "subject": {
+              "reference": "Patient/ex-MHV-patient-1"
+            },
+            "effectiveDateTime": "1995-08-03T14:49:00-0400",
+            "performer": [
+              {
+                "reference": "Organization/ex-MHV-organization-989"
+              }
+            ],
+            "valueString": "NO OVA OR PARASITES FOUND"
+          },
+          {
+            "resourceType": "Observation",
+            "id": "ex-MHV-labTest-3",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+                "value": "LabTestTO.MI;7049269.93;2"
+              }
+            ],
+            "status": "final",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                    "code": "laboratory"
+                  }
+                ]
+              }
+            ],
+            "code": {
+              "text": "Parasitology Remark(s)"
+            },
+            "subject": {
+              "reference": "Patient/ex-MHV-patient-1"
+            },
+            "effectiveDateTime": "1995-08-03T14:49:00-0400",
+            "performer": [
+              {
+                "reference": "Organization/ex-MHV-organization-989"
+              }
+            ],
+            "valueString": "MODERATE WBC'S SEEN"
+          },
+          {
+            "resourceType": "Observation",
+            "id": "ex-MHV-labTest-4",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+                "value": "LabTestTO.MI;7049269.93;3"
+              }
+            ],
+            "status": "final",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                    "code": "laboratory"
+                  }
+                ]
+              }
+            ],
+            "code": {
+              "text": "Parasitology Remark(s)"
+            },
+            "subject": {
+              "reference": "Patient/ex-MHV-patient-1"
+            },
+            "effectiveDateTime": "1995-08-03T14:49:00-0400",
+            "performer": [
+              {
+                "reference": "Organization/ex-MHV-organization-989"
+              }
+            ],
+            "valueString": "MODERATE YEAST"
+          },
+          {
+            "resourceType": "Specimen",
+            "id": "ex-MHV-specimen-2",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+                "value": "LabSpecimenTO.6Y100"
+              }
+            ],
+            "accessionIdentifier": {
+              "use": "usual",
+              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+              "value": "PARAS 95 263"
+            },
+            "status": "available",
+            "type": {
+              "text": "FECES"
+            },
+            "collection": {
+              "collectedDateTime": "1995-07-29T07:00:00-0400"
+            }
           }
         ],
-        "text": "LR MICROBIOLOGY REPORT"
-      },
-      "subject": {
-        "reference": "Patient/ex-MHV-patient-1"
-      },
-      "effectiveDateTime": "1995-08-03T14:49:00-0400",
-      "issued": "1995-08-03T14:49:00-0400",
-      "performer": [
-        {
-          "reference": "Organization/ex-MHV-organization-989"
-        }
-      ],
-      "specimen": [
-        {
-          "reference": "#ex-MHV-specimen-2"
-        }
-      ],
-      "result": [
-        {
-          "reference": "#ex-MHV-labTest-2"
+        "identifier": [
+          {
+            "use": "usual",
+            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+            "value": "LabReportTO.MI;7049269.93"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "79381-0"
+            }
+          ],
+          "text": "LR MICROBIOLOGY REPORT"
         },
-        {
-          "reference": "#ex-MHV-labTest-3"
+        "subject": {
+          "reference": "Patient/ex-MHV-patient-1"
         },
-        {
-          "reference": "#ex-MHV-labTest-4"
-        }
-      ],
-      "conclusion": "Accession [UID]: PARAS 95 263 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 29, 1995 07:00\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT => Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND \nMODERATE WBC'S SEEN \nMODERATE YEAST"
+        "effectiveDateTime": "1995-08-03T14:49:00-0400",
+        "issued": "1995-08-03T14:49:00-0400",
+        "performer": [
+          {
+            "reference": "Organization/ex-MHV-organization-989"
+          }
+        ],
+        "specimen": [
+          {
+            "reference": "#ex-MHV-specimen-2"
+          }
+        ],
+        "result": [
+          {
+            "reference": "#ex-MHV-labTest-2"
+          },
+          {
+            "reference": "#ex-MHV-labTest-3"
+          },
+          {
+            "reference": "#ex-MHV-labTest-4"
+          }
+        ],
+        "conclusion": "Accession [UID]: PARAS 95 263 []            Received: Aug 01, 1995@11:02\nCollection sample: STOOL               Collection date: Jul 29, 1995 07:00\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT => Aug 03, 1995   TECH CODE: 1003\nParasitology Remark(s):\nNO OVA OR PARASITES FOUND \nMODERATE WBC'S SEEN \nMODERATE YEAST"
+      },
+      "search": {
+        "mode": "match"
+      }
     },
     {
-      "resourceType": "DiagnosticReport",
-      "id": "ex-MHV-labReport-3",
-      "meta": {
-        "profile": [
-          "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
-        ]
-      },
-      "text": {
-        "status": "generated",
-        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 79381-0}\">LR MICROBIOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id:\u00a01013699147\u00a0(use:\u00a0OFFICIAL))</td></tr><tr><td>When For</td><td>1995-08-01 11:07:00+0000</td></tr><tr><td>Reported</td><td>1995-08-01 11:07:00+0000</td></tr><tr><td>Identifier:</td><td> id:\u00a0LabReportTO.MI;7049271\u00a0(use:\u00a0USUAL)</td></tr></table><p><b>Report Details</b></p><table class=\"grid\"><tr><td><b>Code</b></td><td><b>Value</b></td><td><b>When For</b></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr></table><p>Accession [UID]: PARAS 95 262 []            Received: Aug 01, 1995@11:00\nCollection sample: STOOL               Collection date: Jul 28, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT =&gt; Aug 01, 1995   TECH CODE: 420\nParasitology Remark(s):\nREJECTED=LEAKED</p></div>"
-      },
-      "contained": [
-        {
-          "resourceType": "Observation",
-          "id": "ex-MHV-labTest-5",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
-            ]
-          },
-          "identifier": [
-            {
-              "use": "usual",
-              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-              "value": "LabTestTO.MI;7049271;1"
-            }
-          ],
-          "status": "final",
-          "category": [
-            {
-              "coding": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                  "code": "laboratory"
-                }
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/DiagnosticReport/8109",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "ex-MHV-labReport-3",
+        "meta": {
+          "profile": [
+            "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 79381-0}\">LR MICROBIOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id: 1013699147 (use: OFFICIAL))</td></tr><tr><td>When For</td><td>1995-08-01 11:07:00+0000</td></tr><tr><td>Reported</td><td>1995-08-01 11:07:00+0000</td></tr><tr><td>Identifier:</td><td> id: LabReportTO.MI;7049271 (use: USUAL)</td></tr></table><p><b>Report Details</b></p><table class=\"grid\"><tr><td><b>Code</b></td><td><b>Value</b></td><td><b>When For</b></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr><tr><td colspan=\"3\"><i>This Observation could not be resolved</i></td></tr></table><p>Accession [UID]: PARAS 95 262 []            Received: Aug 01, 1995@11:00\nCollection sample: STOOL               Collection date: Jul 28, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT =&gt; Aug 01, 1995   TECH CODE: 420\nParasitology Remark(s):\nREJECTED=LEAKED</p></div>"
+        },
+        "contained": [
+          {
+            "resourceType": "Observation",
+            "id": "ex-MHV-labTest-5",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
               ]
-            }
-          ],
-          "code": {
-            "text": "Parasitology Remark(s)"
+            },
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+                "value": "LabTestTO.MI;7049271;1"
+              }
+            ],
+            "status": "final",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                    "code": "laboratory"
+                  }
+                ]
+              }
+            ],
+            "code": {
+              "text": "Parasitology Remark(s)"
+            },
+            "subject": {
+              "reference": "Patient/ex-MHV-patient-1"
+            },
+            "effectiveDateTime": "1995-08-01T11:07:00-0400",
+            "performer": [
+              {
+                "reference": "Organization/ex-MHV-organization-989"
+              }
+            ],
+            "valueString": "REJECTED=LEAKED"
           },
-          "subject": {
-            "reference": "Patient/ex-MHV-patient-1"
-          },
-          "effectiveDateTime": "1995-08-01T11:07:00-0400",
-          "performer": [
-            {
-              "reference": "Organization/ex-MHV-organization-989"
-            }
-          ],
-          "valueString": "REJECTED=LEAKED"
-        },
-        {
-          "resourceType": "Observation",
-          "id": "ex-MHV-labTest-6",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
-            ]
-          },
-          "identifier": [
-            {
-              "use": "usual",
-              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-              "value": "LabTestTO.MI;7049271;2"
-            }
-          ],
-          "status": "final",
-          "category": [
-            {
-              "coding": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                  "code": "laboratory"
-                }
+          {
+            "resourceType": "Observation",
+            "id": "ex-MHV-labTest-6",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
               ]
-            }
-          ],
-          "code": {
-            "text": "Parasitology Remark(s)"
+            },
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+                "value": "LabTestTO.MI;7049271;2"
+              }
+            ],
+            "status": "final",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                    "code": "laboratory"
+                  }
+                ]
+              }
+            ],
+            "code": {
+              "text": "Parasitology Remark(s)"
+            },
+            "subject": {
+              "reference": "Patient/ex-MHV-patient-1"
+            },
+            "effectiveDateTime": "1995-08-01T11:07:00-0400",
+            "performer": [
+              {
+                "reference": "Organization/ex-MHV-organization-989"
+              }
+            ],
+            "valueString": "MODERATE WBC'S SEEN"
           },
-          "subject": {
-            "reference": "Patient/ex-MHV-patient-1"
-          },
-          "effectiveDateTime": "1995-08-01T11:07:00-0400",
-          "performer": [
-            {
-              "reference": "Organization/ex-MHV-organization-989"
-            }
-          ],
-          "valueString": "MODERATE WBC'S SEEN"
-        },
-        {
-          "resourceType": "Observation",
-          "id": "ex-MHV-labTest-7",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
-            ]
-          },
-          "identifier": [
-            {
-              "use": "usual",
-              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-              "value": "LabTestTO.MI;7049271;3"
-            }
-          ],
-          "status": "final",
-          "category": [
-            {
-              "coding": [
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-                  "code": "laboratory"
-                }
+          {
+            "resourceType": "Observation",
+            "id": "ex-MHV-labTest-7",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labTest"
               ]
-            }
-          ],
-          "code": {
-            "text": "Parasitology Remark(s)"
+            },
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+                "value": "LabTestTO.MI;7049271;3"
+              }
+            ],
+            "status": "final",
+            "category": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                    "code": "laboratory"
+                  }
+                ]
+              }
+            ],
+            "code": {
+              "text": "Parasitology Remark(s)"
+            },
+            "subject": {
+              "reference": "Patient/ex-MHV-patient-1"
+            },
+            "effectiveDateTime": "1995-08-01T11:07:00-0400",
+            "performer": [
+              {
+                "reference": "Organization/ex-MHV-organization-989"
+              }
+            ],
+            "valueString": "MODERATE YEAST"
           },
-          "subject": {
-            "reference": "Patient/ex-MHV-patient-1"
-          },
-          "effectiveDateTime": "1995-08-01T11:07:00-0400",
-          "performer": [
-            {
-              "reference": "Organization/ex-MHV-organization-989"
-            }
-          ],
-          "valueString": "MODERATE YEAST"
-        },
-        {
-          "resourceType": "Specimen",
-          "id": "ex-MHV-specimen-3",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
-            ]
-          },
-          "identifier": [
-            {
+          {
+            "resourceType": "Specimen",
+            "id": "ex-MHV-specimen-3",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual",
+                "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+                "value": "LabSpecimenTO.6Y100"
+              }
+            ],
+            "accessionIdentifier": {
               "use": "usual",
               "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-              "value": "LabSpecimenTO.6Y100"
+              "value": "PARAS 95 262"
+            },
+            "status": "available",
+            "type": {
+              "text": "FECES"
+            },
+            "collection": {
+              "collectedDateTime": "1995-07-28"
             }
-          ],
-          "accessionIdentifier": {
-            "use": "usual",
-            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-            "value": "PARAS 95 262"
-          },
-          "status": "available",
-          "type": {
-            "text": "FECES"
-          },
-          "collection": {
-            "collectedDateTime": "1995-07-28"
-          }
-        }
-      ],
-      "identifier": [
-        {
-          "use": "usual",
-          "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-          "value": "LabReportTO.MI;7049271"
-        }
-      ],
-      "status": "final",
-      "category": [
-        {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
-              "code": "LAB"
-            }
-          ]
-        }
-      ],
-      "code": {
-        "coding": [
-          {
-            "system": "http://loinc.org",
-            "code": "79381-0"
           }
         ],
-        "text": "LR MICROBIOLOGY REPORT"
-      },
-      "subject": {
-        "reference": "Patient/ex-MHV-patient-1"
-      },
-      "effectiveDateTime": "1995-08-01T11:07:00-0400",
-      "issued": "1995-08-01T11:07:00-0400",
-      "performer": [
-        {
-          "reference": "Organization/ex-MHV-organization-989"
-        }
-      ],
-      "specimen": [
-        {
-          "reference": "#ex-MHV-specimen-3"
-        }
-      ],
-      "result": [
-        {
-          "reference": "#ex-MHV-labTest-5"
+        "identifier": [
+          {
+            "use": "usual",
+            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+            "value": "LabReportTO.MI;7049271"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "79381-0"
+            }
+          ],
+          "text": "LR MICROBIOLOGY REPORT"
         },
-        {
-          "reference": "#ex-MHV-labTest-6"
+        "subject": {
+          "reference": "Patient/ex-MHV-patient-1"
         },
-        {
-          "reference": "#ex-MHV-labTest-7"
-        }
-      ],
-      "conclusion": "Accession [UID]: PARAS 95 262 []            Received: Aug 01, 1995@11:00\nCollection sample: STOOL               Collection date: Jul 28, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT => Aug 01, 1995   TECH CODE: 420\nParasitology Remark(s):\nREJECTED=LEAKED"
-    },
-    {
-      "resourceType": "DiagnosticReport",
-      "id": "ex-MHV-labReport-4",
-      "meta": {
-        "profile": [
-          "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
-        ]
-      },
-      "text": {
-        "status": "generated",
-        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 60567-5}\">LR SURGICAL PATHOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id:\u00a01013699147\u00a0(use:\u00a0OFFICIAL))</td></tr><tr><td>When For</td><td>2000-08-10 15:56:00+0000</td></tr><tr><td>Reported</td><td>2000-08-10 15:56:00+0000</td></tr><tr><td>Identifier:</td><td> id:\u00a0LabReportTo.SP;6999190\u00a0(use:\u00a0USUAL)</td></tr></table><p><b>Report Details</b></p><p>Date Spec taken: Aug 09, 2000        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: Aug 09, 2000 16:14  Resident: \nDate  completed: Aug 10, 2000        Accession #: SP 00 1982\nSubmitted by: MARK MAZUR MD          Practitioner:MARK MAZUR DPM\n-------------------------------------------------------------------------------\nSpecimen: \nOLD HARDWARE LEFT FOOT X2\nBrief Clinical History:\nThis 71 y/o wm presents with painful hardware L 1st metatarsal head. The\npins were inserted 3 years ago for a bunion procedure. The Bunionprocedure\nis well healed and pt is now wanting the pin removed. Will probably need\nk-wire driver and power for this case.\nPreoperative Diagnosis:\nPAINFUL HARDWARE LEFT FIRST METATARSAL \nPostoperative Diagnosis:\nPAINFUL HARDWARE LEFT FIRST METATARSAL \nGross description:\nRECEIVED UNFIXED AND LABELED &quot;OLD HARDWARE LEFT FOOT X 2&quot; CONSISTS OF TWO\n1.7 CM AND 2.5 CM LONG 1 MM WIDE METALLIC PINS.\n|TAB||NOWRAP|\nDIAGNOSIS: HARDWARE (CLINICALLY FROM LEFT FOOT)</p></div>"
-      },
-      "contained": [
-        {
-          "resourceType": "Specimen",
-          "id": "ex-MHV-specimen-4",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
-            ]
-          },
-          "identifier": [
-            {
-              "use": "usual"
-            }
-          ],
-          "accessionIdentifier": {
-            "use": "usual",
-            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-            "value": "SP 00 1982"
-          },
-          "status": "available",
-          "type": {
-            "text": "OLD HARDWARE LEFT FOOT X2"
-          },
-          "collection": {
-            "collectedDateTime": "2000-08-09"
-          }
-        }
-      ],
-      "identifier": [
-        {
-          "use": "usual",
-          "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-          "value": "LabReportTo.SP;6999190"
-        }
-      ],
-      "status": "final",
-      "category": [
-        {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
-              "code": "LAB"
-            }
-          ]
-        }
-      ],
-      "code": {
-        "coding": [
+        "effectiveDateTime": "1995-08-01T11:07:00-0400",
+        "issued": "1995-08-01T11:07:00-0400",
+        "performer": [
           {
-            "system": "http://loinc.org",
-            "code": "60567-5"
+            "reference": "Organization/ex-MHV-organization-989"
           }
         ],
-        "text": "LR SURGICAL PATHOLOGY REPORT"
-      },
-      "subject": {
-        "reference": "Patient/ex-MHV-patient-1"
-      },
-      "effectiveDateTime": "2000-08-10T15:56:00-0400",
-      "issued": "2000-08-10T15:56:00-0400",
-      "performer": [
-        {
-          "reference": "Organization/ex-MHV-organization-989"
-        }
-      ],
-      "specimen": [
-        {
-          "reference": "#ex-MHV-specimen-4"
-        }
-      ],
-      "conclusion": "Date Spec taken: Aug 09, 2000        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: Aug 09, 2000 16:14  Resident: \nDate  completed: Aug 10, 2000        Accession #: SP 00 1982\nSubmitted by: MARK MAZUR MD          Practitioner:MARK MAZUR DPM\n-------------------------------------------------------------------------------\nSpecimen: \nOLD HARDWARE LEFT FOOT X2\nBrief Clinical History:\nThis 71 y/o wm presents with painful hardware L 1st metatarsal head. The\npins were inserted 3 years ago for a bunion procedure. The Bunionprocedure\nis well healed and pt is now wanting the pin removed. Will probably need\nk-wire driver and power for this case.\nPreoperative Diagnosis:\nPAINFUL HARDWARE LEFT FIRST METATARSAL \nPostoperative Diagnosis:\nPAINFUL HARDWARE LEFT FIRST METATARSAL \nGross description:\nRECEIVED UNFIXED AND LABELED \"OLD HARDWARE LEFT FOOT X 2\" CONSISTS OF TWO\n1.7 CM AND 2.5 CM LONG 1 MM WIDE METALLIC PINS.\n|TAB||NOWRAP|\nDIAGNOSIS: HARDWARE (CLINICALLY FROM LEFT FOOT)"
-    },
-    {
-      "resourceType": "DiagnosticReport",
-      "id": "ex-MHV-labReport-5",
-      "meta": {
-        "profile": [
-          "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
-        ]
-      },
-      "text": {
-        "status": "generated",
-        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 60567-5}\">LR SURGICAL PATHOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id:\u00a01013699147\u00a0(use:\u00a0OFFICIAL))</td></tr><tr><td>When For</td><td>1999-09-27 13:07:00+0000</td></tr><tr><td>Reported</td><td>1999-09-27 13:07:00+0000</td></tr><tr><td>Identifier:</td><td> id:\u00a0LabReportTO.SP;7009075\u00a0(use:\u00a0USUAL)</td></tr></table><p><b>Report Details</b></p><p>Date Spec taken: Sep 24, 1999        Pathologist:JAZBIEH MOEZZI MD\nDate Spec rec'd: Sep 24, 1999 13:46  Resident: \nDate  completed: Sep 27, 1999        Accession #: SP 99 2207\nSubmitted by: KHURSHID YOUSUF MD     Practitioner:KHURSHID YOUSUF\n-------------------------------------------------------------------------------\nSpecimen: \nPOLYPS (A) CECAL\n       (B) PROXIMAL ASCENDING\n       (C) RECTAL\nBrief Clinical History:\nCOLON POLYPS PER FLEX SIG\nPreoperative Diagnosis:\nCOLON POLYPS\nOperative Findings:\n|TAB||NOWRAP|\n1. CECAL POLYPS X 2\n2. ASCENDING COLON POLYP\n3. RECTAL POLYP\nPostoperative Diagnosis:\nSAME\nGross description:\n|TAB||NOWRAP|\nSPECIMEN (A) LABELED CECAL POLYP X 2.  RECEIVED IN FORMALIN IS ONE PALE\nGREY TISSUE FRAGMENT MEASURING 0.4 CM IN DIAMETER.  EMBEDDED ENTIRELY IN\nONE BLOCK.\nSPECIMEN (B) LABELED PROXIMAL ASCENDING COLON.  RECEIVED IN FORMALIN ARE\nTWO PALE BROWN TISSUE FRAGMENTS MEASURING 0.3 CM IN AGGREGATE.  EMBEDDED\nENTIRELY IN ONE BLOCK.\nSPECIMEN (C) LABELED RECTAL POLYP.  RECEIVED IN FORMALIN ARE THREE MINUTE\nTISSUE FRAGMENTS MEASURING 0.3 CM IN AGGREGATE.  EMBEDDED ENTIRELY\nIN ONE BLOCK.\nMicroscopic description: (Date Spec taken: Sep 24, 1999)\n|TAB||BLANK(3)|\n|TAB||NOWRAP|\nDIAGNOSIS:\nA) CECAL POLYP: HYPERPLASTIC POLYP.  (SEE NOTE)\nB &amp;amp; C)\nPROXIMAL ASCENDING COLON AND RECTAL POLYPS: TUBULAR ADENOMAS. (SEE\nNOTE)\n\nNOTE: COAGULATION ARTEFACT AND POOR TISSUE PRESERVATION IS NOTED CAUSING\nDIFFICULTY IN EVALUATION OF LESION.\nDR. YOUSUF WAS NOTIFIED.</p></div>"
-      },
-      "contained": [
-        {
-          "resourceType": "Specimen",
-          "id": "ex-MHV-specimen-5",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
-            ]
-          },
-          "identifier": [
-            {
-              "use": "usual"
-            }
-          ],
-          "accessionIdentifier": {
-            "use": "usual",
-            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-            "value": "SP 99 2207"
-          },
-          "status": "available",
-          "type": {
-            "text": "POLYPS (A) CECAL,        (B) PROXIMAL ASCENDING,        (C) RECTAL"
-          },
-          "collection": {
-            "collectedDateTime": "1999-09-24"
-          }
-        }
-      ],
-      "identifier": [
-        {
-          "use": "usual",
-          "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-          "value": "LabReportTO.SP;7009075"
-        }
-      ],
-      "status": "final",
-      "category": [
-        {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
-              "code": "LAB"
-            }
-          ]
-        }
-      ],
-      "code": {
-        "coding": [
+        "specimen": [
           {
-            "system": "http://loinc.org",
-            "code": "60567-5"
+            "reference": "#ex-MHV-specimen-3"
           }
         ],
-        "text": "LR SURGICAL PATHOLOGY REPORT"
-      },
-      "subject": {
-        "reference": "Patient/ex-MHV-patient-1"
-      },
-      "effectiveDateTime": "1999-09-27T13:07:00-0400",
-      "issued": "1999-09-27T13:07:00-0400",
-      "performer": [
-        {
-          "reference": "Organization/ex-MHV-organization-989"
-        }
-      ],
-      "specimen": [
-        {
-          "reference": "#ex-MHV-specimen-5"
-        }
-      ],
-      "conclusion": "Date Spec taken: Sep 24, 1999        Pathologist:JAZBIEH MOEZZI MD\nDate Spec rec'd: Sep 24, 1999 13:46  Resident: \nDate  completed: Sep 27, 1999        Accession #: SP 99 2207\nSubmitted by: KHURSHID YOUSUF MD     Practitioner:KHURSHID YOUSUF\n-------------------------------------------------------------------------------\nSpecimen: \nPOLYPS (A) CECAL\n       (B) PROXIMAL ASCENDING\n       (C) RECTAL\nBrief Clinical History:\nCOLON POLYPS PER FLEX SIG\nPreoperative Diagnosis:\nCOLON POLYPS\nOperative Findings:\n|TAB||NOWRAP|\n1. CECAL POLYPS X 2\n2. ASCENDING COLON POLYP\n3. RECTAL POLYP\nPostoperative Diagnosis:\nSAME\nGross description:\n|TAB||NOWRAP|\nSPECIMEN (A) LABELED CECAL POLYP X 2.  RECEIVED IN FORMALIN IS ONE PALE\nGREY TISSUE FRAGMENT MEASURING 0.4 CM IN DIAMETER.  EMBEDDED ENTIRELY IN\nONE BLOCK.\nSPECIMEN (B) LABELED PROXIMAL ASCENDING COLON.  RECEIVED IN FORMALIN ARE\nTWO PALE BROWN TISSUE FRAGMENTS MEASURING 0.3 CM IN AGGREGATE.  EMBEDDED\nENTIRELY IN ONE BLOCK.\nSPECIMEN (C) LABELED RECTAL POLYP.  RECEIVED IN FORMALIN ARE THREE MINUTE\nTISSUE FRAGMENTS MEASURING 0.3 CM IN AGGREGATE.  EMBEDDED ENTIRELY\nIN ONE BLOCK.\nMicroscopic description: (Date Spec taken: Sep 24, 1999)\n|TAB||BLANK(3)|\n|TAB||NOWRAP|\nDIAGNOSIS:\nA) CECAL POLYP: HYPERPLASTIC POLYP.  (SEE NOTE)\nB &amp; C)\nPROXIMAL ASCENDING COLON AND RECTAL POLYPS: TUBULAR ADENOMAS. (SEE\nNOTE)\n\nNOTE: COAGULATION ARTEFACT AND POOR TISSUE PRESERVATION IS NOTED CAUSING\nDIFFICULTY IN EVALUATION OF LESION.\nDR. YOUSUF WAS NOTIFIED."
-    },
-    {
-      "resourceType": "DiagnosticReport",
-      "id": "ex-MHV-labReport-6",
-      "meta": {
-        "profile": [
-          "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
-        ]
-      },
-      "text": {
-        "status": "generated",
-        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 60567-5}\">LR SURGICAL PATHOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id:\u00a01013699147\u00a0(use:\u00a0OFFICIAL))</td></tr><tr><td>When For</td><td>1999-08-11 16:09:00+0000</td></tr><tr><td>Reported</td><td>1999-08-11 16:09:00+0000</td></tr><tr><td>Identifier:</td><td> id:\u00a0LabReportTO.SP;7009190\u00a0(use:\u00a0USUAL)</td></tr></table><p><b>Report Details</b></p><p>Date Spec taken: Aug 09, 1999        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: Aug 10, 1999 13:27  Resident: \nDate  completed: Aug 11, 1999        Accession #: SP 99 1804\nSubmitted by: KATHLEEN MARIE WOLNER  Practitioner:KATHLEEN MARIE WOLNER MD\n-------------------------------------------------------------------------------\nSpecimen: \nPOLYP @ 12CM\nBrief Clinical History:\n70 YEAR OLD MALE FOR SCREENING EXAM.  \nOperative Findings:\nSMOOTH BROAD BASED POLYP\nPostoperative Diagnosis:\nPROBABLE BENIGN POLYP\nGross description:\nRECEIVED IN FORMALIN AND LABELED &quot;POLYP&quot;  CONSISTS OF TWO 1 MM FRAGMENTS\nOF PINK TISSUE.  SUBMITTED IN TOTAL IN ONE BLOCK.\nMicroscopic description: (Date Spec taken: Aug 09, 1999)\n|TAB||BLANK(3)|\nDIAGNOSIS:\nPOLYP AT 12 CM. TUBULAR ADENOMA.</p></div>"
-      },
-      "contained": [
-        {
-          "resourceType": "Specimen",
-          "id": "ex-MHV-specimen-6",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
-            ]
-          },
-          "identifier": [
-            {
-              "use": "usual"
-            }
-          ],
-          "accessionIdentifier": {
-            "use": "usual",
-            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-            "value": "SP 99 1804"
-          },
-          "status": "available",
-          "type": {
-            "text": "POLYP @ 12CM"
-          },
-          "collection": {
-            "collectedDateTime": "1999-08-09"
-          }
-        }
-      ],
-      "identifier": [
-        {
-          "use": "usual",
-          "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-          "value": "LabReportTO.SP;7009190"
-        }
-      ],
-      "status": "final",
-      "category": [
-        {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
-              "code": "LAB"
-            }
-          ]
-        }
-      ],
-      "code": {
-        "coding": [
+        "result": [
           {
-            "system": "http://loinc.org",
-            "code": "60567-5"
+            "reference": "#ex-MHV-labTest-5"
+          },
+          {
+            "reference": "#ex-MHV-labTest-6"
+          },
+          {
+            "reference": "#ex-MHV-labTest-7"
           }
         ],
-        "text": "LR SURGICAL PATHOLOGY REPORT"
+        "conclusion": "Accession [UID]: PARAS 95 262 []            Received: Aug 01, 1995@11:00\nCollection sample: STOOL               Collection date: Jul 28, 1995\nSite/Specimen: FECES\nProvider: MANGAS,PHYLLIS A\n\n* PARASITOLOGY FINAL REPORT => Aug 01, 1995   TECH CODE: 420\nParasitology Remark(s):\nREJECTED=LEAKED"
       },
-      "subject": {
-        "reference": "Patient/ex-MHV-patient-1"
-      },
-      "effectiveDateTime": "1999-08-11T16:09:00-0400",
-      "issued": "1999-08-11T16:09:00-0400",
-      "performer": [
-        {
-          "reference": "Organization/ex-MHV-organization-989"
-        }
-      ],
-      "specimen": [
-        {
-          "reference": "#ex-MHV-specimen-6"
-        }
-      ],
-      "conclusion": "Date Spec taken: Aug 09, 1999        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: Aug 10, 1999 13:27  Resident: \nDate  completed: Aug 11, 1999        Accession #: SP 99 1804\nSubmitted by: KATHLEEN MARIE WOLNER  Practitioner:KATHLEEN MARIE WOLNER MD\n-------------------------------------------------------------------------------\nSpecimen: \nPOLYP @ 12CM\nBrief Clinical History:\n70 YEAR OLD MALE FOR SCREENING EXAM.  \nOperative Findings:\nSMOOTH BROAD BASED POLYP\nPostoperative Diagnosis:\nPROBABLE BENIGN POLYP\nGross description:\nRECEIVED IN FORMALIN AND LABELED \"POLYP\"  CONSISTS OF TWO 1 MM FRAGMENTS\nOF PINK TISSUE.  SUBMITTED IN TOTAL IN ONE BLOCK.\nMicroscopic description: (Date Spec taken: Aug 09, 1999)\n|TAB||BLANK(3)|\nDIAGNOSIS:\nPOLYP AT 12 CM. TUBULAR ADENOMA."
+      "search": {
+        "mode": "match"
+      }
     },
     {
-      "resourceType": "DiagnosticReport",
-      "id": "ex-MHV-labReport-7",
-      "meta": {
-        "profile": [
-          "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
-        ]
-      },
-      "text": {
-        "status": "generated",
-        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 60567-5}\">LR SURGICAL PATHOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id:\u00a01013699147\u00a0(use:\u00a0OFFICIAL))</td></tr><tr><td>When For</td><td>1997-09-09 13:13:00+0000</td></tr><tr><td>Reported</td><td>1997-09-09 13:13:00+0000</td></tr><tr><td>Identifier:</td><td> id:\u00a0LabReportTO.SP;7029091\u00a0(use:\u00a0USUAL)</td></tr></table><p><b>Report Details</b></p><p>Date Spec taken: Sep 08, 1997        Pathologist:JAZBIEH MOEZZI MD\nDate Spec rec'd: Sep 08, 1997 13:08  Resident: \nDate  completed: Sep 09, 1997        Accession #: SP 97 2091\nSubmitted by: DEBRA K LATTA MD       Practitioner:DEBRA K LATTA\n-------------------------------------------------------------------------------\nSpecimen: \n(A) BONE FROM RIGHT FOOT\n(B) BONE RIGHT FOOT</p></div>"
-      },
-      "contained": [
-        {
-          "resourceType": "Specimen",
-          "id": "ex-MHV-specimen-7",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
-            ]
-          },
-          "identifier": [
-            {
-              "use": "usual"
-            }
-          ],
-          "accessionIdentifier": {
-            "use": "usual",
-            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-            "value": "SP 97 2091"
-          },
-          "status": "available",
-          "type": {
-            "text": "(A) BONE FROM RIGHT FOOT, (B) BONE RIGHT FOOT"
-          },
-          "collection": {
-            "collectedDateTime": "1997-09-08"
-          }
-        }
-      ],
-      "identifier": [
-        {
-          "use": "usual",
-          "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-          "value": "LabReportTO.SP;7029091"
-        }
-      ],
-      "status": "final",
-      "category": [
-        {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
-              "code": "LAB"
-            }
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/DiagnosticReport/8109",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "ex-MHV-labReport-4",
+        "meta": {
+          "profile": [
+            "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
           ]
-        }
-      ],
-      "code": {
-        "coding": [
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 60567-5}\">LR SURGICAL PATHOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id: 1013699147 (use: OFFICIAL))</td></tr><tr><td>When For</td><td>2000-08-10 15:56:00+0000</td></tr><tr><td>Reported</td><td>2000-08-10 15:56:00+0000</td></tr><tr><td>Identifier:</td><td> id: LabReportTo.SP;6999190 (use: USUAL)</td></tr></table><p><b>Report Details</b></p><p>Date Spec taken: Aug 09, 2000        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: Aug 09, 2000 16:14  Resident: \nDate  completed: Aug 10, 2000        Accession #: SP 00 1982\nSubmitted by: MARK MAZUR MD          Practitioner:MARK MAZUR DPM\n-------------------------------------------------------------------------------\nSpecimen: \nOLD HARDWARE LEFT FOOT X2\nBrief Clinical History:\nThis 71 y/o wm presents with painful hardware L 1st metatarsal head. The\npins were inserted 3 years ago for a bunion procedure. The Bunionprocedure\nis well healed and pt is now wanting the pin removed. Will probably need\nk-wire driver and power for this case.\nPreoperative Diagnosis:\nPAINFUL HARDWARE LEFT FIRST METATARSAL \nPostoperative Diagnosis:\nPAINFUL HARDWARE LEFT FIRST METATARSAL \nGross description:\nRECEIVED UNFIXED AND LABELED &quot;OLD HARDWARE LEFT FOOT X 2&quot; CONSISTS OF TWO\n1.7 CM AND 2.5 CM LONG 1 MM WIDE METALLIC PINS.\n|TAB||NOWRAP|\nDIAGNOSIS: HARDWARE (CLINICALLY FROM LEFT FOOT)</p></div>"
+        },
+        "contained": [
           {
-            "system": "http://loinc.org",
-            "code": "60567-5"
+            "resourceType": "Specimen",
+            "id": "ex-MHV-specimen-4",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual"
+              }
+            ],
+            "accessionIdentifier": {
+              "use": "usual",
+              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+              "value": "SP 00 1982"
+            },
+            "status": "available",
+            "type": {
+              "text": "OLD HARDWARE LEFT FOOT X2"
+            },
+            "collection": {
+              "collectedDateTime": "2000-08-09"
+            }
           }
         ],
-        "text": "LR SURGICAL PATHOLOGY REPORT"
+        "identifier": [
+          {
+            "use": "usual",
+            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+            "value": "LabReportTo.SP;6999190"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "60567-5"
+            }
+          ],
+          "text": "LR SURGICAL PATHOLOGY REPORT"
+        },
+        "subject": {
+          "reference": "Patient/ex-MHV-patient-1"
+        },
+        "effectiveDateTime": "2000-08-10T15:56:00-0400",
+        "issued": "2000-08-10T15:56:00-0400",
+        "performer": [
+          {
+            "reference": "Organization/ex-MHV-organization-989"
+          }
+        ],
+        "specimen": [
+          {
+            "reference": "#ex-MHV-specimen-4"
+          }
+        ],
+        "conclusion": "Date Spec taken: Aug 09, 2000        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: Aug 09, 2000 16:14  Resident: \nDate  completed: Aug 10, 2000        Accession #: SP 00 1982\nSubmitted by: MARK MAZUR MD          Practitioner:MARK MAZUR DPM\n-------------------------------------------------------------------------------\nSpecimen: \nOLD HARDWARE LEFT FOOT X2\nBrief Clinical History:\nThis 71 y/o wm presents with painful hardware L 1st metatarsal head. The\npins were inserted 3 years ago for a bunion procedure. The Bunionprocedure\nis well healed and pt is now wanting the pin removed. Will probably need\nk-wire driver and power for this case.\nPreoperative Diagnosis:\nPAINFUL HARDWARE LEFT FIRST METATARSAL \nPostoperative Diagnosis:\nPAINFUL HARDWARE LEFT FIRST METATARSAL \nGross description:\nRECEIVED UNFIXED AND LABELED \"OLD HARDWARE LEFT FOOT X 2\" CONSISTS OF TWO\n1.7 CM AND 2.5 CM LONG 1 MM WIDE METALLIC PINS.\n|TAB||NOWRAP|\nDIAGNOSIS: HARDWARE (CLINICALLY FROM LEFT FOOT)"
       },
-      "subject": {
-        "reference": "Patient/ex-MHV-patient-1"
-      },
-      "effectiveDateTime": "1997-09-09T13:13:00-0400",
-      "issued": "1997-09-09T13:13:00-0400",
-      "performer": [
-        {
-          "reference": "Organization/ex-MHV-organization-989"
-        }
-      ],
-      "specimen": [
-        {
-          "reference": "#ex-MHV-specimen-7"
-        }
-      ],
-      "conclusion": "Date Spec taken: Sep 08, 1997        Pathologist:JAZBIEH MOEZZI MD\nDate Spec rec'd: Sep 08, 1997 13:08  Resident: \nDate  completed: Sep 09, 1997        Accession #: SP 97 2091\nSubmitted by: DEBRA K LATTA MD       Practitioner:DEBRA K LATTA\n-------------------------------------------------------------------------------\nSpecimen: \n(A) BONE FROM RIGHT FOOT\n(B) BONE RIGHT FOOT"
+      "search": {
+        "mode": "match"
+      }
     },
     {
-      "resourceType": "DiagnosticReport",
-      "id": "ex-MHV-labReport-8",
-      "meta": {
-        "profile": [
-          "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
-        ]
-      },
-      "text": {
-        "status": "generated",
-        "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 60567-5}\">LR SURGICAL PATHOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id:\u00a01013699147\u00a0(use:\u00a0OFFICIAL))</td></tr><tr><td>When For</td><td>1997-05-14 09:54:00+0000</td></tr><tr><td>Reported</td><td>1997-05-14 09:54:00+0000</td></tr><tr><td>Identifier:</td><td> id:\u00a0LabReportTO.SP;7029487\u00a0(use:\u00a0USUAL)</td></tr></table><p><b>Report Details</b></p><p>Date Spec taken: May 12, 1997        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: May 12, 1997 14:00  Resident: \nDate  completed: May 13, 1997        Accession #: SP 97 1099\nSubmitted by: DEBRA K LATTA MD       Practitioner:DEBRA K LATTA\n-------------------------------------------------------------------------------\nSpecimen: \nBONE FRAGMENTS, LEFT FOOT</p></div>"
-      },
-      "contained": [
-        {
-          "resourceType": "Specimen",
-          "id": "ex-MHV-specimen-8",
-          "meta": {
-            "profile": [
-              "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
-            ]
-          },
-          "identifier": [
-            {
-              "use": "usual"
-            }
-          ],
-          "accessionIdentifier": {
-            "use": "usual",
-            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-            "value": "SP 97 1099"
-          },
-          "status": "available",
-          "type": {
-            "text": "BONE FRAGMENTS, LEFT FOOT"
-          },
-          "collection": {
-            "collectedDateTime": "1997-05-12"
-          }
-        }
-      ],
-      "identifier": [
-        {
-          "use": "usual",
-          "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
-          "value": "LabReportTO.SP;7029487"
-        }
-      ],
-      "status": "final",
-      "category": [
-        {
-          "coding": [
-            {
-              "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
-              "code": "LAB"
-            }
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/DiagnosticReport/8109",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "ex-MHV-labReport-5",
+        "meta": {
+          "profile": [
+            "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
           ]
-        }
-      ],
-      "code": {
-        "coding": [
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 60567-5}\">LR SURGICAL PATHOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id: 1013699147 (use: OFFICIAL))</td></tr><tr><td>When For</td><td>1999-09-27 13:07:00+0000</td></tr><tr><td>Reported</td><td>1999-09-27 13:07:00+0000</td></tr><tr><td>Identifier:</td><td> id: LabReportTO.SP;7009075 (use: USUAL)</td></tr></table><p><b>Report Details</b></p><p>Date Spec taken: Sep 24, 1999        Pathologist:JAZBIEH MOEZZI MD\nDate Spec rec'd: Sep 24, 1999 13:46  Resident: \nDate  completed: Sep 27, 1999        Accession #: SP 99 2207\nSubmitted by: KHURSHID YOUSUF MD     Practitioner:KHURSHID YOUSUF\n-------------------------------------------------------------------------------\nSpecimen: \nPOLYPS (A) CECAL\n       (B) PROXIMAL ASCENDING\n       (C) RECTAL\nBrief Clinical History:\nCOLON POLYPS PER FLEX SIG\nPreoperative Diagnosis:\nCOLON POLYPS\nOperative Findings:\n|TAB||NOWRAP|\n1. CECAL POLYPS X 2\n2. ASCENDING COLON POLYP\n3. RECTAL POLYP\nPostoperative Diagnosis:\nSAME\nGross description:\n|TAB||NOWRAP|\nSPECIMEN (A) LABELED CECAL POLYP X 2.  RECEIVED IN FORMALIN IS ONE PALE\nGREY TISSUE FRAGMENT MEASURING 0.4 CM IN DIAMETER.  EMBEDDED ENTIRELY IN\nONE BLOCK.\nSPECIMEN (B) LABELED PROXIMAL ASCENDING COLON.  RECEIVED IN FORMALIN ARE\nTWO PALE BROWN TISSUE FRAGMENTS MEASURING 0.3 CM IN AGGREGATE.  EMBEDDED\nENTIRELY IN ONE BLOCK.\nSPECIMEN (C) LABELED RECTAL POLYP.  RECEIVED IN FORMALIN ARE THREE MINUTE\nTISSUE FRAGMENTS MEASURING 0.3 CM IN AGGREGATE.  EMBEDDED ENTIRELY\nIN ONE BLOCK.\nMicroscopic description: (Date Spec taken: Sep 24, 1999)\n|TAB||BLANK(3)|\n|TAB||NOWRAP|\nDIAGNOSIS:\nA) CECAL POLYP: HYPERPLASTIC POLYP.  (SEE NOTE)\nB &amp;amp; C)\nPROXIMAL ASCENDING COLON AND RECTAL POLYPS: TUBULAR ADENOMAS. (SEE\nNOTE)\n\nNOTE: COAGULATION ARTEFACT AND POOR TISSUE PRESERVATION IS NOTED CAUSING\nDIFFICULTY IN EVALUATION OF LESION.\nDR. YOUSUF WAS NOTIFIED.</p></div>"
+        },
+        "contained": [
           {
-            "system": "http://loinc.org",
-            "code": "60567-5"
+            "resourceType": "Specimen",
+            "id": "ex-MHV-specimen-5",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual"
+              }
+            ],
+            "accessionIdentifier": {
+              "use": "usual",
+              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+              "value": "SP 99 2207"
+            },
+            "status": "available",
+            "type": {
+              "text": "POLYPS (A) CECAL,        (B) PROXIMAL ASCENDING,        (C) RECTAL"
+            },
+            "collection": {
+              "collectedDateTime": "1999-09-24"
+            }
           }
         ],
-        "text": "LR SURGICAL PATHOLOGY REPORT"
+        "identifier": [
+          {
+            "use": "usual",
+            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+            "value": "LabReportTO.SP;7009075"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "60567-5"
+            }
+          ],
+          "text": "LR SURGICAL PATHOLOGY REPORT"
+        },
+        "subject": {
+          "reference": "Patient/ex-MHV-patient-1"
+        },
+        "effectiveDateTime": "1999-09-27T13:07:00-0400",
+        "issued": "1999-09-27T13:07:00-0400",
+        "performer": [
+          {
+            "reference": "Organization/ex-MHV-organization-989"
+          }
+        ],
+        "specimen": [
+          {
+            "reference": "#ex-MHV-specimen-5"
+          }
+        ],
+        "conclusion": "Date Spec taken: Sep 24, 1999        Pathologist:JAZBIEH MOEZZI MD\nDate Spec rec'd: Sep 24, 1999 13:46  Resident: \nDate  completed: Sep 27, 1999        Accession #: SP 99 2207\nSubmitted by: KHURSHID YOUSUF MD     Practitioner:KHURSHID YOUSUF\n-------------------------------------------------------------------------------\nSpecimen: \nPOLYPS (A) CECAL\n       (B) PROXIMAL ASCENDING\n       (C) RECTAL\nBrief Clinical History:\nCOLON POLYPS PER FLEX SIG\nPreoperative Diagnosis:\nCOLON POLYPS\nOperative Findings:\n|TAB||NOWRAP|\n1. CECAL POLYPS X 2\n2. ASCENDING COLON POLYP\n3. RECTAL POLYP\nPostoperative Diagnosis:\nSAME\nGross description:\n|TAB||NOWRAP|\nSPECIMEN (A) LABELED CECAL POLYP X 2.  RECEIVED IN FORMALIN IS ONE PALE\nGREY TISSUE FRAGMENT MEASURING 0.4 CM IN DIAMETER.  EMBEDDED ENTIRELY IN\nONE BLOCK.\nSPECIMEN (B) LABELED PROXIMAL ASCENDING COLON.  RECEIVED IN FORMALIN ARE\nTWO PALE BROWN TISSUE FRAGMENTS MEASURING 0.3 CM IN AGGREGATE.  EMBEDDED\nENTIRELY IN ONE BLOCK.\nSPECIMEN (C) LABELED RECTAL POLYP.  RECEIVED IN FORMALIN ARE THREE MINUTE\nTISSUE FRAGMENTS MEASURING 0.3 CM IN AGGREGATE.  EMBEDDED ENTIRELY\nIN ONE BLOCK.\nMicroscopic description: (Date Spec taken: Sep 24, 1999)\n|TAB||BLANK(3)|\n|TAB||NOWRAP|\nDIAGNOSIS:\nA) CECAL POLYP: HYPERPLASTIC POLYP.  (SEE NOTE)\nB &amp; C)\nPROXIMAL ASCENDING COLON AND RECTAL POLYPS: TUBULAR ADENOMAS. (SEE\nNOTE)\n\nNOTE: COAGULATION ARTEFACT AND POOR TISSUE PRESERVATION IS NOTED CAUSING\nDIFFICULTY IN EVALUATION OF LESION.\nDR. YOUSUF WAS NOTIFIED."
       },
-      "subject": {
-        "reference": "Patient/ex-MHV-patient-1"
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/DiagnosticReport/8109",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "ex-MHV-labReport-6",
+        "meta": {
+          "profile": [
+            "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 60567-5}\">LR SURGICAL PATHOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id: 1013699147 (use: OFFICIAL))</td></tr><tr><td>When For</td><td>1999-08-11 16:09:00+0000</td></tr><tr><td>Reported</td><td>1999-08-11 16:09:00+0000</td></tr><tr><td>Identifier:</td><td> id: LabReportTO.SP;7009190 (use: USUAL)</td></tr></table><p><b>Report Details</b></p><p>Date Spec taken: Aug 09, 1999        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: Aug 10, 1999 13:27  Resident: \nDate  completed: Aug 11, 1999        Accession #: SP 99 1804\nSubmitted by: KATHLEEN MARIE WOLNER  Practitioner:KATHLEEN MARIE WOLNER MD\n-------------------------------------------------------------------------------\nSpecimen: \nPOLYP @ 12CM\nBrief Clinical History:\n70 YEAR OLD MALE FOR SCREENING EXAM.  \nOperative Findings:\nSMOOTH BROAD BASED POLYP\nPostoperative Diagnosis:\nPROBABLE BENIGN POLYP\nGross description:\nRECEIVED IN FORMALIN AND LABELED &quot;POLYP&quot;  CONSISTS OF TWO 1 MM FRAGMENTS\nOF PINK TISSUE.  SUBMITTED IN TOTAL IN ONE BLOCK.\nMicroscopic description: (Date Spec taken: Aug 09, 1999)\n|TAB||BLANK(3)|\nDIAGNOSIS:\nPOLYP AT 12 CM. TUBULAR ADENOMA.</p></div>"
+        },
+        "contained": [
+          {
+            "resourceType": "Specimen",
+            "id": "ex-MHV-specimen-6",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual"
+              }
+            ],
+            "accessionIdentifier": {
+              "use": "usual",
+              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+              "value": "SP 99 1804"
+            },
+            "status": "available",
+            "type": {
+              "text": "POLYP @ 12CM"
+            },
+            "collection": {
+              "collectedDateTime": "1999-08-09"
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "use": "usual",
+            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+            "value": "LabReportTO.SP;7009190"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "60567-5"
+            }
+          ],
+          "text": "LR SURGICAL PATHOLOGY REPORT"
+        },
+        "subject": {
+          "reference": "Patient/ex-MHV-patient-1"
+        },
+        "effectiveDateTime": "1999-08-11T16:09:00-0400",
+        "issued": "1999-08-11T16:09:00-0400",
+        "performer": [
+          {
+            "reference": "Organization/ex-MHV-organization-989"
+          }
+        ],
+        "specimen": [
+          {
+            "reference": "#ex-MHV-specimen-6"
+          }
+        ],
+        "conclusion": "Date Spec taken: Aug 09, 1999        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: Aug 10, 1999 13:27  Resident: \nDate  completed: Aug 11, 1999        Accession #: SP 99 1804\nSubmitted by: KATHLEEN MARIE WOLNER  Practitioner:KATHLEEN MARIE WOLNER MD\n-------------------------------------------------------------------------------\nSpecimen: \nPOLYP @ 12CM\nBrief Clinical History:\n70 YEAR OLD MALE FOR SCREENING EXAM.  \nOperative Findings:\nSMOOTH BROAD BASED POLYP\nPostoperative Diagnosis:\nPROBABLE BENIGN POLYP\nGross description:\nRECEIVED IN FORMALIN AND LABELED \"POLYP\"  CONSISTS OF TWO 1 MM FRAGMENTS\nOF PINK TISSUE.  SUBMITTED IN TOTAL IN ONE BLOCK.\nMicroscopic description: (Date Spec taken: Aug 09, 1999)\n|TAB||BLANK(3)|\nDIAGNOSIS:\nPOLYP AT 12 CM. TUBULAR ADENOMA."
       },
-      "effectiveDateTime": "1997-05-14T09:54:00-0400",
-      "issued": "1997-05-14T09:54:00-0400",
-      "performer": [
-        {
-          "reference": "Organization/ex-MHV-organization-989"
-        }
-      ],
-      "specimen": [
-        {
-          "reference": "#ex-MHV-specimen-8"
-        }
-      ],
-      "conclusion": "Date Spec taken: May 12, 1997        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: May 12, 1997 14:00  Resident: \nDate  completed: May 13, 1997        Accession #: SP 97 1099\nSubmitted by: DEBRA K LATTA MD       Practitioner:DEBRA K LATTA\n-------------------------------------------------------------------------------\nSpecimen: \nBONE FRAGMENTS, LEFT FOOT"
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/DiagnosticReport/8109",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "ex-MHV-labReport-7",
+        "meta": {
+          "profile": [
+            "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 60567-5}\">LR SURGICAL PATHOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id: 1013699147 (use: OFFICIAL))</td></tr><tr><td>When For</td><td>1997-09-09 13:13:00+0000</td></tr><tr><td>Reported</td><td>1997-09-09 13:13:00+0000</td></tr><tr><td>Identifier:</td><td> id: LabReportTO.SP;7029091 (use: USUAL)</td></tr></table><p><b>Report Details</b></p><p>Date Spec taken: Sep 08, 1997        Pathologist:JAZBIEH MOEZZI MD\nDate Spec rec'd: Sep 08, 1997 13:08  Resident: \nDate  completed: Sep 09, 1997        Accession #: SP 97 2091\nSubmitted by: DEBRA K LATTA MD       Practitioner:DEBRA K LATTA\n-------------------------------------------------------------------------------\nSpecimen: \n(A) BONE FROM RIGHT FOOT\n(B) BONE RIGHT FOOT</p></div>"
+        },
+        "contained": [
+          {
+            "resourceType": "Specimen",
+            "id": "ex-MHV-specimen-7",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual"
+              }
+            ],
+            "accessionIdentifier": {
+              "use": "usual",
+              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+              "value": "SP 97 2091"
+            },
+            "status": "available",
+            "type": {
+              "text": "(A) BONE FROM RIGHT FOOT, (B) BONE RIGHT FOOT"
+            },
+            "collection": {
+              "collectedDateTime": "1997-09-08"
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "use": "usual",
+            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+            "value": "LabReportTO.SP;7029091"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "60567-5"
+            }
+          ],
+          "text": "LR SURGICAL PATHOLOGY REPORT"
+        },
+        "subject": {
+          "reference": "Patient/ex-MHV-patient-1"
+        },
+        "effectiveDateTime": "1997-09-09T13:13:00-0400",
+        "issued": "1997-09-09T13:13:00-0400",
+        "performer": [
+          {
+            "reference": "Organization/ex-MHV-organization-989"
+          }
+        ],
+        "specimen": [
+          {
+            "reference": "#ex-MHV-specimen-7"
+          }
+        ],
+        "conclusion": "Date Spec taken: Sep 08, 1997        Pathologist:JAZBIEH MOEZZI MD\nDate Spec rec'd: Sep 08, 1997 13:08  Resident: \nDate  completed: Sep 09, 1997        Accession #: SP 97 2091\nSubmitted by: DEBRA K LATTA MD       Practitioner:DEBRA K LATTA\n-------------------------------------------------------------------------------\nSpecimen: \n(A) BONE FROM RIGHT FOOT\n(B) BONE RIGHT FOOT"
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/DiagnosticReport/8109",
+      "resource": {
+        "resourceType": "DiagnosticReport",
+        "id": "ex-MHV-labReport-8",
+        "meta": {
+          "profile": [
+            "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.labReport"
+          ]
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h2><span title=\"Codes: {http://loinc.org 60567-5}\">LR SURGICAL PATHOLOGY REPORT</span> (<span title=\"Codes: {http://terminology.hl7.org/CodeSystem/v2-0074 LAB}\">Laboratory</span>) </h2><table class=\"grid\"><tr><td>Subject</td><td><b>MTPZEROTWO,DAYTSHR</b> male, DoB Unknown ( id: 1013699147 (use: OFFICIAL))</td></tr><tr><td>When For</td><td>1997-05-14 09:54:00+0000</td></tr><tr><td>Reported</td><td>1997-05-14 09:54:00+0000</td></tr><tr><td>Identifier:</td><td> id: LabReportTO.SP;7029487 (use: USUAL)</td></tr></table><p><b>Report Details</b></p><p>Date Spec taken: May 12, 1997        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: May 12, 1997 14:00  Resident: \nDate  completed: May 13, 1997        Accession #: SP 97 1099\nSubmitted by: DEBRA K LATTA MD       Practitioner:DEBRA K LATTA\n-------------------------------------------------------------------------------\nSpecimen: \nBONE FRAGMENTS, LEFT FOOT</p></div>"
+        },
+        "contained": [
+          {
+            "resourceType": "Specimen",
+            "id": "ex-MHV-specimen-8",
+            "meta": {
+              "profile": [
+                "https://johnmoehrke.github.io/MHV-PHR/StructureDefinition/VA.MHV.PHR.LabSpecimen"
+              ]
+            },
+            "identifier": [
+              {
+                "use": "usual"
+              }
+            ],
+            "accessionIdentifier": {
+              "use": "usual",
+              "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+              "value": "SP 97 1099"
+            },
+            "status": "available",
+            "type": {
+              "text": "BONE FRAGMENTS, LEFT FOOT"
+            },
+            "collection": {
+              "collectedDateTime": "1997-05-12"
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "use": "usual",
+            "system": "urn:oid:2.16.840.1.113883.4.349.4.989",
+            "value": "LabReportTO.SP;7029487"
+          }
+        ],
+        "status": "final",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/v2-0074",
+                "code": "LAB"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "http://loinc.org",
+              "code": "60567-5"
+            }
+          ],
+          "text": "LR SURGICAL PATHOLOGY REPORT"
+        },
+        "subject": {
+          "reference": "Patient/ex-MHV-patient-1"
+        },
+        "effectiveDateTime": "1997-05-14T09:54:00-0400",
+        "issued": "1997-05-14T09:54:00-0400",
+        "performer": [
+          {
+            "reference": "Organization/ex-MHV-organization-989"
+          }
+        ],
+        "specimen": [
+          {
+            "reference": "#ex-MHV-specimen-8"
+          }
+        ],
+        "conclusion": "Date Spec taken: May 12, 1997        Pathologist:SEETHA SURYAPRASAD MD\nDate Spec rec'd: May 12, 1997 14:00  Resident: \nDate  completed: May 13, 1997        Accession #: SP 97 1099\nSubmitted by: DEBRA K LATTA MD       Practitioner:DEBRA K LATTA\n-------------------------------------------------------------------------------\nSpecimen: \nBONE FRAGMENTS, LEFT FOOT"
+      },
+      "search": {
+        "mode": "match"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Minor fix to ensure that list and detail results are both handled properly, allowing the list to be displayed to the user.

## Related issue(s)

### [MHV-59238](https://jira.devops.va.gov/browse/MHV-59238) - Chem/hem data from backend not being displayed in frontend ###

> The backend is properly returning labs and tests DiagnosticReport objects to the frontend (as verified in Chrome network tab). However the frontend is displaying "There are no lab and test results in your VA medical records." Somewhere in the reducer or component there is a disconnect. It may be that we are not doing a proper check for what constitutes a chem/hem report.
> 
> Test User: ICN = 1014045870V412012


## Testing done

- Corrected the test data used by the e2e tests to match real data format

## Screenshots

<img width="300" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/02732836-36a4-44a3-9a84-e8635d18a3a1">

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user