### PR TITLE
Update appointment providers + more and cancel link to secondary button

### DIFF
--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderList.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderList.jsx
@@ -183,7 +183,7 @@ export default function ProviderList({
               <>
                 <button
                   type="button"
-                  className="additional-info-button va-button-link vads-u-display--block vads-u-margin-right--2"
+                  className="additional-info-button usa-button-secondary vads-u-display--block vads-u-margin-right--2"
                   onClick={() => {
                     setProvidersListLength(
                       providersListLength + initialProviderDisplayCount,
@@ -194,13 +194,19 @@ export default function ProviderList({
                   }}
                 >
                   <span className="sr-only">show</span>
-                  <span className="va-button-link">
-                    +{' '}
+                  <span>
+                    Show{' '}
                     {Math.min(
                       communityCareProviderList.length - providersListLength,
                       initialProviderDisplayCount,
                     )}{' '}
-                    more providers
+                    more provider
+                    {Math.min(
+                      communityCareProviderList.length - providersListLength,
+                      initialProviderDisplayCount,
+                    ) > 1
+                      ? 's'
+                      : ''}
                   </span>
                 </button>
               </>
@@ -208,7 +214,7 @@ export default function ProviderList({
             {communityCareProviderList?.length > 0 && (
               <button
                 type="button"
-                className="vaos-appts__cancel-btn va-button-link vads-u-margin--0 vads-u-flex--0"
+                className="vaos-appts__cancel-btn usa-button-secondary vads-u-margin-right--0 vads-u-flex--0"
                 onClick={() => {
                   setProvidersListLength(initialProviderDisplayCount);
                   setShowProvidersList(false);

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderList.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderList.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { shallowEqual, useSelector } from 'react-redux';
 
 import recordEvent from '@department-of-veterans-affairs/platform-monitoring/record-event';
@@ -230,3 +231,14 @@ export default function ProviderList({
     </div>
   );
 }
+ProviderList.propTypes = {
+  checkedProvider: PropTypes.any,
+  idSchema: PropTypes.object,
+  initialProviderDisplayCount: PropTypes.number,
+  providersListLength: PropTypes.number,
+  setCheckedProvider: PropTypes.func,
+  setProvidersListLength: PropTypes.func,
+  setShowProvidersList: PropTypes.func,
+  showProvidersList: PropTypes.bool,
+  onChange: PropTypes.func,
+};

--- a/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderList.jsx
+++ b/src/applications/vaos/new-appointment/components/CommunityCareProviderSelectionPage/ProviderList.jsx
@@ -215,7 +215,7 @@ export default function ProviderList({
             {communityCareProviderList?.length > 0 && (
               <button
                 type="button"
-                className="vaos-appts__cancel-btn usa-button-secondary vads-u-margin-right--0 vads-u-flex--0"
+                className="vaos-appts__cancel-btn usa-button-secondary"
                 onClick={() => {
                   setProvidersListLength(initialProviderDisplayCount);
                   setShowProvidersList(false);

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSortVariant.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/ProviderSortVariant.unit.spec.js
@@ -220,9 +220,9 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       detail: { value: FACILITY_SORT_METHODS.distanceFromCurrentLocation },
     });
 
-    userEvent.click(await screen.findByText(/more providers$/i));
-    userEvent.click(await screen.findByText(/more providers$/i));
-    userEvent.click(await screen.findByText(/more providers$/i));
+    userEvent.click(await screen.findByText(/Show 5 more providers$/i));
+    userEvent.click(await screen.findByText(/Show 5 more providers$/i));
+    userEvent.click(await screen.findByText(/Show 1 more provider$/i));
 
     // Then providers should be displayed in ascending order by distance from current location
     const miles = screen.queryAllByText(/miles$/);
@@ -377,9 +377,9 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       detail: { value: '983' },
     });
 
-    userEvent.click(await screen.findByText(/more providers$/i));
-    userEvent.click(await screen.findByText(/more providers$/i));
-    userEvent.click(await screen.findByText(/more providers$/i));
+    userEvent.click(await screen.findByText(/Show 5 more providers$/i));
+    userEvent.click(await screen.findByText(/Show 5 more providers$/i));
+    userEvent.click(await screen.findByText(/Show 1 more provider$/i));
 
     const miles = screen.queryAllByText(/miles$/);
     // Then providers should be displayed in ascending order by distance from the chosen facility

--- a/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/components/CommunityCareProviderSelectionPage/index.unit.spec.js
@@ -174,7 +174,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     expect(await screen.findByText(/Displaying 5 of 16 providers/i)).to.be.ok;
     expect(screen.getAllByRole('radio').length).to.equal(5);
 
-    userEvent.click(await screen.findByText(/\+ 5 more providers/i));
+    userEvent.click(await screen.findByText(/Show 5 more providers/i));
     expect((await screen.findAllByRole('radio')).length).to.equal(10);
     await waitFor(() => {
       expect(document.activeElement.id).to.equal(
@@ -182,7 +182,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       );
     });
 
-    userEvent.click(await screen.findByText(/\+ 5 more providers/i));
+    userEvent.click(await screen.findByText(/Show 5 more providers/i));
     expect(await screen.findByText(/displaying 15 of 16 providers/i)).to.exist;
     expect((await screen.findAllByRole('radio')).length).to.equal(15);
     await waitFor(() => {
@@ -191,7 +191,7 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
       );
     });
 
-    userEvent.click(await screen.findByText(/\+ 1 more providers/i));
+    userEvent.click(await screen.findByText(/Show 1 more provider/i));
     expect(await screen.findByText(/displaying 16 of 16 providers/i)).to.exist;
     expect((await screen.findAllByRole('radio')).length).to.equal(16);
     await waitFor(() => {
@@ -499,9 +499,9 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     userEvent.click(
       await screen.findByRole('button', { name: /Find a provider/i }),
     );
-    userEvent.click(await screen.findByText(/more providers$/i));
-    userEvent.click(await screen.findByText(/more providers$/i));
-    userEvent.click(await screen.findByText(/more providers$/i));
+    userEvent.click(await screen.findByText(/Show 5 more providers$/i));
+    userEvent.click(await screen.findByText(/Show 5 more providers$/i));
+    userEvent.click(await screen.findByText(/Show 1 more provider$/i));
 
     const miles = screen.queryAllByText(/miles$/);
 
@@ -557,9 +557,9 @@ describe('VAOS Page: CommunityCareProviderSelectionPage', () => {
     const currentLocButton = await screen.findByText(/your current location$/i);
     await screen.findByText(/Displaying 5 of /i);
     userEvent.click(currentLocButton);
-    userEvent.click(await screen.findByText(/more providers$/i));
-    userEvent.click(await screen.findByText(/more providers$/i));
-    userEvent.click(await screen.findByText(/more providers$/i));
+    userEvent.click(await screen.findByText(/Show 5 more providers$/i));
+    userEvent.click(await screen.findByText(/Show 5 more providers$/i));
+    userEvent.click(await screen.findByText(/Show 1 more provider$/i));
 
     const miles = screen.queryAllByText(/miles$/);
 


### PR DESCRIPTION
## Summary

- This PR changes the "+ x more providers" and "Cancel" links in the new CC appointment request workflows to be secondary buttons as part of feedback from the midpoint review
- This work is done by the Appointments team
- This work will not be hidden behind a flipper toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87014

## Testing done

- Prior to this change, the buttons are link style buttons with the text "+ x more providers" and "Cancel"
- To verify this change:
  - navigate to `my-health/appointments/`
  - click "Start scheduling"
  - choose a type of care
  - choose CC
  - choose time
  - choose Cheyenne
  - choose + Find a provider
  - verify the appearance and functionality of the button 
- The above tests was verified locally as part of this change. See screenshot below for result.
- Unit test are also updated to verify this change.

## Screenshots

Before:

<img width="1407" alt="before" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2030323/2d846162-d583-4e52-8d4a-c58f451001b6">

After:

<img width="804" alt="multipleProviders" src="https://github.com/department-of-veterans-affairs/vets-website/assets/2030323/41c57918-baba-4d52-8970-d7061d892557">

## What areas of the site does it impact?

Appointments

## Acceptance criteria

- [ ] Given when the user is on the CC request schedule workflow
       When the user lands on the Provider page and has more than _(5) providers listed_
       Then the secondary buttons will be displayed  for `+more` and `Cancel`
       And page design matches the [design spec](url)

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user