### PR TITLE
VACMS-18287 Remove new tab behavior per DST guidelines

### DIFF
--- a/src/applications/discharge-wizard/components/CarefulConsiderationStatement.jsx
+++ b/src/applications/discharge-wizard/components/CarefulConsiderationStatement.jsx
@@ -151,7 +151,7 @@ const priorServiceStatement = formValues => {
                   request one.{' '}
                   <Link to="/request-dd214" target="_blank">
                     Find out how to request a DD214 for your period of honorable
-                    service
+                    service (opens in a new tab)
                   </Link>
                 </p>
               </div>

--- a/src/applications/discharge-wizard/components/gpMinorComponents/AdditionalInstructions.jsx
+++ b/src/applications/discharge-wizard/components/gpMinorComponents/AdditionalInstructions.jsx
@@ -27,7 +27,7 @@ const AdditionalInstructions = ({ formValues }) => {
               rel="noopener noreferrer"
               href="https://www.dpris.dod.mil/veteranaccess.html"
             >
-              request a copy
+              request a copy (opens in a new tab)
             </a>
             .
           </p>
@@ -41,7 +41,7 @@ const AdditionalInstructions = ({ formValues }) => {
               rel="noopener noreferrer"
               href="https://www.benefits.va.gov/BENEFITS/docs/COD_Factsheet.pdf"
             >
-              requesting a Character of Discharge review
+              requesting a Character of Discharge review (opens in a new tab)
             </a>
             .
           </p>
@@ -64,10 +64,13 @@ const AdditionalInstructions = ({ formValues }) => {
             depending on the complexity of your case. A lawyer or Veterans
             Service Organization (VSO) can collect and submit supporting
             documents for you.{' '}
-            <va-link
+            <a
               href="https://www.benefits.va.gov/vso/varo.asp"
-              text="Find a VSO near you."
-            />
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Find a VSO near you (opens in a new tab).
+            </a>
           </p>
           <p>
             <strong>Note:</strong> You can ask for a VA Character of Discharge
@@ -84,22 +87,33 @@ const AdditionalInstructions = ({ formValues }) => {
           <p>Learn more about:</p>
           <ul>
             <li>
-              <va-link
+              <a
                 href="/health-care/health-needs-conditions/military-sexual-trauma/"
-                text="VA health benefits for Veterans who have experienced military sexual trauma"
-              />
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                VA health benefits for Veterans who have experienced military
+                sexual trauma (opens in a new tab)
+              </a>
             </li>
             <li>
-              <va-link
+              <a
                 href="/health-care/health-needs-conditions/mental-health/"
-                text="VA health benefits for Veterans with mental health conditions"
-              />
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                VA health benefits for Veterans with mental health conditions
+                (opens in a new tab)
+              </a>
             </li>
             <li>
-              <va-link
+              <a
                 href="/health-care/health-needs-conditions/mental-health/ptsd/"
-                text="VA health benefits for Veterans with PTSD"
-              />
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                VA health benefits for Veterans with PTSD (opens in a new tab)
+              </a>
             </li>
           </ul>
         </va-accordion-item>
@@ -114,7 +128,7 @@ const AdditionalInstructions = ({ formValues }) => {
             href="/health-care/health-needs-conditions/military-sexual-trauma/"
           >
             VA health benefits for Veterans who experience military sexual
-            trauma
+            trauma (opens in a new tab)
           </a>
         </li>
         <li>
@@ -123,7 +137,8 @@ const AdditionalInstructions = ({ formValues }) => {
             rel="noopener noreferrer"
             href="/health-care/health-needs-conditions/mental-health/"
           >
-            VA health benefits for Veterans with mental health conditions
+            VA health benefits for Veterans with mental health conditions (opens
+            in a new tab)
           </a>
         </li>
         <li>
@@ -132,7 +147,7 @@ const AdditionalInstructions = ({ formValues }) => {
             rel="noopener noreferrer"
             href="/health-care/health-needs-conditions/mental-health/ptsd/"
           >
-            VA health benefits for Veterans with PTSD
+            VA health benefits for Veterans with PTSD (opens in a new tab)
           </a>
         </li>
         <li>
@@ -141,7 +156,7 @@ const AdditionalInstructions = ({ formValues }) => {
             rel="noopener noreferrer"
             href="https://www.benefits.va.gov/BENEFITS/docs/COD_Factsheet.pdf"
           >
-            VA Guidance on Character of Discharge Reviews
+            VA Guidance on Character of Discharge Reviews (opens in a new tab)
           </a>
         </li>
         {serviceBranch === 'army' && (
@@ -151,7 +166,7 @@ const AdditionalInstructions = ({ formValues }) => {
               rel="noopener noreferrer"
               href="http://arba.army.pentagon.mil"
             >
-              Army Review Boards Agency
+              Army Review Boards Agency (opens in a new tab)
             </a>
           </li>
         )}
@@ -163,7 +178,7 @@ const AdditionalInstructions = ({ formValues }) => {
                 rel="noopener noreferrer"
                 href="http://arba.army.pentagon.mil/adrb-overview.html"
               >
-                Army Discharge Review Board
+                Army Discharge Review Board (opens in a new tab)
               </a>
             </li>
           )}
@@ -175,7 +190,8 @@ const AdditionalInstructions = ({ formValues }) => {
                 rel="noopener noreferrer"
                 href="http://arba.army.pentagon.mil/abcmr-overview.html"
               >
-                Army Board for Correction of Military Records
+                Army Board for Correction of Military Records (opens in a new
+                tab)
               </a>
             </li>
           )}
@@ -186,7 +202,7 @@ const AdditionalInstructions = ({ formValues }) => {
               rel="noopener noreferrer"
               href="http://www.secnav.navy.mil/mra/CORB/pages/ndrb/default.aspx"
             >
-              Naval Discharge Review Board
+              Naval Discharge Review Board (opens in a new tab)
             </a>
           </li>
         )}
@@ -198,7 +214,8 @@ const AdditionalInstructions = ({ formValues }) => {
                 rel="noopener noreferrer"
                 href="http://www.afpc.af.mil/Board-for-Correction-of-Military-Records/"
               >
-                Air Force Board for Correction of Military Records
+                Air Force Board for Correction of Military Records (opens in a
+                new tab)
               </a>
             </li>
           )}
@@ -210,7 +227,8 @@ const AdditionalInstructions = ({ formValues }) => {
                 rel="noopener noreferrer"
                 href="https://www.uscg.mil/Resources/legal/BCMR/"
               >
-                Coast Guard Board for Correction of Military Records
+                Coast Guard Board for Correction of Military Records (opens in a
+                new tab)
               </a>
             </li>
           )}
@@ -222,7 +240,7 @@ const AdditionalInstructions = ({ formValues }) => {
                 rel="noopener noreferrer"
                 href="https://www.uscg.mil/Resources/Legal/DRB.aspx/"
               >
-                Coast Guard Discharge Review Board
+                Coast Guard Discharge Review Board (opens in a new tab)
               </a>
             </li>
           )}

--- a/src/applications/discharge-wizard/components/gpMinorComponents/OptionalStep.jsx
+++ b/src/applications/discharge-wizard/components/gpMinorComponents/OptionalStep.jsx
@@ -33,7 +33,7 @@ const OptionalStep = ({ formValues }) => {
             rel="noopener noreferrer"
             href="https://health.mil/PDBR"
           >
-            Learn more about PBDR reviews
+            Learn more about PBDR reviews (opens in a new tab)
           </a>
           .{' '}
           <a
@@ -41,7 +41,7 @@ const OptionalStep = ({ formValues }) => {
             rel="noopener noreferrer"
             href="https://health.mil/Military-Health-Topics/Conditions-and-Treatments/Physical-Disability/Disability-Evaluation/Physical-Disability-Board-of-Review/PDBR-Application-Process"
           >
-            Apply for a PBDR review
+            Apply for a PBDR review (opens in a new tab)
           </a>
           .
         </p>

--- a/src/applications/discharge-wizard/components/gpSteps/StepOne.jsx
+++ b/src/applications/discharge-wizard/components/gpSteps/StepOne.jsx
@@ -163,8 +163,10 @@ const StepOne = ({ formValues }) => {
         className="vads-u-display--block vads-u-margin-bottom--1 step-1-download"
         download
         href={form.link}
+        target="_blank"
+        rel="noopener noreferrer"
       >
-        Download Form {form.num}
+        Download Form {form.num} (opens in a new tab)
       </a>
       <AlertMessage
         content={
@@ -185,7 +187,7 @@ const StepOne = ({ formValues }) => {
                 rel="noopener noreferrer"
                 href="https://www.benefits.va.gov/vso/varo.asp"
               >
-                Find a VSO near you
+                Find a VSO near you (opens in a new tab)
               </a>
               .
             </p>

--- a/src/applications/discharge-wizard/components/gpSteps/StepThree.jsx
+++ b/src/applications/discharge-wizard/components/gpSteps/StepThree.jsx
@@ -108,7 +108,7 @@ const StepThree = ({ formValues }) => {
           rel="noopener noreferrer"
           href="http://actsonline.army.mil/"
         >
-          Visit ACTSOnline to submit your information
+          Visit ACTSOnline to submit your information (opens in a new tab)
         </a>
         .
       </p>

--- a/src/applications/discharge-wizard/components/gpSteps/StepTwo.jsx
+++ b/src/applications/discharge-wizard/components/gpSteps/StepTwo.jsx
@@ -12,7 +12,8 @@ const renderMedicalRecordInfo = formValues => {
           rel="noopener noreferrer"
           href="https://www.archives.gov/st-louis/military-personnel/ompf-background.html"
         >
-          Find out how to request your military medical records.
+          Find out how to request your military medical records (opens in a new
+          tab).
         </a>
       );
     } else {
@@ -38,8 +39,10 @@ const renderMedicalRecordInfo = formValues => {
             <a
               download
               href="https://www.va.gov/find-forms/about-form-10-5345/"
+              target="_blank"
+              rel="noopener noreferrer"
             >
-              Download VA Form 10-5345
+              Download VA Form 10-5345 (opens in a new tab)
             </a>
           </li>
           <li>{requestQuestion}</li>
@@ -72,7 +75,7 @@ const StepOne = ({ formValues }) => {
           rel="noopener noreferrer"
           href="https://www.archives.gov/veterans/military-service-records"
         >
-          Get your military personnel record.
+          Get your military personnel record (opens in a new tab).
         </a>
       </p>
     );
@@ -88,7 +91,7 @@ const StepOne = ({ formValues }) => {
           rel="noopener noreferrer"
           href="https://www.archives.gov/veterans/military-service-records"
         >
-          Get your military personnel record.
+          Get your military personnel record (opens in a new tab).
         </a>
       </p>
     );

--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -11,24 +11,6 @@ import {
 } from '../constants';
 import FormTitle from './FormTitle';
 
-const deriveLinkPropsFromFormURL = url => {
-  const linkProps = {};
-  if (!url) return linkProps;
-
-  const isSameOrigin = url.startsWith(window.location.origin);
-  const isPDF = url.toLowerCase().includes('.pdf');
-
-  if (!isSameOrigin || !isPDF) {
-    linkProps.target = '_blank';
-  } else {
-    linkProps.download = true;
-
-    if (isPDF) linkProps.type = 'application/pdf';
-  }
-
-  return linkProps;
-};
-
 // helper for replacing the form title to keep same domain for testing in non production
 const regulateURL = url => {
   if (!url) return '';
@@ -165,7 +147,6 @@ const SearchResult = ({
   const relativeFormToolUrl = formToolUrl
     ? replaceWithStagingDomain(formToolUrl)
     : formToolUrl;
-  const linkProps = deriveLinkPropsFromFormURL(url);
   const pdfLabel = url.toLowerCase().includes('.pdf') ? '(PDF)' : '';
   const lastRevision = deriveLatestIssue(firstIssuedOn, lastRevisionOn);
 
@@ -236,7 +217,6 @@ const SearchResult = ({
             }
           }}
           onClick={pdfDownloadHandler}
-          {...linkProps}
         >
           <va-icon icon="file_download" size="3" />
           <span

--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -144,7 +144,7 @@ export const SearchResults = ({
   }
 
   // Show UX friendly message if all forms are tombstone/ deleted in the results returned.
-  if (hasOnlyRetiredForms)
+  if (hasOnlyRetiredForms) {
     return (
       <p
         className="vads-u-font-size--base vads-u-line-height--3 vads-u-font-family--sans
@@ -155,6 +155,7 @@ export const SearchResults = ({
         has been removed from the VA forms database.
       </p>
     );
+  }
 
   if (!results.length) {
     return (
@@ -166,13 +167,10 @@ export const SearchResults = ({
         No results were found for "<strong>{query}</strong>
         ." Try using fewer words or broadening your search. If you’re looking
         for non-VA forms, go to the{' '}
-        <a
+        <va-link
           href="https://www.gsa.gov/reference/forms"
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          GSA Forms Library
-        </a>
+          text="GSA Forms Library"
+        />
         .
       </p>
     );
@@ -272,13 +270,7 @@ export const SearchResults = ({
             >
               Get Acrobat Reader for free from Adobe
             </a>
-            <a
-              href={pdfUrl}
-              className="vads-u-margin-top--2"
-              download
-              rel="noreferrer noopener"
-              target="_blank"
-            >
+            <a href={pdfUrl} className="vads-u-margin-top--2" download>
               <va-icon
                 className="vads-u-margin-right--1"
                 icon="file_download"

--- a/src/applications/find-forms/tests/components/SearchResult.unit.spec.jsx
+++ b/src/applications/find-forms/tests/components/SearchResult.unit.spec.jsx
@@ -81,18 +81,6 @@ describe('Find VA Forms <SearchResult />', () => {
     tree.unmount();
   });
 
-  it('should have download or redirect attribute for form PDF dependant on CORS', () => {
-    const tree = mount(
-      <SearchResult formMetaInfo={formMetaInfo} form={form} />,
-    );
-    const isSameOrigin = form.attributes.url.startsWith(window.location.origin);
-
-    if (isSameOrigin) expect(tree.exists('[download=true]')).to.equal(true);
-    else expect(tree.exists('[target="_blank"]')).to.equal(true);
-
-    tree.unmount();
-  });
-
   it('should have "Fill out VA Form" link', () => {
     const tree = mount(
       <SearchResult formMetaInfo={formMetaInfo} form={form} />,

--- a/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFModal.jsx
+++ b/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFModal.jsx
@@ -68,8 +68,6 @@ const DownloadPDFModal = ({ formNumber, removeNode, url }) => {
             className="usa-button vads-u-margin-top--2"
             download
             role="button"
-            rel="noreferrer noopener"
-            target="_blank"
           >
             Download VA Form {pdfSelected}
           </a>

--- a/src/applications/static-pages/events/components/Results/ResultsWhereContent.jsx
+++ b/src/applications/static-pages/events/components/Results/ResultsWhereContent.jsx
@@ -45,8 +45,6 @@ const WhereContent = ({
           ))}
           <a
             href={`https://maps.google.com?saddr=Current+Location&daddr=${locationAddress}`}
-            rel="noopener noreferrer"
-            target="_blank"
           >
             Get directions on Google Maps{' '}
             <span

--- a/src/platform/site-wide/mega-menu/components/Column.jsx
+++ b/src/platform/site-wide/mega-menu/components/Column.jsx
@@ -44,7 +44,6 @@ const Column = props => {
               data-e2e-id={`${_.kebabCase(data.link.text)}`}
               href={data.link.href}
               onClick={columnThreeLinkClicked.bind(null, data.link)}
-              target={data.link.target || '_self'}
             >
               {data.link.text}
             </a>
@@ -85,7 +84,6 @@ const Column = props => {
               data-e2e-id={`${_.kebabCase(link.text)}-${i}`}
               href={link.href}
               onClick={linkClicked.bind(null, link)}
-              target={link.target || '_self'}
             >
               {link.text}
             </a>
@@ -112,7 +110,6 @@ Column.propTypes = {
     link: PropTypes.shape({
       text: PropTypes.string.isRequired,
       href: PropTypes.string.isRequired,
-      target: PropTypes.string,
     }),
     description: PropTypes.string,
   }),

--- a/src/platform/site-wide/mega-menu/components/MegaMenu.jsx
+++ b/src/platform/site-wide/mega-menu/components/MegaMenu.jsx
@@ -179,7 +179,6 @@ export default class MegaMenu extends React.Component {
                       data-e2e-id={`${_.kebabCase(item.title)}-${i}`}
                       href={item.href}
                       onClick={linkClicked.bind(null, item)}
-                      target={item.target || null}
                     >
                       {item.title}
                     </a>

--- a/src/platform/site-wide/user-nav/tests/components/PageNotFound.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/components/PageNotFound.unit.spec.jsx
@@ -14,11 +14,12 @@ describe('PageNotFound Component', () => {
     const { getByRole } = render(<PageNotFound {...props} />);
     const heading = getByRole('heading', { name: notFoundHeading });
     expect(heading).to.exist;
-    expect(document.activeElement).to.eq(heading);
-    expect(document.title).to.eql(notFoundTitle);
+
     await waitFor(() => {
       expect(recordEvent.calledOnce).to.be.true;
       expect(recordEvent.calledWith({ event: 'nav-404-error' })).to.be.true;
+      expect(document.activeElement).to.eq(heading);
+      expect(document.title).to.eql(notFoundTitle);
     });
   });
 });

--- a/src/platform/site-wide/va-footer/helpers.jsx
+++ b/src/platform/site-wide/va-footer/helpers.jsx
@@ -31,13 +31,7 @@ const renderInnerTag = (link, captureEvent) => (
       </h2>
     ) : null}
     {link.href ? (
-      <a
-        aria-label={link.ariaLabel}
-        href={link.href}
-        onClick={captureEvent}
-        target={link.target}
-        rel={link.rel}
-      >
+      <a aria-label={link.ariaLabel} href={link.href} onClick={captureEvent}>
         {link.title}
       </a>
     ) : (
@@ -72,8 +66,6 @@ function generateSuperLinks(groupedList) {
             aria-label={link.ariaLabel}
             href={link.href}
             onClick={captureEvent}
-            target={link.target}
-            rel={link.rel}
           >
             {link.title}
           </a>


### PR DESCRIPTION
## Summary
Per Design System guidance, links should only open in a new tab if the user will lose some data or progress. This PR includes updates to:

**Find Forms**
- Removes `target` and `rel` attributes from download links as a download link wouldn't open in a new tab anyway
- Removes new tab from "GSA Forms Library" link
- Removes the `deriveLinkPropsFromFormURL` utility and its usage. Previously this utility was used to apply props to an `<a>`, and now that element is a `<button>` that opens a modal so none of these props are applicable anyway.

**Discharge Upgrade Wizard**
- Adds `(opens in a new tab)` and new tab behavior to every link on the results page, as they will all cause a user to lose progress/data if they are clicked

**Events search**
- Removes new tab from "Get directions on Google Maps" links

**Mega menu and footer**
- Removes target attribute from the links. They were previously added as though they would be set coming from Drupal, but there is no way to set a target attribute in Drupal, so these were never used.

Also includes an adjustment to the 404 page as the test started failing in CI. Slack thread for context: https://dsva.slack.com/archives/CBU0KDSB1/p1719341196473059

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18287

## Testing done
Tested the applications locally at:
- `/find-forms`: Search for forms and inspect the results' links and modal triggers
- `/discharge-upgrade-instructions`: Go through several flows for different military branches and view the results page (including the accordions at the bottom). All links should open in a new tab and also have the `(opens in a new tab)` text next to them
- `/outreach-and-events/events`: Search for events and inspect the results' Google links
- `/` (home): Inspect the mega menu and footer links

## Screenshots
<details><summary>Find Forms</summary>
<img width="258" alt="Screenshot 2024-06-24 at 5 21 59 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/0f177e2b-8d52-412c-ae35-fb10843db6d6">
<img width="354" alt="Screenshot 2024-06-24 at 5 22 05 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/01f0859e-0571-4ace-a7d1-a3ab5ddc721b">

<img width="477" alt="Screenshot 2024-06-24 at 5 24 28 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/46d46f8d-0600-408b-a103-1a744ee1a14c">
<img width="344" alt="Screenshot 2024-06-24 at 5 22 32 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/4e72b630-36c2-45ef-8180-ed35240251ba">
<img width="349" alt="Screenshot 2024-06-24 at 5 25 09 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/1df009c0-790b-4928-a15a-2b4d332b6937">

<img width="322" alt="Screenshot 2024-06-24 at 5 26 25 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/ad4f1fdf-54e9-4b20-a8f9-0fe612ca9d3b">
<img width="413" alt="Screenshot 2024-06-24 at 5 26 32 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/41104ad0-9ddf-4ece-b221-301341674fdd">



</details>

<details><summary>Discharge Upgrade Wizard</summary>
<img width="614" alt="Screenshot 2024-06-25 at 10 07 00 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/7525daf3-f36c-4bd1-8ec6-4990b1db1701">
<img width="728" alt="Screenshot 2024-06-25 at 10 06 51 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/e37181b1-8e34-45ea-a5b0-5daecbb483ba">
<img width="683" alt="Screenshot 2024-06-25 at 10 06 48 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/09e4df1e-12b5-4a09-a03e-3d8f9ff68792">
<img width="666" alt="Screenshot 2024-06-25 at 10 06 43 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/24f2aa10-0a43-438a-8010-6619707e4a67">
<img width="598" alt="Screenshot 2024-06-25 at 10 05 04 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/761622c5-37cf-4a93-bca6-7b472b6eb701">
<img width="642" alt="Screenshot 2024-06-25 at 10 01 50 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/9425c25a-5a13-498e-ab44-0c3dc32280ac">
<img width="598" alt="Screenshot 2024-06-25 at 10 01 47 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/bd776a0f-fa04-4933-9fb3-b98fe8cd7c9c">
<img width="581" alt="Screenshot 2024-06-25 at 10 01 41 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/35316b47-d958-4486-a249-18cb501c6371">
<img width="607" alt="Screenshot 2024-06-25 at 10 01 35 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/78ef9fad-dad7-4d9f-bd5d-71db07704fe0">
<img width="584" alt="Screenshot 2024-06-25 at 9 54 49 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/21fb47a9-20a9-42ca-b107-aaac33847a18">
<img width="499" alt="Screenshot 2024-06-25 at 9 54 46 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/998fcade-8121-446a-960b-a16656482459">

</details>


<details><summary>Events</summary>
<img width="383" alt="Screenshot 2024-06-24 at 5 19 58 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/0219eb22-b9ed-4f10-b353-bb9a6e6d9b9d">
<img width="342" alt="Screenshot 2024-06-24 at 5 20 11 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/57dbcc68-2ea0-4cd5-8dc8-fb4ae999c194">


</details>
