### PR TITLE
Update multi-page pattern pages

### DIFF
--- a/src/applications/pensions/config/chapters/02-military-history/otherNamesPages.js
+++ b/src/applications/pensions/config/chapters/02-military-history/otherNamesPages.js
@@ -17,7 +17,6 @@ const options = {
   required: false,
   isItemIncomplete: item =>
     !item?.previousFullName?.first || !item.previousFullName?.last, // include all required fields here
-  maxItems: 5,
   text: {
     getItemName: item => formatFullName(item.previousFullName),
   },
@@ -34,7 +33,7 @@ const summaryPage = {
       options,
       {
         title: 'Did you serve under another name?',
-        hint: ' ',
+        hint: null,
         labels: {
           Y: 'Yes, I have a previous name to report',
           N: 'No, I don’t have a previous name to report',

--- a/src/applications/pensions/config/chapters/04-household-information/dependentChildrenPages.js
+++ b/src/applications/pensions/config/chapters/04-household-information/dependentChildrenPages.js
@@ -63,7 +63,6 @@ const options = {
         !item.personWhoLivesWithChild.first ||
         !item.personWhoLivesWithChild.last)) ||
     (!item.childInHousehold && !item.monthlyPayment), // include all required fields here
-  maxItems: 15,
   text: {
     getItemName: item => formatFullName(item.fullName),
   },
@@ -76,7 +75,10 @@ const options = {
  */
 const summaryPage = {
   uiSchema: {
-    'view:isAddingDependents': arrayBuilderYesNoUI(options),
+    'view:isAddingDependents': arrayBuilderYesNoUI(options, {
+      title: 'Do you have any dependent children?',
+      hint: null,
+    }),
   },
   schema: {
     type: 'object',


### PR DESCRIPTION
## Summary
Update the Multiple Page Response pattern on the Pension Benefits form (21P-527EZ) for other service names and dependent children based on design feedback

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/82850

## How to run in local environment
1. Check out this branch locally
2. In your local environment, set the `pension_multiple_page_response` flipper to 'enabled' at http://localhost:3000/flipper/features/pension_multiple_page_response
3. Run `vets-website` and `vets-api`
4. Go to `http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/` in your browser

## Pages
- Other service names pages in the 'Military history' chapter (/military/other-names/summary)
- Dependent children pages in the 'Household information' chapter (/household/dependents/summary)

## How to verify
1. Add, edit and delete an item via the multiple page list loop pattern
2. Verify that the UI matches the Multiple Page designs
3. Verify the layout on desktop and mobile viewports
4. Verify that the form data is saved to the api and redux store

## What areas of the site does it impact?
Pension Benefits Application

### Quality Assurance & Testing
- [x] Existing unit tests and integration tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
