### PR TITLE
remove TZ stripping for BTSSS submission

### DIFF
--- a/src/applications/check-in/hooks/tests/useTravelPayFlags/useTravelPayFlags.unit.spec.jsx
+++ b/src/applications/check-in/hooks/tests/useTravelPayFlags/useTravelPayFlags.unit.spec.jsx
@@ -102,7 +102,7 @@ describe('check-in', () => {
         expect(component.getByTestId('travelPayVehicle')).to.have.text('yes');
         expect(component.getByTestId('travelPayEligible')).to.have.text('yes');
         expect(component.getByTestId('travelPayData')).to.have.text(
-          '2022-08-12T15:15:00Z',
+          '2022-08-12T15:15:00',
         );
       });
     });
@@ -142,7 +142,7 @@ describe('check-in', () => {
           </Provider>,
         );
         expect(component.getByTestId('travelPayData')).to.contain.text(
-          '2022-08-12T15:15:00Z',
+          '2022-08-12T15:15:00',
         );
       });
     });

--- a/src/applications/check-in/hooks/useTravelPayFlags.jsx
+++ b/src/applications/check-in/hooks/useTravelPayFlags.jsx
@@ -2,7 +2,6 @@ import { useState, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { formatISO } from 'date-fns';
 import { makeSelectCurrentContext, makeSelectForm } from '../selectors';
-import { removeTimezoneOffset } from '../utils/formatters';
 
 const useTravelPayFlags = appointment => {
   const [travelPayClaimSent, setTravelPayClaimSent] = useState();
@@ -21,9 +20,7 @@ const useTravelPayFlags = appointment => {
     'travel-review': travelReview,
   } = data;
 
-  const startDate = removeTimezoneOffset(
-    formatISO(new Date(appointment.startTime)),
-  );
+  const startDate = formatISO(new Date(appointment.startTime));
 
   let travelPayData = {
     uuid: token,

--- a/src/applications/check-in/hooks/useTravelPayFlags.jsx
+++ b/src/applications/check-in/hooks/useTravelPayFlags.jsx
@@ -1,6 +1,5 @@
 import { useState, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import { formatISO } from 'date-fns';
 import { makeSelectCurrentContext, makeSelectForm } from '../selectors';
 
 const useTravelPayFlags = appointment => {
@@ -20,7 +19,7 @@ const useTravelPayFlags = appointment => {
     'travel-review': travelReview,
   } = data;
 
-  const startDate = formatISO(new Date(appointment.startTime));
+  const startDate = appointment.startTime;
 
   let travelPayData = {
     uuid: token,


### PR DESCRIPTION
## Summary
We are currently sending the start time back to BTSSS incorrectly as UTC. This PR changes the post back to travel to send exactly what we get from vista-api/vetext. 

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#85389

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_


## What areas of the site does it impact?

Day-of check-in travel claim

## Acceptance criteria
 - [ ] BTSSS post submission should have the same value that we get from lorota
 
### Quality Assurance & Testing

- [ ] visual

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
