### PR TITLE
Add multi-page other names pattern

### DIFF
--- a/src/applications/pensions/PensionsApp.jsx
+++ b/src/applications/pensions/PensionsApp.jsx
@@ -35,7 +35,7 @@ export default function PensionEntry({ location, children }) {
     () => {
       if (!isLoadingFeatures) {
         window.sessionStorage.setItem(
-          'showDependentsMultiplePage',
+          'showMultiplePageResponse',
           pensionMultiplePageResponse,
         );
       }

--- a/src/applications/pensions/config/chapters/02-military-history/hasOtherNames.js
+++ b/src/applications/pensions/config/chapters/02-military-history/hasOtherNames.js
@@ -3,6 +3,7 @@ import {
   yesNoUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import fullSchemaPensions from 'vets-json-schema/dist/21P-527EZ-schema.json';
+import { showDependentsMultiplePage } from '../../../helpers';
 
 const { serveUnderOtherNames } = fullSchemaPensions.properties;
 
@@ -10,6 +11,7 @@ const { serveUnderOtherNames } = fullSchemaPensions.properties;
 export default {
   title: 'Other service names',
   path: 'military/other-names',
+  depends: () => !showDependentsMultiplePage(),
   uiSchema: {
     ...titleUI('Other service names'),
     serveUnderOtherNames: yesNoUI({

--- a/src/applications/pensions/config/chapters/02-military-history/hasOtherNames.js
+++ b/src/applications/pensions/config/chapters/02-military-history/hasOtherNames.js
@@ -3,7 +3,7 @@ import {
   yesNoUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import fullSchemaPensions from 'vets-json-schema/dist/21P-527EZ-schema.json';
-import { showDependentsMultiplePage } from '../../../helpers';
+import { showMultiplePageResponse } from '../../../helpers';
 
 const { serveUnderOtherNames } = fullSchemaPensions.properties;
 
@@ -11,7 +11,7 @@ const { serveUnderOtherNames } = fullSchemaPensions.properties;
 export default {
   title: 'Other service names',
   path: 'military/other-names',
-  depends: () => !showDependentsMultiplePage(),
+  depends: () => !showMultiplePageResponse(),
   uiSchema: {
     ...titleUI('Other service names'),
     serveUnderOtherNames: yesNoUI({

--- a/src/applications/pensions/config/chapters/02-military-history/index.js
+++ b/src/applications/pensions/config/chapters/02-military-history/index.js
@@ -1,6 +1,7 @@
 import servicePeriod from './servicePeriod';
 import hasOtherNames from './hasOtherNames';
 import otherNames from './otherNames';
+import { otherNamesPages } from './otherNamesPages';
 import pow from './pow';
 
 export default {
@@ -9,6 +10,7 @@ export default {
     servicePeriod,
     hasOtherNames,
     otherNames,
+    ...otherNamesPages,
     pow,
   },
 };

--- a/src/applications/pensions/config/chapters/02-military-history/otherNames.js
+++ b/src/applications/pensions/config/chapters/02-military-history/otherNames.js
@@ -7,7 +7,7 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import ArrayDescription from '../../../components/ArrayDescription';
 import ListItemView from '../../../components/ListItemView';
-import { formatFullName, showDependentsMultiplePage } from '../../../helpers';
+import { formatFullName, showMultiplePageResponse } from '../../../helpers';
 import { doesHavePreviousNames } from './helpers';
 
 export const OtherNameView = ({ formData }) => (
@@ -25,7 +25,7 @@ export default {
   title: 'List of other service names',
   path: 'military/other-names/add',
   depends: formData =>
-    !showDependentsMultiplePage() && doesHavePreviousNames(formData),
+    !showMultiplePageResponse() && doesHavePreviousNames(formData),
   uiSchema: {
     ...titleUI(
       'List of other service names',

--- a/src/applications/pensions/config/chapters/02-military-history/otherNames.js
+++ b/src/applications/pensions/config/chapters/02-military-history/otherNames.js
@@ -7,7 +7,7 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import ArrayDescription from '../../../components/ArrayDescription';
 import ListItemView from '../../../components/ListItemView';
-import { formatFullName } from '../../../helpers';
+import { formatFullName, showDependentsMultiplePage } from '../../../helpers';
 import { doesHavePreviousNames } from './helpers';
 
 export const OtherNameView = ({ formData }) => (
@@ -24,7 +24,8 @@ OtherNameView.propTypes = {
 export default {
   title: 'List of other service names',
   path: 'military/other-names/add',
-  depends: doesHavePreviousNames,
+  depends: formData =>
+    !showDependentsMultiplePage() && doesHavePreviousNames(formData),
   uiSchema: {
     ...titleUI(
       'List of other service names',

--- a/src/applications/pensions/config/chapters/02-military-history/otherNamesPages.js
+++ b/src/applications/pensions/config/chapters/02-military-history/otherNamesPages.js
@@ -7,7 +7,7 @@ import {
 } from '~/platform/forms-system/src/js/web-component-patterns';
 
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
-import { formatFullName, showDependentsMultiplePage } from '../../../helpers';
+import { formatFullName, showMultiplePageResponse } from '../../../helpers';
 
 /** @type {ArrayBuilderOptions} */
 const options = {
@@ -80,14 +80,14 @@ export const otherNamesPages = arrayBuilderPages(options, pageBuilder => ({
   otherNamesSummary: pageBuilder.summaryPage({
     title: 'Other service names',
     path: 'military/other-names/summary',
-    depends: () => showDependentsMultiplePage(),
+    depends: () => showMultiplePageResponse(),
     uiSchema: summaryPage.uiSchema,
     schema: summaryPage.schema,
   }),
   otherNamePage: pageBuilder.itemPage({
     title: 'Other service names',
     path: 'military/other-names/:index/name',
-    depends: () => showDependentsMultiplePage(),
+    depends: () => showMultiplePageResponse(),
     uiSchema: otherNamePage.uiSchema,
     schema: otherNamePage.schema,
   }),

--- a/src/applications/pensions/config/chapters/02-military-history/otherNamesPages.js
+++ b/src/applications/pensions/config/chapters/02-military-history/otherNamesPages.js
@@ -1,0 +1,94 @@
+import {
+  arrayBuilderItemFirstPageTitleUI,
+  arrayBuilderYesNoSchema,
+  arrayBuilderYesNoUI,
+  fullNameUI,
+  fullNameSchema,
+} from '~/platform/forms-system/src/js/web-component-patterns';
+
+import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
+import { formatFullName, showDependentsMultiplePage } from '../../../helpers';
+
+/** @type {ArrayBuilderOptions} */
+const options = {
+  arrayPath: 'previousNames',
+  nounSingular: 'previous name',
+  nounPlural: 'previous names',
+  required: false,
+  isItemIncomplete: item =>
+    !item?.previousFullName?.first || !item.previousFullName?.last, // include all required fields here
+  maxItems: 5,
+  text: {
+    getItemName: item => formatFullName(item.previousFullName),
+  },
+};
+
+/**
+ * Cards are populated on this page above the uiSchema if items are present
+ *
+ * @returns {PageSchema}
+ */
+const summaryPage = {
+  uiSchema: {
+    'view:isAddingOtherNames': arrayBuilderYesNoUI(
+      options,
+      {
+        title: 'Did you serve under another name?',
+        hint: ' ',
+        labels: {
+          Y: 'Yes, I have a previous name to report',
+          N: 'No, I don’t have a previous name to report',
+        },
+      },
+      {
+        title: 'Do you have another previous name to report?',
+        labels: {
+          Y: 'Yes, I have another previous name to report',
+          N: 'No, I don’t have anymore previous names to report',
+        },
+      },
+    ),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      'view:isAddingOtherNames': arrayBuilderYesNoSchema,
+    },
+    required: ['view:isAddingOtherNames'],
+  },
+};
+
+/** @returns {PageSchema} */
+const otherNamePage = {
+  uiSchema: {
+    ...arrayBuilderItemFirstPageTitleUI({
+      title: 'Previous name',
+      nounSingular: options.nounSingular,
+    }),
+    previousFullName: fullNameUI(title => `Previous ${title}`),
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      previousFullName: fullNameSchema,
+    },
+    required: ['previousFullName'],
+  },
+};
+
+export const otherNamesPages = arrayBuilderPages(options, pageBuilder => ({
+  otherNamesSummary: pageBuilder.summaryPage({
+    title: 'Other service names',
+    path: 'military/other-names/summary',
+    depends: () => showDependentsMultiplePage(),
+    uiSchema: summaryPage.uiSchema,
+    schema: summaryPage.schema,
+  }),
+  otherNamePage: pageBuilder.itemPage({
+    title: 'Other service names',
+    path: 'military/other-names/:index/name',
+    depends: () => showDependentsMultiplePage(),
+    uiSchema: otherNamePage.uiSchema,
+    schema: otherNamePage.schema,
+  }),
+}));

--- a/src/applications/pensions/config/chapters/04-household-information/dependentChildAddress.js
+++ b/src/applications/pensions/config/chapters/04-household-information/dependentChildAddress.js
@@ -8,7 +8,7 @@ import {
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import fullSchemaPensions from 'vets-json-schema/dist/21P-527EZ-schema.json';
-import { showDependentsMultiplePage } from '../../../helpers';
+import { showMultiplePageResponse } from '../../../helpers';
 import { getDependentChildTitle, dependentIsOutsideHousehold } from './helpers';
 import createHouseholdMemberTitle from '../../../components/DisclosureTitle';
 
@@ -21,8 +21,7 @@ export default {
   title: item => getDependentChildTitle(item, 'address'),
   path: 'household/dependents/children/address/:index',
   depends: (formData, index) =>
-    !showDependentsMultiplePage() &&
-    dependentIsOutsideHousehold(formData, index),
+    !showMultiplePageResponse() && dependentIsOutsideHousehold(formData, index),
   showPagePerItem: true,
   arrayPath: 'dependents',
   uiSchema: {

--- a/src/applications/pensions/config/chapters/04-household-information/dependentChildInHousehold.js
+++ b/src/applications/pensions/config/chapters/04-household-information/dependentChildInHousehold.js
@@ -4,7 +4,7 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import fullSchemaPensions from 'vets-json-schema/dist/21P-527EZ-schema.json';
 import createHouseholdMemberTitle from '../../../components/DisclosureTitle';
-import { showDependentsMultiplePage } from '../../../helpers';
+import { showMultiplePageResponse } from '../../../helpers';
 import { doesHaveDependents, getDependentChildTitle } from './helpers';
 
 const {
@@ -15,7 +15,7 @@ export default {
   title: item => getDependentChildTitle(item, 'household'),
   path: 'household/dependents/children/inhousehold/:index',
   depends: formData =>
-    !showDependentsMultiplePage() && doesHaveDependents(formData),
+    !showMultiplePageResponse() && doesHaveDependents(formData),
   showPagePerItem: true,
   arrayPath: 'dependents',
   uiSchema: {

--- a/src/applications/pensions/config/chapters/04-household-information/dependentChildInformation.js
+++ b/src/applications/pensions/config/chapters/04-household-information/dependentChildInformation.js
@@ -16,7 +16,7 @@ import fullSchemaPensions from 'vets-json-schema/dist/21P-527EZ-schema.json';
 import createHouseholdMemberTitle from '../../../components/DisclosureTitle';
 import {
   DependentSeriouslyDisabledDescription,
-  showDependentsMultiplePage,
+  showMultiplePageResponse,
 } from '../../../helpers';
 import {
   DisabilityDocsAlert,
@@ -43,7 +43,7 @@ export default {
   title: item => getDependentChildTitle(item, 'information'),
   path: 'household/dependents/children/information/:index',
   depends: formData =>
-    !showDependentsMultiplePage() && doesHaveDependents(formData),
+    !showMultiplePageResponse() && doesHaveDependents(formData),
   showPagePerItem: true,
   arrayPath: 'dependents',
   uiSchema: {

--- a/src/applications/pensions/config/chapters/04-household-information/dependentChildren.js
+++ b/src/applications/pensions/config/chapters/04-household-information/dependentChildren.js
@@ -11,7 +11,7 @@ import ListItemView from '../../../components/ListItemView';
 import {
   DependentsMinItem,
   formatFullName,
-  showDependentsMultiplePage,
+  showMultiplePageResponse,
 } from '../../../helpers';
 import { doesHaveDependents } from './helpers';
 
@@ -30,7 +30,7 @@ export default {
   title: 'Dependent children',
   path: 'household/dependents/add',
   depends: formData =>
-    !showDependentsMultiplePage() && doesHaveDependents(formData),
+    !showMultiplePageResponse() && doesHaveDependents(formData),
   uiSchema: {
     ...titleUI('Dependent children'),
     dependents: {

--- a/src/applications/pensions/config/chapters/04-household-information/dependentChildrenPages.js
+++ b/src/applications/pensions/config/chapters/04-household-information/dependentChildrenPages.js
@@ -34,7 +34,7 @@ import { isBetween18And23 } from './helpers';
 import {
   DependentSeriouslyDisabledDescription,
   formatFullName,
-  showDependentsMultiplePage,
+  showMultiplePageResponse,
 } from '../../../helpers';
 
 /** @type {ArrayBuilderOptions} */
@@ -343,35 +343,35 @@ export const dependentChildrenPages = arrayBuilderPages(
     dependentChildrenSummary: pageBuilder.summaryPage({
       title: 'Dependent children',
       path: 'household/dependents/summary',
-      depends: () => showDependentsMultiplePage(),
+      depends: () => showMultiplePageResponse(),
       uiSchema: summaryPage.uiSchema,
       schema: summaryPage.schema,
     }),
     dependentChildFullNamePage: pageBuilder.itemPage({
       title: 'Dependent children',
       path: 'household/dependents/:index/name',
-      depends: () => showDependentsMultiplePage(),
+      depends: () => showMultiplePageResponse(),
       uiSchema: fullNamePage.uiSchema,
       schema: fullNamePage.schema,
     }),
     dependentChildBirthInformationPage: pageBuilder.itemPage({
       title: 'Dependent children',
       path: 'household/dependents/:index/birth',
-      depends: () => showDependentsMultiplePage(),
+      depends: () => showMultiplePageResponse(),
       uiSchema: birthInformationPage.uiSchema,
       schema: birthInformationPage.schema,
     }),
     dependentChildSocialSecurityNumberPage: pageBuilder.itemPage({
       title: 'Dependent children',
       path: 'household/dependents/:index/social-security-number',
-      depends: () => showDependentsMultiplePage(),
+      depends: () => showMultiplePageResponse(),
       uiSchema: socialSecurityNumberPage.uiSchema,
       schema: socialSecurityNumberPage.schema,
     }),
     dependentChildRelationshipPage: pageBuilder.itemPage({
       title: 'Dependent children',
       path: 'household/dependents/:index/relationship',
-      depends: () => showDependentsMultiplePage(),
+      depends: () => showMultiplePageResponse(),
       uiSchema: relationshipPage.uiSchema,
       schema: relationshipPage.schema,
     }),
@@ -379,7 +379,7 @@ export const dependentChildrenPages = arrayBuilderPages(
       title: 'Dependent children',
       path: 'household/dependents/:index/school',
       depends: (formData, index) =>
-        showDependentsMultiplePage() &&
+        showMultiplePageResponse() &&
         isBetween18And23(
           get(['dependents', index, 'childDateOfBirth'], formData),
         ),
@@ -389,21 +389,21 @@ export const dependentChildrenPages = arrayBuilderPages(
     dependentChildDisabledPage: pageBuilder.itemPage({
       title: 'Dependent children',
       path: 'household/dependents/:index/disabled',
-      depends: () => showDependentsMultiplePage(),
+      depends: () => showMultiplePageResponse(),
       uiSchema: disabledPage.uiSchema,
       schema: disabledPage.schema,
     }),
     dependentChildPreviouslyMarriedPage: pageBuilder.itemPage({
       title: 'Dependent children',
       path: 'household/dependents/:index/married',
-      depends: () => showDependentsMultiplePage(),
+      depends: () => showMultiplePageResponse(),
       uiSchema: previouslyMarriedPage.uiSchema,
       schema: previouslyMarriedPage.schema,
     }),
     dependentChildInHouseholdPage: pageBuilder.itemPage({
       title: 'Dependent children',
       path: 'household/dependents/:index/in-household',
-      depends: () => showDependentsMultiplePage(),
+      depends: () => showMultiplePageResponse(),
       onNavForward: props => {
         return props.formData.childInHousehold
           ? helpers.navForwardFinishedItem(props) // go to next page
@@ -415,7 +415,7 @@ export const dependentChildrenPages = arrayBuilderPages(
     dependentChildAddressPage: pageBuilder.itemPage({
       title: 'Dependent children',
       path: 'household/dependents/:index/address',
-      depends: () => showDependentsMultiplePage(),
+      depends: () => showMultiplePageResponse(),
       uiSchema: addressPage.uiSchema,
       schema: addressPage.schema,
     }),

--- a/src/applications/pensions/config/chapters/04-household-information/hasDependents.js
+++ b/src/applications/pensions/config/chapters/04-household-information/hasDependents.js
@@ -3,13 +3,13 @@ import {
   yesNoSchema,
   yesNoUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { showDependentsMultiplePage } from '../../../helpers';
+import { showMultiplePageResponse } from '../../../helpers';
 
 /** @type {PageSchema} */
 export default {
   title: 'Dependents',
   path: 'household/dependents',
-  depends: () => !showDependentsMultiplePage(),
+  depends: () => !showMultiplePageResponse(),
   uiSchema: {
     ...titleUI('Dependent children'),
     'view:hasDependents': yesNoUI({

--- a/src/applications/pensions/helpers.jsx
+++ b/src/applications/pensions/helpers.jsx
@@ -119,5 +119,5 @@ export const isProductionEnv = () => {
   );
 };
 
-export const showDependentsMultiplePage = () =>
-  window.sessionStorage.getItem('showDependentsMultiplePage') === 'true';
+export const showMultiplePageResponse = () =>
+  window.sessionStorage.getItem('showMultiplePageResponse') === 'true';


### PR DESCRIPTION
## Summary
Implement the Multiple Page Response pattern on the Pension Benefits form (21P-527EZ) for other service names

### Description
Replace the other service names pages with the [Array Builder Pattern (Multiple responses list & loop)](https://design.va.gov/patterns/ask-users-for/multiple-responses#how-to-design-and-build---multi-page) pattern and [Design](https://design.va.gov/patterns/ask-users-for/multiple-responses#how-to-design-and-build---multi-page) reference

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82849

## How to run in local environment
1. Check out this branch locally
2. In your local environment, set the `pension_multiple_page_response` flipper to 'enabled' at http://localhost:3000/flipper/features/pension_multiple_page_response
3. Run `vets-website` and `vets-api`
4. Go to `http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/` in your browser

## How to verify
1. Continue to the other service names pages in the 'Military history' chapter (/military/other-names/summary)
2. Add, edit and delete a previous name via the multiple page list loop pattern
3. Verify that the UI matches the Multiple Page designs
4. Verify the layout on desktop and mobile viewports
5. Verify that the form data is saved to the api and redux store

## How to test
### Previous Name Pages
- [x] Add a previous name
- [x] Verify that field types are validated
- [x] Verify that required fields are required

### Previous Names Summary Page
- [x] Do not add a previous name from the '/military/other-names/summary' page
- [x] Add a previous name from the '/military/other-names/summary' page
- [x] Cancel adding a previous name from any subsequent page after the '/military/other-names/summary' page and verify that the previous name is not added
- [x] Add another(multiple) previous name from the '/military/other-names/summary' page
- [x] Edit a previous name from the '/military/other-names/summary' page and verify that the changes are saved and an alert is displayed after the previous name is edited
- [x] Cancel editing a previous name from any subsequent page after the '/military/other-names/summary' page and verify that changes are not saved
- [x] Delete a previous name and verify that that an alert is displayed after the previous name is deleted

### Review and Submit Page
- [x] On the '/review and submit' page, expand the 'Military history' chapter accordion and add a previous name
- [x] Cancel adding a previous name from any subsequent page from the '/review-and-submit' page and verify that the previous name is not added
- [x] Add another(multiple) previous name from the '/review and submit' page
- [x] Edit a previous name from the 'review and submit' page and verify that the changes are saved and an alert is displayed after the previous name is edited
- [x] Cancel editing a previous name from any subsequent page after the 'review and submit' page and verify that changes are not saved
- [x] Delete a previous name and verify that that an alert is displayed after the previous name is deleted
- [x] Verify that the form cannot be submitted when a previous name is incomplete

## Screenshots
| Before | Before | After |
| ------ | ------ | ------ |
|![localhost_3001_pension_apply-for-veteran-pension-form-21p-527ez_form-saved (15)](https://github.com/user-attachments/assets/a61fc2c3-c8f3-48d3-9a4f-5daf34d8e179)|![localhost_3001_pension_apply-for-veteran-pension-form-21p-527ez_form-saved (14)](https://github.com/user-attachments/assets/8ea39fbe-8a5b-499b-a7c6-f6d99be44fe7)|![localhost_3001_pension_apply-for-veteran-pension-form-21p-527ez_form-saved (13)](https://github.com/user-attachments/assets/0c1da39f-d735-418f-baf1-28a70b21ac50)




## What areas of the site does it impact?
Pension Benefits Application

### Quality Assurance & Testing
- [x] Existing unit tests and integration tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
