### PR TITLE
personalization: replace more fa icons

### DIFF
--- a/src/applications/personalization/dashboard/components/benefit-application-drafts/ApplicationInProgress.jsx
+++ b/src/applications/personalization/dashboard/components/benefit-application-drafts/ApplicationInProgress.jsx
@@ -32,9 +32,9 @@ const ApplicationInProgress = ({
           {formatTitle(formTitle)}
         </h3>
         <div className="vads-u-display--flex">
-          <i
-            aria-hidden="true"
-            className="fas fa-fw fa-exclamation-circle vads-u-margin-right--1 vads-u-margin-top--0p5"
+          <va-icon
+            icon="error"
+            className="vads-u-margin-right--1 vads-u-margin-top--0p5"
           />
           <span className="sr-only">Alert: </span>
           <div>

--- a/src/applications/personalization/dashboard/components/benefit-application-drafts/ApplicationInProgress.jsx
+++ b/src/applications/personalization/dashboard/components/benefit-application-drafts/ApplicationInProgress.jsx
@@ -32,10 +32,10 @@ const ApplicationInProgress = ({
           {formatTitle(formTitle)}
         </h3>
         <div className="vads-u-display--flex">
-          <va-icon
-            icon="error"
-            className="vads-u-margin-right--1 vads-u-margin-top--0p5"
-          />
+          <span className="vads-u-margin-right--1 vads-u-margin-top--0p5">
+            <va-icon icon="error" size={3} />
+          </span>
+
           <span className="sr-only">Alert: </span>
           <div>
             <p className="vads-u-margin-top--0">

--- a/src/applications/personalization/dashboard/tests/components/CTALink.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/CTALink.unit.spec.jsx
@@ -15,7 +15,7 @@ describe('<CTALink />', () => {
 
     expect(tree.getByTestId('12345')).to.not.be.null;
     expect(tree.getByText(linkText)).to.not.be.null;
-    expect(tree.container.querySelector('i.fa-chevron-right')).to.be.null;
+    expect(tree.container.querySelector('va-icon')).to.be.null;
     tree.unmount();
   });
 

--- a/src/applications/personalization/profile/components/notification-settings/NotificationCheckbox.jsx
+++ b/src/applications/personalization/profile/components/notification-settings/NotificationCheckbox.jsx
@@ -56,9 +56,9 @@ export const NotificationCheckbox = ({
         id={loadingSpanId}
         classes="vads-u-font-weight--normal"
       >
-        <i
-          className="fas fa-spinner fa-spin vads-u-margin-right--1"
-          aria-hidden="true"
+        <va-loading-indicator
+          label="Loading"
+          className="vads-u-margin-right--1"
         />{' '}
         {loadingMessage}
       </NotificationStatusMessage>

--- a/src/applications/personalization/view-dependents/components/ViewDependentsList/ViewDependentsListItem.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsList/ViewDependentsListItem.jsx
@@ -50,12 +50,7 @@ function ViewDependentsListItem(props) {
         {manageDependentsToggle && submittedDependents.includes(stateKey) ? (
           <div aria-live="polite">
             <dt>
-              <i
-                aria-hidden="true"
-                role="img"
-                className="fas fa-exclamation-triangle"
-              />{' '}
-              Status:&nbsp;
+              <va-icon icon="warning" size={3} /> Status:&nbsp;
             </dt>
             <dd>Removal of dependent pending</dd>
           </div>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**: Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
- _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

## Summary

This PR replaces font-awesome icons in /personalization with va-icons, in accordance with the deprecation of font-awesome from vets-website

## Related issue(s)

[2944](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2944)

## Testing done

local testing

## Screenshots
<img width="587" alt="Screenshot 2024-07-17 at 2 18 49 PM" src="https://github.com/user-attachments/assets/22971fa4-c665-4c01-8917-104808e90368">

<hr />


<img width="585" alt="Screenshot 2024-07-17 at 8 14 30 PM" src="https://github.com/user-attachments/assets/fcf14707-a59a-43f1-92dd-08752013c58e">

<hr />

Note: I could not find an instance of `NotificationCheckbox`.

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
