### PR TITLE
Add OH direct schedule and request feature toggles

### DIFF
--- a/src/applications/vaos/redux/selectors.js
+++ b/src/applications/vaos/redux/selectors.js
@@ -110,3 +110,9 @@ export const selectFeatureRecentLocationsFilter = state =>
 
 export const selectFeatureMedReviewInstructions = state =>
   toggleValues(state).vaOnlineSchedulingMedReviewInstructions;
+
+export const selectFeatureOHDirectSchedule = state =>
+  toggleValues(state).vaOnlineSchedulingOHDirectSchedule;
+
+export const selectFeatureOHRequest = state =>
+  toggleValues(state).vaOnlineSchedulingOHRequest;

--- a/src/applications/vaos/utils/featureFlags.js
+++ b/src/applications/vaos/utils/featureFlags.js
@@ -28,6 +28,8 @@ module.exports = [
   { name: 'vaOnlineSchedulingAppointmentDetailsRedesign', value: true },
   { name: 'vaOnlineSchedulingCCDirectScheduling', value: false },
   { name: 'vaOnlineSchedulingRecentLocationsFilter', value: false },
+  { name: 'vaOnlineSchedulingOHDirectSchedule', value: false },
+  { name: 'vaOnlineSchedulingOHRequest', value: false },
   { name: 'selectFeaturePocTypeOfCare', value: true },
   { name: 'edu_section_103', value: true },
   { name: 'gibctEybBottomSheet', value: true },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -250,6 +250,8 @@
   "vaOnlineSchedulingCCDirectScheduling": "va_online_scheduling_cc_direct_scheduling",
   "vaOnlineSchedulingRecentLocationsFilter": "va_online_scheduling_recent_locations_filter",
   "vaOnlineSchedulingMedReviewInstructions": "va_online_scheduling_med_review_instructions",
+  "vaOnlineSchedulingOHDirectSchedule": "va_online_scheduling_OH_direct_schedule",
+  "vaOnlineSchedulingOHRequest": "va_online_scheduling_OH_request",
   "veteranOnboardingBetaFlow": "veteran_onboarding_beta_flow",
   "virtualAgentShowFloatingChatbot": "virtual_agent_show_floating_chatbot",
   "virtualAgentEnableParamErrorDetection": "virtual_agent_enable_param_error_detection",


### PR DESCRIPTION
## Summary
This PR add feature toggle `va_online_scheduling_OH_direct_schedule` and `va_online_scheduling_OH_request` for controlling Oracle Health request and direct scheduling workflows.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/89139

## Testing done
N/A

## Screenshots
N/A

## What areas of the site does it impact?
VAOS

## Acceptance criteria
- [x] The toggle is created for VAOS

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
