### PR TITLE
font awesome to va-icon swap avs

### DIFF
--- a/src/applications/avs/components/YourAppointment.jsx
+++ b/src/applications/avs/components/YourAppointment.jsx
@@ -21,9 +21,9 @@ const clinicsVisited = avs => {
         </h3>
         <p>
           <span className="clinic-information" key="clinicSite">
-            <i
-              className="fas fa-building"
-              aria-hidden="true"
+            <va-icon
+              icon="location_city"
+              size={4}
               data-testid="appointment-icon"
             />
             {clinic.site}


### PR DESCRIPTION
As DST has deprecated the use of font-awesome icons, this PR migrates use cases of FA   to _va-icon_ v3