### PR TITLE
Update OMB expiration date for the Health Care Application

### DIFF
--- a/src/applications/caregivers/locales/en/content.json
+++ b/src/applications/caregivers/locales/en/content.json
@@ -43,7 +43,7 @@
   "error--no-results-found": "No search results found.",
   "form-address-same-as-label": "Is the %s mailing address the same as their home address? ",
   "form-address-street-label": "%s street address",
-  "form-address-street2-label": "street address line 2",
+  "form-address-street2-label": "Street address line 2",
   "form-address-city-label": "City",
   "form-address-state-label": "State",
   "form-address-postalCode-label": "Postal code",

--- a/src/applications/hca/components/IntroductionPage/GetStarted/OMBInfo.jsx
+++ b/src/applications/hca/components/IntroductionPage/GetStarted/OMBInfo.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const OMBInfo = () => {
-  const expDate = '07/31/2024';
+  const expDate = '07/31/2027';
   const ombNum = '2900-0091';
   const resBurden = '35';
   return (


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR simply updates the OMB expiration date for the Health Care Application to reflect a 3-year renewal period from OMB.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#88713

## Testing done

- Navigate to the introduction page of the application
- Scroll to the bottom of the content to find the OMB information
- Review the expiration date to be `07/31/2027`

## Acceptance criteria

- OMB details reflect the current renewal period

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution