### PR TITLE
Remove cancel button on noncancelable appointments

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
@@ -28,6 +28,7 @@ import CancelWarningPage from '../cancel/CancelWarningPage';
 import CancelConfirmationPage from '../cancel/CancelConfirmationPage';
 import FacilityAddress from '../../../components/FacilityAddress';
 import ClaimExamLayout from '../../../components/layout/ClaimExamLayout';
+import PhoneLayout from '../../../components/layout/PhoneLayout';
 
 function Content({ appointment, facilityData }) {
   const locationId = getVAAppointmentLocationId(appointment);
@@ -82,8 +83,9 @@ function Content({ appointment, facilityData }) {
     );
   };
 
-  if (featureAppointmentDetailsRedesign && !isPhoneAppointment) {
+  if (featureAppointmentDetailsRedesign) {
     if (isCompAndPenAppointment) return <ClaimExamLayout data={appointment} />;
+    if (isPhoneAppointment) return <PhoneLayout data={appointment} />;
     return <InPersonLayout data={appointment} />;
   }
 

--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/index.jsx
@@ -19,7 +19,6 @@ import {
 import DetailsVA from './DetailsVA';
 import DetailsCC from './DetailsCC';
 import DetailsVideo from './DetailsVideo';
-import PhoneLayout from '../../../components/layout/PhoneLayout';
 import VideoLayout from '../../../components/layout/VideoLayout';
 
 export default function ConfirmedAppointmentDetailsPage() {
@@ -48,7 +47,6 @@ export default function ConfirmedAppointmentDetailsPage() {
   const isVideo = appointment?.vaos?.isVideo;
   const isCommunityCare = appointment?.vaos?.isCommunityCare;
   const isVA = !isVideo && !isCommunityCare;
-  const isPhone = appointment?.vaos?.isPhoneAppointment;
 
   const appointmentTypePrefix = isCommunityCare ? 'cc' : 'va';
 
@@ -110,15 +108,13 @@ export default function ConfirmedAppointmentDetailsPage() {
   if (featureAppointmentDetailsRedesign) {
     return (
       <PageLayout showNeedHelp>
-        {isPhone && <PhoneLayout data={appointment} />}
-        {isVA &&
-          !isPhone && (
-            <DetailsVA
-              appointment={appointment}
-              facilityData={facilityData}
-              useV2={useV2}
-            />
-          )}
+        {isVA && (
+          <DetailsVA
+            appointment={appointment}
+            facilityData={facilityData}
+            useV2={useV2}
+          />
+        )}
         {isCommunityCare && (
           <DetailsCC
             appointment={appointment}

--- a/src/applications/vaos/components/StatusAlert.jsx
+++ b/src/applications/vaos/components/StatusAlert.jsx
@@ -98,7 +98,7 @@ export default function StatusAlert({ appointment, facility }) {
       return (
         <>
           <h2 className="vads-u-margin-bottom--0">After visit summary</h2>
-          <AfterVisitSummary data={appointment} />
+          <AfterVisitSummary data={appointment} /> <br />
         </>
       );
     }

--- a/src/applications/vaos/components/layout/DetailPageLayout.jsx
+++ b/src/applications/vaos/components/layout/DetailPageLayout.jsx
@@ -62,12 +62,7 @@ Where.propTypes = {
 function CancelButton({ appointment }) {
   const dispatch = useDispatch();
   const { status, vaos } = appointment;
-  const {
-    isCommunityCare,
-    isCompAndPenAppointment,
-    isVideo,
-    isPastAppointment,
-  } = vaos;
+  const { isCancellable, isPastAppointment } = vaos;
 
   let event = `${GA_PREFIX}-cancel-booked-clicked`;
   if (APPOINTMENT_STATUS.proposed === status)
@@ -88,14 +83,7 @@ function CancelButton({ appointment }) {
     />
   );
 
-  if (
-    APPOINTMENT_STATUS.cancelled !== status &&
-    !isCommunityCare &&
-    !isCompAndPenAppointment &&
-    !isVideo &&
-    !isPastAppointment
-  )
-    return button;
+  if (!!isCancellable && !isPastAppointment) return button;
 
   if (APPOINTMENT_STATUS.proposed === status) return button;
 

--- a/src/applications/vaos/components/tests/InPersonLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/InPersonLayout.unit.spec.js
@@ -117,6 +117,89 @@ describe('VAOS Component: InPersonLayout', () => {
         screen.container.querySelector('va-button[text="Cancel appointment"]'),
       ).to.be.ok;
     });
+    it('should display in-person layout without cancel button', async () => {
+      // Arrange
+      const store = createTestStore(initialState);
+      const appointment = {
+        comment: 'This is a test:Additional information',
+        location: {
+          stationId: '983',
+          clinicName: 'Clinic 1',
+          clinicPhysicalLocation: 'CHEYENNE',
+        },
+        videoData: {},
+        vaos: {
+          isCommunityCare: false,
+          isCompAndPenAppointment: false,
+          isCOVIDVaccine: false,
+          isPendingAppointment: false,
+          isUpcomingAppointment: true,
+          isCancellable: false,
+          apiData: {
+            serviceType: 'primaryCare',
+          },
+        },
+        status: 'booked',
+      };
+
+      // Act
+      const screen = renderWithStoreAndRouter(
+        <InPersonLayout data={appointment} />,
+        {
+          store,
+        },
+      );
+
+      // Assert
+      expect(
+        screen.getByRole('heading', {
+          level: 1,
+          name: /In-person appointment/i,
+        }),
+      );
+      expect(screen.getByRole('heading', { level: 2, name: /When/i }));
+      expect(
+        screen.container.querySelector('va-button[text="Add to calendar"]'),
+      ).to.be.ok;
+
+      expect(screen.getByRole('heading', { level: 2, name: /What/i }));
+      expect(screen.getByText(/Primary care/i));
+
+      expect(
+        screen.getByRole('heading', { level: 2, name: /Where to attend/i }),
+      );
+      expect(screen.getByText(/Cheyenne VA Medical Center/i));
+      expect(screen.getByText(/2360 East Pershing Boulevard/i));
+
+      expect(screen.container.querySelector('va-icon[icon="directions"]')).to.be
+        .ok;
+
+      expect(screen.getByText(/Location:/i));
+      expect(screen.getByText(/CHEYENNE/));
+
+      expect(screen.getByText(/Clinic:/i));
+      expect(screen.getByText(/Clinic 1/i));
+      expect(screen.getByText(/Clinic phone:/i));
+      expect(
+        screen.container.querySelector('va-telephone[contact="307-778-7550"]'),
+      ).to.be.ok;
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Details you shared with your provider/i,
+        }),
+      );
+      expect(screen.getByText(/Reason:/i));
+      expect(screen.getByText(/This is a test/i));
+      expect(screen.getByText(/Other details:/i));
+      expect(screen.getByText(/Additional information/i));
+
+      expect(screen.container.querySelector('va-button[text="Print"]'));
+      expect(
+        screen.container.querySelector('va-button[text="Cancel appointment"]'),
+      ).not.to.exist;
+    });
 
     it('should display default text for empty data', async () => {
       // Arrange

--- a/src/applications/vaos/components/tests/InPersonLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/InPersonLayout.unit.spec.js
@@ -33,7 +33,7 @@ describe('VAOS Component: InPersonLayout', () => {
     },
   };
 
-  describe('When viewing upcomming appointment details', () => {
+  describe('When viewing upcoming appointment details', () => {
     it('should display in-person layout', async () => {
       // Arrange
       const store = createTestStore(initialState);
@@ -51,6 +51,7 @@ describe('VAOS Component: InPersonLayout', () => {
           isCOVIDVaccine: false,
           isPendingAppointment: false,
           isUpcomingAppointment: true,
+          isCancellable: true,
           apiData: {
             serviceType: 'primaryCare',
           },
@@ -207,6 +208,7 @@ describe('VAOS Component: InPersonLayout', () => {
         videoData: {},
         vaos: {
           isPastAppointment: true,
+          isCancellable: true,
           apiData: {
             localStartTime: moment()
               .subtract(1, 'day')

--- a/src/applications/vaos/components/tests/PhoneLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/PhoneLayout.unit.spec.js
@@ -282,7 +282,7 @@ describe('VAOS Component: PhoneLayout', () => {
   });
 
   describe('When viewing past appointment details', () => {
-    it('should display in-person layout', async () => {
+    it('should display phone layout', async () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {

--- a/src/applications/vaos/components/tests/PhoneLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/PhoneLayout.unit.spec.js
@@ -33,7 +33,7 @@ describe('VAOS Component: PhoneLayout', () => {
     },
   };
 
-  describe('When viewing upcomming appointment details', () => {
+  describe('When viewing upcoming appointment details', () => {
     it('should display in-person layout', async () => {
       // Arrange
       const store = createTestStore(initialState);
@@ -52,6 +52,7 @@ describe('VAOS Component: PhoneLayout', () => {
           isPendingAppointment: false,
           isUpcomingAppointment: true,
           isPhoneAppointment: true,
+          isCancellable: true,
           apiData: {
             serviceType: 'primaryCare',
           },
@@ -210,6 +211,7 @@ describe('VAOS Component: PhoneLayout', () => {
         videoData: {},
         vaos: {
           isPastAppointment: true,
+          isCancellable: true,
           apiData: {
             localStartTime: moment()
               .subtract(1, 'day')

--- a/src/applications/vaos/components/tests/PhoneLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/PhoneLayout.unit.spec.js
@@ -34,7 +34,7 @@ describe('VAOS Component: PhoneLayout', () => {
   };
 
   describe('When viewing upcoming appointment details', () => {
-    it('should display in-person layout', async () => {
+    it('should display phone layout', async () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
@@ -117,6 +117,90 @@ describe('VAOS Component: PhoneLayout', () => {
       expect(
         screen.container.querySelector('va-button[text="Cancel appointment"]'),
       ).to.be.ok;
+    });
+    it('should display phone layout without cancel button', async () => {
+      // Arrange
+      const store = createTestStore(initialState);
+      const appointment = {
+        comment: 'This is a test:Additional information',
+        location: {
+          stationId: '983',
+          clinicName: 'Clinic 1',
+          clinicPhysicalLocation: 'CHEYENNE',
+        },
+        videoData: {},
+        vaos: {
+          isCommunityCare: false,
+          isCompAndPenAppointment: false,
+          isCOVIDVaccine: false,
+          isPendingAppointment: false,
+          isUpcomingAppointment: true,
+          isPhoneAppointment: true,
+          isCancellable: false,
+          apiData: {
+            serviceType: 'primaryCare',
+          },
+        },
+        status: 'booked',
+      };
+
+      // Act
+      const screen = renderWithStoreAndRouter(
+        <PhoneLayout data={appointment} />,
+        {
+          store,
+        },
+      );
+
+      // Assert
+      expect(
+        screen.getByRole('heading', {
+          level: 1,
+          name: /Phone appointment/i,
+        }),
+      );
+      expect(screen.getByRole('heading', { level: 2, name: /How to join/i }));
+      expect(screen.getByRole('heading', { level: 2, name: /When/i }));
+      expect(
+        screen.container.querySelector('va-button[text="Add to calendar"]'),
+      ).to.be.ok;
+
+      expect(screen.getByRole('heading', { level: 2, name: /What/i }));
+      expect(screen.getByText(/Primary care/i));
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Scheduling facility/i,
+        }),
+      );
+      expect(screen.getByText(/Cheyenne VA Medical Center/i));
+      expect(screen.getByText(/2360 East Pershing Boulevard/i));
+      expect(screen.container.querySelector('va-icon[icon="directions"]')).not
+        .to.exist;
+
+      expect(screen.getByText(/Clinic:/i));
+      expect(screen.getByText(/Clinic 1/i));
+      expect(screen.getByText(/Clinic phone:/i));
+      expect(
+        screen.container.querySelector('va-telephone[contact="307-778-7550"]'),
+      ).to.be.ok;
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Details you shared with your provider/i,
+        }),
+      );
+      expect(screen.getByText(/Reason:/i));
+      expect(screen.getByText(/This is a test/i));
+      expect(screen.getByText(/Other details:/i));
+      expect(screen.getByText(/Additional information/i));
+
+      expect(screen.container.querySelector('va-button[text="Print"]'));
+      expect(
+        screen.container.querySelector('va-button[text="Cancel appointment"]'),
+      ).to.not.exist;
     });
 
     it('should display default text for empty data', async () => {

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -1,5 +1,1404 @@
 {
   "data": [
+{
+    "id": "7e5cab9523b99cbe1ca941399ef419f942837cda5dda71bbf95f6e5a375d2710",
+    "type": "appointments",
+    "attributes": {
+        "id": "7e5cab9523b99cbe1ca941399ef419f942837cda5dda71bbf95f6e5a375d2710",
+        "identifier": [
+            {
+                "system": "Appointment/",
+                "value": "413938333133333234"
+            },
+            {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+                "value": "983:13324"
+            }
+        ],
+        "kind": "clinic",
+        "status": "booked",
+        "serviceType": "optometry",
+        "serviceTypes": [
+            {
+                "coding": [
+                    {
+                        "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                        "code": "optometry"
+                    }
+                ]
+            }
+        ],
+        "serviceCategory": [
+            {
+                "coding": [
+                    {
+                        "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                        "code": "REGULAR",
+                        "display": "REGULAR"
+                    }
+                ],
+                "text": "REGULAR"
+            }
+        ],
+        "reasonCode": {
+            "text": "reasonCode:ROUTINEVISIT|comments:test  vaos-7661"
+        },
+        "patientIcn": "1013678363V916823",
+        "locationId": "983",
+        "clinic": "437",
+        "start": "2025-02-25T16:25:00Z",
+        "end": "2025-02-25T16:40:00Z",
+        "minutesDuration": 15,
+        "slot": {
+            "id": "3230323431303235313632353A323032343130323531363430",
+            "start": "2025-02-25T16:25:00Z",
+            "end": "2025-02-25T16:40:00Z"
+        },
+        "created": "2024-11-16T00:00:00Z",
+        "cancellable": true,
+        "extension": {
+            "ccLocation": {
+                "address": {}
+            },
+            "vistaStatus": [
+                "FUTURE"
+            ],
+            "preCheckinAllowed": false,
+            "eCheckinAllowed": false,
+            "clinic": {}
+        },
+        "localStartTime": "2025-02-25T10:25:00.000-06:00",
+        "serviceName": "VISUAL FIELD",
+        "friendlyName": "VISUAL FIELD",
+        "location": {
+            "id": "983",
+            "type": "appointments",
+            "attributes": {
+                "id": "983",
+                "vistaSite": "983",
+                "vastParent": "983",
+                "type": "va_facilities",
+                "name": "Cheyenne VA Medical Center",
+                "classification": "VA Medical Center (VAMC)",
+                "timezone": {
+                    "timeZoneId": "America/Denver"
+                },
+                "lat": 39.744507,
+                "long": -104.830956,
+                "website": "https://www.denver.va.gov/locations/directions.asp",
+                "phone": {
+                    "main": "307-778-7550",
+                    "fax": "307-778-7381",
+                    "pharmacy": "866-420-6337",
+                    "afterHours": "307-778-7550",
+                    "patientAdvocate": "307-778-7550 x7517",
+                    "mentalHealthClinic": "307-778-7349",
+                    "enrollmentCoordinator": "307-778-7550 x7579"
+                },
+                "physicalAddress": {
+                    "type": "physical",
+                    "line": [
+                        "2360 East Pershing Boulevard"
+                    ],
+                    "city": "Cheyenne",
+                    "state": "WY",
+                    "postalCode": "82001-5356"
+                },
+                "mobile": false,
+                "healthService": [
+                    "Audiology",
+                    "Cardiology",
+                    "DentalServices",
+                    "EmergencyCare",
+                    "Gastroenterology",
+                    "Gynecology",
+                    "MentalHealthCare",
+                    "Nutrition",
+                    "Ophthalmology",
+                    "Optometry",
+                    "Orthopedics",
+                    "Podiatry",
+                    "PrimaryCare",
+                    "SpecialtyCare",
+                    "UrgentCare",
+                    "Urology",
+                    "WomensHealth"
+                ],
+                "operatingStatus": {
+                    "code": "NORMAL"
+                }
+            }
+        }
+    }
+},
+{
+    "id": "e01555000d5c7ce9b754ea7ad8fa1d481298fec531ff43919734d31eb34ceb46",
+    "type": "appointments",
+    "attributes": {
+        "id": "e01555000d5c7ce9b754ea7ad8fa1d481298fec531ff43919734d31eb34ceb46",
+        "identifier": [
+            {
+                "system": "Appointment/",
+                "value": "4139383436333437"
+            },
+            {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+                "value": "984:6347"
+            }
+        ],
+        "kind": "phone",
+        "status": "booked",
+        "serviceCategory": [
+            {
+                "coding": [
+                    {
+                        "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                        "code": "REGULAR",
+                        "display": "REGULAR"
+                    }
+                ],
+                "text": "REGULAR"
+            }
+        ],
+        "patientIcn": "1013678363V916823",
+        "locationId": "984",
+        "clinic": "4570",
+        "practitioners": [
+            {
+                "identifier": [
+                    {
+                        "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
+                        "value": null
+                    }
+                ],
+                "name": {
+                    "family": "ISS",
+                    "given": [
+                        "PROVIDERONE"
+                    ]
+                }
+            }
+        ],
+        "start": "2024-12-05T18:00:00Z",
+        "end": "2024-12-05T18:15:00Z",
+        "minutesDuration": 15,
+        "slot": {
+            "id": "3230323331323035313830303A323032333132303531383135",
+            "start": "2024-12-05T18:00:00Z",
+            "end": "2024-12-05T18:15:00Z"
+        },
+        "created": "2024-11-28T00:00:00Z",
+        "cancellable": true,
+        "extension": {
+            "ccLocation": {
+                "address": {}
+            },
+            "vistaStatus": [
+                "NO ACTION TAKEN"
+            ],
+            "preCheckinAllowed": false,
+            "eCheckinAllowed": false,
+            "clinic": {
+                "physicalLocation": "DAYTSHR PHONE Provider",
+                "phoneNumber": "555-555-6551",
+                "phoneNumberExtension": "6001"
+            }
+        },
+        "localStartTime": "2024-12-05T13:00:00.000-05:00",
+        "serviceName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
+        "friendlyName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
+        "physicalLocation": "DAYTSHR PHONE Provider",
+        "location": {
+            "id": "984",
+            "type": "appointments",
+            "attributes": {
+                "id": "984",
+                "vistaSite": "984",
+                "vastParent": "984",
+                "type": "va_health_facility",
+                "name": "Dayton VA Medical Center",
+                "classification": "VA Medical Center (VAMC)",
+                "timezone": {
+                    "timeZoneId": "America/New_York"
+                },
+                "lat": 39.74935,
+                "long": -84.2532,
+                "website": "https://www.dayton.va.gov/locations/directions.asp",
+                "phone": {
+                    "main": "937-268-6511"
+                },
+                "physicalAddress": {
+                    "type": "physical",
+                    "line": [
+                        "4100 West Third Street"
+                    ],
+                    "city": "Dayton",
+                    "state": "OH",
+                    "postalCode": "45428-9000"
+                },
+                "healthService": [
+                    "Audiology",
+                    "Cardiology",
+                    "DentalServices",
+                    "Dermatology",
+                    "Gastroenterology",
+                    "Gynecology",
+                    "MentalHealthCare",
+                    "Nutrition",
+                    "Ophthalmology",
+                    "Optometry",
+                    "Orthopedics",
+                    "Podiatry",
+                    "PrimaryCare",
+                    "SpecialtyCare",
+                    "Urology",
+                    "WomensHealth"
+                ]
+            }
+        }
+    }
+},
+{
+    "id": "9c6a43ce99d9d8406d3cd3b463f4d383d4f6f08d91b56d7ed8282928f9a58957",
+    "type": "appointments",
+    "attributes": {
+        "id": "9c6a43ce99d9d8406d3cd3b463f4d383d4f6f08d91b56d7ed8282928f9a58957",
+        "identifier": [
+            {
+                "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
+                "value": "524670||158||1"
+            },
+            {
+                "system": "http://hl7.org/fhir/sid/us-npi",
+                "value": "1346206547"
+            }
+        ],
+        "kind": "cc",
+        "status": "booked",
+        "serviceTypes": [
+            {
+                "text": "Cardiology Cath - PCI_REV_PRCT SEOC 1.1.14"
+            }
+        ],
+        "description": "Cardiology Cath - PCI_REV_PRCT SEOC 1.1.14",
+        "patientIcn": "1012845331V153043",
+        "locationId": "552",
+        "practitioners": [
+            {
+                "name": {
+                    "family": "HEALTH CARE PROFS",
+                    "given": [
+                        "A & D"
+                    ]
+                }
+            }
+        ],
+        "start": "2025-02-02T13:00:00Z",
+        "created": "2025-02-02T20:29:46Z",
+        "cancellable": false,
+        "extension": {
+            "ccLocation": {
+                "address": {
+                    "line": [
+                        "1601 NEEDMORE RD ; STE 1 &amp; 2"
+                    ],
+                    "city": "DAYTON",
+                    "state": "OH",
+                    "postalCode": "45414",
+                    "text": "1601 NEEDMORE RD ; STE 1 &amp; 2\nDAYTON OH 45414"
+                },
+                "telecom": [
+                    {
+                        "system": "phone",
+                        "value": "937-236-6750"
+                    }
+                ]
+            },
+            "hsrmTaskId": "",
+            "hsrmConsultId": "984_646372",
+            "ccTreatingSpecialty": "Home Health"
+        },
+        "localStartTime": "2025-02-02T09:00:00.000-04:00",
+        "avsPath": null,
+        "location": {
+            "id": "552",
+            "type": "appointments",
+            "attributes": {
+                "id": "552",
+                "facilitiesApiId": "vha_552",
+                "vistaSite": "552",
+                "vastParent": "552",
+                "type": "va_health_facility",
+                "name": "Dayton VA Medical Center",
+                "classification": "VA Medical Center (VAMC)",
+                "timezone": {
+                    "timeZoneId": "America/New_York"
+                },
+                "lat": 39.74935,
+                "long": -84.2532,
+                "website": "https://www.va.gov/dayton-health-care/locations/dayton-va-medical-center/",
+                "phone": {
+                    "main": "937-268-6511",
+                    "fax": "937-262-2179",
+                    "pharmacy": "800-368-8262 x1",
+                    "afterHours": "888-838-6446",
+                    "patientAdvocate": "800-368-8262 x2164",
+                    "mentalHealthClinic": "937-262-2186",
+                    "enrollmentCoordinator": "800-368-8262 x5336"
+                },
+                "hoursOfOperation": [
+                    {
+                        "daysOfWeek": "sun",
+                        "openingTime": "24/7",
+                        "closingTime": "24/7"
+                    },
+                    {
+                        "daysOfWeek": "mon",
+                        "openingTime": "24/7",
+                        "closingTime": "24/7"
+                    },
+                    {
+                        "daysOfWeek": "tue",
+                        "openingTime": "24/7",
+                        "closingTime": "24/7"
+                    },
+                    {
+                        "daysOfWeek": "wed",
+                        "openingTime": "24/7",
+                        "closingTime": "24/7"
+                    },
+                    {
+                        "daysOfWeek": "thu",
+                        "openingTime": "24/7",
+                        "closingTime": "24/7"
+                    },
+                    {
+                        "daysOfWeek": "fri",
+                        "openingTime": "24/7",
+                        "closingTime": "24/7"
+                    },
+                    {
+                        "daysOfWeek": "sat",
+                        "openingTime": "24/7",
+                        "closingTime": "24/7"
+                    }
+                ],
+                "physicalAddress": {
+                    "type": "physical",
+                    "line": [
+                        "4100 West Third Street",
+                        null,
+                        null
+                    ],
+                    "city": "Dayton",
+                    "state": "OH",
+                    "postalCode": "45428-9000"
+                },
+                "mobile": false,
+                "healthService": [
+                    "Addiction",
+                    "Anesthesia",
+                    "Audiology",
+                    "Cardiology",
+                    "CaregiverSupport",
+                    "Chiropractic",
+                    "CriticalCare",
+                    "Dental",
+                    "Dermatology",
+                    "EmergencyCare",
+                    "EmploymentPrograms",
+                    "Endocrinology",
+                    "Gastroenterology",
+                    "Gynecology",
+                    "Hematology",
+                    "Homeless",
+                    "Hospice",
+                    "InfectiousDisease",
+                    "Laboratory",
+                    "Lgbtq",
+                    "MentalHealth",
+                    "MilitarySexualTrauma",
+                    "MinorityCare",
+                    "MyHealtheVetCoordinator",
+                    "Nephrology",
+                    "Neurology",
+                    "Nutrition",
+                    "Ophthalmology",
+                    "Optometry",
+                    "Orthopedics",
+                    "Otolaryngology",
+                    "PainManagement",
+                    "PatientAdvocates",
+                    "Pharmacy",
+                    "PhysicalMedicine",
+                    "PhysicalTherapy",
+                    "Podiatry",
+                    "Polytrauma",
+                    "PrimaryCare",
+                    "Prosthetics",
+                    "Psychiatry",
+                    "Psychology",
+                    "Ptsd",
+                    "PulmonaryMedicine",
+                    "RadiationOncology",
+                    "Radiology",
+                    "RecreationTherapy",
+                    "RegistryExams",
+                    "Rehabilitation",
+                    "Rheumatology",
+                    "SleepMedicine",
+                    "Smoking",
+                    "SocialWork",
+                    "SpinalInjury",
+                    "SuicidePrevention",
+                    "Surgery",
+                    "Telehealth",
+                    "ThoracicSurgery",
+                    "TransitionCounseling",
+                    "TransplantSurgery",
+                    "TravelReimbursement",
+                    "UrgentCare",
+                    "Urology",
+                    "VascularSurgery",
+                    "Vision",
+                    "WeightManagement",
+                    "WomensHealth",
+                    "Wound"
+                ],
+                "operatingStatus": {
+                    "code": "NORMAL"
+                },
+                "visn": "10"
+            }
+        }
+    }
+},
+{
+    "id": "aa6bb54b5f8ba22a82720a30abdfa3efe0805cc0dc1b6b248815e942ad61847e",
+    "type": "appointments",
+    "attributes": {
+        "id": "aa6bb54b5f8ba22a82720a30abdfa3efe0805cc0dc1b6b248815e942ad61847e",
+        "identifier": [
+            {
+                "system": "Appointment/",
+                "value": "413938333133353533"
+            },
+            {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+                "value": "983:13553"
+            }
+        ],
+        "kind": "clinic",
+        "status": "booked",
+        "serviceType": "covid",
+        "serviceTypes": [
+            {
+                "coding": [
+                    {
+                        "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                        "code": "covid"
+                    }
+                ]
+            }
+        ],
+        "serviceCategory": [
+            {
+                "coding": [
+                    {
+                        "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                        "code": "REGULAR",
+                        "display": "REGULAR"
+                    }
+                ],
+                "text": "REGULAR"
+            }
+        ],
+        "patientIcn": "1012846043V576341",
+        "locationId": "983",
+        "clinic": "1038",
+        "practitioners": [
+            {
+                "identifier": [
+                    {
+                        "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
+                        "value": null
+                    }
+                ],
+                "name": {
+                    "family": "BERNARDO",
+                    "given": [
+                        "KENNETH J"
+                    ]
+                }
+            }
+        ],
+        "start": "2024-12-01T14:00:00Z",
+        "end": "2024-08-01T14:15:00Z",
+        "minutesDuration": 15,
+        "slot": {
+            "id": "3230323430383031313430303A323032343038303131343135",
+            "start": "2024-12-01T14:00:00Z",
+            "end": "2024-12-01T14:15:00Z"
+        },
+        "created": "2024-12-09T00:00:00Z",
+        "cancellable": false,
+        "extension": {
+            "ccLocation": {
+                "address": {}
+            },
+            "vistaStatus": [
+                "FUTURE"
+            ],
+            "preCheckinAllowed": true,
+            "eCheckinAllowed": true,
+            "clinic": {
+                "physicalLocation": "MHC"
+            }
+        },
+        "localStartTime": "2024-12-01T08:00:00.000-06:00",
+        "serviceName": "COVID VACCINE CLIN1",
+        "friendlyName": "COVID VACCINE CLIN1",
+        "physicalLocation": "MHC",
+        "location": {
+            "id": "983",
+            "type": "appointments",
+            "attributes": {
+                "id": "983",
+                "vistaSite": "983",
+                "vastParent": "983",
+                "type": "va_facilities",
+                "name": "Cheyenne VA Medical Center",
+                "classification": "VA Medical Center (VAMC)",
+                "timezone": {
+                    "timeZoneId": "America/Denver"
+                },
+                "lat": 39.744507,
+                "long": -104.830956,
+                "website": "https://www.denver.va.gov/locations/directions.asp",
+                "phone": {
+                    "main": "307-778-7550",
+                    "fax": "307-778-7381",
+                    "pharmacy": "866-420-6337",
+                    "afterHours": "307-778-7550",
+                    "patientAdvocate": "307-778-7550 x7517",
+                    "mentalHealthClinic": "307-778-7349",
+                    "enrollmentCoordinator": "307-778-7550 x7579"
+                },
+                "physicalAddress": {
+                    "type": "physical",
+                    "line": [
+                        "2360 East Pershing Boulevard"
+                    ],
+                    "city": "Cheyenne",
+                    "state": "WY",
+                    "postalCode": "82001-5356"
+                },
+                "mobile": false,
+                "healthService": [
+                    "Audiology",
+                    "Cardiology",
+                    "DentalServices",
+                    "EmergencyCare",
+                    "Gastroenterology",
+                    "Gynecology",
+                    "MentalHealthCare",
+                    "Nutrition",
+                    "Ophthalmology",
+                    "Optometry",
+                    "Orthopedics",
+                    "Podiatry",
+                    "PrimaryCare",
+                    "SpecialtyCare",
+                    "UrgentCare",
+                    "Urology",
+                    "WomensHealth"
+                ],
+                "operatingStatus": {
+                    "code": "NORMAL"
+                }
+            }
+        }
+    }
+},
+{
+    "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44cf",
+    "type": "appointments",
+    "attributes": {
+        "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44cf",
+        "identifier": [
+            {
+                "system": "urn:va.gov:masv2:cerner:appointment",
+                "value": "Appointment/52499028"
+            }
+        ],
+        "kind": "clinic",
+        "status": "booked",
+        "serviceTypes": [
+            {
+                "coding": [
+                    {
+                        "system": "https://fhir.cerner.com/d45741b3-8335-463d-ab16-8c5f0bcf78ed/codeSet/14249",
+                        "code": "381456583"
+                    }
+                ]
+            }
+        ],
+        "description": "PC Established Patient",
+        "patientIcn": "1012845331V153043",
+        "locationId": "757",
+        "practitioners": [
+            {
+                "name": {
+                    "family": "Everett",
+                    "given": [
+                        "CERNER",
+                        "DO"
+                    ]
+                }
+            }
+        ],
+        "start": "2024-12-23T13:30:00Z",
+        "end": "2024-12-23T14:00:00Z",
+        "minutesDuration": 30,
+        "comment": "\nContact preference: Secure message",
+        "cancellable": false,
+        "patientInstruction": "Preparations:\n- If you have any new non-VA medical records since your last visit, please bring them.\r\nIf you need to cancel or reschedule your appointment, please call our Contact Center at 614-257-5200 or visit the patient portal.",
+        "extension": {
+            "ccLocation": {
+                "address": {}
+            }
+        },
+        "requestedPeriods": null,
+        "localStartTime": "2024-12-23T09:30:00.000-04:00",
+        "location": {
+            "id": "757",
+            "type": "appointments",
+            "attributes": {
+                "id": "757",
+                "facilitiesApiId": "vha_757",
+                "vistaSite": "757",
+                "vastParent": "757",
+                "type": "va_health_facility",
+                "name": "Chalmers P. Wylie Veterans CERNER Clinic",
+                "classification": "Health Care Center (HCC)",
+                "timezone": {
+                    "timeZoneId": "America/New_York"
+                },
+                "lat": 39.98048,
+                "long": -82.9123,
+                "website": "https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/",
+                "phone": {
+                    "main": "614-257-5200",
+                    "fax": "614-257-5460",
+                    "pharmacy": "614-257-5230",
+                    "afterHours": "614-257-5512",
+                    "patientAdvocate": "614-257-5290",
+                    "mentalHealthClinic": "614-257-5631",
+                    "enrollmentCoordinator": "614-257-5628"
+                },
+                "hoursOfOperation": [
+                    {
+                        "daysOfWeek": "sun",
+                        "openingTime": "800AM",
+                        "closingTime": "400PM"
+                    },
+                    {
+                        "daysOfWeek": "mon",
+                        "openingTime": "730AM",
+                        "closingTime": "600PM"
+                    },
+                    {
+                        "daysOfWeek": "tue",
+                        "openingTime": "730AM",
+                        "closingTime": "600PM"
+                    },
+                    {
+                        "daysOfWeek": "wed",
+                        "openingTime": "730AM",
+                        "closingTime": "600PM"
+                    },
+                    {
+                        "daysOfWeek": "thu",
+                        "openingTime": "730AM",
+                        "closingTime": "600PM"
+                    },
+                    {
+                        "daysOfWeek": "fri",
+                        "openingTime": "730AM",
+                        "closingTime": "600PM"
+                    },
+                    {
+                        "daysOfWeek": "sat",
+                        "openingTime": "800AM",
+                        "closingTime": "400PM"
+                    }
+                ],
+                "physicalAddress": {
+                    "type": "physical",
+                    "line": [
+                        "420 North James Road",
+                        null,
+                        null
+                    ],
+                    "city": "Columbus",
+                    "state": "OH",
+                    "postalCode": "43219-1834"
+                },
+                "mobile": false,
+                "healthService": [
+                    "Allergy",
+                    "Audiology",
+                    "Cardiology",
+                    "CaregiverSupport",
+                    "Covid19Vaccine",
+                    "Dental",
+                    "Dermatology",
+                    "Diabetic",
+                    "Endocrinology",
+                    "Gastroenterology",
+                    "Geriatrics",
+                    "Gynecology",
+                    "Hematology",
+                    "Homeless",
+                    "Hospice",
+                    "Laboratory",
+                    "Lgbtq",
+                    "MinorityCare",
+                    "Nephrology",
+                    "Neurology",
+                    "Nutrition",
+                    "Ophthalmology",
+                    "Optometry",
+                    "Orthopedics",
+                    "Otolaryngology",
+                    "PainManagement",
+                    "PatientAdvocates",
+                    "Pharmacy",
+                    "PhysicalMedicine",
+                    "PlasticSurgery",
+                    "Podiatry",
+                    "PrimaryCare",
+                    "Prosthetics",
+                    "Ptsd",
+                    "PulmonaryMedicine",
+                    "Radiology",
+                    "Rheumatology",
+                    "Smoking",
+                    "SocialWork",
+                    "SpinalInjury",
+                    "SuicidePrevention",
+                    "Surgery",
+                    "TransitionCounseling",
+                    "UrgentCare",
+                    "Urology",
+                    "VascularSurgery",
+                    "Vision",
+                    "WeightManagement",
+                    "WomensHealth",
+                    "Wound"
+                ],
+                "operatingStatus": {
+                    "code": "NORMAL"
+                },
+                "visn": "10"
+            }
+        }
+    }
+},
+{
+    "id": "9726bd1ca2a1cf349d6d56071140e02c3883fc275bde03dd3c44e855b19b3a67",
+    "type": "appointments",
+    "attributes": {
+        "id": "9726bd1ca2a1cf349d6d56071140e02c3883fc275bde03dd3c44e855b19b3a67",
+        "identifier": [
+            {
+                "system": "Appointment/",
+                "value": "413938333132333035"
+            },
+            {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+                "value": "983:12305"
+            }
+        ],
+        "kind": "clinic",
+        "status": "booked",
+        "serviceType": "audiology",
+        "serviceTypes": [
+            {
+                "coding": [
+                    {
+                        "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                        "code": "audiology"
+                    }
+                ]
+            }
+        ],
+        "serviceCategory": [
+            {
+                "coding": [
+                    {
+                        "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                        "code": "COMPENSATION & PENSION",
+                        "display": "COMPENSATION & PENSION"
+                    }
+                ],
+                "text": "COMPENSATION & PENSION"
+            }
+        ],
+        "patientIcn": "1013678363V916823",
+        "locationId": "983GC",
+        "clinic": "945",
+        "start": "2024-12-19T15:40:00Z",
+        "end": "2024-12-19T16:40:00Z",
+        "minutesDuration": 60,
+        "slot": {
+            "id": "3230323431323139313534303A323032343132313931363430",
+            "start": "2024-12-19T15:40:00Z",
+            "end": "2024-12-19T16:40:00Z"
+        },
+        "created": "2024-01-08T00:00:00Z",
+        "cancellable": false,
+        "extension": {
+            "ccLocation": {
+                "address": {}
+            },
+            "vistaStatus": [
+                "FUTURE"
+            ],
+            "preCheckinAllowed": false,
+            "eCheckinAllowed": false,
+            "clinic": {
+                "physicalLocation": "FORT COLLINS AUDIO"
+            }
+        },
+        "localStartTime": "2024-12-19T08:40:00.000-07:00",
+        "serviceName": "C&P BEV AUDIO FTC",
+        "friendlyName": "C&P BEV AUDIO FTC",
+        "physicalLocation": "FORT COLLINS AUDIO",
+        "location": {
+            "id": "983GC",
+            "type": "appointments",
+            "attributes": {
+                "id": "983GC",
+                "vistaSite": "983",
+                "vastParent": "983",
+                "type": "va_facilities",
+                "name": "Fort Collins VA Clinic",
+                "classification": "Multi-Specialty CBOC",
+                "timezone": {
+                    "timeZoneId": "America/Denver"
+                },
+                "lat": 40.553875,
+                "long": -105.08795,
+                "website": "https://www.cheyenne.va.gov/locations/Fort_Collins_VA_CBOC.asp",
+                "phone": {
+                    "main": "970-224-1550"
+                },
+                "physicalAddress": {
+                    "line": [
+                        "2509 Research Boulevard"
+                    ],
+                    "city": "Fort Collins",
+                    "state": "CO",
+                    "postalCode": "80526-8108"
+                },
+                "healthService": [
+                    "Audiology",
+                    "EmergencyCare",
+                    "MentalHealthCare",
+                    "PrimaryCare",
+                    "SpecialtyCare"
+                ]
+            }
+        }
+    }
+},
+{
+    "id": "d9faffb0d9cf0c641e53faf221fb0a08b2f6c661cc470a94817556dc0ce3589a",
+    "type": "appointments",
+    "attributes": {
+        "id": "d9faffb0d9cf0c641e53faf221fb0a08b2f6c661cc470a94817556dc0ce3589a",
+        "identifier": [
+            {
+                "system": "http://med.va.gov/fhir/urn/vaos/vvs/id",
+                "value": "381ba035-c30a-4f21-ad0e-1204a6ef3fc8"
+            }
+        ],
+        "kind": "telehealth",
+        "status": "booked",
+        "patientIcn": "1012846043V576341",
+        "locationId": "983",
+        "practitioners": [
+            {
+                "identifier": [
+                    {
+                        "system": "dfn-983",
+                        "value": "520648070"
+                    }
+                ],
+                "name": {
+                    "family": "Chapman",
+                    "given": [
+                        "Jeremy"
+                    ]
+                },
+                "practiceName": "Cheyenne VA Medical Center"
+            }
+        ],
+        "start": "2024-12-12T19:55:00Z",
+        "end": "2024-12-12T20:15:00Z",
+        "minutesDuration": 20,
+        "created": "2024-12-12T19:57:42.025Z",
+        "cancellable": false,
+        "patientInstruction": "",
+        "telehealth": {
+            "url": "https://pexip.mapsandbox.net/vvc-app/?join=1&media=1&escalate=1&userType=guest&conference=VAC000005810@pexip.mapsandbox.net&pin=356403&aid=381ba035-c30a-4f21-ad0e-1204a6ef3fc8#",
+            "group": false,
+            "vvsKind": "ADHOC"
+        },
+        "extension": {
+            "ccLocation": {
+                "address": {}
+            },
+            "vistaStatus": [],
+            "patientHasMobileGfe": true
+        },
+        "localStartTime": "2024-12-12T13:55:00.000-06:00",
+        "location": {
+            "id": "983",
+            "type": "appointments",
+            "attributes": {
+                "id": "983",
+                "vistaSite": "983",
+                "vastParent": "983",
+                "type": "va_facilities",
+                "name": "Cheyenne VA Medical Center",
+                "classification": "VA Medical Center (VAMC)",
+                "timezone": {
+                    "timeZoneId": "America/Denver"
+                },
+                "lat": 39.744507,
+                "long": -104.830956,
+                "website": "https://www.denver.va.gov/locations/directions.asp",
+                "phone": {
+                    "main": "307-778-7550",
+                    "fax": "307-778-7381",
+                    "pharmacy": "866-420-6337",
+                    "afterHours": "307-778-7550",
+                    "patientAdvocate": "307-778-7550 x7517",
+                    "mentalHealthClinic": "307-778-7349",
+                    "enrollmentCoordinator": "307-778-7550 x7579"
+                },
+                "physicalAddress": {
+                    "type": "physical",
+                    "line": [
+                        "2360 East Pershing Boulevard"
+                    ],
+                    "city": "Cheyenne",
+                    "state": "WY",
+                    "postalCode": "82001-5356"
+                },
+                "mobile": false,
+                "healthService": [
+                    "Audiology",
+                    "Cardiology",
+                    "DentalServices",
+                    "EmergencyCare",
+                    "Gastroenterology",
+                    "Gynecology",
+                    "MentalHealthCare",
+                    "Nutrition",
+                    "Ophthalmology",
+                    "Optometry",
+                    "Orthopedics",
+                    "Podiatry",
+                    "PrimaryCare",
+                    "SpecialtyCare",
+                    "UrgentCare",
+                    "Urology",
+                    "WomensHealth"
+                ],
+                "operatingStatus": {
+                    "code": "NORMAL"
+                }
+            }
+        }
+    }
+},
+{
+    "id": "cbc61b77eab168d7bb886649c0d42f6f2951b912e358cab744ca65b2296468a2",
+    "type": "appointments",
+    "attributes": {
+        "id": "cbc61b77eab168d7bb886649c0d42f6f2951b912e358cab744ca65b2296468a2",
+        "identifier": [
+            {
+                "system": "http://med.va.gov/fhir/urn/vaos/vvs/id",
+                "value": "38fc7910-fa4a-4973-8a50-c9533fb0e3c0"
+            }
+        ],
+        "kind": "telehealth",
+        "status": "booked",
+        "patientIcn": "1013124304V115761",
+        "locationId": "983",
+        "practitioners": [
+            {
+                "identifier": [
+                    {
+                        "system": "dfn-983",
+                        "value": "520647363"
+                    }
+                ],
+                "name": {
+                    "family": "NADEAU",
+                    "given": [
+                        "MARCY"
+                    ]
+                },
+                "practiceName": "Cheyenne VA Medical Center"
+            }
+        ],
+        "start": "2025-02-25T19:00:00Z",
+        "end": "2025-02-25T19:20:00Z",
+        "minutesDuration": 20,
+        "created": "2024-02-29T18:22:31.642Z",
+        "cancellable": false,
+        "patientInstruction": "Medication Review\n\nAs part of your video visit, your provider will review all the medications, vitamins, herbs, and supplements you are taking\n(even items you get from a local store, another provider, or another VA clinic). Please have information about everything you\ntake available during the visit. Informing your provider about all these will help you get the best and safest care possible.\nRemember, it is your medications, your life. Play it safe by reviewing all your medications with your health care team.\n",
+        "telehealth": {
+            "url": "https://pexip.mapsandbox.net/vvc-app/?join=1&media=1&escalate=1&userType=guest&conference=VAC000003848@pexip.mapsandbox.net&pin=111200&aid=38fc7910-fa4a-4973-8a50-c9533fb0e3c0#",
+            "group": false,
+            "vvsKind": "ADHOC"
+        },
+        "extension": {
+            "ccLocation": {
+                "address": {}
+            },
+            "vistaStatus": [],
+            "patientHasMobileGfe": false
+        },
+        "localStartTime": "2025-02-25T12:00:00.000-07:00",
+        "location": {
+            "id": "983",
+            "type": "appointments",
+            "attributes": {
+                "id": "983",
+                "vistaSite": "983",
+                "vastParent": "983",
+                "type": "va_facilities",
+                "name": "Cheyenne VA Medical Center",
+                "classification": "VA Medical Center (VAMC)",
+                "timezone": {
+                    "timeZoneId": "America/Denver"
+                },
+                "lat": 39.744507,
+                "long": -104.830956,
+                "website": "https://www.denver.va.gov/locations/directions.asp",
+                "phone": {
+                    "main": "307-778-7550",
+                    "fax": "307-778-7381",
+                    "pharmacy": "866-420-6337",
+                    "afterHours": "307-778-7550",
+                    "patientAdvocate": "307-778-7550 x7517",
+                    "mentalHealthClinic": "307-778-7349",
+                    "enrollmentCoordinator": "307-778-7550 x7579"
+                },
+                "physicalAddress": {
+                    "type": "physical",
+                    "line": [
+                        "2360 East Pershing Boulevard"
+                    ],
+                    "city": "Cheyenne",
+                    "state": "WY",
+                    "postalCode": "82001-5356"
+                },
+                "mobile": false,
+                "healthService": [
+                    "Audiology",
+                    "Cardiology",
+                    "DentalServices",
+                    "EmergencyCare",
+                    "Gastroenterology",
+                    "Gynecology",
+                    "MentalHealthCare",
+                    "Nutrition",
+                    "Ophthalmology",
+                    "Optometry",
+                    "Orthopedics",
+                    "Podiatry",
+                    "PrimaryCare",
+                    "SpecialtyCare",
+                    "UrgentCare",
+                    "Urology",
+                    "WomensHealth"
+                ],
+                "operatingStatus": {
+                    "code": "NORMAL"
+                }
+            }
+        }
+    }
+},
+{
+    "id": "805eb1710aefb85bcc07813ae36a744f1467fd4306c0a950ba16e023fb514ce9",
+    "type": "appointments",
+    "attributes": {
+        "id": "805eb1710aefb85bcc07813ae36a744f1467fd4306c0a950ba16e023fb514ce9",
+        "identifier": [
+            {
+                "system": "Appointment/",
+                "value": "4139383436323830"
+            },
+            {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+                "value": "984:6280"
+            },
+            {
+                "system": "http://med.va.gov/fhir/urn/vaos/vvs/id",
+                "value": "6641d9ca-bcf0-4040-947a-ed9ed822e495"
+            }
+        ],
+        "kind": "telehealth",
+        "status": "booked",
+        "serviceType": "outpatientMentalHealth",
+        "serviceTypes": [
+            {
+                "coding": [
+                    {
+                        "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                        "code": "outpatientMentalHealth"
+                    }
+                ]
+            }
+        ],
+        "serviceCategory": [
+            {
+                "coding": [
+                    {
+                        "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                        "code": "REGULAR",
+                        "display": "REGULAR"
+                    }
+                ],
+                "text": "REGULAR"
+            }
+        ],
+        "patientIcn": "1012845331V153043",
+        "locationId": "984GA",
+        "clinic": "4284",
+        "practitioners": [
+            {
+                "identifier": [
+                    {
+                        "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
+                        "value": "1034242903"
+                    }
+                ],
+                "name": {
+                    "family": "ALSAHHAR",
+                    "given": [
+                        "SAMI"
+                    ]
+                }
+            }
+        ],
+        "start": "2025-01-14T13:00:00Z",
+        "end": "2025-01-14T13:30:00Z",
+        "minutesDuration": 30,
+        "slot": {
+            "id": "3230323331313134313330303A323032333131313431333330",
+            "start": "2025-01-14T13:00:00Z",
+            "end": "2025-01-14T13:30:00Z"
+        },
+        "created": "2025-01-07T00:00:00Z",
+        "cancellable": false,
+        "telehealth": {
+            "url": "https://dev.care.va.gov/vvc-app/?join=1&media=1&escalate=1&userType=guest&conference=VAC000001440@dev.care.va.gov&pin=590094&aid=6641d9ca-bcf0-4040-947a-ed9ed822e495#",
+            "group": false,
+            "vvsKind": "CLINIC_BASED"
+        },
+        "extension": {
+            "ccLocation": {
+                "address": {}
+            },
+            "vistaStatus": [
+                "NO ACTION TAKEN"
+            ],
+            "patientHasMobileGfe": true,
+            "preCheckinAllowed": false,
+            "eCheckinAllowed": false,
+            "clinic": {}
+        },
+        "localStartTime": "2025-01-14T08:00:00.000-05:00",
+        "avsPath": null,
+        "serviceName": "MID-V10 CRH MH PSY MD PT",
+        "friendlyName": "MID-V10 CRH MH PSY MD PT",
+        "location": {
+            "id": "984GA",
+            "type": "appointments",
+            "attributes": {
+                "id": "984GA",
+                "vistaSite": "984",
+                "vastParent": "984",
+                "type": "va_health_facility",
+                "name": "Middletown VA Clinic",
+                "classification": "Multi-Specialty CBOC",
+                "timezone": {
+                    "timeZoneId": "America/New_York"
+                },
+                "lat": 39.50603,
+                "long": -84.316475,
+                "website": "https://www.dayton.va.gov/locations/midtwn_cboc.asp",
+                "phone": {
+                    "main": "513-423-8387"
+                },
+                "physicalAddress": {
+                    "type": "physical",
+                    "line": [
+                        "4337 North Union Road"
+                    ],
+                    "city": "Middletown",
+                    "state": "OH",
+                    "postalCode": "45005-5211"
+                },
+                "healthService": [
+                    "Audiology",
+                    "MentalHealthCare",
+                    "Optometry",
+                    "Podiatry",
+                    "PrimaryCare",
+                    "SpecialtyCare"
+                ]
+            }
+        }
+    }
+},
+
+{
+    "id": "0fbc293324755816b690f11eab25c827b5e4fbea375ac06e8e9694205f95590e",
+    "type": "appointments",
+    "attributes": {
+        "id": "0fbc293324755816b690f11eab25c827b5e4fbea375ac06e8e9694205f95590e",
+        "identifier": [
+            {
+                "system": "http://med.va.gov/fhir/urn/vaos/vvs/id",
+                "value": "5c21ee08-7bc9-4cc3-b557-0fc543c40148"
+            }
+        ],
+        "kind": "telehealth",
+        "status": "booked",
+        "patientIcn": "1013124304V115761",
+        "locationId": "983",
+        "practitioners": [
+            {
+                "identifier": [
+                    {
+                        "system": "dfn-983",
+                        "value": "520647710"
+                    }
+                ],
+                "name": {
+                    "family": "Poldass",
+                    "given": [
+                        "Aarathi"
+                    ]
+                },
+                "practiceName": "Cheyenne VA Medical Center"
+            }
+        ],
+        "start": "2024-12-01T15:00:00Z",
+        "end": "2024-12-01T15:30:00Z",
+        "minutesDuration": 30,
+        "created": "2024-03-01T18:52:19.23Z",
+        "comment": "Testing ATLAS appt for VAOS team (Marcy)",
+        "cancellable": false,
+        "patientInstruction": "Medication Review\n\nAs part of your video visit, your provider will review all the medications, vitamins, herbs, and supplements you are taking\n(even items you get from a local store, another provider, or another VA clinic). Please have information about everything you\ntake available during the visit. Informing your provider about all these will help you get the best and safest care possible.\nRemember, it is your medications, your life. Play it safe by reviewing all your medications with your health care team.\n",
+        "telehealth": {
+            "url": "https://dev.care2.va.gov/vvc-app/?join=1&media=1&escalate=1&userType=guest&conference=VAC000003896@dev.care2.va.gov&pin=104039&aid=5c21ee08-7bc9-4cc3-b557-0fc543c40148#",
+            "atlas": {
+                "siteCode": "VFW-DC-20011-02",
+                "confirmationCode": "075041",
+                "address": {
+                    "streetAddress": "5929 Georgia Ave NW",
+                    "city": "Washington",
+                    "state": "DC",
+                    "zipCode": "20011",
+                    "country": "USA",
+                    "latitutde": 38.961979,
+                    "longitude": -77.027908,
+                    "additionalDetails": ""
+                }
+            },
+            "group": false,
+            "vvsKind": "ADHOC"
+        },
+        "extension": {
+            "ccLocation": {
+                "address": {}
+            },
+            "vistaStatus": [],
+            "patientHasMobileGfe": false
+        },
+        "localStartTime": "2024-12-01T08:00:00.000-07:00",
+        "location": {
+            "id": "983",
+            "type": "appointments",
+            "attributes": {
+                "id": "983",
+                "vistaSite": "983",
+                "vastParent": "983",
+                "type": "va_facilities",
+                "name": "Cheyenne VA Medical Center",
+                "classification": "VA Medical Center (VAMC)",
+                "timezone": {
+                    "timeZoneId": "America/Denver"
+                },
+                "lat": 39.744507,
+                "long": -104.830956,
+                "website": "https://www.denver.va.gov/locations/directions.asp",
+                "phone": {
+                    "main": "307-778-7550",
+                    "fax": "307-778-7381",
+                    "pharmacy": "866-420-6337",
+                    "afterHours": "307-778-7550",
+                    "patientAdvocate": "307-778-7550 x7517",
+                    "mentalHealthClinic": "307-778-7349",
+                    "enrollmentCoordinator": "307-778-7550 x7579"
+                },
+                "physicalAddress": {
+                    "type": "physical",
+                    "line": [
+                        "2360 East Pershing Boulevard"
+                    ],
+                    "city": "Cheyenne",
+                    "state": "WY",
+                    "postalCode": "82001-5356"
+                },
+                "mobile": false,
+                "healthService": [
+                    "Audiology",
+                    "Cardiology",
+                    "DentalServices",
+                    "EmergencyCare",
+                    "Gastroenterology",
+                    "Gynecology",
+                    "MentalHealthCare",
+                    "Nutrition",
+                    "Ophthalmology",
+                    "Optometry",
+                    "Orthopedics",
+                    "Podiatry",
+                    "PrimaryCare",
+                    "SpecialtyCare",
+                    "UrgentCare",
+                    "Urology",
+                    "WomensHealth"
+                ],
+                "operatingStatus": {
+                    "code": "NORMAL"
+                }
+            }
+        }
+    }
+},
     {
       "id": "167419",
       "type": "appointments",
@@ -13,6 +1412,7 @@
         ],
         "kind": "telehealth",
         "status": "booked",
+        "serviceType": "outpatientMentalHealth",
         "patientIcn": "1012845331V153043",
         "locationId": "984",
         "physicalLocation" : "should not display",
@@ -145,11 +1545,11 @@
         },
         "requestedPeriods": null,
         "serviceType": "covid",
-        "start": "2024-10-13T15:00:00Z",
+        "start": "2023-10-13T15:00:00Z",
         "status": "booked",
         "created": "2024-11-01T00:00:00Z",
         "cancellable": false,
-        "localStartTime": "2024-10-13T09:00:00.000-06:00",
+        "localStartTime": "2023-10-13T09:00:00.000-06:00",
         "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988663350853",
         "telehealth": null
       }
@@ -222,11 +1622,11 @@
             }
           }
         ],
-        "start": "2024-08-22T12:00:00Z",
-        "created": "2024-08-22T20:33:54Z",
+        "start": "2024-08-21T12:00:00Z",
+        "created": "2024-08-21T20:33:54Z",
         "localStartTime": "2024-08-21T09:00:00.000-06:00",
         "avsPath": null,
-        "cancellable": true,
+        "cancellable": false,
         "extension": {
           "ccLocation": {
             "address": {
@@ -316,6 +1716,7 @@
         ],
         "kind": "clinic",
         "status": "booked",
+        "serviceType": "outpatientMentalHealth",
         "serviceCategory": [
           {
             "coding": [
@@ -331,15 +1732,15 @@
         "patientIcn": "1012845331V153043",
         "locationId": "983",
         "clinic": "1049",
-        "start": "2023-10-23T15:00:00Z",
-        "end": "2023-10-23T16:00:00Z",
+        "start": "2023-10-13T15:00:00Z",
+        "end": "2023-10-13T16:00:00Z",
         "minutesDuration": 60,
         "slot": {
           "id": "3230323331303133313530303A323032333130313331363030",
           "start": "2023-10-13T15:00:00Z",
           "end": "2023-10-13T16:00:00Z"
         },
-        "created": "2023-11-01T00:00:00Z",
+        "created": "2023-10-01T00:00:00Z",
         "cancellable": true,
         "extension": {
           "ccLocation": {
@@ -797,12 +2198,12 @@
         "patientIcn": "1012845331V153043",
         "locationId": "983",
         "clinic": "455",
-        "start": "2024-10-19T15:00:00Z",
+        "start": "2023-10-19T15:00:00Z",
         "end": "2023-10-19T16:00:00Z",
         "minutesDuration": 60,
         "slot": {
           "id": "3230323331303139313530303A323032333130313931363030",
-          "start": "2024-10-19T15:00:00Z",
+          "start": "2023-10-19T15:00:00Z",
           "end": "2023-10-19T16:00:00Z"
         },
         "created": "2023-11-01T00:00:00Z",
@@ -818,7 +2219,7 @@
           "eCheckinAllowed": false,
           "clinic": {}
         },
-        "localStartTime": "2024-10-19T09:00:00.000-06:00",
+        "localStartTime": "2023-10-19T09:00:00.000-06:00",
         "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988639578151",
         "serviceName": "CHY PC CASSIDY",
         "physicalLocation": "ARROWHEAD WING, 2ND FLOOR",
@@ -1020,7 +2421,7 @@
             "name": {
               "family": "Everett",
               "given": [
-                "Matthew",
+                "CERNER",
                 "DO"
               ]
             }
@@ -1049,7 +2450,7 @@
             "vistaSite": "757",
             "vastParent": "757",
             "type": "va_health_facility",
-            "name": "Chalmers P. Wylie Veterans Outpatient Clinic",
+            "name": "Chalmers P. Wylie Veterans CERNER Clinic",
             "classification": "Health Care Center (HCC)",
             "timezone": {
               "timeZoneId": "America/New_York"
@@ -1330,9 +2731,9 @@
         "status": "booked",
         "patientIcn": "1013120820V528557",
         "locationId": "984",
-        "start": "2022-11-22T12:00:00Z",
-        "created": "2022-11-22T20:33:54Z",
-        "cancellable": true,
+        "start": "2024-11-22T12:00:00Z",
+        "created": "2024-11-22T20:33:54Z",
+        "localStartTime": "2024-11-22T09:00:00.000-06:00",
         "extension": {
           "ccLocation": {
             "address": {
@@ -1472,141 +2873,6 @@
       }
     },
     {
-      "id": "01aa456cc",
-      "type": "cc_appointments",
-      "attributes": {
-        "cancelationReason": null,
-        "clinic": null,
-        "comment": "test",
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            },
-            {
-              "system": "phone",
-              "value": "723-234-4566"
-            }
-          ]
-        },
-        "description": "community care appointment",
-        "end": null,
-        "id": "01aa456cc",
-        "kind": "cc",
-        "locationId": null,
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "practitioners": [
-          {
-            "identifier": [
-              {
-                "system": null,
-                "value": "1801312053"
-              }
-            ],
-            "name": {
-              "family": "Hyde",
-              "given": [
-                "DR"
-              ]
-            }
-          }
-        ],
-        "extension": {
-          "ccLocation": {
-            "address": {
-              "line": [
-                "1601 Needmore Rd Ste 1"
-              ],
-              "city": "Dayton",
-              "state": "OH",
-              "postalCode": "45414",
-              "text": "1601 Needmore Rd Ste 1\nDayton OH 45414"
-            },
-            "telecom": [
-              {
-                "system": "phone",
-                "value": "723-234-4565"
-              }
-            ]
-          }
-        },
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {},
-        "requestedPeriods": null,
-        "serviceType": "audiology",
-        "slot": null,
-        "start": "2022-08-28T18:19:34",
-        "status": "booked",
-        "telehealth": null
-      }
-    },
-    {
-      "id": "22aa789cc",
-      "type": "cc_appointments",
-      "attributes": {
-        "cancelationReason": {
-          "coding": [
-            {
-              "code": "pat"
-            }
-          ]
-        },
-        "clinic": null,
-        "comment": "test",
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            }
-          ]
-        },
-        "description": "Cancelled community care appointment",
-        "end": null,
-        "id": "22aa789cc",
-        "kind": "cc",
-        "locationId": null,
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "practitioners": [
-          {
-            "identifier": [
-              {
-                "system": null,
-                "value": "1801312053"
-              }
-            ]
-          }
-        ],
-        "extension": {
-          "ccLocation": {
-            "address": {
-              "line": [
-                "1601 Needmore Rd Ste 1"
-              ],
-              "city": "Dayton",
-              "state": "OH",
-              "postalCode": "45414",
-              "text": "1601 Needmore Rd Ste 1\nDayton OH 45414"
-            }
-          },
-          "ccTreatingSpecialty": ""
-        },
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {},
-        "requestedPeriods": null,
-        "serviceType": "audiology",
-        "slot": null,
-        "start": "2022-12-20T18:19:34",
-        "status": "cancelled",
-        "telehealth": null
-      }
-    },
-    {
       "id": "02aa456vvs",
       "type": "Appointment",
       "attributes": {
@@ -1689,7 +2955,7 @@
           ]
         },
         "description": "Upcoming Atlas telehealth appointment",
-        "end": "2023-01-23T20:00:00Z",
+        "end": "2023-01-13T20:00:00Z",
         "id": "03aa456vvs",
         "kind": "telehealth",
         "locationId": "983",
@@ -1718,7 +2984,7 @@
         "requestedPeriods": null,
         "serviceType": "amputation",
         "slot": null,
-        "start": "2023-01-23T20:00:00Z",
+        "start": "2023-01-13T20:00:00Z",
         "localStartTime": "2023-01-13T09:00:00.000-06:00",
         "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988663350853",
         "status": "booked",
@@ -1907,7 +3173,7 @@
         "requestedPeriods": null,
         "serviceType": "primaryCare",
         "slot": null,
-        "start": "2023-11-27T18:19:34",
+        "start": "2023-11-22T18:19:34",
         "status": "booked",
         "telehealth": {
           "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#",


### PR DESCRIPTION

## Summary

This PR fixes the cancel button to not display when `cancellable` is to set to false for upcoming in-person appointment and phone appointment

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#85972

## Testing done

unit test

## Screenshots

**Cancel button does not display when cancellable: false**
---
![Screenshot 2024-06-21 at 4 59 00 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/28bb770c-f1f1-4420-a7ff-d8591b728a2a)

**Cancel button displays when cancellable: true**
---
![Screenshot 2024-06-21 at 5 00 56 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/54327023/b4da8b1c-f1b5-469b-a2db-29971b56c89f)


## What areas of the site does it impact?

VAOS detail appointments

## Acceptance criteria

- [ ] Cancel button should not display in upcoming detail appointment when "cancellable": false is returned as part of appointment object.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user


