### PR TITLE
third-party-app-directory: replace font awesome icons with va-icon

### DIFF
--- a/src/applications/third-party-app-directory/components/SearchResult/index.jsx
+++ b/src/applications/third-party-app-directory/components/SearchResult/index.jsx
@@ -97,7 +97,11 @@ export class SearchResult extends Component {
           >
             <span className="additional-info-title">
               Learn about {item?.name}{' '}
-              <i className={`fa fa-chevron-${learnIcon}`} />
+              {learnIcon === 'down' ? (
+                <va-icon icon="expand_more" size={3} />
+              ) : (
+                <va-icon icon="expand_less" size={3} />
+              )}
             </span>
           </button>
         </div>

--- a/src/applications/third-party-app-directory/components/SearchResult/index.unit.spec.js
+++ b/src/applications/third-party-app-directory/components/SearchResult/index.unit.spec.js
@@ -35,12 +35,12 @@ describe('<SearchResult>', () => {
   it('should toggle to display additional app information', () => {
     const wrapper = shallow(<SearchResult {...props} />);
 
-    expect(wrapper.find('.fa-chevron-down')).to.have.lengthOf(1);
+    expect(wrapper.find('va-icon').props().icon).to.equal('expand_more');
 
     wrapper.find('button').simulate('click');
     const additionalText = wrapper.text();
 
-    expect(wrapper.find('.fa-chevron-up')).to.have.lengthOf(1);
+    expect(wrapper.find('va-icon').props().icon).to.equal('expand_less');
     expect(additionalText).to.include(props.item.description);
 
     wrapper.unmount();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**: Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
- _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

## Summary

This PR replaces some font awesome icons in third-party-app-directory accordance with an initiative to deprecate font awesome on vets-website.

## Related issue(s)

[2944](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2944)

## Testing done

local testing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
