### PR TITLE
Removes toggle:  mhv_landing_page_enable_va_gov_health_tools_links

### DIFF
--- a/src/applications/mhv-landing-page/components/HeaderLayout.jsx
+++ b/src/applications/mhv-landing-page/components/HeaderLayout.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 import { mhvUrl } from '~/platform/site-wide/mhv/utilities';
 import { datadogRum } from '@datadog/browser-rum';
 import { isAuthenticatedWithSSOe } from '../selectors';
@@ -11,11 +10,6 @@ import WelcomeContainer from '../containers/WelcomeContainer';
 const goBackLinkText = 'Go back to the previous version of My HealtheVet';
 
 const HeaderLayout = ({ showWelcomeMessage = false }) => {
-  const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
-  const showHealthToolsLinks = useToggleValue(
-    TOGGLE_NAMES.mhvLandingPageEnableVaGovHealthToolsLinks,
-  );
-
   const ssoe = useSelector(isAuthenticatedWithSSOe);
   const goBackUrl = mhvUrl(ssoe, 'home');
 
@@ -62,92 +56,79 @@ const HeaderLayout = ({ showWelcomeMessage = false }) => {
                 <h1 className="vads-u-margin-y--0">My HealtheVet</h1>
               </div>
               <div className="vads-l-col-2 vads-u-margin-left--2 vads-u-margin-top--2">
-                {showHealthToolsLinks && (
-                  <span className="usa-label vads-u-background-color--cool-blue">
-                    New
-                  </span>
-                )}
+                <span className="usa-label vads-u-background-color--cool-blue">
+                  New
+                </span>
               </div>
             </div>
           </div>
           <div className="va-introtext">
-            {showHealthToolsLinks ? (
-              <>
-                <p>
-                  Welcome to the new home for My HealtheVet. Now you can manage
-                  your health care needs in the same place where you manage your
-                  other VA benefits and services—right here on VA.gov.
-                </p>
-                <p>
-                  If you’re not ready to try the new My HealtheVet, you can use
-                  the previous version anytime.{' '}
-                  <a
-                    onClick={() =>
-                      datadogRum.addAction(
-                        `Click on Landing Page: Intro - ${goBackLinkText}`,
-                      )
-                    }
-                    data-testid="mhv-go-back-1"
-                    href={goBackUrl}
-                  >
-                    {goBackLinkText}
-                  </a>
-                </p>
+            <p>
+              Welcome to the new home for My HealtheVet. Now you can manage your
+              health care needs in the same place where you manage your other VA
+              benefits and services—right here on VA.gov.
+            </p>
+            <p>
+              If you’re not ready to try the new My HealtheVet, you can use the
+              previous version anytime.{' '}
+              <a
+                onClick={() =>
+                  datadogRum.addAction(
+                    `Click on Landing Page: Intro - ${goBackLinkText}`,
+                  )
+                }
+                data-testid="mhv-go-back-1"
+                href={goBackUrl}
+              >
+                {goBackLinkText}
+              </a>
+            </p>
+            <div>
+              <va-alert-expandable
+                status="info"
+                ref={alertExpandableRef}
+                trigger="Learn more about My HealtheVet on VA.gov "
+              >
                 <div>
-                  <va-alert-expandable
-                    status="info"
-                    ref={alertExpandableRef}
-                    trigger="Learn more about My HealtheVet on VA.gov "
-                  >
-                    <div>
-                      <p>
-                        <strong>What you can do now on VA.gov:</strong>
-                      </p>
-                      <ul className="vads-u-font-family--sans">
-                        <li>
-                          Schedule, cancel, and manage some health appointments
-                        </li>
-                        <li>Send secure messages to your health care team</li>
-                        <li>
-                          Refill your prescriptions and get a list of all your
-                          medications
-                        </li>
-                      </ul>
-                      <p>
-                        <strong>What’s coming soon:</strong>
-                      </p>
-                      <ul className="vads-u-font-family--sans">
-                        <li>Find, print, and download your medical records</li>
-                        <li>Get your lab and test results</li>
-                      </ul>
-                      <p className="vads-u-font-family--sans">
-                        We’re working to bring your medical records to VA.gov.
-                        For now, you can download your records using the
-                        previous version of My HealtheVet.{' '}
-                        <a
-                          onClick={() =>
-                            datadogRum.addAction(
-                              `Click on Landing Page: Learn More - ${goBackLinkText}`,
-                            )
-                          }
-                          data-testid="mhv-go-back-2"
-                          href={goBackUrl}
-                        >
-                          {goBackLinkText}
-                        </a>
-                      </p>
-                    </div>
-                  </va-alert-expandable>
+                  <p>
+                    <strong>What you can do now on VA.gov:</strong>
+                  </p>
+                  <ul className="vads-u-font-family--sans">
+                    <li>
+                      Schedule, cancel, and manage some health appointments
+                    </li>
+                    <li>Send secure messages to your health care team</li>
+                    <li>
+                      Refill your prescriptions and get a list of all your
+                      medications
+                    </li>
+                  </ul>
+                  <p>
+                    <strong>What’s coming soon:</strong>
+                  </p>
+                  <ul className="vads-u-font-family--sans">
+                    <li>Find, print, and download your medical records</li>
+                    <li>Get your lab and test results</li>
+                  </ul>
+                  <p className="vads-u-font-family--sans">
+                    We’re working to bring your medical records to VA.gov. For
+                    now, you can download your records using the previous
+                    version of My HealtheVet.{' '}
+                    <a
+                      onClick={() =>
+                        datadogRum.addAction(
+                          `Click on Landing Page: Learn More - ${goBackLinkText}`,
+                        )
+                      }
+                      data-testid="mhv-go-back-2"
+                      href={goBackUrl}
+                    >
+                      {goBackLinkText}
+                    </a>
+                  </p>
                 </div>
-              </>
-            ) : (
-              <p>
-                <a href="/resources/my-healthevet-on-vagov-what-to-know">
-                  Learn more about My HealtheVet on VA.gov,
-                </a>
-                &nbsp;where you can manage your VA health care and your health.
-              </p>
-            )}
+              </va-alert-expandable>
+            </div>
           </div>
         </div>
         <div

--- a/src/applications/mhv-landing-page/mocks/api/feature-toggles/index.js
+++ b/src/applications/mhv-landing-page/mocks/api/feature-toggles/index.js
@@ -4,7 +4,6 @@ const { snakeCase } = require('lodash');
 const APPLICATION_FEATURE_TOGGLES = Object.freeze({
   mhvLandingPagePersonalization: false,
   mhvSecondaryNavigationEnabled: true,
-  mhvLandingPageEnableVaGovHealthToolsLinks: true,
   mhvTransitionalMedicalRecordsLandingPage: true,
   mhvHelpdeskInformationEnabled: true,
 });

--- a/src/applications/mhv-landing-page/tests/components/HeaderLayout.unit.spec.jsx
+++ b/src/applications/mhv-landing-page/tests/components/HeaderLayout.unit.spec.jsx
@@ -6,16 +6,10 @@ import sinon from 'sinon';
 import { Provider } from 'react-redux';
 import HeaderLayout from '../../components/HeaderLayout';
 
-const mockStore = ({
-  mhvLandingPageEnableVaGovHealthToolsLinks = false,
-  ssoe = false,
-} = {}) => ({
+const mockStore = ({ ssoe = false } = {}) => ({
   getState: () => ({
     featureToggles: {
       loading: false,
-      mhvLandingPageEnableVaGovHealthToolsLinks,
-      // eslint-disable-next-line camelcase
-      mhv_landing_page_enable_va_gov_health_tools_links: mhvLandingPageEnableVaGovHealthToolsLinks,
     },
     user: {
       profile: {
@@ -30,13 +24,10 @@ const mockStore = ({
 });
 
 describe('MHV Landing Page -- Header Layout', () => {
-  describe('Health Tools links -- feature toggle enabled', () => {
-    it('shows the new content when mhvLandingPageEnableVaGovHealthToolsLinks is true', async () => {
-      const store = mockStore({
-        mhvLandingPageEnableVaGovHealthToolsLinks: true,
-      });
+  describe('Health Tools links', () => {
+    it('renders', async () => {
       const { getByText } = render(
-        <Provider store={store}>
+        <Provider store={mockStore()}>
           <HeaderLayout />
         </Provider>,
       );
@@ -47,11 +38,8 @@ describe('MHV Landing Page -- Header Layout', () => {
     });
 
     it('renders the non-ssoe link', async () => {
-      const store = mockStore({
-        mhvLandingPageEnableVaGovHealthToolsLinks: true,
-      });
       const { getByTestId } = render(
-        <Provider store={store}>
+        <Provider store={mockStore()}>
           <HeaderLayout />
         </Provider>,
       );
@@ -72,7 +60,6 @@ describe('MHV Landing Page -- Header Layout', () => {
 
     it('renders the ssoe link', async () => {
       const store = mockStore({
-        mhvLandingPageEnableVaGovHealthToolsLinks: true,
         ssoe: true,
       });
       const { getByTestId } = render(
@@ -98,11 +85,8 @@ describe('MHV Landing Page -- Header Layout', () => {
 
   describe('Go back links', () => {
     it('call datadogRum.addAction on click of go-back links', async () => {
-      const store = mockStore({
-        mhvLandingPageEnableVaGovHealthToolsLinks: true,
-      });
       const { getByTestId } = render(
-        <Provider store={store}>
+        <Provider store={mockStore()}>
           <HeaderLayout />
         </Provider>,
       );
@@ -121,23 +105,6 @@ describe('MHV Landing Page -- Header Layout', () => {
         expect(spyDog.calledTwice).to.be.true;
 
         spyDog.restore();
-      });
-    });
-  });
-
-  describe('Health Tools links -- feature toggle disabled', () => {
-    it('shows the old content when mhvLandingPageEnableVaGovHealthToolsLinks is false', async () => {
-      const store = mockStore({
-        mhvLandingPageEnableVaGovHealthToolsLinks: false,
-      });
-      const { getByText } = render(
-        <Provider store={store}>
-          <HeaderLayout />
-        </Provider>,
-      );
-      await waitFor(() => {
-        const result = getByText(/Learn more about My HealtheVet on VA.gov/);
-        expect(result).to.exist;
       });
     });
   });

--- a/src/applications/mhv-landing-page/utilities/data/index.js
+++ b/src/applications/mhv-landing-page/utilities/data/index.js
@@ -1,6 +1,5 @@
 import { mhvUrl } from '@department-of-veterans-affairs/platform-site-wide/utilities';
 // Links to MHV subdomain need to use `mhvUrl`. Va.gov links can just be paths
-import FEATURE_FLAG_NAMES from '~/platform/utilities/feature-toggles/featureFlagNames';
 import { HEALTH_TOOL_HEADINGS, HEALTH_TOOL_LINKS } from '../../constants';
 import resolveLinks from './resolveLinks';
 
@@ -36,46 +35,13 @@ const resolveLandingPageLinks = (
     [
       {
         ...HEALTH_TOOL_LINKS.MESSAGES[0],
-        oldHref: mhvUrl(authdWithSSOe, 'secure-messaging'),
-        oldText: 'Go to inbox',
-        toggle: FEATURE_FLAG_NAMES.mhvLandingPageEnableVaGovHealthToolsLinks,
         ariaLabel: unreadMessageAriaLabel,
       },
       {
         ...HEALTH_TOOL_LINKS.MESSAGES[1],
-        oldHref: mhvUrl(authdWithSSOe, 'compose-message'),
-        oldText: 'Compose message',
-        toggle: FEATURE_FLAG_NAMES.mhvLandingPageEnableVaGovHealthToolsLinks,
       },
       {
         ...HEALTH_TOOL_LINKS.MESSAGES[2],
-        oldHref: mhvUrl(authdWithSSOe, 'manage-folders'),
-        oldText: 'Manage folders',
-        toggle: FEATURE_FLAG_NAMES.mhvLandingPageEnableVaGovHealthToolsLinks,
-      },
-    ],
-    featureToggles,
-  );
-
-  const medicationsLinks = resolveLinks(
-    [
-      {
-        ...HEALTH_TOOL_LINKS.MEDICATIONS[0],
-        oldHref: mhvUrl(authdWithSSOe, 'prescription_refill'),
-        oldText: 'Refill VA prescriptions',
-        toggle: FEATURE_FLAG_NAMES.mhvLandingPageEnableVaGovHealthToolsLinks,
-      },
-      {
-        href: null,
-        oldHref: mhvUrl(authdWithSSOe, '/prescription-tracking'),
-        oldText: 'Track prescription delivery',
-        toggle: FEATURE_FLAG_NAMES.mhvLandingPageEnableVaGovHealthToolsLinks,
-      },
-      {
-        ...HEALTH_TOOL_LINKS.MEDICATIONS[1],
-        oldHref: mhvUrl(authdWithSSOe, '/my-complete-medications-list'),
-        oldText: 'Medications and allergies',
-        toggle: FEATURE_FLAG_NAMES.mhvLandingPageEnableVaGovHealthToolsLinks,
       },
     ],
     featureToggles,
@@ -206,7 +172,7 @@ const resolveLandingPageLinks = (
     {
       title: HEALTH_TOOL_HEADINGS.MEDICATIONS,
       icon: 'pill',
-      links: medicationsLinks,
+      links: HEALTH_TOOL_LINKS.MEDICATIONS,
     },
     {
       title: HEALTH_TOOL_HEADINGS.MEDICAL_RECORDS,

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -110,7 +110,6 @@
   "medicalCopaysHtmlMedicalStatementsViewEnabled": "medical_copays_html_medical_statements_view_enabled",
   "mhvLandingPagePersonalization": "mhv_landing_page_personalization",
   "mhvSecondaryNavigationEnabled": "mhv_secondary_navigation_enabled",
-  "mhvLandingPageEnableVaGovHealthToolsLinks": "mhv_landing_page_enable_va_gov_health_tools_links",
   "mhvTransitionalMedicalRecordsLandingPage": "mhv_transitional_medical_records_landing_page",
   "mhvHelpdeskInformationEnabled": "mhv_helpdesk_information_enabled",
   "mhvSecureMessagingToVaGovRelease": "mhv_secure_messaging_to_va_gov_release",


### PR DESCRIPTION
## Summary

- Removes toggle:  mhv_landing_page_enable_va_gov_health_tools_links

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#87133

## Testing done

- localhost

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

No UI changes.

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

`/my-health`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
