### PR TITLE
[CST] - Update name of tracked item in Recent Activity section to reflect updated 5103 alert 

### DIFF
--- a/src/applications/claims-status/components/claim-document-request-pages/Automated5103Notice.jsx
+++ b/src/applications/claims-status/components/claim-document-request-pages/Automated5103Notice.jsx
@@ -58,7 +58,7 @@ function Automated5103Notice({
     return null;
   }
   return (
-    <div id="automated-5103-notice-page">
+    <div id="automated-5103-notice-page" className="vads-u-margin-bottom--3">
       <h1 className="vads-u-margin-top--0 vads-u-margin-bottom--2">
         5103 Evidence Notice
       </h1>

--- a/src/applications/claims-status/components/claim-document-request-pages/DefaultPage.jsx
+++ b/src/applications/claims-status/components/claim-document-request-pages/DefaultPage.jsx
@@ -24,7 +24,7 @@ export default function DefaultPage({
   uploading,
 }) {
   return (
-    <div id="default-page">
+    <div id="default-page" className="vads-u-margin-bottom--3">
       <h1 className="claims-header">Request for {item.displayName}</h1>
       {item.status === 'NEEDED_FROM_YOU' ? (
         <DueDate date={item.suspenseDate} />

--- a/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
+++ b/src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx
@@ -14,6 +14,9 @@ import {
 
 export default function RecentActivity({ claim }) {
   const { TOGGLE_NAMES, useToggleValue } = useFeatureToggle();
+  const cst5103UpdateEnabled = useToggleValue(
+    TOGGLE_NAMES.cst5103UpdateEnabled,
+  );
   const cstClaimPhasesEnabled = useToggleValue(TOGGLE_NAMES.cstClaimPhases);
   // When feature flag cstClaimPhases is enabled and claim type code is for a disability
   // compensation claim we show 8 phases instead of 5 with updated description, link text
@@ -45,18 +48,29 @@ export default function RecentActivity({ claim }) {
     }
   };
 
+  const is5103Notice = item => {
+    return (
+      item.displayName === 'Automated 5103 Notice Response' ||
+      item.displayName === '5103 Notice Response'
+    );
+  };
+
   const getTrackedItemDescription = item => {
+    const displayName =
+      is5103Notice(item) && cst5103UpdateEnabled
+        ? '5103 Evidence Notice'
+        : item.displayName;
     switch (item.status) {
       case 'NEEDED_FROM_YOU':
       case 'NEEDED_FROM_OTHERS':
-        return `We opened a request for "${item.displayName}"`;
+        return `We opened a request for "${displayName}"`;
       case 'NO_LONGER_REQUIRED':
-        return `We closed a request for "${item.displayName}"`;
+        return `We closed a request for "${displayName}"`;
       case 'SUBMITTED_AWAITING_REVIEW':
-        return `We received your document(s) for "${item.displayName}"`;
+        return `We received your document(s) for "${displayName}"`;
       case 'INITIAL_REVIEW_COMPLETE':
       case 'ACCEPTED':
-        return `We completed a review for "${item.displayName}"`;
+        return `We completed a review for "${displayName}"`;
       default:
         return 'There was an update to this item';
     }

--- a/src/applications/claims-status/tests/components/claim-status-tab/RecentActivity.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-status-tab/RecentActivity.unit.spec.jsx
@@ -8,11 +8,16 @@ import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
 import RecentActivity from '../../../components/claim-status-tab/RecentActivity';
 import { renderWithRouter } from '../../utils';
 
-const getStore = (cstClaimPhasesEnabled = false) =>
+const getStore = (
+  cstClaimPhasesEnabled = false,
+  cst5103UpdateEnabled = false,
+) =>
   createStore(() => ({
     featureToggles: {
       // eslint-disable-next-line camelcase
       cst_claim_phases: cstClaimPhasesEnabled,
+      // eslint-disable-next-line camelcase
+      cst_5103_update_enabled: cst5103UpdateEnabled,
     },
   }));
 
@@ -322,6 +327,59 @@ const openClaimStep4WithMultipleItems = {
   },
 };
 
+const openClaimStep4WithAuto5103Notice = {
+  attributes: {
+    claimDate: '2024-05-02',
+    claimPhaseDates: {
+      phaseChangeDate: '2024-05-22',
+      currentPhaseBack: false,
+      latestPhaseType: 'REVIEW_OF_EVIDENCE',
+      previousPhases: {
+        phase1CompleteDate: '2024-05-10',
+        phase2CompleteDate: '2024-05-22',
+        phase3CompleteDate: '2024-06-07',
+      },
+    },
+    claimTypeCode: '110LCMP7IDES',
+    trackedItems: [
+      {
+        id: 1,
+        requestedDate: '2024-05-12',
+        status: 'NEEDED_FROM_YOU',
+        suspenseDate: '2024-08-07',
+        displayName: 'Automated 5103 Notice Response',
+      },
+    ],
+  },
+};
+
+const openClaimStep4WithClosed5103Notice = {
+  attributes: {
+    claimDate: '2024-05-02',
+    claimPhaseDates: {
+      phaseChangeDate: '2024-05-22',
+      currentPhaseBack: false,
+      latestPhaseType: 'REVIEW_OF_EVIDENCE',
+      previousPhases: {
+        phase1CompleteDate: '2024-05-10',
+        phase2CompleteDate: '2024-05-22',
+        phase3CompleteDate: '2024-06-07',
+      },
+    },
+    claimTypeCode: '110LCMP7IDES',
+    trackedItems: [
+      {
+        id: 1,
+        requestedDate: '2024-05-12',
+        status: 'NO_LONGER_REQUIRED',
+        suspenseDate: '2024-08-07',
+        displayName: '5103 Notice Response',
+        closedDate: '2024-06-12',
+      },
+    ],
+  },
+};
+
 describe('<RecentActivity>', () => {
   context('when cstClaimPhasesEnabled enabled', () => {
     context('when claim doesn’t have trackedItems', () => {
@@ -553,6 +611,106 @@ describe('<RecentActivity>', () => {
           expect(pagination).to.exist;
           expect(pagination.pages).to.equal(2);
         });
+        context(
+          'when cst5103UpdateEnabled and has an Automated 5103 Notice Response item',
+          () => {
+            it('should render list', () => {
+              const { container, getByText } = renderWithRouter(
+                <Provider store={getStore(true, true)}>
+                  <RecentActivity claim={openClaimStep4WithAuto5103Notice} />
+                </Provider>,
+              );
+
+              const recentActivityList = $('ol', container);
+              expect(recentActivityList).to.exist;
+              expect(
+                within(recentActivityList).getAllByRole('listitem').length,
+              ).to.equal(5);
+              getByText('We received your claim in our system');
+              getByText('Your claim moved into Step 2: Initial review');
+              getByText('Your claim moved into Step 3: Evidence gathering');
+              getByText('Your claim moved into Step 4: Evidence review');
+              getByText('Request for you');
+              getByText('We opened a request for "5103 Evidence Notice"');
+              expect($('va-pagination', container)).not.to.exist;
+            });
+          },
+        );
+        context(
+          'when cst5103UpdateEnabled disabled and has an Automated 5103 Notice Response item',
+          () => {
+            it('should render list', () => {
+              const { container, getByText } = renderWithRouter(
+                <Provider store={getStore(true, false)}>
+                  <RecentActivity claim={openClaimStep4WithAuto5103Notice} />
+                </Provider>,
+              );
+
+              const recentActivityList = $('ol', container);
+              expect(recentActivityList).to.exist;
+              expect(
+                within(recentActivityList).getAllByRole('listitem').length,
+              ).to.equal(5);
+              getByText('We received your claim in our system');
+              getByText('Your claim moved into Step 2: Initial review');
+              getByText('Your claim moved into Step 3: Evidence gathering');
+              getByText('Your claim moved into Step 4: Evidence review');
+              getByText('Request for you');
+              getByText(
+                'We opened a request for "Automated 5103 Notice Response"',
+              );
+              expect($('va-pagination', container)).not.to.exist;
+            });
+          },
+        );
+        context(
+          'when cst5103UpdateEnabled and has a closed 5103 Notice Response item',
+          () => {
+            it('should render list', () => {
+              const { container, getByText } = renderWithRouter(
+                <Provider store={getStore(true, true)}>
+                  <RecentActivity claim={openClaimStep4WithClosed5103Notice} />
+                </Provider>,
+              );
+
+              const recentActivityList = $('ol', container);
+              expect(recentActivityList).to.exist;
+              expect(
+                within(recentActivityList).getAllByRole('listitem').length,
+              ).to.equal(5);
+              getByText('We received your claim in our system');
+              getByText('Your claim moved into Step 2: Initial review');
+              getByText('Your claim moved into Step 3: Evidence gathering');
+              getByText('Your claim moved into Step 4: Evidence review');
+              getByText('We closed a request for "5103 Evidence Notice"');
+              expect($('va-pagination', container)).not.to.exist;
+            });
+          },
+        );
+        context(
+          'when cst5103UpdateEnabled disabled and has a closed 5103 Notice Response item',
+          () => {
+            it('should render list', () => {
+              const { container, getByText } = renderWithRouter(
+                <Provider store={getStore(true, false)}>
+                  <RecentActivity claim={openClaimStep4WithClosed5103Notice} />
+                </Provider>,
+              );
+
+              const recentActivityList = $('ol', container);
+              expect(recentActivityList).to.exist;
+              expect(
+                within(recentActivityList).getAllByRole('listitem').length,
+              ).to.equal(5);
+              getByText('We received your claim in our system');
+              getByText('Your claim moved into Step 2: Initial review');
+              getByText('Your claim moved into Step 3: Evidence gathering');
+              getByText('Your claim moved into Step 4: Evidence review');
+              getByText('We closed a request for "5103 Notice Response"');
+              expect($('va-pagination', container)).not.to.exist;
+            });
+          },
+        );
       });
     });
   });
@@ -802,6 +960,110 @@ describe('<RecentActivity>', () => {
           expect(pagination).to.exist;
           expect(pagination.pages).to.equal(2);
         });
+        context(
+          'when cst5103UpdateEnabled and has an Automated 5103 Notice Response item',
+          () => {
+            it('should render list', () => {
+              const { container, getByText } = renderWithRouter(
+                <Provider store={getStore(false, true)}>
+                  <RecentActivity claim={openClaimStep4WithAuto5103Notice} />
+                </Provider>,
+              );
+
+              const recentActivityList = $('ol', container);
+              expect(recentActivityList).to.exist;
+              expect(
+                within(recentActivityList).getAllByRole('listitem').length,
+              ).to.equal(4);
+              getByText('Your claim moved into Step 1: Claim received');
+              getByText('Your claim moved into Step 2: Initial review');
+              getByText(
+                'Your claim moved into Step 3: Evidence gathering, review, and decision',
+              );
+              getByText('Request for you');
+              getByText('We opened a request for "5103 Evidence Notice"');
+              expect($('va-pagination', container)).not.to.exist;
+            });
+          },
+        );
+        context(
+          'when cst5103UpdateEnabled and has an Automated 5103 Notice Response item',
+          () => {
+            it('should render list', () => {
+              const { container, getByText } = renderWithRouter(
+                <Provider store={getStore()}>
+                  <RecentActivity claim={openClaimStep4WithAuto5103Notice} />
+                </Provider>,
+              );
+
+              const recentActivityList = $('ol', container);
+              expect(recentActivityList).to.exist;
+              expect(
+                within(recentActivityList).getAllByRole('listitem').length,
+              ).to.equal(4);
+              getByText('Your claim moved into Step 1: Claim received');
+              getByText('Your claim moved into Step 2: Initial review');
+              getByText(
+                'Your claim moved into Step 3: Evidence gathering, review, and decision',
+              );
+              getByText('Request for you');
+              getByText(
+                'We opened a request for "Automated 5103 Notice Response"',
+              );
+              expect($('va-pagination', container)).not.to.exist;
+            });
+          },
+        );
+        context(
+          'when cst5103UpdateEnabled and has an Automated 5103 Notice Response item',
+          () => {
+            it('should render list', () => {
+              const { container, getByText } = renderWithRouter(
+                <Provider store={getStore(false, true)}>
+                  <RecentActivity claim={openClaimStep4WithClosed5103Notice} />
+                </Provider>,
+              );
+
+              const recentActivityList = $('ol', container);
+              expect(recentActivityList).to.exist;
+              expect(
+                within(recentActivityList).getAllByRole('listitem').length,
+              ).to.equal(4);
+              getByText('Your claim moved into Step 1: Claim received');
+              getByText('Your claim moved into Step 2: Initial review');
+              getByText(
+                'Your claim moved into Step 3: Evidence gathering, review, and decision',
+              );
+              getByText('We closed a request for "5103 Evidence Notice"');
+              expect($('va-pagination', container)).not.to.exist;
+            });
+          },
+        );
+        context(
+          'when cst5103UpdateEnabled and has an Automated 5103 Notice Response item',
+          () => {
+            it('should render list', () => {
+              const { container, getByText } = renderWithRouter(
+                <Provider store={getStore()}>
+                  <RecentActivity claim={openClaimStep4WithClosed5103Notice} />
+                </Provider>,
+              );
+
+              const recentActivityList = $('ol', container);
+              expect(recentActivityList).to.exist;
+              expect(
+                within(recentActivityList).getAllByRole('listitem').length,
+              ).to.equal(4);
+              getByText('Your claim moved into Step 1: Claim received');
+              getByText('Your claim moved into Step 2: Initial review');
+              getByText(
+                'Your claim moved into Step 3: Evidence gathering, review, and decision',
+              );
+              getByText('We closed a request for "5103 Notice Response"');
+              expect($('va-pagination', container)).not.to.exist;
+            });
+          },
+        );
       });
     });
   });


### PR DESCRIPTION
## Summary

- Updated `src/applications/claims-status/components/claim-status-tab/RecentActivity.jsx` so that when `item.displayName `was 'Automated 5103 Notice Response' or '5103 Notice Response' AND the feature toggle `cst5103UpdateEnabled` was enabled the itemDisplayName was set to '5103 Evidence Notice', otherwise the itemDisplayName remained as it was.
- Added tests to `src/applications/claims-status/tests/components/claim-status-tab/RecentActivity.unit.spec.jsx` to cover the new logic that we added
- per my convo with @jstrothman on https://github.com/department-of-veterans-affairs/va.gov-team/issues/80589#issuecomment-2229000786 added changes to `DefaultPage.jsx` and `Automated5103Notice.jsx` so that there was a bottom margin of 24px on the div before the 'Need help' section

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#82603

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

**Changes to the Recent Activity Section:**
|         | Before | After |
| ------- | ------ | ----- |
| Automated 5103 Notice Response  |  ![Screenshot 2024-07-15 at 2 25 02 PM](https://github.com/user-attachments/assets/cd44416f-aab8-4e19-82bb-d9da6007ba3e) |  ![Screenshot 2024-07-15 at 1 54 01 PM](https://github.com/user-attachments/assets/d89205d5-fe4d-4192-bbd2-50f9bf4a077e)|
| Closed 5103 Notice Response |  ![Screenshot 2024-07-15 at 2 53 47 PM](https://github.com/user-attachments/assets/853604d8-5364-4693-ad5f-9f4d23f37bb2)    |  ![Screenshot 2024-07-15 at 2 54 16 PM](https://github.com/user-attachments/assets/010770aa-5bec-4425-b474-52175a192356) |

**Changes to the margins on the Document  Request pages:**
|         | Before | After |
| ------- | ------ | ----- |
| Default Document Request Page  | ![Screenshot 2024-07-15 at 11 53 34 AM](https://github.com/user-attachments/assets/58cce8cd-cf5a-4b22-bfe7-3b3b8951ff25) |  ![Screenshot 2024-07-08 at 3 15 04 PM](https://github.com/user-attachments/assets/a77fe12c-51c8-43fc-a58a-65a836c93db3)|
|  5103 Notice item on Document Request Page |  ![Screenshot 2024-07-05 at 1 07 16 PM](https://github.com/user-attachments/assets/c26689e0-ea5b-41f2-906e-1142d84af9cd)   |   ![Screenshot 2024-07-15 at 11 52 18 AM](https://github.com/user-attachments/assets/3ddd3ae3-824b-419b-9a81-b8e1cff616d0)|
## What areas of the site does it impact?

Claim Status Tool

## Acceptance criteria

- [x] The 5103 description in the Recent Activity section matches the header text we use in the alert associated with the item.
- [x]  The 5103 description in the Recent Activity section no longer says '5103 notice response' and instead says '5103 Evidence Notice'
- [x]  The 5103 description in the Recent Activity section no longer says 'Automated 5103 notice response' and instead says '5103 Evidence Notice'
- [x]  Put behind feature flag cst_5103_update_enabled

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
