### PR TITLE
87686 Fix FormSignature clearing value on submit

### DIFF
--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -88,7 +88,7 @@ const formConfig = {
   },
   preSubmitInfo: {
     required: true,
-    CustomComponent: signatureProps => CustomAttestation(signatureProps),
+    CustomComponent: CustomAttestation,
   },
   saveInProgress: {
     messages: {

--- a/src/platform/forms-system/src/js/components/FormSignature.jsx
+++ b/src/platform/forms-system/src/js/components/FormSignature.jsx
@@ -141,29 +141,10 @@ export const FormSignature = ({
 
 FormSignature.propTypes = {
   formData: PropTypes.object.isRequired,
+  // eslint-disable-next-line react/sort-prop-types
   onSectionComplete: PropTypes.func.isRequired,
   setFormData: PropTypes.func.isRequired,
   showError: PropTypes.bool.isRequired,
-  submission: PropTypes.shape({
-    hasAttemptedSubmit: PropTypes.bool,
-    errorMessage: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-    status: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
-  }),
-  /**
-   * The label for the signature input
-   */
-  signatureLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-
-  /**
-   * The path in the formData to the signature value
-   */
-  signaturePath: PropTypes.string,
-
-  /**
-   * The label for the checkbox input
-   */
-  checkboxLabel: PropTypes.string,
-
   /**
    * The description for the checkbox input
    */
@@ -171,7 +152,24 @@ FormSignature.propTypes = {
     PropTypes.string,
     PropTypes.element,
   ]),
-
+  /**
+   * The label for the checkbox input
+   */
+  checkboxLabel: PropTypes.string,
+  required: PropTypes.bool,
+  /**
+   * The label for the signature input
+   */
+  signatureLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  /**
+   * The path in the formData to the signature value
+   */
+  signaturePath: PropTypes.string,
+  submission: PropTypes.shape({
+    hasAttemptedSubmit: PropTypes.bool,
+    errorMessage: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+    status: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  }),
   /**
    * An array of validator functions. Each function returns a string for the
    * validation message if the input is invalid, or undefined if the input is
@@ -193,6 +191,7 @@ FormSignature.defaultProps = {
     'I certify the information above is correct and true to the best of my knowledge and belief.',
   required: true,
   validations: [],
+  // eslint-disable-next-line react/default-props-match-prop-types
   setFormData: () => {},
 };
 

--- a/src/platform/forms-system/src/js/components/FormSignature.jsx
+++ b/src/platform/forms-system/src/js/components/FormSignature.jsx
@@ -41,8 +41,11 @@ export const FormSignature = ({
   onSectionComplete,
 }) => {
   // Input states
-  const [signature, setSignature] = useState({ value: '', dirty: false });
-  const [checked, setChecked] = useState(false);
+  const [signature, setSignature] = useState({
+    value: formData.signature ?? '', // Pre-populate with existing signature if available
+    dirty: formData?.signature?.length > 0, // will be dirty if any prev signature is present
+  });
+  const [checked, setChecked] = useState(formData.AGREED ?? false);
 
   // Validation states
   const [signatureError, setSignatureError] = useState(null);
@@ -127,6 +130,7 @@ export const FormSignature = ({
         description={null}
         required={required}
         error={showError ? checkboxError : null}
+        checked={checked}
         onVaChange={event => setChecked(event.target.checked)}
       >
         {checkboxDescription && <p slot="description">{checkboxDescription}</p>}

--- a/src/platform/forms-system/src/js/components/FormSignature.jsx
+++ b/src/platform/forms-system/src/js/components/FormSignature.jsx
@@ -42,10 +42,10 @@ export const FormSignature = ({
 }) => {
   // Input states
   const [signature, setSignature] = useState({
-    value: formData.signature ?? '', // Pre-populate with existing signature if available
+    value: formData?.signature ?? '', // Pre-populate with existing signature if available
     dirty: formData?.signature?.length > 0, // will be dirty if any prev signature is present
   });
-  const [checked, setChecked] = useState(formData.AGREED ?? false);
+  const [checked, setChecked] = useState(formData?.AGREED ?? false);
 
   // Validation states
   const [signatureError, setSignatureError] = useState(null);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR updates the `FormSignature` component to preserve existing signature/certification checkbox state if values were previously entered.

When using this signature component inside the `preSubmitInfo` property of form config (`CustomComponent`), the `preSubmitInfo` component re-renders a couple times when the form is Submitted, clearing the internal state of the signature block. Even if the submission is successful, the validation of the (now empty) signature block will re-run. This causes a small amount of time when the user sees a false negative error on screen before being sent to the confirmation page. 

**NOTE** This seems to only impact the signature component when used inside a custom component in `preSubmitInfo`.

Video of issue below:

https://github.com/user-attachments/assets/70378f14-5206-4a31-9aa3-9ff9941044a4

The fix was to set the initial state of the signature block to be any pre-existing signature data in `formData`. If none exists it defaults to being empty and behaves as expected. Video of the fixed version below:

https://github.com/user-attachments/assets/53d78e00-0936-4465-9279-933d2e088ec2

- Updates the initial `useState` logic in FormSignature component
- Updates the `checked` property of the statement of truth checkbox to track with its corresponding react state value
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87686

## Testing done

- Manual
- Verified existing unit tests run and pass

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Validation and Signature state upon submit |![before](https://github.com/user-attachments/assets/3d48fc36-887f-48f1-ba74-68f3ada7f496)|![after](https://github.com/user-attachments/assets/4cf31930-bedb-41e5-a1c4-b77d19726c8f)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA
