### PR TITLE
MHV-58774: Medication Details - removed image from accessibility tree

### DIFF
--- a/src/applications/mhv-medications/components/PrescriptionDetails/VaPrescription.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/VaPrescription.jsx
@@ -230,10 +230,11 @@ const VaPrescription = prescription => {
                     <h4
                       className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-top--2 vads-u-margin--0"
                       data-testid="med-image"
+                      aria-hidden="true"
                     >
                       Image
                     </h4>
-                    <div className="no-print">
+                    <div className="no-print" aria-hidden="true">
                       {entry.cmopNdcNumber ? (
                         <>
                           <img
@@ -243,7 +244,6 @@ const VaPrescription = prescription => {
                             src={getImageUri(entry.cmopNdcNumber)}
                             width="350"
                             height="350"
-                            aria-hidden="true"
                           />
                         </>
                       ) : (


### PR DESCRIPTION
## Summary

By Accessibility team recommendation added `aria-hidden` to both image header and content `div`.

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-58774

<img width="949" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/133991282/c98b2b1e-bde5-4b48-a688-9435a84f9296">

## Testing done

- Dev testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: I'd recommend adding aria-hidden="true" to the H4, or alternatively wrapping both the H4 heading and the image inside a div that has aria-hidden="true" on it. The heading serves no purpose besides helping to find the image, so if the image is hidden it can be hidden as well.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
