### PR TITLE
VACMS-18429 : DUW update logic flow to account for before 1992 question

### DIFF
--- a/src/applications/discharge-wizard/components/v2/questions/DischargeYear.jsx
+++ b/src/applications/discharge-wizard/components/v2/questions/DischargeYear.jsx
@@ -52,7 +52,11 @@ const DischargeYear = ({
   const before1992Key = yearOptions.length + 1;
 
   yearOptions.push(
-    <option data-testid="va-select-option" key={before1992Key} value="1991">
+    <option
+      data-testid="va-select-option"
+      key={before1992Key}
+      value="Before 1992"
+    >
       Before 1992
     </option>,
   );

--- a/src/applications/discharge-wizard/constants/display-conditions.js
+++ b/src/applications/discharge-wizard/constants/display-conditions.js
@@ -8,6 +8,9 @@ const yearResponses = range(currentYear - 1992).map(i => {
   return year.toString();
 });
 
+// This accounts for the before 1992 answer for the Discharge Year question.
+yearResponses.push('1991');
+
 const validYearsForNonOldDischarge = yearResponses.filter(year => {
   return currentYear - year <= 15;
 });

--- a/src/applications/discharge-wizard/constants/display-conditions.js
+++ b/src/applications/discharge-wizard/constants/display-conditions.js
@@ -9,7 +9,7 @@ const yearResponses = range(currentYear - 1992).map(i => {
 });
 
 // This accounts for the before 1992 answer for the Discharge Year question.
-yearResponses.push('1991');
+yearResponses.push('Before 1992');
 
 const validYearsForNonOldDischarge = yearResponses.filter(year => {
   return currentYear - year <= 15;

--- a/src/applications/discharge-wizard/helpers/index.jsx
+++ b/src/applications/discharge-wizard/helpers/index.jsx
@@ -272,7 +272,10 @@ export const answerReviewLabel = (key, formValues) => {
     case SHORT_NAME_MAP.SERVICE_BRANCH:
       return `I served in the ${formValues[key]}.`;
     case SHORT_NAME_MAP.DISCHARGE_YEAR:
-      if (answer === '1991' && !formValues[SHORT_NAME_MAP.DISCHARGE_MONTH]) {
+      if (
+        answer === 'Before 1992' &&
+        !formValues[SHORT_NAME_MAP.DISCHARGE_MONTH]
+      ) {
         return 'I was discharged before 1992.';
       }
 


### PR DESCRIPTION
## Summary
This PR updates the display condition logic for the Before 1992 question for Discharge Year. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18429

## Testing done
Tested locally that you can progress forward in the duw flow

## Screenshots


## What areas of the site does it impact?

DUW

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
