### PR TITLE
Revert "Replace font awesome health care supply"

### DIFF
--- a/src/applications/health-care-supply-reordering/components/Accessories.jsx
+++ b/src/applications/health-care-supply-reordering/components/Accessories.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 
 import classnames from 'classnames';
 import moment from 'moment';
-import { VaCheckbox } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import { setData } from '@department-of-veterans-affairs/platform-forms-system/actions';
 // import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
@@ -130,24 +129,42 @@ class Accessories extends Component {
               </div>
               {currentDate.diff(accessorySupply.nextAvailabilityDate, 'days') <
               0 ? (
-                <va-alert status="warning">
-                  <h3 className="usa-alert-heading vads-u-font-family--sans">
-                    You can't order this accessory online until{' '}
-                    {moment(accessorySupply.nextAvailabilityDate).format(
-                      'MMMM D, YYYY',
-                    )}
-                  </h3>
-                </va-alert>
+                <div className="usa-alert usa-alert-warning vads-u-background-color--white vads-u-padding-x--2p5 vads-u-padding-y--2 vads-u-width--full">
+                  <div className="usa-alert-body">
+                    <h3 className="usa-alert-heading vads-u-font-family--sans">
+                      You can't order this accessory online until{' '}
+                      {moment(accessorySupply.nextAvailabilityDate).format(
+                        'MMMM D, YYYY',
+                      )}
+                    </h3>
+                  </div>
+                </div>
               ) : (
-                <VaCheckbox
-                  id={accessorySupply.productId}
-                  className="vads-u-margin-left--0"
-                  onChange={e =>
-                    this.handleChecked(e.target.checked, accessorySupply)
-                  }
-                  checked={isAccessorySelected(accessorySupply.productId)}
-                  label="Order this hearing aid accessory"
-                />
+                <div>
+                  <input
+                    id={accessorySupply.productId}
+                    className="vads-u-margin-left--0"
+                    type="checkbox"
+                    onChange={e =>
+                      this.handleChecked(e.target.checked, accessorySupply)
+                    }
+                    checked={isAccessorySelected(accessorySupply.productId)}
+                  />
+                  <label
+                    htmlFor={accessorySupply.productId}
+                    className={classnames({
+                      'usa-button vads-u-font-weight--bold vads-u-border--2px vads-u-border-color--primary vads-u-text-align--left vads-u-padding-x--2': true,
+                      'vads-u-color--white': isAccessorySelected(
+                        accessorySupply.productId,
+                      ),
+                      'vads-u-background-color--white vads-u-color--primary': !isAccessorySelected(
+                        accessorySupply.productId,
+                      ),
+                    })}
+                  >
+                    Order this hearing aid accessory
+                  </label>
+                </div>
               )}
             </div>
           ))}

--- a/src/applications/health-care-supply-reordering/components/Batteries.jsx
+++ b/src/applications/health-care-supply-reordering/components/Batteries.jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 
 import classnames from 'classnames';
 import moment from 'moment';
-import { VaCheckbox } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 
 import { setData } from '@department-of-veterans-affairs/platform-forms-system/actions';
 // import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
