### PR TITLE
85787 Update confirmation page - form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
@@ -4,7 +4,10 @@ import { connect } from 'react-redux';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
-import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import {
+  VaAlert,
+  VaLink,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { requiredFiles, optionalFiles } from '../config/requiredUploads';
 import MissingFileOverview from '../../shared/components/fileUploads/MissingFileOverview';
 import { ConfirmationPagePropTypes } from '../../shared/constants';
@@ -70,14 +73,6 @@ export function ConfirmationPage(props) {
 
       {OverviewComp}
 
-      <h2 className="vads-u-font-size--h3">What to expect next</h2>
-      <p>
-        We'll contact you by mail or phone if we have questions or need more
-        information.
-        <br />
-        <br />
-        And we'll send you a letter in the mail with our decision.
-      </p>
       <div className="inset">
         <h3 className="vads-u-margin-top--0 vads-u-font-size--h4">
           Your submission information
@@ -90,7 +85,6 @@ export function ConfirmationPage(props) {
             <br />
           </span>
         )}
-        <br />
         {isValid(submitDate) && (
           <p className="date-submitted">
             <strong>Date submitted</strong>
@@ -104,6 +98,7 @@ export function ConfirmationPage(props) {
           You can print this confirmation for page for your records.
         </span>
         <br />
+        <br />
         <va-button
           uswds
           className="usa-button screen-only"
@@ -111,6 +106,36 @@ export function ConfirmationPage(props) {
           text="Print this page"
         />
       </div>
+
+      <h2 className="vads-u-font-size--h3">What to expect next</h2>
+      <p>
+        You should receive a notification confirming CHAMPVA's receipt of your
+        application within 7 days.
+        <br />
+        <br />
+        It will take approximately 60 days to process your application once
+        received by CHAMPVA.
+        <br />
+        <br />
+        If we have any questions, need additional information, or encounter any
+        issues, we will contact you.
+      </p>
+      <h2 className="vads-u-font-size--h3">
+        How to contact us about your CHAMPVA application
+      </h2>
+      <p>
+        If you have any questions about your application you can call the
+        CHAMPVA call center at 800-733-8387. We’re here Monday through Friday,
+        8:05 a.m. to 7:30 p.m. ET.
+        <br />
+        <br />
+        You can also contact us online through our Ask VA tool.
+        <br />
+        <br />
+        <VaLink text="Go to Ask VA" href="https://ask.va.gov/" />
+      </p>
+      <br />
+      <br />
       <a className="vads-c-action-link--green" href="https://www.va.gov/">
         Go back to VA.gov
       </a>

--- a/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
@@ -7,6 +7,8 @@ import { focusElement } from 'platform/utilities/ui';
 import {
   VaAlert,
   VaLink,
+  VaLinkAction,
+  VaTelephone,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { requiredFiles, optionalFiles } from '../config/requiredUploads';
 import MissingFileOverview from '../../shared/components/fileUploads/MissingFileOverview';
@@ -117,8 +119,8 @@ export function ConfirmationPage(props) {
       <h2>How to contact us about your CHAMPVA application</h2>
       <p>
         If you have any questions about your application you can call the
-        CHAMPVA call center at 800-733-8387. We’re here Monday through Friday,
-        8:05 a.m. to 7:30 p.m. ET.
+        CHAMPVA call center at <VaTelephone contact="800-733-8387" />. We’re
+        here Monday through Friday, 8:05 a.m. to 7:30 p.m. ET.
         <br />
         <br />
         You can also contact us online through our Ask VA tool.
@@ -128,9 +130,7 @@ export function ConfirmationPage(props) {
       </p>
       <br />
       <br />
-      <a className="vads-c-action-link--green" href="https://www.va.gov/">
-        Go back to VA.gov
-      </a>
+      <VaLinkAction href="/" text="Go back to VA.gov" />
     </div>
   );
 }

--- a/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
@@ -74,9 +74,7 @@ export function ConfirmationPage(props) {
       {OverviewComp}
 
       <div className="inset">
-        <h3 className="vads-u-margin-top--0 vads-u-font-size--h4">
-          Your submission information
-        </h3>
+        <h3 className="vads-u-margin-top--0">Your submission information</h3>
         {data.statementOfTruthSignature && (
           <span className="veterans-full-name">
             <strong>Who submitted this form</strong>
@@ -107,7 +105,7 @@ export function ConfirmationPage(props) {
         />
       </div>
 
-      <h2 className="vads-u-font-size--h3">What to expect next</h2>
+      <h2>What to expect next</h2>
       <p>
         You should receive a notification confirming CHAMPVA's receipt of your
         application within 7 days.
@@ -120,9 +118,7 @@ export function ConfirmationPage(props) {
         If we have any questions, need additional information, or encounter any
         issues, we will contact you.
       </p>
-      <h2 className="vads-u-font-size--h3">
-        How to contact us about your CHAMPVA application
-      </h2>
+      <h2>How to contact us about your CHAMPVA application</h2>
       <p>
         If you have any questions about your application you can call the
         CHAMPVA call center at 800-733-8387. We’re here Monday through Friday,

--- a/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
@@ -107,10 +107,6 @@ export function ConfirmationPage(props) {
 
       <h2>What to expect next</h2>
       <p>
-        You should receive a notification confirming CHAMPVA's receipt of your
-        application within 7 days.
-        <br />
-        <br />
         It will take approximately 60 days to process your application once
         received by CHAMPVA.
         <br />

--- a/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/ConfirmationPage.jsx
@@ -91,13 +91,6 @@ export function ConfirmationPage(props) {
           </span>
         )}
         <br />
-        {data.statementOfTruthSignature && (
-          <span className="veterans-full-name">
-            <strong>Confirmation number</strong>
-            <br />
-            {form.submission?.response?.confirmationNumber || ''}
-          </span>
-        )}
         {isValid(submitDate) && (
           <p className="date-submitted">
             <strong>Date submitted</strong>

--- a/src/applications/ivc-champva/shared/components/GetFormHelp.jsx
+++ b/src/applications/ivc-champva/shared/components/GetFormHelp.jsx
@@ -2,7 +2,16 @@ import React from 'react';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 export default function GetFormHelp() {
-  return (
+  // Is the current page a confirmation page under a CHAMPVA form?
+  const isChampvaConfirmation = /.*champva.*confirmation(\/)?$/.test(
+    window.location.href,
+  );
+
+  // Don't show footers on CHAMPVA confirmation pages (we still want them
+  // on all other pages though).
+  return isChampvaConfirmation ? (
+    <div className="row vads-u-margin-bottom--4" />
+  ) : (
     <div className="row vads-u-margin-bottom--4">
       <div className="form-panel">
         <h2 className="vads-u-font-size--h3">Need help?</h2>

--- a/src/applications/ivc-champva/shared/components/fileUploads/MissingFileOverview.jsx
+++ b/src/applications/ivc-champva/shared/components/fileUploads/MissingFileOverview.jsx
@@ -37,50 +37,60 @@ import { getConditionalPages } from '../../utilities';
 import SupportingDocsVerification from './supportingDocsVerification';
 import MissingFileList from './MissingFileList';
 
-const mailInfo = (showOpt = true, address, officeName, faxNum) => (
-  <>
-    <p>
-      Your application will not be considered complete until VA receives all of
-      your remaining required files.
-    </p>
-    {showOpt ? (
-      <p>
-        Optional files are not required to complete your application, but may
-        prevent delays in your processing time.
-        <br />
-      </p>
-    ) : null}
-    Mail your documents to:
-    <address className="vads-u-border-color--primary vads-u-border-left--4px vads-u-margin-left--3">
-      <p className="vads-u-padding-x--10px vads-u-margin-left--1">
-        {address ?? (
-          <>
-            VHA Office of Community Care
-            <br />
-            CHAMPVA Eligibility
-            <br />
-            P.O. Box 469028
-            <br />
-            Denver, CO 80246-9028
-            <br />
-            United States of America
-          </>
-        )}
-      </p>
-    </address>
-    Or fax your documents here:
-    <br />
-    {officeName ? `${officeName},` : ''}
-    <br />
+const mailInfo = (showOpt = true, address, officeName, faxNum) => {
+  const faxNumMarkup = (
     <VaTelephone
       contact={JSON.stringify({
         phoneNumber: faxNum ?? '3033317809',
         description: 'fax number',
       })}
     />
-    <br />
-  </>
-);
+  );
+  return (
+    <>
+      <p>
+        Your application will not be considered complete until VA receives all
+        of your remaining required files.
+      </p>
+      {showOpt ? (
+        <p>
+          Optional files are not required to complete your application, but may
+          prevent delays in your processing time.
+          <br />
+        </p>
+      ) : null}
+      Mail your application and supporting document copies to:
+      <address className="vads-u-border-color--primary vads-u-border-left--4px vads-u-margin-left--3">
+        <p className="vads-u-padding-x--10px vads-u-margin-left--1">
+          {address ?? (
+            <>
+              VHA Office of Community Care
+              <br />
+              CHAMPVA Eligibility
+              <br />
+              P.O. Box 469028
+              <br />
+              Denver, CO 80246-9028
+              <br />
+              United States of America
+            </>
+          )}
+        </p>
+      </address>
+      Or fax it to:
+      {officeName ? (
+        <>
+          <br />
+          {officeName}
+          <br />
+          {faxNumMarkup}
+        </>
+      ) : (
+        <> {faxNumMarkup}</>
+      )}
+    </>
+  );
+};
 
 export const optionalDescription =
   'These documents help us process this application faster.';


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR updates the confirmation page copy of form 10-10d.

- Hides the "Get Help" footer only on the confirmation pages for CHAMPVA forms (information is not accurate for this subset of forms on the confirmation page, but is useful during normal form flow)
- Updated "what happens next" copy
- Updated mailing/faxing copy
- Team: IVC CHAMPVA
- Flipper: in use

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85787

## Testing done

- Manual
- Verified unit tests run and pass

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![Screenshot 2024-07-22 at 12 10 35](https://github.com/user-attachments/assets/9f222193-ee8c-40cd-a126-cd1ba4eed253)|![Screenshot 2024-07-22 at 12 24 10](https://github.com/user-attachments/assets/1afa8097-d5c0-416e-8614-a9e242fe1c2b)|

## What areas of the site does it impact?

IVC form 10-10d (Confirmation page, Get Help footer), IVC form 10-7959c (Get Help footer)

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA