### PR TITLE
Remove helpdesk info toggle from MHV Landing Page

### DIFF
--- a/src/applications/mhv-landing-page/components/LandingPage.jsx
+++ b/src/applications/mhv-landing-page/components/LandingPage.jsx
@@ -24,7 +24,6 @@ import {
   isLOA3,
   isVAPatient,
   personalizationEnabled,
-  helpdeskInfoEnabled,
   hasMhvAccount,
 } from '../selectors';
 import UnregisteredAlert from './UnregisteredAlert';
@@ -37,7 +36,6 @@ const LandingPage = ({ data = {}, recordEvent = recordEventFn }) => {
   const signInService = useSelector(signInServiceName);
   const userHasMhvAccount = useSelector(hasMhvAccount);
   const showWelcomeMessage = useSelector(personalizationEnabled);
-  const showHelpdeskInfo = useSelector(helpdeskInfoEnabled) && userRegistered;
   const serviceLabel = SERVICE_PROVIDERS[signInService]?.label;
   const unVerifiedHeadline = `Verify your identity to use your ${serviceLabel} account on My HealtheVet`;
 
@@ -83,7 +81,7 @@ const LandingPage = ({ data = {}, recordEvent = recordEventFn }) => {
           {userRegistered && !userHasMhvAccount && <MhvRegistrationAlert />}
           {userRegistered && <CardLayout data={cards} />}
         </div>
-        {showHelpdeskInfo && (
+        {userRegistered && (
           <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
             <div className="vads-l-row vads-u-margin-top--3">
               <div className="vads-l-col medium-screen:vads-l-col--8">

--- a/src/applications/mhv-landing-page/mocks/api/feature-toggles/index.js
+++ b/src/applications/mhv-landing-page/mocks/api/feature-toggles/index.js
@@ -5,7 +5,6 @@ const APPLICATION_FEATURE_TOGGLES = Object.freeze({
   mhvLandingPagePersonalization: false,
   mhvSecondaryNavigationEnabled: true,
   mhvTransitionalMedicalRecordsLandingPage: true,
-  mhvHelpdeskInformationEnabled: true,
 });
 
 const generateFeatureToggles = ({

--- a/src/applications/mhv-landing-page/selectors/featureToggles.js
+++ b/src/applications/mhv-landing-page/selectors/featureToggles.js
@@ -9,12 +9,3 @@ import FEATURE_FLAG_NAMES from '~/platform/utilities/feature-toggles/featureFlag
 export const personalizationEnabled = state => {
   return toggleValues(state)[FEATURE_FLAG_NAMES.mhvLandingPagePersonalization];
 };
-
-/**
- * Determines if the helpdesk information changes are enabled.
- * @param {Object} state Current redux state.
- * @returns {Boolean} true if the helpdesk information is enabled
- */
-export const helpdeskInfoEnabled = state => {
-  return toggleValues(state)[FEATURE_FLAG_NAMES.mhvHelpdeskInformationEnabled];
-};

--- a/src/applications/mhv-landing-page/selectors/index.js
+++ b/src/applications/mhv-landing-page/selectors/index.js
@@ -13,7 +13,7 @@ import {
 } from '~/platform/user/selectors';
 import { selectDrupalStaticData } from '~/platform/site-wide/drupal-static-data/selectors';
 
-import { personalizationEnabled, helpdeskInfoEnabled } from './featureToggles';
+import { personalizationEnabled } from './featureToggles';
 import { hasMhvAccount } from './hasMhvAccount';
 import {
   selectGreetingName,
@@ -29,7 +29,6 @@ export {
   isProfileLoading,
   isVAPatient,
   personalizationEnabled,
-  helpdeskInfoEnabled,
   selectDrupalStaticData,
   selectGreetingName,
   selectPersonalInformation,

--- a/src/applications/mhv-landing-page/tests/e2e/helpdesk-info/helpdesk-info.cypress.spec.js
+++ b/src/applications/mhv-landing-page/tests/e2e/helpdesk-info/helpdesk-info.cypress.spec.js
@@ -36,22 +36,4 @@ describe(`${appName} - helpdesk information component`, () => {
       cy.findByTestId('mhv-helpdesk-info').should.exist;
     });
   });
-
-  describe('display content based on feature toggle', () => {
-    it(`toggle is off`, () => {
-      ApiInitializer.initializeFeatureToggle.withAllFeaturesDisabled();
-      LandingPage.visit();
-      cy.injectAxeThenAxeCheck();
-
-      cy.findByTestId('mhv-helpdesk-info').should('not.exist');
-    });
-
-    it(`toggle is on`, () => {
-      ApiInitializer.initializeFeatureToggle.withAllFeatures();
-      LandingPage.visit();
-      cy.injectAxeThenAxeCheck();
-
-      cy.findByTestId('mhv-helpdesk-info').should.exist;
-    });
-  });
 });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -112,7 +112,6 @@
   "mhvLandingPagePersonalization": "mhv_landing_page_personalization",
   "mhvSecondaryNavigationEnabled": "mhv_secondary_navigation_enabled",
   "mhvTransitionalMedicalRecordsLandingPage": "mhv_transitional_medical_records_landing_page",
-  "mhvHelpdeskInformationEnabled": "mhv_helpdesk_information_enabled",
   "mhvSecureMessagingToVaGovRelease": "mhv_secure_messaging_to_va_gov_release",
   "mhvSecureMessagingToPhase1": "mhv_secure_messaging_to_phase_1",
   "mhvSecureMessagingCernerPilot": "mhv_secure_messaging_cerner_pilot",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary
Removed toggle for helpdesk info.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/87130

## Testing done
N/A

## Screenshots
No changes to the UI.

## What areas of the site does it impact?
- MHV Landing Page

## Acceptance criteria
- Remove the helpdesk info toggle.

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

