### PR TITLE
Converting FA icons to va-icon for Form 10203

### DIFF
--- a/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
@@ -5,30 +5,30 @@ import { isChapter33 } from '../helpers';
 import captureEvents from '../analytics-functions';
 import { ExitApplicationButton } from '../components/ExitApplicationButton';
 
+export const CEVIcon = ({ indication }) => {
+  const icon = indication ? 'check' : 'close';
+  const classes = classNames('icon-li', {
+    'vads-u-color--green': indication,
+    'vads-u-color--gray-medium': !indication,
+  });
+  return (
+    <span className={classes}>
+      <va-icon icon={icon} size={3} />
+    </span>
+  );
+};
+
 export class ConfirmEligibilityView extends React.Component {
   onChange = property => {
-    this.props.onChange({
-      ...this.props.formData,
-      ...property,
-    });
+    this.props.onChange({ ...this.props.formData, ...property });
   };
-
-  iconClass = indication =>
-    classNames('fa', {
-      'fa-check': indication,
-      'fa-times': !indication,
-      'vads-u-color--green': indication,
-      'vads-u-color--gray-medium': !indication,
-    });
 
   iconText = indication =>
     indication ? `You answered yes to` : `You answered no to`;
 
-  renderCheck = (classes, iconTitle, title, text) => (
-    <li className="vads-u-margin-bottom--0">
-      <span className="fa-li">
-        <i className={classes} aria-hidden="true" title={iconTitle} />
-      </span>
+  renderCheck = (indication, title, text) => (
+    <li className="vads-u-position--relative">
+      <CEVIcon indication={indication} />
       <span className="vads-u-visibility--screen-reader">{title}</span>
       {text}
     </li>
@@ -39,9 +39,8 @@ export class ConfirmEligibilityView extends React.Component {
     const text =
       'Are using or recently used Post-9/11 GI Bill or Fry Scholarship benefits';
     const title = this.iconText(check);
-    const iconTitle = `${title} ${text}`;
 
-    return this.renderCheck(this.iconClass(check), iconTitle, title, text);
+    return this.renderCheck(check, title, text);
   };
 
   renderBenefitLeftCheck = () => {
@@ -50,9 +49,8 @@ export class ConfirmEligibilityView extends React.Component {
     const text =
       'Have used all of your education benefits or are within 6 months of using all your benefits when you submit your application';
     const title = this.iconText(check);
-    const iconTitle = `${title} ${text}`;
 
-    return this.renderCheck(this.iconClass(check), iconTitle, title, text);
+    return this.renderCheck(check, title, text);
   };
 
   renderEnrolledCheck = () => {
@@ -63,16 +61,10 @@ export class ConfirmEligibilityView extends React.Component {
     } = this.props;
     const check =
       isEnrolledStem || isPursuingTeachingCert || isPursuingClinicalTraining;
-    const text = (
-      <div>
-        Are enrolled in a bachelor’s degree program for science, technology,
-        engineering, or math (STEM), <b>or</b> have already earned a STEM
-        bachelor’s degree and are pursuing a teaching certification
-      </div>
-    );
     const textElement = (
       <div>
-        <p className="vads-u-margin-bottom--neg1px">Are:</p>
+        <span className="vads-u-margin-bottom--neg1px">Are:</span>
+        <br />
         <ul className="circle vads-u-margin-y--0">
           <li className="vads-u-margin-y--0">
             Enrolled in a bachelor’s degree program for science, technology,
@@ -83,7 +75,7 @@ export class ConfirmEligibilityView extends React.Component {
             a teaching certification, <b>or</b>
           </li>
           <li className="vads-u-margin-y--0">
-            Have already earned a STEM bachelor's or graduate degree and are
+            Have already earned a STEM bachelor’s or graduate degree and are
             pursuing a covered clinical training program for health care
             professionals
           </li>
@@ -91,25 +83,20 @@ export class ConfirmEligibilityView extends React.Component {
       </div>
     );
     const title = this.iconText(check);
-    const iconTitle = `${title} ${text}`;
-    return this.renderCheck(
-      this.iconClass(check),
-      iconTitle,
-      title,
-      textElement,
-    );
+
+    return this.renderCheck(check, title, textElement);
   };
 
   renderChecks = () => (
     // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-    <div tabIndex="0">
+    <div tabIndex={0}>
       <div className="vads-u-margin-top--neg2p5">
         <h4>Based on your responses, you may not be eligible</h4>
       </div>
       <div className="vads-u-margin-right--neg7 vads-u-padding-top--1p5">
         <b>Your responses:</b>
       </div>
-      <ul className="fa-ul vads-u-margin-left--3 vads-u-margin-top--0p5 stem-eligibility-ul">
+      <ul className="vads-u-padding-left--0 vads-u-margin-left--3 vads-u-margin-top--0p5 stem-eligibility-ul">
         {this.renderBenefitCheck()}
         {this.renderEnrolledCheck()}
         {this.renderBenefitLeftCheck()}
@@ -179,7 +166,7 @@ export class ConfirmEligibilityView extends React.Component {
           {this.renderConfirmEligibility()}
         </div>
         {/*  eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
-        <div className="vads-u-padding-y--4" tabIndex="0">
+        <div className="vads-u-padding-y--4" tabIndex={0}>
           <b>
             You must meet the above requirements to qualify for the scholarship.
           </b>{' '}

--- a/src/applications/edu-benefits/10203/sass/10203_stem.scss
+++ b/src/applications/edu-benefits/10203/sass/10203_stem.scss
@@ -10,6 +10,14 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/va-pagination";
 @import "~uswds/src/stylesheets/core/utilities";
 
+.icon-li {
+  left: -2em;
+  position: absolute;
+  text-align: center;
+  width: 2em;
+  line-height: inherit;
+}
+
 .process {
   #circle li {
     list-style: circle;

--- a/src/applications/edu-benefits/10203/tests/containers/ConfirmEligibilityView.unit.spec.jsx
+++ b/src/applications/edu-benefits/10203/tests/containers/ConfirmEligibilityView.unit.spec.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
-
-import ConfirmEligibilityView from '../../containers/ConfirmEligibilityView';
 import createCommonStore from 'platform/startup/store';
 import { Provider } from 'react-redux';
+import ConfirmEligibilityView from '../../containers/ConfirmEligibilityView';
 
 const createStore = (data = {}) =>
   createCommonStore({
@@ -59,36 +58,34 @@ describe('<ConfirmEligibilityView>', () => {
         <ConfirmEligibilityView {...defaultProps} />
       </Provider>,
     );
-    const icon = tree
+    const iconLi = tree
       .find('li')
       .at(0)
-      .find('i');
-    expect(icon.hasClass('fa-check')).to.equal(true);
-    expect(icon.hasClass('vads-u-color--green')).to.equal(true);
+      .find('span.icon-li');
+    expect(iconLi).to.not.be.undefined;
+    expect(iconLi.hasClass('vads-u-color--green')).to.equal(true);
+    const icon = iconLi.find('va-icon');
+    expect(icon).to.not.be.undefined;
 
     tree.unmount();
   });
 
   it('should display X for incorrect benefit', () => {
-    const store = createStore({
-      'view:benefit': { chapter30: true },
-    });
-    const props = {
-      ...defaultProps,
-      ...store.getState(),
-    };
+    const store = createStore({ 'view:benefit': { chapter30: true } });
+    const props = { ...defaultProps, ...store.getState() };
     const tree = mount(
       <Provider store={store}>
         <ConfirmEligibilityView {...props} />
       </Provider>,
     );
-    const icon = tree
+    const iconLi = tree
       .find('li')
       .at(0)
-      .find('i');
-
-    expect(icon.hasClass('fa-times')).to.equal(true);
-    expect(icon.hasClass('vads-u-color--gray-medium')).to.equal(true);
+      .find('span.icon-li');
+    expect(iconLi).to.not.be.undefined;
+    expect(iconLi.hasClass('vads-u-color--gray-medium')).to.equal(true);
+    const icon = iconLi.find('va-icon');
+    expect(icon).to.not.be.undefined;
 
     tree.unmount();
   });
@@ -99,12 +96,14 @@ describe('<ConfirmEligibilityView>', () => {
         <ConfirmEligibilityView {...defaultProps} />
       </Provider>,
     );
-    const icon = tree
+    const iconLi = tree
       .find('li')
       .at(1)
-      .find('i');
-    expect(icon.hasClass('fa-check')).to.equal(true);
-    expect(icon.hasClass('vads-u-color--green')).to.equal(true);
+      .find('span.icon-li');
+    expect(iconLi).to.not.be.undefined;
+    expect(iconLi.hasClass('vads-u-color--green')).to.equal(true);
+    const icon = iconLi.find('va-icon');
+    expect(icon).to.not.be.undefined;
 
     tree.unmount();
   });
@@ -121,12 +120,14 @@ describe('<ConfirmEligibilityView>', () => {
         <ConfirmEligibilityView {...defaultProps} />
       </Provider>,
     );
-    const icon = tree
+    const iconLi = tree
       .find('li')
       .at(1)
-      .find('i');
-    expect(icon.hasClass('fa-check')).to.equal(true);
-    expect(icon.hasClass('vads-u-color--green')).to.equal(true);
+      .find('span.icon-li');
+    expect(iconLi).to.not.be.undefined;
+    expect(iconLi.hasClass('vads-u-color--green')).to.equal(true);
+    const icon = iconLi.find('va-icon');
+    expect(icon).to.not.be.undefined;
 
     tree.unmount();
   });
@@ -144,12 +145,14 @@ describe('<ConfirmEligibilityView>', () => {
         <ConfirmEligibilityView {...defaultProps} />
       </Provider>,
     );
-    const icon = tree
+    const iconLi = tree
       .find('li')
       .at(1)
-      .find('i');
-    expect(icon.hasClass('fa-times')).to.equal(true);
-    expect(icon.hasClass('vads-u-color--gray-medium')).to.equal(true);
+      .find('span.icon-li');
+    expect(iconLi).to.not.be.undefined;
+    expect(iconLi.hasClass('vads-u-color--gray-medium')).to.equal(true);
+    const icon = iconLi.find('va-icon');
+    expect(icon).to.not.be.undefined;
 
     tree.unmount();
   });
@@ -160,31 +163,33 @@ describe('<ConfirmEligibilityView>', () => {
         <ConfirmEligibilityView {...defaultProps} />
       </Provider>,
     );
-    const icon = tree
+    const iconLi = tree
       .find('li')
       .at(5)
-      .find('i');
-    expect(icon.hasClass('fa-check')).to.equal(true);
-    expect(icon.hasClass('vads-u-color--green')).to.equal(true);
+      .find('span.icon-li');
+    expect(iconLi).to.not.be.undefined;
+    expect(iconLi.hasClass('vads-u-color--green')).to.equal(true);
+    const icon = iconLi.find('va-icon');
+    expect(icon).to.not.be.undefined;
 
     tree.unmount();
   });
 
   it('should display X for incorrect benefitLeft', () => {
-    const store = createStore({
-      benefitLeft: 'moreThanSixMonths',
-    });
+    const store = createStore({ benefitLeft: 'moreThanSixMonths' });
     const tree = mount(
       <Provider store={store}>
         <ConfirmEligibilityView {...defaultProps} />
       </Provider>,
     );
-    const icon = tree
+    const iconLi = tree
       .find('li')
       .at(5)
-      .find('i');
-    expect(icon.hasClass('fa-times')).to.equal(true);
-    expect(icon.hasClass('vads-u-color--gray-medium')).to.equal(true);
+      .find('span.icon-li');
+    expect(iconLi).to.not.be.undefined;
+    expect(iconLi.hasClass('vads-u-color--gray-medium')).to.equal(true);
+    const icon = iconLi.find('va-icon');
+    expect(icon).to.not.be.undefined;
 
     tree.unmount();
   });

--- a/src/applications/edu-benefits/10203/tests/edu-10203.cypress.spec.js
+++ b/src/applications/edu-benefits/10203/tests/edu-10203.cypress.spec.js
@@ -47,7 +47,7 @@ const testConfig = createTestConfig(
         cy.get('@testKey').then(testKey => {
           if (testKey === 'confirmation-stem-test') {
             cy.get('.stem-eligibility-ul')
-              .find('fa-times')
+              .find('va-icon')
               .to.have.lengthOf(2);
           }
         });


### PR DESCRIPTION
## Summary

- Converting Font Awesome icons to use va-icon instead in Form 10203
- I work for the DST

## Related issue(s)

- Relates to DST 2944

## Testing done

- Ran tests locally.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |  ![Screenshot 2024-07-01 at 2 20 03 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/147893/6e6521bb-1245-4f78-9749-fb432046294d)    |   ![Screenshot 2024-07-01 at 2 19 55 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/147893/6301246b-8601-4a48-b958-0d26ed5e61a2)    |

## What areas of the site does it impact?

Impacts Form 10203

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [X] The vets-website header does not contain any web-components
- [X] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [X] I reached out in the `#sitewide-public-websites` Slack channel for questions

