### PR TITLE
86957 Add statement of truth to review page - form 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959a/config/form.js
+++ b/src/applications/ivc-champva/10-7959a/config/form.js
@@ -59,6 +59,18 @@ const formConfig = {
       saved: 'Your CHAMPVA claim form application has been saved.',
     },
   },
+  preSubmitInfo: {
+    statementOfTruth: {
+      body:
+        'I confirm that the identifying information in this form is accurate and has been represented correctly.',
+      messageAriaDescribedby:
+        'I confirm that the identifying information in this form is accurate and has been represented correctly.',
+      fullNamePath: formData =>
+        formData?.certifierRole === 'applicant'
+          ? 'applicantName'
+          : 'certifierName',
+    },
+  },
   version: 0,
   prefillEnabled: true,
   savedFormMessages: {

--- a/src/applications/ivc-champva/10-7959a/tests/fixtures/data/test-data.json
+++ b/src/applications/ivc-champva/10-7959a/tests/fixtures/data/test-data.json
@@ -13,10 +13,34 @@
     },
     "applicantMemberNumber": "222111123",
     "applicantDOB": "2000-10-25",
+    "applicantAddress": {
+      "country": "USA",
+      "street": "123 Beneficiary Street",
+      "city": "Citytown",
+      "state": "MD",
+      "postalCode": "12345"
+    },
+    "applicantNewAddress": "yes",
     "medicalUpload": [
       {
         "name": "Document1.png",
         "confirmationCode": "3b4a6ba3-f6a0-4257-b383-b001e20c5b63",
+        "attachmentId": "",
+        "isEncrypted": false
+      }
+    ],
+    "primaryEOB": [
+      {
+        "name": "Document1.png",
+        "confirmationCode": "3b4a6ba3-f6a0-4257-b383-b001e20c5b65",
+        "attachmentId": "",
+        "isEncrypted": false
+      }
+    ],
+    "secondaryEOB": [
+      {
+        "name": "Document1.png",
+        "confirmationCode": "3b4a6ba3-f6a0-4257-b383-b001e20c5b66",
         "attachmentId": "",
         "isEncrypted": false
       }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR updates the review page for form 10-7959a to show the statement of truth.

- Adds SOT to review page for form 10-7959a
- Updates a test data file to have more dummy data
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86957

## Testing done

- Manual

## Screenshots

|         |  Screens |
| ------- |  ----- |
| Statement of Truth |<img width="470" alt="Screenshot 2024-07-12 at 11 21 02" src="https://github.com/user-attachments/assets/57ae07e6-ef52-463a-b792-2ec0a583a27a">|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
NA