### PR TITLE
85791 Update headers on insurance section

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/healthInsuranceInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/healthInsuranceInformation.js
@@ -98,12 +98,9 @@ export function applicantProviderSchema(isPrimary) {
     uiSchema: {
       ...titleUI(
         ({ formData }) =>
-          `${nameWording(
-            formData,
-            undefined,
-            undefined,
-            true,
-          )} health insurance information`,
+          `${nameWording(formData, undefined, undefined, true)} ${
+            isPrimary ? '' : 'additional '
+          }health insurance information`,
       ),
       [keyname1]: textUI('Name of insurance provider'),
       [keyname2]: currentOrPastDateUI({

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -354,7 +354,7 @@ const formConfig = {
           path: 'secondary-insurance-info',
           depends: formData => get('applicantHasSecondary', formData),
           title: formData =>
-            `${fnp(formData)} secondary health insurance information`,
+            `${fnp(formData)} additional health insurance information`,
           ...applicantProviderSchema(false),
         },
         secondaryThroughEmployer: {


### PR DESCRIPTION
## Summary

This PR updates the headers in a couple places in the insurance section of form 10-7959c.

- additional insurance screen - updates header (change "secondary" to "additional") and question copy
- insurance information screen - update header (change "secondary" to "additional")
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85791

## Testing done

- Manual

## Screenshots

|         | updated |
| ------- | --- |
| 1 |![Screenshot 2024-06-24 at 09 30 00](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/d7ee91b9-fa55-40c9-9673-81eed094468e)|
|2|![Screenshot 2024-06-24 at 09 33 06](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/18afa589-0ddf-4f2f-86bd-58247e689d00)|

## What areas of the site does it impact?

Form 10-7959c only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA