### PR TITLE
DR | Update contested issues after successful fetch

### DIFF
--- a/src/applications/appeals/10182/containers/FormApp.jsx
+++ b/src/applications/appeals/10182/containers/FormApp.jsx
@@ -7,6 +7,7 @@ import { isLoggedIn } from 'platform/user/selectors';
 import { setData } from 'platform/forms-system/src/js/actions';
 
 import { getContestableIssues as getContestableIssuesAction } from '../actions';
+
 import formConfig from '../config/form';
 import {
   SHOW_PART3,
@@ -20,6 +21,7 @@ import { issuesNeedUpdating } from '../utils/issues';
 import { getEligibleContestableIssues } from '../utils/submit';
 import { checkRedirect } from '../utils/redirect';
 
+import { FETCH_CONTESTABLE_ISSUES_SUCCEEDED } from '../../shared/actions';
 import { wrapWithBreadcrumb } from '../../shared/components/Breadcrumbs';
 import { copyAreaOfDisagreementOptions } from '../../shared/utils/areaOfDisagreement';
 import { useBrowserMonitoring } from '../../shared/utils/useBrowserMonitoring';
@@ -77,7 +79,7 @@ export const FormApp = ({
       }
 
       if (
-        !contestableIssues?.status &&
+        (contestableIssues?.status || '') === '' &&
         // internalTesting is used to test the get contestable issues API call
         // in unit tests; Setting up the unit test to get RoutedSavableApp to
         // work properly is overly complicated
@@ -87,6 +89,7 @@ export const FormApp = ({
       } else if (
         // Checks if the API has returned contestable issues not already reflected
         // in `formData`.
+        contestableIssues.status === FETCH_CONTESTABLE_ISSUES_SUCCEEDED &&
         issuesNeedUpdating(
           contestableIssues?.issues,
           formData.contestedIssues,

--- a/src/applications/appeals/995/containers/App.jsx
+++ b/src/applications/appeals/995/containers/App.jsx
@@ -26,6 +26,7 @@ import {
   SUPPORTED_BENEFIT_TYPES_LIST,
 } from '../constants';
 
+import { FETCH_CONTESTABLE_ISSUES_SUCCEEDED } from '../../shared/actions';
 import { wrapInH1 } from '../../shared/content/intro';
 import { wrapWithBreadcrumb } from '../../shared/components/Breadcrumbs';
 import { useBrowserMonitoring } from '../../shared/utils/useBrowserMonitoring';
@@ -97,11 +98,12 @@ export const App = ({
             setIsLoadingIssues(true);
             getContestableIssues({ benefitType: formData.benefitType });
           } else if (
-            issuesNeedUpdating(
+            contestableIssues.status === FETCH_CONTESTABLE_ISSUES_SUCCEEDED &&
+            (issuesNeedUpdating(
               contestableIssues.issues,
               formData?.contestedIssues,
             ) ||
-            contestableIssues.legacyCount !== formData.legacyCount
+              contestableIssues.legacyCount !== formData.legacyCount)
           ) {
             // resetStoredSubTask();
             setFormData({

--- a/src/applications/appeals/996/containers/Form0996App.jsx
+++ b/src/applications/appeals/996/containers/Form0996App.jsx
@@ -19,6 +19,7 @@ import forcedMigrations from '../migrations/forceMigrations';
 
 import { getContestableIssues as getContestableIssuesAction } from '../actions';
 
+import { FETCH_CONTESTABLE_ISSUES_SUCCEEDED } from '../../shared/actions';
 import { wrapInH1 } from '../../shared/content/intro';
 import { wrapWithBreadcrumb } from '../../shared/components/Breadcrumbs';
 import { copyAreaOfDisagreementOptions } from '../../shared/utils/areaOfDisagreement';
@@ -81,11 +82,12 @@ export const Form0996App = ({
             setIsLoadingIssues(true);
             getContestableIssues({ benefitType: formData.benefitType });
           } else if (
-            issuesNeedUpdating(
+            contestableIssues.status === FETCH_CONTESTABLE_ISSUES_SUCCEEDED &&
+            (issuesNeedUpdating(
               contestableIssues?.issues,
               formData?.contestedIssues,
             ) ||
-            contestableIssues.legacyCount !== formData.legacyCount
+              contestableIssues.legacyCount !== formData.legacyCount)
           ) {
             /**
              * Force HLR v2 update

--- a/src/applications/appeals/996/tests/containers/FormApp.unit.spec.jsx
+++ b/src/applications/appeals/996/tests/containers/FormApp.unit.spec.jsx
@@ -18,7 +18,10 @@ import maximalTestV1 from '../fixtures/data/maximal-test-v1.json';
 import migratedMaximalTestV1 from '../fixtures/data/migrated/maximal-test-v1-to-v2.json';
 
 import { SELECTED } from '../../../shared/constants';
-import { FETCH_CONTESTABLE_ISSUES_SUCCEEDED } from '../../../shared/actions';
+import {
+  FETCH_CONTESTABLE_ISSUES_SUCCEEDED,
+  FETCH_CONTESTABLE_ISSUES_FAILED,
+} from '../../../shared/actions';
 import { contestableIssuesResponse } from '../../../shared/tests/fixtures/mocks/contestable-issues.json';
 
 const hasComp = { benefitType: 'compensation' };
@@ -195,15 +198,14 @@ describe('Form0996App', () => {
     });
   });
 
-  it('should set form data', async () => {
+  it('should update contested issues', async () => {
     const issues = [
       {
         type: 'contestableIssue',
         attributes: {
           ratingIssueSubjectText: 'test1',
-          approxDecisionDate: '2023-06-06',
+          approxDecisionDate: '2023-06-07',
         },
-        [SELECTED]: true,
       },
     ];
     const { props, data } = getData({
@@ -215,7 +217,16 @@ describe('Form0996App', () => {
       },
       formData: {
         benefitType: 'compensation',
-        contestedIssues: [],
+        contestedIssues: [
+          {
+            type: 'contestableIssue',
+            attributes: {
+              ratingIssueSubjectText: 'test1',
+              approxDecisionDate: '2023-06-06',
+            },
+            [SELECTED]: true,
+          },
+        ],
         legacyCount: 0,
         internalTesting: true,
       },
@@ -232,6 +243,59 @@ describe('Form0996App', () => {
       const action = store.getActions()[0];
       expect(action.type).to.eq(SET_DATA);
       expect(action.data.contestedIssues.length).to.eq(1);
+      expect(action.data).to.deep.equal({
+        ...hasComp,
+        contestedIssues: [
+          {
+            type: 'contestableIssue',
+            attributes: {
+              ratingIssueSubjectText: 'test1',
+              approxDecisionDate: '2023-06-07',
+              description: '',
+            },
+          },
+        ],
+        legacyCount: 0,
+        internalTesting: true,
+      });
+    });
+  });
+
+  it('should not update contested issues when the API fails', async () => {
+    const { props, data } = getData({
+      contestableIssues: {
+        benefitType: 'compensation',
+        status: FETCH_CONTESTABLE_ISSUES_FAILED,
+        issues: [],
+        legacyCount: undefined,
+      },
+      formData: {
+        benefitType: 'compensation',
+        areaOfDisagreement: [],
+        contestedIssues: [
+          {
+            type: 'contestableIssue',
+            attributes: {
+              ratingIssueSubjectText: 'test1',
+              approxDecisionDate: '2023-06-06',
+            },
+          },
+        ],
+        legacyCount: 0,
+        internalTesting: true,
+      },
+    });
+    const store = mockStore(data);
+
+    render(
+      <Provider store={store}>
+        <Form0996App {...props} />
+      </Provider>,
+    );
+
+    await waitFor(() => {
+      const actions = store.getActions();
+      expect(actions.length).to.eq(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > When an existing contestable issues is selected, and the application is saved. Upon return to the form, the checked contestable issues are no longer checked. This problem does not occur with manually added, and selected, issues. Upon return, the error messaging in place only notifies the Veteran prior to submission if they only selected existing conditions.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#86921](https://github.com/department-of-veterans-affairs/va.gov-team/issues/86921)

## Testing done

- _Describe what the old behavior was prior to the change_
  > Contested issues in the form data were being updated prior to fetch, clearing out the issues, then repopulating them after a successful fetch - this causes the selection value to be removed from the form data
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

All Decision Review apps: HLR, NOD & SC

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
