### PR TITLE
[MHV-59809] Add datadog tags for FAQ component

### DIFF
--- a/src/applications/mhv-secure-messaging/components/FrequentlyAskedQuestions.jsx
+++ b/src/applications/mhv-secure-messaging/components/FrequentlyAskedQuestions.jsx
@@ -18,7 +18,10 @@ const FrequentlyAskedQuestions = ({ prefLink }) => {
         Questions about this messaging tool
       </h2>
       <va-accordion open-single bordered>
-        <va-accordion-item data-testid="faq-accordion-item">
+        <va-accordion-item
+          data-testid="faq-accordion-item"
+          data-dd-action-name="Who can I send messages to? headline clicked"
+        >
           <h3 slot="headline">Who can I send messages to?</h3>
           <p>
             You can send messages to VA providers and staff on your care team.
@@ -59,7 +62,10 @@ const FrequentlyAskedQuestions = ({ prefLink }) => {
           </p>
         </va-accordion-item>
 
-        <va-accordion-item data-testid="faq-accordion-item">
+        <va-accordion-item
+          data-testid="faq-accordion-item"
+          data-dd-action-name="What if I have an emergency or an urgent question? headline clicked"
+        >
           <h3 slot="headline">
             What if I have an emergency or an urgent question?
           </h3>
@@ -92,7 +98,10 @@ const FrequentlyAskedQuestions = ({ prefLink }) => {
           </ul>
         </va-accordion-item>
 
-        <va-accordion-item data-testid="faq-accordion-item">
+        <va-accordion-item
+          data-testid="faq-accordion-item"
+          data-dd-action-name="Will VA protect my personal health information? headline clicked"
+        >
           <h3 slot="headline">
             Will VA protect my personal health information?
           </h3>
@@ -107,7 +116,10 @@ const FrequentlyAskedQuestions = ({ prefLink }) => {
           </p>
         </va-accordion-item>
 
-        <va-accordion-item data-testid="faq-accordion-item">
+        <va-accordion-item
+          data-testid="faq-accordion-item"
+          data-dd-action-name="What happened to my settings from My HealtheVet secure messaging? headline clicked"
+        >
           <h3 slot="headline">
             What happened to my settings from My HealtheVet secure messaging?
           </h3>
@@ -129,7 +141,10 @@ const FrequentlyAskedQuestions = ({ prefLink }) => {
           </p>
         </va-accordion-item>
 
-        <va-accordion-item data-testid="faq-accordion-item">
+        <va-accordion-item
+          data-testid="faq-accordion-item"
+          data-dd-action-name="Will I need to pay a copay for using this messaging tool? headline clicked"
+        >
           <h3 slot="headline">
             Will I need to pay a copay for using this messaging tool?
           </h3>
@@ -153,7 +168,10 @@ const FrequentlyAskedQuestions = ({ prefLink }) => {
           </a>
         </va-accordion-item>
         {isPilot && (
-          <va-accordion-item data-testid="faq-accordion-item">
+          <va-accordion-item
+            data-testid="faq-accordion-item"
+            data-dd-action-name="What is Secure Messaging Pilot? headline clicked"
+          >
             <h3 slot="headline">What is Secure Messaging Pilot?</h3>
             <p>TBD</p>
           </va-accordion-item>
@@ -165,7 +183,10 @@ const FrequentlyAskedQuestions = ({ prefLink }) => {
       <h2 className="vads-u-margin-top--1">Questions about using messages</h2>
 
       <va-accordion open-single>
-        <va-accordion-item data-testid="faq-accordion-item">
+        <va-accordion-item
+          data-testid="faq-accordion-item"
+          data-dd-action-name="Who can I communicate with in messages? headline clicked"
+        >
           <h3 slot="headline">Who can I communicate with in messages?</h3>
           <p>
             You can communicate with VA providers on your care team. Most VA
@@ -203,7 +224,10 @@ const FrequentlyAskedQuestions = ({ prefLink }) => {
           </p>
         </va-accordion-item>
 
-        <va-accordion-item data-testid="faq-accordion-item">
+        <va-accordion-item
+          data-testid="faq-accordion-item"
+          data-dd-action-name="What if I have an emergency or an urgent question? headline clicked"
+        >
           <h3 slot="headline">
             What if I have an emergency or an urgent question?
           </h3>
@@ -234,7 +258,10 @@ const FrequentlyAskedQuestions = ({ prefLink }) => {
           </ul>
         </va-accordion-item>
 
-        <va-accordion-item data-testid="faq-accordion-item">
+        <va-accordion-item
+          data-testid="faq-accordion-item"
+          data-dd-action-name="Will VA protect my personal health information? headline clicked"
+        >
           <h3 slot="headline">
             Will VA protect my personal health information?
           </h3>
@@ -249,7 +276,10 @@ const FrequentlyAskedQuestions = ({ prefLink }) => {
           </p>
         </va-accordion-item>
 
-        <va-accordion-item data-testid="faq-accordion-item">
+        <va-accordion-item
+          data-testid="faq-accordion-item"
+          data-dd-action-name="What happened to my settings from My HealtheVet secure messaging? headline clicked"
+        >
           <h3 slot="headline">
             What happened to my settings from My HealtheVet secure messaging?
           </h3>


### PR DESCRIPTION
> ## Summary
> 
> Usability UCD reported that they need datadog tags added to the FAQ component within Secure Messaging's Landing page.  This update identifies each FAQ headline when clicked within the accordion and it's action is captured in DD.
> 
> The expected data-dd-action-name is now:  "[Accordion headline text] headline clicked"
> 
> 
> ## Related issue(s)
> [[MHV-59809]](https://jira.devops.va.gov/browse/MHV-59809) Add datadog tags for FAQ component
> 
> ## Testing done
> 
> - Usability testing
> 
> 
> ## Screenshots
> 
> N/A
> 
> |         | Before | After |
> | ------- | ------ | ----- |
> | Mobile  |        |       |
> | Desktop |        |       |
> 
> ## What areas of the site does it impact?
> 
> *(Va.gov - Secure Messaging - FAQ component on Landing Page)*
> 
> ## Acceptance criteria
> 
> ### Quality Assurance & Testing
> 
> - [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
> - [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
> - [ ] Linting warnings have been addressed
> - [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
> - [ ] Screenshot of the developed feature is added
> - [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
> 
> ### Error Handling
> 
> - [ ] Browser console contains no warnings or errors.
> - [ ] Events are being sent to the appropriate logging solution
> - [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
> 
> ### Authentication
> 
> - [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
> 
> ### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:
> 
> - [ ] The vets-website header does not contain any web-components
> - [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
> - [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
> 
> ## Requested Feedback
> 
> (OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
> 