### PR TITLE
cdp-alert check healthcare

### DIFF
--- a/src/applications/combined-debt-portal/medical-copays/containers/OverviewPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/OverviewPage.jsx
@@ -16,6 +16,7 @@ import DisputeCharges from '../components/DisputeCharges';
 import HowToPay from '../components/HowToPay';
 import FinancialHelp from '../components/FinancialHelp';
 import { OnThisPageOverview } from '../components/OnThisPageOverview';
+import MCPAlerts from '../../combined/components/MCPAlerts';
 
 const renderAlert = (alertType, debts) => {
   const alertInfo = alertMessage(alertType, APP_TYPES.COPAY);
@@ -63,7 +64,6 @@ const OverviewPage = () => {
   const { debtLetters, mcp } = useSelector(
     ({ combinedPortal }) => combinedPortal,
   );
-
   const {
     debts,
     isError: debtError,
@@ -73,7 +73,6 @@ const OverviewPage = () => {
   const debtLoading = isDebtPending || isProfileUpdating;
   const { statements, error: mcpError, pending: mcpLoading } = mcp;
   const statementsEmpty = statements?.length === 0;
-
   const sortedStatements = sortStatementsByDate(statements ?? []);
   const statementsByUniqueFacility = uniqBy(sortedStatements, 'pSFacilityNum');
   const title = 'Current copay balances';
@@ -93,7 +92,36 @@ const OverviewPage = () => {
       </div>
     );
   }
-
+  const isNotEnrolledInHealthCare = mcpError?.status === '403';
+  const renderContent = () => {
+    if (isNotEnrolledInHealthCare) {
+      return <MCPAlerts type="no-health-care" />;
+    }
+    if (mcpError) {
+      return renderAlert(
+        debtError ? ALERT_TYPES.ALL_ERROR : ALERT_TYPES.ERROR,
+        debts?.length,
+      );
+    }
+    if (statementsEmpty) {
+      return renderAlert(ALERT_TYPES.ZERO, debts?.length);
+    }
+    return (
+      <>
+        <OnThisPageOverview multiple={statements?.length > 1} />
+        <Balances statements={statementsByUniqueFacility} />
+        {renderOtherVA(debts?.length, debtError)}
+        <HowToPay
+          isOverview="true"
+          acctNum={statementsByUniqueFacility[0].pHAccountNumber}
+          facility={statementsByUniqueFacility[0].station}
+        />
+        <FinancialHelp />
+        <DisputeCharges />
+        <BalanceQuestions />
+      </>
+    );
+  };
   return (
     <>
       <VaBreadcrumbs
@@ -121,31 +149,7 @@ const OverviewPage = () => {
           of your facilities. Find out how to make payments or request financial
           help.
         </p>
-        {mcpError || statementsEmpty ? (
-          <>
-            {mcpError &&
-              renderAlert(
-                debtError ? ALERT_TYPES.ALL_ERROR : ALERT_TYPES.ERROR,
-                debts?.length,
-              )}
-
-            {statementsEmpty && renderAlert(ALERT_TYPES.ZERO, debts?.length)}
-          </>
-        ) : (
-          <>
-            <OnThisPageOverview multiple={statements?.length > 1} />
-            <Balances statements={statementsByUniqueFacility} />
-            {renderOtherVA(debts?.length, debtError)}
-            <HowToPay
-              isOverview="true"
-              acctNum={statementsByUniqueFacility[0].pHAccountNumber}
-              facility={statementsByUniqueFacility[0].station}
-            />
-            <FinancialHelp />
-            <DisputeCharges />
-            <BalanceQuestions />
-          </>
-        )}
+        {renderContent()}
       </div>
     </>
   );

--- a/src/applications/combined-debt-portal/medical-copays/tests/e2e/cdp-alert.cypress.spec.js
+++ b/src/applications/combined-debt-portal/medical-copays/tests/e2e/cdp-alert.cypress.spec.js
@@ -45,6 +45,34 @@ describe('Medical Copays - CDP Alerts', () => {
     cy.injectAxeThenAxeCheck();
   });
 
+  // VHA 403 response (Not enrolled in healthcare)
+  it('should display not enrolled in healthcare alert for VHA 403 response', () => {
+    cy.login(mockUser);
+    cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles);
+    cy.intercept('GET', '/v0/medical_copays', req => {
+      req.reply(403, {
+        errors: [
+          {
+            title: 'Forbidden',
+            detail: 'User does not have access to the requested resource',
+            code: '403',
+            status: '403',
+          },
+        ],
+      });
+    });
+    cy.intercept('GET', '/v0/debts', mockDebt);
+    cy.visit('/manage-va-debt/summary/copay-balances');
+
+    // Ensure the page has loaded
+    cy.findByTestId('overview-page-title').should('exist');
+    cy.injectAxe();
+
+    // Check for the "not enrolled in healthcare" alert
+    cy.findByTestId('no-healthcare-alert').should('exist');
+    cy.injectAxeThenAxeCheck();
+  });
+
   // Has VHA and VBA 404
   it('should display valid copay balances & other VA debt information', () => {
     cy.login(mockUser);


### PR DESCRIPTION

## Summary
On the summary page we [check for a 403 response ](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/combined-debt-portal/combined/components/Balances.jsx#L29) and surface the warning message, so we should probably do the same on the [copay specific page](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/applications/combined-debt-portal/medical-copays/containers/OverviewPage.jsx). 

[Here's the PR](https://github.com/department-of-veterans-affairs/vets-website/pull/21548) where we implemented the warning the first time, looks like `vets.gov.user+3@gmail.com` is a good test case locally and on staging according to [this test case](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/combined_va_debt_portal/use_cases.md#use-case-d---veteran-is-not-enrolled-in-healthcare)

Given: A veteran is not enrolled in healthcare
When: That veteran navigates directly to `/manage-va-debt/summary/copay-balances`
Then: That veteran should see the "Not enrolled in healthcare" alert message instead of the error message


### New Warning

![image](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/a124f5b7-2eca-451c-ab6c-fe1471063278)



## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#85064


## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop | ![image](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/09bc43d0-b210-40b7-91aa-311ea2753744)      |  ![Screenshot 2024-07-10 125238](https://github.com/department-of-veterans-affairs/vets-website/assets/3916436/74549781-5cb6-436a-b115-c27c205b913b)     |


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.


