### PR TITLE
MHV-59473 Fix chem/hem titles

### DIFF
--- a/src/applications/mhv-medical-records/reducers/labsAndTests.js
+++ b/src/applications/mhv-medical-records/reducers/labsAndTests.js
@@ -112,11 +112,20 @@ const getSpecimen = record => {
   return null;
 };
 
-export const extractOrderedTest = record => {
+export const extractOrderedTest = (record, id) => {
+  const serviceReq = extractContainedResource(record, id);
+  return serviceReq?.code?.text || null;
+};
+
+export const extractOrderedTests = record => {
   if (isArrayAndHasItems(record.basedOn)) {
-    const basedOnRef = record.basedOn.find(item => item.reference);
-    const serviceReq = extractContainedResource(record, basedOnRef?.reference);
-    return serviceReq?.code?.text || null;
+    const orderedTests = record.basedOn
+      .map(item => {
+        return extractOrderedTest(record, item?.reference) || null;
+      })
+      .filter(item => item !== null)
+      .join(', ');
+    return orderedTests === '' ? null : orderedTests;
   }
   return null;
 };
@@ -133,8 +142,8 @@ const convertChemHemRecord = record => {
     id: record.id,
     type: labTypes.CHEM_HEM,
     testType: serviceRequest?.code?.text || EMPTY_FIELD,
-    name: extractOrderedTest(record) || 'Chemistry/Hematology',
-    category: concatCategoryCodeText(record) || EMPTY_FIELD,
+    name: extractOrderedTests(record) || 'Chemistry/Hematology',
+    category: 'Chemistry/Hematology',
     orderedBy: getPractitioner(record, serviceRequest) || EMPTY_FIELD,
     date: record.effectiveDateTime
       ? dateFormatWithoutTimezone(record.effectiveDateTime)

--- a/src/applications/mhv-medical-records/reducers/labsAndTests.js
+++ b/src/applications/mhv-medical-records/reducers/labsAndTests.js
@@ -112,6 +112,15 @@ const getSpecimen = record => {
   return null;
 };
 
+export const extractOrderedTest = record => {
+  if (isArrayAndHasItems(record.basedOn)) {
+    const basedOnRef = record.basedOn.find(item => item.reference);
+    const serviceReq = extractContainedResource(record, basedOnRef?.reference);
+    return serviceReq?.code?.text || null;
+  }
+  return null;
+};
+
 /**
  * @param {Object} record - A FHIR DiagnosticReport chem/hem object
  * @returns the appropriate frontend object for display
@@ -124,7 +133,7 @@ const convertChemHemRecord = record => {
     id: record.id,
     type: labTypes.CHEM_HEM,
     testType: serviceRequest?.code?.text || EMPTY_FIELD,
-    name: concatCategoryCodeText(record) || EMPTY_FIELD,
+    name: extractOrderedTest(record) || 'Chemistry/Hematology',
     category: concatCategoryCodeText(record) || EMPTY_FIELD,
     orderedBy: getPractitioner(record, serviceRequest) || EMPTY_FIELD,
     date: record.effectiveDateTime

--- a/src/applications/mhv-medical-records/tests/components/ChemHemDetails.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/ChemHemDetails.unit.spec.jsx
@@ -43,13 +43,10 @@ describe('Chem Hem details component', () => {
   });
 
   it('should display the test name', () => {
-    const header = screen.getAllByText(
-      'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN:',
-      {
-        exact: true,
-        selector: 'h1',
-      },
-    );
+    const header = screen.getAllByText('Potassium', {
+      exact: true,
+      selector: 'h1',
+    });
     expect(header).to.exist;
   });
 

--- a/src/applications/mhv-medical-records/tests/components/ChemHemDetails.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/ChemHemDetails.unit.spec.jsx
@@ -43,7 +43,7 @@ describe('Chem Hem details component', () => {
   });
 
   it('should display the test name', () => {
-    const header = screen.getAllByText('Potassium', {
+    const header = screen.getAllByText('Potassium, Sodium', {
       exact: true,
       selector: 'h1',
     });

--- a/src/applications/mhv-medical-records/tests/components/LabsAndTestsListItem.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/LabsAndTestsListItem.unit.spec.jsx
@@ -34,21 +34,13 @@ describe('LabsAndTestsListItem component', () => {
   });
 
   it('renders without errors', () => {
-    expect(
-      screen.getAllByText(
-        'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN:',
-        { exact: true },
-      )[0],
-    ).to.exist;
+    expect(screen.getAllByText('Potassium', { exact: true })[0]).to.exist;
   });
 
   it('should contain the name of the record', () => {
-    const recordName = screen.getAllByText(
-      'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN:',
-      {
-        exact: true,
-      },
-    )[0];
+    const recordName = screen.getAllByText('Potassium', {
+      exact: true,
+    })[0];
     expect(recordName).to.exist;
   });
 
@@ -60,13 +52,10 @@ describe('LabsAndTestsListItem component', () => {
   });
 
   it('should contain a link to view record details', () => {
-    const recordDetailsLink = screen.getByText(
-      'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN:',
-      {
-        selector: 'span',
-        exact: true,
-      },
-    );
+    const recordDetailsLink = screen.getByText('Potassium', {
+      selector: 'span',
+      exact: true,
+    });
     expect(recordDetailsLink).to.exist;
   });
 });

--- a/src/applications/mhv-medical-records/tests/components/LabsAndTestsListItem.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/LabsAndTestsListItem.unit.spec.jsx
@@ -34,11 +34,12 @@ describe('LabsAndTestsListItem component', () => {
   });
 
   it('renders without errors', () => {
-    expect(screen.getAllByText('Potassium', { exact: true })[0]).to.exist;
+    expect(screen.getAllByText('Potassium, Sodium', { exact: true })[0]).to
+      .exist;
   });
 
   it('should contain the name of the record', () => {
-    const recordName = screen.getAllByText('Potassium', {
+    const recordName = screen.getAllByText('Potassium, Sodium', {
       exact: true,
     })[0];
     expect(recordName).to.exist;
@@ -52,7 +53,7 @@ describe('LabsAndTestsListItem component', () => {
   });
 
   it('should contain a link to view record details', () => {
-    const recordDetailsLink = screen.getByText('Potassium', {
+    const recordDetailsLink = screen.getByText('Potassium, Sodium', {
       selector: 'span',
       exact: true,
     });

--- a/src/applications/mhv-medical-records/tests/containers/LabAndTestDetails.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/LabAndTestDetails.unit.spec.jsx
@@ -42,23 +42,17 @@ describe('LabsAndTests details container', () => {
   });
 
   it('displays the test name as an h1', () => {
-    const testName = screen.getByText(
-      'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN:',
-      {
-        exact: true,
-        selector: 'h1',
-      },
-    );
+    const testName = screen.getByText('Potassium', {
+      exact: true,
+      selector: 'h1',
+    });
     expect(testName).to.exist;
   });
 
   it('displays the type of test', () => {
-    expect(
-      screen.getByText(
-        'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN:',
-        { exact: true, selector: 'p' },
-      ),
-    ).to.exist;
+    const element = screen.getByTestId('chem-hem-category');
+    expect(element).to.exist;
+    expect(element.textContent).to.equal('Chemistry/Hematology');
   });
 
   it('displays the site or sample tested', () => {

--- a/src/applications/mhv-medical-records/tests/containers/LabAndTestDetails.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/LabAndTestDetails.unit.spec.jsx
@@ -42,7 +42,7 @@ describe('LabsAndTests details container', () => {
   });
 
   it('displays the test name as an h1', () => {
-    const testName = screen.getByText('Potassium', {
+    const testName = screen.getByText('Potassium, Sodium', {
       exact: true,
       selector: 'h1',
     });

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-view-labs-chem-hem-details.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-view-labs-chem-hem-details.cypress.spec.js
@@ -10,9 +10,7 @@ describe('Medical Records View Labs And Tests', () => {
     // cy.visit('my-health/medical-records/labs-and-tests');
     LabsAndTestsListPage.goToLabsAndTests();
     LabsAndTestsListPage.clickLabsAndTestsDetailsLink(0, labsAndTests.entry[0]);
-    ChemHemDetailsPage.verifyLabName(
-      'POTASSIUM:SCNC:PT:SER/PLAS:QN:, SODIUM:SCNC:PT:SER/PLAS:QN:',
-    );
+    ChemHemDetailsPage.verifyLabName('Potassium');
     ChemHemDetailsPage.verifyLabDate('January 20, 2021');
     ChemHemDetailsPage.verifySampleTested('SERUM');
     ChemHemDetailsPage.verifyOrderedBy('DOE, JANE A');

--- a/src/applications/mhv-medical-records/tests/reducers/careSummariesAndNotes.unit.spec.js
+++ b/src/applications/mhv-medical-records/tests/reducers/careSummariesAndNotes.unit.spec.js
@@ -112,7 +112,7 @@ describe('extractAuthenticator', () => {
   it('should return null if no "name" item contains a "text" field', () => {
     const badRec = {
       contained: [{ id: 'Provider-0', name: [{ ignore: 'the wrong object' }] }],
-      authenticator: { reference: '#Provider-1' },
+      authenticator: { reference: '#Provider-0' },
     };
     expect(extractAuthenticator(badRec)).to.be.null;
   });
@@ -120,7 +120,7 @@ describe('extractAuthenticator', () => {
   it('should return null if "name" is empty', () => {
     const badRec = {
       contained: [{ id: 'Provider-0', name: [] }],
-      authenticator: { reference: '#Provider-1' },
+      authenticator: { reference: '#Provider-0' },
     };
     expect(extractAuthenticator(badRec)).to.be.null;
   });

--- a/src/applications/mhv-medical-records/tests/reducers/labsAndTests.unit.spec.js
+++ b/src/applications/mhv-medical-records/tests/reducers/labsAndTests.unit.spec.js
@@ -72,7 +72,7 @@ describe('extractOrderedTests', () => {
     expect(extractOrderedTests(badRec)).to.equal(TEST2);
   });
 
-  it('returns null if one of all references return null', () => {
+  it('returns null if all references return null', () => {
     const badRec = {
       contained: [
         { id: 'ServiceRequest-1', ignore: 'wrong field' },

--- a/src/applications/mhv-medical-records/tests/reducers/labsAndTests.unit.spec.js
+++ b/src/applications/mhv-medical-records/tests/reducers/labsAndTests.unit.spec.js
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import { extractOrderedTest } from '../../reducers/labsAndTests';
+
+describe('extractOrderedTest', () => {
+  const TEST_NAME = 'Test Name';
+  const record = {
+    contained: [{ id: 'ServiceRequest-1', code: { text: TEST_NAME } }],
+    basedOn: [{ reference: '#ServiceRequest-1' }],
+  };
+
+  it('returns the code when present', () => {
+    expect(extractOrderedTest(record)).to.equal(TEST_NAME);
+  });
+
+  it('returns null when basedOn is not found', () => {
+    const badRec = {
+      contained: [{ id: 'ServiceRequest-1', code: { text: TEST_NAME } }],
+    };
+    expect(extractOrderedTest(badRec)).to.be.null;
+  });
+
+  it('returns null when the reference is not found', () => {
+    const badRec = {
+      contained: [{ id: 'ServiceRequest-1', code: { text: TEST_NAME } }],
+      basedOn: [{ reference: '#Not-Found' }],
+    };
+    expect(extractOrderedTest(badRec)).to.be.null;
+  });
+
+  it('returns null when the ServiceRequest has no "code" field', () => {
+    const badRec = {
+      contained: [{ id: 'ServiceRequest-1', ignore: 'wrong field' }],
+      basedOn: [{ reference: '#ServiceRequest-1' }],
+    };
+    expect(extractOrderedTest(badRec)).to.be.null;
+  });
+
+  it('returns null when "code" has no "text" field', () => {
+    const badRec = {
+      contained: [{ id: 'ServiceRequest-1', code: { ignore: 'wrong field' } }],
+      basedOn: [{ reference: '#ServiceRequest-1' }],
+    };
+    expect(extractOrderedTest(badRec)).to.be.null;
+  });
+});

--- a/src/applications/mhv-medical-records/tests/reducers/labsAndTests.unit.spec.js
+++ b/src/applications/mhv-medical-records/tests/reducers/labsAndTests.unit.spec.js
@@ -1,44 +1,94 @@
 import { expect } from 'chai';
-import { extractOrderedTest } from '../../reducers/labsAndTests';
+import {
+  extractOrderedTest,
+  extractOrderedTests,
+} from '../../reducers/labsAndTests';
 
 describe('extractOrderedTest', () => {
+  const TEST_ID = 'ServiceRequest-1';
+  const TEST_REF = `#${TEST_ID}`;
   const TEST_NAME = 'Test Name';
   const record = {
     contained: [{ id: 'ServiceRequest-1', code: { text: TEST_NAME } }],
-    basedOn: [{ reference: '#ServiceRequest-1' }],
   };
 
-  it('returns the code when present', () => {
-    expect(extractOrderedTest(record)).to.equal(TEST_NAME);
-  });
-
-  it('returns null when basedOn is not found', () => {
-    const badRec = {
-      contained: [{ id: 'ServiceRequest-1', code: { text: TEST_NAME } }],
-    };
-    expect(extractOrderedTest(badRec)).to.be.null;
+  it('returns the test name when present', () => {
+    expect(extractOrderedTest(record, TEST_REF)).to.equal(TEST_NAME);
   });
 
   it('returns null when the reference is not found', () => {
     const badRec = {
-      contained: [{ id: 'ServiceRequest-1', code: { text: TEST_NAME } }],
-      basedOn: [{ reference: '#Not-Found' }],
+      contained: [{ id: TEST_ID, code: { text: TEST_NAME } }],
     };
-    expect(extractOrderedTest(badRec)).to.be.null;
+    expect(extractOrderedTest(badRec, '#Not-Found')).to.be.null;
   });
 
   it('returns null when the ServiceRequest has no "code" field', () => {
     const badRec = {
-      contained: [{ id: 'ServiceRequest-1', ignore: 'wrong field' }],
-      basedOn: [{ reference: '#ServiceRequest-1' }],
+      contained: [{ id: TEST_ID, ignore: 'wrong field' }],
+      basedOn: [{ reference: TEST_REF }],
     };
     expect(extractOrderedTest(badRec)).to.be.null;
   });
 
   it('returns null when "code" has no "text" field', () => {
     const badRec = {
-      contained: [{ id: 'ServiceRequest-1', code: { ignore: 'wrong field' } }],
-      basedOn: [{ reference: '#ServiceRequest-1' }],
+      contained: [{ id: TEST_ID, code: { ignore: 'wrong field' } }],
+      basedOn: [{ reference: TEST_REF }],
+    };
+    expect(extractOrderedTest(badRec)).to.be.null;
+  });
+});
+
+describe('extractOrderedTests', () => {
+  const TEST1 = 'Test 1 Name';
+  const TEST2 = 'Test 2 Name';
+  const record = {
+    contained: [
+      { id: 'ServiceRequest-1', code: { text: TEST1 } },
+      { id: 'ServiceRequest-2', code: { text: TEST2 } },
+    ],
+    basedOn: [
+      { reference: '#ServiceRequest-1' },
+      { reference: '#ServiceRequest-2' },
+    ],
+  };
+
+  it('returns multiple test names when present', () => {
+    expect(extractOrderedTests(record)).to.equal(`${TEST1}, ${TEST2}`);
+  });
+
+  it('returns one test name if one of two references returns null', () => {
+    const badRec = {
+      contained: [
+        { id: 'ServiceRequest-1', ignore: 'wrong field' },
+        { id: 'ServiceRequest-2', code: { text: TEST2 } },
+      ],
+      basedOn: [
+        { reference: '#ServiceRequest-1' },
+        { reference: '#ServiceRequest-2' },
+      ],
+    };
+    expect(extractOrderedTests(badRec)).to.equal(TEST2);
+  });
+
+  it('returns null if one of all references return null', () => {
+    const badRec = {
+      contained: [
+        { id: 'ServiceRequest-1', ignore: 'wrong field' },
+        { id: 'ServiceRequest-2', ignore: 'wrong field' },
+      ],
+      basedOn: [
+        { reference: '#ServiceRequest-1' },
+        { reference: '#ServiceRequest-2' },
+      ],
+    };
+    expect(extractOrderedTests(badRec)).to.be.null;
+  });
+
+  it('returns null when basedOn is not found', () => {
+    const badRec = {
+      contained: [{ id: 'ServiceRequest-1', code: { text: TEST1 } }],
     };
     expect(extractOrderedTest(badRec)).to.be.null;
   });


### PR DESCRIPTION
## Summary

- Updated the Chem/Hem record title to be the name of the ordered test
- Fixed a couple of old unit tests that were passing for the wrong reason

## Related issue(s)

### [MHV-59473](https://jira.devops.va.gov/browse/MHV-59473) - Use the "basedOn" ServiceRequest code for Chem/Hem title ###

> Currently the titles for Chem/Hem records are opaque and very long. Use instead this field:
> 
> basedOn[].reference --> contained[].(ServiceRequest).code.text

## Testing done

- Comprehensive unit tests for new function

## Screenshots

### Before ###
<img width="300" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/775aab98-05a5-43d6-adda-ca9b12bff76e">

### After ###
<img width="300" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/87040148/a6c5215a-b728-4ba4-ab87-0e723cef84e6">


## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