@@ -148,24 +147,42 @@ class Batteries extends Component {
               </div>
               {currentDate.diff(batterySupply.nextAvailabilityDate, 'days') <
               0 ? (
-                <va-alert status="warning">
-                  <h3 className="usa-alert-heading vads-u-font-family--sans">
-                    You can't reorder batteries for this device until{' '}
-                    {moment(batterySupply.nextAvailabilityDate).format(
-                      'MMMM D, YYYY',
-                    )}
-                  </h3>
-                </va-alert>
+                <div className="usa-alert usa-alert-warning vads-u-background-color--white vads-u-padding-x--2p5 vads-u-padding-y--2 vads-u-width--full">
+                  <div className="usa-alert-body">
+                    <h3 className="usa-alert-heading vads-u-font-family--sans">
+                      You can't reorder batteries for this device until{' '}
+                      {moment(batterySupply.nextAvailabilityDate).format(
+                        'MMMM D, YYYY',
+                      )}
+                    </h3>
+                  </div>
+                </div>
               ) : (
-                <VaCheckbox
-                  id={batterySupply.productId}
-                  className="vads-u-margin-left--0"
-                  onChange={e =>
-                    this.handleChecked(e.target.checked, batterySupply)
-                  }
-                  checked={isBatterySelected(batterySupply.productId)}
-                  label="Order batteries for this device"
-                />
+                <div>
+                  <input
+                    id={batterySupply.productId}
+                    className="vads-u-margin-left--0"
+                    type="checkbox"
+                    onChange={e =>
+                      this.handleChecked(e.target.checked, batterySupply)
+                    }
+                    checked={isBatterySelected(batterySupply.productId)}
+                  />
+                  <label
+                    className={classnames({
+                      'usa-button vads-u-font-weight--bold vads-u-border--2px vads-u-border-color--primary vads-u-text-align--left vads-u-padding-x--2': true,
+                      'vads-u-color--white': isBatterySelected(
+                        batterySupply.productId,
+                      ),
+                      'vads-u-background-color--white vads-u-color--primary': !isBatterySelected(
+                        batterySupply.productId,
+                      ),
+                    })}
+                    htmlFor={batterySupply.productId}
+                  >
+                    Order batteries for this device
+                  </label>
+                </div>
               )}
             </div>
           ))}

--- a/src/applications/health-care-supply-reordering/sass/health-care-supply-reordering.scss
+++ b/src/applications/health-care-supply-reordering/sass/health-care-supply-reordering.scss
@@ -16,6 +16,13 @@
   }
 }
 .battery-page, .accessory-page {
+  [type=checkbox]:checked + label::before {
+    background-color: var(--vads-color-white);
+    color: var(--vads-color-primary);
+    content: "\f00c";
+    font-family: "Font Awesome 5 Free";
+    padding-right: 2px;
+    }
     .usa-alert-warning {
       width: 90%;
       .usa-alert-heading {


### PR DESCRIPTION
This PR appears to have partly broken the app, only Apnea supplies can be selected to order, and they did not get updated to use VaCheckbox. 

References:
- [APM](https://vagov.ddog-gov.com/apm/services/medical-supply-reordering/operations/rack.request/resources?query=env%3Aeks-prod%20operation_name%3Arack.request%20service%3Amedical-supply-reordering&dependencyMap=qson%3A%28data%3A%28telemetrySelection%3Aall_sources%29%2Cversion%3A%210%29&deployments=qson%3A%28data%3A%28hits%3A%28selected%3Aversion_count%29%2Cerrors%3A%28selected%3Aversion_count%29%2Clatency%3A%2195%2CtopN%3A%215%29%2Cversion%3A%210%29&env=eks-prod&errors=qson%3A%28data%3A%28issueSort%3ATOTAL_COUNT%29%2Cversion%3A%210%29&fromUser=true&graphType=flamegraph&groupMapByOperation=null&infrastructure=qson%3A%28data%3A%28viewType%3Apods%29%2Cversion%3A%210%29&logs=qson%3A%28data%3A%28indexes%3A%5B%5D%29%2Cversion%3A%210%29&panels=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&resources=qson%3A%28data%3A%28visible%3A%21t%2Chits%3A%28selected%3Atotal%29%2Cerrors%3A%28selected%3Atotal%29%2Clatency%3A%28selected%3Ap95%29%2CtopN%3A%215%29%2Cversion%3A%211%29&shouldShowLegend=true&sort=time&spanID=3007698248917249931&spanViewType=metadata&summary=qson%3A%28data%3A%28visible%3A%21t%2Cerrors%3A%28selected%3Acount%29%2Chits%3A%28selected%3Acount%29%2Clatency%3A%28selected%3Alatency%2Cslot%3A%28agg%3A95%29%2Cdistribution%3A%28isLogScale%3A%21f%29%2CshowTraceOutliers%3A%21t%29%2Csublayer%3A%28slot%3A%28layers%3Aservice%29%2Cselected%3Apercentage%29%29%2Cversion%3A%211%29&traces=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&view=spans&start=1720018185053&end=1720042952429&paused=true)
- deploy at the time that errors start: https://github.com/department-of-veterans-affairs/vets-website/actions/runs/9782796712/job/27010337972

Reverts department-of-veterans-affairs/vets-website#30677