### PR TITLE
Mhv 59812 cypress testing allergies network response

### DIFF
--- a/src/applications/mhv-medications/tests/e2e/fixtures/allergies-list.json
+++ b/src/applications/mhv-medications/tests/e2e/fixtures/allergies-list.json
@@ -1,0 +1,207 @@
+{
+    "id": "ba0c2690-7273-485e-bcd4-2e529a6f7025",
+    "meta": {
+        "lastUpdated": "2024-06-20T17:24:29.929-04:00"
+    },
+    "type": "searchset",
+    "total": 2,
+    "link": [
+        {
+            "relation": "self",
+            "url": "https://mhv-sysb-api.myhealth.va.gov/fhir/AllergyIntolerance?_count=9999&clinical-status=active&patient=1393&verification-status%3Anot=entered-in-error"
+        }
+    ],
+    "entry": [
+        {
+            "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/AllergyIntolerance/3103",
+            "resource": {
+                "id": "3103",
+                "meta": {
+                    "versionId": "1",
+                    "lastUpdated": "2024-03-21T13:39:30.033-04:00",
+                    "source": "#gsVhmoXXXs2FXxBx",
+                    "profile": [
+                        "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.allergyIntolerance"
+                    ]
+                },
+                "contained": [
+                    {
+                        "id": "Organization-0",
+                        "identifier": [
+                            {
+                                "use": "usual",
+                                "system": "urn:oid:2.16.840.1.113883.4.349",
+                                "value": "SLC10.FO-BAYPINES.MED.VA.GOV"
+                            }
+                        ],
+                        "name": "SLC10 TEST LAB",
+                        "resourceType": "Organization"
+                    }
+                ],
+                "extension": [
+                    {
+                        "url": "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/allergyObservedHistoric",
+                        "valueCode": "h"
+                    }
+                ],
+                "identifier": [
+                    {
+                        "use": "official",
+                        "system": "http://va.gov/systems/979_120.8",
+                        "value": "69213"
+                    }
+                ],
+                "clinicalStatus": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+                            "code": "active"
+                        }
+                    ]
+                },
+                "category": [
+                    "medication"
+                ],
+                "code": {
+                    "text": "PENICILLIN"
+                },
+                "patient": {
+                    "reference": "Patient/1393"
+                },
+                "recordedDate": "2024-03-21T13:31:00-06:00",
+                "recorder": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/alternate-reference",
+                            "valueReference": {
+                                "reference": "#Organization-0"
+                            }
+                        }
+                    ],
+                    "display": "SLC10.FO-BAYPINES.MED.VA.GOV"
+                },
+                "note": [
+                    {
+                        "time": "2024-03-21T13:31:53-06:00",
+                        "text": "moderate rash/hives"
+                    }
+                ],
+                "reaction": [
+                    {
+                        "manifestation": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "urn:oid:2.16.840.1.113883.6.233",
+                                        "code": "4538635"
+                                    }
+                                ],
+                                "text": "RASH"
+                            }
+                        ]
+                    }
+                ],
+                "resourceType": "AllergyIntolerance"
+            },
+            "search": {
+                "mode": "match"
+            }
+        },
+        {
+            "fullUrl": "https://mhv-sysb-api.myhealth.va.gov/fhir/AllergyIntolerance/3102",
+            "resource": {
+                "id": "3102",
+                "meta": {
+                    "versionId": "1",
+                    "lastUpdated": "2024-03-21T13:39:30.033-04:00",
+                    "source": "#gsVhmoXXXs2FXxBx",
+                    "profile": [
+                        "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/VA.MHV.PHR.allergyIntolerance"
+                    ]
+                },
+                "contained": [
+                    {
+                        "id": "Organization-0",
+                        "identifier": [
+                            {
+                                "use": "usual",
+                                "system": "urn:oid:2.16.840.1.113883.4.349",
+                                "value": "SLC10.FO-BAYPINES.MED.VA.GOV"
+                            }
+                        ],
+                        "name": "SLC10 TEST LAB",
+                        "resourceType": "Organization"
+                    }
+                ],
+                "extension": [
+                    {
+                        "url": "https://department-of-veterans-affairs.github.io/mhv-fhir-phr-mapping/StructureDefinition/allergyObservedHistoric",
+                        "valueCode": "o"
+                    }
+                ],
+                "identifier": [
+                    {
+                        "use": "official",
+                        "system": "http://va.gov/systems/979_120.8",
+                        "value": "69212"
+                    }
+                ],
+                "clinicalStatus": {
+                    "coding": [
+                        {
+                            "system": "http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical",
+                            "code": "active"
+                        }
+                    ]
+                },
+                "category": [
+                    "environment"
+                ],
+                "code": {
+                    "text": "POLLEN"
+                },
+                "patient": {
+                    "reference": "Patient/1393"
+                },
+                "recordedDate": "2024-03-21T13:27:00-06:00",
+                "recorder": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/alternate-reference",
+                            "valueReference": {
+                                "reference": "#Organization-0"
+                            }
+                        }
+                    ],
+                    "display": "SLC10.FO-BAYPINES.MED.VA.GOV"
+                },
+                "note": [
+                    {
+                        "time": "2024-03-21T13:29:16-06:00",
+                        "text": "sneezing"
+                    }
+                ],
+                "reaction": [
+                    {
+                        "manifestation": [
+                            {
+                                "coding": [
+                                    {
+                                        "system": "urn:oid:2.16.840.1.113883.6.233",
+                                        "code": "4637169"
+                                    }
+                                ],
+                                "text": "SNEEZING"
+                            }
+                        ]
+                    }
+                ],
+                "resourceType": "AllergyIntolerance"
+            },
+            "search": {
+                "mode": "match"
+            }
+        }
+    ],
+    "resourceType": "Bundle"
+}

