### PR TITLE
87553: fix: close direct deposit form on cancel to prevent white screen issue

### DIFF
--- a/src/applications/personalization/profile/components/direct-deposit/AccountInfoView.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/AccountInfoView.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import { TransitionGroup, CSSTransition } from 'react-transition-group';
 
@@ -10,63 +10,59 @@ import recordEvent from '~/platform/monitoring/record-event';
 import { toggleDirectDepositEdit } from '../../actions/directDeposit';
 import { DIRECT_DEPOSIT_ALERT_SETTINGS } from '../../constants';
 
-const AccountWithInfo = ({
-  paymentAccount,
-  showUpdateSuccess,
-  editButtonRef,
-  toggleEdit,
-  recordEventImpl,
-}) => {
-  return (
-    <div>
-      <dl className="vads-u-margin-y--0 vads-u-line-height--6">
-        <dt className="sr-only">Bank name:</dt>
-        <dd>{paymentAccount?.name}</dd>
-        <dt className="sr-only">Bank account number:</dt>
-        <dd>{paymentAccount?.accountNumber}</dd>
-        <dt className="sr-only">Bank account type:</dt>
-        <dd>{`${paymentAccount?.accountType} account`}</dd>
-      </dl>
+const AccountWithInfo = forwardRef(
+  ({ paymentAccount, showUpdateSuccess, toggleEdit, recordEventImpl }, ref) => {
+    return (
+      <div>
+        <dl className="vads-u-margin-y--0 vads-u-line-height--6">
+          <dt className="sr-only">Bank name:</dt>
+          <dd>{paymentAccount?.name}</dd>
+          <dt className="sr-only">Bank account number:</dt>
+          <dd>{paymentAccount?.accountNumber}</dd>
+          <dt className="sr-only">Bank account type:</dt>
+          <dd>{`${paymentAccount?.accountType} account`}</dd>
+        </dl>
 
-      <div role="alert" aria-atomic="true">
-        <TransitionGroup>
-          {!!showUpdateSuccess && (
-            <CSSTransition
-              classNames="form-expanding-group-inner"
-              appear
-              timeout={{
-                appear: DIRECT_DEPOSIT_ALERT_SETTINGS.FADE_SPEED,
-                enter: DIRECT_DEPOSIT_ALERT_SETTINGS.FADE_SPEED,
-                exit: DIRECT_DEPOSIT_ALERT_SETTINGS.FADE_SPEED,
-              }}
-            >
-              <div data-testid="bankInfoUpdateSuccessAlert">
-                <ContactInformationUpdateSuccessAlert fieldName="direct-deposit" />
-              </div>
-            </CSSTransition>
-          )}
-        </TransitionGroup>
+        <div role="alert" aria-atomic="true">
+          <TransitionGroup>
+            {!!showUpdateSuccess && (
+              <CSSTransition
+                classNames="form-expanding-group-inner"
+                appear
+                timeout={{
+                  appear: DIRECT_DEPOSIT_ALERT_SETTINGS.FADE_SPEED,
+                  enter: DIRECT_DEPOSIT_ALERT_SETTINGS.FADE_SPEED,
+                  exit: DIRECT_DEPOSIT_ALERT_SETTINGS.FADE_SPEED,
+                }}
+              >
+                <div data-testid="bankInfoUpdateSuccessAlert">
+                  <ContactInformationUpdateSuccessAlert fieldName="direct-deposit" />
+                </div>
+              </CSSTransition>
+            )}
+          </TransitionGroup>
+        </div>
+        <VaButton
+          id="edit-bank-info-button"
+          data-testid="edit-bank-info-button"
+          data-field-name="direct-deposit"
+          text="Edit"
+          className="vads-u-margin--0 vads-u-margin-top--1p5 vads-u-width--full"
+          aria-label="Edit your direct deposit bank information"
+          ref={ref}
+          onClick={() => {
+            recordEventImpl({
+              event: 'profile-navigation',
+              'profile-action': 'edit-link',
+              'profile-section': `direct-deposit-information`,
+            });
+            toggleEdit();
+          }}
+        />
       </div>
-      <VaButton
-        id="edit-bank-info-button"
-        data-testid="edit-bank-info-button"
-        data-field-name="direct-deposit"
-        text="Edit"
-        className="vads-u-margin--0 vads-u-margin-top--1p5 vads-u-width--full"
-        aria-label="Edit your direct deposit bank information"
-        ref={editButtonRef}
-        onClick={() => {
-          recordEventImpl({
-            event: 'profile-navigation',
-            'profile-action': 'edit-link',
-            'profile-section': `direct-deposit-information`,
-          });
-          toggleEdit();
-        }}
-      />
-    </div>
-  );
-};
+    );
+  },
+);
 
 AccountWithInfo.propTypes = {
   paymentAccount: PropTypes.shape({
@@ -76,7 +72,6 @@ AccountWithInfo.propTypes = {
   }).isRequired,
   showUpdateSuccess: PropTypes.bool.isRequired,
   toggleEdit: PropTypes.func.isRequired,
-  editButtonRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   recordEventImpl: PropTypes.func,
 };
 
@@ -84,7 +79,7 @@ AccountWithInfo.defaultProps = {
   recordEventImpl: recordEvent,
 };
 
-const NoAccountInfo = ({ editButtonRef, toggleEdit, recordEventImpl }) => {
+const NoAccountInfo = forwardRef(({ toggleEdit, recordEventImpl }, ref) => {
   return (
     <div>
       <p className="vads-u-margin--0">
@@ -95,7 +90,7 @@ const NoAccountInfo = ({ editButtonRef, toggleEdit, recordEventImpl }) => {
         text="Edit"
         data-testid="edit-bank-info-button"
         aria-label="Edit your direct deposit bank information"
-        ref={editButtonRef}
+        ref={ref}
         onClick={() => {
           recordEventImpl({
             event: 'profile-navigation',
@@ -107,11 +102,10 @@ const NoAccountInfo = ({ editButtonRef, toggleEdit, recordEventImpl }) => {
       />
     </div>
   );
-};
+});
 
 NoAccountInfo.propTypes = {
   toggleEdit: PropTypes.func.isRequired,
-  editButtonRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
   recordEventImpl: PropTypes.func,
 };
 
@@ -119,30 +113,27 @@ NoAccountInfo.defaultProps = {
   recordEventImpl: recordEvent,
 };
 
-export const AccountInfoView = ({
-  paymentAccount,
-  showUpdateSuccess,
-  recordEventImpl,
-}) => {
-  const editButtonRef = useRef();
-  const dispatch = useDispatch();
-  const toggleEdit = () => dispatch(toggleDirectDepositEdit());
-  return paymentAccount?.accountNumber ? (
-    <AccountWithInfo
-      paymentAccount={paymentAccount}
-      showUpdateSuccess={showUpdateSuccess}
-      editButtonRef={editButtonRef}
-      toggleEdit={toggleEdit}
-      recordEventImpl={recordEventImpl}
-    />
-  ) : (
-    <NoAccountInfo
-      editButtonRef={editButtonRef}
-      toggleEdit={toggleEdit}
-      recordEventImpl={recordEventImpl}
-    />
-  );
-};
+export const AccountInfoView = forwardRef(
+  ({ paymentAccount, showUpdateSuccess, recordEventImpl }, ref) => {
+    const dispatch = useDispatch();
+    const toggleEdit = () => dispatch(toggleDirectDepositEdit());
+    return paymentAccount?.accountNumber ? (
+      <AccountWithInfo
+        paymentAccount={paymentAccount}
+        showUpdateSuccess={showUpdateSuccess}
+        ref={ref}
+        toggleEdit={toggleEdit}
+        recordEventImpl={recordEventImpl}
+      />
+    ) : (
+      <NoAccountInfo
+        ref={ref}
+        toggleEdit={toggleEdit}
+        recordEventImpl={recordEventImpl}
+      />
+    );
+  },
+);
 
 AccountInfoView.propTypes = {
   showUpdateSuccess: PropTypes.bool.isRequired,

--- a/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
+++ b/src/applications/personalization/profile/components/direct-deposit/DirectDeposit.jsx
@@ -144,7 +144,11 @@ export const DirectDeposit = () => {
       {...directDepositHookResult}
     />
   ) : (
-    <AccountInfoView {...directDepositHookResult} isSaving={ui.isSaving} />
+    <AccountInfoView
+      ref={directDepositHookResult.editButtonRef}
+      isSaving={ui.isSaving}
+      {...directDepositHookResult}
+    />
   );
 
   return (

--- a/src/applications/personalization/profile/hooks/useDirectDepositEffects.js
+++ b/src/applications/personalization/profile/hooks/useDirectDepositEffects.js
@@ -80,7 +80,7 @@ export const useDirectDepositEffects = ({
   useEffect(
     () => {
       if (wasEditing && !ui.isEditing) {
-        focusElement('button', {}, '#edit-bank-info-button');
+        focusElement('button', {}, editButtonRef.current);
       }
     },
     [wasEditing, ui.isEditing, editButtonRef],

--- a/src/applications/personalization/profile/tests/e2e/direct-deposit/focus-accessibility.cypress.spec.js
+++ b/src/applications/personalization/profile/tests/e2e/direct-deposit/focus-accessibility.cypress.spec.js
@@ -1,0 +1,53 @@
+import directDepositMocks from '@@profile/mocks/endpoints/direct-deposits';
+import DirectDepositPage from './page-objects/DirectDeposit';
+
+const directDeposit = new DirectDepositPage();
+
+describe('Direct Deposit', () => {
+  beforeEach(() => {
+    directDeposit.setup();
+  });
+
+  it('should open the bank account information form and return to the original state on cancel', () => {
+    const editButton = 'va-button[text="Edit"]';
+    const cancelButton = 'va-button[text="Cancel"]';
+    // Mock the API response for direct deposits eligibility
+    cy.intercept(
+      'GET',
+      'v0/profile/direct_deposits',
+      directDepositMocks.isEligible,
+    );
+    directDeposit.visitPage();
+    cy.injectAxeThenAxeCheck();
+
+    // Verify initial prompt to add bank information is visible
+    cy.contains('p', 'Edit your profile to add your bank information.').should(
+      'be.visible',
+    );
+    cy.get(editButton)
+      .should('exist')
+      .should('not.be.focused');
+
+    // Click the Edit button and ensure it is removed from the DOM
+    cy.get(editButton).click();
+    cy.get(editButton).should('not.exist');
+
+    // Verify the bank account information form appears and is focused
+    cy.contains(
+      'p',
+      'Provide your account type, routing number, and account number.',
+    ).should('be.visible');
+    cy.get('#bank-account-information').should('be.focused');
+
+    // Click the Cancel button to close the form
+    cy.get(cancelButton)
+      .should('exist')
+      .click();
+
+    // Verify the page returns to the original state and Edit button is focused
+    cy.findByRole('heading', { name: 'Direct deposit information' }).should(
+      'exist',
+    );
+    cy.get(editButton).should('be.focused');
+  });
+});


### PR DESCRIPTION
## Summary

1. Changes Made to the Platform

- On the Direct Deposit page, when the empty Bank Info form was opened and then closed, the page was going blank. This was because the code attempted to focus on a non-existent element with a specific ID.

2. Bug Reproduction Steps

- To reproduce the bug, navigate to the Direct Deposit page in the profile of a user who is eligible but does not have direct deposit information. Click on the `Edit` button, and then click on the `Cancel` button to close the form.

3. Solution

- The `useRef` hook was used, but it wasn't correctly passed down to the child component as props. It needed to be passed using `forwardRef`. Instead of hardcoding to get the edit element to focus, we are now using the reference value to focus it. This ensures the correct element is focused and prevents the page from going blank.

4. Team Ownership

- I work for the Auth Exp Profile team, and our team is responsible for the maintenance of this component.

5. Flipper Usage and End Date

- The flippers `profileHideDirectDeposit`, `profileShowDirectDepositSingleForm`, and `profileShowDirectDepositSingleFormUAT` are turned on. The end date for these flippers should be within the next 1-2 months.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#87553

## Testing done

- **Old Behavior:**
  The old behavior involved the page going blank when the empty Bank Info form was opened and then closed. This was due to the code attempting to focus on a non-existent element with a specific ID.

- **Steps to Verify Changes:**
  1. Navigate to the Direct Deposit page in the profile of a user who is eligible but does not have direct deposit information.
  2. Click on the `Edit` button.
  3. Click on the `Cancel` button to close the form.
  4. Ensure that the page no longer goes blank and functions as expected.

- **Tests Completed and Results:**
  - I ran the app locally and tested the changes to ensure the issue was resolved.
  - I wrote `e2e` tests using Cypress to verify that the changes are working as expected. All tests passed successfully, confirming that the bug has been fixed and the page no longer goes blank when the form is closed.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |  ![before](https://github.com/department-of-veterans-affairs/vets-website/assets/36644181/bd51033a-0ab8-49cb-b2a0-ab8d9c11cdd8) | ![after](https://github.com/department-of-veterans-affairs/vets-website/assets/36644181/93642bc4-581b-4d2f-8d29-46b32db4b372) |

## What areas of the site does it impact?

- Profile > Direct Deposit > Bank account information 

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

