### PR TITLE
[CST] [Frontend] Added a feature flag for making evidence uploads a synchronous task

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -49,6 +49,7 @@
   "cstIncludeDdl5103Letters": "cst_include_ddl_5103_letters",
   "cstUseClaimDetailsV2": "cst_use_claim_details_v2",
   "cstUseDataDogRUM": "cst_use_dd_rum",
+  "cstSynchronousEvidenceUploads": "cst_synchronous_evidence_uploads",
   "debtLettersShowLetters": "debt_letters_show_letters",
   "debtLettersShowLettersVBMS": "debt_letters_show_letters_vbms",
   "dependencyVerification": "dependency_verification",


### PR DESCRIPTION
## Summary

- Added `cst_synchronous_evidence_uploads` feature flag to `vets-website`

## Related issue(s)

- [[CST] Make evidence submission a synchronous task](https://github.com/department-of-veterans-affairs/va.gov-team/issues/76660)
- [[PR] [CST] [Backend] Added a feature flag for making evidence uploads a synchronous task](https://github.com/department-of-veterans-affairs/vets-api/pull/17670)