### PR TITLE
Move datadog RUM config to application-level app-entry.jsx

### DIFF
--- a/src/applications/mhv-landing-page/app-entry.jsx
+++ b/src/applications/mhv-landing-page/app-entry.jsx
@@ -2,10 +2,47 @@ import '@department-of-veterans-affairs/platform-polyfills';
 import './sass/mhv-landing-page.scss';
 import '~/platform/mhv/secondary-nav/sass/mhv-sec-nav.scss';
 import { startAppFromRouter as startApp } from '@department-of-veterans-affairs/platform-startup/exports';
+import { datadogRum } from '@datadog/browser-rum';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 
 import routes from './routes';
 import reducer from './reducers';
 import manifest from './manifest.json';
+
+const initializeDatadogRum = config => {
+  if (
+    // Prevent RUM from running on local/CI environments.
+    !environment.isLocalhost() &&
+    // Prevent re-initializing the SDK.
+    !window.DD_RUM?.getInitConfiguration() &&
+    !window.Mocha
+  ) {
+    const datadogRumConfig = config;
+    if (!datadogRumConfig.env) {
+      datadogRumConfig.env = environment.vspEnvironment();
+    }
+    datadogRum.init(datadogRumConfig);
+    datadogRum.startSessionReplayRecording();
+  }
+  if (environment.isLocalhost()) {
+    // eslint-disable-next-line no-console
+    console.dir(config);
+  }
+};
+
+initializeDatadogRum({
+  applicationId: '1f81f762-c3fc-48c1-89d5-09d9236e340d',
+  clientToken: 'pub3e48a5b97661792510e69581b3b272d1',
+  site: 'ddog-gov.com',
+  service: 'mhv-on-va.gov',
+  sessionSampleRate: 100,
+  sessionReplaySampleRate: 10,
+  trackInteractions: true,
+  trackUserInteractions: true,
+  trackResources: true,
+  trackLongTasks: true,
+  defaultPrivacyLevel: 'mask-user-input',
+});
 
 startApp({
   entryName: manifest.entryName,

--- a/src/applications/mhv-landing-page/app-entry.jsx
+++ b/src/applications/mhv-landing-page/app-entry.jsx
@@ -2,33 +2,11 @@ import '@department-of-veterans-affairs/platform-polyfills';
 import './sass/mhv-landing-page.scss';
 import '~/platform/mhv/secondary-nav/sass/mhv-sec-nav.scss';
 import { startAppFromRouter as startApp } from '@department-of-veterans-affairs/platform-startup/exports';
-import { datadogRum } from '@datadog/browser-rum';
-import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import { initializeDatadogRum } from './utilities/datadogRum';
 
 import routes from './routes';
 import reducer from './reducers';
 import manifest from './manifest.json';
-
-const initializeDatadogRum = config => {
-  if (
-    // Prevent RUM from running on local/CI environments.
-    !environment.isLocalhost() &&
-    // Prevent re-initializing the SDK.
-    !window.DD_RUM?.getInitConfiguration() &&
-    !window.Mocha
-  ) {
-    const datadogRumConfig = config;
-    if (!datadogRumConfig.env) {
-      datadogRumConfig.env = environment.vspEnvironment();
-    }
-    datadogRum.init(datadogRumConfig);
-    datadogRum.startSessionReplayRecording();
-  }
-  if (environment.isLocalhost()) {
-    // eslint-disable-next-line no-console
-    console.dir(config);
-  }
-};
 
 initializeDatadogRum({
   applicationId: '1f81f762-c3fc-48c1-89d5-09d9236e340d',

--- a/src/applications/mhv-landing-page/app-entry.jsx
+++ b/src/applications/mhv-landing-page/app-entry.jsx
@@ -15,7 +15,6 @@ initializeDatadogRum({
   service: 'mhv-on-va.gov',
   sessionSampleRate: 100,
   sessionReplaySampleRate: 10,
-  trackInteractions: true,
   trackUserInteractions: true,
   trackResources: true,
   trackLongTasks: true,

--- a/src/applications/mhv-landing-page/containers/App.jsx
+++ b/src/applications/mhv-landing-page/containers/App.jsx
@@ -10,7 +10,6 @@ import {
   countUnreadMessages,
   resolveUnreadMessageAriaLabel,
 } from '../utilities/data';
-import { useDatadogRum } from '../hooks/useDatadogRum';
 import {
   isAuthenticatedWithSSOe,
   isLandingPageEnabledForUser,
@@ -45,21 +44,6 @@ const App = () => {
     },
     [featureToggles, ssoe, unreadMessageAriaLabel, registered],
   );
-
-  const datadogRumConfig = {
-    applicationId: '1f81f762-c3fc-48c1-89d5-09d9236e340d',
-    clientToken: 'pub3e48a5b97661792510e69581b3b272d1',
-    site: 'ddog-gov.com',
-    service: 'mhv-on-va.gov',
-    sessionSampleRate: 100,
-    sessionReplaySampleRate: 10,
-    trackInteractions: true,
-    trackUserInteractions: true,
-    trackResources: true,
-    trackLongTasks: true,
-    defaultPrivacyLevel: 'mask-user-input',
-  };
-  useDatadogRum(datadogRumConfig);
 
   const loading = featureToggles.loading || profile.loading;
 

--- a/src/applications/mhv-landing-page/utilities/datadogRum.js
+++ b/src/applications/mhv-landing-page/utilities/datadogRum.js
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { datadogRum } from '@datadog/browser-rum';
 
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
@@ -20,13 +19,4 @@ const initializeDatadogRum = config => {
   }
 };
 
-const useDatadogRum = config => {
-  useEffect(
-    () => {
-      initializeDatadogRum(config);
-    },
-    [config],
-  );
-};
-
-export { useDatadogRum };
+export { initializeDatadogRum };


### PR DESCRIPTION
## Summary

- Hoisted Datadog RUM configuration to app-level location, so instrumentation exists regardless of route/page
- Datadog will be configured on all routes, not just within App.jsx

## Related issue(s)

- Follow-on from https://github.com/department-of-veterans-affairs/va.gov-team/issues/86178

## Testing done

- Confirmed app runs in local environment. No way to affirmatively test Datadog locally or in preview environments

## What areas of the site does it impact?

`/my-health`

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

I don't know where the React-hook approach to RUM came from, so unsure of its intended advantages. I think hoisting the DDG config/initialization outside of React might be okay. The [DDG RUM setup](https://docs.datadoghq.com/real_user_monitoring/browser/setup/#npm) doesn't tell me much, so maybe this is just something to load early (before React)?

Google Analytics gets configured via the platform's `startApp` function, and that's in the app-entry.jsx. 🤷 