### PR TITLE
[CDP] 87478  - Adding debt letter download disabled warning message

### DIFF
--- a/src/applications/combined-debt-portal/debt-letters/components/Alerts.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/Alerts.jsx
@@ -63,18 +63,25 @@ export const DowntimeMessage = () => {
   );
 };
 
-export const ErrorMessage = () => (
-  <va-alert status="error">
-    <h3 slot="headline">Information about your current debts is unavailable</h3>
-    <p className="vads-u-font-family--sans">
-      We’re sorry. You can’t view information about your current debts because
-      something went wrong on our end. Please check back soon.
+export const DebtLetterDownloadDisabled = () => (
+  <va-alert status="warning">
+    <h3 className="vads-u-font-size--h3" slot="headline">
+      Information about your current debts is unavailable
+    </h3>
+    <p>
+      If you have VA health care copay debt, go to our
+      <Link className="vads-u-margin-x--0p5" to="/copay-balances/">
+        Pay your VA copay bill
+      </Link>
+      page to learn about your payment options.
     </p>
-    <h4>What you can do</h4>
-    <p className="vads-u-font-family--sans vads-u-margin-y--0">
-      If you continue having trouble viewing information about your current
-      debts, contact us online through <a href="https://ask.va.gov">Ask VA</a>.
-    </p>
+    <va-link
+      href="/manage-va-debt/summary/debt-balances/"
+      icon-name="navigate_before"
+      icon-size={3}
+      text="Back to current debts"
+      class="vads-u-font-weight--bold vads-u-margin-left--neg0p5 vads-u-margin-top--2"
+    />
   </va-alert>
 );
 

--- a/src/applications/combined-debt-portal/debt-letters/components/Alerts.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/Alerts.jsx
@@ -66,7 +66,7 @@ export const DowntimeMessage = () => {
 export const DebtLetterDownloadDisabled = () => (
   <va-alert status="warning">
     <h3 className="vads-u-font-size--h3" slot="headline">
-      Information about your current debts is unavailable
+      Your debt letters are currently unavailable for download.
     </h3>
     <p>
       If you have VA health care copay debt, go to our

--- a/src/applications/combined-debt-portal/debt-letters/components/DebtLettersTable.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/DebtLettersTable.jsx
@@ -3,9 +3,19 @@ import moment from 'moment';
 import environment from 'platform/utilities/environment';
 import recordEvent from 'platform/monitoring/record-event';
 import PropTypes from 'prop-types';
-import { ErrorAlert, DependentDebt, NoDebtLinks } from './Alerts';
+import {
+  DependentDebt,
+  ErrorAlert,
+  NoDebtLinks,
+  DebtLetterDownloadDisabled,
+} from './Alerts';
 
-const DebtLettersTable = ({ debtLinks, hasDependentDebts, isError }) => {
+const DebtLettersTable = ({
+  debtLinks,
+  hasDependentDebts,
+  isError,
+  showDebtLetterDownload,
+}) => {
   const hasDebtLinks = !!debtLinks.length;
   const [showOlder, toggleShowOlderLetters] = useState(false);
 
@@ -29,6 +39,7 @@ const DebtLettersTable = ({ debtLinks, hasDependentDebts, isError }) => {
 
   const [first, second, ...rest] = debtLinksDescending;
 
+  if (!showDebtLetterDownload) return <DebtLetterDownloadDisabled />;
   if (isError) return <ErrorAlert />;
   if (hasDependentDebts) return <DependentDebt />;
   if (!hasDebtLinks) return <NoDebtLinks />;
@@ -155,6 +166,7 @@ DebtLettersTable.propTypes = {
   ),
   hasDependentDebts: PropTypes.bool,
   isError: PropTypes.bool,
+  showDebtLetterDownload: PropTypes.bool,
 };
 
 export default DebtLettersTable;

--- a/src/applications/combined-debt-portal/debt-letters/components/HowDoIPay.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/HowDoIPay.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
-const HowDoIPay = ({ userData }) => (
+const HowDoIPay = ({ userData, showDebtLetterDownload }) => (
   <article className="vads-u-font-family--sans vads-u-padding-x--0">
     <h2 id="howDoIPay" className="vads-u-margin-top--4 vads-u-margin-bottom-2">
       How to pay your VA debt
@@ -86,21 +86,34 @@ const HowDoIPay = ({ userData }) => (
           <va-telephone contact="6127136415" international />.
         </p>
       </va-accordion-item>
-      <va-accordion-item header="Option 3: Pay by mail" id="third">
-        <p className="vads-u-margin-y--0">
-          Find instructions on how to pay by mail in the demand letter sent to
-          your address or you can
-          <Link className="vads-u-margin-left--0p5" to="/debt-balances/letters">
-            download them online
-          </Link>
-          .
-        </p>
-      </va-accordion-item>
+      {showDebtLetterDownload ? (
+        <va-accordion-item header="Option 3: Pay by mail" id="third">
+          <p className="vads-u-margin-y--0">
+            Find instructions on how to pay by mail in the demand letter sent to
+            your address or you can
+            <Link
+              className="vads-u-margin-left--0p5"
+              to="/debt-balances/letters"
+            >
+              download them online
+            </Link>
+            .
+          </p>
+        </va-accordion-item>
+      ) : (
+        <va-accordion-item header="Option 3: Pay by mail" id="third">
+          <p className="vads-u-margin-y--0">
+            Find instructions on how to pay by mail in the demand letter sent to
+            your address.
+          </p>
+        </va-accordion-item>
+      )}
     </va-accordion>
   </article>
 );
 
 HowDoIPay.propTypes = {
+  showDebtLetterDownload: PropTypes.bool,
   userData: PropTypes.shape({
     fileNumber: PropTypes.string,
     payeeNumber: PropTypes.string,

--- a/src/applications/combined-debt-portal/debt-letters/components/HowDoIPay.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/HowDoIPay.jsx
@@ -95,9 +95,8 @@ const HowDoIPay = ({ userData, showDebtLetterDownload }) => (
               className="vads-u-margin-left--0p5"
               to="/debt-balances/letters"
             >
-              download them online
+              download them online.
             </Link>
-            .
           </p>
         </va-accordion-item>
       ) : (

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtDetails.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtDetails.jsx
@@ -154,7 +154,10 @@ const DebtDetails = () => {
             ) : null}
           </>
         )}
-        <HowDoIPay userData={howToUserData} />
+        <HowDoIPay
+          userData={howToUserData}
+          showDebtLetterDownload={showDebtLetterDownload}
+        />
         <NeedHelp />
       </div>
     </>

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersDownload.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersDownload.jsx
@@ -1,7 +1,10 @@
 import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { VaBreadcrumbs } from '@department-of-veterans-affairs/web-components/react-bindings';
-import { setPageFocus } from '../../combined/utils/helpers';
+import {
+  setPageFocus,
+  debtLettersShowLettersVBMS,
+} from '../../combined/utils/helpers';
 import DebtLettersTable from '../components/DebtLettersTable';
 
 const DebtLettersDownload = () => {
@@ -10,6 +13,9 @@ const DebtLettersDownload = () => {
   );
 
   const showError = isError || isVBMSError;
+  const showDebtLetterDownload = useSelector(state =>
+    debtLettersShowLettersVBMS(state),
+  );
 
   useEffect(() => {
     setPageFocus('h1');
@@ -56,6 +62,7 @@ const DebtLettersDownload = () => {
           debtLinks={debtLinks}
           hasDependentDebts={hasDependentDebts}
           isError={showError}
+          showDebtLetterDownload={showDebtLetterDownload}
         />
         <div className="vads-u-margin-bottom--6 vads-u-margin-top--5">
           <h2 className="vads-u-margin-y--0">

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
@@ -172,7 +172,7 @@ const DebtLettersSummary = () => {
                 </section>
               ) : null}
 
-              <HowDoIPay />
+              <HowDoIPay showDebtLetterDownload={showDebtLetterDownload} />
 
               <NeedHelp />
             </>


### PR DESCRIPTION
## Summary
Adding debt letter download disabled warning message since the `/manage-va-debt/summary/debt-balances/letters` url is still reachable even though we've removed references. This is more of a safety net on the odd chance this url is bookmarked somewhere. This alert only displays if the `debt_letters_show_letters_vbms` is `false` when the debt letter download is completely disabled. 

Also removing additional download references in "How do I pay" section" located on summary and debt details pages

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#87478
- Removing references to the download page
department-of-veterans-affairs/vets-website/pull/30795

## Testing done
Manual testing complete

## Screenshots
`/manage-va-debt/summary/debt-balances/letters`
<img width="300" alt="image" src="https://github.com/user-attachments/assets/1d06afbb-c118-4520-ac64-0d6624445787">

### "How do I pay" removal

| Before | After |
| ---  | --- |
| <img width="626" alt="image" src="https://github.com/user-attachments/assets/cee07ca7-8890-4644-977b-534cc5d0e8a8"> | <img width="617" alt="image" src="https://github.com/user-attachments/assets/7fcc688e-21cc-4c2f-836e-3b8d01ea2a46"> |


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
