### PR TITLE
[CDP] 87478 - Hiding references to downloading letters

### DIFF
--- a/src/applications/combined-debt-portal/debt-letters/components/OnThisPageLinks.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/OnThisPageLinks.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const OnThisPageLinks = ({ isDetailsPage, hasHistory }) => (
+const OnThisPageLinks = ({
+  isDetailsPage,
+  hasHistory,
+  showDebtLetterDownload,
+}) => (
   <>
     <nav aria-labelledby="on-this-page" className="on-this-page-links">
       <dl>
@@ -40,7 +44,7 @@ const OnThisPageLinks = ({ isDetailsPage, hasHistory }) => (
               Debt letter history
             </a>
           )}
-          {(!isDetailsPage || hasHistory) && (
+          {showDebtLetterDownload && (!isDetailsPage || hasHistory) ? (
             <a
               href="#downloadDebtLetters"
               data-testid="download-jumplink"
@@ -53,7 +57,7 @@ const OnThisPageLinks = ({ isDetailsPage, hasHistory }) => (
               />
               Download debt letters
             </a>
-          )}
+          ) : null}
           <a
             href="#howDoIPay"
             data-testid="howto-pay-jumplink"

--- a/src/applications/combined-debt-portal/debt-letters/components/OnThisPageLinks.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/OnThisPageLinks.jsx
@@ -103,6 +103,7 @@ const OnThisPageLinks = ({
 OnThisPageLinks.propTypes = {
   hasHistory: PropTypes.bool,
   isDetailsPage: PropTypes.bool,
+  showDebtLetterDownload: PropTypes.bool,
 };
 
 export default OnThisPageLinks;

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtDetails.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtDetails.jsx
@@ -9,7 +9,10 @@ import NeedHelp from '../components/NeedHelp';
 import OnThisPageLinks from '../components/OnThisPageLinks';
 import HistoryTable from '../components/HistoryTable';
 import { getCurrentDebt } from '../utils/page';
-import { setPageFocus } from '../../combined/utils/helpers';
+import {
+  setPageFocus,
+  debtLettersShowLettersVBMS,
+} from '../../combined/utils/helpers';
 import {
   deductionCodes,
   renderWhyMightIHaveThisDebt,
@@ -36,6 +39,10 @@ const DebtDetails = () => {
     personEntitled: currentDebt.personEntitled,
     deductionCode: currentDebt.deductionCode,
   };
+
+  const showDebtLetterDownload = useSelector(state =>
+    debtLettersShowLettersVBMS(state),
+  );
 
   useEffect(() => {
     setPageFocus('h1');
@@ -98,7 +105,11 @@ const DebtDetails = () => {
             {whyContent}
           </va-additional-info>
         )}
-        <OnThisPageLinks isDetailsPage hasHistory={hasFilteredHistory} />
+        <OnThisPageLinks
+          isDetailsPage
+          hasHistory={hasFilteredHistory}
+          showDebtLetterDownload={showDebtLetterDownload}
+        />
         {hasFilteredHistory && (
           <>
             <h2
@@ -108,7 +119,9 @@ const DebtDetails = () => {
               Debt letter history
             </h2>
             <p className="vads-u-margin-y--2">
-              You can check the status or download the letters for this debt.
+              {`You can check the status ${
+                showDebtLetterDownload ? `or download the letters for` : `of`
+              } this debt.`}
             </p>
             <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
               <strong>Note:</strong> The content of the debt letters below may
@@ -122,16 +135,23 @@ const DebtDetails = () => {
               .
             </p>
             <HistoryTable history={filteredHistory} />
-            <h3 id="downloadDebtLetters" className="vads-u-margin-top--0">
-              Download debt letters
-            </h3>
-            <p className="vads-u-margin-bottom--0">
-              You can download some of your letters for education, compensation
-              and pension debt.
-            </p>
-            <Link to="/debt-balances/letters" className="vads-u-margin-top--1">
-              Download letters related to your VA debt
-            </Link>
+            {showDebtLetterDownload ? (
+              <>
+                <h3 id="downloadDebtLetters" className="vads-u-margin-top--0">
+                  Download debt letters
+                </h3>
+                <p className="vads-u-margin-bottom--0">
+                  You can download some of your letters for education,
+                  compensation and pension debt.
+                </p>
+                <Link
+                  to="/debt-balances/letters"
+                  className="vads-u-margin-top--1"
+                >
+                  Download letters related to your VA debt
+                </Link>
+              </>
+            ) : null}
           </>
         )}
         <HowDoIPay userData={howToUserData} />

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
@@ -141,7 +141,9 @@ const DebtLettersSummary = () => {
             </>
           ) : (
             <>
-              <OnThisPageLinks />
+              <OnThisPageLinks
+                showDebtLetterDownload={showDebtLetterDownload}
+              />
 
               <DebtCardsList />
 

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
@@ -6,6 +6,7 @@ import {
   setPageFocus,
   ALERT_TYPES,
   APP_TYPES,
+  debtLettersShowLettersVBMS,
 } from '../../combined/utils/helpers';
 import HowDoIPay from '../components/HowDoIPay';
 import NeedHelp from '../components/NeedHelp';
@@ -61,6 +62,10 @@ const DebtLettersSummary = () => {
   const { debtLetters, mcp } = useSelector(
     ({ combinedPortal }) => combinedPortal,
   );
+  const showDebtLetterDownload = useSelector(state =>
+    debtLettersShowLettersVBMS(state),
+  );
+
   const {
     debts,
     debtLinks,
@@ -142,26 +147,28 @@ const DebtLettersSummary = () => {
 
               {renderOtherVA(mcpStatements?.length, mcpError)}
 
-              <section>
-                <h3
-                  id="downloadDebtLetters"
-                  className="vads-u-margin-top--4 vads-u-font-size--h2"
-                >
-                  Download debt letters
-                </h3>
-                <p className="vads-u-margin-bottom--0 vads-u-font-family--sans">
-                  You can download some of your letters for education,
-                  compensation and pension debt.
-                </p>
+              {showDebtLetterDownload ? (
+                <section>
+                  <h3
+                    id="downloadDebtLetters"
+                    className="vads-u-margin-top--4 vads-u-font-size--h2"
+                  >
+                    Download debt letters
+                  </h3>
+                  <p className="vads-u-margin-bottom--0 vads-u-font-family--sans">
+                    You can download some of your letters for education,
+                    compensation and pension debt.
+                  </p>
 
-                <Link
-                  to="/debt-balances/letters"
-                  className="vads-u-margin-top--1 vads-u-font-family--sans"
-                  data-testid="download-letters-link"
-                >
-                  Download letters related to your VA debt
-                </Link>
-              </section>
+                  <Link
+                    to="/debt-balances/letters"
+                    className="vads-u-margin-top--1 vads-u-font-family--sans"
+                    data-testid="download-letters-link"
+                  >
+                    Download letters related to your VA debt
+                  </Link>
+                </section>
+              ) : null}
 
               <HowDoIPay />
 

--- a/src/applications/combined-debt-portal/debt-letters/tests/e2e/debt-letters.cypress.spec.js
+++ b/src/applications/combined-debt-portal/debt-letters/tests/e2e/debt-letters.cypress.spec.js
@@ -3,7 +3,7 @@ import mockDebts from './fixtures/mocks/debts.json';
 import mockUser from './fixtures/mocks/mock-user.json';
 import mockCopays from '../../../medical-copays/tests/e2e/fixtures/mocks/copays.json';
 
-describe('Debt Letters', () => {
+describe('Debt Letters - downloads enabled', () => {
   beforeEach(() => {
     cy.login(mockUser);
     cy.intercept('GET', '/v0/feature_toggles*', mockFeatureToggles).as(
@@ -52,6 +52,35 @@ describe('Debt Letters', () => {
       waitForAnimations: true,
     });
     cy.get('#howDoIDispute').should('be.visible');
+    cy.injectAxeThenAxeCheck();
+  });
+});
+
+describe('Debt Letters - downloads disabled', () => {
+  beforeEach(() => {
+    cy.login(mockUser);
+    cy.intercept('GET', '/v0/feature_toggles*', {
+      data: {
+        type: 'feature_toggles',
+        features: [
+          { name: 'debt_letters_show_letters_vbms', value: false },
+          {
+            name: 'combined_debt_portal_access',
+            value: true,
+          },
+        ],
+      },
+    }).as('features');
+    cy.intercept('GET', '/v0/debts', mockDebts).as('debts');
+    cy.intercept('GET', '/v0/medical_copays', mockCopays);
+    cy.visit('/manage-va-debt/summary/debt-balances');
+    cy.wait(['@features', '@debts']);
+  });
+
+  it('does not display download debt letters', () => {
+    cy.findByTestId('download-jumplink').should('not.exist');
+    cy.findByTestId('download-letters-link').should('not.exist');
+    cy.get('#downloadDebtLetters').should('not.exist');
     cy.injectAxeThenAxeCheck();
   });
 });

--- a/src/applications/combined-debt-portal/debt-letters/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/combined-debt-portal/debt-letters/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -3,6 +3,7 @@
     "type": "feature_toggles",
     "features": [
       { "name": "debt_letters_show_letters", "value": true },
+      { "name": "debt_letters_show_letters_vbms", "value": true },
       { 
         "name": "combined_debt_portal_access", 
         "value": true 


### PR DESCRIPTION
## Summary
Hiding references to debt letter downloads via existing feature flag (`debt_letters_show_letters_vbms`) which is also disabling the functionality on the BE

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#87478

## Testing done
Manual testing complete

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Debt Summary  | <img width="270" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/25368370/92166188-a316-49bd-8572-7713b12fa998"> | <img width="282" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/25368370/d5fa5111-1735-4b8c-a9f0-4bb3e73c8e61"> |
| Debt Details | <img width="237" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/25368370/b47104cb-440d-49fc-9cf9-a85c1b2d237e"> | <img width="212" alt="image" src="https://github.com/department-of-veterans-affairs/vets-website/assets/25368370/f1152774-ec1e-430e-802d-ee0da3b9a0c1"> |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
