### PR TITLE
VACMS-17948 Income Limits error message text update

### DIFF
--- a/src/applications/income-limits/components/IncomeLimitsApp.jsx
+++ b/src/applications/income-limits/components/IncomeLimitsApp.jsx
@@ -19,8 +19,9 @@ const IncomeLimitsApp = ({
   zipValidationError,
 }) => {
   const location = router?.getCurrentLocation()?.pathname;
-  const GENERAL_ERROR =
-    'We’re sorry. Something went wrong on our end. Please try again.';
+  const GENERAL_ERROR_HEADING = `Your answer didn’t go through.`;
+  const GENERAL_ERROR_BODY =
+    'We’re sorry. There’s a problem with our system. Refresh this page or try again later.';
 
   useEffect(
     () => {
@@ -41,22 +42,21 @@ const IncomeLimitsApp = ({
     ],
   );
 
-  const alertBanner = message => {
+  const alertBanner = (message = null) => {
     return (
       <va-alert data-testid="il-service-error" status="error" uswds>
         <h2 className="vads-u-margin-bottom--2" slot="headline">
-          We&#8217;ve run into a problem
+          {message ? `We've run into a problem` : GENERAL_ERROR_HEADING}
         </h2>
-        <p className="vads-u-margin--0">{message}</p>
+        <p className="vads-u-margin--0">{message || GENERAL_ERROR_BODY}</p>
       </va-alert>
     );
   };
 
   return (
     <div className="income-limits-app row vads-u-padding-bottom--8">
-      {zipValidationError && alertBanner(GENERAL_ERROR)}
-      {resultsValidationError &&
-        alertBanner(resultsValidationErrorText || GENERAL_ERROR)}
+      {zipValidationError && alertBanner()}
+      {resultsValidationError && alertBanner(resultsValidationErrorText)}
       <Breadcrumbs />
       <div className="usa-width-two-thirds medium-8 columns">{children}</div>
     </div>

--- a/src/applications/income-limits/tests/cypress/results-errors.cypress.spec.js
+++ b/src/applications/income-limits/tests/cypress/results-errors.cypress.spec.js
@@ -41,7 +41,7 @@ describe('retrieving results - errors', () => {
       h.verifyLoadingIndicatorShown();
 
       h.checkServiceAlertText(
-        `We’ve run into a problemYour information couldn’t go through. Enter a valid 5 digit zip code.`,
+        `We've run into a problemYour information couldn’t go through. Enter a valid 5 digit zip code.`,
       );
       h.verifyLoadingIndicatorNotShown();
     });
@@ -87,7 +87,7 @@ describe('retrieving results - errors', () => {
       h.verifyLoadingIndicatorShown();
 
       h.checkServiceAlertText(
-        `We’ve run into a problemYour information couldn’t go through. Select a year again.`,
+        `We've run into a problemYour information couldn’t go through. Select a year again.`,
       );
       h.verifyLoadingIndicatorNotShown();
     });
@@ -133,7 +133,7 @@ describe('retrieving results - errors', () => {
       h.verifyLoadingIndicatorShown();
 
       h.checkServiceAlertText(
-        `We’ve run into a problemYour information couldn’t go through. Enter a number of dependents between 0 and 100.`,
+        `We've run into a problemYour information couldn’t go through. Enter a number of dependents between 0 and 100.`,
       );
       h.verifyLoadingIndicatorNotShown();
     });
@@ -180,7 +180,7 @@ describe('retrieving results - errors', () => {
       cy.wait(5200);
 
       h.checkServiceAlertText(
-        `We’ve run into a problemWe’re sorry. Something went wrong on our end. Please try again.`,
+        `Your answer didn’t go through.We’re sorry. There’s a problem with our system. Refresh this page or try again later.`,
       );
       h.verifyLoadingIndicatorNotShown();
     });

--- a/src/applications/income-limits/tests/cypress/zip-validation.cypress.spec.js
+++ b/src/applications/income-limits/tests/cypress/zip-validation.cypress.spec.js
@@ -25,7 +25,7 @@ describe('zip code validation - service errors', () => {
     h.verifyLoadingIndicatorShown();
 
     h.checkServiceAlertText(
-      `We’ve run into a problemWe’re sorry. Something went wrong on our end. Please try again.`,
+      `Your answer didn’t go through.We’re sorry. There’s a problem with our system. Refresh this page or try again later.`,
     );
     h.verifyLoadingIndicatorNotShown();
 


### PR DESCRIPTION
## Summary
In a prior PR, we updated error messaging in some of our applications to remove the word "Please" per content guidelines. The error messaging in Income Limits for zip validation and for limits retrieval still had the word "Please," so we have new text to update it with now.

Here's what the error messaging looks like now (this is an example from the design system storybook, not the live app, but they match):

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/a39bd342-26b0-4d76-9e04-9591b93a6633)

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/17948

## Testing done
Tested locally by forcing the API to error (by removing a character from the API URL that is called). This is not really feasible to test organically as it requires the API to fail. There are 5 error scenarios:

These two error cases still had "Please" in the messaging:
- Zip validation fails due to API error (on `/zip` screen)
- Income limits retrieval fails due to API error (on `/review` screen)

These are edge cases that would happen if the API is hit directly, or if there's a weird session issue where data goes missing before the review screen "Continue" button is clicked. These error cases did not have "Please" in their error messaging and their error messaging was not updated as part of this PR.
- Income limits retrieval fails due to API error because the year is missing in the "past" flow (on `/review` screen)
- Income limits retrieval fails due to API error because the dependents are missing (on `/review` screen)
- Income limits retrieval fails due to API error because the zip code is missing (on `/review` screen)

## Screenshots

### Changed error messaging:

<img width="1127" alt="Screenshot 2024-06-26 at 9 16 59 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/20c5f70b-9efc-4127-aa1b-32ce43a6aafd">
<img width="1148" alt="Screenshot 2024-06-26 at 9 17 36 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/aabb9797-e8fe-46f7-b9be-4ecfc9e42e8a">

### Existing error messaging for the edge cases listed above

<img width="1104" alt="Screenshot 2024-06-26 at 11 15 32 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/6d1fbd56-5624-455b-857a-1ceffe48ec7c">
<img width="1118" alt="Screenshot 2024-06-26 at 11 15 16 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/bc96382c-1457-4082-95dd-3ddc7c1277a1">
<img width="1105" alt="Screenshot 2024-06-26 at 11 14 53 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/19175324/91c6e383-3711-438d-9a56-5a49389b2ab1">