### PR TITLE
[CST] - Update recent activity for claim phase dates

### DIFF
--- a/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
+++ b/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
@@ -3,76 +3,172 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom-v5-compat';
 import { VaPagination } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import moment from 'moment';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 
 import { ITEMS_PER_PAGE } from '../../constants';
-import { buildDateFormatter } from '../../utils/helpers';
-
-const getOldestDocumentDate = item => {
-  const arrDocumentDates = item.documents.map(document => document.uploadDate);
-  return arrDocumentDates.sort()[0]; // Tried to do Math.min() here and it was erroring out
-};
-
-const getTrackedItemDateFromStatus = item => {
-  switch (item.status) {
-    case 'NEEDED_FROM_YOU':
-    case 'NEEDED_FROM_OTHERS':
-      return item.requestedDate;
-    case 'NO_LONGER_REQUIRED':
-      return item.closedDate;
-    case 'SUBMITTED_AWAITING_REVIEW':
-      return getOldestDocumentDate(item);
-    case 'INITIAL_REVIEW_COMPLETE':
-    case 'ACCEPTED':
-      return item.receivedDate;
-    default:
-      return item.requestedDate;
-  }
-};
-
-const getTrackedItemDescription = item => {
-  switch (item.status) {
-    case 'NEEDED_FROM_YOU':
-    case 'NEEDED_FROM_OTHERS':
-      return `We opened a request for "${item.displayName}"`;
-    case 'NO_LONGER_REQUIRED':
-      return `We closed a request for "${item.displayName}"`;
-    case 'SUBMITTED_AWAITING_REVIEW':
-      return `We received your document(s) for "${item.displayName}"`;
-    case 'INITIAL_REVIEW_COMPLETE':
-    case 'ACCEPTED':
-      return `We completed a review for "${item.displayName}"`;
-    default:
-      return 'There was an update to this item';
-  }
-};
-
-const generateTrackedItems = claim => {
-  const { trackedItems } = claim.attributes;
-
-  return trackedItems.map(item => ({
-    id: item.id,
-    date: getTrackedItemDateFromStatus(item),
-    description: getTrackedItemDescription(item),
-    displayName: item.displayName,
-    status: item.status,
-    type: 'tracked_item',
-  }));
-};
-
-const getSortedItems = claim => {
-  // Get items from trackedItems and claimPhaseDates
-  const trackedItems = generateTrackedItems(claim);
-  const phaseItems = [];
-  const items = [...trackedItems, ...phaseItems];
-
-  return items.sort((item1, item2) => {
-    return moment(item2.date) - moment(item1.date);
-  });
-};
+import {
+  buildDateFormatter,
+  getItemDate,
+  getPhaseItemText,
+  getStatusMap,
+} from '../../utils/helpers';
 
 export default function RecentActivity({ claim }) {
+  const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
+  const cstClaimPhasesEnabled = useToggleValue(TOGGLE_NAMES.cstClaimPhases);
+
+  const getOldestDocumentDate = item => {
+    const arrDocumentDates = item.documents.map(
+      document => document.uploadDate,
+    );
+    return arrDocumentDates.sort()[0]; // Tried to do Math.min() here and it was erroring out
+  };
+
+  const getTrackedItemDateFromStatus = item => {
+    switch (item.status) {
+      case 'NEEDED_FROM_YOU':
+      case 'NEEDED_FROM_OTHERS':
+        return item.requestedDate;
+      case 'NO_LONGER_REQUIRED':
+        return item.closedDate;
+      case 'SUBMITTED_AWAITING_REVIEW':
+        return getOldestDocumentDate(item);
+      case 'INITIAL_REVIEW_COMPLETE':
+      case 'ACCEPTED':
+        return item.receivedDate;
+      default:
+        return item.requestedDate;
+    }
+  };
+
+  const getTrackedItemDescription = item => {
+    switch (item.status) {
+      case 'NEEDED_FROM_YOU':
+      case 'NEEDED_FROM_OTHERS':
+        return `We opened a request for "${item.displayName}"`;
+      case 'NO_LONGER_REQUIRED':
+        return `We closed a request for "${item.displayName}"`;
+      case 'SUBMITTED_AWAITING_REVIEW':
+        return `We received your document(s) for "${item.displayName}"`;
+      case 'INITIAL_REVIEW_COMPLETE':
+      case 'ACCEPTED':
+        return `We completed a review for "${item.displayName}"`;
+      default:
+        return 'There was an update to this item';
+    }
+  };
+
+  const getPhaseItemDescription = (currentPhaseBack, phase) => {
+    const phaseItemText = getPhaseItemText(phase, cstClaimPhasesEnabled);
+    switch (phase) {
+      case 1:
+      case 8:
+        return phaseItemText;
+      case 2:
+      case 7:
+        return `Your claim moved into ${phaseItemText}`;
+      case 3:
+      case 4:
+      case 5:
+      case 6:
+        if (currentPhaseBack) {
+          return `Your claim moved back to ${phaseItemText}`;
+        }
+        return `Your claim moved into ${phaseItemText}`;
+      default:
+        return `Your claim moved into ${phaseItemText}`;
+    }
+  };
+
+  const generateTrackedItems = () => {
+    const { trackedItems } = claim.attributes;
+
+    return trackedItems.map(item => ({
+      id: item.id,
+      date: getTrackedItemDateFromStatus(item),
+      description: getTrackedItemDescription(item),
+      displayName: item.displayName,
+      status: item.status,
+      type: 'tracked_item',
+    }));
+  };
+
+  const isEventOrPrimaryPhase = event => {
+    if (event.type === 'phase_entered') {
+      return event.phase <= 3 || event.phase >= 7;
+    }
+
+    return !!getItemDate(event);
+  };
+
+  const getPhaseFromStatus = latestStatus =>
+    [...getStatusMap().keys()].indexOf(latestStatus.toUpperCase()) + 1;
+
+  const isCurrentOrPastPhase = (event, currentPhase) => {
+    return event.phase <= currentPhase;
+  };
+
+  const generatePhaseItems = () => {
+    const {
+      currentPhaseBack,
+      previousPhases,
+    } = claim.attributes.claimPhaseDates;
+    const phases = [];
+
+    const regex = /\d+/;
+
+    // Add phase dates using the complete date of other phases
+    const phaseKeys = Object.keys(previousPhases);
+    phaseKeys.forEach(phaseKey => {
+      const phase = Number(phaseKey.match(regex)[0]) + 1;
+      phases.push({
+        id: phase,
+        type: 'phase_entered',
+        // We are assuming here that each phaseKey is of the format:
+        // phaseXCompleteDate, where X is some integer between 1 and 7
+        // NOTE: Adding 1 because the a phases completion date is
+        // analagous to the phase after it's start date
+        // eg. phase1CompleteDate = start date for phase 2
+        phase,
+        description: getPhaseItemDescription(currentPhaseBack, phase),
+        date: previousPhases[phaseKey],
+      });
+    });
+
+    // Add initial phase date since its not inculded in previousPhases
+    phases.push({
+      id: 1,
+      type: 'filed',
+      phase: 1,
+      description: getPhaseItemDescription(currentPhaseBack, 1),
+      date: claim.attributes.claimDate,
+    });
+
+    // When cst_claim_phases is enabled then we remove steps 4-6 and only keep step 3
+    const firstPass = cstClaimPhasesEnabled
+      ? phases
+      : phases.filter(isEventOrPrimaryPhase);
+
+    const currentPhase = getPhaseFromStatus(
+      claim.attributes.claimPhaseDates.latestPhaseType,
+    );
+    // TODO What is the purpose of this and is it needed?
+    return firstPass.filter(phase => isCurrentOrPastPhase(phase, currentPhase));
+  };
+
+  const getSortedItems = () => {
+    // Get items from trackedItems and claimPhaseDates
+    const trackedItems = generateTrackedItems();
+    const phaseItems = generatePhaseItems();
+    const items = [...trackedItems, ...phaseItems];
+
+    return items.sort((item1, item2) => {
+      return moment(item2.date) - moment(item1.date);
+    });
+  };
+
   const [currentPage, setCurrentPage] = useState(1);
-  const items = getSortedItems(claim);
+  const items = getSortedItems();
   const pageLength = items.length;
   const numPages = Math.ceil(pageLength / ITEMS_PER_PAGE);
   const shouldPaginate = numPages > 1;

--- a/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
+++ b/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
@@ -10,7 +10,6 @@ import {
   buildDateFormatter,
   getItemDate,
   getPhaseItemText,
-  getStatusMap,
 } from '../../utils/helpers';
 
 export default function RecentActivity({ claim }) {
@@ -101,13 +100,6 @@ export default function RecentActivity({ claim }) {
     return !!getItemDate(event);
   };
 
-  const getPhaseFromStatus = latestStatus =>
-    [...getStatusMap().keys()].indexOf(latestStatus.toUpperCase()) + 1;
-
-  const isCurrentOrPastPhase = (event, currentPhase) => {
-    return event.phase <= currentPhase;
-  };
-
   const generatePhaseItems = () => {
     const {
       currentPhaseBack,
@@ -145,15 +137,14 @@ export default function RecentActivity({ claim }) {
     });
 
     // When cst_claim_phases is enabled then we remove steps 4-6 and only keep step 3
-    const firstPass = cstClaimPhasesEnabled
+    return cstClaimPhasesEnabled
       ? phases
       : phases.filter(isEventOrPrimaryPhase);
 
-    const currentPhase = getPhaseFromStatus(
-      claim.attributes.claimPhaseDates.latestPhaseType,
-    );
-    // TODO What is the purpose of this and is it needed?
-    return firstPass.filter(phase => isCurrentOrPastPhase(phase, currentPhase));
+    // const currentPhase = getPhaseFromStatus(
+    //   claim.attributes.claimPhaseDates.latestPhaseType,
+    // );
+    // return firstPass.filter(phase => isCurrentOrPastPhase(phase, currentPhase));
   };
 
   const getSortedItems = () => {

--- a/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
+++ b/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
@@ -76,7 +76,7 @@ export default function RecentActivity({ claim }) {
         }
         return `Your claim moved into ${phaseItemText}`;
       default:
-        return `Your claim moved into ${phaseItemText}`;
+        return '';
     }
   };
 

--- a/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
+++ b/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
@@ -55,10 +55,14 @@ export default function RecentActivity({ claim }) {
 
   const getPhaseItemDescription = (currentPhaseBack, phase) => {
     const phaseItemText = getPhaseItemText(phase, cstClaimPhasesEnabled);
+
     switch (phase) {
       case 1:
       case 8:
-        return phaseItemText;
+        if (cstClaimPhasesEnabled) {
+          return phaseItemText;
+        }
+        return `Your claim moved into ${phaseItemText}`;
       case 2:
       case 7:
         return `Your claim moved into ${phaseItemText}`;
@@ -102,7 +106,7 @@ export default function RecentActivity({ claim }) {
     phaseKeys.forEach(phaseKey => {
       const phase = Number(phaseKey.match(regex)[0]) + 1;
       claimPhases.push({
-        id: phase,
+        id: `phase_${phase}`,
         type: 'phase_entered',
         // We are assuming here that each phaseKey is of the format:
         // phaseXCompleteDate, where X is some integer between 1 and 7
@@ -117,7 +121,7 @@ export default function RecentActivity({ claim }) {
 
     // Add initial phase date since its not inculded in previousPhases
     claimPhases.push({
-      id: 1,
+      id: 'phase_1',
       type: 'filed',
       phase: 1,
       description: getPhaseItemDescription(currentPhaseBack, 1),

--- a/src/applications/claims-status/tests/components/claim-status-tab/RecentActivity.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-status-tab/RecentActivity.unit.spec.jsx
@@ -29,6 +29,22 @@ const openClaimStep1 = {
   },
 };
 
+const openClaimStep3PhaseBack = {
+  attributes: {
+    claimDate: '2024-05-02',
+    claimPhaseDates: {
+      phaseChangeDate: '2024-06-22',
+      currentPhaseBack: true,
+      latestPhaseType: 'GATHERING_OF_EVIDENCE',
+      previousPhases: {
+        phase1CompleteDate: '2024-05-20',
+        phase2CompleteDate: '2024-05-22',
+      },
+    },
+    trackedItems: [],
+  },
+};
+
 const openClaimStep7 = {
   attributes: {
     claimDate: '2024-05-02',
@@ -45,6 +61,22 @@ const openClaimStep7 = {
         phase6CompleteDate: '2024-06-22',
       },
     },
+    trackedItems: [],
+  },
+};
+
+const closedClaimStep8 = {
+  attributes: {
+    claimDate: '2024-05-02',
+    claimPhaseDates: {
+      phaseChangeDate: '2024-06-22',
+      currentPhaseBack: false,
+      latestPhaseType: 'COMPLETE',
+      previousPhases: {
+        phase7CompleteDate: '2024-06-22',
+      },
+    },
+    closeDate: '2024-06-22',
     trackedItems: [],
   },
 };
@@ -279,22 +311,6 @@ const openClaimStep4WithMultipleItems = {
   },
 };
 
-const closedClaimStep8 = {
-  attributes: {
-    claimDate: '2024-05-02',
-    claimPhaseDates: {
-      phaseChangeDate: '2024-06-22',
-      currentPhaseBack: false,
-      latestPhaseType: 'COMPLETE',
-      previousPhases: {
-        phase7CompleteDate: '2024-06-22',
-      },
-    },
-    closeDate: '2024-06-22',
-    trackedItems: [],
-  },
-};
-
 describe('<RecentActivity>', () => {
   context('when cstClaimPhasesEnabled enabled', () => {
     context('when claim doesn’t have trackedItems', () => {
@@ -312,6 +328,25 @@ describe('<RecentActivity>', () => {
             within(recentActivityList).getAllByRole('listitem').length,
           ).to.equal(1);
           getByText('We received your claim in our system');
+          expect($('va-pagination', container)).not.to.exist;
+        });
+      });
+      context('when claim in phase 3 and has phased back', () => {
+        it('should render recent activities section with 3 items', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore(true)}>
+              <RecentActivity claim={openClaimStep3PhaseBack} />
+            </Provider>,
+          );
+          getByText('Recent activity');
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(3);
+          getByText('We received your claim in our system');
+          getByText('Your claim moved into Step 2: Initial review');
+          getByText('Your claim moved back to Step 3: Evidence gathering');
           expect($('va-pagination', container)).not.to.exist;
         });
       });
@@ -527,6 +562,27 @@ describe('<RecentActivity>', () => {
             within(recentActivityList).getAllByRole('listitem').length,
           ).to.equal(1);
           getByText('Your claim moved into Step 1: Claim received');
+          expect($('va-pagination', container)).not.to.exist;
+        });
+      });
+      context('when claim in phase 3 and has phased back', () => {
+        it('should render recent activities section with 3 items', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore()}>
+              <RecentActivity claim={openClaimStep3PhaseBack} />
+            </Provider>,
+          );
+          getByText('Recent activity');
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(3);
+          getByText('Your claim moved into Step 1: Claim received');
+          getByText('Your claim moved into Step 2: Initial review');
+          getByText(
+            'Your claim moved back to Step 3: Evidence gathering, review, and decision',
+          );
           expect($('va-pagination', container)).not.to.exist;
         });
       });

--- a/src/applications/claims-status/tests/components/claim-status-tab/RecentActivity.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-status-tab/RecentActivity.unit.spec.jsx
@@ -25,6 +25,7 @@ const openClaimStep1 = {
       latestPhaseType: 'CLAIM_RECEIVED',
       previousPhases: {},
     },
+    claimTypeCode: '110LCMP7IDES',
     trackedItems: [],
   },
 };
@@ -41,6 +42,7 @@ const openClaimStep3PhaseBack = {
         phase2CompleteDate: '2024-05-22',
       },
     },
