### PR TITLE
MBMS-69248 Sponsor mailing address, state or territory renders properly

### DIFF
--- a/src/applications/pre-need-integration/components/SponsorRadioWidget.jsx
+++ b/src/applications/pre-need-integration/components/SponsorRadioWidget.jsx
@@ -77,7 +77,6 @@ export default function RadioWidget(props) {
               city: undefined,
               state: undefined,
               postalCode: undefined,
-              country: undefined,
             },
             phoneNumber: undefined,
             email: undefined,


### PR DESCRIPTION
## Summary

- In the Preparer non-Veteran flow and in the non-Veteran flow, the sponsor's mailing address is missing the State or Territory field.

## Related issue(s)

- https://jira.devops.va.gov/browse/MBMS-69248

## Testing done

- [x] POR/UI/UX
- [x] QA
- [x] Unit Tests Pass
- [x] Internal Review
- [x] External Review

## Screenshots

https://github.com/department-of-veterans-affairs/vets-website/assets/122034971/1bcd0eed-f7cc-4c78-8cb0-851bdc5f1ea6

## What areas of the site does it impact?

- Pre-need-integration Sponsor Mailing Address

## Acceptance criteria
![image](https://github.com/department-of-veterans-affairs/vets-website/assets/122034971/771bf18a-190d-42b9-a6e1-ea2d9add952f)

