### PR TITLE
Remove required field from Find your VA Health Facility

### DIFF
--- a/src/applications/ask-va/config/chapters/personalInformation/searchVAMedicalCenter.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/searchVAMedicalCenter.js
@@ -1,6 +1,6 @@
+import FormElementTitle from '../../../components/FormElementTitle';
 import MedicalFacilitySearch from '../../../components/MedicalFacilitySearch';
 import PageFieldSummary from '../../../components/PageFieldSummary';
-import FormElementTitle from '../../../components/FormElementTitle';
 
 const searchVAMedicalCenterPage = {
   uiSchema: {
@@ -15,7 +15,7 @@ const searchVAMedicalCenterPage = {
   },
   schema: {
     type: 'object',
-    required: ['vaMedicalCenter'],
+    required: [],
     properties: {
       vaMedicalCenter: {
         type: 'string',


### PR DESCRIPTION
## Summary

- Temporarily removing the required attribute for Find your VA Health Facility to unblock testing efforts while we resolve the api issue on the backend
- The Ask VA team owns this
- This is part of our POC

## Related issue(s)

- Link to ticket created [here](https://github.com/department-of-veterans-affairs/vets-website/compare/Ask-VA-1162/Make-health-facility-not-required-to-unblock-testing?expand=1)

## Testing done

- Manual test locally

## Screenshots

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/49699643/f58fb759-baea-45aa-835d-30b7ad3a44dc)

## What areas of the site does it impact?

- This only impacts the Ask VA Form

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
