### PR TITLE
Fixes the back link on confirmation page of form upload flow

### DIFF
--- a/src/applications/simple-forms/21-4138/config/constants.js
+++ b/src/applications/simple-forms/21-4138/config/constants.js
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 
 export const PrimaryActionLink = ({ href = '/', children, onClick = null }) => (
-  <div className="action-bar-arrow" style={{ maxWidth: '75%' }}>
+  <div className="action-bar-arrow">
     <div className="vads-u-background-color--primary vads-u-padding--1">
       <a className="vads-c-action-link--white" href={href} onClick={onClick}>
         {children}

--- a/src/applications/simple-forms/form-upload/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/form-upload/containers/ConfirmationPage.jsx
@@ -64,10 +64,7 @@ const ConfirmationPage = () => {
           text="Print this page"
         />
       </div>
-      <div
-        className="action-bar-arrow vads-u-margin-bottom--4"
-        style={{ maxWidth: '70%' }}
-      >
+      <div className="action-bar-arrow vads-u-margin-bottom--4">
         <div className="vads-u-background-color--primary vads-u-padding--1">
           <a className="vads-c-action-link--white" href="/">
             Go back to VA.gov

--- a/src/applications/simple-forms/form-upload/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/form-upload/containers/ConfirmationPage.jsx
@@ -64,9 +64,26 @@ const ConfirmationPage = () => {
           text="Print this page"
         />
       </div>
-      <a className="vads-c-action-link--green vads-u-margin-y--2" href="/">
-        Go back to VA.gov
-      </a>
+      <div
+        className="action-bar-arrow vads-u-margin-bottom--4"
+        style={{ maxWidth: '60%' }}
+      >
+        <div className="vads-u-background-color--primary vads-u-padding--1">
+          <a className="vads-c-action-link--white" href="/">
+            Go back to VA.gov
+          </a>
+        </div>
+      </div>
+      <div className="need-help-footer">
+        <h2 className="vads-u-padding-bottom--0p5 vads-u-font-size--h3 vads-u-border-bottom--2px vads-u-border-color--primary">
+          Need help?
+        </h2>
+        <p>
+          You can call us at <va-telephone contact="8772228387" /> (
+          <va-telephone contact="8008778339" tty />
+          ). We’re here Monday through Friday, 8:00 a.m to 9:00 p.m ET.
+        </p>
+      </div>
     </div>
   );
 };

--- a/src/applications/simple-forms/form-upload/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/form-upload/containers/ConfirmationPage.jsx
@@ -66,7 +66,7 @@ const ConfirmationPage = () => {
       </div>
       <div
         className="action-bar-arrow vads-u-margin-bottom--4"
-        style={{ maxWidth: '60%' }}
+        style={{ maxWidth: '70%' }}
       >
         <div className="vads-u-background-color--primary vads-u-padding--1">
           <a className="vads-c-action-link--white" href="/">

--- a/src/applications/simple-forms/form-upload/sass/form-upload.scss
+++ b/src/applications/simple-forms/form-upload/sass/form-upload.scss
@@ -2,3 +2,4 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "../../../../platform/forms/sass/m-form-confirmation";
+@import "../../../../platform/forms/sass/m-schemaform";

--- a/src/applications/static-pages/simple-forms/form-upload/App.js
+++ b/src/applications/static-pages/simple-forms/form-upload/App.js
@@ -33,7 +33,7 @@ export const App = ({ formNumber, hasOnlineTool }) => {
           Once you’ve completed the form you can return here to upload it to us.
         </p>
         {userLoggedIn ? (
-          <div className="action-bar-arrow" style={{ maxWidth: '75%' }}>
+          <div className="action-bar-arrow">
             <div className="vads-u-background-color--primary vads-u-padding--1">
               <a
                 className="vads-c-action-link--white"

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -740,6 +740,11 @@ va-checkbox.statement-of-truth-va-checkbox::part(checkbox) {
 
 .action-bar-arrow {
   position: relative;
+  max-width: 75%;
+
+  @media (max-width: 767px) {
+    max-width: 90%;
+  }
 }
 
 .action-bar-arrow::after {


### PR DESCRIPTION
## Summary
This PR fixes the styling of the Back to VA.gov link at the bottom of the Confirmation Page of the form upload flow. It also adds back the Need Help? footer.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1280

## Screenshots
Before:
<img width="1088" alt="Screenshot 2024-06-25 at 1 47 00 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/10481391/d5e0c7dc-4b8b-446e-8041-4f8016fea717">

After:
<img width="1117" alt="Screenshot 2024-06-25 at 1 46 31 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/10481391/05bbc8ff-c86d-4794-9410-247db655df36">
