### PR TITLE
85582 Display TE pages for new applications and IPF via toggled form …

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
@@ -156,15 +156,20 @@ export function dateRangePageDescription(
 /* ---------- utils ---------- */
 /**
  * Checks if the toxic exposure pages should be displayed using the following criteria
- *  1. prefilled indicator is true
+ *  1. prefilled indicator 'includeToxicExposure' is true or 'startedFormVersion' has appropriate year
  *  2. the claim has a claim type of new
  *  3. claiming at least one new disability
+ *
+ * Note: We will temporarily be checking 2 prefill indicators. The includeToxicExposure
+ * indicator will be removed with https://github.com/department-of-veterans-affairs/va.gov-team/issues/86798
  *
  * @returns true if all criteria are met, false otherwise
  */
 export function showToxicExposurePages(formData) {
   return (
-    formData?.includeToxicExposure === true &&
+    (formData?.includeToxicExposure === true ||
+      formData?.startedFormVersion === '2019' ||
+      formData?.startedFormVersion === '2022') &&
     isClaimingNew(formData) &&
     formData?.newDisabilities?.length > 0
   );

--- a/src/applications/disability-benefits/all-claims/tests/content/toxicExposure.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/toxicExposure.unit.spec.jsx
@@ -21,7 +21,7 @@ describe('toxicExposure', () => {
   let formData;
 
   describe('showToxicExposurePages', () => {
-    describe('includeToxicExposure indicator omitted', () => {
+    describe('includeToxicExposure and startedFormVersion indicators omitted', () => {
       beforeEach(() => {
         formData = {};
       });
@@ -131,6 +131,134 @@ describe('toxicExposure', () => {
               primaryDescription: 'Test description',
               'view:serviceConnectedDisability': {},
               condition: 'anemia',
+            },
+          ],
+        };
+
+        expect(showToxicExposurePages(formData)).to.be.true;
+      });
+    });
+
+    describe('startedFormVersion is 2019', () => {
+      it('returns true when claiming one or more new conditions', () => {
+        formData = {
+          startedFormVersion: '2019',
+          'view:claimType': {
+            'view:claimingIncrease': false,
+            'view:claimingNew': true,
+          },
+          newDisabilities: [
+            {
+              cause: 'NEW',
+              primaryDescription: 'Test description',
+              'view:serviceConnectedDisability': {},
+              condition: 'anemia',
+            },
+          ],
+        };
+
+        expect(showToxicExposurePages(formData)).to.be.true;
+      });
+
+      it('returns false when claim type is CFI only', () => {
+        formData = {
+          startedFormVersion: '2019',
+          'view:claimType': {
+            'view:claimingIncrease': true,
+            'view:claimingNew': false,
+          },
+        };
+
+        expect(showToxicExposurePages(formData)).to.be.false;
+      });
+
+      it('returns true when both claim types', () => {
+        formData = {
+          startedFormVersion: '2019',
+          'view:claimType': {
+            'view:claimingIncrease': true,
+            'view:claimingNew': true,
+          },
+          newDisabilities: [
+            {
+              cause: 'NEW',
+              primaryDescription: 'Test description',
+              'view:serviceConnectedDisability': {},
+              condition: 'anemia',
+            },
+          ],
+        };
+
+        expect(showToxicExposurePages(formData)).to.be.true;
+      });
+    });
+
+    describe('startedFormVersion is 2022', () => {
+      it('returns true when claiming one or more new conditions', () => {
+        formData = {
+          startedFormVersion: '2022',
+          'view:claimType': {
+            'view:claimingIncrease': false,
+            'view:claimingNew': true,
+          },
+          newDisabilities: [
+            {
+              cause: 'NEW',
+              primaryDescription: 'Test description',
+              condition: 'asthma',
+              'view:descriptionInfo': {},
+            },
+            {
+              cause: 'SECONDARY',
+              'view:secondaryFollowUp': {
+                causedByDisability: 'Diabetes Mellitus0',
+                causedByDisabilityDescription: 'Test description 2',
+              },
+              condition:
+                'Cranial nerve paralysis or cranial neuritis (inflammation of cranial nerves)',
+              'view:descriptionInfo': {},
+            },
+          ],
+        };
+
+        expect(showToxicExposurePages(formData)).to.be.true;
+      });
+
+      it('returns false when claim type is CFI only', () => {
+        formData = {
+          startedFormVersion: '2022',
+          'view:claimType': {
+            'view:claimingIncrease': true,
+            'view:claimingNew': false,
+          },
+        };
+
+        expect(showToxicExposurePages(formData)).to.be.false;
+      });
+
+      it('returns true when both claim types', () => {
+        formData = {
+          startedFormVersion: '2022',
+          'view:claimType': {
+            'view:claimingIncrease': true,
+            'view:claimingNew': true,
+          },
+          newDisabilities: [
+            {
+              cause: 'NEW',
+              primaryDescription: 'Test description',
+              'view:serviceConnectedDisability': {},
+              condition: 'anemia',
+            },
+            {
+              cause: 'WORSENED',
+              'view:worsenedFollowUp': {
+                worsenedDescription: 'My knee was strained in the service',
+                worsenedEffects:
+                  "It wasn't great before, but it got bad enough I needed a replacement. Now I have to take medication for it.",
+              },
+              condition: 'ankylosis in knee, bilateral',
+              'view:descriptionInfo': {},
             },
           ],
         };

--- a/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
+++ b/src/applications/disability-benefits/all-claims/tests/cypress.helpers.js
@@ -193,6 +193,10 @@ export const setup = (cy, testOptions = {}) => {
       formData.includeToxicExposure = true;
     }
 
+    if (testOptions?.prefillData?.startedFormVersion) {
+      formData.startedFormVersion = testOptions.prefillData.startedFormVersion;
+    }
+
     cy.intercept('GET', `${MOCK_SIPS_API}*`, {
       formData,
       metadata: mockPrefill.metadata,
@@ -208,7 +212,11 @@ export const setup = (cy, testOptions = {}) => {
  */
 function getUnreleasedPages(testOptions) {
   // if toxic exposure indicator not enabled in prefill data, add those pages to the unreleased pages list
-  if (testOptions?.prefillData?.includeToxicExposure !== true) {
+  if (
+    testOptions?.prefillData?.includeToxicExposure !== true &&
+    testOptions?.prefillData?.startedFormVersion !== '2019' &&
+    testOptions?.prefillData?.startedFormVersion !== '2022'
+  ) {
     return Object.keys(toxicExposurePages).map(page => {
       return toxicExposurePages[page].path;
     });

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-toxic-exposure-2022-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-toxic-exposure-2022-test.json
@@ -1,0 +1,419 @@
+{
+  "data": {
+    "view:claimType": {
+      "view:claimingIncrease": true,
+      "view:claimingNew": true
+    },
+    "standardClaim": false,
+    "view:fdcWarning": {},
+    "isVaEmployee": true,
+    "homelessOrAtRisk": "homeless",
+    "view:isHomeless": {
+      "homelessHousingSituation": "other",
+      "otherHomelessHousing": "Under a bridge",
+      "needToLeaveHousing": true
+    },
+    "homelessnessContact": {
+      "name": "Name Here, and invalid chars with email elmer@fud.com",
+      "phoneNumber": "1231231234"
+    },
+    "view:bankAccount": {
+      "bankAccountType": "Checking",
+      "bankAccountNumber": "1233",
+      "bankRoutingNumber": "123123123",
+      "bankName": "Bigbank Co."
+    },
+    "phoneAndEmail": {
+      "primaryPhone": "4445551212",
+      "emailAddress": "test2@test1.net"
+    },
+    "mailingAddress": {
+      "view:livesOnMilitaryBase": false,
+      "type": "MILITARY",
+      "militaryPostOfficeTypeCode": "APO",
+      "militaryStateCode": "AA",
+      "zipFirstFive": "27103",
+      "country": "USA",
+      "addressLine1": "123 Main",
+      "city": "Bigcity",
+      "state": "AK",
+      "zipCode": "12345"
+    },
+    "view:hasForwardingAddress": true,
+    "forwardingAddress": {
+      "country": "USA",
+      "addressLine1": "321 Secondary",
+      "city": "Smallcity",
+      "state": "NY",
+      "zipCode": "54321",
+      "effectiveDate": {
+        "from": "2099-12-01",
+        "to": "2100-01-01"
+      }
+    },
+    "view:contactInfoDescription": {},
+    "additionalDocuments": [
+      {
+        "name": "lolwut.png",
+        "confirmationCode": "552067b2-9c5d-4bd8-bcd8-bc621b51a145",
+        "attachmentId": "L015"
+      },
+      {
+        "name": "image (1).png",
+        "confirmationCode": "0496e5c2-0675-4a43-83d6-e1eeabd4ea0e",
+        "attachmentId": "L070"
+      },
+      {
+        "name": "Success.jpg",
+        "confirmationCode": "de89492d-2d3f-4486-a73d-1fa4868aa49d",
+        "attachmentId": "L023"
+      }
+    ],
+    "view:uploadPrivateRecordsQualifier": {
+      "view:aboutPrivateMedicalRecords": {},
+      "view:hasPrivateRecordsToUpload": true,
+      "view:privateRecordsChoiceHelp": {}
+    },
+    "privateMedicalRecordAttachments": [
+      {
+        "name": "AngleSettingJig_9_25_15.pdf",
+        "confirmationCode": "544f14cc-4e51-4661-b8f4-d79f71567491",
+        "attachmentId": "L107"
+      },
+      {
+        "name": "image.png",
+        "confirmationCode": "fa0c0f47-a42f-4bbc-88f3-873c5bea6ce7",
+        "attachmentId": "L023"
+      }
+    ],
+    "view:vaMedicalRecordsIntro": {},
+    "vaTreatmentFacilities": [
+      {
+        "treatmentCenterName": "Treatment Center the First",
+        "treatmentDateRange": {
+          "from": "2008-01-XX"
+        },
+        "treatmentCenterAddress": {
+          "country": "USA",
+          "city": "Bigcity",
+          "state": "AK"
+        },
+        "treatedDisabilityNames": {
+          "diabetesmellitus0": true,
+          "diabetesmellitus1": true,
+          "heartattackmyocardialinfarction": true
+        }
+      },
+      {
+        "treatmentCenterName": "Treatment Center the Second",
+        "treatmentDateRange": {
+          "from": "2010-01-XX"
+        },
+        "treatmentCenterAddress": {
+          "country": "Uganda",
+          "city": "Ugandan City"
+        },
+        "treatedDisabilityNames": {
+          "asthma": true,
+          "heartattackmyocardialinfarction": true,
+          "ankylosisinkneebilateral": true
+        }
+      }
+    ],
+    "view:hasEvidence": true,
+    "view:hasEvidenceFollowUp": {
+      "view:selectableEvidenceTypes": {
+        "view:hasVaMedicalRecords": true,
+        "view:hasPrivateMedicalRecords": true,
+        "view:hasOtherEvidence": true
+      },
+      "view:evidenceTypeHelp": {}
+    },
+    "view:unemployable": false,
+    "view:aidAndAttendance": true,
+    "view:modifyingHome": true,
+    "view:modifyingCar": true,
+    "view:needsCarHelp": {
+      "view:alreadyClaimedVehicleAllowance": false
+    },
+    "toxicExposure": {
+      "conditions": {
+        "asthma": true,
+        "heartattackmyocardialinfarction": true
+      },
+      "gulfWar1990": {
+        "afghanistan": true,
+        "iraq": true,
+        "airspace": true
+      },
+      "gulfWar1990Details": {
+        "afghanistan": {
+          "startDate": "1990-01-01",
+          "endDate": "1990-12-31"
+        },
+        "iraq": {
+          "startDate": "1991-02-01",
+          "endDate": "1992-12-15"
+        }
+      },
+      "gulfWar2001": {
+        "yemen": true,
+        "airspace": false
+      },
+      "gulfWar2001Details": {
+        "yemen": {
+          "startDate": "2002-01-01"
+        },
+        "airspace": {}
+      },
+      "herbicide": {
+        "guam": true,
+        "laos": true,
+        "c123": true
+      },
+      "herbicideDetails": {
+        "c123": {
+          "endDate": "1966-02-20"
+        },
+        "laos": {
+          "startDate": "1965-01-01"
+        },
+        "guam": {},
+        "cambodia": {},
+        "koreandemilitarizedzone": {},
+        "johnston": {},
+        "thailand": {},
+        "vietnam": {
+          "view:notSure": true
+        }
+      },
+      "view:herbicideAdditionalInfo": {},
+      "otherHerbicideLocations": {
+        "description": "Test location 1",
+        "startDate": "1968-01-01",
+        "endDate": "1969-01-01"
+      },
+      "otherExposuresDetails": {
+        "asbestos": {},
+        "radiation": {
+          "endDate": "2005-05-30"
+        },
+        "mos": {
+          "startDate": "2001-01-08"
+        },
+        "chemical": {},
+        "water": {},
+        "mustardgas": {}
+      },
+      "view:otherExposuresAdditionalInfo": {},
+      "specifyOtherExposures": {
+        "startDate": "2000-03-20",
+        "endDate": "2001-03-01",
+        "description": "Test substance 1, Test Substance 2, Test Substance 3"
+      },
+      "view:additionalExposuresAdditionalInfo": {},
+      "otherExposures": {
+        "asbestos": true,
+        "mos": true,
+        "radiation": true,
+        "notsure": true
+      }
+    },
+    "view:powStatus": true,
+    "view:isPow": {
+      "confinements": [
+        {
+          "from": "2016-01-01",
+          "to": "2017-01-01"
+        },
+        {
+          "from": "2017-01-06",
+          "to": "2017-04-01"
+        }
+      ],
+      "powDisabilities": {
+        "ankylosisinkneebilateral": true,
+        "heartattackmyocardialinfarction": true
+      }
+    },
+    "newDisabilities": [
+      {
+        "cause": "NEW",
+        "primaryDescription": "It makes no sense for this particular condition, but hey, this is only test data.",
+        "condition": "asthma",
+        "view:descriptionInfo": {}
+      },
+      {
+        "cause": "SECONDARY",
+        "view:secondaryFollowUp": {
+          "causedByDisability": "Diabetes Mellitus0",
+          "causedByDisabilityDescription": "Again, this doesn't really make sense."
+        },
+        "condition": "Cranial nerve paralysis or cranial neuritis (inflammation of cranial nerves)",
+        "view:descriptionInfo": {}
+      },
+      {
+        "cause": "WORSENED",
+        "view:worsenedFollowUp": {
+          "worsenedDescription": "My knee was strained in the service",
+          "worsenedEffects": "It wasn't great before, but it got bad enough I needed a replacement. Now I have to take medication for it. I think. That makes sense, right?"
+        },
+        "condition": "ankylosis in knee, bilateral",
+        "view:descriptionInfo": {}
+      },
+      {
+        "cause": "VA",
+        "view:vaFollowUp": {
+          "vaMistreatmentDescription": "A thing happened.",
+          "vaMistreatmentLocation": "Somewhereville",
+          "vaMistreatmentDate": "A while ago"
+        },
+        "condition": "heart attack (myocardial infarction)",
+        "view:descriptionInfo": {}
+      }
+    ],
+    "ratedDisabilities": [
+      {
+        "name": "Diabetes mellitus0",
+        "ratedDisabilityId": "0",
+        "ratingDecisionId": "63655",
+        "diagnosticCode": 5238,
+        "decisionCode": "SVCCONNCTED",
+        "decisionText": "Service Connected",
+        "ratingPercentage": 100,
+        "disabilityActionType": "NONE",
+        "view:selected": true
+      },
+      {
+        "name": "Diabetes mellitus1",
+        "ratedDisabilityId": "1",
+        "ratingDecisionId": "63655",
+        "diagnosticCode": 5238,
+        "decisionCode": "SVCCONNCTED",
+        "decisionText": "Service Connected",
+        "ratingPercentage": 100,
+        "disabilityActionType": "NONE",
+        "view:selected": true
+      },
+      {
+        "name": "De-selected",
+        "ratedDisabilityId": "2",
+        "ratingDecisionId": "63655",
+        "diagnosticCode": 5238,
+        "decisionCode": "SVCCONNCTED",
+        "decisionText": "Service Connected",
+        "ratingPercentage": 100,
+        "disabilityActionType": "NONE",
+        "view:selected": false
+      },
+      {
+        "name": "Not selected",
+        "ratedDisabilityId": "3",
+        "ratingDecisionId": "63655",
+        "diagnosticCode": 5238,
+        "decisionCode": "SVCCONNCTED",
+        "decisionText": "Service Connected",
+        "ratingPercentage": 100,
+        "disabilityActionType": "NONE"
+      }
+    ],
+    "view:disabilitiesClarification": {},
+    "serviceInformation": {
+      "reservesNationalGuardService": {
+        "view:isTitle10Activated": false,
+        "obligationTermOfServiceDateRange": {
+          "from": "2007-05-22",
+          "to": "2008-06-05"
+        },
+        "unitName": "Seal Team Six"
+      },
+      "servicePeriods": [
+        {
+          "serviceBranch": "Air Force",
+          "dateRange": {
+            "from": "2001-03-21",
+            "to": "2014-07-21"
+          }
+        },
+        {
+          "serviceBranch": "Air National Guard",
+          "dateRange": {
+            "from": "2015-01-01",
+            "to": "2017-05-13"
+          }
+        }
+      ],
+      "view:militaryHistoryNote": {}
+    },
+    "view:selectablePtsdTypes": {},
+    "view:ptsdTypeHelp": {},
+    "view:upload781ChoiceHelp": {},
+    "incident0": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      }
+    },
+    "incident1": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      }
+    },
+    "incident2": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      }
+    },
+    "view:upload781aChoiceHelp": {},
+    "secondaryIncident0": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      },
+      "otherSourcesHelp": {}
+    },
+    "view:otherSourcesHelp": {},
+    "secondaryIncident1": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      },
+      "otherSourcesHelp": {}
+    },
+    "secondaryIncident2": {
+      "unitAssignedDates": {},
+      "incidentLocation": {
+        "country": "USA"
+      },
+      "otherSourcesHelp": {}
+    },
+    "physicalChanges": {},
+    "mentalChanges": {},
+    "workBehaviorChanges": {},
+    "socialBehaviorChanges": {},
+    "view:ancillaryFormsWizardIntro": {},
+    "view:unemployabilityHelp": {},
+    "unemployability": {
+      "view:recordsInfo": {},
+      "view:unemployabilityDatesDesc": {},
+      "view:grossIncomeAdditionalInfo": {},
+      "view:supplementalBenefitsHelp": {},
+      "view:substantiallyGainfulEmploymentInfo": {},
+      "view:statementsAreTrue": {},
+      "view:informOfReturnToWork": {}
+    },
+    "view:privateMedicalFacility": {},
+    "view:upload4192Choice": {},
+    "view:downloadInfo": {},
+    "view:privateRecordsChoiceHelp": {},
+    "view:faqAccordion": {},
+    "view:originalBankAccount": {
+      "view:bankAccountType": "Checking",
+      "view:bankAccountNumber": "*********1234",
+      "view:bankRoutingNumber": "*****2115",
+      "view:bankName": "Comerica"
+    }
+  }
+}

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-toxic-exposure-2022-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-toxic-exposure-2022-test.json
@@ -1,0 +1,237 @@
+{
+  "form526": {
+    "standardClaim": false,
+    "isVaEmployee": true,
+    "homelessOrAtRisk": "homeless",
+    "homelessHousingSituation": "other",
+    "otherHomelessHousing": "Under a bridge",
+    "needToLeaveHousing": true,
+    "homelessnessContact": {
+      "name": "Name Here and invalid chars with email elmer fud com",
+      "phoneNumber": "1231231234"
+    },
+    "bankAccountType": "Checking",
+    "bankAccountNumber": "1233",
+    "bankRoutingNumber": "123123123",
+    "bankName": "Bigbank Co.",
+    "phoneAndEmail": {
+      "primaryPhone": "4445551212",
+      "emailAddress": "test2@test1.net"
+    },
+    "mailingAddress": {
+      "country": "USA",
+      "addressLine1": "123 Main",
+      "city": "Bigcity",
+      "state": "AK",
+      "zipCode": "12345"
+    },
+    "forwardingAddress": {
+      "country": "USA",
+      "addressLine1": "321 Secondary",
+      "city": "Smallcity",
+      "state": "NY",
+      "zipCode": "54321",
+      "effectiveDate": { "from": "2099-12-01", "to": "2100-01-01" }
+    },
+    "startedFormVersion": "2022",
+    "toxicExposure": {
+      "conditions": {
+        "asthma": true,
+        "heartattackmyocardialinfarction": true
+      },
+      "gulfWar1990": {
+        "afghanistan": true,
+        "iraq": true,
+        "airspace": true
+      },
+      "gulfWar1990Details": {
+        "afghanistan": {
+          "startDate": "1990-01-01",
+          "endDate": "1990-12-31"
+        },
+        "iraq": {
+          "startDate": "1991-02-01",
+          "endDate": "1992-12-15"
+        }
+      },
+      "gulfWar2001": {
+        "yemen": true,
+        "airspace": false
+      },
+      "gulfWar2001Details": {
+        "yemen": {
+          "startDate": "2002-01-01"
+        }
+      },
+      "herbicide": {
+        "c123": true,
+        "guam": true,
+        "laos": true
+      },
+      "herbicideDetails": {
+        "c123": {
+          "endDate": "1966-02-20"
+        },
+        "laos": {
+          "startDate": "1965-01-01"
+        }
+      },
+      "otherHerbicideLocations": {
+        "description": "Test location 1",
+        "endDate": "1969-01-01",
+        "startDate": "1968-01-01"
+      },
+      "otherExposuresDetails": {
+        "radiation": {
+          "endDate": "2005-05-30"
+        },
+        "mos": {
+          "startDate": "2001-01-08"
+        }
+      },
+      "specifyOtherExposures": {
+        "startDate": "2000-03-20",
+        "endDate": "2001-03-01",
+        "description": "Test substance 1, Test Substance 2, Test Substance 3"
+      },
+      "otherExposures": {
+        "asbestos": true,
+        "mos": true,
+        "radiation": true,
+        "notsure": true
+      }
+    },
+    "vaTreatmentFacilities": [
+      {
+        "treatmentCenterName": "Treatment Center the First",
+        "treatmentDateRange": { "from": "2008-01-XX" },
+        "treatmentCenterAddress": {
+          "country": "USA",
+          "city": "Bigcity",
+          "state": "AK"
+        },
+        "treatedDisabilityNames": [
+          "Diabetes mellitus0",
+          "Diabetes mellitus1",
+          "heart attack (myocardial infarction)"
+        ]
+      },
+      {
+        "treatmentCenterName": "Treatment Center the Second",
+        "treatmentDateRange": { "from": "2010-01-XX" },
+        "treatmentCenterAddress": {
+          "country": "Uganda",
+          "city": "Ugandan City"
+        },
+        "treatedDisabilityNames": [
+          "asthma",
+          "heart attack (myocardial infarction)",
+          "ankylosis in knee, bilateral"
+        ]
+      }
+    ],
+    "confinements": [
+      { "from": "2016-01-01", "to": "2017-01-01" },
+      { "from": "2017-01-06", "to": "2017-04-01" }
+    ],
+    "ratedDisabilities": [
+      {
+        "name": "Diabetes mellitus0",
+        "ratedDisabilityId": "0",
+        "diagnosticCode": 5238,
+        "disabilityActionType": "INCREASE"
+      },
+      {
+        "name": "Diabetes mellitus1",
+        "ratedDisabilityId": "1",
+        "diagnosticCode": 5238,
+        "disabilityActionType": "INCREASE"
+      },
+      {
+        "name": "De-selected",
+        "ratedDisabilityId": "2",
+        "diagnosticCode": 5238,
+        "disabilityActionType": "NONE"
+      },
+      {
+        "name": "Not selected",
+        "ratedDisabilityId": "3",
+        "diagnosticCode": 5238,
+        "disabilityActionType": "NONE"
+      }
+    ],
+    "serviceInformation": {
+      "reservesNationalGuardService": {
+        "obligationTermOfServiceDateRange": {
+          "from": "2007-05-22",
+          "to": "2008-06-05"
+        },
+        "unitName": "Seal Team Six"
+      },
+      "servicePeriods": [
+        {
+          "serviceBranch": "Air Force",
+          "dateRange": { "from": "2001-03-21", "to": "2014-07-21" }
+        },
+        {
+          "serviceBranch": "Air National Guard",
+          "dateRange": { "from": "2015-01-01", "to": "2017-05-13" }
+        }
+      ]
+    },
+    "newPrimaryDisabilities": [
+      {
+        "cause": "NEW",
+        "primaryDescription": "It makes no sense for this particular condition, but hey, this is only test data.",
+        "condition": "asthma"
+      },
+      {
+        "cause": "WORSENED",
+        "worsenedDescription": "My knee was strained in the service",
+        "worsenedEffects": "It wasn't great before, but it got bad enough I needed a replacement. Now I have to take medication for it. I think. That makes sense, right?",
+        "condition": "ankylosis in knee, bilateral",
+        "specialIssues": ["POW"]
+      },
+      {
+        "cause": "VA",
+        "vaMistreatmentDescription": "A thing happened.",
+        "vaMistreatmentLocation": "Somewhereville",
+        "vaMistreatmentDate": "A while ago",
+        "condition": "heart attack (myocardial infarction)",
+        "specialIssues": ["POW"]
+      },
+      {
+        "cause": "NEW",
+        "primaryDescription": "Secondary to Diabetes Mellitus0\nAgain, this doesn't really make sense.",
+        "condition": "Cranial nerve paralysis or cranial neuritis (inflammation of cranial nerves)"
+      }
+    ],
+    "attachments": [
+      {
+        "name": "AngleSettingJig_9_25_15.pdf",
+        "confirmationCode": "544f14cc-4e51-4661-b8f4-d79f71567491",
+        "attachmentId": "L107"
+      },
+      {
+        "name": "image.png",
+        "confirmationCode": "fa0c0f47-a42f-4bbc-88f3-873c5bea6ce7",
+        "attachmentId": "L023"
+      },
+      {
+        "name": "lolwut.png",
+        "confirmationCode": "552067b2-9c5d-4bd8-bcd8-bc621b51a145",
+        "attachmentId": "L015"
+      },
+      {
+        "name": "image (1).png",
+        "confirmationCode": "0496e5c2-0675-4a43-83d6-e1eeabd4ea0e",
+        "attachmentId": "L070"
+      },
+      {
+        "name": "Success.jpg",
+        "confirmationCode": "de89492d-2d3f-4486-a73d-1fa4868aa49d",
+        "attachmentId": "L023"
+      }
+    ]
+  }
+}

--- a/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
@@ -47,6 +47,9 @@ describe('transform', () => {
         if (fileName === 'maximal-toxic-exposure-test.json') {
           rawData.data.includeToxicExposure = true;
         }
+        if (fileName === 'maximal-toxic-exposure-2022-test.json') {
+          rawData.data.startedFormVersion = '2022';
+        }
 
         let transformedData;
         try {

--- a/src/applications/disability-benefits/all-claims/tests/toxic-exposure-2022.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/toxic-exposure-2022.cypress.spec.js
@@ -1,0 +1,40 @@
+import path from 'path';
+
+import testForm from 'platform/testing/e2e/cypress/support/form-tester';
+import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
+
+import mockUser from './fixtures/mocks/user.json';
+import formConfig from '../config/form';
+import manifest from '../manifest.json';
+import { setup, pageHooks } from './cypress.helpers';
+
+const prefillData = {
+  startedFormVersion: '2022',
+};
+
+const testConfig = createTestConfig(
+  {
+    dataPrefix: 'data',
+
+    // temporarily utilize separate 2022 test until https://github.com/department-of-veterans-affairs/va.gov-team/issues/86798
+    dataSets: ['maximal-toxic-exposure-2022-test'],
+
+    fixtures: {
+      data: path.join(__dirname, 'fixtures', 'data'),
+    },
+
+    pageHooks: pageHooks(cy, { prefillData }),
+    setupPerTest: () => {
+      cy.login(mockUser);
+      setup(cy, { prefillData });
+    },
+
+    useWebComponentFields: true,
+
+    // skip: [],
+  },
+  manifest,
+  formConfig,
+);
+
+testForm(testConfig);


### PR DESCRIPTION
## Summary

- Update the front end to now display TE pages based on new form data property `startedFormVersion`. TE pages will now display only if startedFormVersion is present and has a value of 2019 or 2022
- TE pages will continue to display temporarily for form data property `includeToxicExposure: true`

team: @department-of-veterans-affairs/dbex-trex 
toggle cleanup: department-of-veterans-affairs/va.gov-team#65089

## Related issue(s)
department-of-veterans-affairs/va.gov-team#85582

## Testing done
- Added unit and e2e tests

**Manual tests**
The following manual tests were verified using a combination of flipper, Save In Progress menu and redux dev tools. TRex team will be reviewing this together and will be further tested once vets-api story #85625 is implemented
- TE pages do not display for IPF forms not enabled (flipper disabled)
- TE pages (temporarily) continue to display for new applications (flipper enabled and includeToxicExposure: true)
- TE pages now display for IPF forms with logic enabled (flipper enabled startedFormVersion: "2019")
- TE pages continue to display for new applications (flipper enabled and startedFormVersion: "2022")

## Screenshots
n/a. no changes to ui for this ticket.

## What areas of the site does it impact?
526ez

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] ~Documentation has been updated ([link to documentation](#) \*if necessary)~
- [ ] ~Screenshot of the developed feature is added~
- [ ] ~[Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed~

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] ~Events are being sent to the appropriate logging solution~
- [ ] ~Feature/bug has a monitor built into Datadog or Grafana (if applicable)~

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
