### PR TITLE
update benefits-accredited-rep-facing-engineers CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -221,7 +221,7 @@ src/applications/vaos @department-of-veterans-affairs/vfs-vaos-fe @department-of
 src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page  @department-of-veterans-affairs/vfs-vaos-fe @department-of-veterans-affairs/vfs-public-websites-frontend @department-of-veterans-affairs/va-platform-cop-frontend
 
 # Benefits Accredited Representative Facing (ARF)
-src/applications/accredited-representative-portal @department-of-veterans-affairs/benefits-accredited-rep-facing
+src/applications/accredited-representative-portal @department-of-veterans-affairs/benefits-accredited-rep-facing-engineers
 
 # Income and Asset Statement
 src/applications/income-and-asset-statement @department-of-veterans-affairs/pensions


### PR DESCRIPTION
## Summary
ARF updated the benefits-accredited-rep-facing GH team name, and we'll need to update the CODEOWNERS file accordingly.

## Related issue(s)
https://app.zenhub.com/workspaces/accredited-representative-facing-team-65453a97a9cc36069a2ad1d6/issues/gh/department-of-veterans-affairs/va.gov-team/86862
- fixed in vets-api: https://github.com/department-of-veterans-affairs/vets-api/pull/17242

