### PR TITLE
Update E2E test to account for flipper and data property changes - form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
@@ -19,6 +19,8 @@ import {
   verifyAllDataWasSubmitted,
 } from '../../shared/tests/helpers';
 
+import mockFeatureToggles from './e2e/fixtures/mocks/featureToggles.json';
+
 // All pages from form config i.e.: {page1: {path: '/blah'}}
 const ALL_PAGES = getAllPages(formConfig);
 
@@ -389,9 +391,11 @@ const testConfig = createTestConfig(
       },
     },
     setupPerTest: () => {
+      cy.intercept('GET', '/v0/feature_toggles?*', mockFeatureToggles);
+
       cy.intercept('POST', formConfig.submitUrl, req => {
         cy.get('@testData').then(data => {
-          verifyAllDataWasSubmitted(data, req.body.raw_data);
+          verifyAllDataWasSubmitted(data, req.body.rawData);
         });
         // Mock response
         req.reply({ status: 200 });

--- a/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/mocks/featureToggles.json
+++ b/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/mocks/featureToggles.json
@@ -1,6 +1,6 @@
 {
   "data": {
     "type": "feature_toggles",
-    "features": [{ "name": "form1010D", "value": true }]
+    "features": [{ "name": "form1010d", "value": true }]
   }
 }


### PR DESCRIPTION
## Summary

This PR updates the E2E tests for form 10-10d with local mocks and fixes a false negative due to a misnamed variable.

- Added feature toggle mock
- Updated `raw_data` variable name to `rawData` to match current configuration
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- NA

## Testing done

- E2E

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| 10-10d E2E tets |![Screenshot 2024-07-01 at 13 53 10](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/6ea78f1f-e18e-4949-8fe6-94d12e5e9ea9)|![Screenshot 2024-07-01 at 13 52 00](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/ad256725-64cd-444e-b3d7-93d81ea41ccb)|

## What areas of the site does it impact?

This form's tests only (IVC 10-10d)

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA