### PR TITLE
Add prefill data to our redux data for 21-0966 Simple Forms

### DIFF
--- a/src/applications/simple-forms/21-0966/config/helpers.js
+++ b/src/applications/simple-forms/21-0966/config/helpers.js
@@ -187,10 +187,21 @@ export const initializeFormDataWithPreparerIdentificationAndPrefill = (
   preparerIdentification,
   veteranPrefillStore,
 ) => {
+  let prefillData = {};
+  if (veteranPrefillStore) {
+    const { fullName, ssn, address } = veteranPrefillStore;
+    prefillData = {
+      veteranFullName: fullName,
+      veteranId: preparerIdentification === 'VETERAN' ? { ssn } : undefined,
+      veteranMailingAddress:
+        preparerIdentification === 'VETERAN' ? address : undefined,
+    };
+  }
   return {
     ...createInitialState(formConfig).data,
     preparerIdentification,
     'view:veteranPrefillStore': veteranPrefillStore,
+    ...prefillData,
   };
 };
 


### PR DESCRIPTION
## Summary
This PR is a stab at fixing a problem I've noticed on DD where submissions will come through without `first name` (violating the metadata validator). I believe this is only possible with prefill data so this fix will hopefully plug that up and provide the prefill data in our main redux data object.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/87615
