### PR TITLE
10-7959f-2 Same as mailing address

### DIFF
--- a/src/applications/ivc-champva/10-7959f-2/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-2/config/form.js
@@ -13,6 +13,8 @@ import {
   addressSchema,
   emailUI,
   emailSchema,
+  yesNoUI,
+  yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 import manifest from '../manifest.json';
@@ -118,7 +120,7 @@ const formConfig = {
               "We'll send any important information about your application to this address. This can be your current home address or a more permanent location.",
             ),
             messageAriaDescribedby:
-              "We'll send any important information about your application to this address.",
+              "We'll send any important information about your application to this address. This can be your current home address or a more permanent location.",
             veteranAddress: addressUI({
               required: {
                 state: () => true,
@@ -140,12 +142,35 @@ const formConfig = {
       title: 'Home address',
       pages: {
         page4: {
+          path: 'same-as-mailing-address',
+          title: 'Home address ',
+          uiSchema: {
+            ...titleUI('Home address'),
+            sameMailingAddress: yesNoUI({
+              title: 'Is your home address the same as your mailing address?',
+              labels: {
+                Y: 'Yes',
+                N: 'No',
+              },
+            }),
+          },
+          schema: {
+            type: 'object',
+            required: ['sameMailingAddress'],
+            properties: {
+              titleSchema,
+              sameMailingAddress: yesNoSchema,
+            },
+          },
+        },
+        page4a: {
           path: 'home-address',
           title: 'Home address ',
+          depends: formData => formData.sameMailingAddress === false,
           uiSchema: {
             ...titleUI(
               `Home address`,
-              `Provide the address where you're living right now.`,
+              `Provide the address where you're living right now`,
             ),
             messageAriaDescribedby: `Provide the address where you're living right now.`,
             physicalAddress: {


### PR DESCRIPTION
## Summary
This PR adds a same as mailing address page to f2. It asks if their home address is the same as their mailing address. If they say yes, it skips the home address page. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/87062

## Testing done
Manual tests

## Screenshots
![Screenshot 2024-07-11 at 9 47 33 AM](https://github.com/department-of-veterans-affairs/vets-website/assets/20195737/c97e819e-fbd0-46af-82e5-5f4103c28956)

## What areas of the site does it impact?
NA

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA