### PR TITLE
86839 Add sponsor information chapter - form 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959a/chapters/sponsorInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/sponsorInformation.js
@@ -1,0 +1,33 @@
+import { cloneDeep } from 'lodash';
+import {
+  fullNameUI,
+  fullNameSchema,
+  titleUI,
+  titleSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+
+export const blankSchema = { type: 'object', properties: {} };
+
+const fullNameMiddleInitialUI = cloneDeep(fullNameUI());
+fullNameMiddleInitialUI.middle['ui:title'] = 'Middle initial';
+
+export const sponsorNameSchema = {
+  uiSchema: {
+    ...titleUI('Sponsor information', ({ formData }) => {
+      const isBeneficiary = formData?.certifierRole === 'applicant';
+      return `Enter the information for the sponsor (this is the Veteran or service member ${
+        isBeneficiary ? 'you’re' : 'the beneficiary'
+      } is connected to). We’ll use the sponsor’s information to verify ${
+        isBeneficiary ? 'your' : 'the beneficiary’s'
+      } eligibility`;
+    }),
+    sponsorName: fullNameMiddleInitialUI,
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      titleSchema,
+      sponsorName: fullNameSchema,
+    },
+  },
+};

--- a/src/applications/ivc-champva/10-7959a/config/form.js
+++ b/src/applications/ivc-champva/10-7959a/config/form.js
@@ -53,7 +53,7 @@ const formConfig = {
       pages: {
         page2: {
           path: 'sponsor-information',
-          title: 'Sponsor information',
+          title: 'Name',
           ...sponsorNameSchema,
         },
       },

--- a/src/applications/ivc-champva/10-7959a/config/form.js
+++ b/src/applications/ivc-champva/10-7959a/config/form.js
@@ -5,9 +5,7 @@ import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 
-// const { } = fullSchema.properties;
-
-// const { } = fullSchema.definitions;
+import { sponsorNameSchema } from '../chapters/sponsorInformation';
 
 const formConfig = {
   rootUrl: manifest.rootUrl,
@@ -36,8 +34,8 @@ const formConfig = {
   title: '10-7959a CHAMPVA Claim Form',
   defaultDefinitions: {},
   chapters: {
-    chapter1: {
-      title: 'Chapter 1',
+    signerInformation: {
+      title: 'Signer information',
       pages: {
         page1: {
           path: 'first-page',
@@ -47,6 +45,16 @@ const formConfig = {
             type: 'object',
             properties: {},
           },
+        },
+      },
+    },
+    sponsorInformation: {
+      title: 'Sponsor information',
+      pages: {
+        page2: {
+          path: 'sponsor-information',
+          title: 'Sponsor information',
+          ...sponsorNameSchema,
         },
       },
     },


### PR DESCRIPTION
## Summary

Adds sponsor information chapter (which consists of a single page to collect sponsor full name) to form 10-7959a.

- Adds sponsor full name page to form

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86839

## Testing done

- Manual

## Screenshots

|         | Page | Review |
| ------- | ------ | ----- |
| Desktop | ![Screenshot 2024-06-26 at 17 21 46](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/af9bfcad-a6d5-4baf-95b9-987de6a98da2) |![Screenshot 2024-06-26 at 17 26 40](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/32842410-b205-480e-b7ba-868be788f3b8)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback