### PR TITLE
86810 Update intro page - form 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959a/config/form.js
+++ b/src/applications/ivc-champva/10-7959a/config/form.js
@@ -33,7 +33,8 @@ const formConfig = {
     noAuth:
       'Please sign in again to continue your application for CHAMPVA claim form.',
   },
-  title: '10-7959a CHAMPVA Claim Form',
+  title: 'File a CHAMPVA claim',
+  subTitle: 'CHAMPVA Claim Form (VA Form 10-7959a)',
   defaultDefinitions: {},
   chapters: {
     signerInformation: {

--- a/src/applications/ivc-champva/10-7959a/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959a/containers/App.jsx
@@ -1,12 +1,37 @@
 import React from 'react';
-
+import PropTypes from 'prop-types';
+import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from '../config/form';
 
+const breadcrumbList = [
+  { href: '/', label: 'Home' },
+  {
+    href: `/family-and-caregiver-benefits`,
+    label: `Family and caregiver benefits`,
+  },
+  {
+    href: `/family-and-caregiver-benefits/health-and-disability/`,
+    label: `Health and disability benefits for family and caregivers`,
+  },
+  {
+    href: `/family-and-caregiver-benefits/health-and-disability/champva`,
+    label: `CHAMPVA benefits`,
+  },
+];
+
 export default function App({ location, children }) {
   return (
-    <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      {children}
-    </RoutedSavableApp>
+    <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
+      <VaBreadcrumbs breadcrumbList={breadcrumbList} />
+      <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+        {children}
+      </RoutedSavableApp>
+    </div>
   );
 }
+
+App.propTypes = {
+  children: PropTypes.object,
+  location: PropTypes.object,
+};

--- a/src/applications/ivc-champva/10-7959a/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959a/containers/IntroductionPage.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
 import { focusElement } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import { VaLink } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
@@ -16,9 +18,44 @@ class IntroductionPage extends React.Component {
     return (
       <article className="schemaform-intro">
         <FormTitle
-          title="10-7959a CHAMPVA Claim Form"
-          subtitle="Equal to VA Form 10-7959A (10-7959a CHAMPVA Claim Form)"
+          title="File a CHAMPVA claim"
+          subTitle="CHAMPVA Claim Form (VA Form 10-7959a)"
         />
+        <p>
+          Use this form if you’re currently enrolled in The Civilian Health and
+          Medical Program of the Department of Veterans Affairs (CHAMPVA) and
+          want to file a claim for reimbursement.
+        </p>
+        <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
+          What to know before you fill out this form
+        </h2>
+        <ul>
+          <li>
+            You must file your claim within 1 year of when you got the care. And
+            if you stayed at a hospital for care, you must file your claim
+            within 1 year of when you left the hospital.
+          </li>
+          <li>
+            Each claim needs its own form. If you need to submit more than one
+            claim, you’ll need to submit a new form for each claim.
+          </li>
+          <li>
+            You’ll need to submit separate claims for each beneficiary, even if
+            they’re members of the same family.
+          </li>
+          <li>
+            You’ll also need to submit supporting documents with your claim,
+            like an itemized billing statement or pharmacy receipt. And for
+            certain types of claims, you may need other supporting documents.
+          </li>
+        </ul>
+
+        <VaLink
+          text="Find out which supporting documents to submit with your claim"
+          href="https://www.va.gov/COMMUNITYCARE/programs/dependents/champva/champva-claim.asp"
+        />
+        <br />
+        <br />
         <SaveInProgressIntro
           headingLevel={2}
           prefillEnabled={formConfig.prefillEnabled}
@@ -28,47 +65,6 @@ class IntroductionPage extends React.Component {
         >
           Please complete the 10-7959A form to apply for CHAMPVA claim form.
         </SaveInProgressIntro>
-        <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
-          Follow the steps to get started
-        </h2>
-        <va-process-list uswds>
-          <va-process-list-item header="Gather this information">
-            <p>
-              <b>Here’s what you’ll need to apply:</b>
-              Make sure you meet our eligibility requirements before you apply
-            </p>
-            <ul>
-              <li>
-                <b>Personal information about you</b> and anyone else you’re
-                applying for
-              </li>
-            </ul>
-            <p>
-              You may also need to submit supporting documents, like copies of
-              your Medicare or other health insurance cards
-            </p>
-          </va-process-list-item>
-          <va-process-list-item header="Apply">
-            <p>
-              We’ll take you through each step of the process. This application
-              should take about [XX] minutes.
-            </p>
-          </va-process-list-item>
-          <va-process-list-item header="After you apply">
-            <p>
-              We’ll contact you if we have questions or need more information.
-            </p>
-          </va-process-list-item>
-        </va-process-list>
-        <SaveInProgressIntro
-          buttonOnly
-          headingLevel={2}
-          prefillEnabled={formConfig.prefillEnabled}
-          messages={formConfig.savedFormMessages}
-          pageList={pageList}
-          startText="Start the Application"
-        />
-        <p />
         <va-omb-info
           res-burden={10}
           omb-number="2900-0219"
@@ -78,5 +74,9 @@ class IntroductionPage extends React.Component {
     );
   }
 }
+
+IntroductionPage.propTypes = {
+  route: PropTypes.object,
+};
 
 export default IntroductionPage;


### PR DESCRIPTION
## Summary

Updated copy on intro page and added breadcrumbs to top of app.

- Add new copy to intro page
- Update breadcrumbs
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86810

## Testing done

- Manual

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Intro   |![Screenshot 2024-07-01 at 11 55 00](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/28f1eb1d-03a7-40a5-b739-c074a6bed664)|![Screenshot 2024-07-01 at 11 51 37](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/cb10661e-76e3-433f-a268-c5100441e4aa)|

## What areas of the site does it impact?

This form only


## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA