### PR TITLE
Added a startPage prop to navigate to beginning of form

### DIFF
--- a/src/applications/ezr/components/IntroductionPage/SaveInProgressInfo.jsx
+++ b/src/applications/ezr/components/IntroductionPage/SaveInProgressInfo.jsx
@@ -30,6 +30,7 @@ const SaveInProgressInfo = ({ formConfig, pageList }) => {
   // set the props to use for the SaveInProgressIntro components
   const sipProps = {
     startText: content['sip-start-form-text'],
+    startPage: '/veteran-information/personal-information',
     unauthStartText: content['sip-sign-in-to-start-text'],
     messages: savedFormMessages,
     formConfig: { customText },

--- a/src/applications/ezr/components/IntroductionPage/SaveInProgressInfo.jsx
+++ b/src/applications/ezr/components/IntroductionPage/SaveInProgressInfo.jsx
@@ -25,12 +25,13 @@ const SaveInProgressInfo = ({ formConfig, pageList }) => {
     prefillEnabled,
     savedFormMessages,
     customText,
+    chapters,
   } = formConfig;
 
   // set the props to use for the SaveInProgressIntro components
   const sipProps = {
     startText: content['sip-start-form-text'],
-    startPage: '/veteran-information/personal-information',
+    startPage: chapters.veteranInformation.pages.profileInformation.path,
     unauthStartText: content['sip-sign-in-to-start-text'],
     messages: savedFormMessages,
     formConfig: { customText },


### PR DESCRIPTION
## Summary

- Updated the `SaveInProgressInfo` component to correctly set the `startPage` prop to `/veteran-information/personal-information`. This ensures that users are navigated back to the beginning of the form when they resume their progress.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#86919

## Acceptance criteria

- [x] `startPage` prop in `SaveInProgressIntro` is set to `/veteran-information/personal-information`
- [x] Users are correctly navigated to the beginning of the form upon resuming progress