### PR TITLE
Check in/87721/back to apts test

### DIFF
--- a/src/applications/check-in/components/WhatToDoNext.jsx
+++ b/src/applications/check-in/components/WhatToDoNext.jsx
@@ -20,13 +20,19 @@ const WhatToDoNext = props => {
   const { app } = useSelector(selectApp);
   const { t } = useTranslation();
   const { updateError } = useUpdateError();
-  const { getCheckinComplete } = useStorage(app);
+  const { getCheckinComplete, getPreCheckinComplete } = useStorage(app);
 
   const sortedAppointments = sortAppointmentsByStartTime(appointments);
-  const checkInableAppointments = getCheckinableAppointments(
-    sortedAppointments,
-  );
-  if (!checkInableAppointments.length && !getCheckinComplete(window)) {
+  let actionableAppointments = sortedAppointments;
+  if (app === APP_NAMES.CHECK_IN) {
+    actionableAppointments = getCheckinableAppointments(sortedAppointments);
+  }
+  const complete =
+    app === APP_NAMES.CHECK_IN
+      ? getCheckinComplete(window)
+      : getPreCheckinComplete(window);
+
+  if (!actionableAppointments.length && !complete) {
     updateError(
       app === APP_NAMES.CHECK_IN
         ? 'check-in-past-appointment'
@@ -35,13 +41,13 @@ const WhatToDoNext = props => {
   }
   const appointmentCards =
     app === APP_NAMES.PRE_CHECK_IN
-      ? [checkInableAppointments[0]]
-      : checkInableAppointments;
+      ? [actionableAppointments[0]]
+      : actionableAppointments;
 
   const getPreCheckinCardTitle = () => {
     let title = `${t('review-your-contact-information-for-your')} `;
-    if (checkInableAppointments.length > 1) {
-      checkInableAppointments.forEach((appointment, index) => {
+    if (actionableAppointments.length > 1) {
+      actionableAppointments.forEach((appointment, index) => {
         title += t('day-of-week-month-day-time', {
           date: new Date(appointment.startTime),
         });
@@ -62,7 +68,7 @@ const WhatToDoNext = props => {
   };
 
   const showDetailsLink =
-    (checkInableAppointments.length === 1 && app === APP_NAMES.PRE_CHECK_IN) ||
+    (actionableAppointments.length === 1 && app === APP_NAMES.PRE_CHECK_IN) ||
     app === APP_NAMES.CHECK_IN;
 
   return (
@@ -88,7 +94,7 @@ const WhatToDoNext = props => {
                   key={appointment.appointmentIen}
                   data-testid="what-next-card"
                 >
-                  <va-card show-shadow={checkInableAppointments.length > 1}>
+                  <va-card show-shadow={actionableAppointments.length > 1}>
                     <h3
                       className="vads-u-margin-top--0 vads-u-font-size--h4"
                       data-testid="what-next-card-title"

--- a/src/applications/check-in/components/WhatToDoNext.jsx
+++ b/src/applications/check-in/components/WhatToDoNext.jsx
@@ -12,6 +12,7 @@ import {
   sortAppointmentsByStartTime,
 } from '../utils/appointment';
 import { useUpdateError } from '../hooks/useUpdateError';
+import { useStorage } from '../hooks/useStorage';
 
 const WhatToDoNext = props => {
   const { router, appointments, action, goToDetails } = props;
@@ -19,12 +20,13 @@ const WhatToDoNext = props => {
   const { app } = useSelector(selectApp);
   const { t } = useTranslation();
   const { updateError } = useUpdateError();
+  const { getCheckinComplete } = useStorage(app);
 
   const sortedAppointments = sortAppointmentsByStartTime(appointments);
   const checkInableAppointments = getCheckinableAppointments(
     sortedAppointments,
   );
-  if (!checkInableAppointments.length) {
+  if (!checkInableAppointments.length && !getCheckinComplete(window)) {
     updateError(
       app === APP_NAMES.CHECK_IN
         ? 'check-in-past-appointment'
@@ -65,61 +67,72 @@ const WhatToDoNext = props => {
 
   return (
     <>
-      <h2 data-testid="what-next-header">{t('what-to-do-next')}</h2>
-      <div data-testid="appointments">
-        {appointmentCards.map((appointment, index) => {
-          const cardTitleId = `what-next-card-title-${index}`;
-          let cardTitle = t('its-time-to-check-in-for-your-time-appointment', {
-            time: new Date(appointment.startTime),
-          });
-          if (app === APP_NAMES.PRE_CHECK_IN) {
-            cardTitle = getPreCheckinCardTitle();
-          }
-          return (
-            <div
-              className="vads-u-margin-bottom--2"
-              key={appointment.appointmentIen}
-              data-testid="what-next-card"
-            >
-              <va-card show-shadow={checkInableAppointments.length > 1}>
-                <h3
-                  className="vads-u-margin-top--0 vads-u-font-size--h4"
-                  data-testid="what-next-card-title"
-                  id={cardTitleId}
+      {appointmentCards.length ? (
+        <>
+          <h2 data-testid="what-next-header">{t('what-to-do-next')}</h2>
+          <div data-testid="appointments">
+            {appointmentCards.map((appointment, index) => {
+              const cardTitleId = `what-next-card-title-${index}`;
+              let cardTitle = t(
+                'its-time-to-check-in-for-your-time-appointment',
+                {
+                  time: new Date(appointment.startTime),
+                },
+              );
+              if (app === APP_NAMES.PRE_CHECK_IN) {
+                cardTitle = getPreCheckinCardTitle();
+              }
+              return (
+                <div
+                  className="vads-u-margin-bottom--2"
+                  key={appointment.appointmentIen}
+                  data-testid="what-next-card"
                 >
-                  {cardTitle}
-                </h3>
-                {showDetailsLink && (
-                  <p>
-                    <a
-                      data-testid={`details-link-${index}`}
-                      href={`${
-                        router.location.basename
-                      }/appointment-details/${getAppointmentId(appointment)}`}
-                      onClick={e => goToDetails(e, appointment)}
-                      aria-label={t('details-for-appointment', {
-                        time: new Date(appointment.startTime),
-                        type: appointment.clinicStopCodeName
-                          ? appointment.clinicStopCodeName
-                          : 'VA',
-                      })}
+                  <va-card show-shadow={checkInableAppointments.length > 1}>
+                    <h3
+                      className="vads-u-margin-top--0 vads-u-font-size--h4"
+                      data-testid="what-next-card-title"
+                      id={cardTitleId}
                     >
-                      {t('details')}
-                    </a>
-                  </p>
-                )}
-                <ActionLink
-                  app={app}
-                  action={action}
-                  cardTitleId={cardTitleId}
-                  startTime={appointment.startTime}
-                  appointmentId={getAppointmentId(appointment)}
-                />
-              </va-card>
-            </div>
-          );
-        })}
-      </div>
+                      {cardTitle}
+                    </h3>
+                    {showDetailsLink && (
+                      <p>
+                        <a
+                          data-testid={`details-link-${index}`}
+                          href={`${
+                            router.location.basename
+                          }/appointment-details/${getAppointmentId(
+                            appointment,
+                          )}`}
+                          onClick={e => goToDetails(e, appointment)}
+                          aria-label={t('details-for-appointment', {
+                            time: new Date(appointment.startTime),
+                            type: appointment.clinicStopCodeName
+                              ? appointment.clinicStopCodeName
+                              : 'VA',
+                          })}
+                        >
+                          {t('details')}
+                        </a>
+                      </p>
+                    )}
+                    <ActionLink
+                      app={app}
+                      action={action}
+                      cardTitleId={cardTitleId}
+                      startTime={appointment.startTime}
+                      appointmentId={getAppointmentId(appointment)}
+                    />
+                  </va-card>
+                </div>
+              );
+            })}
+          </div>
+        </>
+      ) : (
+        ''
+      )}
     </>
   );
 };

--- a/src/applications/check-in/components/tests/WhatToDoNext.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/WhatToDoNext.unit.spec.jsx
@@ -7,6 +7,7 @@ import {
   multipleAppointments,
   singleAppointment,
 } from '../../tests/unit/mocks/mock-appointments';
+import { setupI18n, teardownI18n } from '../../utils/i18n/i18n';
 import WhatToDoNext from '../WhatToDoNext';
 
 const mockRouter = {
@@ -22,6 +23,12 @@ const preCheckInMockStore = {
 };
 
 describe('unified check-in experience', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
   describe('WhatToDoNext', () => {
     it('displays the what next header', () => {
       const { getByTestId } = render(
@@ -85,22 +92,27 @@ describe('unified check-in experience', () => {
       initAppointments[0] = {
         ...initAppointments[0],
         startTime: '2022-01-03T14:00:00',
+        eligibility: 'INELIGIBLE_BAD_STATUS',
       };
       initAppointments[1] = {
         ...initAppointments[1],
         startTime: '2022-01-03T14:30:00',
+        eligibility: 'INELIGIBLE_BAD_STATUS',
       };
       initAppointments[2] = {
         ...initAppointments[2],
         startTime: '2022-01-03T15:00:00',
+        eligibility: 'INELIGIBLE_BAD_STATUS',
       };
       initAppointments[3] = {
         ...initAppointments[3],
         startTime: '2022-01-03T16:00:00',
+        eligibility: 'INELIGIBLE_BAD_STATUS',
       };
       initAppointments[4] = {
         ...initAppointments[4],
         startTime: '2022-01-03T17:00:00',
+        eligibility: 'INELIGIBLE_BAD_STATUS',
       };
       const { getByTestId } = render(
         <CheckInProvider store={initStore}>

--- a/src/applications/check-in/day-of/pages/Confirmation/index.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/index.jsx
@@ -119,6 +119,9 @@ const Confirmation = props => {
       token,
       getCheckinComplete,
       setCheckinComplete,
+      setECheckinStartedCalled,
+      isTravelReimbursementEnabled,
+      travelPayEligible,
     ],
   );
 

--- a/src/applications/check-in/day-of/tests/e2e/complete.check.in.go.back.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/complete.check.in.go.back.cypress.spec.js
@@ -1,0 +1,69 @@
+import '../../../tests/e2e/commands';
+import ApiInitializer from '../../../api/local-mock-api/e2e/ApiInitializer';
+import ValidateVeteran from '../../../tests/e2e/pages/ValidateVeteran';
+import AppointmentsPage from '../../../tests/e2e/pages/AppointmentsPage';
+import Arrived from './pages/Arrived';
+import TravelPages from '../../../tests/e2e/pages/TravelPages';
+import Confirmation from './pages/Confirmation';
+
+const dateFns = require('date-fns');
+
+describe('Check In Experience | Day Of |', () => {
+  describe('Patient who completes check-in and navigates back to list', () => {
+    const {
+      initializeFeatureToggle,
+      initializeSessionGet,
+      initializeSessionPost,
+      initializeUpcomingAppointmentsDataGet,
+      initializeCheckInDataGet,
+      initializeCheckInDataPost,
+    } = ApiInitializer;
+    beforeEach(() => {
+      const appointments = [
+        {
+          appointmentIen: '0001',
+        },
+      ];
+      initializeFeatureToggle.withCurrentFeatures();
+      initializeSessionGet.withSuccessfulNewSession();
+      initializeSessionPost.withValidation();
+      initializeUpcomingAppointmentsDataGet.withSuccess();
+      initializeCheckInDataGet.withSuccessAndUpdate({
+        appointments,
+        demographicsNeedsUpdate: false,
+        demographicsConfirmedAt: dateFns.format(
+          new Date(),
+          "yyyy-LL-dd'T'HH:mm:ss",
+        ),
+        nextOfKinNeedsUpdate: false,
+        nextOfKinConfirmedAt: dateFns.format(
+          new Date(),
+          "yyyy-LL-dd'T'HH:mm:ss",
+        ),
+        emergencyContactNeedsUpdate: false,
+        emergencyContactConfirmedAt: dateFns.format(
+          new Date(),
+          "yyyy-LL-dd'T'HH:mm:ss",
+        ),
+      });
+      initializeCheckInDataPost.withSuccess();
+      cy.visitWithUUID();
+      ValidateVeteran.validateVeteran();
+      ValidateVeteran.attemptToGoToNextPage();
+      AppointmentsPage.validatePageLoaded();
+      AppointmentsPage.attemptCheckIn();
+      Arrived.validateArrivedPage();
+      Arrived.attemptToGoToNextPage();
+      TravelPages.validatePageLoaded();
+      TravelPages.attemptToGoToNextPage('no');
+      Confirmation.validatePageLoaded();
+    });
+    it('should see appointment card removed when going back to appointments', () => {
+      Confirmation.attemptGoBackToAppointments();
+
+      AppointmentsPage.validatePageLoaded();
+      AppointmentsPage.validateNoTaskCards();
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+});

--- a/src/applications/check-in/tests/e2e/pages/AppointmentsPage.js
+++ b/src/applications/check-in/tests/e2e/pages/AppointmentsPage.js
@@ -147,6 +147,10 @@ class AppointmentsPage {
       'be.visible',
     );
   };
+
+  validateNoTaskCards = () => {
+    cy.get('[data-testid="what-next-header"]').should('not.exist');
+  };
 }
 
 export default new AppointmentsPage();


### PR DESCRIPTION
## Summary

Fixes a bug where we weren't sending all of the required parameters to patient_check_ins POST. Adds functionality for going back to appointments list after checking-in with only one appointment. Updates the appointments page to not display `What to do next` heading when there are no task cards.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#87721

## Testing done

Adds aa e2e test for going back to appointments

## What areas of the site does it impact?

day-of check-in

## Acceptance criteria

 - [ ] you can go back to the appointments list after checking in with no more eligible appts.
 - [ ] the patient_check_ins POST sends all required params
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

