### PR TITLE
Removing Font Awesome from claims-status.scss file

### DIFF
--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -207,20 +207,6 @@
   &.ssoc {
     background: var(--vads-color-gold-lightest);
     padding-left: 2.5em;
-
-    &:before {
-      left: 1em;
-      top: 1.5em;
-      position: absolute;
-      font-size: 1.25em;
-      display: inline-block;
-      font: normal normal normal 14px/1 "Font Awesome 5 Free";
-      font-size: inherit;
-      text-rendering: auto;
-      -webkit-font-smoothing: antialiased;
-      -moz-osx-font-smoothing: grayscale;
-      content: "\F071";
-    }
   }
 }
 
@@ -558,11 +544,6 @@ h1:focus {
 
   .section-complete {
     border-left: 5px solid var(--vads-color-base-lighter);
-    &::before {
-      font-family: "Font Awesome 5 Free";
-      content: "\f00c";
-      margin-top: 5px; // Aligns the check bullets to their headers better
-    }
   }
 
   // Only let the (+) and "See / Hide past events" be clickable
@@ -571,26 +552,6 @@ h1:focus {
 
     button {
       pointer-events: all;
-    }
-
-    h2::before {
-      position: absolute;
-      /*
-      left: 2.5rem;
-      width: 3.5rem;
-      text-indent: 0.5rem;
-      */
-      font-size: 1.3em;
-      font-weight: 700;
-      text-align: center;
-      width: 1.6em;
-      top: -0.2em;
-      margin-left: -2.15em;
-      font-family: "Font Awesome 5 Free";
-      color: var(--vads-color-primary);
-      background-color: var(--vads-color-white);
-      border: 4px var(--vads-color-primary) solid;
-      border-radius: 50%;
     }
   }
 
@@ -702,11 +663,6 @@ h1:focus {
 .claim-timeline-icon {
   float: right;
   margin-top: 3px;
-}
-
-button .claim-timeline-icon.fa {
-  font-size: 17px;
-  padding-right: 0;
 }
 
 .claims-evidence-list {
@@ -1108,12 +1064,6 @@ $marker-text-width: 5.625rem;
   background-color: var(--vads-color-base-lightest);
   margin-top: 2em;
   margin-bottom: 2em;
-}
-
-.usa-button .fa-chevron-right {
-  margin-left: 0.875rem;
-  margin-right: -0.375rem;
-  font-size: 80%;
 }
 
 .stem-ad-list {


### PR DESCRIPTION
## Summary

- Removing references to Font Awesome from claims-status.scss
- The Claims Status app has already converted to va-icon, so this is just clean up
- I work for the DST

## Related issue(s)

- Relates to DST's 2944

## Testing done

- None

## Screenshots

N/A

## What areas of the site does it impact?

Just the SCSS file, all of the removed styles have already been converted to use va-icon instead of Font Awesome icons.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [X] The vets-website header does not contain any web-components
- [X] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [X] I reached out in the `#sitewide-public-websites` Slack channel for questions

