### PR TITLE
Simplified MHV Landing Page for unregistered and unverified users

### DIFF
--- a/src/applications/mhv-landing-page/components/HeaderLayout.jsx
+++ b/src/applications/mhv-landing-page/components/HeaderLayout.jsx
@@ -9,7 +9,10 @@ import WelcomeContainer from '../containers/WelcomeContainer';
 
 const goBackLinkText = 'Go back to the previous version of My HealtheVet';
 
-const HeaderLayout = ({ showWelcomeMessage = false }) => {
+const HeaderLayout = ({
+  showWelcomeMessage = false,
+  showLearnMore = false,
+}) => {
   const ssoe = useSelector(isAuthenticatedWithSSOe);
   const goBackUrl = mhvUrl(ssoe, 'home');
 
@@ -83,52 +86,54 @@ const HeaderLayout = ({ showWelcomeMessage = false }) => {
                 {goBackLinkText}
               </a>
             </p>
-            <div>
-              <va-alert-expandable
-                status="info"
-                ref={alertExpandableRef}
-                trigger="Learn more about My HealtheVet on VA.gov "
-              >
-                <div>
-                  <p>
-                    <strong>What you can do now on VA.gov:</strong>
-                  </p>
-                  <ul className="vads-u-font-family--sans">
-                    <li>
-                      Schedule, cancel, and manage some health appointments
-                    </li>
-                    <li>Send secure messages to your health care team</li>
-                    <li>
-                      Refill your prescriptions and get a list of all your
-                      medications
-                    </li>
-                  </ul>
-                  <p>
-                    <strong>What’s coming soon:</strong>
-                  </p>
-                  <ul className="vads-u-font-family--sans">
-                    <li>Find, print, and download your medical records</li>
-                    <li>Get your lab and test results</li>
-                  </ul>
-                  <p className="vads-u-font-family--sans">
-                    We’re working to bring your medical records to VA.gov. For
-                    now, you can download your records using the previous
-                    version of My HealtheVet.{' '}
-                    <a
-                      onClick={() =>
-                        datadogRum.addAction(
-                          `Click on Landing Page: Learn More - ${goBackLinkText}`,
-                        )
-                      }
-                      data-testid="mhv-go-back-2"
-                      href={goBackUrl}
-                    >
-                      {goBackLinkText}
-                    </a>
-                  </p>
-                </div>
-              </va-alert-expandable>
-            </div>
+            {showLearnMore && (
+              <div>
+                <va-alert-expandable
+                  status="info"
+                  ref={alertExpandableRef}
+                  trigger="Learn more about My HealtheVet on VA.gov "
+                >
+                  <div>
+                    <p>
+                      <strong>What you can do now on VA.gov:</strong>
+                    </p>
+                    <ul className="vads-u-font-family--sans">
+                      <li>
+                        Schedule, cancel, and manage some health appointments
+                      </li>
+                      <li>Send secure messages to your health care team</li>
+                      <li>
+                        Refill your prescriptions and get a list of all your
+                        medications
+                      </li>
+                    </ul>
+                    <p>
+                      <strong>What’s coming soon:</strong>
+                    </p>
+                    <ul className="vads-u-font-family--sans">
+                      <li>Find, print, and download your medical records</li>
+                      <li>Get your lab and test results</li>
+                    </ul>
+                    <p className="vads-u-font-family--sans">
+                      We’re working to bring your medical records to VA.gov. For
+                      now, you can download your records using the previous
+                      version of My HealtheVet.{' '}
+                      <a
+                        onClick={() =>
+                          datadogRum.addAction(
+                            `Click on Landing Page: Learn More - ${goBackLinkText}`,
+                          )
+                        }
+                        data-testid="mhv-go-back-2"
+                        href={goBackUrl}
+                      >
+                        {goBackLinkText}
+                      </a>
+                    </p>
+                  </div>
+                </va-alert-expandable>
+              </div>
+            )}
           </div>
         </div>
         <div
@@ -147,20 +152,23 @@ const HeaderLayout = ({ showWelcomeMessage = false }) => {
           />
         </div>
       </div>
-      <div
-        className={classnames(
-          'vads-u-border-color--gray-light',
-          'vads-u-border-bottom--1px',
-          'vads-u-margin-bottom--3',
-        )}
-      >
-        {showWelcomeMessage && <WelcomeContainer />}
-      </div>
+      {showWelcomeMessage && (
+        <div
+          className={classnames(
+            'vads-u-border-color--gray-light',
+            'vads-u-border-bottom--1px',
+            'vads-u-margin-bottom--3',
+          )}
+        >
+          <WelcomeContainer />
+        </div>
+      )}
     </>
   );
 };
 
 HeaderLayout.propTypes = {
+  showLearnMore: PropTypes.bool,
   showWelcomeMessage: PropTypes.bool,
 };
 

--- a/src/applications/mhv-landing-page/components/HubLinks.jsx
+++ b/src/applications/mhv-landing-page/components/HubLinks.jsx
@@ -41,7 +41,7 @@ const HubLinks = ({ hubs }) => {
   ));
   return (
     <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
-      <div className="vads-l-row vads-u-margin-bottom--3">{hubLayout}</div>
+      <div className="vads-l-row">{hubLayout}</div>
     </div>
   );
 };