+    claimTypeCode: '110LCMP7IDES',
     trackedItems: [],
   },
 };
@@ -61,6 +63,7 @@ const openClaimStep7 = {
         phase6CompleteDate: '2024-06-22',
       },
     },
+    claimTypeCode: '110LCMP7IDES',
     trackedItems: [],
   },
 };
@@ -76,6 +79,7 @@ const closedClaimStep8 = {
         phase7CompleteDate: '2024-06-22',
       },
     },
+    claimTypeCode: '110LCMP7IDES',
     closeDate: '2024-06-22',
     trackedItems: [],
   },
@@ -93,6 +97,7 @@ const openClaimStep3WithNeededFromYouItem = {
         phase2CompleteDate: '2024-05-22',
       },
     },
+    claimTypeCode: '110LCMP7IDES',
     trackedItems: [
       {
         id: 1,
@@ -116,6 +121,7 @@ const openClaimStep3WithNeededFromOthersItem = {
         phase2CompleteDate: '2024-05-22',
       },
     },
+    claimTypeCode: '110LCMP7IDES',
     trackedItems: [
       {
         id: 1,
@@ -139,6 +145,7 @@ const openClaimStep3WithNoLongerRequiredItem = {
         phase2CompleteDate: '2024-05-22',
       },
     },
+    claimTypeCode: '110LCMP7IDES',
     trackedItems: [
       {
         id: 1,
@@ -162,6 +169,7 @@ const openClaimStep3WithSubmittedAwaitingReviewItem = {
         phase2CompleteDate: '2024-05-22',
       },
     },
+    claimTypeCode: '110LCMP7IDES',
     trackedItems: [
       {
         id: 1,
@@ -189,6 +197,7 @@ const openClaimStep3WithInitialReviewCompleteItem = {
         phase2CompleteDate: '2024-05-22',
       },
     },
+    claimTypeCode: '110LCMP7IDES',
     trackedItems: [
       {
         id: 1,
@@ -212,6 +221,7 @@ const openClaimStep3WithAcceptedItem = {
         phase2CompleteDate: '2024-05-22',
       },
     },
+    claimTypeCode: '110LCMP7IDES',
     trackedItems: [
       {
         id: 1,
@@ -236,6 +246,7 @@ const openClaimStep4WithMultipleItems = {
         phase3CompleteDate: '2024-06-07',
       },
     },
+    claimTypeCode: '110LCMP7IDES',
     trackedItems: [
       {
         id: 1,

--- a/src/applications/claims-status/tests/components/claim-status-tab/RecentActivity.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-status-tab/RecentActivity.unit.spec.jsx
@@ -1,277 +1,741 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { within } from '@testing-library/react';
 import { expect } from 'chai';
-
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
 import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 
 import RecentActivity from '../../../components/claim-status-tab/RecentActivity';
 import { renderWithRouter } from '../../utils';
 
-describe('<RecentActivity>', () => {
-  context('when claim doesn’t have trackedItems', () => {
-    const claim = {
-      attributes: {
-        open: false,
-        trackedItems: [],
+const getStore = (cstClaimPhasesEnabled = false) =>
+  createStore(() => ({
+    featureToggles: {
+      // eslint-disable-next-line camelcase
+      cst_claim_phases: cstClaimPhasesEnabled,
+    },
+  }));
+
+const openClaimStep1 = {
+  attributes: {
+    claimDate: '2024-06-02',
+    claimPhaseDates: {
+      phaseChangeDate: '2024-06-02',
+      currentPhaseBack: false,
+      latestPhaseType: 'CLAIM_RECEIVED',
+      previousPhases: {},
+    },
+    trackedItems: [],
+  },
+};
+
+const openClaimStep7 = {
+  attributes: {
+    claimDate: '2024-05-02',
+    claimPhaseDates: {
+      phaseChangeDate: '2024-06-22',
+      currentPhaseBack: false,
+      latestPhaseType: 'PREPARATION_FOR_NOTIFICATION',
+      previousPhases: {
+        phase1CompleteDate: '2024-05-20',
+        phase2CompleteDate: '2024-05-22',
+        phase3CompleteDate: '2019-07-05',
+        phase4CompleteDate: '2024-06-11',
+        phase5CompleteDate: '2024-06-12',
+        phase6CompleteDate: '2024-06-22',
       },
-    };
-    it('should render empty recent activities section', () => {
-      const { container, getByText } = render(<RecentActivity claim={claim} />);
-      getByText('Recent activity');
-      expect($('ol', container)).not.to.exist;
-      expect($('va-pagination', container)).not.to.exist;
+    },
+    trackedItems: [],
+  },
+};
+
+const openClaimStep3WithNeededFromYouItem = {
+  attributes: {
+    claimDate: '2024-05-02',
+    claimPhaseDates: {
+      phaseChangeDate: '2024-05-22',
+      currentPhaseBack: false,
+      latestPhaseType: 'GATHERING_OF_EVIDENCE',
+      previousPhases: {
+        phase1CompleteDate: '2024-05-10',
+        phase2CompleteDate: '2024-05-22',
+      },
+    },
+    trackedItems: [
+      {
+        id: 1,
+        requestedDate: '2024-05-12',
+        status: 'NEEDED_FROM_YOU',
+        displayName: 'Needed from you Request',
+      },
+    ],
+  },
+};
+
+const openClaimStep3WithNeededFromOthersItem = {
+  attributes: {
+    claimDate: '2024-05-02',
+    claimPhaseDates: {
+      phaseChangeDate: '2024-05-22',
+      currentPhaseBack: false,
+      latestPhaseType: 'GATHERING_OF_EVIDENCE',
+      previousPhases: {
+        phase1CompleteDate: '2024-05-10',
+        phase2CompleteDate: '2024-05-22',
+      },
+    },
+    trackedItems: [
+      {
+        id: 1,
+        requestedDate: '2024-05-12',
+        status: 'NEEDED_FROM_OTHERS',
+        displayName: 'Needed from others Request',
+      },
+    ],
+  },
+};
+
+const openClaimStep3WithNoLongerRequiredItem = {
+  attributes: {
+    claimDate: '2024-05-02',
+    claimPhaseDates: {
+      phaseChangeDate: '2024-05-22',
+      currentPhaseBack: false,
+      latestPhaseType: 'GATHERING_OF_EVIDENCE',
+      previousPhases: {
+        phase1CompleteDate: '2024-05-10',
+        phase2CompleteDate: '2024-05-22',
+      },
+    },
+    trackedItems: [
+      {
+        id: 1,
+        closedDate: '2024-05-12',
+        status: 'NO_LONGER_REQUIRED',
+        displayName: 'No longer required Request',
+      },
+    ],
+  },
+};
+
+const openClaimStep3WithSubmittedAwaitingReviewItem = {
+  attributes: {
+    claimDate: '2024-05-02',
+    claimPhaseDates: {
+      phaseChangeDate: '2024-05-22',
+      currentPhaseBack: false,
+      latestPhaseType: 'GATHERING_OF_EVIDENCE',
+      previousPhases: {
+        phase1CompleteDate: '2024-05-10',
+        phase2CompleteDate: '2024-05-22',
+      },
+    },
+    trackedItems: [
+      {
+        id: 1,
+        status: 'SUBMITTED_AWAITING_REVIEW',
+        displayName: 'Submitted awaiting Request',
+        documents: [
+          {
+            uploadDate: '2024-05-24',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const openClaimStep3WithInitialReviewCompleteItem = {
+  attributes: {
+    claimDate: '2024-05-02',
+    claimPhaseDates: {
+      phaseChangeDate: '2024-05-22',
+      currentPhaseBack: false,
+      latestPhaseType: 'GATHERING_OF_EVIDENCE',
+      previousPhases: {
+        phase1CompleteDate: '2024-05-10',
+        phase2CompleteDate: '2024-05-22',
+      },
+    },
+    trackedItems: [
+      {
+        id: 1,
+        receivedDate: '2024-05-12',
+        status: 'INITIAL_REVIEW_COMPLETE',
+        displayName: 'Initial review complete Request',
+      },
+    ],
+  },
+};
+
+const openClaimStep3WithAcceptedItem = {
+  attributes: {
+    claimDate: '2024-05-02',
+    claimPhaseDates: {
+      phaseChangeDate: '2024-05-22',
+      currentPhaseBack: false,
+      latestPhaseType: 'GATHERING_OF_EVIDENCE',
+      previousPhases: {
+        phase1CompleteDate: '2024-05-10',
+        phase2CompleteDate: '2024-05-22',
+      },
+    },
+    trackedItems: [
+      {
+        id: 1,
+        requestedDate: '2024-05-12',
+        status: 'ACCEPTED',
+        displayName: 'Accepted Request',
+      },
+    ],
+  },
+};
+
+const openClaimStep4WithMultipleItems = {
+  attributes: {
+    claimDate: '2024-05-02',
+    claimPhaseDates: {
+      phaseChangeDate: '2024-06-07',
+      currentPhaseBack: false,
+      latestPhaseType: 'REVIEW_OF_EVIDENCE',
+      previousPhases: {
+        phase1CompleteDate: '2024-05-10',
+        phase2CompleteDate: '2024-05-22',
+        phase3CompleteDate: '2024-06-07',
+      },
+    },
+    trackedItems: [
+      {
+        id: 1,
+        requestedDate: '2024-06-07',
+        status: 'NEEDED_FROM_YOU',
+        displayName: 'Needed from you Request',
+      },
+      {
+        id: 2,
+        requestedDate: '2024-06-07',
+        status: 'NEEDED_FROM_YOU',
+        displayName: 'Needed from you Request 2',
+      },
+      {
+        id: 3,
+        requestedDate: '2024-06-06',
+        status: 'NEEDED_FROM_OTHERS',
+        displayName: 'Needed from others Request',
+      },
+      {
+        id: 4,
+        requestedDate: '2024-06-05',
+        status: 'NEEDED_FROM_OTHERS',
+        displayName: 'Needed from others Request 2',
+      },
+      {
+        id: 5,
+        closedDate: '2024-05-24',
+        status: 'NO_LONGER_REQUIRED',
+        displayName: 'No longer required Request',
+      },
+      {
+        id: 6,
+        status: 'SUBMITTED_AWAITING_REVIEW',
+        displayName: 'Submitted awaiting Request',
+        documents: [
+          {
+            uploadDate: '2024-05-24',
+          },
+        ],
+      },
+      {
+        id: 7,
+        requestedDate: '2024-05-25',
+        status: 'NEEDED_FROM_YOU',
+        displayName: 'Needed from you Request 3',
+      },
+      {
+        id: 8,
+        receivedDate: '2024-05-27',
+        status: 'INITIAL_REVIEW_COMPLETE',
+        displayName: 'Initial review complete Request',
+      },
+      {
+        id: 9,
+        receivedDate: '2024-05-28',
+        status: 'INITIAL_REVIEW_COMPLETE',
+        displayName: 'Initial review complete Request',
+      },
+      {
+        id: 10,
+        requestedDate: '2024-05-29',
+        status: 'ACCEPTED',
+        displayName: 'Accepted Request',
+      },
+      {
+        id: 11,
+        requestedDate: '2024-05-28',
+        status: 'ACCEPTED',
+        displayName: 'Accepted Request',
+      },
+    ],
+  },
+};
+
+const closedClaimStep8 = {
+  attributes: {
+    claimDate: '2024-05-02',
+    claimPhaseDates: {
+      phaseChangeDate: '2024-06-22',
+      currentPhaseBack: false,
+      latestPhaseType: 'COMPLETE',
+      previousPhases: {
+        phase7CompleteDate: '2024-06-22',
+      },
+    },
+    closeDate: '2024-06-22',
+    trackedItems: [],
+  },
+};
+
+describe('<RecentActivity>', () => {
+  context('when cstClaimPhasesEnabled enabled', () => {
+    context('when claim doesn’t have trackedItems', () => {
+      context('when claim in phase 1', () => {
+        it('should render recent activities section with 1 item', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore(true)}>
+              <RecentActivity claim={openClaimStep1} />
+            </Provider>,
+          );
+          getByText('Recent activity');
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(1);
+          getByText('We received your claim in our system');
+          expect($('va-pagination', container)).not.to.exist;
+        });
+      });
+      context('when claim in phase 7', () => {
+        it('should render recent activities section with 7 item', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore(true)}>
+              <RecentActivity claim={openClaimStep7} />
+            </Provider>,
+          );
+          getByText('Recent activity');
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(7);
+          getByText('We received your claim in our system');
+          getByText('Your claim moved into Step 2: Initial review');
+          getByText('Your claim moved into Step 3: Evidence gathering');
+          getByText('Your claim moved into Step 4: Evidence review');
+          getByText('Your claim moved into Step 5: Rating');
+          getByText('Your claim moved into Step 6: Preparing decision letter');
+          getByText('Your claim moved into Step 7: Final review');
+          expect($('va-pagination', container)).not.to.exist;
+        });
+      });
+      context('when claim is closed - phase 8', () => {
+        it('should render recent activities section with 2 items', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore(true)}>
+              <RecentActivity claim={closedClaimStep8} />
+            </Provider>,
+          );
+          getByText('Recent activity');
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(2);
+          getByText('We received your claim in our system');
+          getByText('Your claim was decided');
+          expect($('va-pagination', container)).not.to.exist;
+        });
+      });
+    });
+    context('when claim has trackedItems', () => {
+      context('when claim in phase 3', () => {
+        it('should render recent activities section with NEEDED_FROM_YOU record', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore(true)}>
+              <RecentActivity claim={openClaimStep3WithNeededFromYouItem} />
+            </Provider>,
+          );
+
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(4);
+          getByText('We received your claim in our system');
+          getByText('Your claim moved into Step 2: Initial review');
+          getByText('Your claim moved into Step 3: Evidence gathering');
+          getByText('Request for you');
+          getByText('We opened a request for "Needed from you Request"');
+          expect($('va-pagination', container)).not.to.exist;
+        });
+        it('should render recent activities section with NEEDED_FROM_OTHERS record', () => {
+          const { container, getByText, getByLabelText } = renderWithRouter(
+            <Provider store={getStore(true)}>
+              <RecentActivity claim={openClaimStep3WithNeededFromOthersItem} />
+            </Provider>,
+          );
+
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(4);
+          getByText('We received your claim in our system');
+          getByText('Your claim moved into Step 2: Initial review');
+          getByText('Your claim moved into Step 3: Evidence gathering');
+          getByText('Request for others');
+          getByText('We opened a request for "Needed from others Request"');
+          expect($('va-alert', container)).to.exist;
+          getByLabelText('Add information for Needed from others Request');
+          expect($('va-pagination', container)).not.to.exist;
+        });
+        it('should render recent activities section with NO_LONGER_REQUIRED record', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore(true)}>
+              <RecentActivity claim={openClaimStep3WithNoLongerRequiredItem} />
+            </Provider>,
+          );
+
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(4);
+          getByText('We received your claim in our system');
+          getByText('Your claim moved into Step 2: Initial review');
+          getByText('Your claim moved into Step 3: Evidence gathering');
+          getByText('We closed a request for "No longer required Request"');
+          expect($('va-pagination', container)).not.to.exist;
+        });
+        it('should render recent activities section with SUBMITTED_AWAITING_REVIEW', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore(true)}>
+              <RecentActivity
+                claim={openClaimStep3WithSubmittedAwaitingReviewItem}
+              />
+            </Provider>,
+          );
+
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(4);
+          getByText('We received your claim in our system');
+          getByText('Your claim moved into Step 2: Initial review');
+          getByText('Your claim moved into Step 3: Evidence gathering');
+          getByText(
+            'We received your document(s) for "Submitted awaiting Request"',
+          );
+          expect($('va-pagination', container)).not.to.exist;
+        });
+        it('should render recent activities section with INITIAL_REVIEW_COMPLETE', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore(true)}>
+              <RecentActivity
+                claim={openClaimStep3WithInitialReviewCompleteItem}
+              />
+            </Provider>,
+          );
+
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(4);
+          getByText('We received your claim in our system');
+          getByText('Your claim moved into Step 2: Initial review');
+          getByText('Your claim moved into Step 3: Evidence gathering');
+          getByText(
+            'We completed a review for "Initial review complete Request"',
+          );
+          expect($('va-pagination', container)).not.to.exist;
+        });
+        it('should render recent activities section with ACCEPTED', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore(true)}>
+              <RecentActivity claim={openClaimStep3WithAcceptedItem} />
+            </Provider>,
+          );
+
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(4);
+          getByText('We received your claim in our system');
+          getByText('Your claim moved into Step 2: Initial review');
+          getByText('Your claim moved into Step 3: Evidence gathering');
+          getByText('We completed a review for "Accepted Request"');
+          expect($('va-pagination', container)).not.to.exist;
+        });
+        it('should mask activity descriptions from Datadog because they sometimes contain filenames (no PII)', () => {
+          const { container } = renderWithRouter(
+            <Provider store={getStore(true)}>
+              <RecentActivity claim={openClaimStep3WithAcceptedItem} />
+            </Provider>,
+          );
+          expect(
+            $('.item-description', container).getAttribute('data-dd-privacy'),
+          ).to.equal('mask');
+        });
+      });
+      context('when claim is in phase 4', () => {
+        it('should render list with pagination', () => {
+          const { container } = renderWithRouter(
+            <Provider store={getStore(true)}>
+              <RecentActivity claim={openClaimStep4WithMultipleItems} />
+            </Provider>,
+          );
+
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(10);
+          const pagination = $('va-pagination', container);
+          expect(pagination).to.exist;
+          expect(pagination.pages).to.equal(2);
+        });
+      });
     });
   });
 
-  context('when claim has trackedItems', () => {
-    it('should render list with NEEDED_FROM_YOU list item with no pagination', () => {
-      const claim = {
-        attributes: {
-          open: true,
-          trackedItems: [
-            {
-              id: 1,
-              requestedDate: '2023-02-01',
-              status: 'NEEDED_FROM_YOU',
-              displayName: 'Needed from you Request',
-            },
-          ],
-        },
-      };
-
-      const { container, getByText } = render(<RecentActivity claim={claim} />);
-
-      getByText('Recent activity');
-      getByText('Request for you');
-      getByText('We opened a request for "Needed from you Request"');
-      expect($('ol', container)).to.exist;
-      expect($('va-pagination', container)).not.to.exist;
+  context('when cstClaimPhasesEnabled disabled', () => {
+    context('when claim doesn’t have trackedItems', () => {
+      context('when claim in phase 1', () => {
+        it('should render recent activities section with 1 item', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore()}>
+              <RecentActivity claim={openClaimStep1} />
+            </Provider>,
+          );
+          getByText('Recent activity');
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(1);
+          getByText('Your claim moved into Step 1: Claim received');
+          expect($('va-pagination', container)).not.to.exist;
+        });
+      });
+      context('when claim in phase 7', () => {
+        it('should render recent activities section with 4 items', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore()}>
+              <RecentActivity claim={openClaimStep7} />
+            </Provider>,
+          );
+          getByText('Recent activity');
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(4);
+          getByText('Your claim moved into Step 1: Claim received');
+          getByText('Your claim moved into Step 2: Initial review');
+          getByText(
+            'Your claim moved into Step 3: Evidence gathering, review, and decision',
+          );
+          getByText(
+            'Your claim moved into Step 4: Preparation for notification',
+          );
+          expect($('va-pagination', container)).not.to.exist;
+        });
+      });
+      context('when claim is closed - phase 8', () => {
+        it('should render recent activities section with 2 items', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore()}>
+              <RecentActivity claim={closedClaimStep8} />
+            </Provider>,
+          );
+          getByText('Recent activity');
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(2);
+          getByText('Your claim moved into Step 1: Claim received');
+          getByText('Your claim moved into Step 5: Closed');
+          expect($('va-pagination', container)).not.to.exist;
+        });
+      });
     });
