### PR TITLE
LoadingButton: replace fa spinner in loading button with va-icon

### DIFF
--- a/src/applications/vaos/appointment-list/components/cancel/tests/cancelAppointmentConfirmationModal.unit.spec.js
+++ b/src/applications/vaos/appointment-list/components/cancel/tests/cancelAppointmentConfirmationModal.unit.spec.js
@@ -25,7 +25,7 @@ describe('VAOS Component: CancelAppointmentConfirmationModal', () => {
     expect(screen.baseElement).to.contain.text(
       'If you want to reschedule, you’ll need to call us',
     );
-    expect(screen.container.querySelector('.fa-spin')).to.exist;
+    expect(screen.container.querySelector('.rotate-icon-container')).to.exist;
     expect(
       screen.queryByRole('button', { name: /Yes, cancel this appointment/i }),
     ).to.be.null;

--- a/src/applications/vaos/appointment-list/sass/styles.scss
+++ b/src/applications/vaos/appointment-list/sass/styles.scss
@@ -265,10 +265,6 @@ div[id^="vaos-appts__detail-"] {
   left: calc(50% - 20px);
 }
 
-.fa-blank {
-  margin-right: 0 !important;
-}
-
 .tertiary-button {
   text-decoration: none;
   background-color: transparent;

--- a/src/platform/site-wide/loading-button/LoadingButton.jsx
+++ b/src/platform/site-wide/loading-button/LoadingButton.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import './loading-button.scss';
 
 export default function LoadingButton({
   isLoading,
@@ -10,14 +11,10 @@ export default function LoadingButton({
   ...props
 }) {
   const contents = isLoading ? (
-    <>
-      <i
-        className="fa fa-spinner fa-spin"
-        aria-hidden="true"
-        role="presentation"
-      />
+    <div className="rotate-icon-container">
+      <va-icon id="rotating-icon" icon="autorenew" size={1} />
       {!!loadingText && <span className="sr-only">{loadingText}</span>}
-    </>
+    </div>
   ) : (
     children
   );

--- a/src/platform/site-wide/loading-button/loading-button.scss
+++ b/src/platform/site-wide/loading-button/loading-button.scss
@@ -1,0 +1,16 @@
+.rotate-icon-container {
+  animation: rotation 2s linear infinite;
+}
+
+@keyframes rotation {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+#rotating-icon {
+  color: var(--vads-color-white);
+}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**: Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
- _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

## Summary

This PR updates the LoadingButton so that it does not use a font-awesome icon, in accordance with the deprecation of font-awesome from vets-website.

## Related issue(s)

[2944](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2944)

## Testing done

local testing

## Screenshots


https://github.com/user-attachments/assets/40436fc5-e9e9-46a4-8232-a037f518688d



## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
