### PR TITLE
Added Error Checking to Session URL

### DIFF
--- a/src/platform/user/authentication/constants.js
+++ b/src/platform/user/authentication/constants.js
@@ -10,8 +10,12 @@ import {
 export const API_VERSION = 'v1';
 export const FORCE_NEEDED = 'force-needed';
 
-export const API_SESSION_URL = ({ version = API_VERSION, type = null }) =>
-  `${environment.API_URL}/${version}/sessions/${type}/new`;
+export const API_SESSION_URL = ({ version = API_VERSION, type = null }) => {
+  if (!type) {
+    throw new Error('Attempted to call API_SESSION_URL without a type');
+  }
+  return `${environment.API_URL}/${version}/sessions/${type}/new`;
+};
 
 export const AUTH_EVENTS = {
   MOCK_LOGIN: 'mock-login-link-clicked-modal',

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -653,4 +653,12 @@ describe('Authentication Utilities', () => {
       expect(authUtilities.generateReturnURL('')).to.eql(myVARoute);
     });
   });
+
+  describe('API_SESSION_URL', () => {
+    it('should throw an error if no type is provided', () => {
+      expect(() => API_SESSION_URL({})).to.throw(
+        'Attempted to call API_SESSION_URL without a type',
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

Added a type check to `API_SESSION_URL` that errors if the given type is falsy. Added an additional test for code coverage.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/87774

## Testing done

- A new unit test was added for the `API_SESSION_URL` and was run locally.
- Can be replicated by running `yarn test:unit src/platform/user/tests/authentication/utilities.unit.spec.js`.

## What areas of the site does it impact?

This only impacts `constants.js` and `utilities.unit.spec.js` in authentication.

## Acceptance criteria

- [x] Update the `API_SESSION_URL` so that if `type` is `null` or `undefined` we throw an error
- [x] Update the unit tests accordingly
