### PR TITLE
86842c Small copy changes (round 3) - form 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959a/chapters/beneficiaryInformation.js
+++ b/src/applications/ivc-champva/10-7959a/chapters/beneficiaryInformation.js
@@ -1,4 +1,3 @@
-import VaTextInputField from 'platform/forms-system/src/js/web-component-fields/VaTextInputField';
 import { cloneDeep } from 'lodash';
 import {
   addressUI,
@@ -13,6 +12,7 @@ import {
   radioSchema,
   phoneUI,
   phoneSchema,
+  textUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import { nameWording } from '../../shared/utilities';
 
@@ -27,7 +27,7 @@ export const applicantNameDobSchema = {
           formData?.certifierRole === 'applicant' ? 'Your' : 'Beneficiary’s'
         } information`,
       ({ formData }) =>
-        `Enter the information exactly as it’s listed on ${
+        `Enter the name exactly as it’s listed on ${
           formData?.certifierRole === 'applicant' ? 'your' : 'the beneficiary’s'
         } CHAMPVA identification card.`,
     ),
@@ -51,19 +51,25 @@ export const applicantMemberNumberSchema = {
       ({ formData }) =>
         `${nameWording(formData, true, true, true)} identification information`,
     ),
-    applicantMemberNumber: {
-      'ui:title': 'CHAMPVA member number',
-      'ui:webComponentField': VaTextInputField,
-      'ui:errorMessages': {
-        required: 'Please enter your CHAMPVA member number',
-        pattern: 'Must be 20 or fewer characters (letters and numbers only)',
+    applicantMemberNumber: textUI({
+      updateUiSchema: formData => {
+        return {
+          'ui:title': 'CHAMPVA member number',
+          'ui:errorMessages': {
+            required: 'Please enter your CHAMPVA member number',
+            pattern: 'Must be letters and numbers only',
+          },
+          'ui:options': {
+            uswds: true,
+            hint: `This number is usually the same as ${
+              formData?.certifierRole === 'applicant'
+                ? 'your'
+                : 'the beneficiary’s'
+            } Social Security number.`,
+          },
+        };
       },
-      'ui:options': {
-        uswds: true,
-        hint:
-          'This number is usually the same as the beneficiary’s Social Security number.',
-      },
-    },
+    }),
   },
   schema: {
     type: 'object',
@@ -72,7 +78,8 @@ export const applicantMemberNumberSchema = {
       titleSchema,
       applicantMemberNumber: {
         type: 'string',
-        pattern: '^[0-9a-zA-Z]{0,20}$',
+        pattern: '^[0-9a-zA-Z]+$',
+        maxLength: 20,
       },
     },
   },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

Adjusts copy in beneficiary section of form 10-7959a

- Updates text "the beneficiary" to "your" on the /beneficiary-identification-info screen hint
- Updates "information" to "name" on the /beneficiary-info screen
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86842

## Testing done

- Manual

## Screenshots

|         | 1 | 2 |
| ------- | ------ | ----- |
| Desktop |![Screenshot 2024-07-16 at 07 49 35](https://github.com/user-attachments/assets/08be1928-3bdf-4ef7-a6b3-c300b159e7bb)|![Screenshot 2024-07-16 at 07 57 54](https://github.com/user-attachments/assets/5f8f5985-0d36-4b9e-b84a-b8287e844ccc)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA