### PR TITLE
84311 Update regex and error message for other fields

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
@@ -10,7 +10,7 @@ import {
 import { NULL_CONDITION_STRING } from '../constants';
 
 /* ---------- content ----------*/
-export const conditionsPageTitle = 'Toxic Exposure';
+export const conditionsPageTitle = 'Toxic exposure';
 export const conditionsQuestion =
   'Are any of your new conditions related to toxic exposure during your military service? Check any that are related.';
 export const conditionsDescription = (
@@ -62,6 +62,9 @@ export const noneAndLocationError =
   'You selected a location, and you also selected “None of these locations.” You’ll need to uncheck one of these options to continue.';
 export const noneAndHazardError =
   'You selected a hazard, and you also selected “None of these.” You’ll need to uncheck one of these options to continue.';
+
+export const otherInvalidCharError =
+  'You entered an invalid character in the text field. This field only allows letters, numbers, hyphens, apostrophes, periods, commas, ampersands (& symbol), number signs (# symbol), and spaces.';
 
 export const dateRangeAdditionalInfo = (
   <va-additional-info trigger="What if I have more than one date range?">

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposures.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposures.js
@@ -8,6 +8,7 @@ import {
   additionalExposuresPageTitle,
   specifyOtherExposuresLabel,
   validateSelections,
+  otherInvalidCharError,
 } from '../../content/toxicExposure';
 import { formTitle } from '../../utils';
 import { ADDITIONAL_EXPOSURES } from '../../constants';
@@ -24,6 +25,9 @@ export const uiSchema = {
     specifyOtherExposures: {
       description: textareaUI({
         title: specifyOtherExposuresLabel,
+        errorMessages: {
+          pattern: otherInvalidCharError,
+        },
       }),
     },
   },
@@ -54,7 +58,7 @@ export const schema = {
           properties: {
             description: {
               type: 'string',
-              pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+              pattern: "^([-a-zA-Z0-9'.,&# ])+$",
               maxLength: 250,
             },
           },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideLocations.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideLocations.js
@@ -6,6 +6,7 @@ import {
 import {
   herbicidePageTitle,
   herbicideQuestion,
+  otherInvalidCharError,
   validateSelections,
 } from '../../content/toxicExposure';
 import { formTitle } from '../../utils';
@@ -22,6 +23,9 @@ export const uiSchema = {
     otherHerbicideLocations: {
       description: textareaUI({
         title: 'Other locations not listed here (250 characters maximum)',
+        errorMessages: {
+          pattern: otherInvalidCharError,
+        },
       }),
     },
   },
@@ -51,7 +55,7 @@ export const schema = {
           properties: {
             description: {
               type: 'string',
-              pattern: "^([-a-zA-Z0-9'.,&#]([-a-zA-Z0-9'.,&# ])?)+$",
+              pattern: "^([-a-zA-Z0-9'.,&# ])+$",
               maxLength: 250,
             },
           },

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/additionalExposures.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/additionalExposures.unit.spec.jsx
@@ -123,13 +123,20 @@ describe('Additional Exposures', () => {
 
   it('should display error when other exposures does not match pattern', () => {
     const formData = {};
+    const onSubmit = sinon.spy();
     const { container, getByText } = render(
-      <DefinitionTester schema={schema} uiSchema={uiSchema} data={formData} />,
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        data={formData}
+        onSubmit={onSubmit}
+      />,
     );
 
     inputVaTextInput(container, 'Test hazard?', 'va-textarea');
 
     userEvent.click(getByText('Submit'));
     expect($('va-textarea').error).to.equal(otherInvalidCharError);
+    expect(onSubmit.called).to.be.false;
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/additionalExposures.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/additionalExposures.unit.spec.jsx
@@ -8,12 +8,16 @@ import {
   $$,
 } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
-import { checkVaCheckbox } from '@department-of-veterans-affairs/platform-testing/helpers';
+import {
+  checkVaCheckbox,
+  inputVaTextInput,
+} from '@department-of-veterans-affairs/platform-testing/helpers';
 import formConfig from '../../../config/form';
 import {
   additionalExposuresPageTitle,
   additionalExposuresQuestion,
   noneAndHazardError,
+  otherInvalidCharError,
   specifyOtherExposuresLabel,
 } from '../../../content/toxicExposure';
 import { ADDITIONAL_EXPOSURES } from '../../../constants';
@@ -115,5 +119,17 @@ describe('Additional Exposures', () => {
 
     await userEvent.click(getByText('Submit'));
     expect($('va-checkbox-group').error).to.equal(noneAndHazardError);
+  });
+
+  it('should display error when other exposures does not match pattern', () => {
+    const formData = {};
+    const { container, getByText } = render(
+      <DefinitionTester schema={schema} uiSchema={uiSchema} data={formData} />,
+    );
+
+    inputVaTextInput(container, 'Test hazard?', 'va-textarea');
+
+    userEvent.click(getByText('Submit'));
+    expect($('va-textarea').error).to.equal(otherInvalidCharError);
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideLocations.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideLocations.unit.spec.jsx
@@ -115,14 +115,8 @@ describe('Herbicide Location', () => {
 
   it('should display error when other location and "none"', () => {
     const formData = {};
-    const onSubmit = sinon.spy();
     const { container, getByText } = render(
-      <DefinitionTester
-        schema={schema}
-        uiSchema={uiSchema}
-        data={formData}
-        onSubmit={onSubmit}
-      />,
+      <DefinitionTester schema={schema} uiSchema={uiSchema} data={formData} />,
     );
     const checkboxGroup = $('va-checkbox-group', container);
 
@@ -135,13 +129,18 @@ describe('Herbicide Location', () => {
 
     userEvent.click(getByText('Submit'));
     expect($('va-checkbox-group').error).to.equal(noneAndLocationError);
-    expect(onSubmit.called).to.be.false;
   });
 
   it('should display error when other location does not match pattern', () => {
     const formData = {};
+    const onSubmit = sinon.spy();
     const { container, getByText } = render(
-      <DefinitionTester schema={schema} uiSchema={uiSchema} data={formData} />,
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        data={formData}
+        onSubmit={onSubmit}
+      />,
     );
 
     inputVaTextInput(
@@ -152,6 +151,7 @@ describe('Herbicide Location', () => {
 
     userEvent.click(getByText('Submit'));
     expect($('va-textarea').error).to.equal(otherInvalidCharError);
+    expect(onSubmit.called).to.be.false;
   });
 
   it('should submit with "notsure" and other locations selected', async () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideLocations.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideLocations.unit.spec.jsx
@@ -115,8 +115,14 @@ describe('Herbicide Location', () => {
 
   it('should display error when other location and "none"', () => {
     const formData = {};
+    const onSubmit = sinon.spy();
     const { container, getByText } = render(
-      <DefinitionTester schema={schema} uiSchema={uiSchema} data={formData} />,
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        data={formData}
+        onSubmit={onSubmit}
+      />,
     );
     const checkboxGroup = $('va-checkbox-group', container);
 
@@ -129,6 +135,7 @@ describe('Herbicide Location', () => {
 
     userEvent.click(getByText('Submit'));
     expect($('va-checkbox-group').error).to.equal(noneAndLocationError);
+    expect(onSubmit.called).to.be.false;
   });
 
   it('should display error when other location does not match pattern', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideLocations.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideLocations.unit.spec.jsx
@@ -17,6 +17,7 @@ import {
   herbicidePageTitle,
   herbicideQuestion,
   noneAndLocationError,
+  otherInvalidCharError,
 } from '../../../content/toxicExposure';
 import { HERBICIDE_LOCATIONS } from '../../../constants';
 
@@ -143,7 +144,7 @@ describe('Herbicide Location', () => {
     );
 
     userEvent.click(getByText('Submit'));
-    expect($('va-textarea').error.startsWith('does not match pattern'));
+    expect($('va-textarea').error).to.equal(otherInvalidCharError);
   });
 
   it('should submit with "notsure" and other locations selected', async () => {


### PR DESCRIPTION
## Summary

- Change toxic-exposure conditions page title to have sentence case (i.e. 'Toxic exposure' instead of 'Toxic Exposure')
- Update pattern (regular expression) used for validating the `otherHerbicideLocations` and `specifyOtherExposures` fields
- Update error messages for when invalid character

team: @department-of-veterans-affairs/dbex-trex 
toggle cleanup: department-of-veterans-affairs/va.gov-team#65089

## Related issue(s)
department-of-veterans-affairs/va.gov-team#84311

## Testing done
- Unit Tests updated

**Manual test setup**
1. Enable toggle `disability_526_toxic_exposure`
2. Start a new claim with new conditions
3. **Verify**: On the `toxic-exposure/conditions` page, make sure title has been updated. Select at least one new condition
4. Continue until you get to the `herbicides` page
5. Enter a string in the 'Other locations not listed here' with invalid characters, e.g contains + symbol
6. **Verify**: Make sure the new error message appears `You entered an invalid character in the text field. This field only allows letters, numbers, hyphens, apostrophes, periods, commas, ampersands (& symbol), number signs (# symbol), and spaces.`
7. Remove the invalid character and continue until you get to the `additional-exposures` page
8. Enter a string in the 'Other toxic exposures not listed here' with invalid characters, e.g. contains ? symbol
9. **Verify**: Make sure the same error message appears

## Screenshots
<img width="1242" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/683ea95a-a4ec-419d-8098-a472aa2e8926">

<img width="1169" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/ffeee36b-9333-4ac4-a2ca-1cc27fd4130b">

<img width="1125" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/127446042/e060b689-3ba2-4863-9262-ab07689d4eb2">


## What areas of the site does it impact?
526ez

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] ~Documentation has been updated ([link to documentation](#) \*if necessary)~ Will be updated with #67022
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] ~Events are being sent to the appropriate logging solution~
- [ ] ~Feature/bug has a monitor built into Datadog or Grafana (if applicable)~

### Authentication

- [ ] ~Did you login to a local build and verify all authenticated routes work as expected with a test user~

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] ~The vets-website header does not contain any web-components~
- [ ] ~I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario~
- [ ] ~I reached out in the `#sitewide-public-websites` Slack channel for questions~

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
