### PR TITLE
[CST] - Updated page focus on CST Tabs

### DIFF
--- a/src/applications/claims-status/components/ClaimStatusHeader.jsx
+++ b/src/applications/claims-status/components/ClaimStatusHeader.jsx
@@ -18,7 +18,7 @@ export default function ClaimStatusHeader({ claim }) {
 
   return (
     <div className="claim-status-header-container">
-      <h2 className="vads-u-margin-y--0">Claim status</h2>
+      <h2 className="tab-header vads-u-margin-y--0">Claim status</h2>
       <p className="vads-u-margin-top--1 vads-u-margin-bottom--3 va-introtext">
         Here’s the latest information on your claim.
       </p>

--- a/src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx
@@ -48,6 +48,10 @@ const { Element } = Scroll;
 const filesPath = `../files`;
 
 class AdditionalEvidencePage extends React.Component {
+  componentDidMount() {
+    this.props.resetUploads();
+  }
+
   // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(props) {
     if (props.uploadComplete) {

--- a/src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
 import { getScrollOptions } from '@department-of-veterans-affairs/platform-utilities/ui';
-import scrollToTop from '@department-of-veterans-affairs/platform-utilities/scrollToTop';
 import scrollTo from '@department-of-veterans-affairs/platform-utilities/scrollTo';
 
 import AddFilesForm from './AddFilesForm';
@@ -13,7 +12,7 @@ import FilesOptional from './FilesOptional';
 import FilesNeeded from './FilesNeeded';
 
 import { benefitsDocumentsUseLighthouse } from '../../selectors';
-import { setFocus, setPageFocus, setUpPage } from '../../utils/page';
+import { setFocus, setPageFocus } from '../../utils/page';
 import {
   addFile,
   removeFile,
@@ -49,15 +48,6 @@ const { Element } = Scroll;
 const filesPath = `../files`;
 
 class AdditionalEvidencePage extends React.Component {
-  componentDidMount() {
-    this.props.resetUploads();
-    if (!this.props.loading) {
-      setUpPage();
-    } else {
-      scrollToTop();
-    }
-  }
-
   // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps(props) {
     if (props.uploadComplete) {

--- a/src/applications/claims-status/components/claim-files-tab/ClaimFileHeader.jsx
+++ b/src/applications/claims-status/components/claim-files-tab/ClaimFileHeader.jsx
@@ -9,7 +9,7 @@ function ClaimFileHeader({ isOpen }) {
   };
   return (
     <div className="claim-file-header-container">
-      <h2 className="vads-u-margin-y--0">Claim files</h2>
+      <h2 className="tab-header vads-u-margin-y--0">Claim files</h2>
       <p className="vads-u-margin-top--1 vads-u-margin-bottom--4 va-introtext">
         {headerDescription(isOpen)}
       </p>

--- a/src/applications/claims-status/components/claim-overview-tab/ClaimOverviewHeader.jsx
+++ b/src/applications/claims-status/components/claim-overview-tab/ClaimOverviewHeader.jsx
@@ -17,7 +17,9 @@ export default function ClaimOverviewHeader({ claimTypeCode }) {
     : `Learn about the VA claim process and what happens after you file your claim.`;
   return (
     <div className="claim-overview-header-container">
-      <h2 className="vads-u-margin-y--0">Overview of the claim process</h2>
+      <h2 className="tab-header vads-u-margin-y--0">
+        Overview of the claim process
+      </h2>
       <p className="vads-u-margin-top--1 vads-u-margin-bottom--4 va-introtext">
         {headerText}
       </p>

--- a/src/applications/claims-status/containers/ClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/ClaimStatusPage.jsx
@@ -161,9 +161,10 @@ const generateEventTimeline = claim => {
 
 class ClaimStatusPage extends React.Component {
   componentDidMount() {
+    const { claim, lastPage, loading } = this.props;
+    setTabDocumentTitle(claim, 'Status');
+
     setTimeout(() => {
-      const { claim, lastPage, loading } = this.props;
-      setTabDocumentTitle(claim, 'Status');
       setPageFocus(lastPage, loading);
     });
   }

--- a/src/applications/claims-status/containers/ClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/ClaimStatusPage.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import scrollToTop from '@department-of-veterans-affairs/platform-utilities/scrollToTop';
 import { Toggler } from '~/platform/utilities/feature-toggles';
 
 import { clearNotification } from '../actions';
@@ -21,18 +20,17 @@ import ClosedClaimAlert from '../components/claim-status-tab/ClosedClaimAlert';
 
 import { showClaimLettersFeature } from '../selectors';
 import {
-  buildDateFormatter,
   claimAvailable,
-  getClaimType,
   getItemDate,
   getStatusMap,
   getTrackedItemDate,
   getUserPhase,
   isClaimOpen,
   itemsNeedingAttentionFromVet,
-  setDocumentTitle,
+  setPageFocus,
+  setTabDocumentTitle,
 } from '../utils/helpers';
-import { setUpPage, isTab, setFocus } from '../utils/page';
+import { setUpPage, isTab } from '../utils/page';
 
 // HELPERS
 const STATUSES = getStatusMap();
@@ -163,29 +161,21 @@ const generateEventTimeline = claim => {
 
 class ClaimStatusPage extends React.Component {
   componentDidMount() {
-    this.setTitle();
-
-    if (!isTab(this.props.lastPage)) {
-      if (!this.props.loading) {
-        setUpPage();
-      } else {
-        scrollToTop();
-      }
-    } else {
-      setFocus('#tabPanelStatus');
-    }
+    setTimeout(() => {
+      const { claim, lastPage, loading } = this.props;
+      setTabDocumentTitle(claim, 'Status');
+      setPageFocus(lastPage, loading);
+    });
   }
 
   componentDidUpdate(prevProps) {
-    if (
-      !this.props.loading &&
-      prevProps.loading &&
-      !isTab(this.props.lastPage)
-    ) {
+    const { claim, lastPage, loading } = this.props;
+
+    if (!loading && prevProps.loading && !isTab(lastPage)) {
       setUpPage(false);
     }
-    if (this.props.loading !== prevProps.loading) {
-      this.setTitle();
+    if (loading !== prevProps.loading) {
+      setTabDocumentTitle(claim, 'Status');
     }
   }
 
@@ -267,19 +257,6 @@ class ClaimStatusPage extends React.Component {
         </Toggler>
       </div>
     );
-  }
-
-  setTitle() {
-    const { claim } = this.props;
-
-    if (claimAvailable(claim)) {
-      const claimDate = buildDateFormatter()(claim.attributes.claimDate);
-      const claimType = getClaimType(claim);
-      const title = `Status Of ${claimDate} ${claimType} Claim`;
-      setDocumentTitle(title);
-    } else {
-      setDocumentTitle('Status Of Your Claim');
-    }
   }
 
   render() {

--- a/src/applications/claims-status/containers/ClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/ClaimStatusPage.jsx
@@ -161,12 +161,13 @@ const generateEventTimeline = claim => {
 
 class ClaimStatusPage extends React.Component {
   componentDidMount() {
-    const { claim, lastPage, loading } = this.props;
+    const { claim } = this.props;
     setTabDocumentTitle(claim, 'Status');
 
     setTimeout(() => {
+      const { lastPage, loading } = this.props;
       setPageFocus(lastPage, loading);
-    });
+    }, 100);
   }
 
   componentDidUpdate(prevProps) {

--- a/src/applications/claims-status/containers/ClaimsStatusApp.jsx
+++ b/src/applications/claims-status/containers/ClaimsStatusApp.jsx
@@ -56,7 +56,9 @@ function ClaimsStatusApp({
   const { pathname } = useLocation();
   useEffect(
     () => {
-      dispatchSetLastPage(pathname);
+      return () => {
+        dispatchSetLastPage(pathname);
+      };
     },
     [pathname],
   );

--- a/src/applications/claims-status/containers/ClaimsStatusApp.jsx
+++ b/src/applications/claims-status/containers/ClaimsStatusApp.jsx
@@ -54,14 +54,11 @@ function ClaimsStatusApp({
   loggedIn,
 }) {
   const { pathname } = useLocation();
-  useEffect(
-    () => {
-      return () => {
-        dispatchSetLastPage(pathname);
-      };
-    },
-    [pathname],
-  );
+  useEffect(() => {
+    return () => {
+      dispatchSetLastPage(pathname);
+    };
+  });
 
   // Add Datadog UX monitoring to the application
   useBrowserMonitoring({

--- a/src/applications/claims-status/containers/FilesPage.jsx
+++ b/src/applications/claims-status/containers/FilesPage.jsx
@@ -30,7 +30,7 @@ const FIRST_GATHERING_EVIDENCE_PHASE = 'GATHERING_OF_EVIDENCE';
 class FilesPage extends React.Component {
   componentDidMount() {
     const { claim, lastPage, loading } = this.props;
-    setTabDocumentTitle(claim, 'Overview');
+    setTabDocumentTitle(claim, 'Files');
 
     setTimeout(() => {
       setPageFocus(lastPage, loading);

--- a/src/applications/claims-status/containers/FilesPage.jsx
+++ b/src/applications/claims-status/containers/FilesPage.jsx
@@ -29,9 +29,10 @@ const FIRST_GATHERING_EVIDENCE_PHASE = 'GATHERING_OF_EVIDENCE';
 
 class FilesPage extends React.Component {
   componentDidMount() {
+    const { claim, lastPage, loading } = this.props;
+    setTabDocumentTitle(claim, 'Overview');
+
     setTimeout(() => {
-      const { claim, lastPage, loading } = this.props;
-      setTabDocumentTitle(claim, 'Files');
       setPageFocus(lastPage, loading);
     });
   }

--- a/src/applications/claims-status/containers/FilesPage.jsx
+++ b/src/applications/claims-status/containers/FilesPage.jsx
@@ -29,12 +29,13 @@ const FIRST_GATHERING_EVIDENCE_PHASE = 'GATHERING_OF_EVIDENCE';
 
 class FilesPage extends React.Component {
   componentDidMount() {
-    const { claim, lastPage, loading } = this.props;
+    const { claim } = this.props;
     setTabDocumentTitle(claim, 'Files');
 
     setTimeout(() => {
+      const { lastPage, loading } = this.props;
       setPageFocus(lastPage, loading);
-    });
+    }, 100);
   }
 
   componentDidUpdate(prevProps) {

--- a/src/applications/claims-status/containers/FilesPage.jsx
+++ b/src/applications/claims-status/containers/FilesPage.jsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import scrollToTop from '@department-of-veterans-affairs/platform-utilities/scrollToTop';
-
+import { Toggler } from '~/platform/utilities/feature-toggles';
 import AdditionalEvidenceItem from '../components/AdditionalEvidenceItem';
 import AskVAToDecide from '../components/AskVAToDecide';
 import ClaimDetailLayout from '../components/ClaimDetailLayout';
@@ -15,16 +14,14 @@ import DocumentsFiled from '../components/claim-files-tab/DocumentsFiled';
 
 import { clearNotification } from '../actions';
 import {
-  buildDateFormatter,
-  getClaimType,
-  setDocumentTitle,
+  claimAvailable,
   getFilesNeeded,
   getFilesOptional,
   isClaimOpen,
-  claimAvailable,
+  setPageFocus,
+  setTabDocumentTitle,
 } from '../utils/helpers';
-import { setUpPage, isTab, setFocus } from '../utils/page';
-import { Toggler } from '~/platform/utilities/feature-toggles';
+import { setUpPage, isTab } from '../utils/page';
 
 // CONSTANTS
 const NEED_ITEMS_STATUS = 'NEEDED_FROM_';
@@ -32,28 +29,21 @@ const FIRST_GATHERING_EVIDENCE_PHASE = 'GATHERING_OF_EVIDENCE';
 
 class FilesPage extends React.Component {
   componentDidMount() {
-    this.setTitle();
-    if (!isTab(this.props.lastPage)) {
-      if (!this.props.loading) {
-        setUpPage();
-      } else {
-        scrollToTop();
-      }
-    } else {
-      setFocus('#tabPanelFiles');
-    }
+    setTimeout(() => {
+      const { claim, lastPage, loading } = this.props;
+      setTabDocumentTitle(claim, 'Files');
+      setPageFocus(lastPage, loading);
+    });
   }
 
   componentDidUpdate(prevProps) {
-    if (
-      !this.props.loading &&
-      prevProps.loading &&
-      !isTab(this.props.lastPage)
-    ) {
+    const { claim, lastPage, loading } = this.props;
+
+    if (!loading && prevProps.loading && !isTab(lastPage)) {
       setUpPage(false);
     }
-    if (this.props.loading !== prevProps.loading) {
-      this.setTitle();
+    if (loading !== prevProps.loading) {
+      setTabDocumentTitle(claim, 'Files');
     }
   }
 
@@ -134,19 +124,6 @@ class FilesPage extends React.Component {
         </Toggler>
       </div>
     );
-  }
-
-  setTitle() {
-    const { claim } = this.props;
-
-    if (claimAvailable(claim)) {
-      const claimDate = buildDateFormatter()(claim.attributes.claimDate);
-      const claimType = getClaimType(claim);
-      const title = `Files For ${claimDate} ${claimType} Claim`;
-      setDocumentTitle(title);
-    } else {
-      setDocumentTitle('Files For Your Claim');
-    }
   }
 
   render() {

--- a/src/applications/claims-status/containers/OverviewPage.jsx
+++ b/src/applications/claims-status/containers/OverviewPage.jsx
@@ -153,9 +153,10 @@ const generateEventTimeline = claim => {
 
 class OverviewPage extends React.Component {
   componentDidMount() {
+    const { claim, lastPage, loading } = this.props;
+    setTabDocumentTitle(claim, 'Overview');
+
     setTimeout(() => {
-      const { claim, lastPage, loading } = this.props;
-      setTabDocumentTitle(claim, 'Overview');
       setPageFocus(lastPage, loading);
     });
   }

--- a/src/applications/claims-status/containers/OverviewPage.jsx
+++ b/src/applications/claims-status/containers/OverviewPage.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import scrollToTop from '@department-of-veterans-affairs/platform-utilities/scrollToTop';
 import { Toggler } from '~/platform/utilities/feature-toggles';
 
 import { clearNotification } from '../actions';
@@ -13,17 +12,16 @@ import DesktopClaimPhaseDiagram from '../components/claim-overview-tab/DesktopCl
 import MobileClaimPhaseDiagram from '../components/claim-overview-tab/MobileClaimPhaseDiagram';
 
 import {
-  buildDateFormatter,
   claimAvailable,
-  getClaimType,
   getItemDate,
   getStatusMap,
   getTrackedItemDate,
   getUserPhase,
   isDisabilityCompensationClaim,
-  setDocumentTitle,
+  setPageFocus,
+  setTabDocumentTitle,
 } from '../utils/helpers';
-import { setUpPage, isTab, setFocus } from '../utils/page';
+import { setUpPage, isTab } from '../utils/page';
 import ClaimPhaseStepper from '../components/claim-overview-tab/ClaimPhaseStepper';
 
 // HELPERS
@@ -155,29 +153,21 @@ const generateEventTimeline = claim => {
 
 class OverviewPage extends React.Component {
   componentDidMount() {
-    this.setTitle();
-
-    if (!isTab(this.props.lastPage)) {
-      if (!this.props.loading) {
-        setUpPage();
-      } else {
-        scrollToTop();
-      }
-    } else {
-      setFocus('#tabPanelOverview');
-    }
+    setTimeout(() => {
+      const { claim, lastPage, loading } = this.props;
+      setTabDocumentTitle(claim, 'Overview');
+      setPageFocus(lastPage, loading);
+    });
   }
 
   componentDidUpdate(prevProps) {
-    if (
-      !this.props.loading &&
-      prevProps.loading &&
-      !isTab(this.props.lastPage)
-    ) {
+    const { claim, lastPage, loading } = this.props;
+
+    if (!loading && prevProps.loading && !isTab(lastPage)) {
       setUpPage(false);
     }
-    if (this.props.loading !== prevProps.loading) {
-      this.setTitle();
+    if (loading !== prevProps.loading) {
+      setTabDocumentTitle(claim, 'Overview');
     }
   }
 
@@ -233,19 +223,6 @@ class OverviewPage extends React.Component {
         </Toggler>
       </div>
     );
-  }
-
-  setTitle() {
-    const { claim } = this.props;
-
-    if (claimAvailable(claim)) {
-      const claimDate = buildDateFormatter()(claim.attributes.claimDate);
-      const claimType = getClaimType(claim);
-      const title = `Overview Of ${claimDate} ${claimType} Claim`;
-      setDocumentTitle(title);
-    } else {
-      setDocumentTitle('Overview Of Your Claim');
-    }
   }
 
   render() {

--- a/src/applications/claims-status/containers/OverviewPage.jsx
+++ b/src/applications/claims-status/containers/OverviewPage.jsx
@@ -153,12 +153,13 @@ const generateEventTimeline = claim => {
 
 class OverviewPage extends React.Component {
   componentDidMount() {
-    const { claim, lastPage, loading } = this.props;
+    const { claim } = this.props;
     setTabDocumentTitle(claim, 'Overview');
 
     setTimeout(() => {
+      const { lastPage, loading } = this.props;
       setPageFocus(lastPage, loading);
-    });
+    }, 100);
   }
 
   componentDidUpdate(prevProps) {

--- a/src/applications/claims-status/reducers/routing.js
+++ b/src/applications/claims-status/reducers/routing.js
@@ -7,12 +7,9 @@ const initialState = {
 
 export default function routingReducer(state = initialState, action) {
   if (action.type === SET_LAST_PAGE) {
-    const lastPage = state.history.length
-      ? state.history[state.history.length - 1]
-      : null;
     return {
       ...state,
-      lastPage,
+      lastPage: action.page,
       history: state.history.concat(action.page.substr(1)),
     };
   }

--- a/src/applications/claims-status/tests/components/ClaimStatusPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimStatusPage.unit.spec.jsx
@@ -110,6 +110,9 @@ describe('<ClaimStatusPage>', () => {
             const statusPage = $('#tabPanelStatus', container);
 
             expect(statusPage).to.exist;
+            expect(document.title).to.equal(
+              'Status Of January 1, 2023 Disability Compensation Claim | Veterans Affairs',
+            );
             expect($('.claim-timeline', container)).not.to.exist;
             expect($('.claim-status-header-container', container)).to.exist;
             expect($('.what-were-doing-container', container)).to.exist;
@@ -163,6 +166,9 @@ describe('<ClaimStatusPage>', () => {
             const statusPage = $('#tabPanelStatus', container);
 
             expect(statusPage).to.exist;
+            expect(document.title).to.equal(
+              'Status Of January 1, 2023 Disability Compensation Claim | Veterans Affairs',
+            );
             expect($('.claim-timeline', container)).not.to.exist;
             expect($('.claim-status-header-container', container)).to.exist;
             expect($('.what-were-doing-container', container)).to.exist;
@@ -452,7 +458,6 @@ describe('<ClaimStatusPage>', () => {
       const { container } = renderWithRouter(
         <ClaimStatusPage {...props} loading params={params} />,
       );
-      // expect(document.title).to.equal('Status Of Your Claim | Veterans Affairs');
       expect($('.claim-status', container)).to.not.exist;
       expect($('va-loading-indicator', container)).to.exist;
     });

--- a/src/applications/claims-status/tests/components/ClaimsStatusApp.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimsStatusApp.unit.spec.jsx
@@ -48,6 +48,7 @@ describe('<AppContent>', () => {
     }));
     const props = {
       dispatchSetLastPage: sinon.spy(),
+
       featureFlagsLoading: false,
       user: {
         login: { currentlyLoggedIn: true, hasCheckedKeepAlive: false },
@@ -68,7 +69,7 @@ describe('<AppContent>', () => {
       </Provider>
     );
 
-    const { getByTestId, queryByTestId } = render(
+    const { getByTestId, queryByTestId, unmount } = render(
       <MemoryRouter>
         <Routes>
           <Route element={element}>
@@ -80,6 +81,10 @@ describe('<AppContent>', () => {
 
     expect(queryByTestId('feature-flags-loading')).to.not.exist;
     expect(getByTestId('children')).to.exist;
+
+    unmount();
+
     expect(props.dispatchSetLastPage.called).to.be.true;
+    props.dispatchSetLastPage.restore();
   });
 });

--- a/src/applications/claims-status/tests/components/ClaimsStatusApp.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimsStatusApp.unit.spec.jsx
@@ -48,7 +48,6 @@ describe('<AppContent>', () => {
     }));
     const props = {
       dispatchSetLastPage: sinon.spy(),
-
       featureFlagsLoading: false,
       user: {
         login: { currentlyLoggedIn: true, hasCheckedKeepAlive: false },
@@ -85,6 +84,5 @@ describe('<AppContent>', () => {
     unmount();
 
     expect(props.dispatchSetLastPage.called).to.be.true;
-    props.dispatchSetLastPage.restore();
   });
 });

--- a/src/applications/claims-status/tests/components/claim-files-tab/AdditionalEvidencePage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab/AdditionalEvidencePage.unit.spec.jsx
@@ -181,7 +181,7 @@ describe('<AdditionalEvidencePage>', () => {
       expect(onSubmit.calledWith(1, null, files)).to.be.true;
     });
 
-    it('should reset uploads and set title on mount', () => {
+    it('should reset uploads on mount', () => {
       const resetUploads = sinon.spy();
       const mainDiv = document.createElement('div');
       mainDiv.classList.add('va-nav-breadcrumbs');

--- a/src/applications/claims-status/tests/reducers/routing.unit.spec.js
+++ b/src/applications/claims-status/tests/reducers/routing.unit.spec.js
@@ -4,27 +4,47 @@ import routingReducer from '../../reducers/routing';
 import { SET_LAST_PAGE } from '../../actions/types';
 
 describe('routingReducer', () => {
-  it('should set the last page to null on first call', () => {
+  it('should set the last page to action.page on first call', () => {
     const state = routingReducer(undefined, {
       type: SET_LAST_PAGE,
       page: '/testing',
     });
 
-    expect(state.lastPage).to.be.null;
+    expect(state.lastPage).to.equal('/testing');
     expect(state.history[0]).to.equal('testing');
   });
-  it('should set the last page with history items', () => {
-    const state = routingReducer(
-      {
-        history: ['some-url'],
-      },
-      {
-        type: SET_LAST_PAGE,
-        page: '/testing',
-      },
-    );
+  context('when history already has 1 record', () => {
+    it('should add to the history array and set the last page with the new action.page', () => {
+      const state = routingReducer(
+        {
+          history: ['testing'],
+          lastPage: '/testing',
+        },
+        {
+          type: SET_LAST_PAGE,
+          page: '/new-page',
+        },
+      );
 
-    expect(state.lastPage).to.equal('some-url');
-    expect(state.history.length).to.equal(2);
+      expect(state.lastPage).to.equal('/new-page');
+      expect(state.history.length).to.equal(2);
+    });
+  });
+
+  context('when history already has 2 records', () => {
+    it('should add to the history array and set the last page with the new action.page', () => {
+      const state = routingReducer(
+        {
+          history: ['testing', 'testing2'],
+        },
+        {
+          type: SET_LAST_PAGE,
+          page: '/new-page',
+        },
+      );
+
+      expect(state.lastPage).to.equal('/new-page');
+      expect(state.history.length).to.equal(3);
+    });
   });
 });

--- a/src/applications/claims-status/tests/utils/helpers.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/helpers.unit.spec.js
@@ -3,9 +3,8 @@ import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
+import * as scroll from 'platform/utilities/ui/scroll';
 import * as page from '../../utils/page';
-// import * as scrollToTop from '@department-of-veterans-affairs/platform-utilities/scrollToTop'
-// import * as ui from 'platform/utilities/ui';
 
 import {
   groupTimelineActivity,
@@ -1265,22 +1264,21 @@ describe('Disability benefits helpers: ', () => {
         expect(setUpPage.called).to.be.true;
       });
     });
-    // context('when last page was not a tab and loading is true', () => {
-    //   it('should run scrollToTop', () => {
-    //     const scrollToTopStub = sinon.stub(scrollToTop, 'scrollToTop')
-    //     setPageFocus('/test', true);
+    context('when last page was not a tab and loading is true', () => {
+      it('should run scrollToTop', () => {
+        const scrollToTop = sinon.spy(scroll, 'scrollToTop');
+        setPageFocus('/test', true);
 
-    //     expect(scrollToTopStub.called).to.be.true;
-    //     scrollToTopStub.restore();
-    //   });
-    // });
-    // context('when last page was a tab', () => {
-    //   it('should run scrollAndFocus', () => {
-    //     const scrollAndFocus = sinon.spy(ui, 'scrollAndFocus')
-    //     setPageFocus('/status', false);
+        expect(scrollToTop.called).to.be.true;
+      });
+    });
+    context('when last page was a tab', () => {
+      it('should run scrollAndFocus', () => {
+        const scrollAndFocus = sinon.spy(scroll, 'scrollAndFocus');
+        setPageFocus('/status', false);
 
-    //     expect(scrollAndFocus.called).to.be.true;
-    //   });
-    // });
+        expect(scrollAndFocus.called).to.be.true;
+      });
+    });
   });
 });

--- a/src/applications/claims-status/tests/utils/helpers.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/helpers.unit.spec.js
@@ -3,6 +3,9 @@ import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
+import * as page from '../../utils/page';
+// import * as scrollToTop from '@department-of-veterans-affairs/platform-utilities/scrollToTop'
+// import * as ui from 'platform/utilities/ui';
 
 import {
   groupTimelineActivity,
@@ -34,6 +37,8 @@ import {
   getPhaseItemText,
   getClaimPhaseTypeDescription,
   setDocumentRequestPageTitle,
+  setPageFocus,
+  setTabDocumentTitle,
 } from '../../utils/helpers';
 
 import {
@@ -1180,5 +1185,102 @@ describe('Disability benefits helpers: ', () => {
 
       expect(documentRequestPageTitle).to.equal(`Request for ${displayName}`);
     });
+  });
+
+  describe('setTabDocumentTitle', () => {
+    context('when there is no claim', () => {
+      it('should set tab title for Status', () => {
+        setTabDocumentTitle(null, 'Status');
+
+        expect(document.title).to.equal(
+          'Status Of Your Claim | Veterans Affairs',
+        );
+      });
+      it('should set tab title for Files', () => {
+        setTabDocumentTitle(null, 'Files');
+
+        expect(document.title).to.equal(
+          'Files For Your Claim | Veterans Affairs',
+        );
+      });
+      it('should set tab title for Overview', () => {
+        setTabDocumentTitle(null, 'Overview');
+
+        expect(document.title).to.equal(
+          'Overview Of Your Claim | Veterans Affairs',
+        );
+      });
+    });
+    context('when there is a claim', () => {
+      const claim = {
+        id: '1',
+        attributes: {
+          supportingDocuments: [],
+          claimDate: '2023-01-01',
+          closeDate: null,
+          documentsNeeded: true,
+          decisionLetterSent: false,
+          status: 'INITIAL_REVIEW',
+          claimPhaseDates: {
+            currentPhaseBack: false,
+            phaseChangeDate: '2015-01-01',
+            latestPhaseType: 'INITIAL_REVIEW',
+            previousPhases: {
+              phase1CompleteDate: '2023-02-08',
+              phase2CompleteDate: '2023-02-08',
+            },
+          },
+        },
+      };
+      it('should set tab title for Status', () => {
+        setTabDocumentTitle(claim, 'Status');
+
+        expect(document.title).to.equal(
+          'Status Of January 1, 2023 Disability Compensation Claim | Veterans Affairs',
+        );
+      });
+      it('should set tab title for Files', () => {
+        setTabDocumentTitle(claim, 'Files');
+
+        expect(document.title).to.equal(
+          'Files For January 1, 2023 Disability Compensation Claim | Veterans Affairs',
+        );
+      });
+      it('should set tab title for Overview', () => {
+        setTabDocumentTitle(claim, 'Overview');
+
+        expect(document.title).to.equal(
+          'Overview Of January 1, 2023 Disability Compensation Claim | Veterans Affairs',
+        );
+      });
+    });
+  });
+
+  describe('setPageFocus', () => {
+    context('when last page was not a tab and loading is false', () => {
+      it('should run setUpPage', () => {
+        const setUpPage = sinon.spy(page, 'setUpPage');
+        setPageFocus('/test', false);
+
+        expect(setUpPage.called).to.be.true;
+      });
+    });
+    // context('when last page was not a tab and loading is true', () => {
+    //   it('should run scrollToTop', () => {
+    //     const scrollToTopStub = sinon.stub(scrollToTop, 'scrollToTop')
+    //     setPageFocus('/test', true);
+
+    //     expect(scrollToTopStub.called).to.be.true;
+    //     scrollToTopStub.restore();
+    //   });
+    // });
+    // context('when last page was a tab', () => {
+    //   it('should run scrollAndFocus', () => {
+    //     const scrollAndFocus = sinon.spy(ui, 'scrollAndFocus')
+    //     setPageFocus('/status', false);
+
+    //     expect(scrollAndFocus.called).to.be.true;
+    //   });
+    // });
   });
 });

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -1078,15 +1078,15 @@ export function setTabDocumentTitle(claim, tabName) {
     const claimDate = buildDateFormatter()(claim.attributes.claimDate);
     const claimType = getClaimType(claim);
     const title =
-      tabName === 'Overview'
-        ? `${tabName} Of ${claimDate} ${claimType} Claim`
-        : `${tabName} For ${claimDate} ${claimType} Claim`;
+      tabName === 'Files'
+        ? `${tabName} For ${claimDate} ${claimType} Claim`
+        : `${tabName} Of ${claimDate} ${claimType} Claim`;
     setDocumentTitle(title);
   } else {
     const title =
-      tabName === 'Overview'
-        ? `${tabName} Of Your Claim`
-        : `${tabName} For Your Claim`;
+      tabName === 'Files'
+        ? `${tabName} For Your Claim`
+        : `${tabName} Of Your Claim`;
     setDocumentTitle(title);
   }
 }

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -1,11 +1,11 @@
 import merge from 'lodash/merge';
 import { format, isValid, parseISO } from 'date-fns';
-// import * as Sentry from '@sentry/browser';
 
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
-// import localStorage from 'platform/utilities/storage/localStorage';
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
-// import { fetchAndUpdateSessionExpiration as fetch } from 'platform/utilities/api';
+import scrollToTop from '@department-of-veterans-affairs/platform-utilities/scrollToTop';
+import { scrollAndFocus } from 'platform/utilities/ui';
+import { setUpPage, isTab } from './page';
 
 import { SET_UNAUTHORIZED } from '../actions/types';
 import {
@@ -1070,4 +1070,35 @@ export function setDocumentRequestPageTitle(displayName) {
   return displayName === 'Automated 5103 Notice Response'
     ? '5103 Evidence Notice'
     : `Request for ${displayName}`;
+}
+
+// Used to set page title for the CST Tabs
+export function setTabDocumentTitle(claim, tabName) {
+  if (claimAvailable(claim)) {
+    const claimDate = buildDateFormatter()(claim.attributes.claimDate);
+    const claimType = getClaimType(claim);
+    const title =
+      tabName === 'Overview'
+        ? `${tabName} Of ${claimDate} ${claimType} Claim`
+        : `${tabName} For ${claimDate} ${claimType} Claim`;
+    setDocumentTitle(title);
+  } else {
+    const title =
+      tabName === 'Overview'
+        ? `${tabName} Of Your Claim`
+        : `${tabName} For Your Claim`;
+    setDocumentTitle(title);
+  }
+}
+// Used to set the page focus on the CST Tabs
+export function setPageFocus(lastPage, loading) {
+  if (!isTab(lastPage)) {
+    if (!loading) {
+      setUpPage();
+    } else {
+      scrollToTop();
+    }
+  } else {
+    scrollAndFocus(document.querySelector('.tab-header'));
+  }
 }

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -3,8 +3,7 @@ import { format, isValid, parseISO } from 'date-fns';
 
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
-import scrollToTop from '@department-of-veterans-affairs/platform-utilities/scrollToTop';
-import { scrollAndFocus } from 'platform/utilities/ui';
+import { scrollAndFocus, scrollToTop } from 'platform/utilities/ui';
 import { setUpPage, isTab } from './page';
 
 import { SET_UNAUTHORIZED } from '../actions/types';

--- a/src/applications/claims-status/utils/page.js
+++ b/src/applications/claims-status/utils/page.js
@@ -29,6 +29,9 @@ export function setUpPage(scroll = true, focusSelector = 'va-breadcrumbs') {
 export function isTab(url) {
   return (
     url &&
-    (url.endsWith('status') || url.endsWith('files') || url.endsWith('details'))
+    (url.endsWith('status') ||
+      url.endsWith('files') ||
+      url.endsWith('details') ||
+      url.endsWith('overview'))
   );
 }


### PR DESCRIPTION
## Summary

Resolved the following bugs:
- Updated `src/applications/claims-status/utils/page.js` so that the `overview` tab was included in `isTab()`
- Updated `src/applications/claims-status/reducers/routing.js` so that we were setting the `lastPage` correctly. (This previously was not being set correctly, sometimes being set to null and other times being set to a url that was the second to last page, and was thus causing issues when we were trying to use the lastPage field to set the CST tab page focus)
- Removed  focus and scrollToTop logic in `componentDidMount()` in `src/applications/claims-status/components/claim-files-tab/AdditionalEvidencePage.jsx` . (This this component is used as a child component on the files tab this logic is not needed and was actually overriding the page focus that was occurring on the files tab.)

Updated the following components to have the className `tab-header`, so that we can then use that when setting the CST tab page focus
- `src/applications/claims-status/components/ClaimStatusHeader.jsx`
- `src/applications/claims-status/components/claim-files-tab/ClaimFileHeader.jsx`
- `src/applications/claims-status/components/claim-overview-tab/ClaimOverviewHeader.jsx`

Created 2 new helper functions that were used on the status, files, and overview tabs so that we didnt have duplicate code. 
- `setTabDocumentTitle()` , sets the page title for the CST Tabs
- `setPageFocus()`, sets the page focus on the CST Tabs. When the the previous page was NOT a tab and page is NOT loading the page scrolls to the top and focuses on the page breadcrumbs. When the previous page was NOT a tab and the page is loading the page scrolls to the top. When the previous page was a tab we scroll and focus on the element with the className `tab-header` (this is the H2 of each tab page).

Updated the following componets to use the new helper functions  `setTabDocumentTitle()` and `setPageFocus()` and to  no longer have a function called setTitle().
- `src/applications/claims-status/containers/ClaimStatusPage.jsx`
- `src/applications/claims-status/containers/FilesPage.jsx`
- `src/applications/claims-status/containers/OverviewPage.jsx`

Updated `src/applications/claims-status/containers/ClaimsStatusApp.jsx` to return a value in the useEffect()

Updated and Added tests to the following:
- `src/applications/claims-status/tests/components/ClaimStatusPage.unit.spec.jsx`
- `src/applications/claims-status/tests/components/ClaimsStatusApp.unit.spec.jsx`
- `src/applications/claims-status/tests/components/claim-files-tab/AdditionalEvidencePage.unit.spec.jsx`
- `src/applications/claims-status/tests/reducers/routing.unit.spec.js`
- `src/applications/claims-status/tests/utils/helpers.unit.spec.js`

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#80606

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

Video of CST page focus working. When user navigates from a previous page that was not one of the tab pages the focus goes to the breadcrumbs and when they go from a tab page to another tab page the focus goes to the H2.

https://github.com/user-attachments/assets/9ab8e166-43c6-474c-91d7-58354638cd79



## What areas of the site does it impact?

Claim Status Tool

## Acceptance criteria

- [ ] The focus moves to the page breadcrumbs when the previous page was not a tab
- [ ] The focus moves to the corresponding first H2 when the previous page was a tab and the user moves to the status tab. 
- [ ] The focus moves to the corresponding first  H2 when the previous page was a tab and the user moves to the overview tab. 
- [ ] The focus moves to the corresponding first  H2 when the previous page was a tab and the user moves to the files tab. 
- [ ] When the tab is loading, the focus scrolls to the top of the page. This applies to all 3 aforementioned tabs and is current behavior.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions
