### PR TITLE
Sa 89194 original claim notifications

### DIFF
--- a/src/applications/my-education-benefits/actions/index.js
+++ b/src/applications/my-education-benefits/actions/index.js
@@ -58,6 +58,12 @@ export const FETCH_DUPLICATE_CONTACT_INFO_SUCCESS =
   'FETCH_DUPLICATE_CONTACT_INFO_SUCCESS';
 export const FETCH_DUPLICATE_CONTACT_INFO_FAILURE =
   'FETCH_DUPLICATE_CONTACT_INFO_FAILURE';
+const CONFIRMATION_ENDPOINT = `${
+  environment.API_URL
+}/meb_api/v0/send_confirmation_email`;
+export const SEND_CONFIRMATION = 'SEND_CONFIRMATION';
+export const SEND_CONFIRMATION_SUCCESS = 'SEND_CONFIRMATION_SUCCESS';
+export const SEND_CONFIRMATION_FAILURE = 'SEND_CONFIRMATION_FAILURE';
 export const UPDATE_GLOBAL_EMAIL = 'UPDATE_GLOBAL_EMAIL';
 export const UPDATE_GLOBAL_PHONE_NUMBER = 'UPDATE_GLOBAL_PHONE_NUMBER';
 export const ACKNOWLEDGE_DUPLICATE = 'ACKNOWLEDGE_DUPLICATE';
@@ -93,12 +99,6 @@ export function fetchPersonalInformation(showMebEnhancements09) {
   };
 }
 
-const CONFIRMATION_ENDPOINT = `${
-  environment.API_URL
-}/meb_api/v0/send_confirmation_email`;
-export const SEND_CONFIRMATION = 'SEND_CONFIRMATION';
-export const SEND_CONFIRMATION_SUCCESS = 'SEND_CONFIRMATION_SUCCESS';
-export const SEND_CONFIRMATION_FAILURE = 'SEND_CONFIRMATION_FAILURE';
 const poll = ({
   endpoint,
   validate = response => response && response.data,

--- a/src/applications/my-education-benefits/actions/index.js
+++ b/src/applications/my-education-benefits/actions/index.js
@@ -1,6 +1,8 @@
 import { apiRequest } from 'platform/utilities/api';
 import environment from 'platform/utilities/environment';
 
+import { toSnakeCase } from '../helpers';
+
 export const CLAIMANT_INFO_ENDPOINT = `${
   environment.API_URL
 }/meb_api/v0/claimant_info`;
@@ -177,10 +179,15 @@ export function fetchEligibility() {
   };
 }
 
-export function sendConfirmation() {
+export function sendConfirmation(params) {
   return async dispatch => {
     dispatch({ type: SEND_CONFIRMATION });
-    return apiRequest(CONFIRMATION_ENDPOINT)
+    const snakeCaseParams = toSnakeCase(params);
+    return apiRequest(CONFIRMATION_ENDPOINT, {
+      method: 'POST',
+      body: JSON.stringify(snakeCaseParams),
+      headers: { 'Content-Type': 'application/json' },
+    })
       .then(response =>
         dispatch({
           type: SEND_CONFIRMATION_SUCCESS,

--- a/src/applications/my-education-benefits/actions/index.js
+++ b/src/applications/my-education-benefits/actions/index.js
@@ -90,6 +90,13 @@ export function fetchPersonalInformation(showMebEnhancements09) {
       });
   };
 }
+
+const CONFIRMATION_ENDPOINT = `${
+  environment.API_URL
+}/meb_api/v0/send_confirmation_email`;
+export const SEND_CONFIRMATION = 'SEND_CONFIRMATION';
+export const SEND_CONFIRMATION_SUCCESS = 'SEND_CONFIRMATION_SUCCESS';
+export const SEND_CONFIRMATION_FAILURE = 'SEND_CONFIRMATION_FAILURE';
 const poll = ({
   endpoint,
   validate = response => response && response.data,
@@ -164,6 +171,25 @@ export function fetchEligibility() {
       .catch(errors =>
         dispatch({
           type: FETCH_ELIGIBILITY_FAILURE,
+          errors,
+        }),
+      );
+  };
+}
+
+export function sendConfirmation() {
+  return async dispatch => {
+    dispatch({ type: SEND_CONFIRMATION });
+    return apiRequest(CONFIRMATION_ENDPOINT)
+      .then(response =>
+        dispatch({
+          type: SEND_CONFIRMATION_SUCCESS,
+          response,
+        }),
+      )
+      .catch(errors =>
+        dispatch({
+          type: SEND_CONFIRMATION_FAILURE,
           errors,
         }),
       );

--- a/src/applications/my-education-benefits/components/confirmation/ConfirmationApproved.jsx
+++ b/src/applications/my-education-benefits/components/confirmation/ConfirmationApproved.jsx
@@ -10,7 +10,6 @@ const ConfirmationApproved = ({
   confirmationDate,
   confirmationError,
   confirmationLoading,
-  form1990mebConfirmationEmail,
   printPage,
   sendConfirmation,
   userEmail,
@@ -18,15 +17,13 @@ const ConfirmationApproved = ({
 }) => {
   useEffect(
     () => {
-      if (form1990mebConfirmationEmail) {
-        sendConfirmation({
-          claimStatus: 'ELIGIBLE',
-          email: userEmail,
-          firstName: userFirstName,
-        });
-      }
+      sendConfirmation({
+        claimStatus: 'ELIGIBLE',
+        email: userEmail,
+        firstName: userFirstName,
+      });
     },
-    [sendConfirmation, userEmail, userFirstName, form1990mebConfirmationEmail],
+    [sendConfirmation, userEmail, userFirstName],
   );
 
   if (confirmationLoading) {
@@ -146,7 +143,6 @@ ConfirmationApproved.propTypes = {
   confirmationDate: PropTypes.string.isRequired,
   confirmationError: PropTypes.bool.isRequired,
   confirmationLoading: PropTypes.bool.isRequired,
-  form1990mebConfirmationEmail: PropTypes.bool.isRequired,
   printPage: PropTypes.func.isRequired,
   sendConfirmation: PropTypes.func.isRequired,
   userEmail: PropTypes.string.isRequired,

--- a/src/applications/my-education-benefits/components/confirmation/ConfirmationApproved.jsx
+++ b/src/applications/my-education-benefits/components/confirmation/ConfirmationApproved.jsx
@@ -10,6 +10,7 @@ const ConfirmationApproved = ({
   confirmationDate,
   confirmationError,
   confirmationLoading,
+  printPage,
   sendConfirmation,
   userEmail,
   userFirstName,
@@ -68,12 +69,11 @@ const ConfirmationApproved = ({
           <dd>{confirmationDate}</dd>
         </dl>
         <va-button
+          uswds
           className="usa-button meb-print"
-          onClick={() => window.print()}
-          type="button"
-        >
-          Print this page
-        </va-button>
+          text="Print this page"
+          onClick={printPage}
+        />
       </div>
 
       <h2>What happens next?</h2>
@@ -143,6 +143,7 @@ ConfirmationApproved.propTypes = {
   confirmationDate: PropTypes.string.isRequired,
   confirmationError: PropTypes.bool.isRequired,
   confirmationLoading: PropTypes.bool.isRequired,
+  printPage: PropTypes.func.isRequired,
   sendConfirmation: PropTypes.func.isRequired,
   userEmail: PropTypes.string.isRequired,
   userFirstName: PropTypes.string.isRequired,

--- a/src/applications/my-education-benefits/components/confirmation/ConfirmationApproved.jsx
+++ b/src/applications/my-education-benefits/components/confirmation/ConfirmationApproved.jsx
@@ -10,6 +10,7 @@ const ConfirmationApproved = ({
   confirmationDate,
   confirmationError,
   confirmationLoading,
+  form1990mebConfirmationEmail,
   printPage,
   sendConfirmation,
   userEmail,
@@ -17,13 +18,15 @@ const ConfirmationApproved = ({
 }) => {
   useEffect(
     () => {
-      sendConfirmation({
-        claimStatus: 'ELIGIBLE',
-        email: userEmail,
-        firstName: userFirstName,
-      });
+      if (form1990mebConfirmationEmail) {
+        sendConfirmation({
+          claimStatus: 'ELIGIBLE',
+          email: userEmail,
+          firstName: userFirstName,
+        });
+      }
     },
-    [sendConfirmation, userEmail, userFirstName],
+    [sendConfirmation, userEmail, userFirstName, form1990mebConfirmationEmail],
   );
 
   if (confirmationLoading) {
@@ -143,6 +146,7 @@ ConfirmationApproved.propTypes = {
   confirmationDate: PropTypes.string.isRequired,
   confirmationError: PropTypes.bool.isRequired,
   confirmationLoading: PropTypes.bool.isRequired,
+  form1990mebConfirmationEmail: PropTypes.bool.isRequired,
   printPage: PropTypes.func.isRequired,
   sendConfirmation: PropTypes.func.isRequired,
   userEmail: PropTypes.string.isRequired,

--- a/src/applications/my-education-benefits/components/confirmation/ConfirmationApproved.jsx
+++ b/src/applications/my-education-benefits/components/confirmation/ConfirmationApproved.jsx
@@ -1,13 +1,40 @@
-import React from 'react';
+// components/confirmation/ConfirmationApproved.jsx
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { LETTER_URL } from '../../constants';
+import LoadingIndicator from '../LoadingIndicator';
 import FormFooter from '../FormFooter';
 
-export default function ConfirmationApproved({
+const ConfirmationApproved = ({
   claimantName,
   confirmationDate,
-  printPage,
-}) {
+  confirmationError,
+  confirmationLoading,
+  sendConfirmation,
+  userEmail,
+  userFirstName,
+}) => {
+  useEffect(
+    () => {
+      sendConfirmation({
+        claimStatus: 'ELIGIBLE',
+        email: userEmail,
+        firstName: userFirstName,
+      });
+    },
+    [sendConfirmation, userEmail, userFirstName],
+  );
+
+  if (confirmationLoading) {
+    return <LoadingIndicator message="Sending confirmation email..." />;
+  }
+
+  if (confirmationError) {
+    return (
+      <div>Error sending confirmation email: {confirmationError.message}</div>
+    );
+  }
+
   return (
     <div className="meb-confirmation-page meb-confirmation-page_approved">
       <va-alert status="success">
@@ -24,11 +51,11 @@ export default function ConfirmationApproved({
           download
           href={LETTER_URL}
           text="Download your Certificate of Eligibility"
-          class="vads-u-padding-bottom--2"
+          className="vads-u-padding-bottom--2"
         />
         <br />
         <br />
-        <a href="https://www.va.gov/education/gi-bill/post-9-11/ch-33-benefit/ ">
+        <a href="https://www.va.gov/education/gi-bill/post-9-11/ch-33-benefit/">
           View a statement of your benefits
         </a>
       </va-alert>
@@ -40,13 +67,13 @@ export default function ConfirmationApproved({
           <dt>Date received</dt>
           <dd>{confirmationDate}</dd>
         </dl>
-        <button
+        <va-button
           className="usa-button meb-print"
-          onClick={printPage}
+          onClick={() => window.print()}
           type="button"
         >
           Print this page
-        </button>
+        </va-button>
       </div>
 
       <h2>What happens next?</h2>
@@ -59,7 +86,7 @@ export default function ConfirmationApproved({
         </li>
         <li>
           Use our{' '}
-          <a href="/education/gi-bill-comparison-tool/ ">
+          <a href="/education/gi-bill-comparison-tool/">
             GI Bill Comparison Tool
           </a>{' '}
           to help you decide which education program and school is best for you.
@@ -75,11 +102,7 @@ export default function ConfirmationApproved({
         </li>
         <li>
           Learn more about VA benefits and programs through the{' '}
-          <a
-            href="https://blogs.va.gov/VAntage/78073/new-guide-series-provides-gi-bill-benefits-information/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <a href="https://blogs.va.gov/VAntage/78073/new-guide-series-provides-gi-bill-benefits-information/">
             Building Your Future with the GI Bill Series
           </a>
           .
@@ -109,10 +132,16 @@ export default function ConfirmationApproved({
       <FormFooter />
     </div>
   );
-}
+};
 
 ConfirmationApproved.propTypes = {
   claimantName: PropTypes.string.isRequired,
   confirmationDate: PropTypes.string.isRequired,
-  printPage: PropTypes.func.isRequired,
+  confirmationError: PropTypes.bool.isRequired,
+  confirmationLoading: PropTypes.bool.isRequired,
+  sendConfirmation: PropTypes.func.isRequired,
+  userEmail: PropTypes.string.isRequired,
+  userFirstName: PropTypes.string.isRequired,
 };
+
+export default ConfirmationApproved;

--- a/src/applications/my-education-benefits/components/confirmation/ConfirmationApproved.jsx
+++ b/src/applications/my-education-benefits/components/confirmation/ConfirmationApproved.jsx
@@ -45,13 +45,13 @@ const ConfirmationApproved = ({
           We reviewed your application and have determined that you are entitled
           to educational benefits under the Post-9/11 GI Bill. Your Certificate
           of Eligibility is now available. A physical copy will also be mailed
-          to your mailing address.
+          to your mailing address.{' '}
         </p>
         <va-link
           download
           href={LETTER_URL}
           text="Download your Certificate of Eligibility"
-          className="vads-u-padding-bottom--2"
+          class="vads-u-padding-bottom--2"
         />
         <br />
         <br />
@@ -102,7 +102,11 @@ const ConfirmationApproved = ({
         </li>
         <li>
           Learn more about VA benefits and programs through the{' '}
-          <a href="https://blogs.va.gov/VAntage/78073/new-guide-series-provides-gi-bill-benefits-information/">
+          <a
+            href="https://blogs.va.gov/VAntage/78073/new-guide-series-provides-gi-bill-benefits-information/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Building Your Future with the GI Bill Series
           </a>
           .

--- a/src/applications/my-education-benefits/components/confirmation/ConfirmationDenied.jsx
+++ b/src/applications/my-education-benefits/components/confirmation/ConfirmationDenied.jsx
@@ -9,6 +9,7 @@ const ConfirmationDenied = ({
   confirmationDate,
   confirmationError,
   confirmationLoading,
+  form1990mebConfirmationEmail,
   printPage,
   sendConfirmation,
   userEmail,
@@ -16,14 +17,20 @@ const ConfirmationDenied = ({
 }) => {
   useEffect(
     () => {
-      sendConfirmation({
-        claimStatus: 'DENIED',
-        email: userEmail,
-        firstName: userFirstName,
-      });
+      if (form1990mebConfirmationEmail) {
+        sendConfirmation({
+          claimStatus: 'DENIED',
+          email: userEmail,
+          firstName: userFirstName,
+        });
+      }
     },
-    [sendConfirmation, userEmail, userFirstName],
+    [sendConfirmation, userEmail, userFirstName, form1990mebConfirmationEmail],
   );
+
+  if (confirmationLoading) {
+    return <LoadingIndicator message="Sending confirmation email..." />;
+  }
 
   if (confirmationLoading) {
     return <LoadingIndicator message="Sending confirmation email..." />;
@@ -104,6 +111,7 @@ const ConfirmationDenied = ({
 ConfirmationDenied.propTypes = {
   claimantName: PropTypes.string.isRequired,
   confirmationDate: PropTypes.string.isRequired,
+  form1990mebConfirmationEmail: PropTypes.bool.isRequired,
   printPage: PropTypes.func.isRequired,
   sendConfirmation: PropTypes.func.isRequired,
   userEmail: PropTypes.string.isRequired,

--- a/src/applications/my-education-benefits/components/confirmation/ConfirmationDenied.jsx
+++ b/src/applications/my-education-benefits/components/confirmation/ConfirmationDenied.jsx
@@ -45,7 +45,7 @@ const ConfirmationDenied = ({
         <p>
           Your denial letter, which explains why you are ineligible, is now
           available. A physical copy will also be mailed to your mailing
-          address.
+          address.{' '}
         </p>
         <a
           type="button"

--- a/src/applications/my-education-benefits/components/confirmation/ConfirmationDenied.jsx
+++ b/src/applications/my-education-benefits/components/confirmation/ConfirmationDenied.jsx
@@ -9,7 +9,6 @@ const ConfirmationDenied = ({
   confirmationDate,
   confirmationError,
   confirmationLoading,
-  form1990mebConfirmationEmail,
   printPage,
   sendConfirmation,
   userEmail,
@@ -17,15 +16,13 @@ const ConfirmationDenied = ({
 }) => {
   useEffect(
     () => {
-      if (form1990mebConfirmationEmail) {
-        sendConfirmation({
-          claimStatus: 'DENIED',
-          email: userEmail,
-          firstName: userFirstName,
-        });
-      }
+      sendConfirmation({
+        claimStatus: 'DENIED',
+        email: userEmail,
+        firstName: userFirstName,
+      });
     },
-    [sendConfirmation, userEmail, userFirstName, form1990mebConfirmationEmail],
+    [sendConfirmation, userEmail, userFirstName],
   );
 
   if (confirmationLoading) {
@@ -111,7 +108,6 @@ const ConfirmationDenied = ({
 ConfirmationDenied.propTypes = {
   claimantName: PropTypes.string.isRequired,
   confirmationDate: PropTypes.string.isRequired,
-  form1990mebConfirmationEmail: PropTypes.bool.isRequired,
   printPage: PropTypes.func.isRequired,
   sendConfirmation: PropTypes.func.isRequired,
   userEmail: PropTypes.string.isRequired,

--- a/src/applications/my-education-benefits/components/confirmation/ConfirmationDenied.jsx
+++ b/src/applications/my-education-benefits/components/confirmation/ConfirmationDenied.jsx
@@ -9,6 +9,7 @@ const ConfirmationDenied = ({
   confirmationDate,
   confirmationError,
   confirmationLoading,
+  printPage,
   sendConfirmation,
   userEmail,
   userFirstName,
@@ -65,12 +66,11 @@ const ConfirmationDenied = ({
           <dd>{confirmationDate}</dd>
         </dl>
         <va-button
+          uswds
           className="usa-button meb-print"
-          onClick={() => window.print()}
-          type="button"
-        >
-          Print this page
-        </va-button>
+          text="Print this page"
+          onClick={printPage}
+        />
       </div>
 
       <h2>What happens next?</h2>
@@ -104,11 +104,17 @@ const ConfirmationDenied = ({
 ConfirmationDenied.propTypes = {
   claimantName: PropTypes.string.isRequired,
   confirmationDate: PropTypes.string.isRequired,
-  confirmationError: PropTypes.bool.isRequired,
-  confirmationLoading: PropTypes.bool.isRequired,
+  printPage: PropTypes.func.isRequired,
   sendConfirmation: PropTypes.func.isRequired,
   userEmail: PropTypes.string.isRequired,
   userFirstName: PropTypes.string.isRequired,
+  confirmationError: PropTypes.bool,
+  confirmationLoading: PropTypes.bool,
+};
+
+ConfirmationDenied.defaultProps = {
+  confirmationError: null,
+  confirmationLoading: false,
 };
 
 export default ConfirmationDenied;

--- a/src/applications/my-education-benefits/components/confirmation/ConfirmationDenied.jsx
+++ b/src/applications/my-education-benefits/components/confirmation/ConfirmationDenied.jsx
@@ -1,13 +1,38 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { LETTER_URL } from '../../constants';
+import LoadingIndicator from '../LoadingIndicator';
 import FormFooter from '../FormFooter';
 
-export default function ConfirmationDenied({
+const ConfirmationDenied = ({
   claimantName,
   confirmationDate,
-  printPage,
-}) {
+  confirmationError,
+  confirmationLoading,
+  sendConfirmation,
+  userEmail,
+  userFirstName,
+}) => {
+  useEffect(
+    () => {
+      sendConfirmation({
+        claimStatus: 'DENIED',
+        email: userEmail,
+        firstName: userFirstName,
+      });
+    },
+    [sendConfirmation, userEmail, userFirstName],
+  );
+
+  if (confirmationLoading) {
+    return <LoadingIndicator message="Sending confirmation email..." />;
+  }
+
+  if (confirmationError) {
+    return (
+      <div>Error sending confirmation email: {confirmationError.message}</div>
+    );
+  }
   return (
     <div className="meb-confirmation-page meb-confirmation-page_denied">
       <va-alert status="info">
@@ -20,7 +45,7 @@ export default function ConfirmationDenied({
         <p>
           Your denial letter, which explains why you are ineligible, is now
           available. A physical copy will also be mailed to your mailing
-          address.{' '}
+          address.
         </p>
         <a
           type="button"
@@ -39,13 +64,13 @@ export default function ConfirmationDenied({
           <dt>Date received</dt>
           <dd>{confirmationDate}</dd>
         </dl>
-        <button
+        <va-button
           className="usa-button meb-print"
-          onClick={printPage}
+          onClick={() => window.print()}
           type="button"
         >
           Print this page
-        </button>
+        </va-button>
       </div>
 
       <h2>What happens next?</h2>
@@ -74,10 +99,16 @@ export default function ConfirmationDenied({
       <FormFooter />
     </div>
   );
-}
+};
 
 ConfirmationDenied.propTypes = {
   claimantName: PropTypes.string.isRequired,
   confirmationDate: PropTypes.string.isRequired,
-  printPage: PropTypes.func.isRequired,
+  confirmationError: PropTypes.bool.isRequired,
+  confirmationLoading: PropTypes.bool.isRequired,
+  sendConfirmation: PropTypes.func.isRequired,
+  userEmail: PropTypes.string.isRequired,
+  userFirstName: PropTypes.string.isRequired,
 };
+
+export default ConfirmationDenied;

--- a/src/applications/my-education-benefits/components/confirmation/ConfirmationPending.jsx
+++ b/src/applications/my-education-benefits/components/confirmation/ConfirmationPending.jsx
@@ -8,6 +8,7 @@ const ConfirmationPending = ({
   confirmationDate,
   confirmationError,
   confirmationLoading,
+  form1990mebConfirmationEmail,
   printPage,
   sendConfirmation,
   userEmail,
@@ -15,13 +16,15 @@ const ConfirmationPending = ({
 }) => {
   useEffect(
     () => {
-      sendConfirmation({
-        claimStatus: 'IN_PROGRESS',
-        email: userEmail,
-        firstName: userFirstName,
-      });
+      if (form1990mebConfirmationEmail) {
+        sendConfirmation({
+          claimStatus: 'IN_PROGRESS',
+          email: userEmail,
+          firstName: userFirstName,
+        });
+      }
     },
-    [sendConfirmation, userEmail, userFirstName],
+    [sendConfirmation, userEmail, userFirstName, form1990mebConfirmationEmail],
   );
 
   if (confirmationLoading) {
@@ -128,6 +131,7 @@ const ConfirmationPending = ({
 ConfirmationPending.propTypes = {
   claimantName: PropTypes.string.isRequired,
   confirmationDate: PropTypes.string.isRequired,
+  form1990mebConfirmationEmail: PropTypes.bool.isRequired,
   printPage: PropTypes.func.isRequired,
   sendConfirmation: PropTypes.func.isRequired,
   userEmail: PropTypes.string.isRequired,

--- a/src/applications/my-education-benefits/components/confirmation/ConfirmationPending.jsx
+++ b/src/applications/my-education-benefits/components/confirmation/ConfirmationPending.jsx
@@ -1,14 +1,41 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import LoadingIndicator from '../LoadingIndicator';
 import FormFooter from '../FormFooter';
 
-export default function ConfirmationPending({
+const ConfirmationPending = ({
   claimantName,
   confirmationDate,
+  confirmationError,
+  confirmationLoading,
   printPage,
-}) {
+  sendConfirmation,
+  userEmail,
+  userFirstName,
+}) => {
+  useEffect(
+    () => {
+      sendConfirmation({
+        claimStatus: 'IN_PROGRESS',
+        email: userEmail,
+        firstName: userFirstName,
+      });
+    },
+    [sendConfirmation, userEmail, userFirstName],
+  );
+
+  if (confirmationLoading) {
+    return <LoadingIndicator message="Sending confirmation email..." />;
+  }
+
+  if (confirmationError) {
+    return (
+      <div>Error sending confirmation email: {confirmationError.message}</div>
+    );
+  }
+
   return (
-    <div className="meb-confirmation-page meb-confirmation-page_denied">
+    <div className="meb-confirmation-page meb-confirmation-page_pending">
       <va-alert status="success">
         <h3 slot="headline">We’ve received your application</h3>
         <p>
@@ -24,13 +51,13 @@ export default function ConfirmationPending({
           <dt>Date received</dt>
           <dd>{confirmationDate}</dd>
         </dl>
-        <button
+        <va-button
           className="usa-button meb-print"
           onClick={printPage}
           type="button"
         >
           Print this page
-        </button>
+        </va-button>
       </div>
 
       <h2>When will I hear back about my application?</h2>
@@ -40,9 +67,8 @@ export default function ConfirmationPending({
         <p>
           If more than a month has passed since you gave us your application and
           you haven’t heard back, please don’t apply again. Call our toll-free
-          Education Call Center at{' '}
-          <a href="tel:1-888-442-4551">1-888-442-4551</a> or{' '}
-          <a href="tel:001-918-781-5678">001-918-781-5678</a> if you are outside
+          Education Call Center at <va-telephone contact="8884424551" /> or{' '}
+          <va-telephone contact="9187815678" international /> if you are outside
           the U.S.
         </p>
       </div>
@@ -69,7 +95,7 @@ export default function ConfirmationPending({
         </li>
         <li>
           Use our{' '}
-          <a href="/education/gi-bill-comparison-tool/ ">
+          <a href="/education/gi-bill-comparison-tool/">
             GI Bill Comparison Tool
           </a>{' '}
           to help you decide which education program and school is best for you.
@@ -98,10 +124,17 @@ export default function ConfirmationPending({
       <FormFooter />
     </div>
   );
-}
+};
 
 ConfirmationPending.propTypes = {
   claimantName: PropTypes.string.isRequired,
   confirmationDate: PropTypes.string.isRequired,
+  confirmationError: PropTypes.bool.isRequired,
+  confirmationLoading: PropTypes.bool.isRequired,
   printPage: PropTypes.func.isRequired,
+  sendConfirmation: PropTypes.func.isRequired,
+  userEmail: PropTypes.string.isRequired,
+  userFirstName: PropTypes.string.isRequired,
 };
+
+export default ConfirmationPending;

--- a/src/applications/my-education-benefits/components/confirmation/ConfirmationPending.jsx
+++ b/src/applications/my-education-benefits/components/confirmation/ConfirmationPending.jsx
@@ -52,12 +52,11 @@ const ConfirmationPending = ({
           <dd>{confirmationDate}</dd>
         </dl>
         <va-button
+          uswds
           className="usa-button meb-print"
+          text="Print this page"
           onClick={printPage}
-          type="button"
-        >
-          Print this page
-        </va-button>
+        />
       </div>
 
       <h2>When will I hear back about my application?</h2>
@@ -129,12 +128,17 @@ const ConfirmationPending = ({
 ConfirmationPending.propTypes = {
   claimantName: PropTypes.string.isRequired,
   confirmationDate: PropTypes.string.isRequired,
-  confirmationError: PropTypes.bool.isRequired,
-  confirmationLoading: PropTypes.bool.isRequired,
   printPage: PropTypes.func.isRequired,
   sendConfirmation: PropTypes.func.isRequired,
   userEmail: PropTypes.string.isRequired,
   userFirstName: PropTypes.string.isRequired,
+  confirmationError: PropTypes.bool,
+  confirmationLoading: PropTypes.bool,
+};
+
+ConfirmationPending.defaultProps = {
+  confirmationError: null,
+  confirmationLoading: false,
 };
 
 export default ConfirmationPending;

--- a/src/applications/my-education-benefits/components/confirmation/ConfirmationPending.jsx
+++ b/src/applications/my-education-benefits/components/confirmation/ConfirmationPending.jsx
@@ -8,7 +8,6 @@ const ConfirmationPending = ({
   confirmationDate,
   confirmationError,
   confirmationLoading,
-  form1990mebConfirmationEmail,
   printPage,
   sendConfirmation,
   userEmail,
@@ -16,15 +15,13 @@ const ConfirmationPending = ({
 }) => {
   useEffect(
     () => {
-      if (form1990mebConfirmationEmail) {
-        sendConfirmation({
-          claimStatus: 'IN_PROGRESS',
-          email: userEmail,
-          firstName: userFirstName,
-        });
-      }
+      sendConfirmation({
+        claimStatus: 'IN_PROGRESS',
+        email: userEmail,
+        firstName: userFirstName,
+      });
     },
-    [sendConfirmation, userEmail, userFirstName, form1990mebConfirmationEmail],
+    [sendConfirmation, userEmail, userFirstName],
   );
 
   if (confirmationLoading) {
@@ -131,7 +128,6 @@ const ConfirmationPending = ({
 ConfirmationPending.propTypes = {
   claimantName: PropTypes.string.isRequired,
   confirmationDate: PropTypes.string.isRequired,
-  form1990mebConfirmationEmail: PropTypes.bool.isRequired,
   printPage: PropTypes.func.isRequired,
   sendConfirmation: PropTypes.func.isRequired,
   userEmail: PropTypes.string.isRequired,

--- a/src/applications/my-education-benefits/containers/ConfirmationPage.jsx
+++ b/src/applications/my-education-benefits/containers/ConfirmationPage.jsx
@@ -112,9 +112,9 @@ const mapStateToProps = state => ({
   userFirstName:
     state.user?.profile?.userFullName?.first ||
     state.form?.data[formFields.viewUserFullName]?.first,
-  confirmationLoading: state.confirmationLoading,
-  confirmationSuccess: state.confirmationSuccess,
-  confirmationError: state.confirmationError,
+  confirmationError: state.confirmationError || null,
+  confirmationLoading: state.confirmationLoading || false,
+  confirmationSuccess: state.confirmationSuccess || false,
 });
 const mapDispatchToProps = {
   getClaimStatus: fetchClaimStatus,
@@ -127,8 +127,6 @@ export default connect(
 )(ConfirmationPage);
 
 ConfirmationPage.propTypes = {
-  confirmationLoading: PropTypes.bool.isRequired,
-  confirmationSuccess: PropTypes.bool.isRequired,
   getClaimStatus: PropTypes.func.isRequired,
   sendConfirmation: PropTypes.func.isRequired,
   claimStatus: PropTypes.shape({
@@ -136,6 +134,8 @@ ConfirmationPage.propTypes = {
     receivedDate: PropTypes.string,
   }),
   confirmationError: PropTypes.object,
+  confirmationLoading: PropTypes.bool,
+  confirmationSuccess: PropTypes.bool,
   userEmail: PropTypes.string,
   userFirstName: PropTypes.string,
   userFullName: PropTypes.shape({
@@ -144,4 +144,10 @@ ConfirmationPage.propTypes = {
     last: PropTypes.string,
     suffix: PropTypes.string,
   }),
+};
+
+ConfirmationPage.defaultProps = {
+  confirmationError: null,
+  confirmationLoading: false,
+  confirmationSuccess: false,
 };

--- a/src/applications/my-education-benefits/containers/ConfirmationPage.jsx
+++ b/src/applications/my-education-benefits/containers/ConfirmationPage.jsx
@@ -28,7 +28,6 @@ export const ConfirmationPage = ({
   sendConfirmation,
   confirmationLoading,
   confirmationError,
-  form1990mebConfirmationEmail,
 }) => {
   useEffect(
     () => {
@@ -57,7 +56,6 @@ export const ConfirmationPage = ({
           confirmationDate={confirmationDate}
           confirmationError={confirmationError}
           confirmationLoading={confirmationLoading}
-          form1990mebConfirmationEmail={form1990mebConfirmationEmail}
           printPage={printPage}
           sendConfirmation={sendConfirmation}
           userEmail={userEmail}
@@ -72,7 +70,6 @@ export const ConfirmationPage = ({
           confirmationDate={confirmationDate}
           confirmationError={confirmationError}
           confirmationLoading={confirmationLoading}
-          form1990mebConfirmationEmail={form1990mebConfirmationEmail}
           printPage={printPage}
           sendConfirmation={sendConfirmation}
           userEmail={userEmail}
@@ -88,7 +85,6 @@ export const ConfirmationPage = ({
           confirmationDate={confirmationDate}
           confirmationError={confirmationError}
           confirmationLoading={confirmationLoading}
-          form1990mebConfirmationEmail={form1990mebConfirmationEmail}
           printPage={printPage}
           sendConfirmation={sendConfirmation}
           userEmail={userEmail}
@@ -119,8 +115,6 @@ const mapStateToProps = state => ({
   confirmationError: state.confirmationError || null,
   confirmationLoading: state.confirmationLoading || false,
   confirmationSuccess: state.confirmationSuccess || false,
-  form1990mebConfirmationEmail:
-    state.featureFlags?.form1990mebConfirmationEmail,
 });
 const mapDispatchToProps = {
   getClaimStatus: fetchClaimStatus,

--- a/src/applications/my-education-benefits/containers/ConfirmationPage.jsx
+++ b/src/applications/my-education-benefits/containers/ConfirmationPage.jsx
@@ -28,6 +28,7 @@ export const ConfirmationPage = ({
   sendConfirmation,
   confirmationLoading,
   confirmationError,
+  form1990mebConfirmationEmail,
 }) => {
   useEffect(
     () => {
@@ -56,6 +57,7 @@ export const ConfirmationPage = ({
           confirmationDate={confirmationDate}
           confirmationError={confirmationError}
           confirmationLoading={confirmationLoading}
+          form1990mebConfirmationEmail={form1990mebConfirmationEmail}
           printPage={printPage}
           sendConfirmation={sendConfirmation}
           userEmail={userEmail}
@@ -70,6 +72,7 @@ export const ConfirmationPage = ({
           confirmationDate={confirmationDate}
           confirmationError={confirmationError}
           confirmationLoading={confirmationLoading}
+          form1990mebConfirmationEmail={form1990mebConfirmationEmail}
           printPage={printPage}
           sendConfirmation={sendConfirmation}
           userEmail={userEmail}
@@ -85,6 +88,7 @@ export const ConfirmationPage = ({
           confirmationDate={confirmationDate}
           confirmationError={confirmationError}
           confirmationLoading={confirmationLoading}
+          form1990mebConfirmationEmail={form1990mebConfirmationEmail}
           printPage={printPage}
           sendConfirmation={sendConfirmation}
           userEmail={userEmail}
@@ -115,6 +119,8 @@ const mapStateToProps = state => ({
   confirmationError: state.confirmationError || null,
   confirmationLoading: state.confirmationLoading || false,
   confirmationSuccess: state.confirmationSuccess || false,
+  form1990mebConfirmationEmail:
+    state.featureFlags?.form1990mebConfirmationEmail,
 });
 const mapDispatchToProps = {
   getClaimStatus: fetchClaimStatus,

--- a/src/applications/my-education-benefits/helpers.js
+++ b/src/applications/my-education-benefits/helpers.js
@@ -829,3 +829,13 @@ export function customDirectDepositDescription() {
     </div>
   );
 }
+
+// utils/caseConverter.js
+export const toSnakeCase = obj => {
+  const result = {};
+  Object.keys(obj).forEach(key => {
+    const snakeKey = key.replace(/([A-Z])/g, '_$1').toLowerCase();
+    result[snakeKey] = obj[key];
+  });
+  return result;
+};

--- a/src/applications/my-education-benefits/reducers/index.js
+++ b/src/applications/my-education-benefits/reducers/index.js
@@ -17,6 +17,9 @@ import {
   FETCH_PERSONAL_INFORMATION,
   FETCH_DUPLICATE_CONTACT_INFO_SUCCESS,
   FETCH_DUPLICATE_CONTACT_INFO_FAILURE,
+  SEND_CONFIRMATION,
+  SEND_CONFIRMATION_SUCCESS,
+  SEND_CONFIRMATION_FAILURE,
   UPDATE_GLOBAL_EMAIL,
   UPDATE_GLOBAL_PHONE_NUMBER,
   ACKNOWLEDGE_DUPLICATE,
@@ -30,6 +33,9 @@ const initialState = {
   form: {
     data: {},
   },
+  confirmationLoading: false,
+  confirmationSuccess: false,
+  confirmationError: null,
   exclusionPeriods: null,
   exclusionPeriodsLoading: false,
   exclusionPeriodsError: null,
@@ -162,6 +168,27 @@ export default {
           duplicatePhone: action?.response?.data?.attributes?.phone,
         };
       case FETCH_DUPLICATE_CONTACT_INFO_FAILURE:
+      case SEND_CONFIRMATION:
+        return {
+          ...state,
+          confirmationLoading: true,
+          confirmationSuccess: false,
+          confirmationError: null,
+        };
+      case SEND_CONFIRMATION_SUCCESS:
+        return {
+          ...state,
+          confirmationLoading: false,
+          confirmationSuccess: true,
+          confirmationError: null,
+        };
+      case SEND_CONFIRMATION_FAILURE:
+        return {
+          ...state,
+          confirmationLoading: false,
+          confirmationSuccess: false,
+          confirmationError: action.errors,
+        };
       case UPDATE_GLOBAL_EMAIL:
         return {
           ...state,

--- a/src/applications/my-education-benefits/selectors/selectors.js
+++ b/src/applications/my-education-benefits/selectors/selectors.js
@@ -65,7 +65,4 @@ export const getAppData = state => ({
   dgiRudisillHideBenefitsSelectionStep: !!toggleValues(state)[
     FEATURE_FLAG_NAMES.dgiRudisillHideBenefitsSelectionStep
   ],
-  form1990mebConfirmationEmail: !!toggleValues(state)[
-    FEATURE_FLAG_NAMES.form1990mebConfirmationEmail
-  ],
 });

--- a/src/applications/my-education-benefits/selectors/selectors.js
+++ b/src/applications/my-education-benefits/selectors/selectors.js
@@ -65,4 +65,7 @@ export const getAppData = state => ({
   dgiRudisillHideBenefitsSelectionStep: !!toggleValues(state)[
     FEATURE_FLAG_NAMES.dgiRudisillHideBenefitsSelectionStep
   ],
+  form1990mebConfirmationEmail: !!toggleValues(state)[
+    FEATURE_FLAG_NAMES.form1990mebConfirmationEmail
+  ],
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary
Sends confirmation Email using the claim status of the applicant to designate the email template to send.

## Related issue(s)

![Screenshot 2024-07-26 at 4 45 04 PM](https://github.com/user-attachments/assets/7037ab63-eb0e-4b8f-9193-1f02232777eb)

## Testing done
Logged in as authenticated user and validated each scenario.

![Screenshot 2024-07-26 at 4 46 23 PM](https://github.com/user-attachments/assets/8155a51f-c5ab-4683-9d98-0b7a8644f03f)


## Screenshots
![image (7)](https://github.com/user-attachments/assets/70dfca22-b14a-489d-846e-b88dad651f23)
<img width="1668" alt="meb_eligible" src="https://github.com/user-attachments/assets/47529056-b02d-4ef6-b3d1-acc1ad3ab19b">


## What areas of the site does it impact?
Original Claims 1990 Form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [X] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

### :warning: Team Sites (only applies to modifications made to the VA.gov header) :warning:

- [ ] The vets-website header does not contain any web-components
- [ ] I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#local-dev) to test the injected header scenario
- [ ] I reached out in the `#sitewide-public-websites` Slack channel for questions

## Requested Feedback
