### PR TITLE
[CST] - added required prop and tests

### DIFF
--- a/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AddFilesForm.jsx
@@ -275,6 +275,7 @@ class AddFilesForm extends React.Component {
         <VaCheckbox
           label="The files I uploaded support this claim only."
           className="vads-u-margin-y--3"
+          required
           checked={this.state.checked}
           error={this.state.errorMessageCheckbox}
           onVaChange={event => {

--- a/src/applications/claims-status/tests/components/claim-files-tab/AddFilesForm.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab/AddFilesForm.unit.spec.jsx
@@ -52,6 +52,7 @@ describe('<AddFilesForm>', () => {
       expect(checkbox.label).to.equal(
         'The files I uploaded support this claim only.',
       );
+      expect(checkbox.required).to.be.true;
       const link = $('#how-to-file-claim', container);
       expect(link.text).to.equal('How to File a Claim');
       expect($('.files-form-information', container)).to.exist;


### PR DESCRIPTION
## Summary

- Update `AddFilesForm.jsx` so that it has the prop `required` for the va-checkbox
- Added a test to `AddfilesForm.unit.spec.jsx` to verify the required prop is true for the va-checkbox

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#80590

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| AddFilesForm component va-checkbox   |  ![Screenshot 2024-07-08 at 3 12 34 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/ff692b9d-0d11-48c6-b015-bdc4c323660c)   |  ![Screenshot 2024-07-08 at 2 53 56 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/d550a368-4058-42fd-b9f0-e587aa67fd5e) |

**Updated Files Tab:**
![Screenshot 2024-07-08 at 3 14 46 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/74862915-09bf-4fc7-9072-3ee206fc9aa1)

**Updated Doc Request Page:**
![Screenshot 2024-07-08 at 3 15 04 PM](https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/72e24689-4152-4bfa-bc2d-3c8badb34a86)


## What areas of the site does it impact?

Claim Status Tool 

## Acceptance criteria

- [x] On the files tab, there is an indicator the "the files I uploaded..." checkbox is a required field that doesn't require the user to submit the file to see it.
- [x] On the document request page, there is an indicator the "the files I uploaded..." checkbox is a required field that doesn't require the user to submit the file to see it.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
