### PR TITLE
fixed issue with address validation when the address is UNDELIVERABLE

### DIFF
--- a/src/applications/verify-your-enrollment/components/Buttons.jsx
+++ b/src/applications/verify-your-enrollment/components/Buttons.jsx
@@ -8,8 +8,12 @@ const ButtonsGroup = ({
   secondaryLabel,
 }) => {
   return (
-    <div>
-      <va-button onClick={onPrimaryClick} text={primaryLabel} />
+    <div className="button-container">
+      <va-button
+        onClick={onPrimaryClick}
+        text={primaryLabel}
+        class="vads-u-margin-bottom--1p5"
+      />
       <va-button onClick={onSecondaryClick} secondary text={secondaryLabel} />
     </div>
   );

--- a/src/applications/verify-your-enrollment/constants/index.js
+++ b/src/applications/verify-your-enrollment/constants/index.js
@@ -138,7 +138,10 @@ export const errorAddressAlert = deliveryPointValidation => {
       />
     );
   }
-  if (deliveryPointValidation === 'MISSING_ZIP') {
+  if (
+    deliveryPointValidation === 'MISSING_ZIP' ||
+    deliveryPointValidation === 'UNDELIVERABLE'
+  ) {
     return (
       <Alert
         status="warning"

--- a/src/applications/verify-your-enrollment/helpers.jsx
+++ b/src/applications/verify-your-enrollment/helpers.jsx
@@ -639,7 +639,8 @@ export const noSuggestedAddress = deliveryPointValidation => {
   return (
     deliveryPointValidation === BAD_UNIT_NUMBER ||
     deliveryPointValidation === MISSING_UNIT_NUMBER ||
-    deliveryPointValidation === 'MISSING_ZIP'
+    deliveryPointValidation === 'MISSING_ZIP' ||
+    deliveryPointValidation === 'UNDELIVERABLE'
   );
 };
 

--- a/src/applications/verify-your-enrollment/sass/change-of-address-wrapper.scss
+++ b/src/applications/verify-your-enrollment/sass/change-of-address-wrapper.scss
@@ -25,6 +25,7 @@
     opacity: 0 !important;
     position: absolute !important;
 }
+
 .button-container{
     width: 100%;
     display: flex;


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- _(Summarize the changes that have been made to the platform)_
-fixed issue with address validation when the address is UNDELIVERABL
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)
As:

Frontend developer

I need:

Ensure focus is not lost between actions

So that:

accessibility users always know where they are in the screen.

fix address validation when the deliveryPointValidation is  UNDELIVERABLE 

Considerations:

Launch blocking issue

Acceptance Criteria:

Enter the acceptance criteria that will be used to test the user story.

AC 1: Add focus to each page

AC 2: Use can see 'We can’t confirm the address you entered with the U.S. Postal Service. Confirm that you want us to use this address as you entered it. Or, go back to edit it.' message when the deliveryPointValidation is  UNDELIVERABLE 

New component works properly

Other Considerations:
Staging Review findings on this issue
- _Link to ticket created in va.gov-team repo_ https://jira.devops.va.gov/browse/VYE-437
department-of-veterans-affairs/va.gov-team#0000
- _Link to previous change of the code/bug (if applicable)_
department-of-veterans-affairs/vets-website#0000
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#0000

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots
<img width="364" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/158514667/a8d569ea-8b67-493a-b613-d184f68ab934">
<img width="478" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/158514667/4c42ebbb-5b06-4fba-96ad-714ba9aa8ec6">

<img width="1048" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/158514667/274f802e-5186-408c-a821-6a11c2ae9713">
<img width="1728" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/158514667/51168d70-2ab2-46e9-9953-87c799e1762a">

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
