### PR TITLE
Update form field keys

### DIFF
--- a/src/applications/income-and-asset-statement/config/chapters/01-veteran-information/applicantIsVeteran.js
+++ b/src/applications/income-and-asset-statement/config/chapters/01-veteran-information/applicantIsVeteran.js
@@ -8,15 +8,15 @@ export default {
   title: 'Veteran information',
   path: 'veteran/information/applicant',
   uiSchema: {
-    applicantIsVeteran: yesNoUI({
+    'view:applicantIsVeteran': yesNoUI({
       title: 'Are you the Veteran?',
     }),
   },
   schema: {
     type: 'object',
-    required: ['applicantIsVeteran'],
+    required: ['view:applicantIsVeteran'],
     properties: {
-      applicantIsVeteran: yesNoSchema,
+      'view:applicantIsVeteran': yesNoSchema,
     },
   },
 };

--- a/src/applications/income-and-asset-statement/config/chapters/01-veteran-information/veteranInformation.js
+++ b/src/applications/income-and-asset-statement/config/chapters/01-veteran-information/veteranInformation.js
@@ -14,7 +14,7 @@ export default {
   uiSchema: {
     veteranFullName: fullNameNoSuffixUI(title => `Veteran’s ${title}`),
     veteranSocialSecurityNumber: ssnUI('Veteran’s Social Security number'),
-    veteranFileNumber: vaFileNumberUI('Veteran’s file number'),
+    vaFileNumber: vaFileNumberUI('Veteran’s file number'),
   },
   schema: {
     type: 'object',
@@ -22,7 +22,7 @@ export default {
     properties: {
       veteranFullName: fullNameNoSuffixSchema,
       veteranSocialSecurityNumber: ssnSchema,
-      veteranFileNumber: vaFileNumberSchema,
+      vaFileNumber: vaFileNumberSchema,
     },
   },
 };

--- a/src/applications/income-and-asset-statement/config/chapters/02-claimant-information/claimantInformation.js
+++ b/src/applications/income-and-asset-statement/config/chapters/02-claimant-information/claimantInformation.js
@@ -12,12 +12,12 @@ export default {
   title: 'Claimant information',
   path: 'claimant/information',
   depends: formData => {
-    return formData.applicantIsVeteran === false;
+    return formData['view:applicantIsVeteran'] === false;
   },
   uiSchema: {
     claimantFullName: fullNameNoSuffixUI(title => `Claimant’s ${title}`),
-    claimantSocialSecurityNumber: ssnUI('Claimants’s Social Security number'),
-    claimantPhoneNumber: phoneUI('Claimants’s telephone number (if known)'),
+    claimantSocialSecurityNumber: ssnUI('Claimant’s Social Security number'),
+    claimantPhone: phoneUI('Claimant’s telephone number (if known)'),
   },
   schema: {
     type: 'object',
@@ -25,7 +25,7 @@ export default {
     properties: {
       claimantFullName: fullNameNoSuffixSchema,
       claimantSocialSecurityNumber: ssnSchema,
-      claimantPhoneNumber: phoneSchema,
+      claimantPhone: phoneSchema,
     },
   },
 };

--- a/src/applications/income-and-asset-statement/config/chapters/02-claimant-information/incomeNetWorthDateRange.js
+++ b/src/applications/income-and-asset-statement/config/chapters/02-claimant-information/incomeNetWorthDateRange.js
@@ -29,13 +29,12 @@ export default {
   path: 'claimant/statement-period',
   uiSchema: {
     ...titleUI('Statement Period', Description),
-    statementDateRange: currentOrPastDateRangeUI(),
+    incomeNetWorthDateRange: currentOrPastDateRangeUI(),
   },
   schema: {
     type: 'object',
-    required: ['claimantType'],
     properties: {
-      statementDateRange: currentOrPastDateRangeSchema,
+      incomeNetWorthDateRange: currentOrPastDateRangeSchema,
     },
   },
 };

--- a/src/applications/income-and-asset-statement/config/chapters/02-claimant-information/index.js
+++ b/src/applications/income-and-asset-statement/config/chapters/02-claimant-information/index.js
@@ -1,12 +1,12 @@
 import claimantInformation from './claimantInformation';
 import claimantType from './claimantType';
-import statementDateRange from './statementDateRange';
+import incomeNetWorthDateRange from './incomeNetWorthDateRange';
 
 export default {
   title: 'Claimant information',
   pages: {
     claimantInformation,
     claimantType,
-    statementDateRange,
+    incomeNetWorthDateRange,
   },
 };

--- a/src/applications/income-and-asset-statement/containers/IntroductionPage.jsx
+++ b/src/applications/income-and-asset-statement/containers/IntroductionPage.jsx
@@ -25,6 +25,7 @@ class IntroductionPage extends React.Component {
           messages={formConfig.savedFormMessages}
           pageList={pageList}
           startText="Start the Application"
+          devOnly={{ forceShowFormControls: true }}
         >
           Please complete the 21P-0969 form to apply for benefits.
         </SaveInProgressIntro>

--- a/src/applications/income-and-asset-statement/tests/e2e/fixtures/data/test-data.json
+++ b/src/applications/income-and-asset-statement/tests/e2e/fixtures/data/test-data.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "statementDateRange": {
+    "incomeNetWorthDateRange": {
       "from": "2023-07-01",
       "to": "2024-01-01"
     },
@@ -9,7 +9,7 @@
       "last": "Doe"
     },
     "veteranSocialSecurityNumber": "321654987",
-    "applicantIsVeteran": false,
+    "view:applicantIsVeteran": false,
     "claimantFullName": {
       "first": "Jane",
       "last": "Doe"

--- a/src/applications/income-and-asset-statement/tests/unit/chapters/02-claimant-information/statementDateRange.unit.spec.jsx
+++ b/src/applications/income-and-asset-statement/tests/unit/chapters/02-claimant-information/statementDateRange.unit.spec.jsx
@@ -1,14 +1,14 @@
 import testData from '../../../e2e/fixtures/data/test-data.json';
 
 import formConfig from '../../../../config/form';
-import statementDateRange from '../../../../config/chapters/02-claimant-information/statementDateRange';
+import incomeNetWorthDateRange from '../../../../config/chapters/02-claimant-information/incomeNetWorthDateRange';
 import {
   testNumberOfErrorsOnSubmitForWebComponents,
   testNumberOfFieldsByType,
   testSubmitsWithoutErrors,
 } from '../pageTests.spec';
 
-const { schema, uiSchema } = statementDateRange;
+const { schema, uiSchema } = incomeNetWorthDateRange;
 
 describe('income and asset statement date range page', () => {
   testNumberOfFieldsByType(


### PR DESCRIPTION
## THIS FORM IS DISABLED IN PRODUCTION

## Summary
Income and Asset Statement Form (21P-0969)

## Description
Update form field keys to align with vets-json-schema

### Related Issues
n/a

### Epic
[Digitize Income and Asset Statement Form 21P-0969](https://app.zenhub.com/workspaces/benefits-pension-64e775aaa6b1ca1ed49b2ede/issues/gh/department-of-veterans-affairs/va.gov-team/80925)

### Screenshots
n/a

## How to run in local environment
1. Check out this branch locally in 'vets-website'
2.  Checkout this [branch](https://github.com/department-of-veterans-affairs/content-build/pull/2075) locally in 'content-build'
3. Run 'vets-api' in your local environment
4. Run the 'vets-website' app with `yarn watch --env entry=static-pages,auth,login-page,profile,dashboard,income-and-asset-statement`

## How to toggle feature flag in local environment
1. Go to [income_and_assets_form_enabled](http://localhost:3000/flipper/features/income_and_assets_form_enabled)

## How to verify
1. Go to `http://localhost:3001/income-and-asset-statement-form-21p-0969` in your browser
2. Verify the app loads in the browser
3. Verify that form progress is saved to the api and in the redux store
4. Verify that the form data field keys are inline with the vets-json-schema
5. Verify that the form can be submitted

## Testing
- [x]  Unit tests passing

## What areas of the site does it impact?
Income and Asset Statement Application

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user