### PR TITLE
Unit test sigint error

### DIFF
--- a/script/utils.js
+++ b/script/utils.js
@@ -1,5 +1,12 @@
 const { spawn, spawnSync } = require('child_process');
 
+const childProcesses = [];
+process.on('SIGINT', () => {
+  childProcesses.forEach(child => {
+    child.kill('SIGINT');
+  });
+});
+
 const runCommand = cmd => {
   const child = spawn(cmd, [], { shell: true, stdio: 'inherit' });
 
@@ -11,9 +18,7 @@ const runCommand = cmd => {
   });
 
   // When we ^C out of the parent Node script, also interrupt the child
-  process.on('SIGINT', () => {
-    child.kill('SIGINT');
-  });
+  childProcesses.push(child);
 };
 
 const runCommandSync = cmd => {

--- a/src/applications/edu-benefits/10203/components/ExitApplicationButton.jsx
+++ b/src/applications/edu-benefits/10203/components/ExitApplicationButton.jsx
@@ -13,7 +13,7 @@ export const ExitApplicationButton = ({ formId, isLoggedIn }) => {
 
   return (
     <a
-      className="vads-c-action-link--greenn"
+      className="vads-c-action-link--green"
       href="/education/"
       onClick={onClick}
     >

--- a/src/applications/edu-benefits/10203/components/ExitApplicationButton.jsx
+++ b/src/applications/edu-benefits/10203/components/ExitApplicationButton.jsx
@@ -13,7 +13,7 @@ export const ExitApplicationButton = ({ formId, isLoggedIn }) => {
 
   return (
     <a
-      className="vads-c-action-link--green"
+      className="vads-c-action-link--greenn"
       href="/education/"
       onClick={onClick}
     >


### PR DESCRIPTION

## Summary

- Fixes the SiGINT error from having too many events watching processes.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/85782

## Testing done

- Forced a change on a unit test to ensure the unit test stress test does not break.



