### PR TITLE
86842 Beneficiary section and shared address changes - form 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959a/chapters/beneficiaryInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/beneficiaryInformation.js
@@ -1,0 +1,152 @@
+import VaTextInputField from 'platform/forms-system/src/js/web-component-fields/VaTextInputField';
+import { cloneDeep } from 'lodash';
+import {
+  addressUI,
+  addressSchema,
+  dateOfBirthUI,
+  dateOfBirthSchema,
+  fullNameUI,
+  fullNameSchema,
+  titleUI,
+  titleSchema,
+  radioUI,
+  radioSchema,
+  phoneUI,
+  phoneSchema,
+} from 'platform/forms-system/src/js/web-component-patterns';
+import { nameWording } from '../../shared/utilities';
+
+const fullNameMiddleInitialUI = cloneDeep(fullNameUI());
+fullNameMiddleInitialUI.middle['ui:title'] = 'Middle initial';
+
+export const applicantNameDobSchema = {
+  uiSchema: {
+    ...titleUI(
+      ({ formData }) =>
+        `${
+          formData?.certifierRole === 'applicant' ? 'Your' : 'Beneficiary’s'
+        } information`,
+      ({ formData }) =>
+        `Enter the information exactly as it’s listed on ${
+          formData?.certifierRole === 'applicant' ? 'your' : 'the beneficiary’s'
+        } CHAMPVA identification card.`,
+    ),
+    applicantName: fullNameMiddleInitialUI,
+    applicantDOB: dateOfBirthUI(),
+  },
+  schema: {
+    type: 'object',
+    required: ['applicantDOB'],
+    properties: {
+      titleSchema,
+      applicantName: fullNameSchema,
+      applicantDOB: dateOfBirthSchema,
+    },
+  },
+};
+
+export const applicantMemberNumberSchema = {
+  uiSchema: {
+    ...titleUI(
+      ({ formData }) =>
+        `${nameWording(formData, true, true, true)} identification information`,
+    ),
+    applicantMemberNumber: {
+      'ui:title': 'CHAMPVA member number',
+      'ui:webComponentField': VaTextInputField,
+      'ui:errorMessages': {
+        required: 'Please enter your CHAMPVA member number',
+        pattern: 'Must be 20 or fewer characters (letters and numbers only)',
+      },
+      'ui:options': {
+        uswds: true,
+        hint:
+          'This number is usually the same as the beneficiary’s Social Security number.',
+      },
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['applicantMemberNumber'],
+    properties: {
+      titleSchema,
+      applicantMemberNumber: {
+        type: 'string',
+        pattern: '^[0-9a-zA-Z]{0,20}$',
+      },
+    },
+  },
+};
+
+export const applicantAddressSchema = {
+  uiSchema: {
+    ...titleUI(
+      ({ formData }) =>
+        `${nameWording(formData, true, true, true)} mailing address`,
+    ),
+    applicantAddress: {
+      ...addressUI({
+        labels: {
+          militaryCheckbox:
+            'Address is on a United States military base outside of the U.S.',
+        },
+      }),
+    },
+    applicantNewAddress: {
+      ...radioUI({
+        updateUiSchema: formData => {
+          const labels = {
+            yes: 'Yes',
+            no: 'No',
+            unknown: 'I’m not sure',
+          };
+
+          return {
+            'ui:title': `Has ${nameWording(
+              formData,
+            )} mailing address changed since ${
+              formData.certifierRole === 'applicant' ? 'your' : 'their'
+            } last CHAMPVA claim or benefits application submission?`,
+            'ui:options': {
+              labels,
+              hint: `If the mailing address has changed, we’ll update our records with the new address`,
+            },
+          };
+        },
+      }),
+    },
+  },
+  schema: {
+    type: 'object',
+    required: ['applicantNewAddress'],
+    properties: {
+      titleSchema,
+      applicantAddress: addressSchema({ omit: ['street3'] }),
+      applicantNewAddress: radioSchema(['yes', 'no', 'unknown']),
+    },
+  },
+};
+
+export const applicantPhoneSchema = {
+  uiSchema: {
+    ...titleUI(
+      ({ formData }) =>
+        `${nameWording(formData, true, true, true)} contact information`,
+      ({ formData }) =>
+        `We’ll use this information to contact ${
+          formData?.certifierRole === 'applicant'
+            ? 'you'
+            : nameWording(formData, true, true, true)
+        } if we have more questions.`,
+    ),
+    applicantPhone: phoneUI(),
+  },
+  schema: {
+    type: 'object',
+    required: ['applicantPhone'],
+    properties: {
+      titleSchema,
+      applicantPhone: phoneSchema,
+    },
+  },
+};

--- a/src/applications/ivc-champva/10-7959a/config/form.js
+++ b/src/applications/ivc-champva/10-7959a/config/form.js
@@ -4,6 +4,7 @@ import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import { nameWording } from '../../shared/utilities';
+import { ApplicantAddressCopyPage } from '../../shared/components/applicantLists/ApplicantAddressPage';
 import {
   certifierRoleSchema,
   certifierNameSchema,
@@ -23,8 +24,14 @@ import {
   eobUploadSchema,
   pharmacyClaimUploadSchema,
 } from '../chapters/claimInformation';
+import {
+  applicantNameDobSchema,
+  applicantMemberNumberSchema,
+  applicantAddressSchema,
+  applicantPhoneSchema,
+} from '../chapters/beneficiaryInformation';
 
-import { sponsorNameSchema } from '../chapters/sponsorInformation';
+import { blankSchema, sponsorNameSchema } from '../chapters/sponsorInformation';
 
 // import mockData from '../tests/fixtures/data/test-data.json';
 
@@ -69,8 +76,8 @@ const formConfig = {
         page1: {
           path: 'signer-type',
           title: 'Your information',
+          // initialData: mockData.data,
           // Placeholder data so that we display "beneficiary" in title when `fnp` is used
-          initialData: { applicantName: { first: 'Beneficiary' } },
           ...certifierRoleSchema,
         },
         page1a: {
@@ -103,9 +110,58 @@ const formConfig = {
       title: 'Sponsor information',
       pages: {
         page2: {
-          path: 'sponsor-information',
+          path: 'sponsor-info',
           title: 'Name',
           ...sponsorNameSchema,
+        },
+      },
+    },
+    beneficiaryInformation: {
+      title: 'Beneficiary information',
+      pages: {
+        page2a: {
+          path: 'beneficiary-info',
+          title: 'Beneficiary information',
+          ...applicantNameDobSchema,
+        },
+        page2b: {
+          path: 'beneficiary-identification-info',
+          title: formData => `${fnp(formData)} identification information`,
+          ...applicantMemberNumberSchema,
+        },
+        page2c: {
+          path: 'beneficiary-address',
+          title: formData => `${fnp(formData)} address`,
+          // Only show if we have addresses to pull from:
+          depends: formData =>
+            get('certifierRole', formData) !== 'applicant' &&
+            get('street', formData?.certifierAddress),
+          CustomPage: props => {
+            const extraProps = {
+              ...props,
+              customTitle: `${fnp(props.data)} address`,
+              customDescription:
+                'We’ll send any important information about this form to this address.',
+              customSelectText:
+                'Does the beneficiary have the same address as you?',
+              positivePrefix: 'Yes, their address is',
+              negativePrefix: 'No, they have a different address',
+            };
+            return ApplicantAddressCopyPage(extraProps);
+          },
+          CustomPageReview: null,
+          uiSchema: {},
+          schema: blankSchema,
+        },
+        page2d: {
+          path: 'beneficiary-mailing-address',
+          title: formData => `${fnp(formData)} mailing address`,
+          ...applicantAddressSchema,
+        },
+        page2e: {
+          path: 'beneficiary-contact-info',
+          title: formData => `${fnp(formData)} phone information`,
+          ...applicantPhoneSchema,
         },
       },
     },

--- a/src/applications/ivc-champva/10-7959a/tests/fixtures/data/test-data.json
+++ b/src/applications/ivc-champva/10-7959a/tests/fixtures/data/test-data.json
@@ -1,5 +1,18 @@
 {
   "data": {
+    "certifierRole": "applicant",
+    "sponsorName": {
+      "first": "Sponsor",
+      "middle": "Quincy",
+      "last": "Jones",
+      "suffix": "Jr."
+    },
+    "applicantName": {
+      "first": "Beneficiary",
+      "last": "Jones"
+    },
+    "applicantMemberNumber": "222111123",
+    "applicantDOB": "2000-10-25",
     "medicalUpload": [
       {
         "name": "Document1.png",
@@ -12,15 +25,6 @@
     "claimIsWorkRelated": true,
     "claimType": "medical",
     "hasOhi": true,
-    "sponsorName": {
-      "first": "Sponsor",
-      "middle": "Quincy",
-      "last": "Jones",
-      "suffix": "Jr."
-    },
-    "applicantName": {
-      "first": "Beneficiary"
-    },
     "policies": [
       {
         "type": "group",

--- a/src/applications/ivc-champva/shared/components/applicantLists/ApplicantAddressPage.jsx
+++ b/src/applications/ivc-champva/shared/components/applicantLists/ApplicantAddressPage.jsx
@@ -16,8 +16,18 @@ export function ApplicantAddressCopyPage({
   pagePerItemIndex,
   updatePage,
   onReviewPage,
+  customTitle,
+  customDescription,
+  customSelectText,
+  positivePrefix,
+  negativePrefix,
 }) {
-  const currentApp = data?.applicants?.[pagePerItemIndex];
+  // Get the current applicant from list, OR if we don't have a list of
+  // applicants, just treat the whole form data object as a single applicant
+  const currentApp =
+    pagePerItemIndex && data?.applicants
+      ? data?.applicants?.[pagePerItemIndex]
+      : data;
   const [selectValue, setSelectValue] = useState(currentApp?.sharesAddressWith);
   const [address, setAddress] = useState(currentApp?.applicantAddress);
   // const [radioError, setRadioError] = useState(undefined);
@@ -69,22 +79,26 @@ export function ApplicantAddressCopyPage({
       allAddresses.push({
         originatorName: fullName(data.certifierName),
         originatorAddress: data.certifierAddress,
-        displayText: data.certifierAddress.street,
+        displayText: `${data.certifierAddress.street} ${data.certifierAddress
+          ?.state ?? ''}`,
       });
     if (data.sponsorAddress?.street && data.veteransFullName)
       allAddresses.push({
         originatorName: fullName(data.veteransFullName),
         originatorAddress: data.sponsorAddress,
-        displayText: data.sponsorAddress.street,
+        displayText: `${data.sponsorAddress.street} ${data.sponsorAddress
+          ?.state ?? ''}`,
       });
 
-    data.applicants.filter(app => isValidOrigin(app)).forEach(app =>
-      allAddresses.push({
-        originatorName: fullName(app.applicantName),
-        originatorAddress: app.applicantAddress,
-        displayText: app.applicantAddress?.street,
-      }),
-    );
+    if (data?.applicants)
+      data.applicants.filter(app => isValidOrigin(app)).forEach(app =>
+        allAddresses.push({
+          originatorName: fullName(app.applicantName),
+          originatorAddress: app.applicantAddress,
+          displayText: `${app.applicantAddress.street} ${app.applicantAddress
+            ?.state ?? ''}`,
+        }),
+      );
     // Drop any entries with duplicate addresses
     return eliminateDuplicatesByKey(allAddresses, 'originatorAddress');
   }
@@ -125,7 +139,11 @@ export function ApplicantAddressCopyPage({
       event.preventDefault();
       if (!handlers.validate()) return;
       const tmpVal = { ...data };
-      const tmpApp = tmpVal.applicants[pagePerItemIndex];
+      // Either use the current list loop applicant, or treat whole form data as an applicant
+      const tmpApp =
+        pagePerItemIndex && data?.applicants
+          ? tmpVal?.applicants[pagePerItemIndex]
+          : tmpVal;
       tmpApp.sharesAddressWith = selectValue;
       if (selectValue !== 'not-shared') {
         tmpApp.applicantAddress = address;
@@ -155,18 +173,21 @@ export function ApplicantAddressCopyPage({
 
   // We use this a few times, so compute now.
   const curAppFullName = fullName(currentApp.applicantName);
-  const selectWording = `${
-    pagePerItemIndex === 0 && data.certifierRole === 'applicant'
-      ? 'Do you'
-      : `Does ${curAppFullName}`
-  } have the same mailing address as another person listed in this application?`;
+  const selectWording =
+    customSelectText ??
+    `${
+      pagePerItemIndex === 0 && data.certifierRole === 'applicant'
+        ? 'Do you'
+        : `Does ${curAppFullName}`
+    } have the same mailing address as another person listed in this application?`;
 
   return (
     <>
       {
         titleUI(
-          `${applicantWording(currentApp)} address selection`,
-          'We’ll send any important information about your application to this address.',
+          customTitle ?? `${applicantWording(currentApp)} address selection`,
+          customDescription ??
+            'We’ll send any important information about your application to this address.',
         )['ui:title']
       }
 
@@ -179,10 +200,13 @@ export function ApplicantAddressCopyPage({
           label={selectWording}
           name="shared-address-select"
         >
-          <option value="not-shared">No, use a new address</option>
+          <option value="not-shared">
+            {negativePrefix ?? 'No, use a new address'}
+          </option>
           {getSelectOptions().map(el => (
             <option key={el.originatorName} value={JSON.stringify(el)}>
-              Use {el.displayText}
+              {`${positivePrefix ?? 'Use'} `}
+              {el.displayText}
             </option>
           ))}
         </VaSelect>
@@ -199,12 +223,17 @@ export function ApplicantAddressCopyPage({
 ApplicantAddressCopyPage.propTypes = {
   contentAfterButtons: PropTypes.element,
   contentBeforeButtons: PropTypes.element,
+  customDescription: PropTypes.string,
+  customSelectText: PropTypes.string,
+  customTitle: PropTypes.string,
   data: PropTypes.object,
   genOp: PropTypes.func,
   goBack: PropTypes.func,
   goForward: PropTypes.func,
   keyname: PropTypes.string,
+  negativePrefix: PropTypes.string,
   pagePerItemIndex: PropTypes.string || PropTypes.number,
+  positivePrefix: PropTypes.string,
   setFormData: PropTypes.func,
   updatePage: PropTypes.func,
   onReviewPage: PropTypes.bool,


### PR DESCRIPTION
## Summary

This PR adds all the pages to the beneficiary information section of form 10-7959a. It also extends the shared address component so it can work in non-listloop forms.

- Added all pages to beneficiary section
- Updated shared address component to work when no list loop present
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86842

## Testing done

- Manual

## Screenshots

|         | Screens|
| ------- | ------ |
| Beneficiary Name | ![Screenshot 2024-07-10 at 12 37 54](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/ac4d3e24-299d-49f1-9cfb-3aa7921c9e6c)|
|Member num|![2](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/2ddc07fd-9076-46f2-a07e-cb169194a1ff)|
|Shared|![3](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/a065ef75-f8ef-48d2-81c9-7e6ee6239fd3)|
|Shared (detail) |![4](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/b319ebbe-1cd6-47c0-a04f-484edca82b4c)|
|Address|![5](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/d6c218a9-444d-49e5-9f15-da9b5e389250)|
|Phone|![6](https://github.com/department-of-veterans-affairs/vets-website/assets/18408628/2d4f6891-844c-4576-b66b-bdf3c743dc52)|

## What areas of the site does it impact?

Forms 10-7959a and 10-10d

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA