### PR TITLE
DR | Fix re-focus on error alert

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -50,7 +50,7 @@ import { appStateSelector } from '../../shared/utils/issues';
 import { CONTESTABLE_ISSUES_PATH } from '../../shared/constants';
 import GetFormHelp from '../../shared/content/GetFormHelp';
 import reviewErrors from '../../shared/content/reviewErrors';
-import { focusRadioH3, focusH3 } from '../../shared/utils/focus';
+import { focusRadioH3, focusH3, focusOnAlert } from '../../shared/utils/focus';
 
 // import initialData from '../tests/initialData';
 
@@ -163,6 +163,7 @@ const formConfig = {
           schema: contestableIssues.schema,
           appStateSelector,
           scrollAndFocusTarget: focusH3,
+          onContinue: focusOnAlert,
         },
         addIssue: {
           title: 'Add issues for review',

--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -72,7 +72,12 @@ import { focusEvidence } from '../utils/focus';
 import submissionError from '../../shared/content/submissionError';
 import GetFormHelp from '../../shared/content/GetFormHelp';
 import { CONTESTABLE_ISSUES_PATH } from '../../shared/constants';
-import { focusAlertH3, focusRadioH3, focusH3 } from '../../shared/utils/focus';
+import {
+  focusAlertH3,
+  focusRadioH3,
+  focusH3,
+  focusOnAlert,
+} from '../../shared/utils/focus';
 import {
   mayHaveLegacyAppeals,
   appStateSelector,
@@ -166,6 +171,7 @@ const formConfig = {
           schema: contestableIssues.schema,
           appStateSelector,
           scrollAndFocusTarget: focusH3,
+          onContinue: focusOnAlert,
         },
         addIssue: {
           title: 'Add issues for review',

--- a/src/applications/appeals/996/config/form.js
+++ b/src/applications/appeals/996/config/form.js
@@ -38,7 +38,7 @@ import GetFormHelp from '../../shared/content/GetFormHelp';
 import { CONTESTABLE_ISSUES_PATH } from '../../shared/constants';
 import { appStateSelector } from '../../shared/utils/issues';
 import reviewErrors from '../../shared/content/reviewErrors';
-import { focusRadioH3, focusH3 } from '../../shared/utils/focus';
+import { focusRadioH3, focusH3, focusOnAlert } from '../../shared/utils/focus';
 
 // import initialData from '../tests/initialData';
 
@@ -148,6 +148,7 @@ const formConfig = {
           schema: contestableIssuesPage.schema,
           appStateSelector,
           scrollAndFocusTarget: focusH3,
+          onContinue: focusOnAlert,
         },
         // v2 - add issue. Accessed from contestableIssues page only
         addIssue: {

--- a/src/applications/appeals/shared/components/ContestableIssues.jsx
+++ b/src/applications/appeals/shared/components/ContestableIssues.jsx
@@ -98,11 +98,11 @@ const ContestableIssues = props => {
   useEffect(
     () => {
       if (showEditModeError) {
-        focusElement('va-alert[status="error"] h3');
+        focusElement(`va-alert[status="error"] h${onReviewPage ? 4 : 3}`);
         scrollTo('va-alert[status="error"]');
       }
     },
-    [showEditModeError, submitted],
+    [onReviewPage, showEditModeError, submitted],
   );
 
   if (onReviewPage && inReviewMode && items.length && !hasSelected) {

--- a/src/applications/appeals/shared/components/ContestableIssues.jsx
+++ b/src/applications/appeals/shared/components/ContestableIssues.jsx
@@ -98,7 +98,7 @@ const ContestableIssues = props => {
   useEffect(
     () => {
       if (showEditModeError) {
-        focusElement('va-alert[status="error"]');
+        focusElement('va-alert[status="error"] h3');
         scrollTo('va-alert[status="error"]');
       }
     },

--- a/src/applications/appeals/shared/tests/components/ContestableIssues.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/components/ContestableIssues.unit.spec.jsx
@@ -131,7 +131,7 @@ describe('<ContestableIssues>', () => {
       'at least 1 issue before you can continue',
     );
     await waitFor(() => {
-      expect(document.activeElement).to.equal(alert);
+      expect(document.activeElement).to.equal($('h3', alert));
     });
   });
 
@@ -170,7 +170,7 @@ describe('<ContestableIssues>', () => {
     );
 
     await waitFor(() => {
-      expect(document.activeElement).to.equal($('va-alert', container));
+      expect(document.activeElement).to.equal($('va-alert h4', container));
     });
   });
 

--- a/src/applications/appeals/shared/tests/utils/focus.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/focus.unit.spec.js
@@ -14,6 +14,7 @@ import {
   focusRadioH3,
   focusAlertH3,
   focusH3,
+  focusOnAlert,
 } from '../../utils/focus';
 import { LAST_ISSUE } from '../../constants';
 
@@ -372,6 +373,35 @@ describe('focusH3', () => {
     await waitFor(() => {
       const target = $('h3', container);
       expect(document.activeElement).to.eq(target);
+    });
+  });
+});
+
+describe('focusOnAlert', () => {
+  const renderPage = (hasErrorAlert = true) =>
+    render(
+      <div id="main">
+        <div />
+        <va-alert status="info" />
+        {hasErrorAlert && <va-alert status="error" />}
+      </div>,
+    );
+
+  it('should focus on alert', async () => {
+    const { container } = await renderPage();
+
+    await focusOnAlert();
+    await waitFor(() => {
+      const target = $('va-alert[status="error"]', container);
+      expect(document.activeElement).to.eq(target);
+    });
+  });
+  it('should not focus on alert', async () => {
+    await renderPage(false);
+
+    await focusOnAlert();
+    await waitFor(() => {
+      expect(document.activeElement?.tagName).to.not.eq('VA-ALERT');
     });
   });
 });

--- a/src/applications/appeals/shared/tests/utils/focus.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/focus.unit.spec.js
@@ -382,8 +382,14 @@ describe('focusOnAlert', () => {
     render(
       <div id="main">
         <div />
-        <va-alert status="info" />
-        {hasErrorAlert && <va-alert status="error" />}
+        <va-alert status="info">
+          <h3>Test</h3>
+        </va-alert>
+        {hasErrorAlert && (
+          <va-alert status="error">
+            <h3>Test 2</h3>
+          </va-alert>
+        )}
       </div>,
     );
 
@@ -392,7 +398,7 @@ describe('focusOnAlert', () => {
 
     await focusOnAlert();
     await waitFor(() => {
-      const target = $('va-alert[status="error"]', container);
+      const target = $('va-alert[status="error"] h3', container);
       expect(document.activeElement).to.eq(target);
     });
   });
@@ -401,7 +407,7 @@ describe('focusOnAlert', () => {
 
     await focusOnAlert();
     await waitFor(() => {
-      expect(document.activeElement?.tagName).to.not.eq('VA-ALERT');
+      expect(document.activeElement?.tagName).to.eq('BODY');
     });
   });
 });

--- a/src/applications/appeals/shared/utils/focus.js
+++ b/src/applications/appeals/shared/utils/focus.js
@@ -115,7 +115,7 @@ export const focusAlertH3 = () => {
 
 // Used for onContinue callback on the contestable issues page
 export const focusOnAlert = () => {
-  const alert = $('va-alert[status="error"]');
+  const alert = $('va-alert[status="error"] h3');
   if (alert) {
     scrollAndFocus(alert);
   }

--- a/src/applications/appeals/shared/utils/focus.js
+++ b/src/applications/appeals/shared/utils/focus.js
@@ -4,6 +4,7 @@ import {
   focusByOrder,
   scrollTo,
   waitForRenderThenFocus,
+  scrollAndFocus,
 } from '~/platform/utilities/ui';
 import { $, $$ } from '~/platform/forms-system/src/js/utilities/ui';
 
@@ -110,4 +111,12 @@ export const focusAlertH3 = () => {
   // va-alert header is not in the shadow DOM, but still the content doesn't
   // immediately render
   waitForRenderThenFocus('h3');
+};
+
+// Used for onContinue callback on the contestable issues page
+export const focusOnAlert = () => {
+  const alert = $('va-alert[status="error"]');
+  if (alert) {
+    scrollAndFocus(alert);
+  }
 };


### PR DESCRIPTION
## Summary

- _(Summarize the changes that have been made to the platform)_
  > In all three of our appeals forms, move focus to the alert at the top of the page after the user attempts to "Continue" on to the next page. It appears that the focus happens initially, but focus remains on the "Continue" button on subsequent attempts to use the button. This happens in both the HLR and Supplemental Claims forms. For NOD, the user is inadvertently allowed to continue past the contestable issues page without selecting or adding any issues - this needs to be fixed prior to fixing the focus management.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#60784](https://github.com/department-of-veterans-affairs/va.gov-team/issues/60784)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
  > Added unit tests
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

![focus on alert initially, then focus on h3](https://github.com/department-of-veterans-affairs/vets-website/assets/136959/7748590b-731a-40d6-ac26-4b97f111a768)

## What areas of the site does it impact?

Decision Reviews: HLR, NOD & Supplemental Claim

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
