### PR TITLE
Updated text on breadcrumbs that show on the Document Request page

### DIFF
--- a/src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx
@@ -127,6 +127,7 @@ class AdditionalEvidencePage extends React.Component {
                   evidenceWaiverSubmitted5103={
                     claim.attributes.evidenceWaiverSubmitted5103
                   }
+                  previousPage="files"
                 />
               ))}
               {this.props.filesOptional.map(item => (

--- a/src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx
@@ -5,7 +5,11 @@ import PropTypes from 'prop-types';
 import { truncateDescription } from '../../utils/helpers';
 import DueDate from '../DueDate';
 
-function FilesNeeded({ item, evidenceWaiverSubmitted5103 = false }) {
+function FilesNeeded({
+  item,
+  evidenceWaiverSubmitted5103 = false,
+  previousPage = null,
+}) {
   // We will not use the truncateDescription() here as these descriptions are custom and specific to what we want
   // the user to see based on the given item type.
   const itemsWithNewDescriptions = [
@@ -59,6 +63,11 @@ function FilesNeeded({ item, evidenceWaiverSubmitted5103 = false }) {
           title={`Details for ${item.displayName}`}
           className="vads-c-action-link--blue"
           to={`../document-request/${item.id}`}
+          onClick={() => {
+            if (previousPage !== null) {
+              sessionStorage.setItem('previousPage', previousPage);
+            }
+          }}
         >
           Details
         </Link>
@@ -70,6 +79,7 @@ function FilesNeeded({ item, evidenceWaiverSubmitted5103 = false }) {
 FilesNeeded.propTypes = {
   item: PropTypes.object.isRequired,
   evidenceWaiverSubmitted5103: PropTypes.bool,
+  previousPage: PropTypes.string,
 };
 
 export default FilesNeeded;

--- a/src/applications/claims-status/components/claim-status-tab/WhatYouNeedToDo.jsx
+++ b/src/applications/claims-status/components/claim-status-tab/WhatYouNeedToDo.jsx
@@ -29,6 +29,7 @@ function WhatYouNeedToDo({ claim }) {
           evidenceWaiverSubmitted5103={
             claim.attributes.evidenceWaiverSubmitted5103
           }
+          previousPage="status"
         />
       ))}
     </>

--- a/src/applications/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/applications/claims-status/containers/DocumentRequestPage.jsx
@@ -31,7 +31,7 @@ import {
 // START lighthouse_migration
 import { benefitsDocumentsUseLighthouse } from '../selectors';
 // END lighthouse_migration
-import { setDocumentTitle } from '../utils/helpers';
+import { setDocumentTitle, getClaimType } from '../utils/helpers';
 import { setPageFocus, setUpPage } from '../utils/page';
 import withRouter from '../utils/withRouter';
 import Automated5103Notice from '../components/claim-document-request-pages/Automated5103Notice';
@@ -43,6 +43,7 @@ const scrollToError = () => {
 const { Element } = Scroll;
 
 const filesPath = '../files';
+const statusPath = '../status';
 
 class DocumentRequestPage extends React.Component {
   componentDidMount() {
@@ -172,12 +173,34 @@ class DocumentRequestPage extends React.Component {
       );
     }
 
+    const { claim } = this.props;
+    const claimType = getClaimType(claim).toLowerCase();
+
+    const previousPageIsFilesTab = () => {
+      const previousPage = sessionStorage.getItem('previousPage');
+      if (previousPage === 'files') {
+        return true;
+      }
+      return false;
+    };
+
+    const filesBreadcrumb = {
+      href: filesPath,
+      label: `Files for your ${claimType}`,
+      isRouterLink: true,
+    };
+    const statusBreadcrumb = {
+      href: statusPath,
+      label: `Status of your ${claimType}`,
+      isRouterLink: true,
+    };
+
+    const previousPageBreadcrumb = previousPageIsFilesTab()
+      ? filesBreadcrumb
+      : statusBreadcrumb;
+
     const crumbs = [
-      {
-        href: filesPath,
-        label: 'Status details',
-        isRouterLink: true,
-      },
+      previousPageBreadcrumb,
       {
         href: `../document-request/${this.props.params.trackedItemId}`,
         label: 'Document request',

--- a/src/applications/claims-status/containers/DocumentRequestPage.jsx
+++ b/src/applications/claims-status/containers/DocumentRequestPage.jsx
@@ -186,12 +186,12 @@ class DocumentRequestPage extends React.Component {
 
     const filesBreadcrumb = {
       href: filesPath,
-      label: `Files for your ${claimType}`,
+      label: `Files for your ${claimType} claim`,
       isRouterLink: true,
     };
     const statusBreadcrumb = {
       href: statusPath,
-      label: `Status of your ${claimType}`,
+      label: `Status of your ${claimType} claim`,
       isRouterLink: true,
     };
 

--- a/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
@@ -106,7 +106,7 @@ describe('<DocumentRequestPage>', () => {
       expect(document.title).to.equal('Document Request | Veterans Affairs');
     });
 
-    it('when component mounts should set document title', async () => {
+    it('when component mounts should scroll to breadcrumbs', async () => {
       const trackedItem = {
         status: 'NEEDED_FROM_YOU',
         displayName: 'Testing',
@@ -133,6 +133,64 @@ describe('<DocumentRequestPage>', () => {
       await waitFor(() => {
         expect(document.activeElement).to.equal($('va-breadcrumbs', container));
       });
+    });
+
+    it('when component mounts without sessionStorage previousPage value should set previous breadcrumb to status', () => {
+      const trackedItem = {
+        status: 'NEEDED_FROM_YOU',
+        displayName: 'Testing',
+      };
+
+      const { container } = renderWithRouter(
+        <Provider store={getStore(false)}>
+          <DocumentRequestPage {...defaultProps} trackedItem={trackedItem} />,
+        </Provider>,
+      );
+      const breadcrumbs = $('va-breadcrumbs', container);
+      expect(breadcrumbs.breadcrumbList[2].href).to.equal('../status');
+      expect(breadcrumbs.breadcrumbList[2].label).to.equal(
+        'Status of your disability compensation',
+      );
+    });
+
+    it('when component mounts with sessionStorage previousPage value of files should set previous breadcrumb', () => {
+      const trackedItem = {
+        status: 'NEEDED_FROM_YOU',
+        displayName: 'Testing',
+      };
+
+      sessionStorage.setItem('previousPage', 'files');
+
+      const { container } = renderWithRouter(
+        <Provider store={getStore(false)}>
+          <DocumentRequestPage {...defaultProps} trackedItem={trackedItem} />,
+        </Provider>,
+      );
+      const breadcrumbs = $('va-breadcrumbs', container);
+      expect(breadcrumbs.breadcrumbList[2].href).to.equal('../files');
+      expect(breadcrumbs.breadcrumbList[2].label).to.equal(
+        'Files for your disability compensation',
+      );
+    });
+
+    it('when component mounts with sessionStorage previousPage value of status should set previous breadcrumb', () => {
+      const trackedItem = {
+        status: 'NEEDED_FROM_YOU',
+        displayName: 'Testing',
+      };
+
+      sessionStorage.setItem('previousPage', 'status');
+
+      const { container } = renderWithRouter(
+        <Provider store={getStore(false)}>
+          <DocumentRequestPage {...defaultProps} trackedItem={trackedItem} />,
+        </Provider>,
+      );
+      const breadcrumbs = $('va-breadcrumbs', container);
+      expect(breadcrumbs.breadcrumbList[2].href).to.equal('../status');
+      expect(breadcrumbs.breadcrumbList[2].label).to.equal(
+        'Status of your disability compensation',
+      );
     });
 
     it('should render loading div', () => {

--- a/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx
@@ -149,7 +149,7 @@ describe('<DocumentRequestPage>', () => {
       const breadcrumbs = $('va-breadcrumbs', container);
       expect(breadcrumbs.breadcrumbList[2].href).to.equal('../status');
       expect(breadcrumbs.breadcrumbList[2].label).to.equal(
-        'Status of your disability compensation',
+        'Status of your disability compensation claim',
       );
     });
 
@@ -169,7 +169,7 @@ describe('<DocumentRequestPage>', () => {
       const breadcrumbs = $('va-breadcrumbs', container);
       expect(breadcrumbs.breadcrumbList[2].href).to.equal('../files');
       expect(breadcrumbs.breadcrumbList[2].label).to.equal(
-        'Files for your disability compensation',
+        'Files for your disability compensation claim',
       );
     });
 
@@ -189,7 +189,7 @@ describe('<DocumentRequestPage>', () => {
       const breadcrumbs = $('va-breadcrumbs', container);
       expect(breadcrumbs.breadcrumbList[2].href).to.equal('../status');
       expect(breadcrumbs.breadcrumbList[2].label).to.equal(
-        'Status of your disability compensation',
+        'Status of your disability compensation claim',
       );
     });
 

--- a/src/applications/claims-status/tests/components/claim-files-tab/FilesNeeded.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab/FilesNeeded.unit.spec.jsx
@@ -1,58 +1,89 @@
 import React from 'react';
 import { expect } from 'chai';
+import { fireEvent } from '@testing-library/dom';
 
 import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import FilesNeeded from '../../../components/claim-files-tab/FilesNeeded';
 import { renderWithRouter } from '../../utils';
 
 const item = {
+  id: 1,
   displayName: 'Request 1',
   description: 'This is a alert',
   suspenseDate: '2024-12-01',
 };
 
+const filesTab = 'files';
+const statusTab = 'status';
+
 describe('<FilesNeeded>', () => {
-  it('should render va-alert with item data and show DueDate', () => {
-    const { getByText } = renderWithRouter(<FilesNeeded item={item} />);
-    getByText('December 1, 2024', { exact: false });
-    getByText(item.displayName);
-    getByText(item.description);
-    getByText('Details');
-  });
-
-  context('when item type is Automated 5103 Notice Response', () => {
-    const item5103 = {
-      displayName: 'Automated 5103 Notice Response',
-      description: 'This is a alert',
-      suspenseDate: '2024-12-01',
-    };
-    context('when evidenceWaiverSubmitted5103 is false', () => {
-      it('should render va-alert with item data and hide DueDate', () => {
-        const { queryByText, getByText } = renderWithRouter(
-          <FilesNeeded item={item5103} />,
-        );
-
-        expect(queryByText('December 1, 2024')).to.not.exist;
-        expect(queryByText(item5103.description)).to.not.exist;
-        getByText(item5103.displayName);
-        getByText(
-          `We sent you a "5103 notice" letter that lists the types of evidence we may need to decide your claim.`,
-        );
-        getByText(
-          `Upload the waiver attached to the letter if you’re finished adding evidence.`,
-        );
-        getByText('Details');
-      });
+  context('when user navigates to page directly', () => {
+    it('should render va-alert with item data and show DueDate', () => {
+      const { getByText } = renderWithRouter(<FilesNeeded item={item} />);
+      getByText('December 1, 2024', { exact: false });
+      getByText(item.displayName);
+      getByText(item.description);
+      getByText('Details');
+      expect(sessionStorage.getItem('previousPage')).to.not.exist;
     });
 
-    context('when evidenceWaiverSubmitted5103 is true', () => {
-      it('should not render va-alert', () => {
-        const { container } = renderWithRouter(
-          <FilesNeeded item={item5103} evidenceWaiverSubmitted5103 />,
-        );
+    context('when item type is Automated 5103 Notice Response', () => {
+      const item5103 = {
+        displayName: 'Automated 5103 Notice Response',
+        description: 'This is a alert',
+        suspenseDate: '2024-12-01',
+      };
+      context('when evidenceWaiverSubmitted5103 is false', () => {
+        it('should render va-alert with item data and hide DueDate', () => {
+          const { queryByText, getByText } = renderWithRouter(
+            <FilesNeeded item={item5103} />,
+          );
 
-        expect($('va-alert', container)).to.not.exist;
+          expect(queryByText('December 1, 2024')).to.not.exist;
+          expect(queryByText(item5103.description)).to.not.exist;
+          getByText(item5103.displayName);
+          getByText(
+            `We sent you a "5103 notice" letter that lists the types of evidence we may need to decide your claim.`,
+          );
+          getByText(
+            `Upload the waiver attached to the letter if you’re finished adding evidence.`,
+          );
+          getByText('Details');
+        });
       });
+
+      context('when evidenceWaiverSubmitted5103 is true', () => {
+        it('should not render va-alert', () => {
+          const { container } = renderWithRouter(
+            <FilesNeeded item={item5103} evidenceWaiverSubmitted5103 />,
+          );
+
+          expect($('va-alert', container)).to.not.exist;
+        });
+      });
+    });
+  });
+  context('when user navigates to page from the files tab', () => {
+    it('clicking details link should set session storage', () => {
+      const { getByRole } = renderWithRouter(
+        <FilesNeeded item={item} previousPage={filesTab} />,
+      );
+
+      fireEvent.click(getByRole('link'));
+
+      expect(sessionStorage.getItem('previousPage')).to.equal(filesTab);
+    });
+  });
+
+  context('when user navigates to page from the status tab', () => {
+    it('clicking details link should set session storage', () => {
+      const { getByRole } = renderWithRouter(
+        <FilesNeeded item={item} previousPage={statusTab} />,
+      );
+
+      fireEvent.click(getByRole('link'));
+
+      expect(sessionStorage.getItem('previousPage')).to.equal(statusTab);
     });
   });
 });

--- a/src/applications/claims-status/tests/e2e/05.claim-document-request.cypress.spec.js
+++ b/src/applications/claims-status/tests/e2e/05.claim-document-request.cypress.spec.js
@@ -5,7 +5,7 @@ import claimDetailsOpen from './fixtures/mocks/lighthouse/claim-detail-open.json
 import claimDetail from './fixtures/mocks/lighthouse/claim-detail.json';
 
 describe('When feature toggle cst_use_claim_details_v2 and cst_5103_update_enabled disabled', () => {
-  context('A user can view primary alert details from the status tab', () => {
+  context('A user can view primary alert details from the files tab', () => {
     context('when alert is a Submit Buddy Statement', () => {
       it('Shows primary alert details', () => {
         const trackClaimsPage = new TrackClaimsPage();
@@ -15,6 +15,7 @@ describe('When feature toggle cst_use_claim_details_v2 and cst_5103_update_enabl
         trackClaimsPage.verifyNumberOfFiles(15);
         trackClaimsPage.verifyPrimaryAlertforSubmitBuddyStatement();
         trackClaimsPage.verifyDocRequestforDefaultPage();
+        trackClaimsPage.verifyDocRequestBreadcrumbs();
         trackClaimsPage.submitFilesForReview();
         cy.axeCheck();
       });
@@ -29,6 +30,7 @@ describe('When feature toggle cst_use_claim_details_v2 and cst_5103_update_enabl
         trackClaimsPage.verifyNumberOfFiles(15);
         trackClaimsPage.verifyPrimaryAlertfor5103Notice();
         trackClaimsPage.verifyDocRequestforDefaultPage(true);
+        trackClaimsPage.verifyDocRequestBreadcrumbs();
         trackClaimsPage.submitFilesForReview();
         cy.axeCheck();
       });
@@ -45,6 +47,7 @@ describe('When feature toggle cst_use_claim_details_v2 enabled and cst_5103_upda
         trackClaimsPage.verifyInProgressClaim(false);
         trackClaimsPage.verifyPrimaryAlertforSubmitBuddyStatement();
         trackClaimsPage.verifyDocRequestforDefaultPage();
+        trackClaimsPage.verifyDocRequestBreadcrumbs();
         trackClaimsPage.submitFilesForReview(false);
         cy.axeCheck();
       });
@@ -57,6 +60,36 @@ describe('When feature toggle cst_use_claim_details_v2 enabled and cst_5103_upda
         trackClaimsPage.verifyInProgressClaim(false);
         trackClaimsPage.verifyPrimaryAlertfor5103Notice();
         trackClaimsPage.verifyDocRequestforDefaultPage(true, true);
+        trackClaimsPage.verifyDocRequestBreadcrumbs();
+        trackClaimsPage.submitFilesForReview(false);
+        cy.axeCheck();
+      });
+    });
+  });
+  context('A user can view primary alert details from the files tab', () => {
+    context('when alert is a Submit Buddy Statement', () => {
+      it('Shows primary alert details', () => {
+        const trackClaimsPage = new TrackClaimsPageV2();
+        trackClaimsPage.loadPage(claimsList, claimDetailsOpen);
+        trackClaimsPage.verifyInProgressClaim(false);
+        trackClaimsPage.navigateToFilesTab();
+        trackClaimsPage.verifyPrimaryAlertforSubmitBuddyStatement();
+        trackClaimsPage.verifyDocRequestforDefaultPage();
+        trackClaimsPage.verifyDocRequestBreadcrumbs(true);
+        trackClaimsPage.submitFilesForReview(false);
+        cy.axeCheck();
+      });
+    });
+
+    context('when alert is a 5103 Notice', () => {
+      it('Shows primary alert details', () => {
+        const trackClaimsPage = new TrackClaimsPageV2();
+        trackClaimsPage.loadPage(claimsList, claimDetailsOpen);
+        trackClaimsPage.verifyInProgressClaim(false);
+        trackClaimsPage.navigateToFilesTab();
+        trackClaimsPage.verifyPrimaryAlertfor5103Notice();
+        trackClaimsPage.verifyDocRequestforDefaultPage(true, true);
+        trackClaimsPage.verifyDocRequestBreadcrumbs(true);
         trackClaimsPage.submitFilesForReview(false);
         cy.axeCheck();
       });
@@ -65,7 +98,7 @@ describe('When feature toggle cst_use_claim_details_v2 enabled and cst_5103_upda
 });
 
 describe('When feature toggle cst_use_claim_details_v2 disabled and cst_5103_update_enabled enabled', () => {
-  context('A user can view primary alert details from the status tab', () => {
+  context('A user can view primary alert details from the files tab', () => {
     context('when alert is a Submit Buddy Statement', () => {
       it('Shows primary alert details', () => {
         const trackClaimsPage = new TrackClaimsPage();
@@ -75,6 +108,7 @@ describe('When feature toggle cst_use_claim_details_v2 disabled and cst_5103_upd
         trackClaimsPage.verifyNumberOfFiles(15);
         trackClaimsPage.verifyPrimaryAlertforSubmitBuddyStatement();
         trackClaimsPage.verifyDocRequestforDefaultPage();
+        trackClaimsPage.verifyDocRequestBreadcrumbs();
         trackClaimsPage.submitFilesForReview();
         cy.axeCheck();
       });
@@ -89,6 +123,7 @@ describe('When feature toggle cst_use_claim_details_v2 disabled and cst_5103_upd
         trackClaimsPage.verifyNumberOfFiles(15);
         trackClaimsPage.verifyPrimaryAlertfor5103Notice();
         trackClaimsPage.verifyDocRequestfor5103Notice();
+        trackClaimsPage.verifyDocRequestBreadcrumbs();
         trackClaimsPage.submitEvidenceWaiver();
         cy.axeCheck();
       });
@@ -112,6 +147,7 @@ describe('When feature toggle cst_use_claim_details_v2 and cst_5103_update_enabl
         trackClaimsPage.verifyInProgressClaim(false);
         trackClaimsPage.verifyPrimaryAlertforSubmitBuddyStatement();
         trackClaimsPage.verifyDocRequestforDefaultPage();
+        trackClaimsPage.verifyDocRequestBreadcrumbs();
         trackClaimsPage.submitFilesForReview(false);
         cy.axeCheck();
       });
@@ -131,6 +167,50 @@ describe('When feature toggle cst_use_claim_details_v2 and cst_5103_update_enabl
         trackClaimsPage.verifyInProgressClaim(false);
         trackClaimsPage.verifyPrimaryAlertfor5103Notice();
         trackClaimsPage.verifyDocRequestfor5103Notice();
+        trackClaimsPage.verifyDocRequestBreadcrumbs();
+        trackClaimsPage.submitEvidenceWaiver();
+        cy.axeCheck();
+      });
+    });
+  });
+  context('A user can view primary alert details from the files tab', () => {
+    context('when alert is a Submit Buddy Statement', () => {
+      it('Shows primary alert details', () => {
+        const trackClaimsPage = new TrackClaimsPageV2();
+        trackClaimsPage.loadPage(
+          claimsList,
+          claimDetailsOpen,
+          false,
+          false,
+          false,
+          true,
+        );
+        trackClaimsPage.verifyInProgressClaim(false);
+        trackClaimsPage.navigateToFilesTab();
+        trackClaimsPage.verifyPrimaryAlertforSubmitBuddyStatement();
+        trackClaimsPage.verifyDocRequestforDefaultPage();
+        trackClaimsPage.verifyDocRequestBreadcrumbs(true);
+        trackClaimsPage.submitFilesForReview(false);
+        cy.axeCheck();
+      });
+    });
+
+    context('when alert is a 5103 Notice', () => {
+      it('Shows primary alert details', () => {
+        const trackClaimsPage = new TrackClaimsPageV2();
+        trackClaimsPage.loadPage(
+          claimsList,
+          claimDetailsOpen,
+          true,
+          false,
+          false,
+          true,
+        );
+        trackClaimsPage.verifyInProgressClaim(false);
+        trackClaimsPage.navigateToFilesTab();
+        trackClaimsPage.verifyPrimaryAlertfor5103Notice();
+        trackClaimsPage.verifyDocRequestfor5103Notice();
+        trackClaimsPage.verifyDocRequestBreadcrumbs(true);
         trackClaimsPage.submitEvidenceWaiver();
         cy.axeCheck();
       });

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js
@@ -324,6 +324,27 @@ class TrackClaimsPage {
     }
   }
 
+  verifyDocRequestBreadcrumbs() {
+    cy.get('va-breadcrumbs').should('be.visible');
+    cy.get('.usa-breadcrumb__list-item').should('have.length', 4);
+    cy.get('.usa-breadcrumb__list > li:nth-child(1) a').should(
+      'contain',
+      'VA.gov home',
+    );
+    cy.get('.usa-breadcrumb__list > li:nth-child(2) a').should(
+      'contain',
+      'Check your claims and appeals',
+    );
+    cy.get('.usa-breadcrumb__list > li:nth-child(3) a').should(
+      'contain',
+      'Status of your compensation claim',
+    );
+    cy.get('.usa-breadcrumb__list > li:nth-child(4) a').should(
+      'contain',
+      'Document request',
+    );
+  }
+
   verifyDocRequestfor5103Notice() {
     cy.get('#automated-5103-notice-page').should('be.visible');
     cy.get('a.active-va-link').should('contain', 'Go to claim letters');

--- a/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
+++ b/src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js
@@ -579,6 +579,35 @@ class TrackClaimsPageV2 {
       .should('contain', 'I’m finished adding evidence to support my claim.');
   }
 
+  verifyDocRequestBreadcrumbs(previousPageFiles = false) {
+    cy.get('va-breadcrumbs').should('be.visible');
+    cy.get('.usa-breadcrumb__list-item').should('have.length', 4);
+    cy.get('.usa-breadcrumb__list > li:nth-child(1) a').should(
+      'contain',
+      'VA.gov home',
+    );
+    cy.get('.usa-breadcrumb__list > li:nth-child(2) a').should(
+      'contain',
+      'Check your claims and appeals',
+    );
+    if (previousPageFiles) {
+      cy.get('.usa-breadcrumb__list > li:nth-child(3) a').should(
+        'contain',
+        'Files for your compensation claim',
+      );
+    } else {
+      cy.get('.usa-breadcrumb__list > li:nth-child(3) a').should(
+        'contain',
+        'Status of your compensation claim',
+      );
+    }
+
+    cy.get('.usa-breadcrumb__list > li:nth-child(4) a').should(
+      'contain',
+      'Document request',
+    );
+  }
+
   submitEvidenceWaiver() {
     cy.get('va-checkbox')
       .shadow()


### PR DESCRIPTION
## Summary

- Updated `src/applications/claims-status/components/claim-files-tab/FilesNeeded.jsx` to have the prop `previousPage` that is defaulted to null. This prop will set the sessionStorage field 'previousPage' and will be what we use to determine what the breadcrumb should be on the Document Requested page
- Updated `src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx` so that it was setting the new prop previousPage to "files"
- Updated `src/applications/claims-status/components/claim-status-tab/WhatYouNeedToDo.jsx` so that it was setting the new prop previousPage to "status"
- Updated `src/applications/claims-status/containers/DocumentRequestPage.jsx` so that the previous breadcrumb is set correctly to either navigate to the status tab or the files tab. Set the name so that it matches what we currently have on the files and status tabs for the breadcrumb `Files for your <Claim Type> claim` OR `Status of your <Claim Type> claim`
- Added unit tests to `src/applications/claims-status/tests/components/claim-files-tab/FilesNeeded.unit.spec.jsx`
- Added unit tests to `src/applications/claims-status/tests/components/DocumentRequestPage.unit.spec.jsx`
- Added cypress tests to`src/applications/claims-status/tests/e2e/05.claim-document-request.cypress.spec.js`, `src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPage.js` and `src/applications/claims-status/tests/e2e/page-objects/TrackClaimsPageV2.js` for the breadcrumbs


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#73022

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Navigating from a primary alert on the Status Tab to a 5103 tracked item on the Document Request Page  |  ![Screenshot 2024-07-02 at 1 38 31 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/c61428ee-ec7e-4233-b2c8-67ee8fa648db)  |  ![Screenshot 2024-07-05 at 1 07 16 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/d3b59845-89e4-431c-b7f7-4f6f4433763f) |
| Navigating from a primary alert on the Files Tab to a 5103 Document Request Page  |   ![Screenshot 2024-07-02 at 1 38 31 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/c61428ee-ec7e-4233-b2c8-67ee8fa648db)  |  ![Screenshot 2024-07-05 at 1 06 40 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/9d61ec7c-8001-4c16-af78-8a16484b4ef2) |
| Navigating from a primary alert on the Status Tab to a default tracked item on the Document Request Page | ![Screenshot 2024-07-05 at 10 48 47 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/2435bf17-6472-4ee2-8b58-6429fc773004)     | ![Screenshot 2024-07-05 at 1 05 37 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/f5fe0ca3-5bb4-4729-9f0b-0eb12edc6da7) |
| Navigating from a primary alert on the Files Tab to a default tracked item on the Document Request Page | ![Screenshot 2024-07-05 at 10 48 47 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/3095df64-bdab-4de7-a1f9-9d62ba317efd) | ![Screenshot 2024-07-05 at 1 05 54 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/370e0708-c93d-49a1-82dd-3eba47d7f341)  |

## What areas of the site does it impact?

Claim Status Tool 

## Acceptance criteria

- [x] Breadcrumb names are intuitive to the user and will allow them to navigate back to pages relevant to the workflows they're following.
- [x] Breadcrumbs follow the logical hierarchy of how the user navigates to the document request page.
- [x] In the scenario where the user goes directly to the request page, the breadcrumb label should be the "status" label as if they came from the status tab.
- [x] When navigating to the document request page from the files tab, the breadcrumb says Files for your <Claim Type> and navigates you back to the Files tab.
- [x] When navigating to the document request page from the status tab, the breadcrumb says Status of your <Claim Type> and navigates you back to the status tab.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
