### PR TITLE
VACMS-18317: Added new text for pdf alert 

### DIFF
--- a/src/applications/find-forms/components/PdfAlert.jsx
+++ b/src/applications/find-forms/components/PdfAlert.jsx
@@ -34,8 +34,12 @@ const PdfAlert = () => {
       <p>
         Some VA forms may not work with older versions of Acrobat Reader. You
         may also need to download a new copy of the VA form.&nbsp;
+      </p>
+      <p>
         <strong>{'Note: '}</strong> You never need to pay for special software
         to fill out VA forms.
+      </p>
+      <p>
         <va-link
           href="https://get.adobe.com/reader/"
           text="Get Acrobat Reader for free from Adobe"

--- a/src/applications/find-forms/components/PdfAlert.jsx
+++ b/src/applications/find-forms/components/PdfAlert.jsx
@@ -34,6 +34,8 @@ const PdfAlert = () => {
       <p>
         Some VA forms may not work with older versions of Acrobat Reader. You
         may also need to download a new copy of the VA form.&nbsp;
+        <strong>{'Note: '}</strong> You never need to pay for special software
+        to fill out VA forms.
         <va-link
           href="https://get.adobe.com/reader/"
           text="Get Acrobat Reader for free from Adobe"

--- a/src/applications/find-forms/components/PdfAlert.jsx
+++ b/src/applications/find-forms/components/PdfAlert.jsx
@@ -36,14 +36,14 @@ const PdfAlert = () => {
         may also need to download a new copy of the VA form.&nbsp;
       </p>
       <p>
-        <strong>{'Note: '}</strong> You never need to pay for special software
-        to fill out VA forms.
-      </p>
-      <p>
         <va-link
           href="https://get.adobe.com/reader/"
           text="Get Acrobat Reader for free from Adobe"
         />
+      </p>
+      <p>
+        <strong>{'Note: '}</strong> You never need to pay for special software
+        to fill out VA forms.
       </p>
     </va-alert>,
     pdfCertWarningElement,


### PR DESCRIPTION
## Summary
We have added a new note, to the pdf alert to let veterans know they do not need to pay for va forms.

`Note: You never need to pay for special software to fill out VA forms.`

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18317

## Testing done
Tested in review instance `/find-forms/`

## Screenshots
![Find_A_VA_Form___Veterans_Affairs](https://github.com/department-of-veterans-affairs/vets-website/assets/42885441/af986e54-caf9-4da4-afd3-d6e51b941da7)


## What areas of the site does it impact?

Find forms

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
