### PR TITLE
Update appointment facilities + more link to secondary button

### DIFF
--- a/src/applications/vaos/covid-19-vaccine/components/VAFacilityPage/FacilitiesRadioWidget.jsx
+++ b/src/applications/vaos/covid-19-vaccine/components/VAFacilityPage/FacilitiesRadioWidget.jsx
@@ -93,14 +93,16 @@ export default function FacilitiesRadioWidget({
         hiddenCount > 0 && (
           <button
             type="button"
-            className="additional-info-button va-button-link vads-u-display--block"
+            className="additional-info-button usa-button-secondary vads-u-display--block"
             onClick={() => {
               setDisplayAll(!displayAll);
             }}
           >
             <span className="sr-only">show</span>
-            <span className="va-button-link">
-              {`+ ${hiddenCount} more location${hiddenCount === 1 ? '' : 's'}`}
+            <span>
+              {`Show ${hiddenCount} more location${
+                hiddenCount === 1 ? '' : 's'
+              }`}
             </span>
           </button>
         )}

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
@@ -182,14 +182,16 @@ export default function FacilitiesRadioWidget({
         hiddenCount > 0 && (
           <button
             type="button"
-            className="additional-info-button va-button-link vads-u-display--block"
+            className="additional-info-button usa-button-secondary vads-u-display--block"
             onClick={() => {
               setDisplayAll(!displayAll);
             }}
           >
             <span className="sr-only">show</span>
-            <span className="va-button-link">
-              {`+ ${hiddenCount} more location${hiddenCount === 1 ? '' : 's'}`}
+            <span>
+              {`Show ${hiddenCount} more location${
+                hiddenCount === 1 ? '' : 's'
+              }`}
             </span>
           </button>
         )}

--- a/src/applications/vaos/tests/covid-19-vaccine/components/VAFacilityPage/index.unit.spec.js
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/VAFacilityPage/index.unit.spec.js
@@ -121,7 +121,7 @@ describe('VAOS vaccine flow: VAFacilityPage', () => {
       expect(screen.baseElement).not.to.contain.text('Fake facility name 6');
 
       // Find show more button and fire click event
-      const moreLocationsBtn = screen.getByText('+ 1 more location');
+      const moreLocationsBtn = screen.getByText('Show 1 more location');
       expect(moreLocationsBtn).to.have.tagName('span');
       fireEvent.click(moreLocationsBtn);
 

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.js
@@ -762,7 +762,7 @@ describe('VAOS Page: VAFacilityPage', () => {
       expect(screen.baseElement).not.to.contain.text('Fake facility name 6');
 
       // Find show more button and fire click event
-      const moreLocationsBtn = screen.getByText('+ 1 more location');
+      const moreLocationsBtn = screen.getByText('Show 1 more location');
       expect(moreLocationsBtn).to.have.tagName('span');
       fireEvent.click(moreLocationsBtn);
 


### PR DESCRIPTION
## Summary

- This PR changes the "+ more" facilities links in the new appointment request workflows to be secondary buttons as part of feedback from the midpoint review
- This work is done by the Appointments team
- This work will not be hidden behind a flipper toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86803

## Testing done

- Prior to this change, the button is a link style button with the text "+ x more location(s)"
- To verify this change:
  - navigate to `my-health/appointments/`
  - click "Start scheduling"
  - choose a type of care (covid vs non-covid)
  - choose VA
  - verify the appearance and functionality of the button 
- The above tests was verified locally as part of this change. See screenshot below for result.
- Unit test are also updated to verify this change.

## Screenshots

Before:

<img width="744" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2030323/58b5554c-e1fe-4979-baf8-ade2d995f419">

After:

<img width="750" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2030323/930f121e-f26e-48cc-a292-ca3aa6911f63">


## What areas of the site does it impact?

Appointments

## Acceptance criteria

- [ ] Given when the user is on the direct schedule workflow (all type of cares except for COVID-19 appointment) 
       When the user lands on the Facilities page and has more than 5 facilities listed
       Then the secondary button will be displayed `Show X locations`
       And page design matches the [design spec](https://www.figma.com/design/E3tsRYjRAo2sTIY4yWK4RY/Show-%23-more-secondary-button-%7C-Appointments-FE?node-id=2003-14186&t=PGFtqkMezFxltI29-0l)

- [ ] Given when the user is on the direct schedule workflow for COVID-19 appointment 
       When the user lands on the Facilities page and has more than 5 facilities listed
       Then the seconday button will be displayed `Show X locations`
       And page design matches the [design spec](https://www.figma.com/design/E3tsRYjRAo2sTIY4yWK4RY/Show-%23-more-secondary-button-%7C-Appointments-FE?node-id=2003-14186&t=PGFtqkMezFxltI29-0)

- [ ] Given when the user is on the VA request schedule workflow (all type of cares) 
       When the user lands on the Facilities page and has more than 5 facilities listed
       Then the secondary button will be displayed `Show X locations`
       And page design matches the [design spec](https://www.figma.com/design/E3tsRYjRAo2sTIY4yWK4RY/Show-%23-more-secondary-button-%7C-Appointments-FE?node-id=2003-14186&t=PGFtqkMezFxltI29-0)

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user