### PR TITLE
82997 update urls - form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -201,7 +201,7 @@ const formConfig = {
       pages: {
         page1: {
           // initialData: mockData.data,
-          path: 'signer',
+          path: 'signer-type',
           title: 'Which of these best describes you?',
           uiSchema: {
             ...titleUI('Your information'),
@@ -229,7 +229,7 @@ const formConfig = {
           },
         },
         page2: {
-          path: 'signer-information',
+          path: 'signer-info',
           title: 'Certification',
           depends: formData => get('certifierRole', formData) === 'other',
           uiSchema: {
@@ -268,7 +268,7 @@ const formConfig = {
           },
         },
         page4: {
-          path: 'signer-contact-information',
+          path: 'signer-contact-info',
           title: 'Certification',
           depends: formData => get('certifierRole', formData) === 'other',
           uiSchema: {
@@ -385,14 +385,14 @@ const formConfig = {
       title: 'Sponsor information',
       pages: {
         page6: {
-          path: 'sponsor-information',
+          path: 'sponsor-info',
           title: formData =>
             `${sponsorWording(formData)} name and date of birth`,
           uiSchema: sponsorNameDobConfig.uiSchema,
           schema: sponsorNameDobConfig.schema,
         },
         page7: {
-          path: 'sponsor-identification-information',
+          path: 'sponsor-identification-info',
           title: formData =>
             `${sponsorWording(formData)} identification information`,
           uiSchema: {
@@ -496,7 +496,7 @@ const formConfig = {
           },
         },
         page11: {
-          path: 'sponsor-contact-information',
+          path: 'sponsor-contact-info',
           title: formData => `${sponsorWording(formData)} contact information`,
           depends: formData => !get('sponsorIsDeceased', formData),
           uiSchema: {
@@ -535,7 +535,7 @@ const formConfig = {
       pages: {
         page13: {
           title: 'Applicant information',
-          path: 'applicant-information',
+          path: 'applicant-info',
           uiSchema: {
             ...titleUI('Applicant name and date of birth', () => (
               <>
@@ -570,7 +570,7 @@ const formConfig = {
           }),
         },
         page13a: {
-          path: 'applicant-information-intro/:index',
+          path: 'applicant-info-intro/:index',
           arrayPath: 'applicants',
           title: item => `${applicantWording(item)} information`,
           showPagePerItem: true,
@@ -602,7 +602,7 @@ const formConfig = {
           }),
         },
         page14: {
-          path: 'applicant-identification-information/:index',
+          path: 'applicant-identification-info/:index',
           arrayPath: 'applicants',
           title: item => `${applicantWording(item)} identification information`,
           showPagePerItem: true,
@@ -690,7 +690,7 @@ const formConfig = {
           }),
         },
         page16: {
-          path: 'applicant-contact-information/:index',
+          path: 'applicant-contact-info/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} contact information`,
@@ -765,7 +765,7 @@ const formConfig = {
           },
         },
         page18c: {
-          path: 'applicant-child-relationship/:index',
+          path: 'applicant-relationship-child/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} dependent status`,
@@ -799,7 +799,7 @@ const formConfig = {
           }),
         },
         page18a: {
-          path: 'applicant-child-file/:index',
+          path: 'applicant-relationship-child-upload/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} birth certificate`,
@@ -927,7 +927,7 @@ const formConfig = {
           }),
         },
         page18b: {
-          path: 'applicant-child-school-file/:index',
+          path: 'applicant-child-school-upload/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} school documents`,
@@ -1070,7 +1070,7 @@ const formConfig = {
           schema: marriageDatesSchema.separatedSchema,
         },
         page18f: {
-          path: 'applicant-marriage-file/:index',
+          path: 'applicant-marriage-upload/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} marriage documents`,
@@ -1139,7 +1139,7 @@ const formConfig = {
         // If applicant remarried after 55 but the second marriage is not viable,
         // upload a certificate proving the marriage dissolved
         page18f8: {
-          path: 'applicant-remarriage-separation-file/:index',
+          path: 'applicant-remarriage-separation-upload/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item =>
@@ -1225,7 +1225,7 @@ const formConfig = {
           },
         },
         page20a: {
-          path: 'applicant-medicare-ab-file/:index',
+          path: 'applicant-medicare-upload/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} Medicare Part A and B card`,
@@ -1251,7 +1251,7 @@ const formConfig = {
           }),
         },
         page20b: {
-          path: 'applicant-medicare-d-file/:index',
+          path: 'applicant-medicare-d-upload/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} Medicare Part D card`,
@@ -1333,7 +1333,7 @@ const formConfig = {
           },
         },
         page21a: {
-          path: 'applicant-other-insurance-file/:index',
+          path: 'applicant-other-insurance-upload/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} other health insurance`,

--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -884,7 +884,7 @@ const formConfig = {
           }),
         },
         page18b1: {
-          path: 'applicant-child-age/:index',
+          path: 'applicant-dependent-status/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} status`,

--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -743,7 +743,7 @@ const formConfig = {
           }),
         },
         page18: {
-          path: 'applicant-sponsor-relationship/:index',
+          path: 'applicant-relationship/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} relationship to sponsor`,
@@ -959,7 +959,7 @@ const formConfig = {
           }),
         },
         page18b2: {
-          path: 'applicant-child-helpless/:index',
+          path: 'applicant-dependent-upload/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} helpless child documents`,
@@ -1107,7 +1107,7 @@ const formConfig = {
           }),
         },
         page18f7: {
-          path: 'applicant-remarriage-file/:index',
+          path: 'applicant-remarriage-upload/:index',
           arrayPath: 'applicants',
           showPagePerItem: true,
           title: item => `${applicantWording(item)} second marriage documents`,


### PR DESCRIPTION
## Summary

This PR updates a few URLs in the 10-10d form. The key changes are that the words "information" and "file" have been replaced with "info" and "upload" respectively.

- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82997

## Testing done

- Manual
- Unit
- E2E

## Screenshots

NA

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA