### PR TITLE
89380 Improve Primary Contact - form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-10D/config/submitTransformer.js
@@ -101,6 +101,11 @@ function getPrimaryContact(data) {
   const useCert =
     data?.certification?.firstName && data?.certification?.firstName !== '';
 
+  // Either the first applicant with an email address, or the first applicant
+  const primaryApp =
+    data?.applicants?.filter(app => app.email && app.email.length > 0)[0] ??
+    data?.applicants?.[0];
+
   // Depending on the result of useCert, grab the first and last name, phone,
   // and email from either the `certification` object or the first applicant,
   // then return so we can set up the `primaryContactInfo` for the backend
@@ -110,19 +115,16 @@ function getPrimaryContact(data) {
       first:
         (useCert
           ? data?.certification?.firstName
-          : data?.applicants?.[0]?.fullName?.first) ?? false,
+          : primaryApp?.fullName?.first) ?? false,
       last:
         (useCert
           ? data?.certification?.lastName
-          : data?.applicants?.[0]?.fullName?.last) ?? false,
+          : primaryApp?.fullName?.last) ?? false,
     },
-    email:
-      (useCert ? data?.certification?.email : data?.applicants?.[0]?.email) ??
-      false,
+    email: (useCert ? data?.certification?.email : primaryApp?.email) ?? false,
     phone:
-      (useCert
-        ? data?.certification?.phoneNumber
-        : data?.applicants?.[0]?.phoneNumber) ?? false,
+      (useCert ? data?.certification?.phoneNumber : primaryApp?.phoneNumber) ??
+      false,
   };
 }
 

--- a/src/applications/ivc-champva/10-10D/tests/unit/config/submitTransformer.unit.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/unit/config/submitTransformer.unit.spec.js
@@ -122,7 +122,7 @@ describe('transform for submit', () => {
       certifierCert.data.certifierPhone,
     );
   });
-  it('should set first applicant info as primary contact if certifierRole == applicant', () => {
+  it('should set first applicant info as primary contact if no applicants have an email address and certifierRole == applicant', () => {
     const appCert = {
       data: {
         certifierRole: 'applicant',
@@ -131,6 +131,11 @@ describe('transform for submit', () => {
             applicantAddress: {},
             applicantName: { first: 'Jack', last: 'Applicant' },
             applicantPhone: '1231231234',
+          },
+          {
+            applicantAddress: {},
+            applicantName: { first: 'John', last: 'Applicant' },
+            applicantPhone: '555333222',
           },
         ],
       },
@@ -151,5 +156,44 @@ describe('transform for submit', () => {
       transformForSubmit(formConfig, { data: {} }),
     );
     expect(transformed.primaryContactInfo.name.first).to.be.false;
+  });
+  it('should set primary contact to first applicant with an email if certifierRole == applicant', () => {
+    const appCert = {
+      data: {
+        certifierRole: 'applicant',
+        applicants: [
+          {
+            applicantAddress: {},
+            applicantName: { first: 'First', last: 'Applicant' },
+            applicantPhone: '5554443333',
+          },
+          {
+            applicantAddress: {},
+            applicantName: { first: 'Second', last: 'Applicant' },
+            applicantPhone: '1112223333',
+            applicantEmailAddress: 'second@applicant.com',
+          },
+          {
+            applicantAddress: {},
+            applicantName: { first: 'Third', last: 'Applicant' },
+            applicantPhone: '5552223333',
+            applicantEmailAddress: 'third@applicant.com',
+          },
+        ],
+      },
+    };
+    const transformed = JSON.parse(transformForSubmit(formConfig, appCert));
+    expect(transformed.primaryContactInfo.name.first).to.equal(
+      appCert.data.applicants[1].applicantName.first,
+    );
+    expect(transformed.primaryContactInfo.name.last).to.equal(
+      appCert.data.applicants[1].applicantName.last,
+    );
+    expect(transformed.primaryContactInfo.phone).to.equal(
+      appCert.data.applicants[1].applicantPhone,
+    );
+    expect(transformed.primaryContactInfo.email).to.equal(
+      appCert.data.applicants[1].applicantEmailAddress,
+    );
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

Previously, when the primary contact for a form submission was set to an `applicant`, we defaulted to the first applicant. Now, we set it to the first applicant _with an email address_, and if none are found, then we default back to the first applicant overall.

- Updated submit transformer
- Added unit test
- Team: IVC CHAMPVA
- Flipper: Yes

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89380

## Testing done

- Unit

## Screenshots

NA

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA