### PR TITLE
MHV-59482 SM signature banner focus

### DIFF
--- a/src/applications/mhv-secure-messaging/components/ComposeForm/RecipientsSelect.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/RecipientsSelect.jsx
@@ -77,16 +77,6 @@ const RecipientsSelect = ({
     [recipientsList, isSignatureRequired],
   );
 
-  const SignatureStatus = props => {
-    return (
-      <p className="sr-only" aria-live="assertive" role="alert">
-        {props.isSignatureRequired
-          ? Prompts.Compose.SIGNATURE_REQUIRED
-          : Prompts.Compose.SIGNATURE_NOT_REQUIRED}
-      </p>
-    );
-  };
-
   return (
     <>
       <VaSelect
@@ -109,32 +99,26 @@ const RecipientsSelect = ({
         ))}
       </VaSelect>
       {alertDisplayed && (
-        <>
-          <SignatureStatus
-            selectedRecipient={selectedRecipient}
-            isSignatureRequired={isSignatureRequired}
-          />
-          <VaAlert
-            aria-live="assertive"
-            role="alert"
-            ref={alertRef}
-            class="vads-u-margin-y--2"
-            closeBtnAriaLabel="Close notification"
-            closeable
-            onCloseEvent={() => {
-              setAlertDisplayed(false);
-            }}
-            status="info"
-            visible
-            data-testid="signature-alert"
-          >
-            <p className="vads-u-margin-y--0">
-              {isSignatureRequired === true
-                ? Prompts.Compose.SIGNATURE_REQUIRED
-                : Prompts.Compose.SIGNATURE_NOT_REQUIRED}
-            </p>
-          </VaAlert>
-        </>
+        <VaAlert
+          role="alert"
+          aria-live="polite"
+          ref={alertRef}
+          class="vads-u-margin-y--2"
+          closeBtnAriaLabel="Close notification"
+          closeable
+          onCloseEvent={() => {
+            setAlertDisplayed(false);
+          }}
+          status="info"
+          visible
+          data-testid="signature-alert"
+        >
+          <p className="vads-u-margin-y--0">
+            {isSignatureRequired === true
+              ? Prompts.Compose.SIGNATURE_REQUIRED
+              : Prompts.Compose.SIGNATURE_NOT_REQUIRED}
+          </p>
+        </VaAlert>
       )}
     </>
   );

--- a/src/applications/mhv-secure-messaging/components/ComposeForm/RecipientsSelect.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/RecipientsSelect.jsx
@@ -31,7 +31,6 @@ import {
   VaSelect,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import PropTypes from 'prop-types';
-import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { sortRecipients } from '../../util/helpers';
 import { Prompts } from '../../util/constants';
 
@@ -62,16 +61,6 @@ const RecipientsSelect = ({
     () => {
       if (selectedRecipient) {
         onValueChange(selectedRecipient);
-        if (
-          selectedRecipient.signatureRequired ||
-          isSignatureRequiredRef.current !== null
-        ) {
-          setTimeout(() => {
-            focusElement(
-              document.querySelector('[data-testid="signature-alert"]'),
-            );
-          }, 500);
-        }
       }
     },
     [selectedRecipient],
@@ -87,6 +76,16 @@ const RecipientsSelect = ({
     },
     [recipientsList, isSignatureRequired],
   );
+
+  const SignatureStatus = props => {
+    return (
+      <p className="sr-only" aria-live="assertive" role="alert">
+        {props.isSignatureRequired
+          ? Prompts.Compose.SIGNATURE_REQUIRED
+          : Prompts.Compose.SIGNATURE_NOT_REQUIRED}
+      </p>
+    );
+  };
 
   return (
     <>
@@ -110,24 +109,32 @@ const RecipientsSelect = ({
         ))}
       </VaSelect>
       {alertDisplayed && (
-        <VaAlert
-          ref={alertRef}
-          class="vads-u-margin-y--2"
-          closeBtnAriaLabel="Close notification"
-          closeable
-          onCloseEvent={() => {
-            setAlertDisplayed(false);
-          }}
-          status="info"
-          visible
-          data-testid="signature-alert"
-        >
-          <p className="vads-u-margin-y--0">
-            {isSignatureRequired === true
-              ? Prompts.Compose.SIGNATURE_REQUIRED
-              : Prompts.Compose.SIGNATURE_NOT_REQUIRED}
-          </p>
-        </VaAlert>
+        <>
+          <SignatureStatus
+            selectedRecipient={selectedRecipient}
+            isSignatureRequired={isSignatureRequired}
+          />
+          <VaAlert
+            aria-live="assertive"
+            role="alert"
+            ref={alertRef}
+            class="vads-u-margin-y--2"
+            closeBtnAriaLabel="Close notification"
+            closeable
+            onCloseEvent={() => {
+              setAlertDisplayed(false);
+            }}
+            status="info"
+            visible
+            data-testid="signature-alert"
+          >
+            <p className="vads-u-margin-y--0">
+              {isSignatureRequired === true
+                ? Prompts.Compose.SIGNATURE_REQUIRED
+                : Prompts.Compose.SIGNATURE_NOT_REQUIRED}
+            </p>
+          </VaAlert>
+        </>
       )}
     </>
   );

--- a/src/platform/mhv/api/mocks/index.js
+++ b/src/platform/mhv/api/mocks/index.js
@@ -102,4 +102,4 @@ const responses = {
   },
 };
 
-module.exports = delay(responses, 200);
+module.exports = delay(responses, 3000);

--- a/src/platform/mhv/api/mocks/index.js
+++ b/src/platform/mhv/api/mocks/index.js
@@ -102,4 +102,4 @@ const responses = {
   },
 };
 
-module.exports = delay(responses, 3000);
+module.exports = delay(responses, 200);

--- a/src/platform/mhv/api/mocks/secure-messaging/allrecipients/index.js
+++ b/src/platform/mhv/api/mocks/secure-messaging/allrecipients/index.js
@@ -5,7 +5,7 @@ const allRecipients = {
       type: 'triage_teams',
       attributes: {
         triageTeamId: 1013155,
-        name: '***MEDICATION_AWARENESS_100% @ MOH_DAYT29',
+        name: 'Triage Team 1',
         stationNumber: '989',
         blockedStatus: false,
         preferredTeam: true,
@@ -17,8 +17,32 @@ const allRecipients = {
       type: 'triage_teams_test',
       attributes: {
         triageTeamId: 2710520,
-        name: 'SM_TO_VA_GOV_TRIAGE_GROUP_TEST _ OLD',
-        stationNumber: '110',
+        name: 'Triage Team 2',
+        stationNumber: '989',
+        blockedStatus: false,
+        preferredTeam: true,
+        relationshipType: 'PATIENT',
+      },
+    },
+    {
+      id: '2710521',
+      type: 'triage_teams_test',
+      attributes: {
+        triageTeamId: 2710521,
+        name: 'DC - Privacy Issues Admin',
+        stationNumber: '989',
+        blockedStatus: false,
+        preferredTeam: true,
+        relationshipType: 'PATIENT',
+      },
+    },
+    {
+      id: '2710522',
+      type: 'triage_teams_test',
+      attributes: {
+        triageTeamId: 2710522,
+        name: 'VA - Record Amendment Admin',
+        stationNumber: '989',
         blockedStatus: false,
         preferredTeam: true,
         relationshipType: 'PATIENT',


### PR DESCRIPTION
## Summary

Signature:  Use aria-live="assertive" to announce the banner

Robert M BaileyRobert M Bailey  [10:35 AM](https://dsva.slack.com/archives/C06HY3C1ZR9/p1719419707339709)
I've been reflecting on the signature flow and focus state.  I've been discussing with others and I've been emphasizing the importance of not moving focus states to non-interactive elements unless absolutely necessary. WCAG says "Visible focus may not move to revealed content that does not contain focusable elements or if the revealed content is not itself focusable." We were setting it to the banner because if it goes to the cancel button, it often doesnt announce the content within the banner. The importance here is for keyboard-only users, changing the focus can be frustrating and due to accidental clicks - it requires them to navigate back up if they want to select a different option.

We need to use aria-live="assertive" to announce the banner instead of shifting the focus state to it. We would need to update the content inside the aria-live region whenever a new option is selected.
 
https://dsva.slack.com/archives/C06HY3C1ZR9/p1719419707339709

## Related issue(s)

- https://jira.devops.va.gov/browse/MHV-59482

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
