### PR TITLE
Nhv 57765 draft kb nav filter sort

### DIFF
--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-draft-kb-nav-filter-sort.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-draft-kb-nav-filter-sort.cypress.spec.js
@@ -1,0 +1,56 @@
+import SecureMessagingSite from '../sm_site/SecureMessagingSite';
+import PatientInboxPage from '../pages/PatientInboxPage';
+import PatientMessageDraftsPage from '../pages/PatientMessageDraftsPage';
+import inboxFilterResponse from '../fixtures/inboxResponse/sorted-inbox-messages-response.json';
+import { AXE_CONTEXT } from '../utils/constants';
+import mockDraftMessages from '../fixtures/draftsResponse/drafts-messages-response.json';
+import FolderLoadPage from '../pages/FolderLoadPage';
+
+describe('Draft page keyboard navigation for filter & sort features', () => {
+  const site = new SecureMessagingSite();
+  const draftPage = new PatientMessageDraftsPage();
+  const filteredData = {
+    data: inboxFilterResponse.data.filter(item =>
+      item.attributes.subject.toLowerCase().includes('test'),
+    ),
+  };
+
+  beforeEach(() => {
+    site.login();
+    PatientInboxPage.loadInboxMessages(mockDraftMessages);
+    FolderLoadPage.loadDraftMessages(mockDraftMessages);
+  });
+
+  it('verify filter works correctly', () => {
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+
+    draftPage.inputFilterDataByKeyboard('test');
+    draftPage.submitFilterByKeyboard(filteredData, -2);
+    draftPage.verifyFilterResults('test', filteredData);
+  });
+
+  it('verify clear filter btn works correctly', () => {
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+
+    draftPage.inputFilterDataByKeyboard('test');
+    draftPage.submitFilterByKeyboard(filteredData, -2);
+    draftPage.clearFilterByKeyboard();
+    draftPage.verifyFilterFieldCleared();
+  });
+
+  it('verify sorting works properly', () => {
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+
+    const testData = {
+      data: Array.from(mockDraftMessages.data).sort(
+        (a, b) =>
+          new Date(a.attributes.draftDate) - new Date(b.attributes.draftDate),
+      ),
+    };
+
+    draftPage.verifySortingByKeyboard('Oldest to newest', testData, -2);
+  });
+});

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-inbox-kb-nav-filter-sort.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-inbox-kb-nav-filter-sort.cypress.spec.js
@@ -3,7 +3,7 @@ import PatientInboxPage from '../pages/PatientInboxPage';
 import inboxFilterResponse from '../fixtures/inboxResponse/sorted-inbox-messages-response.json';
 import { AXE_CONTEXT } from '../utils/constants';
 
