### PR TITLE
Remove duplicate header from formNav

### DIFF
--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -79,7 +79,6 @@ export default function FormNav(props) {
     );
   }
 
-  const showHeader = Math.abs(current - index) === 1;
   // Some chapters may have progress-bar & step-header hidden via hideFormNavProgress.
   const hideFormNavProgress =
     formConfig?.chapters[page.chapterKey]?.hideFormNavProgress;
@@ -93,10 +92,6 @@ export default function FormNav(props) {
   });
   // Returns NaN if the current chapter isn't found
   const currentChapterDisplay = getCurrentChapterDisplay(formConfig, current);
-  const stepText = Number.isNaN(currentChapterDisplay)
-    ? ''
-    : `Step ${currentChapterDisplay} of ${chaptersLengthDisplay}: ${chapterName ||
-        ''}`;
 
   // The goal with this is to quickly "remove" the header from the DOM, and
   // immediately re-render the component with the header included.
@@ -148,39 +143,26 @@ export default function FormNav(props) {
   return (
     <div>
       {!hideFormNavProgress && (
-        <va-segmented-progress-bar
-          total={chaptersLengthDisplay}
-          current={currentChapterDisplay}
-          uswds={v3SegmentedProgressBar}
-          heading-text={chapterName ?? ''} // functionality only available for v3
-          name="v3SegmentedProgressBar"
-          labels={v3SegmentedProgressBar && stepLabels ? stepLabels : ''}
-          {...(v3SegmentedProgressBar ? { 'header-level': '2' } : {})}
-          {...(v3SegmentedProgressBar?.useDiv ? { 'use-div': 'true' } : {})}
-        />
-      )}
-      {!v3SegmentedProgressBar &&
-        !hideFormNavProgress && (
+        <>
+          <va-segmented-progress-bar
+            id="nav-form-header"
+            total={chaptersLengthDisplay}
+            current={currentChapterDisplay}
+            heading-text={chapterName ?? ''} // functionality only available for v3
+            name="v3SegmentedProgressBar"
+            labels={v3SegmentedProgressBar && stepLabels ? stepLabels : ''}
+            header-level="2"
+            {...(v3SegmentedProgressBar?.useDiv ? { 'use-div': 'true' } : {})}
+          />
           <div className="schemaform-chapter-progress">
             <div className="nav-header nav-header-schemaform">
-              {showHeader ? (
-                <h2
-                  id="nav-form-header"
-                  data-testid="navFormHeader"
-                  className="vads-u-font-size--h4"
-                >
-                  {stepText}
-                  {inProgressMessage}
-                </h2>
-              ) : (
-                <div data-testid="navFormDiv" className="vads-u-font-size--h4">
-                  {stepText}
-                  {inProgressMessage}
-                </div>
-              )}
+              <div data-testid="navFormDiv" className="vads-u-font-size--h4">
+                {inProgressMessage}
+              </div>
             </div>
           </div>
-        )}
+        </>
+      )}
     </div>
   );
 }

--- a/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
@@ -60,13 +60,18 @@ describe('Schemaform FormNav', () => {
   it('should render current chapter stepText', () => {
     const currentPath = 'testing1';
     const formConfigDefaultData = getDefaultData();
-    const tree = render(
+    const { container } = render(
       <FormNav formConfig={formConfigDefaultData} currentPath={currentPath} />,
     );
-
-    expect(tree.getByTestId('navFormHeader').textContent).to.contain(
-      'Step 1 of 4: Testing',
+    const v3SegmentedProgressBar = container.querySelector(
+      'va-segmented-progress-bar',
     );
+
+    expect(v3SegmentedProgressBar.getAttribute('heading-text')).to.eq(
+      'Testing',
+    );
+    expect(v3SegmentedProgressBar.getAttribute('current')).to.eq('1');
+    expect(v3SegmentedProgressBar.getAttribute('total')).to.eq('4');
   });
   it('should optionally hide current chapter progress-bar & stepText', () => {
     const currentPath = 'testing1';
@@ -97,11 +102,14 @@ describe('Schemaform FormNav', () => {
       return '[no params provided to function]';
     };
 
-    const tree = render(
+    const { container } = render(
       <FormNav formConfig={formConfigDefaultData} currentPath={currentPath} />,
     );
+    const v3SegmentedProgressBar = container.querySelector(
+      'va-segmented-progress-bar',
+    );
 
-    expect(tree.getByTestId('navFormHeader').textContent).to.include(
+    expect(v3SegmentedProgressBar.getAttribute('heading-text')).to.eq(
       'Title [from function]',
     );
   });
@@ -138,12 +146,15 @@ describe('Schemaform FormNav', () => {
       return formPageChapterTitle;
     };
 
-    const tree = render(
+    const { container } = render(
       <FormNav formConfig={formConfigDefaultData} currentPath="testing1" />,
+    );
+    const v3SegmentedProgressBar = container.querySelector(
+      'va-segmented-progress-bar',
     );
 
     // assert actual chapter title on form-page
-    expect(tree.getByTestId('navFormHeader').textContent).to.include(
+    expect(v3SegmentedProgressBar.getAttribute('heading-text')).to.eq(
       formPageChapterTitle,
     );
 
@@ -158,11 +169,16 @@ describe('Schemaform FormNav', () => {
     const formConfigReviewData = getReviewData();
     const currentPath = 'review-and-submit';
 
-    const tree = render(
+    const { container } = render(
       <FormNav formConfig={formConfigReviewData} currentPath={currentPath} />,
     );
-    expect(tree.getByText('Custom Review Page Title', { exact: false })).to.not
-      .be.null;
+    const v3SegmentedProgressBar = container.querySelector(
+      'va-segmented-progress-bar',
+    );
+
+    expect(v3SegmentedProgressBar.getAttribute('heading-text')).to.eq(
+      'Custom Review Page Title',
+    );
   });
   it('should display the auto-save message & application ID', () => {
     const formConfigReviewData = getReviewData();
@@ -199,8 +215,7 @@ describe('Schemaform FormNav', () => {
         isLoggedIn={false}
       />,
     );
-    expect(tree.getByText(/^step [0-9]+ of [0-9]+: Custom Review Page Title$/i))
-      .to.not.be.null;
+    expect(tree.queryByTestId('navFormDiv').textContent).to.eq('');
   });
 
   // Can't get this test to work... useEffect callback is calling the focus
@@ -232,9 +247,13 @@ describe('Schemaform FormNav', () => {
   it('should render current chapter stepText', () => {
     const currentPath = 'testing4';
     const formConfigDefaultData = getDefaultData();
-    const tree = render(
+    const { container } = render(
       <FormNav formConfig={formConfigDefaultData} currentPath={currentPath} />,
     );
-    expect(tree.getByTestId('navFormDiv').textContent).to.eq('');
+    const v3SegmentedProgressBar = container.querySelector(
+      'va-segmented-progress-bar',
+    );
+
+    expect(v3SegmentedProgressBar.getAttribute('heading-text')).to.eq('');
   });
 });


### PR DESCRIPTION
## Summary
This pull request fixes a bug caused by the switch to V3 web components. Because the segmented-progress-bar contains the page header inside the web component, forms that had not manually switched to using the v3 web component were showing duplicate headers. These changes remove the duplicate header for all forms as well as restore the `inProgressMessage` that was accidentally removed for forms that were using the v3 flag.

## Related issue(s)
department-of-veterans-affairs/va.gov-team#79012