### PR TITLE
VACMS-18538: Update links to va-action-link for health care widget

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -223,20 +223,10 @@ export class CernerCallToAction extends Component {
                       ehrDataByVhaId={ehrDataByVhaId}
                     />
                   </ul>
-                  <a
-                    className="vads-c-action-link--blue"
+                  <va-link-action
                     href={myVAHealthLink}
-                    onClick={() => {
-                      recordEvent({
-                        event: `vaos-cerner-redirect-static-landing-page`,
-                      });
-                      onCTALinkClick();
-                    }}
-                    rel="noreferrer noopener"
-                    target="_blank"
-                  >
-                    Go to My VA Health
-                  </a>
+                    text="Go to My VA Health"
+                  />
                 </div>
                 <va-additional-info trigger="Having trouble opening My VA health?">
                   Try these steps:
@@ -253,13 +243,10 @@ export class CernerCallToAction extends Component {
                     fillins.featureLocation
                   }.`}
                 </p>
-                <a
-                  className="vads-c-action-link--blue"
+                <va-link-action
                   href={myHealtheVetLink}
-                  onClick={onCTALinkClick}
-                >
-                  {`Go to ${fillins.cta2} on VA.gov`}
-                </a>
+                  text={`Go to ${fillins.cta2} on VA.gov`}
+                />
               </>
             )}
           {((featureStaticLandingPage &&


### PR DESCRIPTION
## Summary
This PR changes links to use the va-action-link component for the health care widget.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18538

## Testing done
Tested markup and GA events

`/health-care/schedule-view-va-appointments`

## Screenshots

## What areas of the site does it impact?


## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
