### PR TITLE
85560 update copy in medicare section - form 10-7959c

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/healthInsuranceInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/healthInsuranceInformation.js
@@ -98,9 +98,12 @@ export function applicantProviderSchema(isPrimary) {
     uiSchema: {
       ...titleUI(
         ({ formData }) =>
-          `${nameWording(formData, undefined, undefined, true)} ${
-            isPrimary ? '' : 'additional '
-          }health insurance information`,
+          `${nameWording(
+            formData,
+            undefined,
+            undefined,
+            true,
+          )} health insurance information`,
       ),
       [keyname1]: textUI('Name of insurance provider'),
       [keyname2]: currentOrPastDateUI({

--- a/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/medicareInformation.js
@@ -43,7 +43,7 @@ export const applicantHasMedicareSchema = {
               false,
               undefined,
               true,
-            )} need to provide or update Medicare coverage?`,
+            )} have Medicare information to provide or update at this time?`,
             'ui:options': { hint: additionalFilesHint },
           };
         },
@@ -293,7 +293,7 @@ export const applicantHasMedicareDSchema = {
               false,
               undefined,
               true,
-            )} need to provide or update Medicare Part D coverage?`,
+            )} have Medicare Part D information to provide or update at this time?`,
             'ui:options': { hint: additionalFilesHint },
           };
         },

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -353,8 +353,7 @@ const formConfig = {
         secondaryProvider: {
           path: 'secondary-insurance-info',
           depends: formData => get('applicantHasSecondary', formData),
-          title: formData =>
-            `${fnp(formData)} additional health insurance information`,
+          title: formData => `${fnp(formData)} health insurance information`,
           ...applicantProviderSchema(false),
         },
         secondaryThroughEmployer: {


### PR DESCRIPTION
## Summary

This PR makes minor changes to question and hint copy across the 10-7959c form Medicare section.

- Updated medicare and medicare D question text
- Verified "carrier" is always lowercased in titles

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85560

## Testing done

- Manual

## Screenshots

|         | S1 |S2|
| ------- | ------ | - |
| Medicare question |![Screenshot 2024-06-28 at 07 38 32](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/93dd1217-c250-4719-86aa-122d009c7545)|![Screenshot 2024-06-28 at 07 39 02](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/1d81023c-8f12-4d3f-8095-83df53db3b2e)| 
|capitalization|![Screenshot 2024-06-28 at 07 38 51](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/aeba4a84-e7b6-4df1-9797-35c6e2829b71)| |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
