### PR TITLE
Check in/87064/already filed date

### DIFF
--- a/src/applications/check-in/travel-claim/pages/error/Error.unit.spec.jsx
+++ b/src/applications/check-in/travel-claim/pages/error/Error.unit.spec.jsx
@@ -2,8 +2,10 @@ import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
 
+import MockDate from 'mockdate';
 import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
+
 import Error from './index';
 
 const appointments = [
@@ -18,6 +20,7 @@ describe('check-in', () => {
   });
   afterEach(() => {
     teardownI18n();
+    MockDate.reset();
   });
   describe('travel-claim', () => {
     describe('Error component', () => {
@@ -64,6 +67,7 @@ describe('check-in', () => {
         expect(component.getByTestId('find-out-link')).to.exist;
       });
       it('renders the correct error on already-filed-claim', () => {
+        MockDate.set('2024-01-01T12:30:00.000-05:00');
         const component = render(
           <CheckInProvider
             store={{ error: 'already-filed-claim', appointments }}

--- a/src/applications/check-in/travel-claim/pages/error/index.jsx
+++ b/src/applications/check-in/travel-claim/pages/error/index.jsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
-import { makeSelectError, makeSelectTravelClaimData } from '../../../selectors';
+import { makeSelectError } from '../../../selectors';
 import Wrapper from '../../../components/layout/Wrapper';
 import ExternalLink from '../../../components/ExternalLink';
 
@@ -10,12 +10,6 @@ const Error = () => {
   const { t } = useTranslation();
   const selectError = useMemo(makeSelectError, []);
   const { error } = useSelector(selectError);
-
-  // @TODO refactor using something else from redux
-  const selectTravelClaimData = useMemo(makeSelectTravelClaimData, []);
-  const appointments = useSelector(selectTravelClaimData);
-  const appointmentDateTime =
-    appointments.length > 0 ? new Date(appointments[0].startTime) : null;
 
   let alerts = [];
   let header = '';
@@ -120,7 +114,7 @@ const Error = () => {
                 className="vads-u-margin-top--0"
               >
                 {t('were-sorry-you-already-filed-a-claim', {
-                  date: appointmentDateTime,
+                  date: new Date(),
                 })}
               </p>
               <ExternalLink


### PR DESCRIPTION
## Summary

This PR fixes a problem where we were trying to use a date from a non-existent appointments payload. The work here uses today's date instead since this message will always be displayed in context of the current day.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#87064

## Testing done

Updated unit test

## Screenshots

<img src="https://github.com/department-of-veterans-affairs/vets-website/assets/13967174/8f06305f-ea56-4cdd-821e-5f3b6a1e7bea" width="200" />

## What areas of the site does it impact?

Stand alone travel app for Oracle Health appointments.

## Acceptance criteria
 - [ ] the date in the already filed message is no longer missing
 - [ ] the date reflects the current date
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

