### PR TITLE
21a into arp - basic correction to expected reducer structure

### DIFF
--- a/src/applications/accredited-representative-portal/reducers/form21aSaveInProgress.js
+++ b/src/applications/accredited-representative-portal/reducers/form21aSaveInProgress.js
@@ -2,6 +2,4 @@ import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress
 
 import formConfig from '../accreditation/21a/config/form';
 
-export default {
-  form: createSaveInProgressFormReducer(formConfig),
-};
+export default createSaveInProgressFormReducer(formConfig);

--- a/src/applications/accredited-representative-portal/reducers/index.js
+++ b/src/applications/accredited-representative-portal/reducers/index.js
@@ -6,7 +6,7 @@ import form21aSaveInProgress from './form21aSaveInProgress';
 const rootReducer = combineReducers({
   user: arpUserReducer,
   featureToggles: FeatureToggleReducer,
-  form21aSaveInProgress,
+  form: form21aSaveInProgress,
 });
 
 export default rootReducer;


### PR DESCRIPTION
Fixing this error unlocks the next error which I believe exposes a more meaningful incompatibility that SIP experiences when the app's state has not been set up by the platform user component which we don't use in our app. The key idea here is that in progress forms are fundamentally related to a user and their lifecycle within the app. to integrate in progress forms into our app we'll need to introduce and expose user state that in progress forms understands.