### PR TITLE
Converting icon for covid screener to use va-icon

### DIFF
--- a/src/applications/coronavirus-screener/components/FormResult.jsx
+++ b/src/applications/coronavirus-screener/components/FormResult.jsx
@@ -55,7 +55,7 @@ export default function FormResult({
       selectedLanguage={selectedLanguage}
       selectedColors={passFormResultsColors}
     >
-      <i aria-hidden="true" role="presentation" className="fas fa-check" />
+      <va-icon icon="check" size={9} />
       <h2 className="vads-u-font-size--2xl">
         {resultText.passText[selectedLanguage]}
       </h2>


### PR DESCRIPTION
## Summary

- Converting the Font Awesome icon in the coronavirus screener app to use va-icon instead.
- I work for the DST

## Related issue(s)

- Relates to DST 2944

## Testing done

- Tested locally

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | ![Screenshot 2024-07-01 at 2 38 09 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/147893/1296cf44-eb17-4ec4-b3c6-7c4310e821f9) | ![Screenshot 2024-07-01 at 2 38 00 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/147893/6e94f16b-1c65-4bbc-b328-4632ac5e0748) |

## What areas of the site does it impact?

Impacts the coronavirus screener completion page.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [X] The vets-website header does not contain any web-components
- [X] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [X] I reached out in the `#sitewide-public-websites` Slack channel for questions