### PR TITLE
Removes profileContacts toggle

### DIFF
--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -183,7 +183,6 @@ class Profile extends Component {
     const toggles = this.props.profileToggles;
 
     const routes = getRoutes({
-      profileContacts: toggles.profileContacts,
       profileShowDirectDepositSingleForm:
         toggles.profileShowDirectDepositSingleForm,
     });

--- a/src/applications/personalization/profile/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile/components/ProfileWrapper.jsx
@@ -50,13 +50,11 @@ const ProfileWrapper = ({
   const location = useLocation();
 
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
-  const profileContactsToggle = useToggleValue(TOGGLE_NAMES.profileContacts);
   const profileShowDirectDepositSingleFormToggle = useToggleValue(
     TOGGLE_NAMES.profileShowDirectDepositSingleForm,
   );
 
   const routesForNav = getRoutesForNav({
-    profileContacts: profileContactsToggle,
     profileShowDirectDepositSingleForm: profileShowDirectDepositSingleFormToggle,
   });
 

--- a/src/applications/personalization/profile/components/hub/Hub.jsx
+++ b/src/applications/personalization/profile/components/hub/Hub.jsx
@@ -1,8 +1,6 @@
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 
-import { selectProfileContactsToggle } from '@@profile/selectors';
-
 import { hasBadAddress as hasBadAddressSelector } from '@@vap-svc/selectors';
 
 import { PROFILE_PATHS, PROFILE_PATH_NAMES } from '@@profile/constants';
@@ -17,7 +15,6 @@ import { EduMigrationAlert } from '../direct-deposit/legacy/alerts/EduMigrationA
 export const Hub = () => {
   const { label, link } = useSignInServiceProvider();
   const hasBadAddress = useSelector(hasBadAddressSelector);
-  const profileContactsEnabled = useSelector(selectProfileContactsToggle);
 
   useEffect(() => {
     document.title = `Profile | Veterans Affairs`;
@@ -60,18 +57,16 @@ export const Hub = () => {
           />
         </HubCard>
 
-        {profileContactsEnabled && (
-          <HubCard
-            heading={PROFILE_PATH_NAMES.CONTACTS}
-            content="Medical emergency contact and next of kin contact information"
-          >
-            <ProfileLink
-              className="small-screen--line-break-at-32-characters"
-              text="Review your personal health care contacts"
-              href={PROFILE_PATHS.CONTACTS}
-            />
-          </HubCard>
-        )}
+        <HubCard
+          heading={PROFILE_PATH_NAMES.CONTACTS}
+          content="Medical emergency contact and next of kin contact information"
+        >
+          <ProfileLink
+            className="small-screen--line-break-at-32-characters"
+            text="Review your personal health care contacts"
+            href={PROFILE_PATHS.CONTACTS}
+          />
+        </HubCard>
 
         <HubCard
           heading={PROFILE_PATH_NAMES.MILITARY_INFORMATION}

--- a/src/applications/personalization/profile/constants.js
+++ b/src/applications/personalization/profile/constants.js
@@ -1,6 +1,5 @@
 // all the active feature toggles for the profile app with a default value of false
 export const PROFILE_TOGGLES = {
-  profileContacts: false,
   profileShowPronounsAndSexualOrientation: false,
   profileHideDirectDeposit: false,
   profileShowPaymentsNotificationSetting: false,

--- a/src/applications/personalization/profile/mocks/endpoints/feature-toggles/index.js
+++ b/src/applications/personalization/profile/mocks/endpoints/feature-toggles/index.js
@@ -4,7 +4,6 @@ const { snakeCase } = require('lodash');
 // instead use generateFeatureToggles in server.js to set the toggle values
 const profileToggles = {
   authExpVbaDowntimeMessage: false,
-  profileContacts: false,
   profileShowPronounsAndSexualOrientation: false,
   profileHideDirectDeposit: false,
   profileShowPaymentsNotificationSetting: false,

--- a/src/applications/personalization/profile/mocks/server.js
+++ b/src/applications/personalization/profile/mocks/server.js
@@ -92,7 +92,6 @@ const responses = {
         res.json(
           generateFeatureToggles({
             authExpVbaDowntimeMessage: false,
-            profileContacts: true,
             profileHideDirectDeposit: true,
             profileShowCredentialRetirementMessaging: true,
             profileShowEmailNotificationSettings: true,

--- a/src/applications/personalization/profile/routes.js
+++ b/src/applications/personalization/profile/routes.js
@@ -5,14 +5,12 @@ import { Hub } from './components/hub/Hub';
 
 // conditionally add the profile hub route based on feature toggle
 const getRoutes = (
-  { profileContacts = false, profileShowDirectDepositSingleForm = false } = {
-    profileContacts: false,
+  { profileShowDirectDepositSingleForm = false } = {
     profileShowDirectDepositSingleForm: false,
   },
 ) => {
   return [
     ...getRoutesForNav({
-      profileContacts,
       profileShowDirectDepositSingleForm,
     }),
     {

--- a/src/applications/personalization/profile/routesForNav.js
+++ b/src/applications/personalization/profile/routesForNav.js
@@ -72,17 +72,11 @@ export const routesForNav = [
 ];
 
 export const getRoutesForNav = (
-  { profileContacts = false, profileShowDirectDepositSingleForm = false } = {
-    profileContacts: false,
+  { profileShowDirectDepositSingleForm = false } = {
     profileShowDirectDepositSingleForm: false,
   },
 ) => {
   return routesForNav.reduce((acc, route) => {
-    // don't include the contacts route if the profileContacts flag is false
-    if (!profileContacts && route.name === PROFILE_PATH_NAMES.CONTACTS) {
-      return acc;
-    }
-
     // use the new direct deposit root route component if profileShowDirectDepositSingleForm flag is true
     if (
       profileShowDirectDepositSingleForm &&

--- a/src/applications/personalization/profile/selectors.js
+++ b/src/applications/personalization/profile/selectors.js
@@ -130,9 +130,6 @@ export const selectIsBlocked = state => {
     : getIsBlocked(cnpDirectDepositInformation(state)?.controlInformation);
 };
 
-export const selectProfileContactsToggle = state =>
-  toggleValues(state)?.[FEATURE_FLAG_NAMES.profileContacts] || false;
-
 export const selectProfileContacts = state => state?.profileContacts || {};
 
 export const selectHasRetiringSignInService = state => {

--- a/src/applications/personalization/profile/tests/components/hub/Hub.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/hub/Hub.unit.spec.jsx
@@ -15,9 +15,7 @@ function createInitialState(
 ) {
   return {
     featureToggles: {
-      ...{
-        loading: false,
-      },
+      loading: false,
       ...toggles,
     },
     user: {

--- a/src/applications/personalization/profile/tests/components/hub/Hub.unit.spec.jsx
+++ b/src/applications/personalization/profile/tests/components/hub/Hub.unit.spec.jsx
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 import { renderWithProfileReducersAndRouter } from '@@profile/tests/unit-test-helpers';
 import { Hub } from '@@profile/components/hub/Hub';
 import { SERVICE_PROVIDERS } from '~/platform/user/authentication/constants';
-import { Toggler } from '~/platform/utilities/feature-toggles';
 import { PROFILE_PATHS } from '../../../constants';
 
 function createInitialState(
@@ -18,7 +17,6 @@ function createInitialState(
     featureToggles: {
       ...{
         loading: false,
-        [Toggler.TOGGLE_NAMES.profileContacts]: false,
       },
       ...toggles,
     },
@@ -79,20 +77,6 @@ describe('<Hub />', () => {
         getByText(`Update your sign-in info on the ${service.label} website`),
       ).to.exist;
       expect(container.querySelector(`[href="${service.link}"]`)).to.exist;
-    });
-  });
-
-  describe('render Personal health care contacts card based on feature toggle', () => {
-    it('should NOT render Personal health care contacts card if feature toggle is off', () => {
-      const { queryByText } = setup();
-      expect(queryByText('Personal health care contacts')).not.to.exist;
-    });
-
-    it('should render Personal health care contacts card if feature toggle is on', () => {
-      const { getByText } = setup({
-        toggles: { [Toggler.TOGGLE_NAMES.profileContacts]: true },
-      });
-      expect(getByText('Personal health care contacts')).to.exist;
     });
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/personal-health-care-contacts/contacts.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-health-care-contacts/contacts.cypress.spec.js
@@ -7,8 +7,6 @@ import contactsSingleNok from '@@profile/tests/fixtures/contacts-single-nok.json
 import { PROFILE_PATHS } from '@@profile/constants';
 import { loa3User72, nonVeteranUser } from '@@profile/mocks/endpoints/user';
 
-let featureToggles;
-
 describe('Personal health care contacts -- feature enabled', () => {
   beforeEach(() => {
     const otherEndpoints = [
@@ -21,8 +19,7 @@ describe('Personal health care contacts -- feature enabled', () => {
     ];
     mockGETEndpoints(otherEndpoints, 200, {});
 
-    featureToggles = generateFeatureToggles();
-    cy.intercept('GET', '/v0/feature_toggles*', featureToggles);
+    cy.intercept('GET', '/v0/feature_toggles*', generateFeatureToggles());
   });
 
   it('links from the hub page', () => {

--- a/src/applications/personalization/profile/tests/e2e/personal-health-care-contacts/contacts.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/personal-health-care-contacts/contacts.cypress.spec.js
@@ -21,7 +21,7 @@ describe('Personal health care contacts -- feature enabled', () => {
     ];
     mockGETEndpoints(otherEndpoints, 200, {});
 
-    featureToggles = generateFeatureToggles({ profileContacts: true });
+    featureToggles = generateFeatureToggles();
     cy.intercept('GET', '/v0/feature_toggles*', featureToggles);
   });
 
@@ -92,19 +92,6 @@ describe('Personal health care contacts -- feature enabled', () => {
     cy.login(nonVeteranUser);
     cy.visit(PROFILE_PATHS.CONTACTS);
     cy.findByTestId('non-va-patient-message');
-    cy.injectAxeThenAxeCheck();
-  });
-});
-
-describe('Personal health care contacts -- feature disabled', () => {
-  it('removes the link from the nav', () => {
-    featureToggles = generateFeatureToggles({ profileContacts: false });
-    cy.intercept('GET', '/v0/feature_toggles*', featureToggles);
-    cy.intercept('GET', '/v0/profile/contacts', contacts);
-    cy.login(loa3User72);
-    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
-    cy.get('h1');
-    cy.get('a[href$="/profile/contacts"]').should('not.exist');
     cy.injectAxeThenAxeCheck();
   });
 });

--- a/src/applications/personalization/profile/tests/e2e/profile-breadcrumbs.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-breadcrumbs.cypress.spec.js
@@ -26,11 +26,7 @@ describe('Profile Breadcrumbs', () => {
       return;
     }
     it('render the active page name in the breadcrumbs', () => {
-      cy.intercept(
-        'GET',
-        '/v0/feature_toggles*',
-        generateFeatureToggles({ profileContacts: true }),
-      );
+      cy.intercept('GET', '/v0/feature_toggles*', generateFeatureToggles());
       cy.visit(`${path}/`);
       cy.get('va-breadcrumbs')
         .shadow()

--- a/src/applications/personalization/profile/tests/e2e/profile-hub-keyboard-navigation.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-hub-keyboard-navigation.cypress.spec.js
@@ -21,11 +21,7 @@ describe('Profile - Hub page, Keyboard navigation', () => {
   it('should allow tabbing through all links on the page, in order', () => {
     cy.login(mockUser);
 
-    mockProfileLOA3(
-      generateFeatureToggles({
-        profileContacts: true,
-      }),
-    );
+    mockProfileLOA3(generateFeatureToggles());
 
     cy.visit(PROFILE_PATHS.PROFILE_ROOT);
 

--- a/src/applications/personalization/profile/tests/e2e/profile-hub.blocked.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-hub.blocked.cypress.spec.js
@@ -16,11 +16,7 @@ describe('Profile - Hub page', () => {
   beforeEach(() => {
     cy.login(mockUser);
 
-    mockProfileLOA3(
-      generateFeatureToggles({
-        profileContacts: true,
-      }),
-    );
+    mockProfileLOA3(generateFeatureToggles());
   });
 
   it('should render blocked profile content when user is deceased', () => {

--- a/src/applications/personalization/profile/tests/e2e/profile-hub.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/profile-hub.cypress.spec.js
@@ -8,11 +8,7 @@ import user from '../../mocks/endpoints/user';
 describe('Profile - Hub page', () => {
   beforeEach(() => {
     cy.login(mockUser);
-    mockProfileLOA3(
-      generateFeatureToggles({
-        profileContacts: true,
-      }),
-    );
+    mockProfileLOA3(generateFeatureToggles());
   });
 
   it('should render the correct content', () => {

--- a/src/applications/personalization/profile/tests/routes.unit.spec.js
+++ b/src/applications/personalization/profile/tests/routes.unit.spec.js
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 
 import getRoutes from '@@profile/routes';
-import { getRoutesForNav, routesForNav } from '@@profile/routesForNav';
 import { PROFILE_PATH_NAMES } from '@@profile/constants.js';
 
 describe('getRoutes', () => {
@@ -14,43 +13,5 @@ describe('getRoutes', () => {
 
       expect(hasDirectDepositRoute).to.be.true;
     });
-  });
-
-  it('enables contacts route when true', () => {
-    const phccRoute = routesForNav.find(
-      route => route.name === PROFILE_PATH_NAMES.CONTACTS,
-    );
-    expect(phccRoute).to.exist;
-    const routes = getRoutes({ profileContacts: true });
-    expect(routes).to.include(phccRoute);
-  });
-
-  it('disables contacts route when false', () => {
-    const phccRoute = routesForNav.find(
-      route => route.name === PROFILE_PATH_NAMES.CONTACTS,
-    );
-    expect(phccRoute).to.exist;
-    const routes = getRoutes({ profileContacts: false });
-    expect(routes).to.not.include(phccRoute);
-  });
-});
-
-describe('getRoutesForNav', () => {
-  it('enables contacts route when true', () => {
-    const phccRoute = routesForNav.find(
-      route => route.name === PROFILE_PATH_NAMES.CONTACTS,
-    );
-    expect(phccRoute).to.exist;
-    const routes = getRoutesForNav({ profileContacts: true });
-    expect(routes).to.include(phccRoute);
-  });
-
-  it('disables contacts route when false', () => {
-    const phccRoute = routesForNav.find(
-      route => route.name === PROFILE_PATH_NAMES.CONTACTS,
-    );
-    expect(phccRoute).to.exist;
-    const routes = getRoutesForNav({ profileContacts: false });
-    expect(routes).to.not.include(phccRoute);
   });
 });

--- a/src/applications/representative-appoint/mocks/server.js
+++ b/src/applications/representative-appoint/mocks/server.js
@@ -75,7 +75,6 @@ const responses = {
         res.json(
           generateFeatureToggles({
             authExpVbaDowntimeMessage: false,
-            profileContacts: true,
             profileHideDirectDeposit: false,
             profileShowCredentialRetirementMessaging: true,
             profileShowEmailNotificationSettings: true,


### PR DESCRIPTION
## Summary

- **Removes profileContacts toggle**

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#81337

## Testing done

- unit/e2e

## Screenshots

No UI changes

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

`/profile` and `/profile/contacts` paths

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

