### PR TITLE
added feature flag name for f1 form

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -89,6 +89,7 @@
   "form264555": "form264555",
   "form400247": "form400247",
   "form1010d": "form1010d",
+  "form107959f1": "form107959f1",
   "formUploadFlow": "form_upload_flow",
   "fsrConfirmationEmail": "fsr_confirmation_email",
   "gibctEybBottomSheet": "gibct_eyb_bottom_sheet",


### PR DESCRIPTION
## Summary
This PR adds form 10-7959f-1 to the feature flag names so that we can create a toggle for it prior to release. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/85561

## Testing done
Manual tests

## Screenshots
NA

## What areas of the site does it impact?
NA

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA
