### PR TITLE
[MHV on VA.gov] Mask all text for medications and medical-records apps

### DIFF
--- a/src/applications/mhv-medical-records/containers/App.jsx
+++ b/src/applications/mhv-medical-records/containers/App.jsx
@@ -99,7 +99,7 @@ const App = ({ children }) => {
     trackUserInteractions: true,
     trackResources: true,
     trackLongTasks: true,
-    defaultPrivacyLevel: 'mask-user-input',
+    defaultPrivacyLevel: 'mask',
   };
   useDatadogRum(datadogRumConfig);
 

--- a/src/applications/mhv-medications/containers/App.jsx
+++ b/src/applications/mhv-medications/containers/App.jsx
@@ -43,7 +43,7 @@ const App = ({ children }) => {
     trackUserInteractions: true,
     trackResources: true,
     trackLongTasks: true,
-    defaultPrivacyLevel: 'mask-user-input',
+    defaultPrivacyLevel: 'mask',
   };
   useDatadogRum(datadogRumConfig);
 


### PR DESCRIPTION
## Summary

- updates datadog settings to [mask](https://docs.datadoghq.com/real_user_monitoring/session_replay/browser/privacy_options/#mask-mode) all data for MHV medications and medical records apps

## Screenshots

- No UI changes
 
## What areas of the site does it impact?

- MHV medications and medical records only

## Acceptance criteria

- all data is masked in session replays

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
