### PR TITLE
EZR: Fix bug when reloading page and rendering finanical info

### DIFF
--- a/src/applications/ezr/containers/App.jsx
+++ b/src/applications/ezr/containers/App.jsx
@@ -6,8 +6,8 @@ import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { setData } from 'platform/forms-system/src/js/actions';
 
 import { fetchEnrollmentStatus as fetchEnrollmentStatusAction } from '../utils/actions/enrollment-status';
-import { selectEnrollmentStatus } from '../utils/selectors/entrollment-status';
 import { selectAuthStatus } from '../utils/selectors/auth-status';
+import { selectEnrollmentStatus } from '../utils/selectors/entrollment-status';
 import { useBrowserMonitoring } from '../hooks/useBrowserMonitoring';
 import { parseVeteranDob, parseVeteranGender } from '../utils/helpers/general';
 import content from '../locales/en/content.json';
@@ -67,10 +67,7 @@ const App = props => {
           'view:userDob': parseVeteranDob(veteranDateOfBirth),
           'view:isSigiEnabled': isSigiEnabled,
           'view:isTeraEnabled': isTeraEnabled,
-          'view:householdEnabled':
-            canSubmitFinancialInfo === undefined
-              ? true
-              : canSubmitFinancialInfo,
+          'view:householdEnabled': !!canSubmitFinancialInfo,
         };
 
         setFormData({


### PR DESCRIPTION
This doesn't solve the refresh bug since refreshing a form page has known issues in the form library.

I removed the logic to default to `true` for showing the financial info pages and instead just use the `canSubmitFinancialInfo` state, coercing it into a boolean.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#85622

## Testing done

- Ensure specs still pass
- Deployed to review instance and verified that showing the finanical info form defaults to false

## What areas of the site does it impact?
Form 10-10EZR

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)