### PR TITLE
MHV-55166 filter dates wrap

### DIFF
--- a/src/applications/mhv-secure-messaging/sass/search.scss
+++ b/src/applications/mhv-secure-messaging/sass/search.scss
@@ -83,6 +83,7 @@
     margin-right: -20px;
     margin-top: -40px;
     background-color: var(--color-gray-lightest);
+    flex-wrap: wrap;
   }
   .headline-text {
     margin-left: -20px;


### PR DESCRIPTION
## Summary
Makes the date select for filtering messages wrap on small screens

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-55166
> Start and end dates are wider than the container holding them (Mobile issue) See screen shots below
> 
> The user has a very slim area on the screen to interact with the year entry field. This causes the unintended action of being able to horizontally scroll inside of the filter component on the screen--Antonio/UCD
> 
> User Story: As a Secure Messaging User, I want to be able to view the entire container for start and end dates, so that I have access to all data.

> ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/108146636/cdff2b21-3954-42e5-a77c-92b72c8ddc55)


## Testing done
All tests passing locally

## Screenshots
![Screen Shot 2024-06-21 at 11 16 05 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/108146636/63a78f39-5cd2-4833-b7c3-796e3e43df09)

## What areas of the site does it impact?
mhv-secure-messaging

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
