### PR TITLE
VYE-443 added page not found for when toggle is off for VYE

### DIFF
--- a/src/applications/verify-your-enrollment/routes.jsx
+++ b/src/applications/verify-your-enrollment/routes.jsx
@@ -1,15 +1,15 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import { RequiredLoginView } from '@department-of-veterans-affairs/platform-user/RequiredLoginView';
 import backendServices from 'platform/user/profile/constants/backendServices';
 import { selectUser } from '@department-of-veterans-affairs/platform-user/selectors';
+import PageNotFound from '@department-of-veterans-affairs/platform-site-wide/PageNotFound';
 import { useSelector } from 'react-redux';
 import {
   BENEFITS_PROFILE_RELATIVE_URL,
   VERIFICATION_REVIEW_RELATIVE_URL,
 } from './constants';
-// import App from './containers/App';
 import EnrollmentVerificationPageWrapper from './containers/EnrollmentVerificationPageWrapper';
 import BenefitsProfileWrapper from './containers/BenefitsProfilePageWrapper';
 import VerificationReviewWrapper from './containers/VerificationReviewWrapper';
@@ -23,37 +23,47 @@ const IsUserLoggedIn = () => {
   const serverError = response?.error?.errors
     ? response?.error?.errors[0]
     : response?.error;
+
+  const isError500 = useMemo(() => parseInt(serverError?.status, 10) === 500, [
+    serverError,
+  ]);
+
+  const Routes = useMemo(
+    () => (
+      <Switch>
+        <Route exact key="EnrollmentVerificationPage" path="/">
+          <EnrollmentVerificationPageWrapper />
+        </Route>
+        <Route
+          exact
+          key="BenefitsProfilePage"
+          path={BENEFITS_PROFILE_RELATIVE_URL}
+        >
+          <BenefitsProfileWrapper />
+        </Route>
+        <Route
+          exact
+          key="VerificationReview"
+          path={VERIFICATION_REVIEW_RELATIVE_URL}
+        >
+          <VerificationReviewWrapper />
+        </Route>
+      </Switch>
+    ),
+    [],
+  );
+
   return toggleValue || window.isProduction ? (
     <RequiredLoginView
       serviceRequired={backendServices.USER_PROFILE}
       user={user}
     >
-      {parseInt(serverError?.status, 10) === 500 ? (
-        <LoadFail />
-      ) : (
-        <Switch>
-          <Route exact key="EnrollmentVerificationPage" path="/">
-            <EnrollmentVerificationPageWrapper />
-          </Route>
-          <Route
-            exact
-            key="BenefitsProfilePage"
-            path={`${BENEFITS_PROFILE_RELATIVE_URL}`}
-          >
-            <BenefitsProfileWrapper />
-          </Route>
-          <Route
-            exact
-            key="VerificationReview"
-            path={`${VERIFICATION_REVIEW_RELATIVE_URL}`}
-          >
-            <VerificationReviewWrapper />
-          </Route>
-        </Switch>
-      )}
+      {isError500 ? <LoadFail /> : Routes}
     </RequiredLoginView>
   ) : (
-    <></>
+    <div className="not-found">
+      <PageNotFound />
+    </div>
   );
 };
 

--- a/src/applications/verify-your-enrollment/sass/verify-your-enrollment.scss
+++ b/src/applications/verify-your-enrollment/sass/verify-your-enrollment.scss
@@ -90,3 +90,14 @@
 .icon-color svg use {
     width: 20px !important;
 }
+.not-found{
+    .row{
+        display: flex;
+        @media (max-width: $small-screen){
+        flex-direction: column;
+        }
+        form{
+            margin: 0;
+    }
+}
+}


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary
As:

VYE Developer

I need:

to see Page not found when the Feature toggle is off for the VYE application

So that: 

a blank page is not rendered.

Considerations:

 

Acceptance Criteria: 

Enter the acceptance criteria that will be used to test the user story. 

User should see 'Sorry - we can't find that page' message (See attached screenshot)
Testing Considerations:

Testing will be conducted on local host and in staging

Other Considerations: 

This screen will only be shown when the VYE feature toggle is off, otherwise the application itself will be shown.

- _(Summarize the changes that have been made to the platform)_
 added the Page not found component to show when feature toggle is off for the VYE application
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- _Link to ticket created in va.gov-team repo_ https://jira.devops.va.gov/browse/VYE-443
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/158514667/1da1e1fc-4867-443f-906d-8da62c56ef39)
<img width="413" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/158514667/dbe4f801-a161-4972-bd06-c1efc8e213e7">

<img width="1728" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/158514667/49ecd795-f364-4662-bd16-9f68c9ffbda7">

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
