### PR TITLE
Updated MHV registration link

### DIFF
--- a/src/applications/mhv-landing-page/components/MhvRegistrationAlert.jsx
+++ b/src/applications/mhv-landing-page/components/MhvRegistrationAlert.jsx
@@ -1,8 +1,10 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { mhvBaseUrl } from '@department-of-veterans-affairs/platform-site-wide/utilities';
+import { useSelector } from 'react-redux';
+import { mhvUrl } from '@department-of-veterans-affairs/platform-site-wide/utilities';
 // eslint-disable-next-line import/no-named-default
 import { default as recordEventFn } from '~/platform/monitoring/record-event';
+import { isAuthenticatedWithSSOe } from '../selectors';
 
 const MhvRegistrationAlert = ({ headline, recordEvent, status, icon }) => {
   useEffect(
@@ -16,6 +18,9 @@ const MhvRegistrationAlert = ({ headline, recordEvent, status, icon }) => {
     },
     [headline, recordEvent, status],
   );
+
+  const hasSsoe = useSelector(isAuthenticatedWithSSOe);
+  const mhvLink = `${mhvUrl(hasSsoe, '')}home&postLogin=true`;
 
   return (
     <div
@@ -36,10 +41,7 @@ const MhvRegistrationAlert = ({ headline, recordEvent, status, icon }) => {
             this page.
           </p>
           <p>
-            <a
-              className="vads-c-action-link--green"
-              href={`${mhvBaseUrl()}/mhv-portal-web/web/myhealthevet/user-registration`}
-            >
+            <a className="vads-c-action-link--green" href={mhvLink}>
               Register with My HealtheVet
             </a>
           </p>

--- a/src/applications/mhv-landing-page/tests/components/MhvRegistrationAlert.unit.spec.jsx
+++ b/src/applications/mhv-landing-page/tests/components/MhvRegistrationAlert.unit.spec.jsx
@@ -2,17 +2,35 @@ import React from 'react';
 import { render, waitFor } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { Provider } from 'react-redux';
 
 import MhvRegistrationAlert from '../../components/MhvRegistrationAlert';
 
 const defaultHeadline = MhvRegistrationAlert.defaultProps.headline;
 
 describe('MhvRegistrationAlert', () => {
+  const mockStore = () => ({
+    getState: () => ({
+      user: {
+        profile: {
+          session: {
+            ssoe: true,
+          },
+        },
+      },
+    }),
+    subscribe: () => {},
+    dispatch: () => {},
+  });
+
   it('renders', () => {
-    const { getByRole } = render(<MhvRegistrationAlert />);
+    const { getByRole } = render(
+      <Provider store={mockStore()}>
+        <MhvRegistrationAlert />
+      </Provider>,
+    );
     getByRole('heading', { name: defaultHeadline });
-    const link = getByRole('link', { name: /Register with My HealtheVet/ });
-    expect(link.href).to.not.be.empty;
+    getByRole('link', { name: /Register with My HealtheVet/ });
   });
 
   it('reports to GA via recordEvent when rendered', async () => {
@@ -24,7 +42,11 @@ describe('MhvRegistrationAlert', () => {
     };
     const recordEventSpy = sinon.spy();
     const props = { recordEvent: recordEventSpy };
-    render(<MhvRegistrationAlert {...props} />);
+    render(
+      <Provider store={mockStore()}>
+        <MhvRegistrationAlert {...props} />
+      </Provider>,
+    );
     await waitFor(() => {
       expect(recordEventSpy.calledOnce).to.be.true;
       expect(recordEventSpy.calledWith(event)).to.be.true;


### PR DESCRIPTION
## Summary
- Updated MHV registration link to allow for deep linking

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/87852

## Testing done
- Updated unit test
- Manual testing

## Screenshots
There are no changes to the UI

## What areas of the site does it impact?
- MHV Landing Page

## Acceptance criteria
- The Register with My HealhteVet link goes to `https://<MHV host>/mhv-portal-web/eauth?deeplinking=home&postLogin=true` for SSOe authenticated users.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