-describe('Keyboard Navigation for Filter & Sort functionalities', () => {
+describe('Inbox page keyboard navigation for filter & sort features', () => {
   const site = new SecureMessagingSite();
   const filteredData = {
     data: inboxFilterResponse.data.filter(item =>

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-sent-kb-nav-filter-sort.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-sent-kb-nav-filter-sort.cypress.spec.js
@@ -6,7 +6,7 @@ import { AXE_CONTEXT } from '../utils/constants';
 import mockSentMessages from '../fixtures/sentResponse/sent-messages-response.json';
 import FolderLoadPage from '../pages/FolderLoadPage';
 
-describe('Keyboard Navigation for Filter & Sort functionalities', () => {
+describe('Sent page keyboard navigation for filter & sort features', () => {
   const site = new SecureMessagingSite();
   const filteredData = {
     data: inboxFilterResponse.data.filter(item =>

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-trash-kb-nav-filter-sort.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-trash-kb-nav-filter-sort.cypress.spec.js
@@ -6,7 +6,7 @@ import { AXE_CONTEXT } from '../utils/constants';
 import mockTrashMessages from '../fixtures/trashResponse/trash-messages-response.json';
 import FolderLoadPage from '../pages/FolderLoadPage';
 
-describe('Keyboard Navigation for Filter & Sort functionalities', () => {
+describe('Trash page keyboard navigation for filter & sort features', () => {
   const site = new SecureMessagingSite();
   const filteredData = {
     data: inboxFilterResponse.data.filter(item =>

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDraftsPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDraftsPage.js
@@ -553,13 +553,6 @@ class PatientMessageDraftsPage {
     cy.get(Locators.BUTTONS.SORT).click({ force: true });
   };
 
-  verifyFilterFieldCleared = () => {
-    cy.get(Locators.FILTER_INPUT)
-      .shadow()
-      .find('#inputField')
-      .should('be.empty');
-  };
-
   verifySorting = () => {
     let listBefore;
     let listAfter;

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDraftsPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientMessageDraftsPage.js
@@ -6,7 +6,6 @@ import { AXE_CONTEXT, Locators, Paths } from '../utils/constants';
 import sentSearchResponse from '../fixtures/sentResponse/sent-search-response.json';
 import mockSortedMessages from '../fixtures/draftsResponse/sorted-drafts-messages-response.json';
 import { Alerts } from '../../../util/constants';
-import mockDraftMessages from '../fixtures/draftsResponse/drafts-messages-response.json';
 import mockMultiDraftsResponse from '../fixtures/draftsResponse/multi-draft-response.json';
 import mockMessages from '../fixtures/messages-response.json';
 import FolderLoadPage from './FolderLoadPage';
@@ -425,6 +424,16 @@ class PatientMessageDraftsPage {
       .type(`${text}`, { force: true });
   };
 
+  submitFilterByKeyboard = (mockFilterResponse, folderId) => {
+    cy.intercept(
+      'POST',
+      `${Paths.SM_API_BASE + Paths.FOLDERS}/${folderId}/search`,
+      mockFilterResponse,
+    ).as('filterResult');
+
+    cy.realPress('Enter');
+  };
+
   clickFilterMessagesButton = () => {
     cy.intercept(
       'POST',
@@ -438,6 +447,76 @@ class PatientMessageDraftsPage {
     this.inputFilterDataText('any');
     this.clickFilterMessagesButton();
     cy.get(Locators.CLEAR_FILTERS).click({ force: true });
+  };
+
+  verifyFilterResults = (filterValue, responseData = sentSearchResponse) => {
+    cy.get(Locators.MESSAGES).should(
+      'have.length',
+      `${responseData.data.length}`,
+    );
+
+    cy.get(Locators.ALERTS.HIGHLIGHTED).each(element => {
+      cy.wrap(element)
+        .invoke('text')
+        .then(text => {
+          const lowerCaseText = text.toLowerCase();
+          expect(lowerCaseText).to.contain(`${filterValue}`);
+        });
+    });
+  };
+
+  clearFilterByKeyboard = () => {
+    // next line required to start tab navigation from the header of the page
+    cy.get('[data-testid="folder-header"]').click();
+    cy.contains('Clear Filters').then(el => {
+      cy.tabToElement(el)
+        .first()
+        .click();
+    });
+  };
+
+  verifyFilterFieldCleared = () => {
+    cy.get(Locators.FILTER_INPUT)
+      .shadow()
+      .find('#inputField')
+      .should('be.empty');
+  };
+
+  sortMessagesByKeyboard = (text, data, folderId) => {
+    cy.get(Locators.DROPDOWN)
+      .shadow()
+      .find('select')
+      .select(`${text}`, { force: true });
+
+    cy.intercept(
+      'GET',
+      `${Paths.INTERCEPT.MESSAGE_FOLDERS}/${folderId}/threads**`,
+      data,
+    ).as('sortResponse');
+    cy.tabToElement('[data-testid="sort-button"]');
+    cy.realPress('Enter');
+  };
+
+  verifySortingByKeyboard = (text, data, folderId) => {
+    let listBefore;
+    let listAfter;
+    cy.get(Locators.THREAD_LIST)
+      .find(Locators.DATE_RECEIVED)
+      .then(list => {
+        listBefore = Cypress._.map(list, el => el.innerText);
+        cy.log(`List before sorting${JSON.stringify(listBefore)}`);
+      })
+      .then(() => {
+        this.sortMessagesByKeyboard(`${text}`, data, folderId);
+        cy.get(Locators.THREAD_LIST)
+          .find(Locators.DATE_RECEIVED)
+          .then(list2 => {
+            listAfter = Cypress._.map(list2, el => el.innerText);
+            cy.log(`List after sorting${JSON.stringify(listAfter)}`);
+            expect(listBefore[0]).to.eq(listAfter[listAfter.length - 1]);
+            expect(listBefore[listBefore.length - 1]).to.eq(listAfter[0]);
+          });
+      });
   };
 
   verifyFilterResultsText = (
@@ -503,20 +582,10 @@ class PatientMessageDraftsPage {
       });
   };
 
-  loadMessages = (mockMessagesResponse = mockDraftMessages) => {
-    cy.intercept(
-      'GET',
-      `${Paths.INTERCEPT.MESSAGE_FOLDERS}/-2*`,
-      mockDraftFolderMetaResponse,
-    ).as('draftFolder');
-    cy.intercept(
-      'GET',
-      `${Paths.INTERCEPT.MESSAGE_FOLDERS}/-2/threads**`,
-      mockMessagesResponse,
-    ).as('draftFolderMessages');
-    cy.get(Locators.FOLDERS.DRAFTS).click();
-    cy.wait('@draftFolder');
-    cy.wait('@draftFolderMessages');
+  inputFilterDataByKeyboard = text => {
+    cy.tabToElement('#inputField')
+      .first()
+      .type(`${text}`, { force: true });
   };
 
   verifyDraftMessageBannerTextHasFocus = () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-manage-folder.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-manage-folder.cypress.spec.js
@@ -7,7 +7,7 @@ import { AXE_CONTEXT } from './utils/constants';
 import FolderLoadPage from './pages/FolderLoadPage';
 
 describe('manage folders', () => {
-  describe('folder created message', () => {
+  describe('verify folder created', () => {
     const site = new SecureMessagingSite();
     const newFolder = `folder${Date.now()}`;
 
@@ -17,7 +17,7 @@ describe('manage folders', () => {
       FolderLoadPage.loadFolders();
     });
 
-    it('verify folder created', () => {
+    it('verify message and focus', () => {
       cy.injectAxe();
       cy.axeCheck(AXE_CONTEXT, {});
 
@@ -27,7 +27,7 @@ describe('manage folders', () => {
     });
   });
 
-  describe('folder deleted message', () => {
+  describe('verify folder deleted', () => {
     const site = new SecureMessagingSite();
     const folderName = createdFolderResponse.data.attributes.name;
     const { folderId } = createdFolderResponse.data.attributes;
@@ -38,7 +38,7 @@ describe('manage folders', () => {
       FolderLoadPage.loadFolders();
     });
 
-    it('verify folder deleted', () => {
+    it('verify message and focus', () => {
       cy.injectAxe();
       cy.axeCheck(AXE_CONTEXT, {});
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- This PR adds tests to cover E2E scenarios for draft page filter and sort features by keyboard.
## Related issue(s)

- https://jira.devops.va.gov/browse/MHV-57765

## Testing done

- Relevant tests have been executed in headed mode with a 200x pattern.
- All tests have been successfully conducted in headless mode without any failures.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
