### PR TITLE
CDP Chapter 33 Alert

### DIFF
--- a/src/applications/combined-debt-portal/debt-letters/components/DebtDetailsCard.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtDetailsCard.jsx
@@ -23,54 +23,92 @@ const DebtDetailsCard = ({ debt }) => {
     convertedAr,
   );
 
+  // Check if the debt is a Chapter 33 debt
+  const isChapter33Debt = debt.benefitType.includes('CH33');
+
+  // Get the current date
+  const currentDate = new Date();
+  const endDate = new Date('2024-07-19');
+
+  // Check if the current date is before the end date
+  const showChapter33Alert = isChapter33Debt && currentDate <= endDate;
+
   return (
-    <va-alert
-      class="vads-u-margin-bottom--1"
-      disable-analytics="false"
-      full-width="false"
-      show-icon={debtCardContent.showIcon}
-      status={debtCardContent.status}
-      visible="true"
-    >
-      <h2 slot="headline">{debtCardContent.headerText}</h2>
-
-      {debtCardContent.bodyText}
-
-      {debtCardContent.showLinks && (
-        <>
-          {debtCardContent.showMakePayment && (
-            <p>
-              <a
-                aria-label="Make a payment"
-                className="vads-c-action-link--blue"
-                data-testid="link-make-payment"
-                href="https://www.pay.va.gov/"
-                onClick={() => {
-                  recordEvent({ event: 'cta-link-click-debt-make-payment' });
-                }}
-              >
-                Make a payment
-              </a>
-            </p>
-          )}
-          {debtCardContent.showRequestHelp && (
-            <p>
-              <a
-                aria-label="Request help with your debt"
-                className="vads-c-action-link--blue"
-                data-testid="link-request-help"
-                href="/manage-va-debt/request-debt-help-form-5655"
-                onClick={() => {
-                  recordEvent({ event: 'cta-link-click-debt-request-help' });
-                }}
-              >
-                Request help with your debt
-              </a>
-            </p>
-          )}
-        </>
+    <>
+      {showChapter33Alert && (
+        <va-alert
+          class="vads-u-margin-bottom--2"
+          close-btn-aria-label="Close notification"
+          disable-analytics="false"
+          full-width="false"
+          slim
+          status="warning"
+          visible="true"
+        >
+          <p className="vads-u-margin-y--0">
+            VA is transitioning to a new system for processing Post 9-11 Chapter
+            33 financial transactions. Due to this transition, Chapter 33 debt
+            balance information may not reflect recent payments you have made by
+            check, credit card, or ACH. If you believe your Chapter 33 debt
+            balance does not reflect recent payments, we encourage you to
+            contact the Debt Management Center: at{' '}
+            <va-link href="https://ask.va.gov/" text="ask.va.gov" /> or call{' '}
+            <va-telephone contact="8008270648" />, after 07/12/2024. Your
+            payment will not be considered late and will reflect the date
+            received once system updates are completed. This message only
+            applies to Post 9-11, Chapter 33 debts.
+          </p>
+        </va-alert>
       )}
-    </va-alert>
+
+      <va-alert
+        class="vads-u-margin-bottom--1"
+        disable-analytics="false"
+        full-width="false"
+        show-icon={debtCardContent.showIcon}
+        status={debtCardContent.status}
+        visible="true"
+      >
+        <h2 slot="headline">{debtCardContent.headerText}</h2>
+
+        {debtCardContent.bodyText}
+
+        {debtCardContent.showLinks && (
+          <>
+            {debtCardContent.showMakePayment && (
+              <p>
+                <a
+                  aria-label="Make a payment"
+                  className="vads-c-action-link--blue"
+                  data-testid="link-make-payment"
+                  href="https://www.pay.va.gov/"
+                  onClick={() => {
+                    recordEvent({ event: 'cta-link-click-debt-make-payment' });
+                  }}
+                >
+                  Make a payment
+                </a>
+              </p>
+            )}
+            {debtCardContent.showRequestHelp && (
+              <p>
+                <a
+                  aria-label="Request help with your debt"
+                  className="vads-c-action-link--blue"
+                  data-testid="link-request-help"
+                  href="/manage-va-debt/request-debt-help-form-5655"
+                  onClick={() => {
+                    recordEvent({ event: 'cta-link-click-debt-request-help' });
+                  }}
+                >
+                  Request help with your debt
+                </a>
+              </p>
+            )}
+          </>
+        )}
+      </va-alert>
+    </>
   );
 };
 

--- a/src/applications/combined-debt-portal/debt-letters/components/DebtDetailsCard.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtDetailsCard.jsx
@@ -8,8 +8,10 @@ import recordEvent from '~/platform/monitoring/record-event';
 import { getDebtDetailsCardContent } from '../const/diary-codes/debtDetailsCardContent';
 import { currency } from '../utils/page';
 
+// Define the Chapter 33 debt codes
+const CHAPTER_33_DEBT_CODES = ['70', '71', '72', '73', '74', '75'];
+
 const DebtDetailsCard = ({ debt }) => {
-  // TODO: currently we do not have a debtID so we need to make one by combining fileNumber and diaryCode
   const dates = debt?.debtHistory?.map(m => new Date(m.date)) ?? [];
   const sortedHistory = dates.sort((a, b) => Date.parse(b) - Date.parse(a));
   const mostRecentDate = isValid(head(sortedHistory))
@@ -23,8 +25,8 @@ const DebtDetailsCard = ({ debt }) => {
     convertedAr,
   );
 
-  // Check if the debt is a Chapter 33 debt
-  const isChapter33Debt = debt.benefitType.includes('CH33');
+  // Check if the debt is a Chapter 33 debt based on the deduction code
+  const isChapter33Debt = CHAPTER_33_DEBT_CODES.includes(debt.deductionCode);
 
   // Get the current date
   const currentDate = new Date();


### PR DESCRIPTION
## Summary

This will only impact Chapter 33 debts so can/should appear specifically when a Veteran is reviewing their Chapter 33 debt on the portal.

DMC would like to add a message - they described it as a 'banner' that stays active until July 19, 2024

They would like the message to read as follows:

"VA is transitioning to a new system for processing Post 9-11 Chapter 33 financial transactions. Due to this transition, Chapter 33 debt balance information may not reflect recent payments you have made by check, credit card, or ACH. If you believe your Chapter 33 debt balance does not reflect recent payments, we encourage you to contact the Debt Management Center: at [www.ask.va.gov](http://www.ask.va.gov/) or call 800-827-0648, after 07/12/2024. Your payment will not be considered late and will reflect the date received once system updates are completed. This message only applies to Post 9-11, Chapter 33 debts."

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#86976


## Testing done

- Manual


## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | ![staging va gov_manage-va-debt_summary_debt-balances_details_79612301871](https://github.com/department-of-veterans-affairs/vets-website/assets/1631062/ba533146-28c0-4063-b9f2-2b526c356a7d) | ![localhost_3001_manage-va-debt_summary_debt-balances_details_79612301871](https://github.com/department-of-veterans-affairs/vets-website/assets/1631062/eec9cdf7-544f-437b-bbc8-4d2084a7d0c8) |

## What areas of the site does it impact?

Combined Debt Portal detail page for only chapter 33 debts.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
