### PR TITLE
88523 Remove aria-label from the Yes, cancel and No, do not cancel buttons

### DIFF
--- a/src/applications/vaos/appointment-list/components/cancel/CancelWarningPage.jsx
+++ b/src/applications/vaos/appointment-list/components/cancel/CancelWarningPage.jsx
@@ -55,18 +55,13 @@ export default function CancelWarningPage({ appointment, cancelInfo }) {
       <AppointmentCard appointment={appointment}>
         <CancelPageContent type={type} />
         <div className="vads-u-display--flex vads-u-align-items--center vads-u-margin-top--3 vaos-hide-for-print">
-          <button
-            type="button"
-            aria-label="Cancel appointment"
-            onClick={handleConfirm(dispatch)}
-          >
+          <button type="button" onClick={handleConfirm(dispatch)}>
             {buttonText}
           </button>
         </div>
         <div className="vads-u-display--flex vads-u-align-items--center vaos-hide-for-print">
           <button
             type="button"
-            aria-label="Cancel appointment"
             className="usa-button-secondary"
             onClick={handleClose(dispatch)}
           >


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**: Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
- _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

## Summary
This PR removes the aria label from the yes and no cancel appointment buttons.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#88523

## Testing done
Unit and e2e testing

## Screenshots
<img width="902" alt="Screenshot 2024-07-17 at 7 26 30 AM" src="https://github.com/user-attachments/assets/ffa2c77d-f652-494e-99ea-4fd438d7b9eb">


## What areas of the site does it impact?
VAOS

## Acceptance criteria
Background: the `va_online_scheduling_appointment_details_redesign` toggle is on

- [ ] Given the user is on the Upcoming list page
        When the user clicks on `Details` for an upcoming booked appointment and clicks `Cancel appointment` button 
        Then the aria-label will be removed for the buttons `Yes, cancel` and `No, do not cancel `

- [ ] Given the user is on the Pending list page
        When the user clicks on `Details` for an pending request and clicks `Cancel` button 
        Then the aria-label will be removed for the buttons `Yes, cancel request` and `No, do not cancel`

- [ ] Given the user is on the scheduling flow for direct scheduling
        When the user clicks on `Confirm appointment` and clicks `Cancel appointment` button from the confirmation screen
        Then the aria-label will be removed for the buttons `Yes, cancel` and `No, do not cancel `

- [ ] Given the user is on the scheduling flow to submit a VA appointment request
        When the user clicks on `Submit request` and clicks `Cancel request` button from the confirmation screen
        Then the aria-label will be removed for the buttons `Yes, cancel request` and `No, do not cancel`

- [ ] Given the user is on the scheduling flow to submit a Community Care appointment request
        When the user clicks on `Submit request` and clicks `Cancel request` button from the confirmation screen
        Then the aria-label will be removed for the buttons `Yes, cancel request` and `No, do not cancel`


### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
