### PR TITLE
updates 110 error code on the front end

### DIFF
--- a/src/applications/auth/components/RenderErrorContainer.jsx
+++ b/src/applications/auth/components/RenderErrorContainer.jsx
@@ -399,12 +399,13 @@ export default function RenderErrorContainer({
     case AUTH_ERRORS.CERNER_PROVISIONING_FAILURE.errorCode:
       alertContent = (
         <p className="vads-u-margin-top--0">
-          We’re having trouble provisioning your My VA Health account right now.
+          We’re having trouble provisioning your My HealtheVet account right now
         </p>
       );
       troubleshootingContent = (
         <>
           <h2>How can I fix this issue?</h2>
+          <p>Try signing in again in a few minutes.</p>
           <Helpdesk startScentence />
         </>
       );

--- a/src/platform/user/authentication/errors.js
+++ b/src/platform/user/authentication/errors.js
@@ -61,7 +61,7 @@ export const AUTH_ERRORS = {
   },
   CERNER_PROVISIONING_FAILURE: {
     errorCode: '110',
-    message: `We're having trouble provisioning your My VA Health account right now.`,
+    message: `We’re having trouble provisioning your My HealtheVet account right now`,
   },
   CERNER_NOT_ELIGIBLE: {
     errorCode: '111',


### PR DESCRIPTION
## Description
We needed a new error code added to VA.gov for the MHV User Creation API that will be coming up in a few weeks as stated in [this ticket](https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/gh/department-of-veterans-affairs/va.gov-team/86858)

[Related documentation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity/Troubleshooting_logging/Authentication_Errors/112.md)

## Tasks
- [x] Add error codes to `vets-website`
- [x] Update `authentication/errors.js` and `RenderErrorContainer`

<img width="796" alt="Screenshot 2024-06-25 at 10 52 53 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/78328496/3764c9a9-0c7a-4500-943b-58ef6b7ea5ba">
