### PR TITLE
[CST] - Update CST pages to be indented after the va heading

### DIFF
--- a/src/applications/claims-status/components/ClaimDetailLayout.jsx
+++ b/src/applications/claims-status/components/ClaimDetailLayout.jsx
@@ -119,26 +119,12 @@ export default function ClaimDetailLayout(props) {
   return (
     <div>
       <div name="topScrollElement" />
-      <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
-        <div className="vads-l-row vads-u-margin-x--neg1p5 medium-screen:vads-u-margin-x--neg2p5">
-          <div className="vads-l-col--12">
-            <ClaimsBreadcrumbs crumbs={[crumb]} />
-          </div>
-        </div>
-        {!!headingContent && (
-          <div className="vads-l-row vads-u-margin-x--neg2p5">
-            <div className="vads-l-col--12">{headingContent}</div>
-          </div>
-        )}
-        <div className="vads-l-row vads-u-margin-x--neg2p5">
-          <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-            {bodyContent}
-          </div>
-        </div>
-        <div className="vads-l-row vads-u-margin-x--neg2p5">
-          <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-            <NeedHelp />
-          </div>
+      <div className="row">
+        <div className="usa-width-two-thirds medium-8 columns">
+          <ClaimsBreadcrumbs crumbs={[crumb]} />
+          {!!headingContent && <div>{headingContent}</div>}
+          <div>{bodyContent}</div>
+          <NeedHelp />
         </div>
       </div>
     </div>

--- a/src/applications/claims-status/containers/AppealInfo.jsx
+++ b/src/applications/claims-status/containers/AppealInfo.jsx
@@ -161,35 +161,29 @@ export class AppealInfo extends React.Component {
 
     return (
       <div>
-        <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
-          <div className="vads-l-row vads-u-margin-x--neg1p5 medium-screen:vads-u-margin-x--neg2p5">
-            <div className="vads-l-col--12">
-              <ClaimsBreadcrumbs crumbs={[crumb]} />
-            </div>
+        <div className="row">
+          <div className="usa-width-two-thirds medium-8 column">
+            <ClaimsBreadcrumbs crumbs={[crumb]} />
           </div>
-          <div className="vads-l-row vads-u-margin-x--neg2p5">
-            <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-              {!!(claimHeading && appeal) && (
-                <AppealHeader
-                  heading={claimHeading}
-                  lastUpdated={appeal.attributes.updated}
-                />
-              )}
-            </div>
+        </div>
+        <div className="row">
+          <div className="usa-width-two-thirds medium-8 column">
+            {!!(claimHeading && appeal) && (
+              <AppealHeader
+                heading={claimHeading}
+                lastUpdated={appeal.attributes.updated}
+              />
+            )}
+            {appealContent}
           </div>
-          <div className="vads-l-row vads-u-margin-x--neg2p5">
-            <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-              {appealContent}
-            </div>
-            <div className="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--4">
-              {appeal && (
-                <AppealHelpSidebar
-                  location={appeal.attributes.location}
-                  aoj={appeal.attributes.aoj}
-                />
-              )}
-              <CopyOfExam />
-            </div>
+          <div className="usa-width-one-third medium-4 column">
+            {appeal && (
+              <AppealHelpSidebar
+                location={appeal.attributes.location}
+                aoj={appeal.attributes.aoj}
+              />
+            )}
+            <CopyOfExam />
           </div>
         </div>
       </div>

--- a/src/applications/claims-status/containers/ClaimEstimationPage.jsx
+++ b/src/applications/claims-status/containers/ClaimEstimationPage.jsx
@@ -29,75 +29,62 @@ class ClaimEstimationPage extends React.Component {
     ];
 
     return (
-      <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
-        <div className="vads-l-row vads-u-margin-x--neg1p5 medium-screen:vads-u-margin-x--neg2p5">
-          <div className="vads-l-col--12">
-            <ClaimsBreadcrumbs crumbs={crumbs} />
-          </div>
-        </div>
-        <div className="vads-l-row vads-u-margin-x--neg2p5">
-          <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-            <div>
-              <h1>How we come up with your estimated decision date</h1>
-              <p className="first-of-type">
-                We look at every claim carefully before making a decision.
-                Sometimes we can decide quickly, but more complex claims take
-                longer to review.
-              </p>
-              <h2 className="claims-paragraph-header">
-                We base your estimated decision date on:
-              </h2>
-              <ul>
-                <li>The type of claim you submitted</li>
-                <li>The number of claims you submitted</li>
-                <li>Whether there were any unusual circumstances</li>
-                <li>How long it took us to decide other claims like yours</li>
-                <li>How long it takes us to get supporting documents</li>
-              </ul>
-              <h2 className="claims-paragraph-header">
-                Estimated dates may change when:
-              </h2>
-              <ul>
-                <li>You upload optional evidence that we need to process</li>
-                <li>
-                  You filed a second claim that we combined with an existing
-                  claim
-                </li>
-                <li>
-                  We decide we need more evidence that supports your claim
-                </li>
-                <li>
-                  We have a high volume of claims that we weren’t expecting
-                </li>
-              </ul>
-              <h2 className="claims-paragraph-header">
-                When we don’t meet the estimated decision date:
-              </h2>
-              <p>
-                The above reasons sometimes result in your claim needing
-                additional time that exceeds the estimated completion date. We
-                are working to process your claim as quickly as possible.
-              </p>
-              <h2 className="claims-paragraph-header">
-                When we don’t give you an estimated decision date:
-              </h2>
-              <p>
-                Sometimes we can’t estimate the decision date because we don’t
-                have enough information. We can give you an estimated decision
-                date after we have gathered all the information we need.
-              </p>
-            </div>
-            <p>
-              You can help speed up the process by promptly and electronically
-              uploading the documents requested by VA.
+      <div className="row">
+        <div className="usa-width-two-thirds medium-8 columns">
+          <ClaimsBreadcrumbs crumbs={crumbs} />
+          <div>
+            <h1>How we come up with your estimated decision date</h1>
+            <p className="first-of-type">
+              We look at every claim carefully before making a decision.
+              Sometimes we can decide quickly, but more complex claims take
+              longer to review.
             </p>
+            <h2 className="claims-paragraph-header">
+              We base your estimated decision date on:
+            </h2>
+            <ul>
+              <li>The type of claim you submitted</li>
+              <li>The number of claims you submitted</li>
+              <li>Whether there were any unusual circumstances</li>
+              <li>How long it took us to decide other claims like yours</li>
+              <li>How long it takes us to get supporting documents</li>
+            </ul>
+            <h2 className="claims-paragraph-header">
+              Estimated dates may change when:
+            </h2>
+            <ul>
+              <li>You upload optional evidence that we need to process</li>
+              <li>
+                You filed a second claim that we combined with an existing claim
+              </li>
+              <li>We decide we need more evidence that supports your claim</li>
+              <li>We have a high volume of claims that we weren’t expecting</li>
+            </ul>
+            <h2 className="claims-paragraph-header">
+              When we don’t meet the estimated decision date:
+            </h2>
             <p>
-              If you have questions, <CallVBACenter />
+              The above reasons sometimes result in your claim needing
+              additional time that exceeds the estimated completion date. We are
+              working to process your claim as quickly as possible.
+            </p>
+            <h2 className="claims-paragraph-header">
+              When we don’t give you an estimated decision date:
+            </h2>
+            <p>
+              Sometimes we can’t estimate the decision date because we don’t
+              have enough information. We can give you an estimated decision
+              date after we have gathered all the information we need.
             </p>
           </div>
-          <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-            <NeedHelp />
-          </div>
+          <p>
+            You can help speed up the process by promptly and electronically
+            uploading the documents requested by VA.
+          </p>
+          <p>
+            If you have questions, <CallVBACenter />
+          </p>
+          <NeedHelp />
         </div>
       </div>
     );

--- a/src/applications/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/applications/claims-status/containers/DocumentRequestPage.jsx
@@ -188,21 +188,11 @@ class DocumentRequestPage extends React.Component {
     return (
       <div>
         <div name="topScrollElement" />
-        <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
-          <div className="vads-l-row vads-u-margin-x--neg1p5 medium-screen:vads-u-margin-x--neg2p5">
-            <div className="vads-l-col--12">
-              <ClaimsBreadcrumbs crumbs={crumbs} />
-            </div>
-          </div>
-          <div className="vads-l-row vads-u-margin-x--neg2p5">
-            <div className="vads-l-col--12 vads-u-padding-bottom--4 medium-screen:vads-l-col--8">
-              {content}
-            </div>
-          </div>
-          <div className="vads-l-row vads-u-margin-x--neg2p5">
-            <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-              <NeedHelp />
-            </div>
+        <div className="row">
+          <div className="usa-width-two-thirds medium-8 columns">
+            <ClaimsBreadcrumbs crumbs={crumbs} />
+            <div>{content}</div>
+            <NeedHelp />
           </div>
         </div>
       </div>

--- a/src/applications/claims-status/containers/StemClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/StemClaimStatusPage.jsx
@@ -64,19 +64,15 @@ class StemClaimStatusPage extends React.Component {
     return (
       <div>
         <div name="topScrollElement" />
-        <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
-          <div className="vads-l-row vads-u-margin-x--neg1p5 medium-screen:vads-u-margin-x--neg2p5">
-            <div className="vads-l-col--12">
-              <ClaimsBreadcrumbs crumbs={[crumb]} />
-            </div>
+        <div className="row">
+          <div className="usa-width-two-thirds medium-8 column">
+            <ClaimsBreadcrumbs crumbs={[crumb]} />
           </div>
-          <div className="vads-l-row vads-u-margin-x--neg2p5">
-            <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-              {content}
-            </div>
-            <div className="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--4 help-sidebar">
-              <StemAskVAQuestions />
-            </div>
+        </div>
+        <div className="row">
+          <div className="usa-width-two-thirds medium-8 column">{content}</div>
+          <div className="usa-width-one-third medium-4 column">
+            <StemAskVAQuestions />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Noticed that the pages that we fixed the indentation on in [this](https://github.com/department-of-veterans-affairs/vets-website/pull/30497) ticket by removing the padding also had an issue where the va heading indentation was deeper then the page indentation and it looked off. Fixed this issue for the following pages:

-  src/applications/claims-status/components/ClaimDetailLayout.jsx
- src/applications/claims-status/containers/AppealInfo.jsx
- src/applications/claims-status/containers/ClaimEstimationPage.jsx
- src/applications/claims-status/containers/DocumentRequestPage.jsx
- src/applications/claims-status/containers/StemClaimStatusPage.jsx

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#85386
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#30497

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Appeal Page  | ![Screenshot 2024-06-25 at 1 43 01 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/0b66e122-babd-4c60-8a69-96c56c76ec82) |  ![Screenshot 2024-06-25 at 2 21 14 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/6a6266eb-6ccb-4a94-8bc6-82d098b5c4b3)  |
| Stem Page |  ![Screenshot 2024-06-25 at 12 24 53 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/6534138b-4e9f-47bb-884f-de34a9e24cf4)  | ![Screenshot 2024-06-25 at 1 42 27 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/afb46f2a-001e-41e2-a8af-9db3fe7e6c0f) |
| Claim Estimation Page | ![Screenshot 2024-06-25 at 12 06 18 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/99376a1c-1bda-4ac1-bedd-d4c33b220883) |  ![Screenshot 2024-06-25 at 12 11 10 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/d5ba5ecd-0729-418e-a146-edd37f00545c)    |
| Document Request Page |  ![Screenshot 2024-06-25 at 12 25 23 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/f747c889-650a-40b3-896b-b007cfa9b594)   |  ![Screenshot 2024-06-25 at 12 17 01 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/de6dab59-8e0f-4e4f-90ff-fe56a57ee8dc) |
| Claim Page |  ![Screenshot 2024-06-25 at 12 05 14 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/331eaf0d-e0df-45fd-ac8f-2468038c77b5) |  ![Screenshot 2024-06-25 at 12 05 47 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/f4efc8b3-59f3-46c4-afee-554a120cccca) |
| AppealPage - Mobile |  ![Screenshot 2024-06-25 at 2 39 12 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/dd3a8a7c-bf5e-432c-bafa-7da70a20606b) |  ![Screenshot 2024-06-25 at 2 33 02 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/35ab01da-41cb-475d-bb8f-4d34225bcf8f)|
| AppealPage - Mobile |  ![Screenshot 2024-06-25 at 2 39 21 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/8c6ab3bc-4af0-4c86-bec1-37602612b9f7) |  ![Screenshot 2024-06-25 at 2 33 25 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/7f52297e-2a42-49c8-b624-b135ba342fd0)  |


## What areas of the site does it impact?

Claim Status Tool

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
