### PR TITLE
VFEP-1502 Form 22-1990 Remove benefits to relinquish under Benefits eligibility - Front-end

### DIFF
--- a/src/applications/edu-benefits/1990/config/form.js
+++ b/src/applications/edu-benefits/1990/config/form.js
@@ -47,6 +47,7 @@ import {
   SeventeenOrOlder,
   eighteenOrOver,
   ageWarning,
+  isShowBenefitsRelinquished,
 } from '../helpers';
 
 import { urlMigration } from '../../config/migrations';
@@ -78,6 +79,198 @@ const {
   address,
   usaPhone,
 } = fullSchema1990.definitions;
+
+const viewSelectedBenefitsSchema = () => {
+  if (isShowBenefitsRelinquished()) {
+    return {
+      type: 'object',
+      required: ['view:selectedBenefits'],
+      properties: {
+        'view:selectedBenefits': {
+          type: 'object',
+          properties: {
+            chapter33,
+            'view:chapter33ExpandedContent': {
+              type: 'object',
+              properties: {},
+            },
+            chapter30,
+            chapter1606,
+          },
+        },
+      },
+    };
+  }
+  return {
+    type: 'object',
+    required: [],
+    properties: {
+      'view:selectedBenefits': {
+        type: 'object',
+        properties: {
+          chapter33,
+          chapter30,
+          chapter1606,
+        },
+      },
+    },
+  };
+};
+/*
+const contributionsUiSchema = () => {
+  if (isShowBenefitsRelinquished()) {
+    return {
+      'ui:title': 'Contributions',
+      'ui:description': 'Select all that apply:',
+      additionalContributions: {
+        'ui:title':
+          'I made contributions (up to $600) to increase the amount of my monthly benefits.',
+      },
+      activeDutyKicker: {
+        'ui:title':
+          'I qualify for an Active Duty Kicker (sometimes called a college fund).',
+      },
+      reserveKicker: {
+        'ui:title':
+          'I qualify for a Reserve Kicker (sometimes called a college fund).',
+      },
+      'view:reserveKickerWarning': {
+        'ui:description': reserveKickerWarning,
+        'ui:options': {
+          expandUnder: 'reserveKicker',
+          hideIf: data =>
+            get(
+              'view:benefitsRelinquishedContainer.benefitsRelinquished',
+              data,
+            ) !== 'chapter30',
+        },
+      },
+      'view:activeDutyRepayingPeriod': {
+        'ui:title':
+          'I have a period of service that the Department of Defense counts toward an education loan payment.',
+        'ui:options': {
+          expandUnderClassNames: 'schemaform-expandUnder-indent',
+        },
+      },
+      activeDutyRepayingPeriod: merge(
+        {},
+        {
+          'ui:options': {
+            expandUnder: 'view:activeDutyRepayingPeriod',
+          },
+          to: {
+            'ui:required': formData =>
+              formData['view:activeDutyRepayingPeriod'],
+          },
+          from: {
+            'ui:required': formData =>
+              formData['view:activeDutyRepayingPeriod'],
+          },
+        },
+        dateRangeUI('Start date', 'End date'),
+      ),
+    };
+  }
+  return {
+    'ui:title': 'Contributions',
+    'ui:description': 'Select all that apply:',
+    additionalContributions: {
+      'ui:title':
+        'I made contributions (up to $600) to increase the amount of my monthly benefits.',
+    },
+    activeDutyKicker: {
+      'ui:title':
+        'I qualify for an Active Duty Kicker (sometimes called a college fund).',
+    },
+    reserveKicker: {
+      'ui:title':
+        'I qualify for a Reserve Kicker (sometimes called a college fund).',
+    },
+    'view:activeDutyRepayingPeriod': {
+      'ui:title':
+        'I have a period of service that the Department of Defense counts toward an education loan payment.',
+      'ui:options': {
+        expandUnderClassNames: 'schemaform-expandUnder-indent',
+      },
+    },
+    activeDutyRepayingPeriod: merge(
+      {},
+      {
+        'ui:options': {
+          expandUnder: 'view:activeDutyRepayingPeriod',
+        },
+        to: {
+          'ui:required': formData => formData['view:activeDutyRepayingPeriod'],
+        },
+        from: {
+          'ui:required': formData => formData['view:activeDutyRepayingPeriod'],
+        },
+      },
+      dateRangeUI('Start date', 'End date'),
+    ),
+  };
+};
+*/
+const viewSelectedBenefitsUiSchema = () => {
+  if (isShowBenefitsRelinquished()) {
+    return {
+      'ui:description': benefitsEligibilityBox,
+      'view:selectedBenefits': {
+        'ui:title': 'Select the benefit that is the best match for you.',
+        'ui:validations': [validateBooleanGroup],
+        'ui:errorMessages': {
+          atLeastOne: 'Please select at least one benefit',
+        },
+        'ui:options': {
+          showFieldLabel: true,
+        },
+        chapter33: {
+          'ui:title': benefitsLabels.chapter33,
+          'ui:options': {
+            expandUnderClassNames: 'schemaform-expandUnder-indent',
+          },
+        },
+        'view:chapter33ExpandedContent': {
+          'ui:description': benefitsLabels.chapter33Description,
+          'ui:options': {
+            expandUnder: 'chapter33',
+          },
+        },
+        chapter30: {
+          'ui:title': benefitsLabels.chapter30,
+        },
+        chapter1606: {
+          'ui:title': benefitsLabels.chapter1606,
+        },
+      },
+    };
+  }
+  return {
+    'ui:description': benefitsEligibilityBox,
+    'view:selectedBenefits': {
+      'ui:title': 'Select the benefit that is the best match for you.',
+      'ui:validations': [validateBooleanGroup],
+      'ui:errorMessages': {
+        atLeastOne: 'Please select at least one benefit',
+      },
+      'ui:options': {
+        showFieldLabel: true,
+      },
+      chapter33: {
+        'ui:title': benefitsLabels.chapter33,
+        'ui:options': {
+          expandUnderClassNames: 'schemaform-expandUnder-indent',
+        },
+      },
+      chapter30: {
+        'ui:title': benefitsLabels.chapter30,
+      },
+      chapter1606: {
+        'ui:title': benefitsLabels.chapter1606,
+      },
+    },
+  };
+};
 
 const formConfig = {
   rootUrl: manifest.rootUrl,
@@ -275,55 +468,8 @@ const formConfig = {
         benefitsEligibility: {
           title: 'Benefits eligibility',
           path: 'benefits-eligibility/benefits-selection',
-          uiSchema: {
-            'ui:description': benefitsEligibilityBox,
-            'view:selectedBenefits': {
-              'ui:title': 'Select the benefit that is the best match for you.',
-              'ui:validations': [validateBooleanGroup],
-              'ui:errorMessages': {
-                atLeastOne: 'Please select at least one benefit',
-              },
-              'ui:options': {
-                showFieldLabel: true,
-              },
-              chapter33: {
-                'ui:title': benefitsLabels.chapter33,
-                'ui:options': {
-                  expandUnderClassNames: 'schemaform-expandUnder-indent',
-                },
-              },
-              'view:chapter33ExpandedContent': {
-                'ui:description': benefitsLabels.chapter33Description,
-                'ui:options': {
-                  expandUnder: 'chapter33',
-                },
-              },
-              chapter30: {
-                'ui:title': benefitsLabels.chapter30,
-              },
-              chapter1606: {
-                'ui:title': benefitsLabels.chapter1606,
-              },
-            },
-          },
-          schema: {
-            type: 'object',
-            required: ['view:selectedBenefits'],
-            properties: {
-              'view:selectedBenefits': {
-                type: 'object',
-                properties: {
-                  chapter33,
-                  'view:chapter33ExpandedContent': {
-                    type: 'object',
-                    properties: {},
-                  },
-                  chapter30,
-                  chapter1606,
-                },
-              },
-            },
-          },
+          uiSchema: viewSelectedBenefitsUiSchema(),
+          schema: viewSelectedBenefitsSchema(),
         },
         benefitsRelinquishment: {
           title: 'Benefits relinquishment',

--- a/src/applications/edu-benefits/1990/config/form.js
+++ b/src/applications/edu-benefits/1990/config/form.js
@@ -116,7 +116,7 @@ const viewSelectedBenefitsSchema = () => {
     },
   };
 };
-/*
+
 const contributionsUiSchema = () => {
   if (isShowBenefitsRelinquished()) {
     return {
@@ -210,7 +210,7 @@ const contributionsUiSchema = () => {
     ),
   };
 };
-*/
+
 const viewSelectedBenefitsUiSchema = () => {
   if (isShowBenefitsRelinquished()) {
     return {
@@ -474,7 +474,9 @@ const formConfig = {
         benefitsRelinquishment: {
           title: 'Benefits relinquishment',
           path: 'benefits-eligibility/benefits-relinquishment',
-          depends: formData => formData['view:selectedBenefits'].chapter33,
+          depends: formData =>
+            formData['view:selectedBenefits'].chapter33 &&
+            isShowBenefitsRelinquished(),
           initialData: {
             'view:benefitsRelinquishedContainer': {
               benefitsRelinquishedDate: moment().format('YYYY-MM-DD'),
@@ -630,57 +632,7 @@ const formConfig = {
         contributions: {
           title: 'Contributions',
           path: 'military-history/contributions',
-          uiSchema: {
-            'ui:title': 'Contributions',
-            'ui:description': 'Select all that apply:',
-            additionalContributions: {
-              'ui:title':
-                'I made contributions (up to $600) to increase the amount of my monthly benefits.',
-            },
-            activeDutyKicker: {
-              'ui:title':
-                'I qualify for an Active Duty Kicker (sometimes called a college fund).',
-            },
-            reserveKicker: {
-              'ui:title':
-                'I qualify for a Reserve Kicker (sometimes called a college fund).',
-            },
-            'view:reserveKickerWarning': {
-              'ui:description': reserveKickerWarning,
-              'ui:options': {
-                expandUnder: 'reserveKicker',
-                hideIf: data =>
-                  get(
-                    'view:benefitsRelinquishedContainer.benefitsRelinquished',
-                    data,
-                  ) !== 'chapter30',
-              },
-            },
-            'view:activeDutyRepayingPeriod': {
-              'ui:title':
-                'I have a period of service that the Department of Defense counts toward an education loan payment.',
-              'ui:options': {
-                expandUnderClassNames: 'schemaform-expandUnder-indent',
-              },
-            },
-            activeDutyRepayingPeriod: merge(
-              {},
-              {
-                'ui:options': {
-                  expandUnder: 'view:activeDutyRepayingPeriod',
-                },
-                to: {
-                  'ui:required': formData =>
-                    formData['view:activeDutyRepayingPeriod'],
-                },
-                from: {
-                  'ui:required': formData =>
-                    formData['view:activeDutyRepayingPeriod'],
-                },
-              },
-              dateRangeUI('Start date', 'End date'),
-            ),
-          },
+          uiSchema: contributionsUiSchema(),
           schema: {
             type: 'object',
             properties: {

--- a/src/applications/edu-benefits/1990/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/1990/containers/ConfirmationPage.jsx
@@ -5,7 +5,10 @@ import { connect } from 'react-redux';
 import { focusElement } from 'platform/utilities/ui';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { getListOfBenefits } from '../../utils/helpers';
-import { benefitsRelinquishmentLabels } from '../helpers';
+import {
+  benefitsRelinquishmentLabels,
+  isShowBenefitsRelinquished,
+} from '../helpers';
 import { ConfirmationPageContent } from '../../components/ConfirmationPageContent';
 
 class ConfirmationPage extends React.Component {
@@ -28,7 +31,7 @@ class ConfirmationPage extends React.Component {
   }
 
   render() {
-    const form = this.props.form;
+    const { form } = this.props;
     const { submission, formId } = form;
     const benefits = form.data['view:selectedBenefits'];
     const benefitsRelinquished = get(
@@ -39,20 +42,19 @@ class ConfirmationPage extends React.Component {
     return (
       <ConfirmationPageContent
         claimInfoListItems={[
-          <li key={'benefit'}>
+          <li key="benefit">
             <strong>Benefit claimed</strong>
             <br />
             {this.makeList(getListOfBenefits(benefits))}
-            {benefits.chapter33 && (
-              <div className="claim-relinquished">
-                <span>
-                  <i>Relinquished:</i>
-                </span>
-                {this.makeList([
-                  benefitsRelinquishmentLabels[benefitsRelinquished],
-                ])}
-              </div>
-            )}
+            {isShowBenefitsRelinquished() &&
+              benefits.chapter33 && (
+                <div className="claim-relinquished">
+                  <span>Relinquished:</span>
+                  {this.makeList([
+                    benefitsRelinquishmentLabels[benefitsRelinquished],
+                  ])}
+                </div>
+              )}
           </li>,
         ]}
         docExplanationHeader="No documents required at this time"

--- a/src/applications/edu-benefits/1990/helpers.jsx
+++ b/src/applications/edu-benefits/1990/helpers.jsx
@@ -2,6 +2,27 @@ import React from 'react';
 import _ from 'lodash';
 import moment from 'moment';
 import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
+import environment from 'platform/utilities/environment';
+
+export const isReviewInstance = () => {
+  const { hostname } = window.location;
+  const globalRegex = new RegExp('review.vetsgov-internal', 'g');
+  return globalRegex.test(hostname);
+};
+
+export const isShowBenefitsRelinquished = (automatedTest = false) => {
+  const isTest = global && global?.window && global?.window?.buildType;
+  if (isTest || automatedTest) {
+    return false;
+  }
+  return (
+    // environment.isProduction() || // Comment out to send to production
+    environment.isStaging() ||
+    environment.isDev() ||
+    isReviewInstance() /* ||
+    environment.isLocalhost() */
+  );
+};
 
 export function prefillTransformer(pages, formData, metadata) {
   const newFormData = {
@@ -121,7 +142,10 @@ export const ageWarning = (
     aria-live="polite"
   >
     <div className="vads-u-flex--1 vads-u-margin-top--2p5 vads-u-margin-x--2 ">
-      <i className="fas fa-info-circle" />
+      <va-icon
+        size={4}
+        icon="see name mappings here https://design.va.gov/foundation/icons"
+      />
     </div>
     <div className="vads-u-flex--5">
       <p className="vads-u-font-size--base">

--- a/src/applications/edu-benefits/1990/helpers.jsx
+++ b/src/applications/edu-benefits/1990/helpers.jsx
@@ -17,9 +17,9 @@ export const isShowBenefitsRelinquished = (automatedTest = false) => {
   }
   return (
     // environment.isProduction() || // Comment out to send to production
-    environment.isStaging() ||
     environment.isDev() ||
     isReviewInstance() /* ||
+    environment.isStaging() ||
     environment.isLocalhost() */
   );
 };

--- a/src/applications/edu-benefits/1990/tests/config/contributions.unit.spec.jsx
+++ b/src/applications/edu-benefits/1990/tests/config/contributions.unit.spec.jsx
@@ -6,7 +6,6 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-  submitForm,
 } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
@@ -30,43 +29,7 @@ describe('Edu 1990 contributions', () => {
 
     expect(formDOM.querySelectorAll('input').length).to.equal(4);
   });
-  it('should have no required inputs', () => {
-    const onSubmit = sinon.spy();
-    const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester
-        schema={schema}
-        onSubmit={onSubmit}
-        data={{}}
-        uiSchema={uiSchema}
-        definitions={definitions}
-      />,
-    );
-    const formDOM = getFormDOM(form);
-    submitForm(form);
 
-    expect(formDOM.querySelectorAll('.usa-input-error')).to.be.empty;
-    expect(onSubmit.called).to.be.true;
-  });
-  it('should reveal warning', () => {
-    const onSubmit = sinon.spy();
-    const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester
-        schema={schema}
-        onSubmit={onSubmit}
-        data={{
-          'view:benefitsRelinquishedContainer': {
-            benefitsRelinquished: 'chapter30',
-          },
-        }}
-        uiSchema={uiSchema}
-        definitions={definitions}
-      />,
-    );
-    const formDOM = getFormDOM(form);
-    formDOM.setCheckbox('#root_reserveKicker', true);
-
-    expect(formDOM.querySelectorAll('.usa-alert-warning').length).to.equal(1);
-  });
   it('should reveal date fields', () => {
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(

--- a/src/applications/edu-benefits/1990/tests/e2e/fixtures/data/minimal.json
+++ b/src/applications/edu-benefits/1990/tests/e2e/fixtures/data/minimal.json
@@ -23,10 +23,6 @@
       "applyPeriodToSelected": true
     }
   ],
-  "view:benefitsRelinquishedContainer": {
-    "benefitsRelinquished": "unknown",
-    "benefitsRelinquishedDate": "2020-09-01"
-  },
   "view:questionText": {},
   "view:selectedBenefits": {
     "chapter33": true,


### PR DESCRIPTION
## Summary

- VFEP-1502 Form 22-1990 Remove benefits to relinquish under Benefits eligibility - Front-end


## Related issue(s)

22-1990 Remove benefits to relinquish under Benefits eligibility - Front-end

As a...
VFEP Business User
I want...
to view my benefit choices
So that...
I can select the benefit I would like to use
 
Acceptance Criteria:
•	The 22-1990 has a question in the Benefit eligibility section "Select the benefit that is the best match for you."  If the user selects Post-9/11 GI Bill (Chapter 33), the following text is displayed and should be removed: "When you choose to apply for your Post-9/11 benefit, you have to relinquish (give up) 1 other benefit you may be eligible for. You’ll make this decision on the next page." ( Done )

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/95312667/803c7a4e-bdb6-4fc5-b174-8509f7ce9fae)

•	The 22-1990 has a question in the Benefit eligibility section "Select the benefit that is the best match for you."  If the user selects Post-9/11 GI Bill (Chapter 33),  the following page is presented to the user and should be removed:


![image](https://github.com/department-of-veterans-affairs/vets-website/assets/95312667/90caafe5-f8f8-47a6-9a81-6e79ebda5353)




