### PR TITLE
update import pattern in SMSite page

### DIFF
--- a/src/applications/mhv-secure-messaging/tests/e2e/Secure-messaging-components-search-inbox.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/Secure-messaging-components-search-inbox.cypress.spec.js
@@ -6,8 +6,7 @@ import PatientErrorPage from './pages/PatientErrorPage';
 
 describe('Secure Messaging Inbox', () => {
   it('Secure Messaging Inbox Filter Validation', () => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     const messageDetails = PatientInboxPage.getNewMessageDetails();
 
     PatientInboxPage.loadInboxMessages(mockMessages, messageDetails);

--- a/src/applications/mhv-secure-messaging/tests/e2e/facilities-tests/secure-messaging-cerner-compose.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/facilities-tests/secure-messaging-cerner-compose.cypress.spec.js
@@ -10,8 +10,7 @@ import { AXE_CONTEXT } from '../utils/constants';
 
 describe('Secure Messaging Inbox Cerner', () => {
   it('Displays warning with cerner facilities list for mixed Cerner Facilities', () => {
-    const site = new SecureMessagingSite();
-    site.login(
+    SecureMessagingSite.login(
       mockEhrData,
       true,
       mockMixedCernerFacilitiesUser,
@@ -27,8 +26,12 @@ describe('Secure Messaging Inbox Cerner', () => {
   });
 
   it('Displays warning with cerner facilities list for one Cerner Facility', () => {
-    const site = new SecureMessagingSite();
-    site.login(mockEhrData, true, mockOneCernerFacilitiesUser, mockFacilities);
+    SecureMessagingSite.login(
+      mockEhrData,
+      true,
+      mockOneCernerFacilitiesUser,
+      mockFacilities,
+    );
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.verifyFilterMessageHeadingText();
     PatientInboxPage.verifyCernerFacilityNames(
@@ -41,8 +44,12 @@ describe('Secure Messaging Inbox Cerner', () => {
   });
 
   it('Does not display warning with no cerner facilities', () => {
-    const site = new SecureMessagingSite();
-    site.login(mockEhrData, true, noCernerFacilitiesUser, mockFacilities);
+    SecureMessagingSite.login(
+      mockEhrData,
+      true,
+      noCernerFacilitiesUser,
+      mockFacilities,
+    );
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.verifyCernerFacilityNames(
       noCernerFacilitiesUser,

--- a/src/applications/mhv-secure-messaging/tests/e2e/facilities-tests/secure-messaging-mixed-facilities-inbox.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/facilities-tests/secure-messaging-mixed-facilities-inbox.cypress.spec.js
@@ -8,8 +8,7 @@ import { AXE_CONTEXT, Locators } from '../utils/constants';
 
 describe('Secure Messaging Inbox Cerner', () => {
   it('verify cerner facilities displays in alert banner', () => {
-    const site = new SecureMessagingSite();
-    site.login(
+    SecureMessagingSite.login(
       mockEhrData,
       true,
       mockMixedCernerFacilitiesUser,

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-compose-error-message-keyboard-nav.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-compose-error-message-keyboard-nav.cypress.spec.js
@@ -8,9 +8,8 @@ import { AXE_CONTEXT, Data } from '../utils/constants';
 // Focus states go to interactive form fields (Select, text input, textarea, checkboxes, and radio buttons.)
 
 describe('Secure Messaging Compose Errors Keyboard Nav', () => {
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-compose-keyboard-nav-send.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-compose-keyboard-nav-send.cypress.spec.js
@@ -5,8 +5,7 @@ import { AXE_CONTEXT, Data } from '../utils/constants';
 
 describe('Secure Messaging Compose', () => {
   it('verify user can send message with keyboard', () => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
     cy.injectAxe();

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-compose-keyboard-nav.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-compose-keyboard-nav.cypress.spec.js
@@ -4,9 +4,8 @@ import { AXE_CONTEXT } from '../utils/constants';
 import PatientComposePage from '../pages/PatientComposePage';
 
 describe('Secure Messaging Compose Keyboard Nav', () => {
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
   });
   it('Tab to Message Body', () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-compose-nav-validate-category.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-compose-nav-validate-category.cypress.spec.js
@@ -6,10 +6,9 @@ import categories from '../fixtures/categories-response.json';
 
 describe('Validate the category', () => {
   it('verify category focus', () => {
-    const site = new SecureMessagingSite();
     const listOfCategories = categories.data.attributes.messageCategoryType;
 
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     cy.get(Locators.LINKS.CREATE_NEW_MESSAGE).click();
     PatientInterstitialPage.getContinueButton().click();

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-draft-kb-nav-filter-sort.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-draft-kb-nav-filter-sort.cypress.spec.js
@@ -7,7 +7,6 @@ import mockDraftMessages from '../fixtures/draftsResponse/drafts-messages-respon
 import FolderLoadPage from '../pages/FolderLoadPage';
 
 describe('Draft page keyboard navigation for filter & sort features', () => {
-  const site = new SecureMessagingSite();
   const draftPage = new PatientMessageDraftsPage();
   const filteredData = {
     data: inboxFilterResponse.data.filter(item =>
@@ -16,7 +15,7 @@ describe('Draft page keyboard navigation for filter & sort features', () => {
   };
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(mockDraftMessages);
     FolderLoadPage.loadDraftMessages(mockDraftMessages);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-inbox-kb-nav-filter-sort.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-inbox-kb-nav-filter-sort.cypress.spec.js
@@ -4,7 +4,6 @@ import inboxFilterResponse from '../fixtures/inboxResponse/sorted-inbox-messages
 import { AXE_CONTEXT } from '../utils/constants';
 
 describe('Inbox page keyboard navigation for filter & sort features', () => {
-  const site = new SecureMessagingSite();
   const filteredData = {
     data: inboxFilterResponse.data.filter(item =>
       item.attributes.subject.toLowerCase().includes('test'),
@@ -12,7 +11,7 @@ describe('Inbox page keyboard navigation for filter & sort features', () => {
   };
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
   });
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-keyboard-nav-save-draft.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-keyboard-nav-save-draft.cypress.spec.js
@@ -5,10 +5,8 @@ import requestBody from '../fixtures/message-compose-request-body.json';
 import { AXE_CONTEXT } from '../utils/constants';
 
 describe('Check confirmation message after save draft', () => {
-  const site = new SecureMessagingSite();
-
   it('Check confirmation message after save draft', () => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
 
     PatientInboxPage.navigateToComposePage(true);

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-keyboard-nav-to-attachments-compose-page.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-keyboard-nav-to-attachments-compose-page.cypress.spec.js
@@ -7,8 +7,7 @@ import requestBody from '../fixtures/message-compose-request-body.json';
 describe('Secure Messaging Keyboard Nav to Attachment', () => {
   it('Keyboard Nav to Focus on Attachment', () => {
     // const composePage = new PatientComposePage();
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
     PatientComposePage.selectRecipient(requestBody.recipientId);
@@ -21,16 +20,19 @@ describe('Secure Messaging Keyboard Nav to Attachment', () => {
     PatientComposePage.getMessageBodyField().type(`${requestBody.body}`, {
       force: true,
     });
+
     // verify attachments button has "Attach file" with no attachments
     PatientComposePage.verifyAttachmentButtonText(0);
     PatientComposePage.attachMessageFromFile(Data.TEST_IMAGE);
     PatientComposePage.verifyFocusOnMessageAttachment();
+
     // verify attachments button has "Attach additional file" with one or more attachments
     PatientComposePage.verifyAttachmentButtonText(1);
     PatientComposePage.attachMessageFromFile(Data.SAMPLE_DOC);
     PatientComposePage.verifyFocusOnMessageAttachment();
-    //
+
     cy.realPress('Enter');
+
     // After closing the attachment banner, first attachment remove button has focus
     PatientComposePage.verifyRemoveAttachmentButtonHasFocus(0);
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-keyboard-nav-to-compose.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-keyboard-nav-to-compose.cypress.spec.js
@@ -3,9 +3,8 @@ import PatientInboxPage from '../pages/PatientInboxPage';
 import { AXE_CONTEXT, Data, Locators } from '../utils/constants';
 
 describe('Secure Messaging Keyboard Nav To Compose', () => {
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
   });
   it('Keyboard Nav from Welcome Page to Compose', () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-keyboard-nav-to-links-buttons-landing-page.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-keyboard-nav-to-links-buttons-landing-page.cypress.spec.js
@@ -4,8 +4,7 @@ import SecureMessagingLandingPage from '../pages/SecureMessagingLandingPage';
 
 describe('Secure Messaging Verify Links and Buttons Keyboard Nav', () => {
   it('Tab to Links and Buttons on the Landing Page', () => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     SecureMessagingLandingPage.loadMainPage();
 
     cy.tabToElement('[text="Go to your inbox"]').should(

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-keyboard-nav-to-message-details.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-keyboard-nav-to-message-details.cypress.spec.js
@@ -9,8 +9,7 @@ import { AXE_CONTEXT, Locators } from '../utils/constants';
 describe('Navigate to Message Details ', () => {
   it('Keyboard Nav Access to Expended Messages', () => {
     const messageDetailsPage = new PatientMessageDetailsPage();
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     mockMessageWithAttachment.data.id = '7192838';
     mockMessageWithAttachment.data.attributes.attachment = true;
     mockMessageWithAttachment.data.attributes.body = 'attachment';
@@ -36,8 +35,7 @@ describe('Navigate to Message Details ', () => {
   });
   it('Keyboard Navigation to Print Button', () => {
     const messageDetailsPage = new PatientMessageDetailsPage();
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     mockMessageWithAttachment.data.id = '7192838';
     mockMessageWithAttachment.data.attributes.attachment = true;
     mockMessageWithAttachment.data.attributes.body = 'attachment';

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-keyboard-nav-to-search-results.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-keyboard-nav-to-search-results.cypress.spec.js
@@ -3,8 +3,6 @@ import SecureMessagingSite from '../sm_site/SecureMessagingSite';
 import mockMessages from '../fixtures/messages-response.json';
 
 describe('Secure Messaging Inbox Folder checks', () => {
-  const site = new SecureMessagingSite();
-
   const {
     data: [, secondElement, thirdElement],
     ...rest
@@ -13,7 +11,7 @@ describe('Secure Messaging Inbox Folder checks', () => {
   const mockFilterResults = { data: [secondElement, thirdElement], ...rest };
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
   });
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-sent-kb-nav-filter-sort.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-sent-kb-nav-filter-sort.cypress.spec.js
@@ -7,7 +7,6 @@ import mockSentMessages from '../fixtures/sentResponse/sent-messages-response.js
 import FolderLoadPage from '../pages/FolderLoadPage';
 
 describe('Sent page keyboard navigation for filter & sort features', () => {
-  const site = new SecureMessagingSite();
   const filteredData = {
     data: inboxFilterResponse.data.filter(item =>
       item.attributes.subject.toLowerCase().includes('test'),
@@ -15,7 +14,7 @@ describe('Sent page keyboard navigation for filter & sort features', () => {
   };
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(mockSentMessages);
     FolderLoadPage.loadSentMessages(mockSentMessages);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-trash-kb-nav-filter-sort.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-trash-kb-nav-filter-sort.cypress.spec.js
@@ -7,7 +7,6 @@ import mockTrashMessages from '../fixtures/trashResponse/trash-messages-response
 import FolderLoadPage from '../pages/FolderLoadPage';
 
 describe('Trash page keyboard navigation for filter & sort features', () => {
-  const site = new SecureMessagingSite();
   const filteredData = {
     data: inboxFilterResponse.data.filter(item =>
       item.attributes.subject.toLowerCase().includes('test'),
@@ -15,7 +14,7 @@ describe('Trash page keyboard navigation for filter & sort features', () => {
   };
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(mockTrashMessages);
     FolderLoadPage.loadDeletedMessages(mockTrashMessages);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messsaging-keyboard-nav-to-message-draft.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messsaging-keyboard-nav-to-message-draft.cypress.spec.js
@@ -7,11 +7,10 @@ import mockThreadResponse from '../fixtures/single-draft-response.json';
 import { AXE_CONTEXT } from '../utils/constants';
 
 describe('Secure Messaging Delete Draft', () => {
-  const site = new SecureMessagingSite();
   const draftsPage = new PatientMessageDraftsPage();
 
   it('delete Drafts on key press', () => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     draftsPage.loadDraftMessages(mockDraftMessages, mockDraftResponse);
     draftsPage.loadMessageDetails(mockDraftResponse, mockThreadResponse);

--- a/src/applications/mhv-secure-messaging/tests/e2e/multiple-drafts-tests/secure-messaging-multiple-drafts-delete.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/multiple-drafts-tests/secure-messaging-multiple-drafts-delete.cypress.spec.js
@@ -7,7 +7,6 @@ import mockMultiDraftsResponse from '../fixtures/draftsResponse/multi-draft-resp
 import { Alerts } from '../../../util/constants';
 
 describe('verify delete functionality of multiple drafts in one thread', () => {
-  const site = new SecureMessagingSite();
   const draftPage = new PatientMessageDraftsPage();
 
   const updatedMultiDraftResponse = GeneralFunctionsPage.updatedThreadDates(
@@ -15,7 +14,7 @@ describe('verify delete functionality of multiple drafts in one thread', () => {
   );
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     draftPage.loadMultiDraftThread(updatedMultiDraftResponse);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/multiple-drafts-tests/secure-messaging-multiple-drafts-interface.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/multiple-drafts-tests/secure-messaging-multiple-drafts-interface.cypress.spec.js
@@ -6,7 +6,6 @@ import PatientMessageDraftsPage from '../pages/PatientMessageDraftsPage';
 import mockMultiDraftsResponse from '../fixtures/draftsResponse/multi-draft-response.json';
 
 describe('handle multiple drafts in one thread', () => {
-  const site = new SecureMessagingSite();
   const draftPage = new PatientMessageDraftsPage();
 
   const updatedMultiDraftResponse = GeneralFunctionsPage.updatedThreadDates(
@@ -14,7 +13,7 @@ describe('handle multiple drafts in one thread', () => {
   );
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     draftPage.loadMultiDraftThread(updatedMultiDraftResponse);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/multiple-drafts-tests/secure-messaging-multiple-drafts-old.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/multiple-drafts-tests/secure-messaging-multiple-drafts-old.cypress.spec.js
@@ -5,11 +5,10 @@ import PatientMessageDraftsPage from '../pages/PatientMessageDraftsPage';
 import mockMultiDraftsResponse from '../fixtures/draftsResponse/multi-draft-response.json';
 
 describe('handle multiple drafts older than 45 days', () => {
-  const site = new SecureMessagingSite();
   const draftPage = new PatientMessageDraftsPage();
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     draftPage.loadMultiDraftThread(mockMultiDraftsResponse);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/multiple-drafts-tests/secure-messaging-multiple-drafts-resave.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/multiple-drafts-tests/secure-messaging-multiple-drafts-resave.cypress.spec.js
@@ -6,7 +6,6 @@ import PatientMessageDraftsPage from '../pages/PatientMessageDraftsPage';
 import mockMultiDraftsResponse from '../fixtures/draftsResponse/multi-draft-response.json';
 
 describe('re-save multiple drafts in one thread', () => {
-  const site = new SecureMessagingSite();
   const draftPage = new PatientMessageDraftsPage();
 
   const updatedMultiDraftResponse = GeneralFunctionsPage.updatedThreadDates(
@@ -14,7 +13,7 @@ describe('re-save multiple drafts in one thread', () => {
   );
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     draftPage.loadMultiDraftThread(updatedMultiDraftResponse);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-back-navigation.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-back-navigation.cypress.spec.js
@@ -9,9 +9,8 @@ import mockThreadResponse from './fixtures/single-draft-response.json';
 import { Alerts, DefaultFolders } from '../../util/constants';
 
 describe('SM back navigation', () => {
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
   });
   it('user navigate to inbox folder after message sent', () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-clickable-URL.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-clickable-URL.cypress.spec.js
@@ -7,9 +7,7 @@ import { AXE_CONTEXT, Locators } from './utils/constants';
 
 describe('Secure Messaging - Compose with Clickable URL', () => {
   it('search for clickable URL', () => {
-    const site = new SecureMessagingSite();
-    // const composePage = new PatientComposePage();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT, {});

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-empty-subject-body.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-empty-subject-body.cypress.spec.js
@@ -4,10 +4,8 @@ import PatientComposePage from './pages/PatientComposePage';
 import { AXE_CONTEXT, Data } from './utils/constants';
 
 describe('Secure Messaging Compose with No Subject or Body', () => {
-  // const composePage = new PatientComposePage();
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
     PatientComposePage.selectRecipient('CAMRY_PCMM RELATIONSHIP_05092022_SLC4'); // trieageTeams with preferredTeam = true will appear in a recipients dropdown only
@@ -27,7 +25,7 @@ describe('Secure Messaging Compose with No Subject or Body', () => {
       force: true,
     });
     PatientComposePage.clickOnSendMessageButton();
-    // composePage.verifySubjectErrorMessage();
+    // PatientComposePage.verifySubjectErrorMessage();
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-errors.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-errors.cypress.spec.js
@@ -7,9 +7,9 @@ import { AXE_CONTEXT, Data } from './utils/constants';
 // Focus states go to interactive form fields (Select, text input, textarea, checkboxes, and radio buttons.)
 
 describe('Secure Messaging Compose Errors', () => {
-  const site = new SecureMessagingSite();
+  SecureMessagingSite;
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-no-provider.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-no-provider.cypress.spec.js
@@ -4,8 +4,7 @@ import { AXE_CONTEXT, Locators, Data, Paths } from './utils/constants';
 
 describe('Secure Messaging Compose with No Provider', () => {
   it('can not send message', () => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadPageForNoProvider();
     cy.get(Locators.ALERTS.TRIAGE_GROUP).should(
       'contain',

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-recipients-dropdown.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-recipients-dropdown.cypress.spec.js
@@ -9,8 +9,7 @@ import mockBlockedRecipientsResponse from './fixtures/recipientsResponse/blocked
 
 describe('recipients dropdown box', () => {
   it('preferredTriageTeam select dropdown default ', () => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
 
     cy.get(Locators.LINKS.CREATE_NEW_MESSAGE).click();
@@ -29,8 +28,7 @@ describe('recipients dropdown box', () => {
   });
 
   it('preferredTriageTeam select dropdown false', () => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(
       mockMessages,
       mockSpecialCharsMessage,

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-reply-with-attachment-errors-1.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-reply-with-attachment-errors-1.cypress.spec.js
@@ -5,8 +5,7 @@ import { AXE_CONTEXT, Data } from './utils/constants';
 
 describe('Start a new message With Attacments and Errors', () => {
   it('start a new message with attachment', () => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
     cy.injectAxe();

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-reply-with-attachment-errors-2.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-reply-with-attachment-errors-2.cypress.spec.js
@@ -5,9 +5,7 @@ import { AXE_CONTEXT, Data, Locators } from './utils/constants';
 
 describe('Start a new message With Attacments and Errors', () => {
   it('start a new message with attachment', () => {
-    // const composePage = new PatientComposePage();
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
     cy.injectAxe();
@@ -43,7 +41,7 @@ describe('Start a new message With Attacments and Errors', () => {
     // logic has changed here. After attaching 4th file, Attach File button becomes hidden
     cy.get(Locators.ATTACH_FILE_INPUT).should('not.exist');
 
-    // composePage.verifyAttachmentErrorMessage(
+    // PatientComposePage.verifyAttachmentErrorMessage(
     //   'You may only attach up to 4 files',
     // );
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-with-attachment.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-with-attachment.cypress.spec.js
@@ -4,9 +4,8 @@ import PatientComposePage from './pages/PatientComposePage';
 import { AXE_CONTEXT, Data, Locators } from './utils/constants';
 
 describe('Compose a new message with attachments', () => {
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
   });
@@ -47,9 +46,8 @@ describe('Compose a new message with attachments', () => {
 });
 
 describe('verify attach file button behaviour', () => {
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose.cypress.spec.js
@@ -5,9 +5,8 @@ import requestBody from './fixtures/message-compose-request-body.json';
 import { AXE_CONTEXT, Locators } from './utils/constants';
 
 describe('Secure Messaging Compose', () => {
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-create-folder-errors.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-create-folder-errors.cypress.spec.js
@@ -6,14 +6,13 @@ import FolderLoadPage from './pages/FolderLoadPage';
 
 describe('create folder errors check', () => {
   beforeEach(() => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
   });
 
   it('create folder network error check', () => {
     cy.injectAxe();
-    cy.axeCheck(AXE_CONTEXT, {});
+    cy.axeCheck(AXE_CONTEXT);
     FolderLoadPage.loadFolders();
 
     FolderManagementPage.createANewFolderButton().click({
@@ -42,7 +41,7 @@ describe('create folder errors check', () => {
 
   it('create blank name folder error check', () => {
     cy.injectAxe();
-    cy.axeCheck(AXE_CONTEXT, {});
+    cy.axeCheck(AXE_CONTEXT);
     FolderLoadPage.loadFolders();
     cy.get(Locators.ALERTS.CREATE_NEW_FOLDER).click();
     cy.get(Locators.BUTTONS.CREATE_FOLDER).click({

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-cross-site-scripting.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-cross-site-scripting.cypress.spec.js
@@ -5,10 +5,8 @@ import requestBody from './fixtures/message-compose-request-body.json';
 import { AXE_CONTEXT } from './utils/constants';
 
 describe('Secure Messaging - Cross Site Scripting', () => {
-  const site = new SecureMessagingSite();
-
   it('search for script', () => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT, {});

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-custom-folder.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-custom-folder.cypress.spec.js
@@ -6,8 +6,7 @@ import FolderLoadPage from './pages/FolderLoadPage';
 
 describe('Secure Messaging Custom Folder AXE Check', () => {
   beforeEach(() => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     FolderLoadPage.loadFolders();
     PatientMessageCustomFolderPage.loadMessages();

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-delete-draft-no-changes.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-delete-draft-no-changes.cypress.spec.js
@@ -7,8 +7,7 @@ import { AXE_CONTEXT, Locators } from './utils/constants';
 describe('Secure Messaging Delete Draft Navigate to Inbox', () => {
   it('Navigates to Inbox after Delete Draft With No Changes and No Confirmation', () => {
     const draftsPage = new PatientMessageDraftsPage();
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
     draftsPage.clickDeleteButton();

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-delete-draft.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-delete-draft.cypress.spec.js
@@ -8,11 +8,9 @@ import mockThreadResponse from './fixtures/single-draft-response.json';
 import { AXE_CONTEXT } from './utils/constants';
 
 describe('Secure Messaging Delete Draft', () => {
-  const site = new SecureMessagingSite();
-
   const draftsPage = new PatientMessageDraftsPage();
   it(' Delete Existing Draft', () => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     draftsPage.loadDraftMessages(mockDraftMessages, mockDraftResponse);
     draftsPage.loadMessageDetails(mockDraftResponse, mockThreadResponse);

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-delete-message-with-attachment.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-delete-message-with-attachment.cypress.spec.js
@@ -9,11 +9,10 @@ import { AXE_CONTEXT, Paths } from './utils/constants';
 
 describe('Secure Messaging - Delete Message with Attachment', () => {
   it('delete message with attachment', () => {
-    const site = new SecureMessagingSite();
     const detailsPage = new PatientMessageDetailsPage();
     // const composePage = new PatientComposePage();
 
-    site.login();
+    SecureMessagingSite.login();
     mockMessagewithAttachment.data.id = '7192838';
     mockMessagewithAttachment.data.attributes.messageId = '7192838';
     mockMessagewithAttachment.data.attributes.attachment = true;

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-delete-reply-draft.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-delete-reply-draft.cypress.spec.js
@@ -11,8 +11,7 @@ describe('Secure Messaging Delete Reply Draft', () => {
   it('Axe Check Message Delete Reply Draft with Axe Check', () => {
     const draftsPage = new PatientMessageDraftsPage();
     const messageDetailsPage = new PatientMessageDetailsPage();
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     const messageDetails = PatientInboxPage.getNewMessageDetails();
 
     PatientInboxPage.loadInboxMessages(mockMessages, messageDetails);

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-delete-unsaved-draft.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-delete-unsaved-draft.cypress.spec.js
@@ -4,9 +4,8 @@ import PatientComposePage from './pages/PatientComposePage';
 import { AXE_CONTEXT, Data, Locators, Assertions } from './utils/constants';
 
 describe('Secure Messaging Delete Unsaved Compose Draft', () => {
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-detail-sent.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-detail-sent.cypress.spec.js
@@ -9,8 +9,7 @@ import { AXE_CONTEXT } from './utils/constants';
 describe('Secure Messaging Message Details in Sent AXE Check', () => {
   it('Axe Check message details page', () => {
     const detailsPage = new PatientMessageDetailsPage();
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     const messageDetails = mockMessageDetails;
     // const messageDetails = landingPage.setMessageDateToYesterday(mockMessageDetails);
     const date = new Date();

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-detail.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-detail.cypress.spec.js
@@ -9,8 +9,7 @@ import { AXE_CONTEXT } from './utils/constants';
 describe('Secure Messaging Message Details AXE Check', () => {
   it('Axe Check Message Details Page', () => {
     const detailsPage = new PatientMessageDetailsPage();
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     // const messageDetails = mockMessageDetails;
     // const messageDetails = landingPage.setMessageDateToYesterday(mockMessageDetails);
     const date = new Date();

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-digital-signature-alerts.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-digital-signature-alerts.cypress.spec.js
@@ -4,9 +4,8 @@ import PatientComposePage from './pages/PatientComposePage';
 import { AXE_CONTEXT, Data, Locators } from './utils/constants';
 
 describe('Secure Messaging Digital Signature Error flows', () => {
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
     PatientComposePage.selectRecipient('Record Amendment Admin');

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-digital-signature.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-digital-signature.cypress.spec.js
@@ -6,9 +6,8 @@ import mockResponseBody from './fixtures/message-compose-DS-response-body.json';
 import { AXE_CONTEXT } from './utils/constants';
 
 describe('Secure Messaging Compose', () => {
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-draft-folder.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-draft-folder.cypress.spec.js
@@ -6,8 +6,7 @@ import FolderLoadPage from './pages/FolderLoadPage';
 
 describe('secure Messaging Draft Folder checks', () => {
   beforeEach(() => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     FolderLoadPage.loadFolders();
     FolderLoadPage.loadDraftMessages();

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-draft-save-with-attachments.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-draft-save-with-attachments.cypress.spec.js
@@ -10,10 +10,9 @@ import { AXE_CONTEXT, Data, Locators } from './utils/constants';
 
 describe('Secure Messaging Draft Save with Attachments', () => {
   it('Axe Check Draft Save with Attachments', () => {
-    const site = new SecureMessagingSite();
     const draftsPage = new PatientMessageDraftsPage();
 
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     draftsPage.loadDraftMessages(mockDraftMessages, mockDraftResponse);
     draftsPage.loadMessageDetails(mockDraftResponse, mockThreadResponse);

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-edit-folder-name.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-edit-folder-name.cypress.spec.js
@@ -5,23 +5,18 @@ import PatientMessageCustomFolderPage from './pages/PatientMessageCustomFolderPa
 import FolderLoadPage from './pages/FolderLoadPage';
 
 describe('edit custom folder name validation', () => {
-  it('verify axe check', () => {
-    const site = new SecureMessagingSite();
-    site.login();
+  beforeEach(() => {
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     FolderLoadPage.loadFolders();
-
+  });
+  it('verify axe check', () => {
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT, {});
   });
 
   it('verify edit folder name buttons', () => {
-    const site = new SecureMessagingSite();
-    site.login();
-    PatientInboxPage.loadInboxMessages();
-    FolderLoadPage.loadFolders();
     PatientMessageCustomFolderPage.loadMessages();
-
     PatientMessageCustomFolderPage.editFolderButton()
       .should('be.visible')
       .click({ waitForAnimations: true });
@@ -35,12 +30,7 @@ describe('edit custom folder name validation', () => {
   });
 
   it('verify edit folder name error', () => {
-    const site = new SecureMessagingSite();
-    site.login();
-    PatientInboxPage.loadInboxMessages();
-    FolderLoadPage.loadFolders();
     PatientMessageCustomFolderPage.loadMessages();
-
     PatientMessageCustomFolderPage.editFolderButton()
       .should('be.visible')
       .click({ waitForAnimations: true });

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-edit-signature.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-edit-signature.cypress.spec.js
@@ -3,9 +3,8 @@ import PatientInboxPage from './pages/PatientInboxPage';
 import { AXE_CONTEXT, Data, Locators } from './utils/constants';
 
 describe('verify deeplinking sending the draft', () => {
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
     PatientInboxPage.composeMessage();

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-folders.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-folders.cypress.spec.js
@@ -6,8 +6,7 @@ import PatientInboxPage from './pages/PatientInboxPage';
 
 describe(manifest.appName, () => {
   beforeEach(() => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
   });
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-inbox-folder.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-inbox-folder.cypress.spec.js
@@ -6,8 +6,7 @@ import FolderLoadPage from './pages/FolderLoadPage';
 
 describe('Secure Messaging Inbox Message Sort', () => {
   beforeEach(() => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
   });
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-inbox-no-messages.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-inbox-no-messages.cypress.spec.js
@@ -5,9 +5,7 @@ import { AXE_CONTEXT, Data, Locators } from './utils/constants';
 
 describe('Secure Messaging Inbox No Messages', () => {
   it('inbox no messages', () => {
-    const site = new SecureMessagingSite();
-
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(mockInboxNoMessages);
 
     cy.get('@inboxMessages')

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-inbox-pilot-env.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-inbox-pilot-env.cypress.spec.js
@@ -4,7 +4,6 @@ import mockFeatureToggles from './fixtures/toggles-response.json';
 import SecureMessagingLandingPage from './pages/SecureMessagingLandingPage';
 
 describe('Secure Messaging Pilot feature flag', () => {
-  const site = new SecureMessagingSite();
   const pilotFeatureFlag = {
     name: 'mhv_secure_messaging_cerner_pilot',
     value: true,
@@ -17,8 +16,7 @@ describe('Secure Messaging Pilot feature flag', () => {
     },
   };
   it('pilot OF landing page view', () => {
-    site.login();
-
+    SecureMessagingSite.login();
     SecureMessagingLandingPage.loadMainPage(mockFeatureToggles, Paths.UI_PILOT);
 
     cy.injectAxe();
@@ -32,7 +30,7 @@ describe('Secure Messaging Pilot feature flag', () => {
   });
 
   it('pilot ON landing page view', () => {
-    site.login();
+    SecureMessagingSite.login();
     SecureMessagingLandingPage.loadMainPage(
       mockPilotFeatureToggles,
       Paths.UI_PILOT,

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-inbox-user-navigation.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-inbox-user-navigation.cypress.spec.js
@@ -6,8 +6,7 @@ import { AXE_CONTEXT, Data, Paths } from './utils/constants';
 
 describe('Secure Messaging Compose', () => {
   it('can send message', () => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
 
     cy.intercept('GET', Paths.INTERCEPT.MESSAGE_SIGNATURE, mockSignature).as(

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-interstitial-page.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-interstitial-page.cypress.spec.js
@@ -4,8 +4,7 @@ import { AXE_CONTEXT, Locators } from './utils/constants';
 
 describe('Secure Messaging Compose', () => {
   it('can send message', () => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToInterstitialPage();
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-landing-page-load.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-landing-page-load.cypress.spec.js
@@ -6,8 +6,7 @@ import mockRecipients from './fixtures/recipients-response.json';
 
 describe('SM main page', () => {
   beforeEach(() => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     SecureMessagingLandingPage.loadMainPage();
   });
 
@@ -61,8 +60,7 @@ describe('SM main page', () => {
 
 describe('SM main page without API calls', () => {
   it('validate Inbox and New Message links exists in the page', () => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     cy.intercept(
       'GET',
       Paths.INTERCEPT.MESSAGE_ALLRECIPIENTS,

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-manage-folder.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-manage-folder.cypress.spec.js
@@ -8,11 +8,10 @@ import FolderLoadPage from './pages/FolderLoadPage';
 
 describe('manage folders', () => {
   describe('verify folder created', () => {
-    const site = new SecureMessagingSite();
     const newFolder = `folder${Date.now()}`;
 
     before(() => {
-      site.login();
+      SecureMessagingSite.login();
       PatientInboxPage.loadInboxMessages();
       FolderLoadPage.loadFolders();
     });
@@ -28,12 +27,11 @@ describe('manage folders', () => {
   });
 
   describe('verify folder deleted', () => {
-    const site = new SecureMessagingSite();
     const folderName = createdFolderResponse.data.attributes.name;
     const { folderId } = createdFolderResponse.data.attributes;
 
     before(() => {
-      site.login();
+      SecureMessagingSite.login();
       PatientInboxPage.loadInboxMessages();
       FolderLoadPage.loadFolders();
     });

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-categories.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-categories.cypress.spec.js
@@ -5,11 +5,10 @@ import { AXE_CONTEXT } from './utils/constants';
 import categories from './fixtures/categories-response.json';
 
 describe('Secure Messaging Compose Categories', () => {
-  const site = new SecureMessagingSite();
   const listOfCategories = categories.data.attributes.messageCategoryType;
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
   });
 
   it('can send message for categories', () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-details-button-check.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-details-button-check.cypress.spec.js
@@ -10,9 +10,8 @@ import { AXE_CONTEXT } from './utils/constants';
 
 describe('Secure Messaging Message Details Buttons Check', () => {
   it('Message Details Buttons Check', () => {
-    const site = new SecureMessagingSite();
     const messageDetailsPage = new PatientMessageDetailsPage();
-    site.login();
+    SecureMessagingSite.login();
     const messageDetails = PatientInboxPage.setMessageDateToYesterday(
       mockMessageDetails,
     );

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-accordions.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-accordions.cypress.spec.js
@@ -4,14 +4,13 @@ import mockThreadResponse from './fixtures/thread-response.json';
 import { AXE_CONTEXT } from './utils/constants';
 
 describe('Secure Messaging Thread Details', () => {
-  const site = new SecureMessagingSite();
   const date = new Date();
   const messageIdList = mockThreadResponse.data.map(
     el => el.attributes.messageId,
   );
 
   it('verify expanded messages focus', () => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.loadSingleThread(mockThreadResponse, date);
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-detail-reply-page.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-detail-reply-page.cypress.spec.js
@@ -10,8 +10,7 @@ import { AXE_CONTEXT } from './utils/constants';
 describe('Secure Messaging Reply Message Details Thread', () => {
   it('Axe Check Message Reply Details', () => {
     const messageDetailsPage = new PatientMessageDetailsPage();
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     const testMessage = PatientInboxPage.getNewMessageDetails();
     PatientInboxPage.loadInboxMessages(mockMessages, testMessage);
     messageDetailsPage.loadMessageDetails(testMessage);

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details-expand-all.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details-expand-all.cypress.spec.js
@@ -9,13 +9,11 @@ import { AXE_CONTEXT } from './utils/constants';
 
 describe('Secure Messaging Message Details', () => {
   const detailsPage = new PatientMessageDetailsPage();
-  const site = new SecureMessagingSite();
-
   const messageDetails = mockMessageDetails;
   const date = new Date();
 
   before('Axe Check Message Details Page', () => {
-    site.login();
+    SecureMessagingSite.login();
     date.setDate(date.getDate() - 2);
     messageDetails.data.attributes.sentDate = date.toISOString();
     cy.log(`New Message Details ==== ${JSON.stringify(messageDetails)}`);

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-message-thread-details.cypress.spec.js
@@ -9,13 +9,11 @@ import { AXE_CONTEXT } from './utils/constants';
 
 describe('Secure Messaging Message Details', () => {
   const detailsPage = new PatientMessageDetailsPage();
-  const site = new SecureMessagingSite();
-
   let messageDetails = mockMessageDetails;
   const date = new Date();
 
   before('Axe Check Message Details Page', () => {
-    site.login();
+    SecureMessagingSite.login();
     date.setDate(date.getDate() - 2);
     messageDetails = {
       data: {

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-move-message-from-folder-to-folder.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-move-message-from-folder-to-folder.cypress.spec.js
@@ -12,10 +12,9 @@ import FolderLoadPage from './pages/FolderLoadPage';
 
 describe('Secure Messaging Move Message tests', () => {
   it('move message from custom folder to Deleted', () => {
-    const site = new SecureMessagingSite();
     const folderName = mockFoldersResponse.data.at(4).attributes.name;
     const { folderId } = mockFoldersResponse.data.at(4).attributes;
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     FolderLoadPage.loadFolders();
 
@@ -34,13 +33,12 @@ describe('Secure Messaging Move Message tests', () => {
     FolderManagementPage.verifyMoveMessageSuccessConfirmationMessage();
     FolderManagementPage.verifyMoveMessageSuccessConfirmationHasFocus();
     cy.injectAxe();
-    cy.axeCheck(AXE_CONTEXT, {});
+    cy.axeCheck(AXE_CONTEXT);
   });
 
   it('move message from inbox to deleted', () => {
     const messageDetailsPage = new PatientMessageDetailsPage();
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(mockMessages, mockMessagewithAttachment);
     messageDetailsPage.loadMessageDetails(mockMessagewithAttachment);
 
@@ -49,6 +47,6 @@ describe('Secure Messaging Move Message tests', () => {
     FolderManagementPage.verifyMoveMessageSuccessConfirmationMessage();
     FolderManagementPage.verifyMoveMessageSuccessConfirmationHasFocus();
     cy.injectAxe();
-    cy.axeCheck(AXE_CONTEXT, {});
+    cy.axeCheck(AXE_CONTEXT);
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-move-message-with-attachment.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-move-message-with-attachment.cypress.spec.js
@@ -8,9 +8,8 @@ import { AXE_CONTEXT, Locators, Paths } from './utils/constants';
 
 describe('Secure Messaging - Move Message with Attachment', () => {
   it('can move with attachment', () => {
-    const site = new SecureMessagingSite();
     const messageDetailsPage = new PatientMessageDetailsPage();
-    site.login();
+    SecureMessagingSite.login();
     mockMessagewithAttachment.data.id = '7192838';
     mockMessagewithAttachment.data.attributes.messageId = '7192838';
     mockMessagewithAttachment.data.attributes.attachment = true;

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-navigate-away-from-compose-message-modal.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-navigate-away-from-compose-message-modal.cypress.spec.js
@@ -5,9 +5,8 @@ import FolderLoadPage from './pages/FolderLoadPage';
 import { AXE_CONTEXT, Locators } from './utils/constants';
 
 describe('Secure Messaging Navigate Away From `Start a new message`', () => {
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
   });
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-navigate-away-from-replying-message.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-navigate-away-from-replying-message.cypress.spec.js
@@ -11,8 +11,7 @@ import PatientComposePage from './pages/PatientComposePage';
 describe('Secure Messaging Reply', () => {
   it('Navigate Away From `Reply to message` To Inbox', () => {
     const messageDetailsPage = new PatientMessageDetailsPage();
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     const testMessage = PatientInboxPage.getNewMessageDetails();
     PatientInboxPage.loadInboxMessages(mockMessages, testMessage);
     messageDetailsPage.loadMessageDetails(testMessage);

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-navigate-away-from-unsaved-reply-draft.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-navigate-away-from-unsaved-reply-draft.cypress.spec.js
@@ -10,8 +10,7 @@ import { AXE_CONTEXT, Data } from './utils/constants';
 describe('Secure Messaging navigate away from unsaved draft', () => {
   it(' Check navigation away from unsaved draft', () => {
     const messageDetailsPage = new PatientMessageDetailsPage();
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     const testMessage = PatientInboxPage.getNewMessageDetails();
     PatientInboxPage.loadInboxMessages(mockMessages, testMessage);
     messageDetailsPage.loadMessageDetails(testMessage);

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-pagination.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-pagination.cypress.spec.js
@@ -6,9 +6,8 @@ import { AXE_CONTEXT, Data } from './utils/constants';
 import FolderLoadPage from './pages/FolderLoadPage';
 
 describe('Secure Messaging Reply', () => {
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
   });
   it('Axe Pagination Test', () => {
     const threadLength = 28;
@@ -24,17 +23,45 @@ describe('Secure Messaging Reply', () => {
 
     PatientInboxPage.loadInboxMessages(mockMessagesPageOne);
     cy.get('va-pagination').should('be.visible');
-    site.clickAndLoadVAPaginationNextMessagesButton(2, mockMessagesPageTwo);
-    site.verifyPaginationMessagesDisplayedText(11, 20, threadLength);
+    SecureMessagingSite.clickAndLoadVAPaginationNextMessagesButton(
+      2,
+      mockMessagesPageTwo,
+    );
+    SecureMessagingSite.verifyPaginationMessagesDisplayedText(
+      11,
+      20,
+      threadLength,
+    );
     FolderLoadPage.verifyPaginationElements();
-    site.clickAndLoadVAPaginationPreviousMessagesButton(1, mockMessagesPageOne);
-    site.verifyPaginationMessagesDisplayedText(1, 10, threadLength);
+    SecureMessagingSite.clickAndLoadVAPaginationPreviousMessagesButton(
+      1,
+      mockMessagesPageOne,
+    );
+    SecureMessagingSite.verifyPaginationMessagesDisplayedText(
+      1,
+      10,
+      threadLength,
+    );
     FolderLoadPage.verifyPaginationElements();
 
-    site.clickAndLoadVAPaginationPageMessagesLink(2, mockMessagesPageTwo);
-    site.verifyPaginationMessagesDisplayedText(11, 20, threadLength);
-    site.clickAndLoadVAPaginationPageMessagesLink(1, mockMessagesPageOne);
-    site.verifyPaginationMessagesDisplayedText(1, 10, threadLength);
+    SecureMessagingSite.clickAndLoadVAPaginationPageMessagesLink(
+      2,
+      mockMessagesPageTwo,
+    );
+    SecureMessagingSite.verifyPaginationMessagesDisplayedText(
+      11,
+      20,
+      threadLength,
+    );
+    SecureMessagingSite.clickAndLoadVAPaginationPageMessagesLink(
+      1,
+      mockMessagesPageOne,
+    );
+    SecureMessagingSite.verifyPaginationMessagesDisplayedText(
+      1,
+      10,
+      threadLength,
+    );
 
     cy.get('.usa-pagination__list li').then(pagesList => {
       const lastPageIndex = pagesList.length - 2;
@@ -63,7 +90,7 @@ describe('Secure Messaging Reply', () => {
     };
 
     PatientInboxPage.loadInboxMessages(mockMessagesPageOne);
-    site.clickAndLoadVAPaginationLastPageButton(
+    SecureMessagingSite.clickAndLoadVAPaginationLastPageButton(
       pageNumber,
       mockSingleMessageThread,
     );

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-print-messages.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-print-messages.cypress.spec.js
@@ -6,11 +6,10 @@ import defaultMockThread from './fixtures/thread-response.json';
 import { AXE_CONTEXT, Locators } from './utils/constants';
 
 describe('Secure Messaging - Print Functionality', () => {
-  const site = new SecureMessagingSite();
   const messageDetailsPage = new PatientMessageDetailsPage();
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(
       mockMessages,
       PatientInboxPage.getNewMessageDetails(),

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-remove-folder-modal-error.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-remove-folder-modal-error.cypress.spec.js
@@ -7,13 +7,12 @@ import { AXE_CONTEXT, Locators } from './utils/constants';
 import FolderLoadPage from './pages/FolderLoadPage';
 
 describe('remove folder error modal', () => {
-  const site = new SecureMessagingSite();
   const folderName =
     mockFolders.data[mockFolders.data.length - 1].attributes.name;
   const { folderId } = mockFolders.data[mockFolders.data.length - 1].attributes;
 
   before(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     FolderLoadPage.loadFolders();
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-reply-expired.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-reply-expired.cypress.spec.js
@@ -5,11 +5,10 @@ import mockMessages from './fixtures/messages-response.json';
 import defaultMockThread from './fixtures/thread-response.json';
 import { AXE_CONTEXT } from './utils/constants';
 
-describe('Secure Messaging Reply to Expired Mesage', () => {
+describe('Secure Messaging Reply to Expired Message', () => {
   it('reply expired messages', () => {
     const messageDetailsPage = new PatientMessageDetailsPage();
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(
       mockMessages,
       PatientInboxPage.getExpired46DayOldMessageDetails(),

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-reply-with-attachment.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-reply-with-attachment.cypress.spec.js
@@ -8,11 +8,10 @@ import PatientInterstitialPage from './pages/PatientInterstitialPage';
 import PatientReplyPage from './pages/PatientReplyPage';
 
 describe('Reply with attachments', () => {
-  const site = new SecureMessagingSite();
   const messageDetailsPage = new PatientMessageDetailsPage();
   const testMessage = PatientInboxPage.getNewMessageDetails();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(mockMessages, testMessage);
 
     messageDetailsPage.loadMessageDetails(testMessage);
@@ -55,11 +54,10 @@ describe('Reply with attachments', () => {
 });
 
 describe('verify attach file button behaviour', () => {
-  const site = new SecureMessagingSite();
   const messageDetailsPage = new PatientMessageDetailsPage();
   const testMessage = PatientInboxPage.getNewMessageDetails();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(mockMessages, testMessage);
 
     messageDetailsPage.loadMessageDetails(testMessage);

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-reply.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-reply.cypress.spec.js
@@ -9,8 +9,7 @@ import { AXE_CONTEXT } from './utils/constants';
 describe('Secure Messaging Reply', () => {
   it('Axe Check Message Reply', () => {
     const messageDetailsPage = new PatientMessageDetailsPage();
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     const testMessage = PatientInboxPage.getNewMessageDetails();
     PatientInboxPage.loadInboxMessages(mockMessages, testMessage);
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-save-draft-errors.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-save-draft-errors.cypress.spec.js
@@ -7,9 +7,8 @@ import { AXE_CONTEXT, Data } from './utils/constants';
 // Focus states go to interactive form fields (Select, text input, textarea, checkboxes, and radio buttons.)
 
 describe('Secure Messaging Compose Errors', () => {
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-save-draft.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-save-draft.cypress.spec.js
@@ -8,8 +8,7 @@ import mockDraftResponse from './fixtures/message-draft-response.json';
 
 describe('save draft feature tests', () => {
   it('save new draft', () => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
 
@@ -28,8 +27,7 @@ describe('save draft feature tests', () => {
 
   it('re-save existing draft', () => {
     const draftsPage = new PatientMessageDraftsPage();
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     draftsPage.loadDraftMessages(mockDraftMessages, mockDraftResponse);
     draftsPage.loadMessageDetails(mockDraftResponse);

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-save-reply-draft.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-save-reply-draft.cypress.spec.js
@@ -10,7 +10,6 @@ import { AXE_CONTEXT, Data, Locators } from './utils/constants';
 describe('Secure Messaging Reply', () => {
   it('Axe Check Message Reply', () => {
     // declare pages & constants
-    const site = new SecureMessagingSite();
     const draftPage = new PatientMessageDraftsPage();
     const messageDetailsPage = new PatientMessageDetailsPage();
 
@@ -19,7 +18,7 @@ describe('Secure Messaging Reply', () => {
     singleMessage.data.attributes.body = bodyText;
 
     // load single thread
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(mockMessages);
     PatientInboxPage.loadSingleThread(mockSingleThread);
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-sent-folder.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-sent-folder.cypress.spec.js
@@ -6,8 +6,7 @@ import FolderLoadPage from './pages/FolderLoadPage';
 
 describe('secure Messaging Sent Folder checks', () => {
   beforeEach(() => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     FolderLoadPage.loadFolders();
     FolderLoadPage.loadSentMessages();

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-signature.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-signature.cypress.spec.js
@@ -4,10 +4,9 @@ import { AXE_CONTEXT } from './utils/constants';
 import mockThread from './fixtures/thread-response.json';
 
 describe('verify signature', () => {
-  const site = new SecureMessagingSite();
   const currentDate = new Date().toISOString();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
   });
   it('signature added on composing', () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-thread-load-errors.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-thread-load-errors.cypress.spec.js
@@ -2,16 +2,14 @@ import SecureMessagingSite from './sm_site/SecureMessagingSite';
 import PatientErrorPage from './pages/PatientErrorPage';
 
 describe('Thread list load error', () => {
-  const site = new SecureMessagingSite();
-
   it('verify error on particular folder', () => {
-    site.login();
+    SecureMessagingSite.login();
     PatientErrorPage.loadParticularFolderError();
     PatientErrorPage.verifyAlertMessageText();
   });
 
   it('verify error in My folders', () => {
-    site.login();
+    SecureMessagingSite.login();
     PatientErrorPage.loadMyFoldersError();
     PatientErrorPage.verifyAlertMessageText();
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-thread-metadata.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-thread-metadata.cypress.spec.js
@@ -5,8 +5,7 @@ import { AXE_CONTEXT, Locators } from './utils/constants';
 
 describe('Secure Messaging Message Details AXE Check', () => {
   it('Axe Check Message Details Page', () => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     const date = new Date();
     date.setDate(date.getDate() - 2);
     PatientInboxPage.loadInboxMessages(inboxMessages);

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-trash-folder.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-trash-folder.cypress.spec.js
@@ -6,8 +6,7 @@ import { AXE_CONTEXT, Data } from './utils/constants';
 
 describe('Secure Messaging Trash Folder checks', () => {
   beforeEach(() => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     FolderLoadPage.loadFolders();
     FolderLoadPage.loadDeletedMessages();

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-unauthenticated-landing-page.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-unauthenticated-landing-page.cypress.spec.js
@@ -5,14 +5,13 @@ import mockEhrData from './fixtures/userResponse/vamc-ehr-cerner-mixed.json';
 
 describe('Secure Messaging Compose', () => {
   it('can send message', () => {
-    const site = new SecureMessagingSite();
-    site.login(mockEhrData, false);
-    site.loadPageUnauthenticated();
+    SecureMessagingSite.login(mockEhrData, false);
+    SecureMessagingSite.loadPageUnauthenticated();
 
     cy.url().should('contain', Paths.HEALTH_CARE_SECURE_MSG);
 
     // lines below are only for axeCheck (as test couldn't be committed without axeCheck verification)
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
 
     cy.injectAxe();

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-verify-data-when-cancel-navigate-away.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-verify-data-when-cancel-navigate-away.cypress.spec.js
@@ -5,11 +5,10 @@ import FolderLoadPage from './pages/FolderLoadPage';
 import { AXE_CONTEXT } from './utils/constants';
 
 describe('Secure Messaging Verify Compose Data When Cancel Navigate Away', () => {
-  const site = new SecureMessagingSite();
   // const composePage = new PatientComposePage();
 
   it('Verify Data When Cancel Navigate Away', () => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     PatientInboxPage.navigateToComposePage();
     cy.injectAxe();

--- a/src/applications/mhv-secure-messaging/tests/e2e/sm_site/SecureMessagingSite.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sm_site/SecureMessagingSite.js
@@ -139,4 +139,4 @@ class SecureMessagingSite {
   };
 }
 
-export default SecureMessagingSite;
+export default new SecureMessagingSite();

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-advanced-search.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-advanced-search.cypress.spec.js
@@ -10,8 +10,7 @@ import FolderLoadPage from '../pages/FolderLoadPage';
 describe(manifest.appName, () => {
   describe('Advanced search in Inbox', () => {
     beforeEach(() => {
-      const site = new SecureMessagingSite();
-      site.login();
+      SecureMessagingSite.login();
       PatientInboxPage.loadInboxMessages();
       cy.intercept(
         'POST',
@@ -42,8 +41,7 @@ describe(manifest.appName, () => {
 
   describe('Advanced search in Drafts', () => {
     beforeEach(() => {
-      const site = new SecureMessagingSite();
-      site.login();
+      SecureMessagingSite.login();
       PatientInboxPage.loadInboxMessages();
       FolderLoadPage.loadFolders();
       FolderLoadPage.loadDraftMessages();
@@ -76,8 +74,7 @@ describe(manifest.appName, () => {
 
   describe('Advanced search in Sent', () => {
     beforeEach(() => {
-      const site = new SecureMessagingSite();
-      site.login();
+      SecureMessagingSite.login();
       PatientInboxPage.loadInboxMessages();
       FolderLoadPage.loadFolders();
       FolderLoadPage.loadSentMessages();
@@ -111,8 +108,7 @@ describe(manifest.appName, () => {
 
   describe('Advanced search in Trash', () => {
     beforeEach(() => {
-      const site = new SecureMessagingSite();
-      site.login();
+      SecureMessagingSite.login();
       PatientInboxPage.loadInboxMessages();
       FolderLoadPage.loadFolders();
       FolderLoadPage.loadDeletedMessages();
@@ -146,8 +142,7 @@ describe(manifest.appName, () => {
 
   describe('Advanced search in Custom folder', () => {
     beforeEach(() => {
-      const site = new SecureMessagingSite();
-      site.login();
+      SecureMessagingSite.login();
       PatientInboxPage.loadInboxMessages();
       FolderLoadPage.loadFolders();
       PatientMessageCustomFolderPage.loadMessages();

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-custom-folder-filter-sort.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-custom-folder-filter-sort.cypress.spec.js
@@ -6,8 +6,7 @@ import { AXE_CONTEXT } from '../utils/constants';
 
 describe('Secure Messaging Custom Folder filter-sort checks', () => {
   beforeEach(() => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
     FolderLoadPage.loadFolders();
     PatientMessageCustomFolderPage.loadMessages();

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-draft-folder-filter-sort.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-draft-folder-filter-sort.cypress.spec.js
@@ -6,10 +6,9 @@ import FolderLoadPage from '../pages/FolderLoadPage';
 import mockDraftMessages from '../fixtures/draftsResponse/drafts-messages-response.json';
 
 describe('Secure Messaging Draft Folder filter-sort checks', () => {
-  const site = new SecureMessagingSite();
   const draftsPage = new PatientMessagesDraftsPage();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(mockDraftMessages);
     FolderLoadPage.loadDraftMessages();
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-inbox-folder-filter-sort.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-inbox-folder-filter-sort.cypress.spec.js
@@ -4,8 +4,6 @@ import mockMessages from '../fixtures/messages-response.json';
 import { Locators, AXE_CONTEXT } from '../utils/constants';
 
 describe('Secure Messaging Inbox Folder filter-sort checks', () => {
-  const site = new SecureMessagingSite();
-
   const {
     data: [, secondElement, thirdElement],
     ...rest
@@ -14,7 +12,7 @@ describe('Secure Messaging Inbox Folder filter-sort checks', () => {
   const mockFilterResults = { data: [secondElement, thirdElement], ...rest };
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(mockMessages);
   });
 
@@ -50,8 +48,6 @@ describe('Secure Messaging Inbox Folder filter-sort checks', () => {
 });
 
 describe('Verify sorting feature with only one filter result', () => {
-  const site = new SecureMessagingSite();
-
   const {
     data: [, secondElement],
     ...rest
@@ -60,7 +56,7 @@ describe('Verify sorting feature with only one filter result', () => {
   const mockSingleFilterResult = { data: [secondElement], ...rest };
 
   it('verify sorting does not appear with only one filter result', () => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
 
     PatientInboxPage.inputFilterData('draft');

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-sent-folder-filter-sort.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-sent-folder-filter-sort.cypress.spec.js
@@ -7,8 +7,7 @@ import { AXE_CONTEXT } from '../utils/constants';
 
 describe('Secure Messaging Trash Folder filter-sort checks', () => {
   beforeEach(() => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(mockSentMessages);
     FolderLoadPage.loadSentMessages(mockSentMessages);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-specialcharacter-search.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-specialcharacter-search.cypress.spec.js
@@ -9,9 +9,7 @@ describe('Secure Messaging Basic Search Tests', () => {
   // const searchText = 'special %$#';  Known-Issue... special chars don't highlight
   const searchText = 'special';
   beforeEach(() => {
-    const site = new SecureMessagingSite();
-
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages();
   });
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-trash-folder-filter-sort.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/sort-filter-test/secure-messaging-trash-folder-filter-sort.cypress.spec.js
@@ -7,8 +7,7 @@ import mockTrashMessages from '../fixtures/trashResponse/trash-messages-response
 
 describe('Secure Messaging Trash Folder filter-sort checks', () => {
   beforeEach(() => {
-    const site = new SecureMessagingSite();
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(mockTrashMessages);
     FolderLoadPage.loadDeletedMessages(mockTrashMessages);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-drafts-blocked-from-facility.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-drafts-blocked-from-facility.cypress.spec.js
@@ -8,11 +8,10 @@ import mockFacilityBlockedRecipients from '../fixtures/recipientsResponse/facili
 import mockThread from '../fixtures/thread-response.json';
 
 describe('verify drafts - blocked from facility', () => {
-  const site = new SecureMessagingSite();
   const newDate = new Date().toISOString();
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
 
     PatientInboxPage.loadInboxMessages(
       mockMessages,

--- a/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-drafts-no-association-at-all.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-drafts-no-association-at-all.cypress.spec.js
@@ -8,12 +8,10 @@ import mockThread from '../fixtures/thread-response.json';
 import mockNoRecipients from '../fixtures/recipientsResponse/no-recipients-response.json';
 
 describe('Verify drafts - No association with particular Triage Group', () => {
-  const site = new SecureMessagingSite();
   const newDate = new Date().toISOString();
 
   beforeEach(() => {
-    site.login();
-
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(
       mockMessages,
       mockSingleMessage,

--- a/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-drafts-no-association.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-drafts-no-association.cypress.spec.js
@@ -8,7 +8,6 @@ import mockThread from '../fixtures/thread-response.json';
 import PatientMessageDraftsPage from '../pages/PatientMessageDraftsPage';
 
 describe('Verify drafts - No association with particular Triage Group', () => {
-  const site = new SecureMessagingSite();
   const draftPage = new PatientMessageDraftsPage();
   const newDate = new Date().toISOString();
   const updatedData = mockRecipients.data.slice(1);
@@ -19,7 +18,7 @@ describe('Verify drafts - No association with particular Triage Group', () => {
   };
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
 
     PatientInboxPage.loadInboxMessages(
       mockMessages,

--- a/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-old-messages-blocked-from-facility.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-old-messages-blocked-from-facility.cypress.spec.js
@@ -8,14 +8,12 @@ import mockRecipients from '../fixtures/recipients-response.json';
 import mockThread from '../fixtures/thread-response.json';
 
 describe('Verify old messages - blocked from facility', () => {
-  const site = new SecureMessagingSite();
-
   const currentDate = new Date();
   const fortyFiveDaysAgo = new Date();
   fortyFiveDaysAgo.setDate(currentDate.getDate() - 46);
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
 
     PatientInboxPage.loadInboxMessages(
       mockMessages,

--- a/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-old-messages-no-association-at-all.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-old-messages-no-association-at-all.cypress.spec.js
@@ -8,14 +8,12 @@ import mockThread from '../fixtures/thread-response.json';
 import mockNoRecipients from '../fixtures/recipientsResponse/no-recipients-response.json';
 
 describe('Verify old messages - No association with particular Triage Group', () => {
-  const site = new SecureMessagingSite();
-
   const currentDate = new Date();
   const fortyFiveDaysAgo = new Date();
   fortyFiveDaysAgo.setDate(currentDate.getDate() - 46);
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
 
     PatientInboxPage.loadInboxMessages(
       mockMessages,

--- a/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-old-messages-no-association.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-old-messages-no-association.cypress.spec.js
@@ -7,8 +7,6 @@ import mockRecipients from '../fixtures/recipients-response.json';
 import mockThread from '../fixtures/thread-response.json';
 
 describe('Verify old messages - No association with particular Triage Group', () => {
-  const site = new SecureMessagingSite();
-
   const updatedData = mockRecipients.data.slice(1);
   const updatedMeta = { ...mockRecipients.meta, associatedTriageGroups: 6 };
   const removedFirstRecipientsList = {
@@ -20,7 +18,7 @@ describe('Verify old messages - No association with particular Triage Group', ()
   fortyFiveDaysAgo.setDate(currentDate.getDate() - 46);
 
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
 
     PatientInboxPage.loadInboxMessages(
       mockMessages,

--- a/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-thread-blocked-from-facility.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-thread-blocked-from-facility.cypress.spec.js
@@ -7,9 +7,8 @@ import mockFacilityBlockedRecipients from '../fixtures/recipientsResponse/facili
 import blockedThread from '../fixtures/recipientsResponse/thread-with-blocked-group-response.json';
 
 describe('Verify Thread - Blocked from Facility', () => {
-  const site = new SecureMessagingSite();
   it('create message view - verify user can not create a message to any group in blocked facility', () => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(
       mockMessages,
       mockSingleMessage,
@@ -38,7 +37,7 @@ describe('Verify Thread - Blocked from Facility', () => {
   });
 
   it('detailed view', () => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(
       mockMessages,
       mockSingleMessage,

--- a/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-thread-blocked-from-particular-group.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-thread-blocked-from-particular-group.cypress.spec.js
@@ -7,9 +7,8 @@ import mockBlockedRecipients from '../fixtures/recipientsResponse/blocked-recipi
 import blockedThread from '../fixtures/recipientsResponse/thread-with-blocked-group-response.json';
 
 describe('Verify Thread - Blocked from particular Triage Group', () => {
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
     PatientInboxPage.loadInboxMessages(
       mockMessages,
       mockSingleMessage,
@@ -24,13 +23,7 @@ describe('Verify Thread - Blocked from particular Triage Group', () => {
 
     it('verify alert header', () => {
       cy.injectAxe();
-      cy.axeCheck(AXE_CONTEXT, {
-        rules: {
-          'aria-required-children': {
-            enabled: false,
-          },
-        },
-      });
+      cy.axeCheck(AXE_CONTEXT);
 
       cy.get(Locators.ALERTS.EXPANDABLE_TITLE)
         .should('be.visible')
@@ -39,13 +32,7 @@ describe('Verify Thread - Blocked from particular Triage Group', () => {
 
     it('verify alert not expanded', () => {
       cy.injectAxe();
-      cy.axeCheck(AXE_CONTEXT, {
-        rules: {
-          'aria-required-children': {
-            enabled: false,
-          },
-        },
-      });
+      cy.axeCheck(AXE_CONTEXT);
 
       cy.get(Locators.ALERTS.BLOCKED_GROUP)
         .shadow()
@@ -66,13 +53,7 @@ describe('Verify Thread - Blocked from particular Triage Group', () => {
     });
     it('alert expanded', () => {
       cy.injectAxe();
-      cy.axeCheck(AXE_CONTEXT, {
-        rules: {
-          'aria-required-children': {
-            enabled: false,
-          },
-        },
-      });
+      cy.axeCheck(AXE_CONTEXT);
 
       cy.get(Locators.ALERTS.BLOCKED_GROUP)
         .shadow()
@@ -82,13 +63,7 @@ describe('Verify Thread - Blocked from particular Triage Group', () => {
 
     it('verify alert paragraph', () => {
       cy.injectAxe();
-      cy.axeCheck(AXE_CONTEXT, {
-        rules: {
-          'aria-required-children': {
-            enabled: false,
-          },
-        },
-      });
+      cy.axeCheck(AXE_CONTEXT);
       cy.get(Locators.ALERTS.BLOCKED_GROUP)
         .find('p')
         .should('include.text', Alerts.BLOCKED.PARAGRAPH);
@@ -96,13 +71,7 @@ describe('Verify Thread - Blocked from particular Triage Group', () => {
 
     it('verify link text', () => {
       cy.injectAxe();
-      cy.axeCheck(AXE_CONTEXT, {
-        rules: {
-          'aria-required-children': {
-            enabled: false,
-          },
-        },
-      });
+      cy.axeCheck(AXE_CONTEXT);
       cy.get(Locators.ALERTS.BLOCKED_GROUP)
         .find('a')
         .should('include.text', Alerts.BLOCKED.LINK);
@@ -110,13 +79,7 @@ describe('Verify Thread - Blocked from particular Triage Group', () => {
 
     it('verify link', () => {
       cy.injectAxe();
-      cy.axeCheck(AXE_CONTEXT, {
-        rules: {
-          'aria-required-children': {
-            enabled: false,
-          },
-        },
-      });
+      cy.axeCheck(AXE_CONTEXT);
       cy.get(Locators.ALERTS.BLOCKED_GROUP)
         .find('a')
         .should('have.attr', 'href', Paths.FIND_LOCATIONS);
@@ -124,13 +87,7 @@ describe('Verify Thread - Blocked from particular Triage Group', () => {
 
     it('reply btn does not exist', () => {
       cy.injectAxe();
-      cy.axeCheck(AXE_CONTEXT, {
-        rules: {
-          'aria-required-children': {
-            enabled: false,
-          },
-        },
-      });
+      cy.axeCheck(AXE_CONTEXT);
 
       cy.get(Locators.BUTTONS.REPLY).should('not.exist');
     });
@@ -139,13 +96,7 @@ describe('Verify Thread - Blocked from particular Triage Group', () => {
   describe('verify user can not create a message to blocked group', () => {
     it('creating message view', () => {
       cy.injectAxe();
-      cy.axeCheck(AXE_CONTEXT, {
-        rules: {
-          'aria-required-children': {
-            enabled: false,
-          },
-        },
-      });
+      cy.axeCheck(AXE_CONTEXT);
 
       cy.get(Locators.LINKS.CREATE_NEW_MESSAGE).click({
         waitForAnimations: true,

--- a/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-thread-no-association-at-all.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-thread-no-association-at-all.cypress.spec.js
@@ -8,9 +8,8 @@ import mockNoRecipients from '../fixtures/recipientsResponse/no-recipients-respo
 import secureMessagingLandingPage from '../pages/SecureMessagingLandingPage';
 
 describe('Verify thread - No association at all', () => {
-  const site = new SecureMessagingSite();
   beforeEach(() => {
-    site.login();
+    SecureMessagingSite.login();
   });
 
   it('landing page view', () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-thread-no-association.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-thread-no-association.cypress.spec.js
@@ -7,8 +7,6 @@ import mockRecipients from '../fixtures/recipients-response.json';
 import mockThread from '../fixtures/thread-response.json';
 
 describe('Verify thread - No association with particular Triage Group', () => {
-  const site = new SecureMessagingSite();
-
   const updatedData = mockRecipients.data.slice(1);
   const updatedMeta = { ...mockRecipients.meta, associatedTriageGroups: 6 };
   const removedFirstRecipientsList = {
@@ -17,7 +15,7 @@ describe('Verify thread - No association with particular Triage Group', () => {
   };
 
   it('creating message view', () => {
-    site.login();
+    SecureMessagingSite.login();
 
     PatientInboxPage.loadInboxMessages(
       mockMessages,
@@ -59,7 +57,7 @@ describe('Verify thread - No association with particular Triage Group', () => {
         ...mockThread.data,
       ],
     };
-    site.login();
+    SecureMessagingSite.login();
 
     PatientInboxPage.loadInboxMessages(
       mockMessages,

--- a/src/applications/mhv-secure-messaging/tests/e2e/use-case-test/secure-messaging-basic-user-sm-access.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/use-case-test/secure-messaging-basic-user-sm-access.cypress.spec.js
@@ -12,8 +12,7 @@ describe('Secure Messaging Basic User', () => {
       service => service !== 'messaging',
     );
 
-    const site = new SecureMessagingSite();
-    site.login(true, basicUser);
+    SecureMessagingSite.login(true, basicUser);
 
     cy.intercept('GET', Paths.INTERCEPT.FEATURE_TOGGLES, mockFeatureToggles).as(
       'featureToggles',


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- This PR implements new import pattern for SecureMessagingSite page. This updates will reduce code lines quantity and increase readability of tests. Also some E2E tests was refactored and cleaned up.

## Related issue(s)

- https://jira.devops.va.gov/browse/MHV-59361

## Testing done

- All tests have been successfully conducted in headless mode without any failures.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
