### PR TITLE
Sets link font-size for cards to 20px/1.25rem

### DIFF
--- a/src/applications/mhv-landing-page/components/HubLinks.jsx
+++ b/src/applications/mhv-landing-page/components/HubLinks.jsx
@@ -6,7 +6,6 @@ const HubSection = ({ title, links }) => {
   const listItems = links.map(({ href, text }, index) => (
     <li key={`${href}--${index}`}>
       <va-link
-        class="mhv-c-link"
         disable-analytics
         href={href}
         text={text}

--- a/src/applications/mhv-landing-page/components/MedicalRecordsCard.jsx
+++ b/src/applications/mhv-landing-page/components/MedicalRecordsCard.jsx
@@ -61,6 +61,7 @@ const MedicalRecordsCard = ({ href }) => {
       </p>
       <p>
         <a
+          className="mhv-c-link"
           data-dd-action-name="Medical Records Card – Go back to the previous version of My HealtheVet"
           href={href}
         >

--- a/src/applications/mhv-landing-page/components/Welcome.jsx
+++ b/src/applications/mhv-landing-page/components/Welcome.jsx
@@ -27,21 +27,12 @@ const Welcome = ({ loading, name }) => (
       {!name && <>Welcome</>}
     </h2>
     <div className="vads-u-font-size--md medium-screen:vads-u-font-size--lg">
-      <i
+      <va-icon
+        size={4}
+        icon="see name mappings here https://design.va.gov/foundation/icons"
         aria-hidden="true"
-        className={classnames(
-          'fas',
-          'fa-user',
-          'vads-u-color--primary-darker',
-          'vads-u-padding-left--4',
-          'vads-u-padding-right--0p5',
-        )}
       />
-      <va-link
-        href="/profile"
-        text="Profile"
-        className="vads-u-visibility--screen-reader"
-      />
+      <va-link href="/profile" text="Profile" />
     </div>
   </div>
 );

--- a/src/applications/mhv-landing-page/sass/mhv-landing-page.scss
+++ b/src/applications/mhv-landing-page/sass/mhv-landing-page.scss
@@ -1,6 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 
-$anchor-font-size: 1.1875rem;
+$anchor-font-size: 1.25rem;  // == 20px
 
 // Font smoothing adjustment for macOS users
 // https://github.com/department-of-veterans-affairs/va.gov-team/issues/54087
@@ -67,6 +67,10 @@ $anchor-font-size: 1.1875rem;
 
   > li {
     margin: 0 0 units(2);
+  }
+
+  > li > a {
+    font-size: $anchor-font-size;
   }
 }
 

--- a/src/applications/mhv-landing-page/sass/mhv-landing-page.scss
+++ b/src/applications/mhv-landing-page/sass/mhv-landing-page.scss
@@ -68,10 +68,6 @@ $anchor-font-size: 1.25rem;  // == 20px
   > li {
     margin: 0 0 units(2);
   }
-
-  > li > a {
-    font-size: $anchor-font-size;
-  }
 }
 
 .mhv-c-link {


### PR DESCRIPTION
## Summary

**Sets link font-size for cards to 20px/1.25rem**

- currently unable to set font size for va-link web components (below cards)

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#85688

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
