### PR TITLE
Manually block special characters in TERA-other

### DIFF
--- a/src/applications/ezr/config/chapters/militaryService/otherToxicExposureDetails.js
+++ b/src/applications/ezr/config/chapters/militaryService/otherToxicExposureDetails.js
@@ -5,6 +5,7 @@ import OtherToxicExposureDescription from '../../../components/FormDescriptions/
 import content from '../../../locales/en/content.json';
 
 const { otherToxicExposure } = ezrSchema.properties;
+const alphaNumericSpaceRegex = '^[a-zA-Z0-9 ]{1,100}$';
 
 export default {
   uiSchema: {
@@ -22,6 +23,15 @@ export default {
       'ui:options': {
         hint: content['military-service-other-exposure-description-2-hint'],
       },
+      'ui:validations': [
+        (errors, field) => {
+          if (field && !field.match(alphaNumericSpaceRegex)) {
+            errors.addError(
+              content['military-service-other-exposure-error-message'],
+            );
+          }
+        },
+      ],
     },
   },
   schema: {

--- a/src/applications/hca/config/chapters/militaryService/otherToxicExposureDetails.js
+++ b/src/applications/hca/config/chapters/militaryService/otherToxicExposureDetails.js
@@ -6,6 +6,9 @@ import {
 } from '../../../components/FormDescriptions';
 
 const { otherToxicExposure } = fullSchemaHca.properties;
+const alphaNumericSpaceRegex = '^[a-zA-Z0-9 ]{1,100}$';
+const specialCharacterErrorMessage =
+  'You entered a character we can\u2019t accept. Remove any special characters like commas or dashes';
 
 export default {
   uiSchema: {
@@ -18,9 +21,15 @@ export default {
       'ui:title': 'Enter any toxins or hazards you\u2019ve been exposed to',
       'ui:description': OtherToxicExposureHint,
       'ui:errorMessages': {
-        pattern:
-          'You entered a character we can\u2019t accept. Remove any special characters like commas or dashes',
+        pattern: specialCharacterErrorMessage,
       },
+      'ui:validations': [
+        (errors, field) => {
+          if (field && !field.match(alphaNumericSpaceRegex)) {
+            errors.addError(specialCharacterErrorMessage);
+          }
+        },
+      ],
     },
   },
   schema: {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)

## Summary
Adding validation to the Toxic Exposure - Other free-text field to block any special characters, allowing only alphanumeric and spaces. This matches the current description, and is more restrictive than the recently loosened validation in `vets-schema-json`, to match downstream constraints in VES.

This should be a temporary workaround until the downstream changes roll out (see `VES-42117`), at which point this can be reverted. For now, this will prevent Vets from submitting EZ and EZR forms that wind up producing errors.

- 10-10 Health Enrollment

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/88797

## Testing done

Manual testing locally. Before the change, typing some special characters (`,.?1`) into the `Enter any toxins or hazards you’ve been exposed to` field such as `,` would be valid. Now it produces the same error message as other special characters (like `@`).

## Screenshots
<img width="770" alt="Screenshot 2024-07-19 at 11 48 57 AM" src="https://github.com/user-attachments/assets/5fd406ec-dcf1-4684-b8eb-20ad2f6341b1">

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