+    context('when claim has trackedItems', () => {
+      context('when claim in phase 3', () => {
+        it('should render recent activities section with NEEDED_FROM_YOU record', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore()}>
+              <RecentActivity claim={openClaimStep3WithNeededFromYouItem} />
+            </Provider>,
+          );
 
-    it('should render list with NEEDED_FROM_OTHERS list item, an alert and no pagination', () => {
-      const claim = {
-        attributes: {
-          open: true,
-          trackedItems: [
-            {
-              id: 1,
-              requestedDate: '2023-01-01',
-              status: 'NEEDED_FROM_OTHERS',
-              displayName: 'Needed from others Request',
-            },
-          ],
-        },
-      };
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(4);
+          getByText('Your claim moved into Step 1: Claim received');
+          getByText('Your claim moved into Step 2: Initial review');
+          getByText(
+            'Your claim moved into Step 3: Evidence gathering, review, and decision',
+          );
+          getByText('Request for you');
+          getByText('We opened a request for "Needed from you Request"');
+          expect($('va-pagination', container)).not.to.exist;
+        });
+        it('should render recent activities section with NEEDED_FROM_OTHERS record', () => {
+          const { container, getByText, getByLabelText } = renderWithRouter(
+            <Provider store={getStore()}>
+              <RecentActivity claim={openClaimStep3WithNeededFromOthersItem} />
+            </Provider>,
+          );
 
-      const { container, getByText, getByLabelText } = renderWithRouter(
-        <RecentActivity claim={claim} />,
-      );
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(4);
+          getByText('Your claim moved into Step 1: Claim received');
+          getByText('Your claim moved into Step 2: Initial review');
+          getByText(
+            'Your claim moved into Step 3: Evidence gathering, review, and decision',
+          );
+          getByText('Request for others');
+          getByText('We opened a request for "Needed from others Request"');
+          expect($('va-alert', container)).to.exist;
+          getByLabelText('Add information for Needed from others Request');
+          expect($('va-pagination', container)).not.to.exist;
+        });
+        it('should render recent activities section with NO_LONGER_REQUIRED record', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore()}>
+              <RecentActivity claim={openClaimStep3WithNoLongerRequiredItem} />
+            </Provider>,
+          );
 
-      getByText('Recent activity');
-      getByText('Request for others');
-      getByText('We opened a request for "Needed from others Request"');
-      expect($('ol', container)).to.exist;
-      expect($('va-alert', container)).to.exist;
-      getByLabelText('Add information for Needed from others Request');
-      expect($('va-pagination', container)).not.to.exist;
-    });
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(4);
+          getByText('Your claim moved into Step 1: Claim received');
+          getByText('Your claim moved into Step 2: Initial review');
+          getByText(
+            'Your claim moved into Step 3: Evidence gathering, review, and decision',
+          );
+          getByText('We closed a request for "No longer required Request"');
+          expect($('va-pagination', container)).not.to.exist;
+        });
+        it('should render recent activities section with SUBMITTED_AWAITING_REVIEW', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore()}>
+              <RecentActivity
+                claim={openClaimStep3WithSubmittedAwaitingReviewItem}
+              />
+            </Provider>,
+          );
 
-    it('should render list with NO_LONGER_REQUIRED list item with no pagination', () => {
-      const claim = {
-        attributes: {
-          open: true,
-          trackedItems: [
-            {
-              id: 1,
-              closedDate: '2023-01-11',
-              status: 'NO_LONGER_REQUIRED',
-              displayName: 'No longer required Request',
-            },
-          ],
-        },
-      };
-      const { container, getByText } = render(<RecentActivity claim={claim} />);
-      getByText('Recent activity');
-      getByText('We closed a request for "No longer required Request"');
-      expect($('ol', container)).to.exist;
-      expect($('va-pagination', container)).not.to.exist;
-    });
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(4);
+          getByText('Your claim moved into Step 1: Claim received');
+          getByText('Your claim moved into Step 2: Initial review');
+          getByText(
+            'Your claim moved into Step 3: Evidence gathering, review, and decision',
+          );
+          getByText(
+            'We received your document(s) for "Submitted awaiting Request"',
+          );
+          expect($('va-pagination', container)).not.to.exist;
+        });
+        it('should render recent activities section with INITIAL_REVIEW_COMPLETE', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore()}>
+              <RecentActivity
+                claim={openClaimStep3WithInitialReviewCompleteItem}
+              />
+            </Provider>,
+          );
 
-    it('should render list with SUBMITTED_AWAITING_REVIEW list item with no pagination', () => {
-      const claim = {
-        attributes: {
-          open: true,
-          trackedItems: [
-            {
-              id: 1,
-              status: 'SUBMITTED_AWAITING_REVIEW',
-              displayName: 'Submitted awaiting Request',
-              documents: [
-                {
-                  uploadDate: '2023-07-01',
-                },
-              ],
-            },
-          ],
-        },
-      };
-      const { container, getByText } = render(<RecentActivity claim={claim} />);
-      getByText('Recent activity');
-      getByText(
-        'We received your document(s) for "Submitted awaiting Request"',
-      );
-      expect($('ol', container)).to.exist;
-      expect($('va-pagination', container)).not.to.exist;
-    });
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(4);
+          getByText('Your claim moved into Step 1: Claim received');
+          getByText('Your claim moved into Step 2: Initial review');
+          getByText(
+            'Your claim moved into Step 3: Evidence gathering, review, and decision',
+          );
+          getByText(
+            'We completed a review for "Initial review complete Request"',
+          );
+          expect($('va-pagination', container)).not.to.exist;
+        });
+        it('should render recent activities section with ACCEPTED', () => {
+          const { container, getByText } = renderWithRouter(
+            <Provider store={getStore()}>
+              <RecentActivity claim={openClaimStep3WithAcceptedItem} />
+            </Provider>,
+          );
 
-    it('should render list with INITIAL_REVIEW_COMPLETE list item with no pagination', () => {
-      const claim = {
-        attributes: {
-          open: true,
-          trackedItems: [
-            {
-              id: 1,
-              receivedDate: '2023-02-12',
-              status: 'INITIAL_REVIEW_COMPLETE',
-              displayName: 'Initial review complete Request',
-            },
-          ],
-        },
-      };
-      const { container, getByText } = render(<RecentActivity claim={claim} />);
-      getByText('Recent activity');
-      getByText('We completed a review for "Initial review complete Request"');
-      expect($('ol', container)).to.exist;
-      expect($('va-pagination', container)).not.to.exist;
-    });
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(4);
+          getByText('Your claim moved into Step 1: Claim received');
+          getByText('Your claim moved into Step 2: Initial review');
+          getByText(
+            'Your claim moved into Step 3: Evidence gathering, review, and decision',
+          );
+          getByText('We completed a review for "Accepted Request"');
+          expect($('va-pagination', container)).not.to.exist;
+        });
+        it('should mask activity descriptions from Datadog because they sometimes contain filenames (no PII)', () => {
+          const { container } = renderWithRouter(
+            <Provider store={getStore()}>
+              <RecentActivity claim={openClaimStep3WithAcceptedItem} />
+            </Provider>,
+          );
+          expect(
+            $('.item-description', container).getAttribute('data-dd-privacy'),
+          ).to.equal('mask');
+        });
+      });
+      context('when claim is in phase 4', () => {
+        it('should render list with pagination and ', () => {
+          const { container } = renderWithRouter(
+            <Provider store={getStore()}>
+              <RecentActivity claim={openClaimStep4WithMultipleItems} />
+            </Provider>,
+          );
 
-    it('should render list with ACCEPTED list item with no pagination', () => {
-      const claim = {
-        attributes: {
-          open: true,
-          trackedItems: [
-            {
-              id: 1,
-              requestedDate: '2022-12-01',
-              status: 'ACCEPTED',
-              displayName: 'Accepted Request',
-            },
-          ],
-        },
-      };
-      const { container, getByText } = render(<RecentActivity claim={claim} />);
-      getByText('Recent activity');
-      getByText('We completed a review for "Accepted Request"');
-      expect($('ol', container)).to.exist;
-      expect($('va-pagination', container)).not.to.exist;
-    });
-
-    it('should render list with pagination', () => {
-      const claim = {
-        attributes: {
-          open: true,
-          trackedItems: [
-            {
-              id: 1,
-              requestedDate: '2023-02-01',
-              status: 'NEEDED_FROM_YOU',
-              displayName: 'Needed from you Request',
-            },
-            {
-              id: 2,
-              requestedDate: '2023-02-01',
-              status: 'NEEDED_FROM_YOU',
-              displayName: 'Needed from you Request 2',
-            },
-            {
-              id: 3,
-              requestedDate: '2023-01-01',
-              status: 'NEEDED_FROM_OTHERS',
-              displayName: 'Needed from others Request',
-            },
-            {
-              id: 4,
-              requestedDate: '2023-06-01',
-              status: 'NEEDED_FROM_OTHERS',
-              displayName: 'Needed from others Request 2',
-            },
-            {
-              id: 5,
-              closedDate: '2023-01-11',
-              status: 'NO_LONGER_REQUIRED',
-              displayName: 'No longer required Request',
-            },
-            {
-              id: 6,
-              status: 'SUBMITTED_AWAITING_REVIEW',
-              displayName: 'Submitted awaiting Request',
-              documents: [
-                {
-                  uploadDate: '2023-07-01',
-                },
-              ],
-            },
-            {
-              id: 7,
-              requestedDate: '2023-02-14',
-              status: 'NEEDED_FROM_YOU',
-              displayName: 'Needed from you Request 3',
-            },
-            {
-              id: 8,
-              receivedDate: '2023-02-12',
-              status: 'INITIAL_REVIEW_COMPLETE',
-              displayName: 'Initial review complete Request',
-            },
-            {
-              id: 9,
-              receivedDate: '2023-08-01',
-              status: 'INITIAL_REVIEW_COMPLETE',
-              displayName: 'Initial review complete Request',
-            },
-            {
-              id: 10,
-              requestedDate: '2022-12-01',
-              status: 'ACCEPTED',
-              displayName: 'Accepted Request',
-            },
-            {
-              id: 11,
-              requestedDate: '2023-03-01',
-              status: 'ACCEPTED',
-              displayName: 'Accepted Request',
-            },
-          ],
-        },
-      };
-
-      const { container, getByText } = renderWithRouter(
-        <RecentActivity claim={claim} />,
-      );
-
-      getByText('Recent activity');
-      expect($('ol', container)).to.exist;
-      expect($('va-pagination', container)).to.exist;
-    });
-
-    it('should mask activity descriptions from Datadog because they sometimes contain filenames (no PII)', () => {
-      const claim = {
-        attributes: {
-          open: true,
-          trackedItems: [
-            {
-              id: 1,
-              requestedDate: '2022-12-01',
-              status: 'ACCEPTED',
-              displayName: 'Accepted Request',
-            },
-          ],
-        },
-      };
-      const { container } = render(<RecentActivity claim={claim} />);
-      expect(
-        $('.item-description', container).getAttribute('data-dd-privacy'),
-      ).to.equal('mask');
+          const recentActivityList = $('ol', container);
+          expect(recentActivityList).to.exist;
+          expect(
+            within(recentActivityList).getAllByRole('listitem').length,
+          ).to.equal(10);
+          const pagination = $('va-pagination', container);
+          expect(pagination).to.exist;
+          expect(pagination.pages).to.equal(2);
+        });
+      });
     });
   });
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status.v2.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status.v2.cypress.spec.js
@@ -56,7 +56,7 @@ describe('When feature toggle cst_claim_phases disabled', () => {
       const trackClaimsPage = new TrackClaimsPageV2();
       trackClaimsPage.loadPage(claimsList, claimDetails);
       trackClaimsPage.verifyInProgressClaim(false);
-      trackClaimsPage.verifyRecentActivity();
+      trackClaimsPage.verifyRecentActivity(true);
       cy.axeCheck();
     });
 
