### PR TITLE
86230  Require two files on card upload screens

### DIFF
--- a/src/applications/ivc-champva/10-10D/components/Applicant/applicantFileUpload.js
+++ b/src/applications/ivc-champva/10-10D/components/Applicant/applicantFileUpload.js
@@ -323,9 +323,15 @@ export const applicantMedicarePartAPartBCardsUploadUiSchema = {
         },
       ),
       ...applicantMedicarePartAPartBCardsConfig.uiSchema,
-      applicantMedicarePartAPartBCard: fileUploadUI({
-        label: 'Upload Medicare cards',
-      }),
+      applicantMedicarePartAPartBCard: {
+        ...fileUploadUI({
+          label: 'Upload Medicare cards',
+        }),
+        'ui:errorMessages': {
+          minItems:
+            'You must add both the front and back of your card as separate files.',
+        },
+      },
     },
   },
 };
@@ -362,9 +368,15 @@ export const applicantMedicarePartDCardsUploadUiSchema = {
         },
       ),
       ...applicantMedicarePartDCardsConfig.uiSchema,
-      applicantMedicarePartDCard: fileUploadUI({
-        label: 'Upload Medicare card',
-      }),
+      applicantMedicarePartDCard: {
+        ...fileUploadUI({
+          label: 'Upload Medicare card',
+        }),
+        'ui:errorMessages': {
+          minItems:
+            'You must add both the front and back of your card as separate files.',
+        },
+      },
     },
   },
 };
@@ -436,9 +448,15 @@ export const applicantOhiCardsUploadUiSchema = {
         </>,
       ),
       ...applicantOhiCardsConfig.uiSchema,
-      applicantOhiCard: fileUploadUI({
-        label: 'Upload other health insurance cards',
-      }),
+      applicantOhiCard: {
+        ...fileUploadUI({
+          label: 'Upload other health insurance cards',
+        }),
+        'ui:errorMessages': {
+          minItems:
+            'You must add both the front and back of your card as separate files.',
+        },
+      },
     },
   },
 };

--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -1247,6 +1247,7 @@ const formConfig = {
             ...applicantMedicarePartAPartBCardsConfig.schema,
             applicantMedicarePartAPartBCard: fileWithMetadataSchema(
               acceptableFiles.medicareABCert,
+              2,
             ),
           }),
         },
@@ -1277,6 +1278,7 @@ const formConfig = {
             ...applicantMedicarePartDCardsConfig.schema,
             applicantMedicarePartDCard: fileWithMetadataSchema(
               acceptableFiles.medicareDCert,
+              2,
             ),
           }),
         },
@@ -1353,6 +1355,7 @@ const formConfig = {
             ...applicantOhiCardsConfig.schema,
             applicantOhiCard: fileWithMetadataSchema(
               acceptableFiles.healthInsCert,
+              2,
             ),
           }),
         },


### PR DESCRIPTION
## Summary

Updates the `minItems` property across the three different card uploads in form 10-10d (medicare A/B, medicare D, and OHI card). Adds requirement for two files to be uploaded.

- Set minimum items to 2 on all card-type uploads (for front and back of card)
- Added error message that indicates we want the front and back of a card if user uploads < 2 files
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86230

## Testing done

- Manual

## Screenshots

|         | New error |
| ------- | ----- |
| Medicare AB card |![Screenshot 2024-06-24 at 10 32 38](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/fddb39eb-1259-48a5-bcc0-2a01d2f86a2e)|
| Medicare D card |![Screenshot 2024-06-24 at 10 32 57](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/b33774c4-79dc-46a6-b942-099370137220)|
| OHI card |![Screenshot 2024-06-24 at 10 33 14](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/5c26dbd7-b4b7-4fcc-81aa-45ff9db77594)|

## What areas of the site does it impact?

IVC form 10-10d only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA