### PR TITLE
adds mhv provisioning error code

### DIFF
--- a/src/applications/auth/components/RenderErrorContainer.jsx
+++ b/src/applications/auth/components/RenderErrorContainer.jsx
@@ -396,6 +396,21 @@ export default function RenderErrorContainer({
       );
       break;
 
+    case AUTH_ERRORS.MHV_PROVISIONING_FAILURE.errorCode:
+      alertContent = (
+        <p className="vads-u-margin-top--0">
+          We’re having trouble provisioning your My HealtheVet account right now
+        </p>
+      );
+      troubleshootingContent = (
+        <>
+          <h2>How can I fix this issue?</h2>
+          <p>Try signing in again in a few minutes.</p>
+          <Helpdesk startScentence />
+        </>
+      );
+      break;
+
     case AUTH_ERRORS.CERNER_PROVISIONING_FAILURE.errorCode:
       alertContent = (
         <p className="vads-u-margin-top--0">

--- a/src/platform/user/authentication/errors.js
+++ b/src/platform/user/authentication/errors.js
@@ -67,6 +67,10 @@ export const AUTH_ERRORS = {
     errorCode: '111',
     message: `You’re not eligible for a My VA Health account.`,
   },
+  MHV_PROVISIONING_FAILURE: {
+    errorCode: '112',
+    message: `We’re having trouble provisioning your My HealtheVet account right now.`,
+  },
   OAUTH_DEFAULT_ERROR: {
     errorCode: '201',
     message: `Unknown OAuth Error`,


### PR DESCRIPTION
## Description
We needed a new error code added to VA.gov for the MHV User Creation API that will be coming up in a few weeks as stated in [this ticket](https://app.zenhub.com/workspaces/identity-5f5bab705a94c9001ba33734/issues/gh/department-of-veterans-affairs/va.gov-team/86858)
[Related documentation](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity/Troubleshooting_logging/Authentication_Errors/112.md)

## Tasks
- [x] Add error codes to `vets-website`
- [x] Update `authentication/errors.js` and `RenderErrorContainer`

<img width="831" alt="Screenshot 2024-06-25 at 12 45 09 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/78328496/11ac3cf1-c1b4-4f0b-9f86-1800e6aaf676">


