### PR TITLE
Sa 93106/removes extra start application link

### DIFF
--- a/src/applications/my-education-benefits/config/form.js
+++ b/src/applications/my-education-benefits/config/form.js
@@ -746,8 +746,8 @@ const formConfig = {
               'ui:validations': [
                 (errors, field) => {
                   if (
-                    field[formFields.email]?.downcase() !==
-                    field[formFields.confirmEmail]?.downcase()
+                    field[formFields.email]?.toLowerCase() !==
+                    field[formFields.confirmEmail]?.toLowerCase()
                   ) {
                     errors.confirmEmail.addError(
                       'Sorry, your emails must match',

--- a/src/applications/my-education-benefits/config/form.js
+++ b/src/applications/my-education-benefits/config/form.js
@@ -745,7 +745,7 @@ const formConfig = {
               },
               'ui:validations': [
                 (errors, field) => {
-                  if (field.email !== field.confirmEmail) {
+                  if (field.email.downcase !== field.confirmEmail.downcase) {
                     errors.confirmEmail.addError(
                       'Sorry, your emails must match',
                     );

--- a/src/applications/my-education-benefits/config/form.js
+++ b/src/applications/my-education-benefits/config/form.js
@@ -745,7 +745,10 @@ const formConfig = {
               },
               'ui:validations': [
                 (errors, field) => {
-                  if (field.email.downcase !== field.confirmEmail.downcase) {
+                  if (
+                    field[formFields.email]?.downcase() !==
+                    field[formFields.confirmEmail]?.downcase()
+                  ) {
                     errors.confirmEmail.addError(
                       'Sorry, your emails must match',
                     );

--- a/src/applications/toe/config/form.js
+++ b/src/applications/toe/config/form.js
@@ -783,7 +783,8 @@ const formConfig = {
               'ui:validations': [
                 (errors, field) => {
                   if (
-                    field[formFields.email] !== field[formFields.confirmEmail]
+                    field[formFields.email.downcase] !==
+                    field[formFields.confirmEmail.downcase]
                   ) {
                     errors[formFields.confirmEmail].addError(
                       'Sorry, your emails must match',

--- a/src/applications/toe/containers/IntroductionPage.jsx
+++ b/src/applications/toe/containers/IntroductionPage.jsx
@@ -3,26 +3,11 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
 import { getIntroState } from 'platform/forms/save-in-progress/selectors';
-import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
-import featureFlagNames from 'platform/utilities/feature-toggles/featureFlagNames';
 import IntroductionLogin from '../components/IntroductionLogin';
 
 import { getAppData } from '../selectors';
-import { START_APPLICATION_TEXT } from '../constants';
 
-export const IntroductionPage = ({
-  isLOA3,
-  isLoggedIn,
-  isPersonalInfoFetchComplete,
-  isPersonalInfoFetchFailed,
-  isSponsorsFetchComplete,
-  showMeb1990EMaintenanceAlert,
-  route,
-  user,
-}) => {
-  const apiCallsComplete =
-    isPersonalInfoFetchComplete && isSponsorsFetchComplete;
-
+export const IntroductionPage = ({ route, user }) => {
   return (
     <div className="schemaform-intro">
       <h1>Apply to use transferred education benefits</h1>
@@ -36,21 +21,6 @@ export const IntroductionPage = ({
         <strong>Transfer of Entitlement for Post-9/11 GI Bill</strong> (Chapter
         33) education benefits.
       </p>
-
-      {isLoggedIn &&
-      isPersonalInfoFetchFailed === false && // Ensure the error didn't occur.
-      showMeb1990EMaintenanceAlert === false && // Ensure the mainenance flag is not on.
-        apiCallsComplete &&
-        isLOA3 && (
-          <SaveInProgressIntro
-            buttonOnly
-            user={user}
-            prefillEnabled={route.formConfig.prefillEnabled}
-            messages={route.formConfig.savedFormMessages}
-            pageList={route.pageList}
-            startText={START_APPLICATION_TEXT}
-          />
-        )}
 
       <h2 className="vads-u-font-size--h3">
         Follow these steps to get started
@@ -134,8 +104,6 @@ const mapStateToProps = state => ({
   ...getIntroState(state),
   ...getAppData(state),
   isPersonalInfoFetchFailed: state.data.isPersonalInfoFetchFailed || false,
-  showMeb1990EMaintenanceAlert:
-    state.featureToggles[featureFlagNames.showMeb1990EZMaintenanceAlert],
 });
 
 export default connect(mapStateToProps)(IntroductionPage);
@@ -148,11 +116,5 @@ IntroductionPage.propTypes = {
     }),
     pageList: PropTypes.array,
   }).isRequired,
-  isLOA3: PropTypes.bool,
-  isLoggedIn: PropTypes.bool,
-  isPersonalInfoFetchComplete: PropTypes.bool,
-  isPersonalInfoFetchFailed: PropTypes.bool,
-  isSponsorsFetchComplete: PropTypes.bool,
-  showMeb1990EMaintenanceAlert: PropTypes.bool,
   user: PropTypes.object,
 };


### PR DESCRIPTION
## Summary
Removes Extra Start Your Application link from application introduction page. Need to remove so we can use the downtime banner to block users from starting application when API is down.

## Related issue(s)
<img width="736" alt="Screenshot 2024-06-24 at 4 00 15 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/8945799/0054134b-e4cc-42ed-9d37-926681a78fbc">

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots
###Before
![image (5)](https://github.com/department-of-veterans-affairs/vets-website/assets/8945799/e458a644-519f-4226-80b1-aec05fb645ef)


## What areas of the site does it impact?
TOE Application Introduction page.


## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