--- a/src/applications/mhv-landing-page/components/LandingPage.jsx
+++ b/src/applications/mhv-landing-page/components/LandingPage.jsx
@@ -36,11 +36,10 @@ const LandingPage = ({ data = {}, recordEvent = recordEventFn }) => {
   const userRegistered = userVerified && vaPatient;
   const signInService = useSelector(signInServiceName);
   const userHasMhvAccount = useSelector(hasMhvAccount);
-  const serviceLabel = SERVICE_PROVIDERS[signInService]?.label;
-  const unVerifiedHeadline = `Verify your identity to use your ${serviceLabel} account on My HealtheVet`;
-
   const showWelcomeMessage = useSelector(personalizationEnabled);
   const showHelpdeskInfo = useSelector(helpdeskInfoEnabled) && userRegistered;
+  const serviceLabel = SERVICE_PROVIDERS[signInService]?.label;
+  const unVerifiedHeadline = `Verify your identity to use your ${serviceLabel} account on My HealtheVet`;
 
   useEffect(
     () => {

--- a/src/applications/mhv-landing-page/mocks/api/index.js
+++ b/src/applications/mhv-landing-page/mocks/api/index.js
@@ -4,8 +4,8 @@ const delay = require('mocker-api/lib/delay');
 const MOCK_TYPES = Object.freeze({
   UNVERIFIED_USER: 'unverified',
   UNREGISTERED_USER: 'unregistered',
-  VERIFIED_USER: 'verified',
   VERIFIED_NO_MHV_USER: 'verified_no_mhv',
+  VERIFIED_USER: 'verified',
   VERIFIED_USER_ALL_FEATURES: 'verified_all',
 });
 

--- a/src/applications/mhv-landing-page/tests/components/HeaderLayout.unit.spec.jsx
+++ b/src/applications/mhv-landing-page/tests/components/HeaderLayout.unit.spec.jsx
@@ -25,8 +25,8 @@ const mockStore = ({ ssoe = false } = {}) => ({
 
 describe('MHV Landing Page -- Header Layout', () => {
   describe('Health Tools links', () => {
-    it('renders', async () => {
-      const { getByText } = render(
+    it('renders without learn more', async () => {
+      const { queryByTestId, getByText } = render(
         <Provider store={mockStore()}>
           <HeaderLayout />
         </Provider>,
@@ -34,13 +34,27 @@ describe('MHV Landing Page -- Header Layout', () => {
       await waitFor(() => {
         const result = getByText(/Welcome to the new home for My HealtheVet/);
         expect(result).to.exist;
+        expect(queryByTestId('mhv-go-back-2')).to.be.null;
+      });
+    });
+
+    it('renders with learn more', async () => {
+      const { getByTestId, getByText } = render(
+        <Provider store={mockStore()}>
+          <HeaderLayout showLearnMore />
+        </Provider>,
+      );
+      await waitFor(() => {
+        const result = getByText(/Welcome to the new home for My HealtheVet/);
+        expect(result).to.exist;
+        expect(getByTestId('mhv-go-back-2')).to.exist;
       });
     });
 
     it('renders the non-ssoe link', async () => {
       const { getByTestId } = render(
         <Provider store={mockStore()}>
-          <HeaderLayout />
+          <HeaderLayout showLearnMore />
         </Provider>,
       );
       await waitFor(() => {
@@ -64,7 +78,7 @@ describe('MHV Landing Page -- Header Layout', () => {
       });
       const { getByTestId } = render(
         <Provider store={store}>
-          <HeaderLayout />
+          <HeaderLayout showLearnMore />
         </Provider>,
       );
       await waitFor(() => {
@@ -87,7 +101,7 @@ describe('MHV Landing Page -- Header Layout', () => {
     it('call datadogRum.addAction on click of go-back links', async () => {
       const { getByTestId } = render(
         <Provider store={mockStore()}>
-          <HeaderLayout />
+          <HeaderLayout showLearnMore />
         </Provider>,
       );
 

--- a/src/applications/mhv-landing-page/tests/e2e/alerts/unregistered.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/alerts/unregistered.cypress.spec.js
@@ -29,10 +29,12 @@ describe(appName, () => {
         cy.findAllByTestId(/^mhv-link-group-card-/).should('not.exist');
 
         // Check the hubs are visible
-        cy.findAllByTestId(/^mhv-link-group-hub-/).should.exist;
+        cy.findAllByTestId(/^mhv-link-group-hub-/).should('not.exist');
 
         // Test for the conditional heading for VA health benefits
-        cy.findByRole('heading', { name: /VA health benefits/i }).should.exist;
+        cy.findByRole('heading', { name: /VA health benefits/i }).should(
+          'not.exist',
+        );
       });
 
       it(`registered patient on ${size} screen`, () => {

--- a/src/applications/mhv-landing-page/tests/e2e/alerts/unverified.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/alerts/unverified.cypress.spec.js
@@ -36,10 +36,12 @@ describe(appName, () => {
         cy.findAllByTestId(/^mhv-link-group-card-/).should('not.exist');
 
         // Check the hubs are visible
-        cy.findAllByTestId(/^mhv-link-group-hub-/).should.exist;
+        cy.findAllByTestId(/^mhv-link-group-hub-/).should('not.exist');
 
         // Test for the conditional heading for VA health benefits
-        cy.findByRole('heading', { name: 'VA health benefits' }).should.exist;
+        cy.findByRole('heading', { name: 'VA health benefits' }).should(
+          'not.exist',
+        );
       });
 
       it(`Shows landing page on ${size} screen`, () => {

--- a/src/applications/mhv-landing-page/tests/e2e/helpdesk-info/helpdesk-info.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/helpdesk-info/helpdesk-info.cypress.spec.js
@@ -28,6 +28,13 @@ describe(`${appName} - helpdesk information component`, () => {
 
       cy.findByTestId('mhv-helpdesk-info').should.exist;
     });
+
+    it(`renders for users without an MHV account`, () => {
+      LandingPage.visit({ mhvAccountState: false });
+      cy.injectAxeThenAxeCheck();
+
+      cy.findByTestId('mhv-helpdesk-info').should.exist;
+    });
   });
 
   describe('display content based on feature toggle', () => {

--- a/src/applications/mhv-landing-page/tests/e2e/newsletter/newsletter.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/newsletter/newsletter.cypress.spec.js
@@ -2,12 +2,14 @@ import { appName } from '../../../manifest.json';
 import ApiInitializer from '../utilities/ApiInitializer';
 import LandingPage from '../pages/LandingPage';
 
-describe(`${appName} -- MHV Secondary Nav enabled`, () => {
+describe(`${appName} -- MHV Newsletter Signup`, () => {
   describe('registered user', () => {
     it('renders', () => {
       ApiInitializer.initializeFeatureToggle.withAllFeatures();
       LandingPage.visit();
-      LandingPage.secondaryNavRendered();
+      cy.findByRole('heading', {
+        name: /Subscribe to the My HealtheVet newsletter/,
+      }).should.exist;
       cy.injectAxeThenAxeCheck();
     });
   });
@@ -16,7 +18,9 @@ describe(`${appName} -- MHV Secondary Nav enabled`, () => {
     it('does not render', () => {
       ApiInitializer.initializeFeatureToggle.withAllFeatures();
       LandingPage.visit({ verified: false, registered: false });
-      LandingPage.secondaryNav().should('not.exist');
+      cy.findByRole('heading', {
+        name: /Subscribe to the My HealtheVet newsletter/,
+      }).should('not.exist');
       cy.injectAxeThenAxeCheck();
     });
   });
@@ -25,17 +29,10 @@ describe(`${appName} -- MHV Secondary Nav enabled`, () => {
     it('does not render', () => {
       ApiInitializer.initializeFeatureToggle.withAllFeatures();
       LandingPage.visit({ registered: false });
-      LandingPage.secondaryNav().should('not.exist');
+      cy.findByRole('heading', {
+        name: /Subscribe to the My HealtheVet newsletter/,
+      }).should('not.exist');
       cy.injectAxeThenAxeCheck();
     });
-  });
-});
-
-describe(`${appName} -- MHV Secondary Nav disabled`, () => {
-  it('does not render', () => {
-    ApiInitializer.initializeFeatureToggle.withAllFeaturesDisabled();
-    LandingPage.visit();
-    LandingPage.secondaryNav().should('not.exist');
-    cy.injectAxeThenAxeCheck();
   });
 });

--- a/src/applications/mhv-landing-page/tests/e2e/newsletter/newsletter.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/newsletter/newsletter.cypress.spec.js
@@ -35,4 +35,15 @@ describe(`${appName} -- MHV Newsletter Signup`, () => {
       cy.injectAxeThenAxeCheck();
     });
   });
+
+  describe('user without MHV account', () => {
+    it('renders', () => {
+      ApiInitializer.initializeFeatureToggle.withAllFeatures();
+      LandingPage.visit({ mhvAccountState: false });
+      cy.findByRole('heading', {
+        name: /Subscribe to the My HealtheVet newsletter/,
+      }).should.exist;
+      cy.injectAxeThenAxeCheck();
+    });
+  });
 });

--- a/src/applications/mhv-landing-page/tests/e2e/secondary-nav/secondary-nav.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/secondary-nav/secondary-nav.cypress.spec.js
@@ -29,6 +29,15 @@ describe(`${appName} -- MHV Secondary Nav enabled`, () => {
       cy.injectAxeThenAxeCheck();
     });
   });
+
+  describe('user without MHV account', () => {
+    it('renders', () => {
+      ApiInitializer.initializeFeatureToggle.withAllFeatures();
+      LandingPage.visit({ mhvAccountState: false });
+      LandingPage.secondaryNavRendered();
+      cy.injectAxeThenAxeCheck();
+    });
+  });
 });
 
 describe(`${appName} -- MHV Secondary Nav disabled`, () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary
We reviewed what content is shown to the different types of users and made changes to simplify the page for unverified and unregistered users.
- Unverified users do not see the resource links (hub links), helpdesk info, "learn more" expandable area in the header,  or newsletter signup
- Unregistered users (not a VA patient) do not see the resource links (hub links), helpdesk info, "learn more" expandable area in the header, or newsletter signup
- Users without an MHV account see all components including the appropriate alert.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/85897

## Testing done
- Updated unit and e2e tests

## Screenshots
|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   ![localhost_3001_my-health_(iPhone 14 Pro Max) (5)](https://github.com/user-attachments/assets/3697dd1e-c177-437e-98a3-95fce6aacb00)     |  ![localhost_3001_my-health_(iPhone 14 Pro Max) (5)](https://github.com/user-attachments/assets/40af4a61-a26c-438c-af95-e9e6eb2548c3)  |
| Desktop |    ![localhost_3001_my-health_ (10)](https://github.com/user-attachments/assets/4efd24b6-463a-45b9-bc73-ac53d63befd6)    |   ![localhost_3001_my-health_ (10)](https://github.com/user-attachments/assets/867bf33a-0469-4f3a-919d-afd856004907)  |

## What areas of the site does it impact?
- MHV Landing page

## Acceptance criteria
- Implemented the hiding of some landing page content per designs when the "no access to MHV" alert is displayed
  - secondary nav
  - expanding alert
  - links below "need help?"

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

