### PR TITLE
Fix memory leak in actions test coverage

### DIFF
--- a/src/applications/caregivers/tests/unit/actions/fetchMapBoxBBoxCoordinates.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/actions/fetchMapBoxBBoxCoordinates.unit.spec.js
@@ -13,9 +13,17 @@ describe('CG fetchMapBoxBBoxCoordinates action', () => {
       .resolves({ body: { features: [{ bbox: coordinates }] } }),
   };
   const mockClient = mockMapBoxClient();
-  const clientStub = sinon
-    .stub(mockClient, 'forwardGeocode')
-    .returns(successResponse);
+  let clientStub;
+
+  beforeEach(() => {
+    clientStub = sinon
+      .stub(mockClient, 'forwardGeocode')
+      .returns(successResponse);
+  });
+
+  afterEach(() => {
+    clientStub.restore();
+  });
 
   context('when the query is omitted', () => {
     it('should return an error object', async () => {


### PR DESCRIPTION
## Summary

This PR fixes some small memory leaks in the stubbing of fetch responses in the mapbox actions of the Caregivers form.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#87630

## Acceptance criteria

- Unit tests are free of potential memory leaks.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution