### PR TITLE
Update keyname for date of birth fields - form 1010d

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -559,14 +559,14 @@ const formConfig = {
               },
               items: {
                 applicantName: fullNameUI(),
-                applicantDOB: dateOfBirthUI({ required: true }),
+                applicantDob: dateOfBirthUI({ required: true }),
               },
             },
           },
-          schema: applicantListSchema(['applicantDOB'], {
+          schema: applicantListSchema(['applicantDob'], {
             titleSchema,
             applicantName: fullNameSchema,
-            applicantDOB: dateOfBirthSchema,
+            applicantDob: dateOfBirthSchema,
           }),
         },
         page13a: {
@@ -894,7 +894,7 @@ const formConfig = {
               formData.applicants[index]?.applicantRelationshipToSponsor
                 ?.relationshipToVeteran === 'child' &&
               isInRange(
-                getAgeInYears(formData.applicants[index]?.applicantDOB),
+                getAgeInYears(formData.applicants[index]?.applicantDob),
                 18,
                 23,
               )
@@ -937,7 +937,7 @@ const formConfig = {
               formData.applicants[index]?.applicantRelationshipToSponsor
                 ?.relationshipToVeteran === 'child' &&
               isInRange(
-                getAgeInYears(formData.applicants[index]?.applicantDOB),
+                getAgeInYears(formData.applicants[index]?.applicantDob),
                 18,
                 23,
               ) &&
@@ -968,7 +968,7 @@ const formConfig = {
             return (
               formData.applicants[index]?.applicantRelationshipToSponsor
                 ?.relationshipToVeteran === 'child' &&
-              getAgeInYears(formData.applicants[index]?.applicantDOB) >= 18 &&
+              getAgeInYears(formData.applicants[index]?.applicantDob) >= 18 &&
               formData.applicants[index]?.applicantDependentStatus?.status ===
                 'over18HelplessChild'
             );
@@ -1297,7 +1297,7 @@ const formConfig = {
                 'applicantMedicareStatus.eligibility',
                 formData?.applicants?.[index],
               ) === 'ineligible' &&
-              getAgeInYears(formData.applicants[index]?.applicantDOB) >= 65
+              getAgeInYears(formData.applicants[index]?.applicantDob) >= 65
             );
           },
           CustomPage: FileFieldWrapped,

--- a/src/applications/ivc-champva/10-10D/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-10D/config/submitTransformer.js
@@ -36,7 +36,7 @@ function transformApplicants(applicants) {
     const transformedApp = {
       fullName: app.applicantName ?? '',
       ssnOrTin: app.applicantSSN?.ssn ?? '',
-      dateOfBirth: fmtDate(app.applicantDOB) ?? '',
+      dateOfBirth: fmtDate(app.applicantDob) ?? '',
       phoneNumber: app.applicantPhone ?? '',
       email: app.applicantEmailAddress ?? '',
       vetRelationship: transformRelationship(
@@ -136,7 +136,7 @@ export default function transformForSubmit(formConfig, form) {
       fullName: transformedData?.veteransFullName || {},
       ssnOrTin: transformedData?.ssn?.ssn || '',
       vaClaimNumber: transformedData?.ssn?.vaFileNumber || '',
-      dateOfBirth: fmtDate(transformedData?.sponsorDOB) || '',
+      dateOfBirth: fmtDate(transformedData?.sponsorDob) || '',
       phoneNumber: transformedData?.sponsorPhone || '',
       address: transformedData?.sponsorAddress || {
         street: 'NA',

--- a/src/applications/ivc-champva/10-10D/pages/Sponsor/sponsorInfoConfig.js
+++ b/src/applications/ivc-champva/10-10D/pages/Sponsor/sponsorInfoConfig.js
@@ -35,15 +35,15 @@ export const sponsorNameDobConfig = {
       ({ formData }) => descriptionText(formData),
     ),
     veteransFullName: fullNameUI(),
-    sponsorDOB: dateOfBirthUI(),
+    sponsorDob: dateOfBirthUI(),
   },
   schema: {
     type: 'object',
-    required: ['sponsorDOB'],
+    required: ['sponsorDob'],
     properties: {
       titleSchema,
       veteransFullName: fullNameSchema,
-      sponsorDOB: dateOfBirthSchema,
+      sponsorDob: dateOfBirthSchema,
     },
   },
 };

--- a/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
@@ -78,7 +78,7 @@ const testConfig = createTestConfig(
               'veteransFullName',
               data.veteransFullName,
             );
-            fillDateWebComponentPattern('sponsorDOB', data.sponsorDOB);
+            fillDateWebComponentPattern('sponsorDob', data.sponsorDob);
             cy.axeCheck();
             cy.findByText(/continue/i, { selector: 'button' }).click();
           });
@@ -133,8 +133,8 @@ const testConfig = createTestConfig(
                 data.applicants[i].applicantName,
               );
               fillDateWebComponentPattern(
-                `applicants_${i}_applicantDOB`,
-                data.applicants[i].applicantDOB,
+                `applicants_${i}_applicantDob`,
+                data.applicants[i].applicantDob,
               );
               // Add another if we're not out of applicants:
               if (i < numApps - 1)

--- a/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/app-sa-cs-medab.json
+++ b/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/app-sa-cs-medab.json
@@ -19,7 +19,7 @@
           "first": "Applicant",
           "last": "Jones"
         },
-        "applicantDOB": "2000-02-02",
+        "applicantDob": "2000-02-02",
         "applicantGender": {
           "gender": "male"
         },
@@ -83,7 +83,7 @@
       "last": "Jones",
       "suffix": "Sr."
     },
-    "sponsorDOB": "1999-01-01",
+    "sponsorDob": "1999-01-01",
     "certifierRole": "applicant",
     "consentToMailMissingRequiredFiles": true,
     "statementOfTruthSignature": "applicant jones",

--- a/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/app-sd-cb-ohi.json
+++ b/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/app-sd-cb-ohi.json
@@ -20,7 +20,7 @@
           "last": "Jones",
           "suffix": "II"
         },
-        "applicantDOB": "2000-02-02",
+        "applicantDob": "2000-02-02",
         "applicantGender": {
           "gender": "male"
         },
@@ -63,7 +63,7 @@
       "last": "Jones",
       "suffix": "Jr."
     },
-    "sponsorDOB": "1999-01-01",
+    "sponsorDob": "1999-01-01",
     "sponsorDOD": "2000-01-01",
     "sponsorDeathConditions": true,
     "sponsorIsDeceased": true,

--- a/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/cert-sd-spoused.json
+++ b/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/cert-sd-spoused.json
@@ -21,7 +21,7 @@
           "first": "Applicant",
           "last": "Jones"
         },
-        "applicantDOB": "2001-02-02",
+        "applicantDob": "2001-02-02",
         "applicantGender": {
           "gender": "female"
         },
@@ -49,7 +49,7 @@
       "first": "Sponsor",
       "last": "Jones"
     },
-    "sponsorDOB": "1950-01-01",
+    "sponsorDob": "1950-01-01",
     "certifierRelationship": {
       "relationshipToVeteran": {
         "spouse": false,

--- a/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/maximal-test.json
@@ -19,7 +19,7 @@
           "first": "Applicant1",
           "last": "Jones"
         },
-        "applicantDOB": "2004-04-03",
+        "applicantDob": "2004-04-03",
         "applicantGender": {
           "gender": "male"
         },
@@ -71,7 +71,7 @@
           "first": "Applicant2",
           "last": "Jones"
         },
-        "applicantDOB": "1955-04-02",
+        "applicantDob": "1955-04-02",
         "missingUploads": [
           {
             "name": "applicantMedicareIneligibleProof",
@@ -129,7 +129,7 @@
           "first": "Applicant3",
           "last": "Jones"
         },
-        "applicantDOB": "2000-01-02",
+        "applicantDob": "2000-01-02",
         "missingUploads": [
           {
             "name": "applicantMedicarePartAPartBCard",
@@ -190,7 +190,7 @@
       "first": "Sponsor",
       "last": "Jones"
     },
-    "sponsorDOB": "1950-01-01",
+    "sponsorDob": "1950-01-01",
     "certifierRelationship": {
       "relationshipToVeteran": {
         "spouse": true,

--- a/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/test-data.json
+++ b/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/test-data.json
@@ -22,7 +22,7 @@
         },
         "applicantDependentStatus": { "status": "enrolled" },
         "applicantEnrolledInOHI": false,
-        "applicantDOB": "2003-01-04",
+        "applicantDob": "2003-01-04",
         "applicantName": {
           "first": "Johnny",
           "middle": "T",
@@ -43,7 +43,7 @@
       "first": "Joe",
       "last": "Johnson"
     },
-    "sponsorDOB": "1958-01-01",
+    "sponsorDob": "1958-01-01",
     "sponsorIsDeceased": true,
     "sponsorDOD": "2001-01-01",
     "sponsorDeathConditions": false,

--- a/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/vet-2a-spouse-child-medabd-ohi.json
+++ b/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/vet-2a-spouse-child-medabd-ohi.json
@@ -20,7 +20,7 @@
           "first": "Applicant",
           "last": "Jones"
         },
-        "applicantDOB": "2001-01-01",
+        "applicantDob": "2001-01-01",
         "applicantGender": {
           "gender": "female"
         },
@@ -89,7 +89,7 @@
           "first": "Applicant2",
           "last": "Jones2"
         },
-        "applicantDOB": "2000-04-03",
+        "applicantDob": "2000-04-03",
         "missingUploads": [
           {
             "name": "applicantBirthCertOrSocialSecCard",
@@ -131,7 +131,7 @@
       "first": "Sponsor",
       "last": "Jones"
     },
-    "sponsorDOB": "1950-04-01",
+    "sponsorDob": "1950-04-01",
     "certifierRole": "sponsor",
     "consentToMailMissingRequiredFiles": true,
     "statementOfTruthSignature": "Sponsor Jones",

--- a/src/applications/ivc-champva/10-10D/tests/unit/config/form.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10D/tests/unit/config/form.unit.spec.jsx
@@ -22,7 +22,7 @@ import mockData from '../../e2e/fixtures/data/test-data.json';
 const applicants = [
   {
     applicantSSN: '111221234',
-    applicantDOB: '2007-01-03',
+    applicantDob: '2007-01-03',
     applicantName: {
       first: 'Jerry',
       middle: 'J',
@@ -117,7 +117,7 @@ testNumberOfWebComponentFields(
   formConfig.chapters.applicantInformation.pages.page13.schema,
   formConfig.chapters.applicantInformation.pages.page13.uiSchema,
   5,
-  'Applicant - Name DOB',
+  'Applicant - Name Dob',
   { ...mockData.data },
 );
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR updates two date of birth keynames to fix bug when using save-in-progress data in IVC-CHAMPVA form 10-10d.

| |Prev|New|
|-|-|-|
|Applicant date of birth|`applicantDOB`|`applicantDob`|
|Sponsor date of birth|`sponsorDOB`|`sponsorDob`|

The issue seems to come from the fact that the backend automatically converts camelCase names to snake_case. When a variable with multiple contiguous capital letters (as in the case of `applicantDOB` is snake_cased, the contiguous letters are treated as one word in the keyname (e.g., `applicant_dob`. When converting back to camelcase (as happens when the frontend requests the save in progress data), only the first letter of that "word" (in this case "dob") is capitalized. This creates a mismatch between the form fields and the SIP data that is available to populate them. The form has a field named `applicantDOB`, but the SIP data only contains data for `applicantDob`.

- Updated all instances of capital `DOB` in keynames to be `Dob`
- Updated test data files with new keynames
- Updated unit/cypress tests

## Related issue(s)

- NA

## Testing done

- Manual
- Verified E2E and Unit tests succeeded

## Screenshots

|         | Codebase compared with Staging |
| ------- | ------ |
|   |![dob](https://github.com/user-attachments/assets/af692d15-0b5e-4acb-a1a8-7167f4334a66)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback

NA