### PR TITLE
VACMS-18419: Change btsss link to va-link-action

### DIFF
--- a/src/applications/static-pages/BTSSS-login/AuthContext/index.jsx
+++ b/src/applications/static-pages/BTSSS-login/AuthContext/index.jsx
@@ -1,24 +1,11 @@
 import React from 'react';
-import recordEvent from 'platform/monitoring/record-event';
-
-const recordActionLinkClick = () => {
-  recordEvent({
-    event: 'cta-action-link-click',
-    'action-link-type': 'primary',
-    'action-link-click-label': 'Go to BTSSS to file a claim',
-    'action-link-icon-color': 'green',
-  });
-};
 
 const AuthContext = () => (
   <>
-    <a
-      className="vads-c-action-link--green"
+    <va-link-action
       href="https://dvagov-btsss.dynamics365portals.us/signin"
-      onClick={recordActionLinkClick}
-    >
-      Go to BTSSS to file a claim
-    </a>
+      text="Go to BTSSS to file a claim"
+    />
   </>
 );
 


### PR DESCRIPTION
## Summary
This PR changes the BTSSS action link to use the new DST va-link-action so that we can catch proper GA. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18419

## Testing done
Tested locally at `/health-care/get-reimbursed-for-travel-pay/`.
Changed code to view as a logged in user to see the auth'd action link.

## Screenshots
<img width="1261" alt="Cursor_and_VA_Travel_Pay_Reimbursement___Veterans_Affairs" src="https://github.com/department-of-veterans-affairs/vets-website/assets/42885441/afc53537-26f5-4211-8a26-733b4421d9db">

<img width="571" alt="VA_Travel_Pay_Reimbursement___Veterans_Affairs" src="https://github.com/department-of-veterans-affairs/vets-website/assets/42885441/b27e6625-40c8-4b14-b7a0-30c6fc6860e7">


## What areas of the site does it impact?
Travel pay action link

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

