### PR TITLE
#83872: Add alert scenarios on provider list page

### DIFF
--- a/src/applications/vaos/referral-appointments/ChooseCommunityCare.jsx
+++ b/src/applications/vaos/referral-appointments/ChooseCommunityCare.jsx
@@ -3,7 +3,8 @@ import React, { useState, useEffect } from 'react';
 import { hi } from 'date-fns/locale';
 import { useHistory } from 'react-router-dom';
 import FormLayout from '../new-appointment/components/FormLayout';
-import mockData from '../services/mocks/wellHive/providerServices.json';
+import ProviderAlert from './components/ProviderAlert';
+// import mockData from '../services/mocks/wellHive/providerServices.json';
 
 export default function ChooseCommunityCare() {
   const history = useHistory();
@@ -47,28 +48,34 @@ export default function ChooseCommunityCare() {
     { value: 'name', label: 'Name' },
   ]);
 
+  const showAlert = true;
+
   return (
     <FormLayout pageTitle="Choose a community care provider">
       <div>
         <h1>Choose a [community care] provider</h1>
-        <va-card background>
-          <div>Your preferred provider</div>
-          <div className="vads-u-font-weight--bold">
-            {providerDetails.providerName}
-          </div>
-          <div>{providerDetails.providerGroup}</div>
-          <div>{providerDetails.driveDistance}</div>
-          <div>Next available: {providerDetails.nextAvailable}</div>
-          <div>{providerDetails.reviewText}</div>
-          <div className="vads-u-font-weight--bold vads-u-margin-top--2">
-            <va-link
-              aria-label="Review available appointments"
-              text="Review available appointments"
-              data-testid="review-available-appointments-link"
-              tabindex="0"
-            />
-          </div>
-        </va-card>
+        {showAlert ? (
+          <ProviderAlert status="info" />
+        ) : (
+          <va-card background>
+            <div>Your preferred provider</div>
+            <div className="vads-u-font-weight--bold">
+              {providerDetails.providerName}
+            </div>
+            <div>{providerDetails.providerGroup}</div>
+            <div>{providerDetails.driveDistance}</div>
+            <div>Next available: {providerDetails.nextAvailable}</div>
+            <div>{providerDetails.reviewText}</div>
+            <div className="vads-u-font-weight--bold vads-u-margin-top--2">
+              <va-link
+                aria-label="Review available appointments"
+                text="Review available appointments"
+                data-testid="review-available-appointments-link"
+                tabindex="0"
+              />
+            </div>
+          </va-card>
+        )}
         <h3>All providers</h3>
         <va-select
           hint={null}

--- a/src/applications/vaos/referral-appointments/components/ProviderAlert.jsx
+++ b/src/applications/vaos/referral-appointments/components/ProviderAlert.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import InfoAlert from '../../components/InfoAlert';
+
+export const ProviderAlert = ({ status }) => {
+  return (
+    <InfoAlert status={status}>
+      <p className="vads-u-margin-y--0">
+        You are not authorized to schedule with your indicated provider at this
+        time. You can use this tool to schedule with another provider.
+      </p>
+    </InfoAlert>
+  );
+};
+
+ProviderAlert.propTypes = {
+  status: PropTypes.oneOf(['info', 'error', 'success', 'warning', 'continue'])
+    .isRequired,
+};
+
+export default ProviderAlert;

--- a/src/applications/vaos/utils/featureFlags.js
+++ b/src/applications/vaos/utils/featureFlags.js
@@ -26,7 +26,7 @@ module.exports = [
   { name: 'vaOnlineSchedulingStartSchedulingLink', value: true },
   { name: 'vaOnlineSchedulingDatadogRum', value: true },
   { name: 'vaOnlineSchedulingAppointmentDetailsRedesign', value: false },
-  { name: 'vaOnlineSchedulingCCDirectScheduling', value: false },
+  { name: 'vaOnlineSchedulingCCDirectScheduling', value: true },
   { name: 'vaOnlineSchedulingRecentLocationsFilter', value: false },
   { name: 'selectFeaturePocTypeOfCare', value: true },
   { name: 'edu_section_103', value: true },

--- a/src/applications/vaos/utils/featureFlags.js
+++ b/src/applications/vaos/utils/featureFlags.js
@@ -26,7 +26,7 @@ module.exports = [
   { name: 'vaOnlineSchedulingStartSchedulingLink', value: true },
   { name: 'vaOnlineSchedulingDatadogRum', value: true },
   { name: 'vaOnlineSchedulingAppointmentDetailsRedesign', value: false },
-  { name: 'vaOnlineSchedulingCCDirectScheduling', value: true },
+  { name: 'vaOnlineSchedulingCCDirectScheduling', value: false },
   { name: 'vaOnlineSchedulingRecentLocationsFilter', value: false },
   { name: 'selectFeaturePocTypeOfCare', value: true },
   { name: 'edu_section_103', value: true },


### PR DESCRIPTION
Added Provider list Alert
GH ticket: https://app.zenhub.com/workspaces/appointments-cc-direct-scheduling-660abc13699bfa00195d685a/issues/gh/department-of-veterans-affairs/va.gov-team/83872

<img width="323" alt="Screenshot 2024-07-05 at 2 20 35 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/47654119/a8624548-ffee-465d-aeb8-c45281f67177">
<img width="718" alt="Screenshot 2024-07-05 at 2 21 30 PM" src="https://github.com/department-of-veterans-affairs/vets-website/assets/47654119/0c459b47-023f-47b5-aa84-19104527667e">
