### PR TITLE
Add Prepare for Appointment section for Claim Exams

### DIFF
--- a/src/applications/vaos/components/layout/ClaimExamLayout.jsx
+++ b/src/applications/vaos/components/layout/ClaimExamLayout.jsx
@@ -8,12 +8,14 @@ import {
   AppointmentTime,
 } from '../../appointment-list/components/AppointmentDateTime';
 import { selectConfirmedAppointmentData } from '../../appointment-list/redux/selectors';
+import { selectFeatureMedReviewInstructions } from '../../redux/selectors';
 import DetailPageLayout, {
   When,
   What,
   Where,
   Section,
   ClinicOrFacilityPhone,
+  Prepare,
 } from './DetailPageLayout';
 import { APPOINTMENT_STATUS } from '../../utils/constants';
 import FacilityDirectionsLink from '../FacilityDirectionsLink';
@@ -38,6 +40,10 @@ export default function ClaimExamLayout({ data: appointment }) {
   } = useSelector(
     state => selectConfirmedAppointmentData(state, appointment),
     shallowEqual,
+  );
+
+  const featureMedReviewInstructions = useSelector(
+    selectFeatureMedReviewInstructions,
   );
 
   if (!appointment) return null;
@@ -159,6 +165,21 @@ export default function ClaimExamLayout({ data: appointment }) {
             </>
           )}
         </Section>
+      )}
+      {featureMedReviewInstructions && (
+        <Prepare>
+          <ul>
+            <li>You don't need to bring anything to your exam.</li>
+            <li>
+              If you have any new non-VA medical records (like records from a
+              recent surgery or illness), be sure to submit them before your
+              appointment.
+            </li>
+          </ul>
+          <NewTabAnchor href="https://www.va.gov/disability/va-claim-exam/">
+            Learn more about claim exam appointments
+          </NewTabAnchor>
+        </Prepare>
       )}
       {APPOINTMENT_STATUS.booked === status &&
         !isPastAppointment && (

--- a/src/applications/vaos/components/layout/DetailPageLayout.jsx
+++ b/src/applications/vaos/components/layout/DetailPageLayout.jsx
@@ -69,6 +69,13 @@ Where.propTypes = {
   heading: PropTypes.string,
 };
 
+export function Prepare({ children } = {}) {
+  return <Section heading="Prepare for your appointment">{children}</Section>;
+}
+Prepare.propTypes = {
+  children: PropTypes.node,
+};
+
 export function ClinicOrFacilityPhone({
   clinicPhone,
   clinicPhoneExtension,

--- a/src/applications/vaos/components/tests/ClaimExamLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/ClaimExamLayout.unit.spec.js
@@ -30,6 +30,7 @@ describe('VAOS Component: ClaimExamLayout', () => {
     },
     featureToggles: {
       vaOnlineSchedulingAppointmentDetailsRedesign: true,
+      vaOnlineSchedulingMedReviewInstructions: true,
     },
   };
 
@@ -332,6 +333,27 @@ describe('VAOS Component: ClaimExamLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
+          name: /Prepare for your appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(/You don't need to bring anything to your exam./i),
+      );
+      expect(
+        screen.getByText(
+          /If you have any new non-VA medical records \(like records from a recent surgery or illness\), be sure to submit them before your appointment./i,
+        ),
+      );
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/disability/va-claim-exam/"]',
+        ),
+      ).to.be.ok;
+      expect(screen.getByText(/Learn more about claim exam appointments/i));
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
           name: /Need to make changes/i,
         }),
       ).to.be.ok;
@@ -430,16 +452,38 @@ describe('VAOS Component: ClaimExamLayout', () => {
         }),
       );
 
-      expect(screen.container.querySelector('va-button[text="Print"]')).to.be
-        .ok;
       expect(
-        screen.container.querySelector('va-button[text="Cancel appointment"]'),
-      ).not.to.exist;
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Prepare for your appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(/You don't need to bring anything to your exam./i),
+      );
+      expect(
+        screen.getByText(
+          /If you have any new non-VA medical records \(like records from a recent surgery or illness\), be sure to submit them before your appointment./i,
+        ),
+      );
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/disability/va-claim-exam/"]',
+        ),
+      ).to.be.ok;
+      expect(screen.getByText(/Learn more about claim exam appointments/i));
+
       expect(
         screen.queryByRole('heading', {
           level: 2,
           name: /Need to make changes/i,
         }),
+      ).not.to.exist;
+
+      expect(screen.container.querySelector('va-button[text="Print"]')).to.be
+        .ok;
+      expect(
+        screen.container.querySelector('va-button[text="Cancel appointment"]'),
       ).not.to.exist;
     });
   });
@@ -528,6 +572,28 @@ describe('VAOS Component: ClaimExamLayout', () => {
           name: /Scheduling facility/i,
         }),
       );
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Prepare for your appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(/You don't need to bring anything to your exam./i),
+      );
+      expect(
+        screen.getByText(
+          /If you have any new non-VA medical records \(like records from a recent surgery or illness\), be sure to submit them before your appointment./i,
+        ),
+      );
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/disability/va-claim-exam/"]',
+        ),
+      ).to.be.ok;
+      expect(screen.getByText(/Learn more about claim exam appointments/i));
+
       expect(
         screen.queryByRole('heading', {
           level: 2,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Add "Prepare for your appointment" section to claim exam appointments.
- This feature is toggled by the Flipper flag `va_online_scheduling_med_review_instructions `
- Appointments (VAOS) team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85825

## Testing done

- Unit tests updated to account for the new content
- The new content (text and link) is verified locally with the feature toggle enabled

## Screenshots

New screenshots:

| Confirmed CE Appointment | Cancelled CE Appointment |
| ------ | ----- |
| <img height="1000" alt="image" src="https://github.com/user-attachments/assets/766824ab-70e9-4113-9b0e-7c5ce7be3f84"> | <img height="1000" alt="image" src="https://github.com/user-attachments/assets/0a9338df-5ef9-4988-bd53-552a457c0eca"> |

## What areas of the site does it impact?

N/A

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
