### PR TITLE
Remove unnecessary aria label on sign-in button to Form Upload

### DIFF
--- a/src/applications/static-pages/simple-forms/form-upload/App.js
+++ b/src/applications/static-pages/simple-forms/form-upload/App.js
@@ -47,7 +47,6 @@ export const App = ({ formNumber, hasOnlineTool }) => {
             <p>By signing in you will be able to submit a completed PDF form</p>
             <VaButton
               onClick={onSignInClicked}
-              label="ariaLabel"
               uswds
               text="Sign in to upload your form"
             />


### PR DESCRIPTION
## Summary
This PR removes an unnecessary aria label from the sign in button on the Form Upload entry page.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1470

## Screenshots
Before:
<img width="807" alt="Screenshot 2024-07-22 at 7 38 36 PM" src="https://github.com/user-attachments/assets/80e5a51c-4a47-4318-9e35-c4d3159ad580">

After:
<img width="689" alt="Screenshot 2024-07-22 at 7 37 39 PM" src="https://github.com/user-attachments/assets/5082a265-0ee7-454a-b477-8ccb85f1b354">
