### PR TITLE
87214: remove unnecessary request during downtime

### DIFF
--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -92,7 +92,7 @@ class Profile extends Component {
     if (shouldFetchTotalDisabilityRating) {
       fetchTotalDisabilityRating();
     }
-    if (shouldFetchEDUDirectDepositInformation) {
+    if (togglesLoaded && shouldFetchEDUDirectDepositInformation) {
       fetchEDUPaymentInformation();
     }
   }
@@ -316,14 +316,16 @@ const mapStateToProps = state => {
     isEligibleForDD &&
     isLighthouseAvailable &&
     !profileToggles?.profileShowDirectDepositSingleForm;
-  const shouldFetchEDUDirectDepositInformation = isEligibleForDD;
+  const shouldFetchEDUDirectDepositInformation =
+    isEligibleForDD && !profileToggles?.profileShowDirectDepositSingleForm;
   const currentlyLoggedIn = isLoggedIn(state);
   const isLOA1 = isLOA1Selector(state);
   const isLOA3 = isLOA3Selector(state);
   const shouldFetchDirectDeposit =
     isEligibleForDD &&
     isLighthouseAvailable &&
-    profileToggles?.profileShowDirectDepositSingleForm;
+    profileToggles?.profileShowDirectDepositSingleForm &&
+    !profileToggles?.profileHideDirectDeposit;
 
   // block profile access for deceased, fiduciary flagged, and incompetent veterans
   const isBlocked = selectIsBlocked(state);

--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -325,7 +325,10 @@ const mapStateToProps = state => {
     isEligibleForDD &&
     isLighthouseAvailable &&
     profileToggles?.profileShowDirectDepositSingleForm &&
-    !profileToggles?.profileHideDirectDeposit;
+    !(
+      profileToggles?.profileHideDirectDeposit &&
+      !profileToggles?.profileShowDirectDepositSingleFormUAT
+    );
 
   // block profile access for deceased, fiduciary flagged, and incompetent veterans
   const isBlocked = selectIsBlocked(state);


### PR DESCRIPTION
## Summary

- Added conditions to avoid making request to backend during downtime for Direct Deposit, except when `profileShowDirectDepositSingleFormUAT` is turned on
- This change is an improvement, not a bug fix
- Updated the condition to ensure no Direct Deposit request is made when the `profileHideDirectDeposit` toggle is on, and no request to get Ch33 is made when the `profileShowDirectDepositSingleForm` toggle is on
- Authenticated Experience Profile: we maintain this component
- Estimated date to turn off the `profileHideDirectDeposit` flipper is July 10th


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#87214

## Testing done

- Observed that the `ch33_bank_accounts` and `direct_deposit` endpoints were being hit during downtime by checking the dev tool's network tab. After implementing the new logic, verified that these endpoints are no longer being hit during the downtime using the network tab

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | ![before](https://github.com/department-of-veterans-affairs/vets-website/assets/36644181/586dbb8a-04d3-4bd3-88b8-c454b9c0efd8) | ![after](https://github.com/department-of-veterans-affairs/vets-website/assets/36644181/cc5acad2-d0a1-483d-a639-2e1bbe2b610c) |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