@@ -185,9 +185,9 @@ describe('When feature toggle cst_claim_phases enabled', () => {
   context('A user that has tracked items can view recent activity', () => {
     it('Shows recent activity for a user with tracked items on a closed claim', () => {
       const trackClaimsPage = new TrackClaimsPageV2();
-      trackClaimsPage.loadPage(claimsList, claimDetails);
+      trackClaimsPage.loadPage(claimsList, claimDetails, false, true);
       trackClaimsPage.verifyInProgressClaim(false);
-      trackClaimsPage.verifyRecentActivity();
+      trackClaimsPage.verifyRecentActivity(true, true);
       cy.axeCheck();
     });
 
@@ -195,7 +195,7 @@ describe('When feature toggle cst_claim_phases enabled', () => {
       const trackClaimsPage = new TrackClaimsPageV2();
       trackClaimsPage.loadPage(claimsList, claimDetailsOpen, false, true);
       trackClaimsPage.verifyInProgressClaim(true);
-      trackClaimsPage.verifyRecentActivity();
+      trackClaimsPage.verifyRecentActivity(false, true);
       cy.axeCheck();
     });
   });

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
@@ -402,7 +402,7 @@ class TrackClaimsPageV2 {
       });
   }
 
-  verifyRecentActivity() {
+  verifyRecentActivity(claimClosed = false, showEightPhases = false) {
     cy.get('.recent-activity-container').should('be.visible');
     cy.get('.recent-activity-container > h3').should(
       'contain',
@@ -412,6 +412,57 @@ class TrackClaimsPageV2 {
       'have.length.greaterThan',
       0,
     );
+    if (showEightPhases) {
+      if (claimClosed) {
+        cy.get('.recent-activity-container > ol > li > p').should(
+          'contain',
+          'Your claim was decided',
+        );
+      } else {
+        cy.get('.recent-activity-container va-pagination')
+          .shadow()
+          .find(
+            '.usa-pagination__list > li.usa-pagination__item.usa-pagination__arrow > a',
+          )
+          .click();
+        cy.get('.recent-activity-container > ol > li > p').should(
+          'contain',
+          'We received your claim in our system',
+        );
+        cy.get('.recent-activity-container > ol > li > p').should(
+          'contain',
+          'Your claim moved into Step 2: Initial review',
+        );
+        cy.get('.recent-activity-container > ol > li > p').should(
+          'contain',
+          'Your claim moved into Step 3: Evidence gathering',
+        );
+      }
+    } else if (claimClosed) {
+      cy.get('.recent-activity-container > ol > li > p').should(
+        'contain',
+        'Your claim moved into Step 5: Closed',
+      );
+    } else {
+      cy.get('.recent-activity-container va-pagination')
+        .shadow()
+        .find(
+          '.usa-pagination__list > li.usa-pagination__item.usa-pagination__arrow > a',
+        )
+        .click();
+      cy.get('.recent-activity-container > ol > li > p').should(
+        'contain',
+        'Your claim moved into Step 1: Claim received',
+      );
+      cy.get('.recent-activity-container > ol > li > p').should(
+        'contain',
+        'Your claim moved into Step 2: Initial review',
+      );
+      cy.get('.recent-activity-container > ol > li > p').should(
+        'contain',
+        'Your claim moved into Step 3: Evidence gathering, review, and decision',
+      );
+    }
   }
 
   verifyRecentActivityPagination() {

--- a/src/applications/claims-status/tests/utils/helpers.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/helpers.unit.spec.js
@@ -31,6 +31,7 @@ import {
   groupClaimsByDocsNeeded,
   claimAvailable,
   getClaimPhaseTypeHeaderText,
+  getPhaseItemText,
   getClaimPhaseTypeDescription,
 } from '../../utils/helpers';
 
@@ -1074,6 +1075,86 @@ describe('Disability benefits helpers: ', () => {
       const desc = getClaimPhaseTypeHeaderText('CLAIM_RECEIVED');
 
       expect(desc).to.equal('Step 1 of 8: Claim received');
+    });
+  });
+
+  describe('getPhaseItemText', () => {
+    context('when cst_claim_phases disabled - 5 steps', () => {
+      it('should display phase item text from map when step 1', () => {
+        const desc = getPhaseItemText(1);
+        expect(desc).to.equal('Step 1: Claim received');
+      });
+      it('should display phase item text from map when step 2', () => {
+        const desc = getPhaseItemText(2);
+
+        expect(desc).to.equal('Step 2: Initial review');
+      });
+      it('should display phase item text from map when step 3', () => {
+        const desc = getPhaseItemText(3);
+        expect(desc).to.equal(
+          'Step 3: Evidence gathering, review, and decision',
+        );
+      });
+      it('should display phase item text from map when step 4', () => {
+        const desc = getPhaseItemText(4);
+        expect(desc).to.equal(
+          'Step 3: Evidence gathering, review, and decision',
+        );
+      });
+      it('should display phase item text from map when step 5', () => {
+        const desc = getPhaseItemText(5);
+        expect(desc).to.equal(
+          'Step 3: Evidence gathering, review, and decision',
+        );
+      });
+      it('should display phase item text from map when step 6', () => {
+        const desc = getPhaseItemText(6);
+        expect(desc).to.equal(
+          'Step 3: Evidence gathering, review, and decision',
+        );
+      });
+      it('should display phase item text from map when step 7', () => {
+        const desc = getPhaseItemText(7);
+        expect(desc).to.equal('Step 4: Preparation for notification');
+      });
+      it('should display phase item text from map when step 8', () => {
+        const desc = getPhaseItemText(8);
+        expect(desc).to.equal('Step 5: Closed');
+      });
+    });
+    context('when cst_claim_phases enabled - 8 steps', () => {
+      it('should display phase item text from map when step 1', () => {
+        const desc = getPhaseItemText(1, true);
+        expect(desc).to.equal('We received your claim in our system');
+      });
+      it('should display phase item text from map when step 2', () => {
+        const desc = getPhaseItemText(2, true);
+        expect(desc).to.equal('Step 2: Initial review');
+      });
+      it('should display phase item text from map when step 3', () => {
+        const desc = getPhaseItemText(3, true);
+        expect(desc).to.equal('Step 3: Evidence gathering');
+      });
+      it('should display phase item text from map when step 4', () => {
+        const desc = getPhaseItemText(4, true);
+        expect(desc).to.equal('Step 4: Evidence review');
+      });
+      it('should display phase item text from map when step 5', () => {
+        const desc = getPhaseItemText(5, true);
+        expect(desc).to.equal('Step 5: Rating');
+      });
+      it('should display phase item text from map when step 6', () => {
+        const desc = getPhaseItemText(6, true);
+        expect(desc).to.equal('Step 6: Preparing decision letter');
+      });
+      it('should display phase item text from map when step 7', () => {
+        const desc = getPhaseItemText(7, true);
+        expect(desc).to.equal('Step 7: Final review');
+      });
+      it('should display phase item text from map when step 8', () => {
+        const desc = getPhaseItemText(8, true);
+        expect(desc).to.equal('Your claim was decided');
+      });
     });
   });
 

--- a/src/applications/claims-status/tests/utils/helpers.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/helpers.unit.spec.js
@@ -1079,7 +1079,7 @@ describe('Disability benefits helpers: ', () => {
   });
 
   describe('getPhaseItemText', () => {
-    context('when cst_claim_phases disabled - 5 steps', () => {
+    context('when showEightPhases false - 5 steps', () => {
       it('should display phase item text from map when step 1', () => {
         const desc = getPhaseItemText(1);
         expect(desc).to.equal('Step 1: Claim received');
@@ -1122,7 +1122,7 @@ describe('Disability benefits helpers: ', () => {
         expect(desc).to.equal('Step 5: Closed');
       });
     });
-    context('when cst_claim_phases enabled - 8 steps', () => {
+    context('when showEightPhases true - 8 steps', () => {
       it('should display phase item text from map when step 1', () => {
         const desc = getPhaseItemText(1, true);
         expect(desc).to.equal('We received your claim in our system');

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -61,6 +61,32 @@ export function getClaimPhaseTypeHeaderText(claimPhaseType) {
   return claimPhaseTypeStepMap[claimPhaseType];
 }
 
+const phase8ItemTextMap = {
+  1: 'We received your claim in our system',
+  2: 'Step 2: Initial review',
+  3: 'Step 3: Evidence gathering',
+  4: 'Step 4: Evidence review',
+  5: 'Step 5: Rating',
+  6: 'Step 6: Preparing decision letter',
+  7: 'Step 7: Final review',
+  8: 'Your claim was decided',
+};
+
+const phase5ItemTextMap = {
+  1: 'Step 1: Claim received',
+  2: 'Step 2: Initial review',
+  3: 'Step 3: Evidence gathering, review, and decision',
+  4: 'Step 3: Evidence gathering, review, and decision',
+  5: 'Step 3: Evidence gathering, review, and decision',
+  6: 'Step 3: Evidence gathering, review, and decision',
+  7: 'Step 4: Preparation for notification',
+  8: 'Step 5: Closed',
+};
+
+export function getPhaseItemText(phase, cstClaimPhases = false) {
+  return cstClaimPhases ? phase8ItemTextMap[phase] : phase5ItemTextMap[phase];
+}
+
 const claimPhaseTypeDescriptionMap = {
   CLAIM_RECEIVED: 'We received your claim in our system.',
   UNDER_REVIEW:

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -83,8 +83,8 @@ const phase5ItemTextMap = {
   8: 'Step 5: Closed',
 };
 
-export function getPhaseItemText(phase, cstClaimPhases = false) {
-  return cstClaimPhases ? phase8ItemTextMap[phase] : phase5ItemTextMap[phase];
+export function getPhaseItemText(phase, showEightPhases = false) {
+  return showEightPhases ? phase8ItemTextMap[phase] : phase5ItemTextMap[phase];
 }
 
 const claimPhaseTypeDescriptionMap = {


### PR DESCRIPTION
## Summary

Updated `RecentActivity.jsx` so that phaseItems aka claimPhaseDates are displayed
- We display the 1st phase to the current phase
- When the claim is closed (phase 8 or phase 5 depending on the feature flag) we only show phase 1 and phase 8 due to what BGS returns us
- When a claim is phased back we are not returned the previous phases. EX: were in phase 6 moved to phase 3; we would only see phases 1 - 3 noted

Updated `helpers.js` so that there is a new method called getPhaseItemText() that takes in the phase # and a boolean that determines if we show eight phases or not

Added cypress tests for when a claim in closed and opened for the recent activity section
- `src/applications/claims-status/tests/e2e/01.claim-status.v2.cypress.spec.js`
- In `TrackClaimsPageV2.js` modified verifyRecentActivity() to include props `claimClosed` and `showEightPhases`

Added unit tests for ...
- `src/applications/claims-status/tests/utils/helpers.unit.spec.js`
- `src/applications/claims-status/tests/components/claim-status-tab/RecentActivity.unit.spec.jsx`

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#86582

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | `cst_claim_phases` disabled  | `cst_claim_phases` enabled  |
| ------- | ------ | ----- |
| Claim in Step 1 - CLAIM_RECEIVED |  ![Screenshot 2024-07-01 at 10 08 41 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/fd365a3d-5556-403c-866a-03fd71d91361) |  ![Screenshot 2024-07-01 at 10 27 48 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/d359015c-4b7f-4593-b1d2-79fbafab5150) |
| Claim in Step 2 - UNDER_REVIEW | ![Screenshot 2024-07-01 at 10 07 25 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/c4216099-3b6f-4248-a400-3df7453d3928) | ![Screenshot 2024-07-01 at 10 26 10 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/05667373-3644-4307-be93-64c4da59bc7a)  |
| Claim in Step 3 - GATHERING_OF_EVIDENCE |  ![Screenshot 2024-07-01 at 11 12 49 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/2c10419f-f7fa-4265-b48c-46bccc07df1e)  |  ![Screenshot 2024-07-01 at 11 13 06 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/10af75d6-5b5a-452d-ae3c-3607b69c0fd7) |
| Claim in Step 4 - REVIEW_OF_EVIDENCE  | ![Screenshot 2024-07-01 at 9 28 29 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/c4c401ae-ffef-41a8-bf9a-51099a0792b3) | ![Screenshot 2024-07-01 at 9 34 01 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/ea9b3920-b96b-482a-b736-622190c12ccf) |
| Claim in Step 5 - PREPARATION_FOR_DECISION |  ![Screenshot 2024-07-01 at 10 10 26 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/0a45c5c3-476e-43df-a916-c687d1f1f71f) | ![Screenshot 2024-07-01 at 10 10 43 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/cf46bccc-61ee-4df8-b883-eb4f63ed1e02) |
| Claim in Step 6 - PENDING_DECISION_APPROVAL |  ![Screenshot 2024-07-01 at 10 06 17 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/a5e8b540-dcfc-454d-b73d-60f20efbc9fd)  |   ![Screenshot 2024-07-01 at 10 05 47 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/b921428d-d067-471d-870f-c990d87f5e9e) |
| Claim in Step 7 - PREPARATION_FOR_NOTIFICATION |  ![Screenshot 2024-07-01 at 9 35 21 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/f4d49cbd-2828-4ec3-bd3e-b799d0bf9319) | ![Screenshot 2024-07-01 at 9 35 04 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/c221339f-ef47-4317-b2b8-cca751745d71)  |
| Claim in Step 8 - COMPLETE |  ![Screenshot 2024-07-01 at 10 15 02 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/3f18f333-7381-4359-aaa5-54961b354a8d) |   ![Screenshot 2024-07-01 at 10 14 13 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/d6e28645-7462-41af-afd3-06652815c2a9)  |
| Claim phased back and in Step 3 - GATHERING_OF_EVIDENCE |  ![Screenshot 2024-07-01 at 10 29 50 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/dfcd6340-e251-4eba-9a91-ca40f28099fc)  |  ![Screenshot 2024-07-01 at 10 29 20 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/c4426ba8-3478-4d94-b46b-1527b511f6ab)  |



## What areas of the site does it impact?

Claim Status Tool

## Acceptance criteria

- [x] The recent activity section includes ALL claim phase changes
- [x] The recent activity section includes claim phase changes where the phase has currentPhaseBack
- [x] When feature flag `cst_claim_phases` is enabled and when the claim is a disability compensation claim we show the text for 8 steps
- [x] When feature flag `cst_claim_phases` is disabled and when the claim is a disability compensation claim we show the text for 5 steps
- [x] Mockdata is accurate for phases

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
