### PR TITLE
Supply the data with the right keys for 21-0966 submit transformer

### DIFF
--- a/src/applications/simple-forms/21-0966/config/submit-transformer.js
+++ b/src/applications/simple-forms/21-0966/config/submit-transformer.js
@@ -5,9 +5,41 @@ import {
 } from '../definitions/constants';
 
 export default function transformForSubmit(formConfig, form) {
-  const transformedData = JSON.parse(
+  const sharedTransformedData = JSON.parse(
     sharedTransformForSubmit(formConfig, form),
   );
+
+  // We need to transform the data this way because the prefill keys don't have the 'veteran'
+  // prefix. The backend expects 'veteranFullName' and not 'fullName', for example.
+  const transformedData = {
+    ...sharedTransformedData,
+    veteranFullName:
+      sharedTransformedData.veteranFullName || sharedTransformedData.fullName,
+    veteranDateOfBirth:
+      sharedTransformedData.veteranDateOfBirth ||
+      sharedTransformedData.dateOfBirth,
+    veteranId: {
+      ssn: sharedTransformedData.veteranId.ssn || sharedTransformedData.ssn,
+      vaFileNumber: sharedTransformedData.veteranId.vaFileNumber,
+    },
+    veteranMailingAddress:
+      sharedTransformedData.veteranMailingAddress ||
+      sharedTransformedData.address,
+    veteranPhone:
+      sharedTransformedData.veteranPhone ||
+      (sharedTransformedData.homePhone || sharedTransformedData.mobilePhone),
+    veteranEmail:
+      sharedTransformedData.veteranEmail || sharedTransformedData.email,
+  };
+
+  // These properties are supplied by prefill, not the user
+  delete transformedData.fullName;
+  delete transformedData.dateOfBirth;
+  delete transformedData.ssn;
+  delete transformedData.address;
+  delete transformedData.homePhone;
+  delete transformedData.mobilePhone;
+  delete transformedData.email;
 
   return JSON.stringify({
     ...transformedData,


### PR DESCRIPTION
## Summary
This PR modifies the submit transformer for 21-0966 to correct the object keys in case the user had prefill.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team/87615
