### PR TITLE
Re-add icons and links that open in a new tab in essential locations

### DIFF
--- a/src/applications/simple-forms/21-0845/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-0845/containers/ConfirmationPage.jsx
@@ -18,7 +18,11 @@ const content = {
           1-800-827-1000
         </a>{' '}
         or contact VA online at{' '}
-        <va-link href="https://ask.va.gov" text="Ask VA" />.
+        <a href="https://ask.va.gov" target="_blank" rel="noopener noreferrer">
+          Ask VA
+          <va-icon icon="launch" srtext="opens in a new window" />
+        </a>
+        .
       </p>
       <p>
         Upon notification from you VA will no longer give out benefit or claim

--- a/src/applications/simple-forms/21-0845/pages/authorizerType.js
+++ b/src/applications/simple-forms/21-0845/pages/authorizerType.js
@@ -35,11 +35,14 @@ export default {
           You can authorize the release of only your own information with this
           online form. If you’re a court-ordered or VA-appointed fiduciary
           representing a beneficiary, you’ll need to{' '}
-          <va-link
-            download
+          <a
             href="http://www.vba.va.gov/pubs/forms/VBA-21-0845-ARE.pdf"
-            text="download the PDF version of this form"
-          />
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            download the PDF version of this form
+            <va-icon icon="launch" srtext="opens in a new window" />
+          </a>
           . Then submit it in person or by mail.
         </p>
       ),

--- a/src/platform/forms/components/review/PreSubmitSection.jsx
+++ b/src/platform/forms/components/review/PreSubmitSection.jsx
@@ -141,7 +141,15 @@ export function PreSubmitSection(props) {
             {statementOfTruthBodyElement(form?.data, statementOfTruth.body)}
             <p>
               I have read and accept the{' '}
-              <va-link href="/privacy-policy/" text="privacy policy" />.
+              <a
+                href="/privacy-policy/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                privacy policy
+                <va-icon icon="launch" srtext="opens in a new window" />
+              </a>
+              .
             </p>
             <VaTextInput
               id="veteran-signature"


### PR DESCRIPTION
## Summary
This pull request reverts back to `<a>` in a few locations in our forms where opening in a new tab is essential to not messing up the experience for the user (the confirmation page, review page, etc.). See this PR for the original changes: https://github.com/department-of-veterans-affairs/vets-website/pull/30321

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#1416