### PR TITLE
1737 - solution for rx interception with cirrusMD

### DIFF
--- a/src/applications/virtual-agent/middleware/attachmentMiddleware.js
+++ b/src/applications/virtual-agent/middleware/attachmentMiddleware.js
@@ -7,27 +7,12 @@ export const VhcButtonAttachment = props => (
   </form>
 );
 
-export function extractContent(input) {
-  // Extract the JSON string from the input
-  const jsonString = input
-    .toString()
-    .trim()
-    .split('The input from PVA is: ')[1]
-    .split('. Now exiting the skill')[0];
-
-  // Parse the JSON string to an object
-  const jsonObject = JSON.parse(jsonString);
-
-  // Extract the URL from the object
-  return jsonObject.attachments[0].content;
-}
-
 export const attachmentMiddleware = () => next => card => {
   if (
-    card.attachment.contentType === 'text/markdown' &&
-    card.attachment.content.includes('The input from PVA is:')
+    card.attachment.contentType ===
+    'application/vnd.va_chatbot.card.formPostButton'
   ) {
-    const content = extractContent(card.attachment.content);
+    const { content } = card.attachment;
     return (
       <VhcButtonAttachment
         action={content.action}

--- a/src/applications/virtual-agent/tests/middleware/attachmentMiddleware.unit.spec.js
+++ b/src/applications/virtual-agent/tests/middleware/attachmentMiddleware.unit.spec.js
@@ -1,8 +1,9 @@
 import sinon from 'sinon';
 import { expect } from 'chai';
+import React from 'react';
 import {
   attachmentMiddleware,
-  extractContent,
+  VhcButtonAttachment,
 } from '../../middleware/attachmentMiddleware';
 
 function generateFakeCard(contentType, content) {
@@ -24,6 +25,27 @@ describe('attachmentMiddleware', () => {
   afterEach(() => {
     sandbox.restore();
   });
+
+  it('should render VhcButtonAttachment component for vhc-form-button content type', () => {
+    const card = generateFakeCard(
+      'application/vnd.va_chatbot.card.formPostButton',
+      {
+        action: 'some-action',
+        jwt: 'some-jwt',
+        title: 'Button Title',
+      },
+    );
+    const nextSpy = sinon.spy();
+    const result = attachmentMiddleware()(nextSpy)(card);
+    expect(nextSpy.calledOnce).to.be.false;
+    expect(result).to.deep.equal(
+      <VhcButtonAttachment
+        action={card.attachment.content.action}
+        jwt={card.attachment.content.jwt}
+        title={card.attachment.content.title}
+      />,
+    );
+  });
   it('should call next middleware for other content types', () => {
     const card = generateFakeCard('other-content-type', {
       action: 'some-action',
@@ -34,18 +56,5 @@ describe('attachmentMiddleware', () => {
     const nextSpy = sinon.spy();
     attachmentMiddleware()(nextSpy)(card);
     expect(nextSpy.calledWithExactly(card)).to.be.true;
-  });
-
-  it('should extract the URL from the input', () => {
-    const input =
-      'The input from PVA is: {   "type": "message",   "attachments": [     {       "content": {         "action": "https://app.hermes.cirrusmd.com/va/jwt/auth?plan_uuid=b6a7375d-f442-43f4-b65b-f20086155f3b",         "jwt": "jwt goes here",         "title": "Open VA Health Chat"       },       "contentType": "application/vnd.microsoft.botframework.samples.vhc-form-button"     }   ] }. Now exiting the skill.';
-    const expectedUrl =
-      'https://app.hermes.cirrusmd.com/va/jwt/auth?plan_uuid=b6a7375d-f442-43f4-b65b-f20086155f3b';
-
-    const result = extractContent(input);
-
-    expect(result.action).to.equal(expectedUrl);
-    expect(result.jwt).to.equal('jwt goes here');
-    expect(result.title).to.equal('Open VA Health Chat');
   });
 });


### PR DESCRIPTION
implement proper solution for attachment middleware

## Summary

- change middleware to intercept message from prescriptions skill when content type is application/vnd.va_chatbot.card.formPostButton
- Chatbot Platform
- End date for flipper will be after code is tested in staging

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va-virtual-agent/issues/1737

## Testing done

- Before middleware intercepted messages of type tex markdown, now it will intercept text of type application/vnd.va_chatbot.card.formPostButton
- Updated tests to intercept new message type

## What areas of the site does it impact?

Webchat

### Quality Assurance & Testing

- [ x ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ x ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ x ] Linting warnings have been addressed
