### PR TITLE
Autosuggest hint text ui option

### DIFF
--- a/src/applications/pre-need-integration/utils/helpers.js
+++ b/src/applications/pre-need-integration/utils/helpers.js
@@ -1140,6 +1140,7 @@ export const selfServiceRecordsUI = {
     serviceBranch: autosuggest.uiSchema('Branch of service', null, {
       'ui:options': {
         labels: serviceLabels,
+        hint: 'Enter your hint here',
       },
     }),
     dateRange: dateRangeUI(

--- a/src/applications/pre-need-integration/utils/helpers.js
+++ b/src/applications/pre-need-integration/utils/helpers.js
@@ -1140,7 +1140,6 @@ export const selfServiceRecordsUI = {
     serviceBranch: autosuggest.uiSchema('Branch of service', null, {
       'ui:options': {
         labels: serviceLabels,
-        hint: 'Enter your hint here',
       },
     }),
     dateRange: dateRangeUI(

--- a/src/platform/forms-system/src/js/fields/AutosuggestField.jsx
+++ b/src/platform/forms-system/src/js/fields/AutosuggestField.jsx
@@ -213,6 +213,7 @@ export default class AutosuggestField extends React.Component {
     const highlightText = uiSchema['ui:options']?.highlightText ?? true;
     const { inputProps } = uiSchema['ui:options'];
     const value = this.state.input?.toLowerCase() || '';
+    const hint = uiSchema['ui:options'].hint || null;
     const caseInsensitiveMatch = new RegExp(`(${escapeRegExp(value)})`, 'i');
     const highLightMatchingText = query => {
       if (value.length > 2) {
@@ -250,64 +251,68 @@ export default class AutosuggestField extends React.Component {
     }
 
     return (
-      <Downshift
-        onChange={this.handleChange}
-        onInputValueChange={this.handleInputValueChange}
-        inputValue={this.state.input}
-        selectedItem={this.state.input}
-        onOuterClick={this.handleBlur}
-        itemToString={item => {
-          if (typeof item === 'string') {
-            return item;
-          }
+      <>
+        {hint && <div className="usa-hint">{hint}</div>}
+        <Downshift
+          onChange={this.handleChange}
+          onInputValueChange={this.handleInputValueChange}
+          inputValue={this.state.input}
+          selectedItem={this.state.input}
+          onOuterClick={this.handleBlur}
+          itemToString={item => {
+            if (typeof item === 'string') {
+              return item;
+            }
 
-          return item.label;
-        }}
-        render={({
-          getInputProps,
-          getItemProps,
-          isOpen,
-          selectedItem,
-          highlightedIndex,
-        }) => (
-          <div className="autosuggest-container">
-            <input
-              {...getInputProps({
-                autoComplete: 'off',
-                id,
-                name: id,
-                className: 'autosuggest-input',
-                onBlur: isOpen ? undefined : this.handleBlur,
-                onKeyDown: this.handleKeyDown,
-                ...inputProps,
-              })}
-            />
-            {isOpen && (
-              <div className="autosuggest-list" role="listbox">
-                {this.state.suggestions.map((item, index) => (
-                  <div
-                    {...getItemProps({ item })}
-                    role="option"
-                    aria-selected={
-                      selectedItem === item.label ? 'true' : 'false'
-                    }
-                    className={classNames('autosuggest-item', {
-                      'autosuggest-item-highlighted':
-                        highlightedIndex === index,
-                      'autosuggest-item-selected': selectedItem === item.label,
-                    })}
-                    key={item.id}
-                  >
-                    {highlightText
-                      ? highLightMatchingText(item.label)
-                      : item.label}
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-      />
+            return item.label;
+          }}
+          render={({
+            getInputProps,
+            getItemProps,
+            isOpen,
+            selectedItem,
+            highlightedIndex,
+          }) => (
+            <div className="autosuggest-container">
+              <input
+                {...getInputProps({
+                  autoComplete: 'off',
+                  id,
+                  name: id,
+                  className: 'autosuggest-input',
+                  onBlur: isOpen ? undefined : this.handleBlur,
+                  onKeyDown: this.handleKeyDown,
+                  ...inputProps,
+                })}
+              />
+              {isOpen && (
+                <div className="autosuggest-list" role="listbox">
+                  {this.state.suggestions.map((item, index) => (
+                    <div
+                      {...getItemProps({ item })}
+                      role="option"
+                      aria-selected={
+                        selectedItem === item.label ? 'true' : 'false'
+                      }
+                      className={classNames('autosuggest-item', {
+                        'autosuggest-item-highlighted':
+                          highlightedIndex === index,
+                        'autosuggest-item-selected':
+                          selectedItem === item.label,
+                      })}
+                      key={item.id}
+                    >
+                      {highlightText
+                        ? highLightMatchingText(item.label)
+                        : item.label}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        />
+      </>
     );
   }
 }

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -740,3 +740,7 @@ va-checkbox.statement-of-truth-va-checkbox::part(checkbox) {
 .rjsf-web-component-field[error]:not([error=""]) {
   margin-top: 1.5rem;
 }
+
+.usa-hint {
+  color: var(--vads-color-gray-medium);
+}


### PR DESCRIPTION
## Summary

- Added hint text functionailty to the platforms `AutoSuggestField` so a developer can add custom hint text by passing in their own custom `ui:options`

## Testing done

- [x] Unit Tests Passing
- [ ] QA
- [x] Internal Review
- [x] Platform Review 

## Screenshots

https://github.com/user-attachments/assets/8151aa39-0c5b-4937-8542-35a415941827

## What areas of the site does it impact?

`vets-website/src/platform/forms-system/src/js/fields/AutosuggestField.jsx`

### Quality Assurance & Testing

- Unless a dev passes in the `hint` ui:option to the AutoSuggestField, the component will act exactly as it did before. 
- Only once the hint option is merged with the components default ui:options (found in `vets-website/src/platform/forms-system/src/js/definitions/autosuggest.js`), will the hint text appear

### Usage
 _Using the `pre-need-integration` form as an example_
```
import * as autosuggest from 'platform/forms-system/src/js/definitions/autosuggest';
// Other code
    serviceBranch: autosuggest.uiSchema('Branch of service', null, {
      'ui:options': {
        labels: serviceLabels,
        hint: 'Enter your hint here',
      },
    }),
```
