### PR TITLE
fix drafts page default sort order

### DIFF
--- a/src/applications/mhv-secure-messaging/containers/FolderThreadListView.jsx
+++ b/src/applications/mhv-secure-messaging/containers/FolderThreadListView.jsx
@@ -113,13 +113,23 @@ const FolderThreadListView = props => {
           updatePageTitle(`${folder.name} ${PageTitles.PAGE_TITLE_TAG}`);
         }
         if (folder.folderId !== threadSort?.folderId) {
-          dispatch(
-            setThreadSortOrder(
-              threadSortingOptions.SENT_DATE_DESCENDING.value,
-              folder.folderId,
-              1,
-            ),
-          );
+          if (location.pathname === Paths.DRAFTS) {
+            dispatch(
+              setThreadSortOrder(
+                threadSortingOptions.DRAFT_DATE_DESCENDING.value,
+                folder.folderId,
+                1,
+              ),
+            );
+          } else {
+            dispatch(
+              setThreadSortOrder(
+                threadSortingOptions.SENT_DATE_DESCENDING.value,
+                folder.folderId,
+                1,
+              ),
+            );
+          }
           // updates page title
         } else {
           dispatch(


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- Fixes a bug where the default sort option for the drafts page showed as "-Select-" when it should be "Newest to oldest".

## Related issue(s)

### [MHV-57395](https://jira.devops.va.gov/browse/MHV-57395) 0 Draft Sorting is not selected from Newest to oldest by default. ###

> Under draft the sort feature should be Newest to oldest by default.
> 
> Step to reproduce
> 
> 1) Login to va.gov SM
> 
> 2) Navigate to Drafts
> 
> 3) Sort  drop down is not selected by default from Newest to oldest (Issue)
> 
>  
> 
> Resolution- Sort is selected from Newest to oldest by default
> 
>  
> 
> User Story:  As a SM user, I want to    so that I can
> 
>  
> 
> GIVEN:
> 
> WHEN:
> 
> THEN:
> 
>  
> 
> Feature Flag Y/N ?
> 
> DataDog Analytics  Y/N ?
> 
> Manual Testing Y/N ? Y-Rakesh
> 
> Automated Testing Y/N ?
> 
> Accessibility Testing Y/N ?
> 
> UCD Validation Y/N
> 
> 
> Acceptance Criteria:
> 
> AC1 Sort is selected from Newest to oldest by default in Drafts - sort
> 
> AC2

## Testing done

- tested locally

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |<img width="775" alt="Screenshot 2024-06-21 at 1 46 59 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/79024398/b2426daf-3cf5-4569-a32a-aafa67e6fac5">|<img width="775" alt="Screenshot 2024-06-21 at 1 45 10 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/79024398/b89152e0-1dea-4965-b9ca-e6ebe7b4b9c6">|

## What areas of the site does it impact?

Va.gov - Secure Messaging

## Acceptance criteria

- Sort is selected from Newest to oldest by default in Drafts - sort

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
