### PR TITLE
HLR & NOD | Review areas of disagreement to sentence format

### DIFF
--- a/src/applications/appeals/shared/content/areaOfDisagreement.jsx
+++ b/src/applications/appeals/shared/content/areaOfDisagreement.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import { getIssueName, getIssueDate } from '../utils/issues';
-import {
-  DISAGREEMENT_TYPES,
-  FORMAT_YMD_DATE_FNS,
-  FORMAT_READABLE_DATE_FNS,
-} from '../constants';
+import { FORMAT_YMD_DATE_FNS, FORMAT_READABLE_DATE_FNS } from '../constants';
 
 import { parseDate } from '../utils/dates';
+import { disagreeWith } from '../utils/areaOfDisagreement';
 
 export const errorMessages = {
   maxOtherEntry: max => `This field should be less than ${max} characters`,
@@ -78,18 +76,43 @@ export const issueTitle = (props = {}) => {
 };
 
 // Only show set values (ignore false & undefined)
-export const AreaOfDisagreementReviewField = ({ children }) => {
-  const { formData, name } = children?.props || {};
-  const hidden = name === 'otherEntry';
-  return formData ? (
-    <div className="review-row">
-      <dt>{DISAGREEMENT_TYPES[name]}</dt>
-      <dd
-        className={hidden ? 'dd-privacy-hidden' : ''}
-        data-dd-action-name={hidden ? 'something else' : ''}
-      >
-        {children}
-      </dd>
-    </div>
-  ) : null;
+export const AreaOfDisagreementReviewField = props => {
+  const { defaultEditButton, formData } = props;
+
+  if (!getIssueName(formData)) {
+    return null;
+  }
+
+  // Not using props.title since it's a React component and can't be used in the
+  // edit button label
+  const plainTitle = getIssueTitle(formData, { plainText: true });
+  const list = disagreeWith(formData, { prefix: '' });
+  return (
+    <>
+      <div className="form-review-panel-page-header-row">
+        <h4 className="form-review-panel-page-header vads-u-font-size--h5">
+          {plainTitle}
+        </h4>
+        <div className="vads-u-justify-content--flex-end">
+          {defaultEditButton({ label: `Edit ${plainTitle}` })}
+        </div>
+      </div>
+      <dl className="review">
+        <div className="review-row">
+          <dt>What you disagree with</dt>
+          <dd
+            className="dd-privacy-hidden"
+            data-dd-action-name="Areas of disagreement"
+          >
+            {list}
+          </dd>
+        </div>
+      </dl>
+    </>
+  );
+};
+
+AreaOfDisagreementReviewField.propTypes = {
+  defaultEditButton: PropTypes.any,
+  formData: PropTypes.shape({}),
 };

--- a/src/applications/appeals/shared/pages/areaOfDisagreement.js
+++ b/src/applications/appeals/shared/pages/areaOfDisagreement.js
@@ -28,6 +28,7 @@ export default {
         'ui:errorMessages': {
           required: errorMessages.missingDisagreement,
         },
+        'ui:objectViewField': AreaOfDisagreementReviewField,
         'ui:options': {
           itemAriaLabel: data => getIssueTitle(data, { plainText: true }),
         },
@@ -36,22 +37,28 @@ export default {
           'ui:title': content.disagreementLegend,
           serviceConnection: {
             'ui:title': DISAGREEMENT_TYPES.serviceConnection,
-            'ui:reviewField': AreaOfDisagreementReviewField,
+            'ui:options': {
+              hideOnReview: true,
+            },
           },
           effectiveDate: {
             'ui:title': DISAGREEMENT_TYPES.effectiveDate,
-            'ui:reviewField': AreaOfDisagreementReviewField,
+            'ui:options': {
+              hideOnReview: true,
+            },
           },
           evaluation: {
             'ui:title': DISAGREEMENT_TYPES.evaluation,
-            'ui:reviewField': AreaOfDisagreementReviewField,
+            'ui:options': {
+              hideOnReview: true,
+            },
           },
         },
         otherEntry: {
           'ui:title': DISAGREEMENT_TYPES.otherEntry,
-          'ui:reviewField': AreaOfDisagreementReviewField,
           'ui:description': content.otherEntryHint,
           'ui:options': {
+            hideOnReview: true,
             updateSchema: (formData, _schema, _uiSchema, index) => ({
               type: 'string',
               maxLength: calculateOtherMaxLength(

--- a/src/applications/appeals/shared/tests/content/areaOfDisagreement.unit.spec.jsx
+++ b/src/applications/appeals/shared/tests/content/areaOfDisagreement.unit.spec.jsx
@@ -82,46 +82,70 @@ describe('issueTitle', () => {
 });
 
 describe('AreaOfDisagreementReviewField', () => {
-  it('should render AreaOfDisagreementReviewField', () => {
-    const title = 'Your evaluation of my condition';
-    const { container } = render(
-      <AreaOfDisagreementReviewField>
-        {React.createElement(
-          'div',
-          {
-            id: 'foo',
-            name: 'evaluation',
-            formData: {},
-          },
-          'Bar',
-        )}
-      </AreaOfDisagreementReviewField>,
+  const defaultEditButton = ({ label }) => (
+    <va-button text="edit" label={label} />
+  );
+  const setup = (
+    issue,
+    decisionDate,
+    serviceConnection = false,
+    effectiveDate = false,
+    evaluation = false,
+    otherEntry = false,
+  ) => {
+    const formData = {
+      issue,
+      decisionDate,
+      disagreementOptions: { serviceConnection, effectiveDate, evaluation },
+      otherEntry,
+    };
+    return render(
+      <div>
+        <AreaOfDisagreementReviewField
+          formData={formData}
+          defaultEditButton={defaultEditButton}
+        />
+      </div>,
     );
-    expect($('dt', container).textContent).to.equal(title);
-    expect($('dd', container).textContent).to.equal('Bar');
-    expect(
-      $$('dd.dd-privacy-hidden[data-dd-action-name]', container).length,
-    ).to.equal(0);
+  };
+
+  it('should not render AreaOfDisagreementReviewField when issue name is missing', () => {
+    const { container } = setup('', '2020-01-01', true);
+
+    expect($('h4', container)).to.not.exist;
+    expect(container.innerHTML).to.eq('<div></div>');
+  });
+  it('should render AreaOfDisagreementReviewField with service connection only', () => {
+    const { container } = setup('Headaches', '2020-01-01', true);
+
+    expect($('h4', container).textContent).to.equal(
+      'Disagreement with Headaches decision on January 1, 2020',
+    );
+
+    expect($('dt', container).textContent).to.equal('What you disagree with');
+    expect($('dd', container).textContent).to.equal('the service connection');
   });
 
-  it('should render AreaOfDisagreementReviewField with hidden Datadog class', () => {
-    const title = 'Something else';
-    const { container } = render(
-      <AreaOfDisagreementReviewField>
-        {React.createElement(
-          'div',
-          {
-            id: 'foo',
-            name: 'otherEntry',
-            formData: {},
-          },
-          'Bar',
-        )}
-      </AreaOfDisagreementReviewField>,
+  it('should render AreaOfDisagreementReviewField with everything selected & hidden Datadog class', () => {
+    const { container } = setup(
+      'Tinnitus',
+      '2023-03-03',
+      true,
+      true,
+      true,
+      'Lorem ipsum lorem ipsum lorem ipsu',
     );
-    expect($('dt', container).textContent).to.equal(title);
+
+    expect($('h4', container).textContent).to.equal(
+      'Disagreement with Tinnitus decision on March 3, 2023',
+    );
+
+    expect($('dt', container).textContent).to.equal('What you disagree with');
+    expect($('dd', container).textContent).to.equal(
+      'the service connection, the effective date of award, your evaluation of my condition, and Lorem ipsum lorem ipsum lorem ipsu',
+    );
     expect(
-      $('dd.dd-privacy-hidden[data-dd-action-name]', container).textContent,
-    ).to.equal('Bar');
+      $$('dd.dd-privacy-hidden[data-dd-action-name]', container).length,
+    ).to.equal(1);
   });
 });

--- a/src/applications/appeals/shared/tests/utils/areaOfDisagreement.unit.spec.js
+++ b/src/applications/appeals/shared/tests/utils/areaOfDisagreement.unit.spec.js
@@ -118,9 +118,9 @@ describe('disagreeWith', () => {
     otherEntry,
   });
   it('should return an empty list', () => {
-    expect(disagreeWith()).to.eq('Disagree with ');
-    expect(disagreeWith({})).to.eq('Disagree with ');
-    expect(disagreeWith(getData())).to.eq('Disagree with ');
+    expect(disagreeWith()).to.eq('Disagree with');
+    expect(disagreeWith({})).to.eq('Disagree with');
+    expect(disagreeWith(getData())).to.eq('Disagree with');
   });
   it('should return a list of selected disagreements', () => {
     expect(disagreeWith(getData(true))).to.eq(
@@ -164,5 +164,15 @@ describe('disagreeWith', () => {
     expect(disagreeWith(getData(true, true, true, 'test 6'))).to.eq(
       'Disagree with the service connection, the effective date of award, your evaluation of my condition, and test 6',
     );
+  });
+  it('should return a list with custom prefix & trimmed string', () => {
+    expect(disagreeWith('', { prefix: 'prefix test' })).to.eq('prefix test');
+    expect(disagreeWith({}, { prefix: 'lorem ipsum   ' })).to.eq('lorem ipsum');
+    expect(
+      disagreeWith(getData(false, false, true), { prefix: 'Prefix: ' }),
+    ).to.eq('Prefix:  your evaluation of my condition');
+    expect(
+      disagreeWith(getData(false, false, false, 'other'), { prefix: '' }),
+    ).to.eq('other');
   });
 });

--- a/src/applications/appeals/shared/utils/areaOfDisagreement.js
+++ b/src/applications/appeals/shared/utils/areaOfDisagreement.js
@@ -71,7 +71,7 @@ export const calculateOtherMaxLength = areaOfDisagreement => {
   return MAX_LENGTH.DISAGREEMENT_REASON - stringLength;
 };
 
-export const disagreeWith = (data = {}) => {
+export const disagreeWith = (data = {}, { prefix = 'Disagree with' } = {}) => {
   const list = Object.keys(DISAGREEMENT_TYPES).map(type => {
     if (type === 'otherEntry') {
       return data?.otherEntry || '';
@@ -80,5 +80,5 @@ export const disagreeWith = (data = {}) => {
       ? DISAGREEMENT_TYPES[type]?.toLowerCase()
       : '';
   });
-  return `Disagree with ${readableList(list)}`;
+  return `${prefix} ${readableList(list)}`.trim();
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?

- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Changed the review page to list selected areas of disagreement in a sentence format instead of showing each checkbox label and showing that it was selected. See screenshots.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

[#88527](https://github.com/department-of-veterans-affairs/va.gov-team/issues/88527)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Review & submit page | <img width="500" alt="area of disagreement showing each checked checkbox label and 'selected' as the value. Unchecked values are not shown" src="https://github.com/user-attachments/assets/f13dc026-df18-4b16-bf55-b45aee83bb75"> | <img width="500" alt="area of disagreement updated to show 'what you disagree with' on the left and all checked checkbox labels as a sentence on the right" src="https://github.com/user-attachments/assets/c75db4e1-fef4-4b9c-a5ea-c9fc591313e0"> |

## What areas of the site does it impact?

Higher-Level Review & Notice of Disagreement

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