--- a/src/applications/mhv-medications/tests/e2e/medications-allergies-network-response-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-allergies-network-response-list-page.cypress.spec.js
@@ -13,6 +13,8 @@ describe('Medications List Page Allergies', () => {
     cy.injectAxe();
     cy.axeCheck('main');
     listPage.clickGotoMedicationsLinkForUserWithAllergies();
-    listPage.verifyAllergiesNetworkResponseWithObservedHistoric(valueCode);
+    listPage.verifyAllergiesListNetworkResponseWithAllergyTypeReported(
+      valueCode,
+    );
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/medications-allergies-network-response-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-allergies-network-response-list-page.cypress.spec.js
@@ -1,0 +1,18 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import MedicationsLandingPage from './pages/MedicationsLandingPage';
+import MedicationsListPage from './pages/MedicationsListPage';
+
+describe('Medications List Page Allergies', () => {
+  it('visits Medications List Page Allergies Network Response', () => {
+    const site = new MedicationsSite();
+    const listPage = new MedicationsListPage();
+    const landingPage = new MedicationsLandingPage();
+    const valueCode = 'h';
+    site.login();
+    landingPage.visitLandingPageURL();
+    cy.injectAxe();
+    cy.axeCheck('main');
+    listPage.clickGotoMedicationsLinkForUserWithAllergies();
+    listPage.verifyAllergiesNetworkResponseWithObservedHistoric(valueCode);
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/medications-allergies-observed-historic-url-network-response-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-allergies-observed-historic-url-network-response-list-page.cypress.spec.js
@@ -1,0 +1,18 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import MedicationsLandingPage from './pages/MedicationsLandingPage';
+import MedicationsListPage from './pages/MedicationsListPage';
+
+describe('Medications List Page Allergies Observed Historic URL', () => {
+  it('visits Medications List Page Allergies Network Response URL', () => {
+    const site = new MedicationsSite();
+    const listPage = new MedicationsListPage();
+    const landingPage = new MedicationsLandingPage();
+    const url = 'allergyObservedHistoric';
+    site.login();
+    landingPage.visitLandingPageURL();
+    cy.injectAxe();
+    cy.axeCheck('main');
+    listPage.clickGotoMedicationsLinkForUserWithAllergies();
+    listPage.verifyAllergiesListNetworkResponseURL(url, 0);
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/medications-allergies-observed-network-response-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-allergies-observed-network-response-list-page.cypress.spec.js
@@ -2,19 +2,20 @@ import MedicationsSite from './med_site/MedicationsSite';
 import MedicationsLandingPage from './pages/MedicationsLandingPage';
 import MedicationsListPage from './pages/MedicationsListPage';
 
-describe('Medications List Page Allergies', () => {
+describe('Medications List Page Allergies Observed', () => {
   it('visits Medications List Page Allergies Network Response', () => {
     const site = new MedicationsSite();
     const listPage = new MedicationsListPage();
     const landingPage = new MedicationsLandingPage();
-    const valueCode = 'h';
+    const valueCode = 'o';
     site.login();
     landingPage.visitLandingPageURL();
     cy.injectAxe();
     cy.axeCheck('main');
     listPage.clickGotoMedicationsLinkForUserWithAllergies();
-    listPage.verifyAllergiesListNetworkResponseWithAllergyTypeReported(
+    listPage.verifyAllergiesListNetworkResponseWithAllergyTypeObserved(
       valueCode,
+      1,
       0,
     );
   });

--- a/src/applications/mhv-medications/tests/e2e/medications-allergies-reported-org-name-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-allergies-reported-org-name-list-page.cypress.spec.js
@@ -1,0 +1,18 @@
+import MedicationsSite from './med_site/MedicationsSite';
+import MedicationsLandingPage from './pages/MedicationsLandingPage';
+import MedicationsListPage from './pages/MedicationsListPage';
+
+describe('Medications List Page Allergies Reported Org Name', () => {
+  it('visits Medications List Page Allergies Network Response Org Name', () => {
+    const site = new MedicationsSite();
+    const listPage = new MedicationsListPage();
+    const landingPage = new MedicationsLandingPage();
+    const orgName = 'SLC10 TEST LAB';
+    site.login();
+    landingPage.visitLandingPageURL();
+    cy.injectAxe();
+    cy.axeCheck('main');
+    listPage.clickGotoMedicationsLinkForUserWithAllergies();
+    listPage.verifyAllergiesListContainedResourceOrgName(orgName, 0);
+  });
+});

--- a/src/applications/mhv-medications/tests/e2e/medications-refill-submit-inline-error-list.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-refill-submit-inline-error-list.cypress.spec.js
@@ -21,5 +21,8 @@ describe('Medications Refill Submit Error Message List Page', () => {
       failedRefill,
     );
     refillPage.verifyFailedRequestMessageAlertOnRefillPage();
+    refillPage.verifyNetworkResponseForFailedRefillRequest(
+      failedRequest.data.attributes.prescriptionId,
+    );
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/medications-verify-success-message-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-verify-success-message-list-page.cypress.spec.js
@@ -24,5 +24,8 @@ describe('Medications Refill Submit Success Message Refill Page', () => {
     refillPage.verifyMedicationRefillRequested(
       prescription.data.attributes.prescriptionName,
     );
+    refillPage.verifyNetworkResponseForSuccessfulRefillRequest(
+      prescription.data.attributes.prescriptionId,
+    );
   });
 });

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -1,6 +1,7 @@
 import moment from 'moment-timezone';
 import prescriptions from '../fixtures/listOfPrescriptions.json';
 import allergies from '../fixtures/allergies.json';
+import allergiesList from '../fixtures/allergies-list.json';
 
 import activeRxRefills from '../fixtures/active-prescriptions-with-refills.json';
 
@@ -56,6 +57,39 @@ class MedicationsListPage {
     if (waitForMeds) {
       cy.wait('@medicationsList');
     }
+  };
+
+  clickGotoMedicationsLinkForUserWithAllergies = (waitForMeds = false) => {
+    // cy.intercept('GET', '/my-health/medications', prescriptions);
+    cy.intercept(
+      'GET',
+      '/my_health/v1/medical_records/allergies',
+      allergiesList,
+    ).as('allergiesList');
+    cy.intercept(
+      'GET',
+      '/my_health/v1/prescriptions?page=1&per_page=20&sort[]=disp_status&sort[]=prescription_name&sort[]=dispensed_date',
+      prescriptions,
+    ).as('medicationsList');
+    cy.intercept(
+      'GET',
+      '/my_health/v1/prescriptions?&sort[]=disp_status&sort[]=prescription_name&sort[]=dispensed_date&include_image=true',
+      prescriptions,
+    );
+    cy.get('[data-testid ="prescriptions-nav-link"]').click({ force: true });
+    if (waitForMeds) {
+      cy.wait('@medicationsList');
+    }
+  };
+
+  verifyAllergiesNetworkResponseWithObservedHistoric = valueCode => {
+    cy.get('@allergiesList')
+      .its('response')
+      .then(res => {
+        expect(res.body.entry[0].resource.extension[0]).to.include({
+          valueCode,
+        });
+      });
   };
 
   clickPrintThisPageOfTheListButtonOnListPage = () => {

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -82,11 +82,30 @@ class MedicationsListPage {
     }
   };
 
-  verifyAllergiesListNetworkResponseWithAllergyTypeReported = valueCode => {
+  verifyAllergiesListNetworkResponseWithAllergyTypeReported = (
+    valueCode,
+    allergy,
+  ) => {
     cy.get('@allergiesList')
       .its('response')
       .then(res => {
-        expect(res.body.entry[0].resource.extension[0]).to.include({
+        expect(res.body.entry[allergy].resource.extension[allergy]).to.include({
+          valueCode,
+        });
+      });
+  };
+
+  verifyAllergiesListNetworkResponseWithAllergyTypeObserved = (
+    valueCode,
+    allergy,
+    listNumber,
+  ) => {
+    cy.get('@allergiesList')
+      .its('response')
+      .then(res => {
+        expect(
+          res.body.entry[allergy].resource.extension[listNumber],
+        ).to.include({
           valueCode,
         });
       });

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -111,6 +111,26 @@ class MedicationsListPage {
       });
   };
 
+  verifyAllergiesListNetworkResponseURL = (url, allergy) => {
+    cy.get('@allergiesList')
+      .its('response')
+      .then(res => {
+        expect(
+          res.body.entry[allergy].resource.extension[allergy].url,
+        ).to.include(url);
+      });
+  };
+
+  verifyAllergiesListContainedResourceOrgName = (orgName, allergy) => {
+    cy.get('@allergiesList')
+      .its('response')
+      .then(res => {
+        expect(
+          res.body.entry[allergy].resource.contained[allergy].name,
+        ).to.include(orgName);
+      });
+  };
+
   clickPrintThisPageOfTheListButtonOnListPage = () => {
     cy.get('[data-testid="download-print-button"]').should('exist');
     cy.get('[data-testid="download-print-button"]').click({

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -82,7 +82,7 @@ class MedicationsListPage {
     }
   };
 
-  verifyAllergiesNetworkResponseWithObservedHistoric = valueCode => {
+  verifyAllergiesListNetworkResponseWithAllergyTypeReported = valueCode => {
     cy.get('@allergiesList')
       .its('response')
       .then(res => {

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsRefillPage.js
@@ -315,7 +315,7 @@ class MedicationsRefillPage {
       'PATCH',
       `/my_health/v1/prescriptions/refill_prescriptions?ids[]=${prescriptionId}`,
       failedRequest,
-    );
+    ).as('failedRefillRequest');
     cy.get('[data-testid="request-refill-button"]').should('exist');
     cy.get('[data-testid="request-refill-button"]').click({
       waitForAnimations: true,
@@ -345,7 +345,7 @@ class MedicationsRefillPage {
       'PATCH',
       `/my_health/v1/prescriptions/refill_prescriptions?ids[]=${prescriptionId}`,
       success,
-    );
+    ).as('refillSuccess');
     cy.get('[data-testid="request-refill-button"]').should('exist');
     cy.get('[data-testid="request-refill-button"]').click({
       waitForAnimations: true,
@@ -383,6 +383,14 @@ class MedicationsRefillPage {
     );
   };
 
+  verifyNetworkResponseForFailedRefillRequest = failedId => {
+    cy.get('@failedRefillRequest')
+      .its('response')
+      .then(res => {
+        expect(res.body.failedIds[0]).to.contain(failedId);
+      });
+  };
+
   verifyErrorMessageWhenRefillRequestWithoutSelectingPrescription = () => {
     cy.get('[data-testid="select-rx-error-message"]').should(
       'contain',
@@ -402,6 +410,14 @@ class MedicationsRefillPage {
       'contain',
       refillName,
     );
+  };
+
+  verifyNetworkResponseForSuccessfulRefillRequest = successfulId => {
+    cy.get('@refillSuccess')
+      .its('response')
+      .then(res => {
+        expect(res.body.successfulIds[0]).to.contain(successfulId);
+      });
   };
 
   verifyNoMedicationsAvailableMessageOnRefillPage = () => {


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [X ] No, I'm not changing any folders (skip to Summary and delete the rest of this section)

## Summary

Cypress Tests are added to validate network response for 
-allergies observed 
-allergies reported
-successful refill requests
-failed refill requests

## Related issue(s)

MHV-59812

## Testing done

Testing is completed locally  150x and all tests are passing

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

This is for medications va.gov

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)


