### PR TITLE
88091  Fix display of save link on form submit errors

### DIFF
--- a/src/platform/forms/components/review/FormSaveErrorMessage.jsx
+++ b/src/platform/forms/components/review/FormSaveErrorMessage.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
+import PropTypes from 'prop-types';
 
 // platform - forms - actions
 import {
@@ -78,8 +79,9 @@ function FormSaveErrorMessage(props) {
           We’re working to fix the problem. Please make sure you’re connected to
           the Internet, and then try saving your {appType} again.
         </p>
-        {saveLink}.
-        {!user.login.currentlyLoggedIn && (
+        {user.login.currentlyLoggedIn ? (
+          <>{saveLink}.</>
+        ) : (
           <p>
             If you don’t have an account, you’ll have to start over. Try
             submitting your {appType} again tomorrow.
@@ -123,3 +125,14 @@ export default withRouter(
     mapDispatchToProps,
   )(FormSaveErrorMessage),
 );
+
+FormSaveErrorMessage.propTypes = {
+  form: PropTypes.object,
+  formConfig: PropTypes.object,
+  location: PropTypes.object,
+  route: PropTypes.object,
+  saveAndRedirectToReturnUrl: PropTypes.func,
+  showLoginModal: PropTypes.bool,
+  toggleLoginModal: PropTypes.func,
+  user: PropTypes.object,
+};


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR fixes a text bug that shows an empty line with period on the default form submission error message when a user is not signed in.

- Updates conditional render of save link to check user status
- Adds proptypes to `FormSaveErrorMessage.jsx`
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88091

## Testing done

- Manual (set `user.login.currentlyLoggedIn` to `true` or `false` to check results)
- Verified unit tests run and pass

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Unauthenticated |![Screenshot 2024-07-16 at 14 12 57](https://github.com/user-attachments/assets/18b167df-6b0f-4d0e-b6bb-ad627e56d96a)|![Screenshot 2024-07-16 at 14 16 58](https://github.com/user-attachments/assets/075923b6-3223-46cd-a987-b36689457b73)|
|Authenticated|![Screenshot 2024-07-16 at 15 30 50](https://github.com/user-attachments/assets/7eb72afb-12c8-48cd-a80b-2cda64778e4d)|![Screenshot 2024-07-16 at 15 30 50](https://github.com/user-attachments/assets/32d95db7-7368-4dae-9f41-e66acbcd59b0)|

## What areas of the site does it impact?

Applications that use the default form save error (`FormSaveErrorMessage.jsx`)

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
