### PR TITLE
Bump vets-json-schema to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -332,7 +332,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#dc951ce1f982db10f3df12ae92a418dc07853453"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#b85554087545c8f035a68f7d1cd37f7732ad7613"
   },
   "resolutions": {
     "**/lodash": "4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21246,9 +21246,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#dc951ce1f982db10f3df12ae92a418dc07853453":
-  version "22.3.6"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#dc951ce1f982db10f3df12ae92a418dc07853453"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#b85554087545c8f035a68f7d1cd37f7732ad7613":
+  version "23.0.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#b85554087545c8f035a68f7d1cd37f7732ad7613"
   dependencies:
     minimist "^1.2.3"
 


### PR DESCRIPTION
## Summary

This PR just bumps the `vets-json-schema` library to the latest version.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#80742

## Acceptance criteria

- Lib is up to date with the latest version

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution