### PR TITLE
[CST] - Updates for claim phase stepper on the overview tab

### DIFF
--- a/src/applications/claims-status/components/claim-overview-tab/ClaimPhaseStepper.jsx
+++ b/src/applications/claims-status/components/claim-overview-tab/ClaimPhaseStepper.jsx
@@ -150,6 +150,7 @@ export default function ClaimPhaseStepper({
       ),
     },
   ];
+
   const isCurrentPhase = phase => {
     return phase === currentPhase;
   };
@@ -159,13 +160,11 @@ export default function ClaimPhaseStepper({
   const isPhaseComplete = phase => {
     return phase < currentPhase || (isCurrentPhase(phase) && phase === 8)
   };
-
   const phaseCanRepeat = phase => {
     return [3, 4, 5, 6].includes(phase);
   };
 
   let headerIconAttributes = {};
-
   const showIcon = phase => {
     if (isCurrentPhaseAndNotFinalPhase(phase)) {
       // Set headerIcon object
@@ -202,11 +201,11 @@ export default function ClaimPhaseStepper({
           >
             {showIcon(claimPhase.phase) &&(
               <va-icon
-              icon={headerIconAttributes.icon}
-              class={headerIconAttributes.class}
-              srtext={headerIconAttributes.text}
-              slot="icon"
-            />
+                icon={headerIconAttributes.icon}
+                class={headerIconAttributes.class}
+                srtext={headerIconAttributes.text}
+                slot="icon"
+              />
             )}
             {isCurrentPhase(claimPhase.phase) && (
               <strong className="current-phase">

--- a/src/applications/claims-status/components/claim-overview-tab/ClaimPhaseStepper.jsx
+++ b/src/applications/claims-status/components/claim-overview-tab/ClaimPhaseStepper.jsx
@@ -153,46 +153,42 @@ export default function ClaimPhaseStepper({
   const isCurrentPhase = phase => {
     return phase === currentPhase;
   };
+  const isCurrentPhaseAndNotFinalPhase = phase => {
+    return isCurrentPhase(phase) && phase !== 8
+  };
+  const isPhaseComplete = phase => {
+    return phase < currentPhase || (isCurrentPhase(phase) && phase === 8)
+  };
 
   const phaseCanRepeat = phase => {
     return [3, 4, 5, 6].includes(phase);
   };
 
-  const headerIcon = phase => {
-    if (isCurrentPhase(phase) && phase !== 8) {
-      return 'flag';
+  let headerIconAttributes = {};
+
+  const showIcon = phase => {
+    if (isCurrentPhaseAndNotFinalPhase(phase)) {
+      // Set headerIcon object
+      headerIconAttributes = {
+        icon: 'flag',
+        text: 'Current',
+        class: 'phase-current'
+      };
+      return true;
     }
 
-    if (phase < currentPhase || (isCurrentPhase(phase) && phase === 8)) {
-      return 'check_circle';
+    if (isPhaseComplete(phase)) {
+      // Set headerIcon object
+      headerIconAttributes = {
+        icon: 'check_circle',
+        text: 'Completed',
+        class: 'phase-complete'
+      };
+      return true;
     }
 
-    return '';
-  };
-
-  const headerIconText = phase => {
-    if (isCurrentPhase(phase) && phase !== 8) {
-      return 'Current';
-    }
-
-    if (phase < currentPhase || (isCurrentPhase(phase) && phase === 8)) {
-      return 'Completed';
-    }
-
-    return '';
-  };
-
-  const headerIconColor = phase => {
-    if (isCurrentPhase(phase) && phase !== 8) {
-      return 'phase-current';
-    }
-
-    if (phase < currentPhase || (isCurrentPhase(phase) && phase === 8)) {
-      return 'phase-complete';
-    }
-
-    return '';
-  };
+    return false;
+  }
 
   return (
     <div className="claim-phase-stepper">
@@ -204,12 +200,14 @@ export default function ClaimPhaseStepper({
             id={`phase${claimPhase.phase}`}
             open={isCurrentPhase(claimPhase.phase)}
           >
-            <va-icon
-              icon={headerIcon(claimPhase.phase)}
-              class={headerIconColor(claimPhase.phase)}
-              srtext={headerIconText(claimPhase.phase)}
+            {showIcon(claimPhase.phase) &&(
+              <va-icon
+              icon={headerIconAttributes.icon}
+              class={headerIconAttributes.class}
+              srtext={headerIconAttributes.text}
               slot="icon"
             />
+            )}
             {isCurrentPhase(claimPhase.phase) && (
               <strong className="current-phase">
                 Your claim is in this step as of{' '}

--- a/src/applications/claims-status/components/claim-overview-tab/ClaimPhaseStepper.jsx
+++ b/src/applications/claims-status/components/claim-overview-tab/ClaimPhaseStepper.jsx
@@ -155,10 +155,10 @@ export default function ClaimPhaseStepper({
     return phase === currentPhase;
   };
   const isCurrentPhaseAndNotFinalPhase = phase => {
-    return isCurrentPhase(phase) && phase !== 8
+    return isCurrentPhase(phase) && phase !== 8;
   };
   const isPhaseComplete = phase => {
-    return phase < currentPhase || (isCurrentPhase(phase) && phase === 8)
+    return phase < currentPhase || (isCurrentPhase(phase) && phase === 8);
   };
   const phaseCanRepeat = phase => {
     return [3, 4, 5, 6].includes(phase);
@@ -171,7 +171,7 @@ export default function ClaimPhaseStepper({
       headerIconAttributes = {
         icon: 'flag',
         text: 'Current',
-        class: 'phase-current'
+        class: 'phase-current',
       };
       return true;
     }
@@ -181,13 +181,13 @@ export default function ClaimPhaseStepper({
       headerIconAttributes = {
         icon: 'check_circle',
         text: 'Completed',
-        class: 'phase-complete'
+        class: 'phase-complete',
       };
       return true;
     }
 
     return false;
-  }
+  };
 
   return (
     <div className="claim-phase-stepper">
@@ -199,7 +199,7 @@ export default function ClaimPhaseStepper({
             id={`phase${claimPhase.phase}`}
             open={isCurrentPhase(claimPhase.phase)}
           >
-            {showIcon(claimPhase.phase) &&(
+            {showIcon(claimPhase.phase) && (
               <va-icon
                 icon={headerIconAttributes.icon}
                 class={headerIconAttributes.class}

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -1251,6 +1251,7 @@ va-icon.phase-current {
   display: inline-block;
 }
 
+
 .repeat-phase {
   display: inline-flex;
   flex-direction: row;
@@ -1258,7 +1259,7 @@ va-icon.phase-current {
   va-icon {
     float: left;
     align-content: center;
-    margin-left: 8px;
+    margin-left: 16px;
   }
   span {
     display: inline-block;


### PR DESCRIPTION
## Summary

Updated `ClaimPhaseStepper.jsx` 
- Updated the logic of how the header icon attributes were being set so that it was cleaner and code wasnt being repeated
- Moved some of the logic into constants; to make the code easier to read
- Added logic to hide the va-icon for steps where it hasnt been complete and is not the current step
- Made the accordion headers with no icon attributes left align with the step headers that have icons - the va-icon should not be shown if the icon is nothing instead of it being hidden
-Updated the repeat phase div in step 3 so that the va-icon has 16px on the left instead of 8px 

Updated `src/applications/claims-status/sass/claims-status.scss`
-Updated the repeat phase div in step 3 so that the va-icon has 16px on the left instead of 8px 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#85479

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Step 3 - changed va-icon margin |  ![Screenshot 2024-06-21 at 12 22 04 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/69a5733b-f155-47ea-bba2-51a319da42c1)  |  ![Screenshot 2024-06-21 at 11 15 17 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/1b118613-7866-46d8-8631-4e1171f3427f)|
| step header icon is hidden and the header is aligned with above steps when step has not been completed and it is not the current step | ![Screenshot 2024-06-21 at 12 22 15 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/bd2114a4-2ceb-4f0f-be6f-2ee9a62f25b1) | ![Screenshot 2024-06-21 at 11 15 55 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/f71d2092-9c29-4d52-80ee-f6f48f77deee)|

## What areas of the site does it impact?

Claim Status Tool

## Acceptance criteria

- [x] Accordion headers are left-aligned regardless of whether they have an icon or not.
- [x] Repeat phase message container evenly spaced

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
