### PR TITLE
stylelint: ignore files under .git dir

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,7 @@
 {
   "plugins": ["stylelint-scss", "stylelint-order"],
   "ignoreFiles": [
+    ".git/**",
     "src/applications/proxy-rewrite/sass/style-consolidated.scss",
     "src/applications/vaos/docs/styles/*.css",
     "mochawesome-report/**/*.css"


### PR DESCRIPTION
## Summary

- Prevents stylelint from checking files under the `.git` directory

## Related issue(s)

- https://dsva.slack.com/archives/CBU0KDSB1/p1720726966565249
