### PR TITLE
10-7959f-1 Same as address

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -173,10 +173,16 @@ const formConfig = {
             },
           },
         },
-        page3a: {
+      },
+    },
+    physicalAddress: {
+      title: 'Home address',
+      pages: {
+        page4: {
           path: 'same-as-mailing-address',
+          title: 'Home address',
           uiSchema: {
-            ...titleUI('Mailing address'),
+            ...titleUI('Home address'),
             sameMailingAddress: yesNoUI({
               title: 'Is your mailing address the same as your home address?',
               labels: {
@@ -194,14 +200,9 @@ const formConfig = {
             },
           },
         },
-      },
-    },
-    physicalAddress: {
-      title: 'Home Address',
-      pages: {
-        page4: {
+        page4a: {
           path: 'home-address',
-          title: "Veteran's Home address",
+          title: 'Home address',
           depends: formData => formData.sameMailingAddress === false,
           uiSchema: {
             ...titleUI(

--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -15,6 +15,8 @@ import {
   phoneSchema,
   emailUI,
   emailSchema,
+  yesNoUI,
+  yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import transformForSubmit from './submitTransformer';
 import manifest from '../manifest.json';
@@ -178,7 +180,7 @@ const formConfig = {
       pages: {
         page4: {
           path: 'same-as-mailing-address',
-          title: 'Home address',
+          title: 'Home address ',
           uiSchema: {
             ...titleUI('Home address'),
             sameMailingAddress: yesNoUI({
@@ -200,7 +202,7 @@ const formConfig = {
         },
         page4a: {
           path: 'home-address',
-          title: 'Home address',
+          title: 'Home address ',
           depends: formData => formData.sameMailingAddress === false,
           uiSchema: {
             ...titleUI(

--- a/src/applications/ivc-champva/10-7959f-1/tests/unit/config/form.unit.spec.js
+++ b/src/applications/ivc-champva/10-7959f-1/tests/unit/config/form.unit.spec.js
@@ -33,10 +33,19 @@ testNumberOfWebComponentFields(
 
 testNumberOfWebComponentFields(
   formConfig,
-  formConfig.chapters.physicalAddress.pages.page4.schema,
-  formConfig.chapters.physicalAddress.pages.page4.uiSchema,
+  formConfig.chapters.physicalAddress.pages.page4a.schema,
+  formConfig.chapters.physicalAddress.pages.page4a.uiSchema,
   8,
   'Applicant home address',
+  { ...mockdata.data },
+);
+
+testNumberOfWebComponentFields(
+  formConfig,
+  formConfig.chapters.physicalAddress.pages.page4.schema,
+  formConfig.chapters.physicalAddress.pages.page4.uiSchema,
+  1,
+  'Applicant home address yes/no',
   { ...mockdata.data },
 );
 


### PR DESCRIPTION
## Summary
This PR moves the same as address to a different chapter so the numbers in the heading will remain consistent.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/83695

## Testing done
Manual testing
Unit tests

## Screenshots
![Screenshot 2024-06-27 at 9 57 27 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/653b2fb4-76e1-4773-8c58-7e24239f2431)
![Screenshot 2024-06-27 at 10 04 13 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/2553abb3-0fd0-43c0-a3d3-0583efc564b2)
![Screenshot 2024-06-27 at 10 04 26 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/c21b7e36-5f35-4031-a754-f2319d68e01a)
![Screenshot 2024-06-27 at 10 04 34 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/47d38bb7-f48e-4af6-9121-5b94f0d40468)
![Screenshot 2024-06-27 at 10 04 41 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/35ec6cac-cfa1-4597-b7e3-172fcc61b340)

## What areas of the site does it impact?
This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
