### PR TITLE
add PageNotFound tests

### DIFF
--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/FolderLoadPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/FolderLoadPage.js
@@ -6,7 +6,7 @@ import mockRecipients from '../fixtures/recipients-response.json';
 import mockDraftMessages from '../fixtures/draftsResponse/drafts-messages-response.json';
 import mockSentMessages from '../fixtures/sentResponse/sent-messages-response.json';
 import mockTrashMessages from '../fixtures/trashResponse/trash-messages-response.json';
-import { Data, Assertions, Locators, Paths } from '../utils/constants';
+import { Data, Assertions, Locators, Paths, Alerts } from '../utils/constants';
 
 class FolderLoadPage {
   foldersSetup = () => {
@@ -118,6 +118,20 @@ class FolderLoadPage {
         .eq(index)
         .should('contain.text', text);
     });
+  };
+
+  verifyUrlError = () => {
+    cy.visit(`${Paths.UI_MAIN}/dummy`);
+    cy.get('[data-testid="secure-messaging"]')
+      .find('h1')
+      .should('have.text', Alerts.PAGE_NOT_FOUND);
+    cy.get('[data-testid="secure-messaging"]')
+      .find('p')
+      .should('have.text', Alerts.TRY_SEARCH);
+    cy.get('#mobile-query').should('be.visible');
+    cy.get('input[type="submit"]').should('be.visible');
+    cy.get('#common-questions').should('be.visible');
+    cy.get('#popular-on-vagov').should('be.visible');
   };
 }
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-url-errors.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-url-errors.cypress.spec.js
@@ -1,0 +1,29 @@
+import SecureMessagingSite from './sm_site/SecureMessagingSite';
+import FolderLoadPage from './pages/FolderLoadPage';
+import { AXE_CONTEXT, Paths } from './utils/constants';
+
+describe('Verify alert for invalid url', () => {
+  beforeEach(() => {
+    SecureMessagingSite.login();
+  });
+
+  it('Invalid landing page url', () => {
+    FolderLoadPage.verifyUrlError();
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('Invalid Inbox page url', () => {
+    cy.visit(`${Paths.UI_MAIN}/inbox1`);
+    FolderLoadPage.verifyUrlError();
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it('Invalid folders url', () => {
+    cy.visit(`${Paths.UI_MAIN}/folder`);
+    FolderLoadPage.verifyUrlError();
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+});

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -228,6 +228,8 @@ export const Alerts = {
     LINK: 'Find your VA health facility',
   },
   OUTAGE: 'We’re sorry. We couldn’t load this page. Try again later.',
+  PAGE_NOT_FOUND: 'Sorry — we can’t find that page',
+  TRY_SEARCH: 'Try the search box or one of the common questions below.',
 };
 
 export const Data = {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- This PR adds a few tests for invalid url alerts - 'Sorry — we can’t find that page'

## Related issue(s)

- https://jira.devops.va.gov/browse/MHV-59635

## Testing done

- Relevant tests have been executed in headed mode with a 200x pattern.
- All tests have been successfully conducted in headless mode without any failures.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
