### PR TITLE
Small copy changes

### DIFF
--- a/src/applications/ivc-champva/10-10D/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/IntroductionPage.jsx
@@ -1,7 +1,5 @@
 import React, { useEffect } from 'react';
-import { Link } from 'react-router';
 import { connect } from 'react-redux';
-import recordEvent from 'platform/monitoring/record-event';
 import { focusElement } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import FormTitle from '@department-of-veterans-affairs/platform-forms-system/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro'; // '@' import not working
@@ -11,10 +9,6 @@ import PropTypes from 'prop-types';
 const IntroductionPage = props => {
   const { route, isLoggedIn } = props;
   const { formConfig, pageList } = route;
-
-  const handleClick = () => {
-    recordEvent({ event: 'no-login-start-form' });
-  };
 
   useEffect(
     () => {
@@ -98,41 +92,14 @@ const IntroductionPage = props => {
         </va-process-list-item>
       </va-process-list>
 
-      {!isLoggedIn ? (
-        <VaAlert status="info" visible uswds>
-          <h2>Sign in now to save time and save your work in progress</h2>
-          <p>Here’s how signing in now helps you:</p>
-          <ul>
-            <li>
-              We can fill in some of your information for you to save you time.
-            </li>
-            <li>
-              You can save your work in progress. You’ll have 60 days from when
-              you start or make updates to your application to come back and
-              finish it.
-            </li>
-          </ul>
-          <p>
-            <strong>Note:</strong> You can sign in after you start your
-            application. But you’ll lose any information you already filled in.
-          </p>
-          <p className="vads-u-margin-top--2">
-            <Link onClick={handleClick} to={pageList[1]?.path}>
-              Start your form without signing in
-            </Link>
-          </p>
-        </VaAlert>
-      ) : (
-        <SaveInProgressIntro
-          formId={formConfig.formId}
-          headingLevel={2}
-          prefillEnabled={formConfig.prefillEnabled}
-          messages={formConfig.savedFormMessages}
-          pageList={pageList}
-          startText="Start the Application"
-        />
-      )}
-
+      <SaveInProgressIntro
+        formId={formConfig.formId}
+        headingLevel={2}
+        prefillEnabled={formConfig.prefillEnabled}
+        messages={formConfig.savedFormMessages}
+        pageList={pageList}
+        startText="Start the Application"
+      />
       <br />
 
       <va-omb-info

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantRelOriginPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantRelOriginPage.jsx
@@ -7,7 +7,7 @@ const KEYNAME = 'applicantRelationshipOrigin';
 
 function generateOptions({ data, pagePerItemIndex }) {
   const bp = appRelBoilerplate({ data, pagePerItemIndex });
-  const customTitle = `${bp.applicant}’s relationship to the ${bp.personTitle}`;
+  const customTitle = `${bp.applicant}’s dependent status`;
   const relativeBeingVerb = `${bp.relative} ${bp.beingVerbPresent}`;
   const surv = data.sponsorIsDeceased ? 'surviving' : '';
 

--- a/src/applications/ivc-champva/10-7959C/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/applicantInformation.js
@@ -24,7 +24,7 @@ fullNameMiddleInitialUI.middle['ui:title'] = 'Middle initial';
 
 export const applicantNameDobSchema = {
   uiSchema: {
-    ...titleUI('Beneficiary’s name and date of birth'),
+    ...titleUI('Name and date of birth'),
     applicantName: fullNameMiddleInitialUI,
     applicantDOB: dateOfBirthUI({
       required: true,

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -120,7 +120,7 @@ const formConfig = {
         applicantNameDob: {
           // initialData: mockdata.data,
           path: 'applicant-info',
-          title: 'Beneficiary’s name and date of birth',
+          title: 'Name and date of birth',
           ...applicantNameDobSchema,
         },
         applicantIdentity: {

--- a/src/applications/ivc-champva/10-7959C/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959C/containers/IntroductionPage.jsx
@@ -1,20 +1,13 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
 import { connect } from 'react-redux';
-import recordEvent from 'platform/monitoring/record-event';
 import { focusElement } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import FormTitle from '@department-of-veterans-affairs/platform-forms-system/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
-import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 const IntroductionPage = props => {
-  const { route, isLoggedIn } = props;
+  const { route } = props;
   const { formConfig, pageList } = route;
-
-  const handleClick = () => {
-    recordEvent({ event: 'no-login-start-form' });
-  };
 
   useEffect(
     () => {
@@ -64,46 +57,21 @@ const IntroductionPage = props => {
         And you can also provide your updated non-VA health insurance
         information and copies of your Medicare or other health insurance cards.
       </p>
-      {!isLoggedIn ? (
-        <>
-          <VaAlert status="info" visible uswds>
-            <h2>Sign in now to save time and save your work in progress</h2>
-            <p>Here’s how signing in now helps you:</p>
-            <ul>
-              <li>
-                We can fill in some of your information for you to save you
-                time.
-              </li>
-              <li>
-                You can save your work in progress. You’ll have 60 days from
-                when you start or make updates to your application to come back
-                and finish it.
-              </li>
-            </ul>
-            <p>
-              <strong>Note:</strong> You can sign in after you start your
-              application. But you’ll lose any information you already filled
-              in.
-            </p>
-            <p className="vads-u-margin-top--2">
-              <Link onClick={handleClick} to={pageList[1]?.path}>
-                Start your form without signing in
-              </Link>
-            </p>
-          </VaAlert>
-          <div className="vads-u-margin-top--3" />
-        </>
-      ) : (
-        <SaveInProgressIntro
-          formId={formConfig.formId}
-          headingLevel={2}
-          prefillEnabled={formConfig.prefillEnabled}
-          messages={formConfig.savedFormMessages}
-          pageList={pageList}
-          startText="Start the application"
-        />
-      )}
-
+      <SaveInProgressIntro
+        formId={formConfig.formId}
+        headingLevel={2}
+        prefillEnabled={formConfig.prefillEnabled}
+        messages={formConfig.savedFormMessages}
+        pageList={pageList}
+        unauthStartText="Sign in to start your form"
+        formConfig={{
+          customText: {
+            appType: 'form',
+            continueAppButtonText: 'Continue your form',
+            startNewAppButtonText: 'Start a new form',
+          },
+        }}
+      />
       <va-omb-info
         res-burden={10}
         omb-number="2900-0219"

--- a/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/IntroductionPage.jsx
@@ -4,17 +4,10 @@ import { connect } from 'react-redux';
 import { focusElement } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
-import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { Link } from 'react-router';
-import recordEvent from 'platform/monitoring/record-event';
 
 const IntroductionPage = props => {
-  const { route, isLoggedIn } = props;
+  const { route } = props;
   const { formConfig, pageList } = route;
-
-  const handleClick = () => {
-    recordEvent({ event: 'no-login-start-form' });
-  };
 
   useEffect(
     () => {
@@ -48,40 +41,14 @@ const IntroductionPage = props => {
           </li>
         </ul>
       </div>
-      {!isLoggedIn ? (
-        <VaAlert status="info" visible uswds>
-          <h2>Sign in now to save time and save your work in progress</h2>
-          <p>Here’s how signing in now helps you:</p>
-          <ul>
-            <li>
-              We can fill in some of your information for you to save you time.
-            </li>
-            <li>
-              You can save your work in progress. You’ll have 60 days from when
-              you start, or make updates, to come back and finish it.
-            </li>
-          </ul>
-          <p>
-            <strong>Note:</strong> You can sign in after you start your
-            registration form. But you’ll lose any information you already
-            filled in.
-          </p>
-          <p className="vads-u-margin-top--2">
-            <Link onClick={handleClick} to={pageList[1]?.path}>
-              Start your form without signing in
-            </Link>
-          </p>
-        </VaAlert>
-      ) : (
-        <SaveInProgressIntro
-          formId={formConfig.formId}
-          headingLevel={2}
-          prefillEnabled={formConfig.prefillEnabled}
-          messages={formConfig.savedFormMessages}
-          pageList={pageList}
-          startText="Start"
-        />
-      )}
+      <SaveInProgressIntro
+        formId={formConfig.formId}
+        headingLevel={2}
+        prefillEnabled={formConfig.prefillEnabled}
+        messages={formConfig.savedFormMessages}
+        pageList={pageList}
+        startText="Start"
+      />
 
       <va-omb-info
         res-burden={4}


### PR DESCRIPTION
## Summary

This PR fixes a few small copy issues across three IVC forms:
- 10-10d
- 10-7959c
- 10-7959f-1

It does the following:
- Removes the word "Beneficiary's" at the front of the name/date of birth heading in 10-7959c
- Adds the applicant's name to the front of the dependent status header in 10-10d
- Updates the SIP intro block on 10-10d, 10-7959c, and 10-7959f-1 to show the "sign in" button to unauthenticated users.
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85390
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86099
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86011


## Testing done

- Unit

## Screenshots

|         | Screens |
| ------- | ------ | 
| dependent status header |![Screenshot 2024-06-24 at 08 09 53](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/335e32da-240a-43dc-a3f3-9603a4b725b9)|
|Name/DOB header|![Screenshot 2024-06-24 at 08 12 46](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/6fdedc4c-e69a-4cb6-b57a-4d590cd458f6)|
|sign in button added|![Screenshot 2024-06-24 at 09 21 23](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/dcb34a52-e849-4c6e-8130-c872fb581e19)|

## What areas of the site does it impact?

IVC forms only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA