### PR TITLE
Small updates to remove set-output warnings

### DIFF
--- a/.github/workflows/daily-deploy-production.yml
+++ b/.github/workflows/daily-deploy-production.yml
@@ -173,7 +173,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@cd7d8d697e10461458bc61a30d094dc601a8b017
 
       - name: Configure AWS credentials (1)
         uses: ./.github/workflows/configure-aws-credentials

--- a/.github/workflows/e2e-stress-test.yml
+++ b/.github/workflows/e2e-stress-test.yml
@@ -106,7 +106,7 @@ jobs:
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
       - name: Init Dashboard Data Repo
-        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
+        uses: ./.github/workflows/init-data-repo
 
       - name: Set Up BigQuery Creds
         uses: ./.github/workflows/configure-bigquery
@@ -136,7 +136,7 @@ jobs:
           env_variable_name: VA_VSP_BOT_GITHUB_TOKEN
 
       - name: Init Dashboard Data Repo
-        uses: department-of-veterans-affairs/platform-release-tools-actions/init-data-repo@main
+        uses: ./.github/workflows/init-data-repo
 
       - name: Set Up BigQuery Creds
         uses: ./.github/workflows/configure-bigquery


### PR DESCRIPTION
## Summary

- Update github actions to remove set-output warnings
- This had been removed where we were using it, but some versions of third party actions had it still running under the hood
- The lighthouse action will be addressed via a separate ticket, as will the changed-files action.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/74672