### PR TITLE
MHV-59535 adjusted error focus to be on first interactive form field

### DIFF
--- a/src/applications/mhv-secure-messaging/components/MessageActionButtons/MoveMessageToFolderBtn.jsx
+++ b/src/applications/mhv-secure-messaging/components/MessageActionButtons/MoveMessageToFolderBtn.jsx
@@ -40,6 +40,15 @@ const MoveMessageToFolderBtn = props => {
     [dispatch],
   );
 
+  useEffect(
+    () => {
+      if (folderInputError) {
+        focusOnErrorField();
+      }
+    },
+    [folderInputError],
+  );
+
   const openModal = () => {
     setIsMoveModalVisible(true);
   };
@@ -63,7 +72,6 @@ const MoveMessageToFolderBtn = props => {
       setFolderInputError(
         Constants.ErrorMessages.MoveConversation.FOLDER_REQUIRED,
       );
-      focusOnErrorField();
     } else {
       if (selectedFolder === 'newFolder') {
         closeModal();

--- a/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-compose-error-message-keyboard-nav.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/keyboard-nav-test/secure-messaging-compose-error-message-keyboard-nav.cypress.spec.js
@@ -4,9 +4,6 @@ import PatientComposePage from '../pages/PatientComposePage';
 import FolderLoadPage from '../pages/FolderLoadPage';
 import { AXE_CONTEXT, Data } from '../utils/constants';
 
-// TODO error focus assertions should be refactored later
-// Focus states go to interactive form fields (Select, text input, textarea, checkboxes, and radio buttons.)
-
 describe('Secure Messaging Compose Errors Keyboard Nav', () => {
   beforeEach(() => {
     SecureMessagingSite.login();
@@ -21,9 +18,12 @@ describe('Secure Messaging Compose Errors Keyboard Nav', () => {
       force: true,
     });
     PatientComposePage.pushSendMessageWithKeyboardPress();
-    PatientComposePage.verifyFocusOnErrorMessage(Data.PLEASE_SELECT_RECIPIENT);
+    PatientComposePage.verifyErrorText(Data.PLEASE_SELECT_RECIPIENT);
+    PatientComposePage.verifyFocusOnErrorMessage();
+
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
+
     PatientComposePage.selectRecipient('CAMRY_PCMM RELATIONSHIP_05092022_SLC4');
     FolderLoadPage.backToInbox();
     PatientComposePage.clickOnDeleteDraftButton();
@@ -32,9 +32,12 @@ describe('Secure Messaging Compose Errors Keyboard Nav', () => {
   it('focus on error message for empty category', () => {
     PatientComposePage.selectRecipient('CAMRY_PCMM RELATIONSHIP_05092022_SLC4');
     PatientComposePage.pushSendMessageWithKeyboardPress();
-    PatientComposePage.verifyFocusOnErrorMessage(Data.PLEASE_SELECT_CATEGORY);
+    PatientComposePage.verifyErrorText(Data.PLEASE_SELECT_CATEGORY);
+    PatientComposePage.verifyFocusOnErrorMessage();
+
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
+
     PatientComposePage.selectCategory();
     FolderLoadPage.backToInbox();
     PatientComposePage.clickOnDeleteDraftButton();
@@ -44,9 +47,12 @@ describe('Secure Messaging Compose Errors Keyboard Nav', () => {
     PatientComposePage.selectRecipient('CAMRY_PCMM RELATIONSHIP_05092022_SLC4');
     PatientComposePage.selectCategory();
     PatientComposePage.pushSendMessageWithKeyboardPress();
-    PatientComposePage.verifyFocusOnErrorMessage(Data.SUBJECT_CANNOT_BLANK);
+    PatientComposePage.verifyErrorText(Data.SUBJECT_CANNOT_BLANK);
+    PatientComposePage.verifyFocusOnErrorMessage();
+
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
+
     PatientComposePage.getMessageSubjectField().type(
       Data.TEST_MESSAGE_SUBJECT,
       { force: true },
@@ -55,16 +61,19 @@ describe('Secure Messaging Compose Errors Keyboard Nav', () => {
     PatientComposePage.clickOnDeleteDraftButton();
   });
 
-  it.skip('focus on error message for empty message body', () => {
+  it('focus on error message for empty message body', () => {
     PatientComposePage.selectRecipient('CAMRY_PCMM RELATIONSHIP_05092022_SLC4');
     PatientComposePage.selectCategory();
     PatientComposePage.getMessageSubjectField().type(Data.TEST_SUBJECT, {
       force: true,
     });
     PatientComposePage.pushSendMessageWithKeyboardPress();
-    PatientComposePage.verifyFocusOnErrorMessage(Data.BODY_CANNOT_BLANK);
+    PatientComposePage.verifyErrorText(Data.BODY_CANNOT_BLANK);
+    PatientComposePage.verifyFocusOnErrorMessage();
+
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
+
     PatientComposePage.getMessageBodyField().type(Data.TEST_MESSAGE_BODY);
     FolderLoadPage.backToInbox();
     PatientComposePage.clickOnDeleteDraftButton();

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientComposePage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientComposePage.js
@@ -115,8 +115,16 @@ class PatientComposePage {
       .should('have.focus');
   };
 
-  verifyFocusOnErrorMessage = text => {
-    return cy.focused().should('contain.text', text);
+  verifyErrorText = text => {
+    cy.get('.usa-error-message').should('contain.text', text);
+  };
+
+  verifyFocusOnErrorMessage = () => {
+    const allowedTags = ['INPUT', 'TEXTAREA', 'SELECT'];
+    return cy.focused().then(el => {
+      const tagName = el.prop('tagName');
+      expect(tagName).to.be.oneOf(allowedTags);
+    });
   };
 
   clickOnSendMessageButton = (mockResponse = mockDraftMessage) => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-errors.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-compose-errors.cypress.spec.js
@@ -3,9 +3,6 @@ import PatientInboxPage from './pages/PatientInboxPage';
 import PatientComposePage from './pages/PatientComposePage';
 import { AXE_CONTEXT, Data } from './utils/constants';
 
-// TODO error focus assertions should be refactored later
-// Focus states go to interactive form fields (Select, text input, textarea, checkboxes, and radio buttons.)
-
 describe('Secure Messaging Compose Errors', () => {
   SecureMessagingSite;
   beforeEach(() => {
@@ -20,18 +17,26 @@ describe('Secure Messaging Compose Errors', () => {
     PatientComposePage.getMessageBodyField().type(Data.TEST_MESSAGE_BODY, {
       force: true,
     });
+
     PatientComposePage.clickSendMessageButton();
+    PatientComposePage.verifyErrorText(Data.PLEASE_SELECT_RECIPIENT);
+    PatientComposePage.verifyFocusOnErrorMessage();
+
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
-    PatientComposePage.verifyFocusOnErrorMessage(Data.PLEASE_SELECT_RECIPIENT);
   });
 
   it('focus on error message for empty category', () => {
     PatientComposePage.selectRecipient('CAMRY_PCMM RELATIONSHIP_05092022_SLC4');
     PatientComposePage.getMessageSubjectField().type(Data.TEST_SUBJECT);
-    PatientComposePage.getMessageBodyField();
+    PatientComposePage.getMessageBodyField().type(Data.TEST_MESSAGE_BODY, {
+      force: true,
+    });
+
     PatientComposePage.clickSendMessageButton();
-    PatientComposePage.verifyFocusOnErrorMessage(Data.PLEASE_SELECT_CATEGORY);
+    PatientComposePage.verifyErrorText(Data.PLEASE_SELECT_CATEGORY);
+    PatientComposePage.verifyFocusOnErrorMessage();
+
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });
@@ -42,22 +47,26 @@ describe('Secure Messaging Compose Errors', () => {
     PatientComposePage.getMessageBodyField().type(Data.TEST_MESSAGE_BODY, {
       force: true,
     });
+
     PatientComposePage.clickSendMessageButton();
-    PatientComposePage.verifyFocusOnErrorMessage(Data.SUBJECT_CANNOT_BLANK);
+    PatientComposePage.verifyErrorText(Data.SUBJECT_CANNOT_BLANK);
+    PatientComposePage.verifyFocusOnErrorMessage();
+
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });
 
-  it.skip('focus on error message for empty message body', () => {
+  it('focus on error message for empty message body', () => {
     PatientComposePage.selectRecipient('CAMRY_PCMM RELATIONSHIP_05092022_SLC4');
     PatientComposePage.selectCategory();
     PatientComposePage.getMessageSubjectField().type(Data.TEST_SUBJECT, {
       force: true,
     });
+
     PatientComposePage.clickSendMessageButton();
-    PatientComposePage.verifyFocusOnErrorMessage(
-      'Message body cannot be blank.',
-    );
+    PatientComposePage.verifyErrorText(Data.BODY_CANNOT_BLANK);
+    PatientComposePage.verifyFocusOnErrorMessage();
+
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-save-draft-errors.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-save-draft-errors.cypress.spec.js
@@ -3,9 +3,6 @@ import PatientInboxPage from './pages/PatientInboxPage';
 import PatientComposePage from './pages/PatientComposePage';
 import { AXE_CONTEXT, Data } from './utils/constants';
 
-// TODO error focus assertions should be refactored later
-// Focus states go to interactive form fields (Select, text input, textarea, checkboxes, and radio buttons.)
-
 describe('Secure Messaging Compose Errors', () => {
   beforeEach(() => {
     SecureMessagingSite.login();
@@ -20,9 +17,12 @@ describe('Secure Messaging Compose Errors', () => {
       force: true,
     });
     PatientComposePage.clickSaveDraftButton();
+
+    PatientComposePage.verifyErrorText(Data.PLEASE_SELECT_RECIPIENT);
+    PatientComposePage.verifyFocusOnErrorMessage();
+
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
-    PatientComposePage.verifyFocusOnErrorMessage(Data.PLEASE_SELECT_RECIPIENT);
   });
 
   it('focus on error message for empty category', () => {
@@ -30,7 +30,10 @@ describe('Secure Messaging Compose Errors', () => {
     PatientComposePage.getMessageSubjectField().type(Data.TEST_SUBJECT);
     PatientComposePage.getMessageBodyField();
     PatientComposePage.clickSaveDraftButton();
-    PatientComposePage.verifyFocusOnErrorMessage(Data.PLEASE_SELECT_CATEGORY);
+
+    PatientComposePage.verifyErrorText(Data.PLEASE_SELECT_CATEGORY);
+    PatientComposePage.verifyFocusOnErrorMessage();
+
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });
@@ -42,21 +45,24 @@ describe('Secure Messaging Compose Errors', () => {
       force: true,
     });
     PatientComposePage.clickSaveDraftButton();
-    PatientComposePage.verifyFocusOnErrorMessage(Data.SUBJECT_CANNOT_BLANK);
+
+    PatientComposePage.verifyErrorText(Data.SUBJECT_CANNOT_BLANK);
+    PatientComposePage.verifyFocusOnErrorMessage();
+
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });
 
-  it.skip('focus on error message for empty message body', () => {
+  it('focus on error message for empty message body', () => {
     PatientComposePage.selectRecipient('CAMRY_PCMM RELATIONSHIP_05092022_SLC4');
     PatientComposePage.selectCategory();
     PatientComposePage.getMessageSubjectField().type(Data.TEST_SUBJECT, {
       force: true,
     });
     PatientComposePage.clickSaveDraftButton();
-    PatientComposePage.verifyFocusOnErrorMessage(
-      'Message body cannot be blank.',
-    );
+
+    PatientComposePage.verifyErrorText(Data.BODY_CANNOT_BLANK);
+    PatientComposePage.verifyFocusOnErrorMessage();
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);
   });

--- a/src/applications/mhv-secure-messaging/util/formHelpers.js
+++ b/src/applications/mhv-secure-messaging/util/formHelpers.js
@@ -4,9 +4,8 @@ export const focusOnErrorField = () => {
   const errors = document.querySelectorAll('[error]:not([error=""])');
   const firstError =
     errors.length > 0 &&
-    errors[0]?.shadowRoot?.querySelector(
-      '[aria-describedby="error-message"], #error-message, #input-error-message, .usa-error-message',
-    );
+    (errors[0]?.shadowRoot?.querySelector('select, input, textarea') ||
+      errors[0].querySelector('input'));
   if (firstError) {
     focusElement(firstError);
   }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Summary

- When a form is saved or sent, but contains errors, the error focus moves to the interactive field of the component that has an error (previously, the error label received focus)

## Related issue(s)

### [MHV-59535](https://jira.devops.va.gov/browse/MHV-59535) - When sending a message with an error the focus should go to the interactive form fields ###

> When sending a message with an error the  focus should go to the interactive form fields
> 
> User flow:
> 
> Given:  User fills out a form with an error
> When:  User hits submit
> Then:  User focus state goes to first error in question (field, interactive element - not the label) 
> 
> See slack discussion:
> 
> https://dsva.slack.com/archives/C03T8JY2DM2/p1719428995156689
> 
> User Story: As a Secure Messaging user, I want the focus to be on the interactive form fields when I send a message and receive an error.
> 
> Feature Flag Y/N ? N
> Manual Testing Y/N ? Y
> Automated Testing Y/N ? Y-Fazil
> Accessibility Testing Y/N Y
> UCD Validation Y/N 
> 
> Acceptance Criteria:
> AC1 Focus should go to the interactive form fields when user send a message with an error.

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Compose - Recipient Select |        |![Screenshot 2024-07-09 at 11 18 10 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/79024398/21e6d6ce-81e6-4b49-b8d6-5eed8e36c21a)|
| Compose - Category Select |        |![Screenshot 2024-07-09 at 11 18 24 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/79024398/219c6b25-825c-4274-911b-b50f85046d60)|
| Compose - Subject |        |![Screenshot 2024-07-09 at 11 18 39 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/79024398/96e7dee0-86ae-4172-b59e-f874a7f15cb7)|
| Compose - Message |        |![Screenshot 2024-07-09 at 11 18 57 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/79024398/12f7728c-9b0a-4d96-9808-f321f76e8a01)|
| Reply Draft - Message |        |![Screenshot 2024-07-09 at 11 19 44 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/79024398/17b83383-a59f-452d-b8ab-63354837b02a)|
| Move Folder - Folder Select |        |![Screenshot 2024-07-09 at 9 29 47 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/79024398/04203b81-3a28-469f-8ac8-30943a5ed089)|

## What areas of the site does it impact?

Va.gov - Secure Messaging

## Acceptance criteria

- AC1 Focus should go to the interactive form fields when user send a message with an error.
- 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
