### PR TITLE
lgy: update va-alert to v3

### DIFF
--- a/src/applications/lgy/coe/form/components/MissingEDIPI.jsx
+++ b/src/applications/lgy/coe/form/components/MissingEDIPI.jsx
@@ -15,7 +15,7 @@ const MissingEDIPI = () => {
   });
 
   return (
-    <va-alert status="error" uswds="false">
+    <va-alert status="error">
       <h2 className="vads-u-display--inline-block vads-u-font-size--h3 vads-u-margin-top--0">
         We need more information for your application
       </h2>

--- a/src/applications/lgy/coe/form/components/NeedsToVerify.jsx
+++ b/src/applications/lgy/coe/form/components/NeedsToVerify.jsx
@@ -17,7 +17,7 @@ const NeedsToVerify = ({ pathname }) => {
   });
 
   return (
-    <va-alert status="continue" uswds="false">
+    <va-alert status="continue">
       <h2 slot="headline">
         You’ll need to verify your identity to access more VA.gov tools and
         features

--- a/src/applications/lgy/coe/form/containers/ConfirmationPage.jsx
+++ b/src/applications/lgy/coe/form/containers/ConfirmationPage.jsx
@@ -30,7 +30,7 @@ const ConfirmationPage = ({ form }) => {
 
   return (
     <div className="vads-u-margin-bottom--9">
-      <va-alert status="success" uswds="false">
+      <va-alert status="success">
         <h2 slot="headline" className="vads-u-font-size--h3">
           You’ve successfully submitted your request for a COE.
         </h2>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**: Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
- _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

## Summary

This PR updates some v1 va-alert instances to v3 in accordance with the removal of v1 from component-library

## Related issue(s)

[2657](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2657)

## Testing done

local testing

## Screenshots

<img width="777" alt="Screenshot 2024-07-18 at 4 32 29 PM" src="https://github.com/user-attachments/assets/a3929283-558f-43bd-ac5b-6612ae04b010">

<hr /> 

<img width="657" alt="Screenshot 2024-07-18 at 5 15 19 PM" src="https://github.com/user-attachments/assets/c6810741-2f93-45ee-bb58-056b5f82dd30">

<hr />

<img width="649" alt="Screenshot 2024-07-18 at 5 18 27 PM" src="https://github.com/user-attachments/assets/f362f07b-a69e-413f-b1c9-521474eb8fc0">


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
