### PR TITLE
Swap font awesome icons for va-icon in EZR

### DIFF
--- a/src/applications/ezr/components/FormFields/InsurancePolicyList.jsx
+++ b/src/applications/ezr/components/FormFields/InsurancePolicyList.jsx
@@ -127,10 +127,7 @@ const InsurancePolicyList = ({ labelledBy, list, mode, onDelete }) => {
           >
             {content['button-edit']}{' '}
             <span className="sr-only dd-privacy-mask">{srLabel}</span>{' '}
-            <i
-              role="presentation"
-              className="fas fa-chevron-right vads-u-margin-left--0p5"
-            />
+            <va-icon icon="chevron_right" size={3} />
           </Link>
           {/* eslint-disable-next-line @department-of-veterans-affairs/prefer-button-component */}
           <button
@@ -140,11 +137,7 @@ const InsurancePolicyList = ({ labelledBy, list, mode, onDelete }) => {
               handlers.showConfirm({ index, description: modalDescription })
             }
           >
-            <i
-              role="presentation"
-              className="fas fa-times vads-u-margin-right--0p5"
-            />{' '}
-            {content['button-remove']}{' '}
+            <va-icon icon="close" size={3} /> {content['button-remove']}{' '}
             <span className="sr-only dd-privacy-mask">{srLabel}</span>
           </button>
         </span>

--- a/src/applications/ezr/components/PreSubmitNotice/NoticeAgreement.jsx
+++ b/src/applications/ezr/components/PreSubmitNotice/NoticeAgreement.jsx
@@ -26,11 +26,9 @@ const NoticeAgreement = () => (
             <span className="vads-u-visibility--screen-reader">
               , will open in new tab
             </span>
-            <i
-              className="fas fa-external-link-alt vads-u-margin-left--1"
-              role="presentation"
-              aria-hidden="true"
-            />
+            <span className="vads-u-margin-left--1">
+              <va-icon icon="launch" size={3} />
+            </span>
           </a>
         </span>
       </li>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

This PR replaces instances of font-awesome icons with va-icon in `ezr` as font-awesome is now deprecated on `vets-website`.

## Related issue(s)
[2994](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2944)

## Testing done
Local testing of unit/e2e to verify no regressions introduced.

## Screenshots



_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

**Before - InsurancePolicyList.jsx**
<img width="483" alt="Screenshot 2024-06-28 at 10 05 18 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/8867779/ad54d9f8-bbcd-4d6e-96b0-b025c7d3c572">

**After - InsurancePolicyList.jsx**
<img width="491" alt="Screenshot 2024-06-28 at 10 05 08 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/8867779/75fbca50-90a7-409c-99c0-5d59f656b362">

<hr />

**Before - NoticeAgreement**
<img width="634" alt="Screenshot 2024-06-28 at 10 14 21 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/8867779/3e19b212-7e93-4ce5-95d3-8e53133bcb12">

**After - NoticeAgreement**
<img width="647" alt="Screenshot 2024-06-28 at 10 17 20 AM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/8867779/888b2a88-7839-44a8-bd46-8c3733d8aec0">


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
