### PR TITLE
Finalize copy on third party signature - form 10-7959c

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/formSignature.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/formSignature.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
   titleUI,
   radioUI,
@@ -7,44 +6,41 @@ import {
 
 export const formSignatureSchema = {
   uiSchema: {
-    ...titleUI('Form signature'),
+    ...titleUI('Signer information'),
     certifierRole: {
       ...radioUI({
-        title: 'Select who will sign for the beneficiary today.',
+        updateUiSchema: formData => {
+          const labels = {
+            applicant: `I'm ${
+              formData?.applicantName?.first
+            } and I'm signing for myself`,
+            other: `I'm a parent, spouse, or legal representative signing on behalf of ${
+              formData?.applicantName?.first
+            }`,
+          };
+
+          return {
+            'ui:title': `Who’s signing this form for ${
+              formData?.applicantName?.first
+            }?`,
+            'ui:options': {
+              labels,
+            },
+          };
+        },
         required: () => true,
         labels: {
           applicant: 'The beneficiary',
-          spouse: 'The spouse of the beneficiary',
-          parentOrGuardian: 'The parent of the beneficiary',
-          other:
-            'A representative with legal authority to make decisions for the beneficiary who is not also the parent, legal guardian or spouse',
+          other: 'A representative on behalf of the beneficiary',
         },
       }),
-    },
-    'view:additionalInfo': {
-      'ui:description': (
-        <p className="vads-u-font-size--sm vads-u-padding-left--4">
-          Not having a legal document on file with us that proves you have
-          authority to make decisions for the beneficiary may cause delays with
-          processing this form.
-        </p>
-      ),
     },
   },
   schema: {
     type: 'object',
     required: ['certifierRole'],
     properties: {
-      certifierRole: radioSchema([
-        'applicant',
-        'spouse',
-        'parentOrGuardian',
-        'other',
-      ]),
-      'view:additionalInfo': {
-        type: 'object',
-        properties: {},
-      },
+      certifierRole: radioSchema(['applicant', 'other']),
     },
   },
 };

--- a/src/applications/ivc-champva/10-7959C/components/CustomAttestation.jsx
+++ b/src/applications/ivc-champva/10-7959C/components/CustomAttestation.jsx
@@ -30,7 +30,7 @@ function signatureValidator(signatureName, formData) {
     .join('')
     .toLowerCase();
   if (signatureName.replaceAll(' ', '').toLowerCase() !== name) {
-    return `Please enter your name exactly as entered on the form: ${nameWording(
+    return `Please enter your full name exactly as entered on the form: ${nameWording(
       { ...formData, certifierRole: '' },
       false,
     )}`;
@@ -66,10 +66,6 @@ export default function CustomAttestation(signatureProps) {
     </>
   ) : (
     <>
-      <p>
-        Signed by the beneficiary’s spouse, parent, legal guardian or legal
-        representative on behalf of the beneficiary.
-      </p>
       {isCorrect}
       {pp}
       <p>
@@ -81,7 +77,7 @@ export default function CustomAttestation(signatureProps) {
   );
 
   const sigLabel = isBeneficiary
-    ? 'Your name'
+    ? 'Your full name'
     : 'Enter your full name to sign as the beneficiary’s representative';
 
   const validators = isBeneficiary ? [signatureValidator] : [];
@@ -95,7 +91,10 @@ export default function CustomAttestation(signatureProps) {
         (Reference: 18 U.S.C. 1001).
       </p>
       <section className="box vads-u-background-color--gray-lightest vads-u-padding-bottom--6 vads-u-padding-x--3 vads-u-padding-top--1px vads-u-margin-bottom--7">
-        <h3>Statement of truth</h3>
+        <h3>
+          {formData?.certifierRole !== 'applicant' ? 'Representative’s ' : ''}
+          Statement of truth
+        </h3>
         {content}
         <FormSignature
           {...signatureProps}

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -450,7 +450,7 @@ const formConfig = {
       },
     },
     formSignature: {
-      title: 'Form signature',
+      title: 'Signer information',
       pages: {
         formSignature: {
           path: 'form-signature',

--- a/src/applications/ivc-champva/10-7959C/tests/containers/ConfirmationPage.unit.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/containers/ConfirmationPage.unit.spec.js
@@ -75,7 +75,7 @@ describe('presubmit section', () => {
       </Provider>,
     );
 
-    expect(tree.getByText('Statement of truth')).to.exist;
+    expect(tree.getByText('Representative’s Statement of truth')).to.exist;
 
     tree.unmount();
   });


### PR DESCRIPTION
## Summary

This PR includes the final CAIA copy changes for the signer info page on form 10-7959c + the statement of truth signature.

- Removes extra options from signer info screen and tweaks copy
- Removes unecessary copy from statement of truth and updates header

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/83952

## Testing done

- Manual

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Signer info     |![Screenshot 2024-07-01 at 12 37 28](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/5a5b52dc-60a3-45df-b8d7-75bdd4ed735e)|![Screenshot 2024-07-01 at 12 12 36](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/a189d3e2-28ea-4702-ae3b-ddb73b6cc524)|
| Signature block |![Screenshot 2024-07-01 at 12 37 32](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/43d997a4-b241-48d5-b4f1-aba6750a2216)|![Screenshot 2024-07-01 at 12 26 50](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/85ffca00-f534-459f-8eea-42ac3eb36e27)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
