### PR TITLE
[CST] - Update Claim Cards on the Claims List to show 8 steps

### DIFF
--- a/src/applications/claims-status/components/ClaimsListItem.jsx
+++ b/src/applications/claims-status/components/ClaimsListItem.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 
 import {
   getClaimType,
+  getClaimPhaseTypeHeaderText,
   buildDateFormatter,
   getStatusDescription,
+  isDisabilityCompensationClaim,
 } from '../utils/helpers';
 import ClaimCard from './ClaimCard';
 
@@ -52,15 +55,28 @@ CommunicationsItem.propTypes = {
 export default function ClaimsListItem({ claim }) {
   const {
     claimDate,
+    claimPhaseDates,
+    claimTypeCode,
     decisionLetterSent,
     developmentLetterSent,
     documentsNeeded,
     status,
   } = claim.attributes;
+
+  const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
+  const cstClaimPhasesEnabled = useToggleValue(TOGGLE_NAMES.cstClaimPhases);
+  // When feature flag cstClaimPhases is enabled and claim type code is for a disability
+  // compensation claim we show 8 phases instead of 5 with updated description, link text
+  // and statuses
+  const showEightPhases =
+    cstClaimPhasesEnabled && isDisabilityCompensationClaim(claimTypeCode);
+
   const inProgress = !isClaimComplete(claim);
   const showPrecomms = showPreDecisionCommunications(claim);
   const formattedReceiptDate = formatDate(claimDate);
-  const humanStatus = getStatusDescription(status);
+  const humanStatus = showEightPhases
+    ? getClaimPhaseTypeHeaderText(claimPhaseDates.phaseType)
+    : getStatusDescription(status);
   const showAlert = showPrecomms && documentsNeeded;
 
   const ariaLabel = `Details for claim submitted on ${formattedReceiptDate}`;

--- a/src/applications/claims-status/tests/components/ClaimsListItem.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimsListItem.unit.spec.jsx
@@ -68,7 +68,7 @@ describe('<ClaimsListItem>', () => {
         );
         getByText('Step 8 of 8: Claim decided');
       });
-      it('should show the correct status', () => {
+      it('should show the correct status when UNDER_REVIEW', () => {
         const claim = {
           id: 1,
           attributes: {
@@ -87,6 +87,86 @@ describe('<ClaimsListItem>', () => {
           </Provider>,
         );
         getByText('Step 2 of 8: Initial review');
+      });
+      it('should show the correct status when REVIEW_OF_EVIDENCE', () => {
+        const claim = {
+          id: 1,
+          attributes: {
+            claimPhaseDates: {
+              phaseChangeDate: '2024-06-08',
+              phaseType: 'REVIEW_OF_EVIDENCE',
+            },
+            claimTypeCode: compensationClaimTypeCode,
+            status: 'EVIDENCE_GATHERING_REVIEW_DECISION',
+          },
+        };
+
+        const { getByText } = renderWithRouter(
+          <Provider store={getStore()}>
+            <ClaimsListItem claim={claim} />
+          </Provider>,
+        );
+        getByText('Step 4 of 8: Evidence review');
+      });
+      it('should show the correct status when PREPARATION_FOR_DECISION', () => {
+        const claim = {
+          id: 1,
+          attributes: {
+            claimPhaseDates: {
+              phaseChangeDate: '2024-06-08',
+              phaseType: 'PREPARATION_FOR_DECISION',
+            },
+            claimTypeCode: compensationClaimTypeCode,
+            status: 'EVIDENCE_GATHERING_REVIEW_DECISION',
+          },
+        };
+
+        const { getByText } = renderWithRouter(
+          <Provider store={getStore()}>
+            <ClaimsListItem claim={claim} />
+          </Provider>,
+        );
+        getByText('Step 5 of 8: Rating');
+      });
+      it('should show the correct status when PENDING_DECISION_APPROVAL', () => {
+        const claim = {
+          id: 1,
+          attributes: {
+            claimPhaseDates: {
+              phaseChangeDate: '2024-06-08',
+              phaseType: 'PENDING_DECISION_APPROVAL',
+            },
+            claimTypeCode: compensationClaimTypeCode,
+            status: 'PREPARATION_FOR_NOTIFICATION',
+          },
+        };
+
+        const { getByText } = renderWithRouter(
+          <Provider store={getStore()}>
+            <ClaimsListItem claim={claim} />
+          </Provider>,
+        );
+        getByText('Step 6 of 8: Preparing decision letter');
+      });
+      it('should show the correct status when PREPARATION_FOR_NOTIFICATION', () => {
+        const claim = {
+          id: 1,
+          attributes: {
+            claimPhaseDates: {
+              phaseChangeDate: '2024-06-08',
+              phaseType: 'PREPARATION_FOR_NOTIFICATION',
+            },
+            claimTypeCode: compensationClaimTypeCode,
+            status: 'PREPARATION_FOR_NOTIFICATION',
+          },
+        };
+
+        const { getByText } = renderWithRouter(
+          <Provider store={getStore()}>
+            <ClaimsListItem claim={claim} />
+          </Provider>,
+        );
+        getByText('Step 7 of 8: Final review');
       });
       it('should show development letter flag', () => {
         const claim = {
@@ -263,7 +343,7 @@ describe('<ClaimsListItem>', () => {
         );
         getByText('Step 5 of 5: Closed');
       });
-      it('should show the correct status', () => {
+      it('should show the correct status when UNDER_REVIEW', () => {
         const claim = {
           id: 1,
           attributes: {
@@ -282,6 +362,86 @@ describe('<ClaimsListItem>', () => {
           </Provider>,
         );
         getByText('Step 2 of 5: Initial review');
+      });
+      it('should show the correct status when REVIEW_OF_EVIDENCE', () => {
+        const claim = {
+          id: 1,
+          attributes: {
+            claimPhaseDates: {
+              phaseChangeDate: '2024-06-08',
+              phaseType: 'REVIEW_OF_EVIDENCE',
+            },
+            claimTypeCode: dependencyClaimTypeCode,
+            status: 'EVIDENCE_GATHERING_REVIEW_DECISION',
+          },
+        };
+
+        const { getByText } = renderWithRouter(
+          <Provider store={getStore()}>
+            <ClaimsListItem claim={claim} />
+          </Provider>,
+        );
+        getByText('Step 3 of 5: Evidence gathering, review, and decision');
+      });
+      it('should show the correct status when PREPARATION_FOR_DECISION', () => {
+        const claim = {
+          id: 1,
+          attributes: {
+            claimPhaseDates: {
+              phaseChangeDate: '2024-06-08',
+              phaseType: 'PREPARATION_FOR_DECISION',
+            },
+            claimTypeCode: dependencyClaimTypeCode,
+            status: 'EVIDENCE_GATHERING_REVIEW_DECISION',
+          },
+        };
+
+        const { getByText } = renderWithRouter(
+          <Provider store={getStore()}>
+            <ClaimsListItem claim={claim} />
+          </Provider>,
+        );
+        getByText('Step 3 of 5: Evidence gathering, review, and decision');
+      });
+      it('should show the correct status when PENDING_DECISION_APPROVAL', () => {
+        const claim = {
+          id: 1,
+          attributes: {
+            claimPhaseDates: {
+              phaseChangeDate: '2024-06-08',
+              phaseType: 'PENDING_DECISION_APPROVAL',
+            },
+            claimTypeCode: dependencyClaimTypeCode,
+            status: 'PREPARATION_FOR_NOTIFICATION',
+          },
+        };
+
+        const { getByText } = renderWithRouter(
+          <Provider store={getStore()}>
+            <ClaimsListItem claim={claim} />
+          </Provider>,
+        );
+        getByText('Step 4 of 5: Preparation for notification');
+      });
+      it('should show the correct status when PREPARATION_FOR_NOTIFICATION', () => {
+        const claim = {
+          id: 1,
+          attributes: {
+            claimPhaseDates: {
+              phaseChangeDate: '2024-06-08',
+              phaseType: 'PREPARATION_FOR_NOTIFICATION',
+            },
+            claimTypeCode: dependencyClaimTypeCode,
+            status: 'PREPARATION_FOR_NOTIFICATION',
+          },
+        };
+
+        const { getByText } = renderWithRouter(
+          <Provider store={getStore()}>
+            <ClaimsListItem claim={claim} />
+          </Provider>,
+        );
+        getByText('Step 4 of 5: Preparation for notification');
       });
       it('should show development letter flag', () => {
         const claim = {
@@ -458,7 +618,7 @@ describe('<ClaimsListItem>', () => {
         );
         getByText('Step 5 of 5: Closed');
       });
-      it('should show the correct status', () => {
+      it('should show the correct status when UNDER_REVIEW', () => {
         const claim = {
           id: 1,
           attributes: {
@@ -477,6 +637,86 @@ describe('<ClaimsListItem>', () => {
           </Provider>,
         );
         getByText('Step 2 of 5: Initial review');
+      });
+      it('should show the correct status when REVIEW_OF_EVIDENCE', () => {
+        const claim = {
+          id: 1,
+          attributes: {
+            claimPhaseDates: {
+              phaseChangeDate: '2024-06-08',
+              phaseType: 'REVIEW_OF_EVIDENCE',
+            },
+            claimTypeCode: compensationClaimTypeCode,
+            status: 'EVIDENCE_GATHERING_REVIEW_DECISION',
+          },
+        };
+
+        const { getByText } = renderWithRouter(
+          <Provider store={getStore(false)}>
+            <ClaimsListItem claim={claim} />
+          </Provider>,
+        );
+        getByText('Step 3 of 5: Evidence gathering, review, and decision');
+      });
+      it('should show the correct status when PREPARATION_FOR_DECISION', () => {
+        const claim = {
+          id: 1,
+          attributes: {
+            claimPhaseDates: {
+              phaseChangeDate: '2024-06-08',
+              phaseType: 'PREPARATION_FOR_DECISION',
+            },
+            claimTypeCode: compensationClaimTypeCode,
+            status: 'EVIDENCE_GATHERING_REVIEW_DECISION',
+          },
+        };
+
+        const { getByText } = renderWithRouter(
+          <Provider store={getStore(false)}>
+            <ClaimsListItem claim={claim} />
+          </Provider>,
+        );
+        getByText('Step 3 of 5: Evidence gathering, review, and decision');
+      });
+      it('should show the correct status when PENDING_DECISION_APPROVAL', () => {
+        const claim = {
+          id: 1,
+          attributes: {
+            claimPhaseDates: {
+              phaseChangeDate: '2024-06-08',
+              phaseType: 'PENDING_DECISION_APPROVAL',
+            },
+            claimTypeCode: compensationClaimTypeCode,
+            status: 'PREPARATION_FOR_NOTIFICATION',
+          },
+        };
+
+        const { getByText } = renderWithRouter(
+          <Provider store={getStore(false)}>
+            <ClaimsListItem claim={claim} />
+          </Provider>,
+        );
+        getByText('Step 4 of 5: Preparation for notification');
+      });
+      it('should show the correct status when PREPARATION_FOR_NOTIFICATION', () => {
+        const claim = {
+          id: 1,
+          attributes: {
+            claimPhaseDates: {
+              phaseChangeDate: '2024-06-08',
+              phaseType: 'PREPARATION_FOR_NOTIFICATION',
+            },
+            claimTypeCode: compensationClaimTypeCode,
+            status: 'PREPARATION_FOR_NOTIFICATION',
+          },
+        };
+
+        const { getByText } = renderWithRouter(
+          <Provider store={getStore(false)}>
+            <ClaimsListItem claim={claim} />
+          </Provider>,
+        );
+        getByText('Step 4 of 5: Preparation for notification');
       });
       it('should show development letter flag', () => {
         const claim = {


### PR DESCRIPTION
## Summary

- Updated the `ClaimsListItem` component so that there is logic on the Claim Card to determine when the text  'Step # of #: <Status>' displays 5 or 8 steps depending on is the toggle `cst_claim_phases` is enabled and the claim code is for  a disability claim
- Updated ClaimsListItem.unit.spec.jsx so that there are tests that throughouly cover these new changes

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#82376


## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

**Video when `cst_claim_phases` is enabled and new logic is applied:**
https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/09b06cb8-1f4a-4429-878c-69b6a13da0b8

**Video when `cst_claim_phases` is disabled and new logic is not applied:**
https://github.com/department-of-veterans-affairs/vets-website/assets/141954992/c185f61e-c5f3-47ee-a4aa-3262fb9895b9


## What areas of the site does it impact?

Claim Status Tool

## Acceptance criteria

- [x]  LH api call for Claims List returns the field claim.attributes.claimPhaseDates.latestPhaseType
- [x]  vets-api-mockdata for file lighthouse/benefits_claims/index/default.yml has the field claim.attributes.claimPhaseDates.latestPhaseType
- [x]  Update vets-api-mockdata so that lighthouse/benefits_claims/index/default.yml has the field claim.attributes.claimTypeCode
- [x]  The component in the "Your claims, decision reviews, or appeals" section matches the details in the mocks
- [x]  Phase titles conform to the new 8 step phase process; when a claim is in phase x it shows that the claim is in phase x.
- [x]  The name of the step the claim is in matches exactly the name of the the claim phase step on the Overview page.
- [x]  The claim cards only shows the 8 steps language when claim is a disability claim and no other claim types
- [x]  Behind cst_claim_phases feature flag

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
