### PR TITLE
Simple Forms - Add alerts when uploaded PDF is wrong number of pages (21-0779)

### DIFF
--- a/src/applications/simple-forms/form-upload/config/constants.js
+++ b/src/applications/simple-forms/form-upload/config/constants.js
@@ -1,3 +1,4 @@
+import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import React from 'react';
 
 export const PrimaryActionLink = ({ href = '/', children, onClick = null }) => (
@@ -27,6 +28,50 @@ export const UPLOAD_GUIDELINES = Object.freeze(
     </div>
   </>,
 );
+
+export const ALERT_TOO_MANY_PAGES = formNumber =>
+  Object.freeze(
+    <VaAlert
+      close-btn-aria-label="Close notification"
+      status="warning"
+      visible
+      closeable
+    >
+      <h2 slot="headline">
+        Are you sure the file you uploaded is VA Form {formNumber}?
+      </h2>
+      <React.Fragment key=".1">
+        <p className="vads-u-margin-y--0">
+          The file you uploaded has more pages than the form usually has. Please
+          check the file you uploaded is a recent VA Form {formNumber}.
+        </p>
+        <p>LINK HERE!</p>
+        <p>If you’re sure this is the right file, you can continue.</p>
+      </React.Fragment>
+    </VaAlert>,
+  );
+
+export const ALERT_TOO_FEW_PAGES = formNumber =>
+  Object.freeze(
+    <VaAlert
+      close-btn-aria-label="Close notification"
+      status="warning"
+      visible
+      closeable
+    >
+      <h2 slot="headline">
+        Are you sure the file you uploaded is VA Form {formNumber}?
+      </h2>
+      <React.Fragment key=".1">
+        <p className="vads-u-margin-y--0">
+          The file you uploaded has fewer pages than the original form. Please
+          check your uploaded form to be sure it is the correct form.
+        </p>
+        <p>LINK HERE!</p>
+        <p>If you’re sure this is the right file, you can continue.</p>
+      </React.Fragment>
+    </VaAlert>,
+  );
 
 export const SAVE_IN_PROGRESS_CONFIG = {
   messages: {

--- a/src/applications/simple-forms/form-upload/helpers/index.js
+++ b/src/applications/simple-forms/form-upload/helpers/index.js
@@ -1,5 +1,6 @@
 import { srSubstitute } from '~/platform/forms-system/src/js/utilities/ui/mask-string';
 import { focusByOrder, scrollTo } from 'platform/utilities/ui';
+import * as pdfjsLib from 'pdfjs-dist/webpack.mjs';
 import {
   SUBTITLE_0779,
   CHILD_CONTENT_0779,
@@ -69,4 +70,27 @@ export const mask = value => {
     `●●●–●●–${number}`,
     `ending with ${number.split('').join(' ')}`,
   );
+};
+
+export const getOcrResults = async file => {
+  const pdf = await pdfjsLib.getDocument(URL.createObjectURL(file)).promise;
+  return pdf.numPages;
+};
+
+export const hideAlertTooManyPages = formData => {
+  const ocrResults = formData.uploadedFile?.ocrResults;
+  if (!ocrResults) {
+    return true;
+  }
+  // 2 is hardcoded here. When we go beyond 21-0779, make this flexible
+  return ocrResults <= 2;
+};
+
+export const hideAlertTooFewPages = formData => {
+  const ocrResults = formData.uploadedFile?.ocrResults;
+  if (!ocrResults) {
+    return true;
+  }
+  // 2 is hardcoded here. When we go beyond 21-0779, make this flexible
+  return ocrResults >= 2;
 };

--- a/src/applications/simple-forms/form-upload/pages/upload.jsx
+++ b/src/applications/simple-forms/form-upload/pages/upload.jsx
@@ -3,8 +3,16 @@ import {
   fileInputSchema,
 } from '~/platform/forms-system/src/js/web-component-patterns';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
-import { UPLOAD_GUIDELINES } from '../config/constants';
-import { getFormContent } from '../helpers';
+import {
+  UPLOAD_GUIDELINES,
+  ALERT_TOO_MANY_PAGES,
+  ALERT_TOO_FEW_PAGES,
+} from '../config/constants';
+import {
+  getFormContent,
+  hideAlertTooManyPages,
+  hideAlertTooFewPages,
+} from '../helpers';
 
 const { formNumber, title } = getFormContent();
 
@@ -24,6 +32,18 @@ export const uploadPage = {
         required: () => true,
       }),
     },
+    'view:alertTooManyPages': {
+      'ui:description': ALERT_TOO_MANY_PAGES(formNumber),
+      'ui:options': {
+        hideIf: formData => hideAlertTooManyPages(formData),
+      },
+    },
+    'view:alertTooFewPages': {
+      'ui:description': ALERT_TOO_FEW_PAGES(formNumber),
+      'ui:options': {
+        hideIf: formData => hideAlertTooFewPages(formData),
+      },
+    },
   },
   schema: {
     type: 'object',
@@ -33,6 +53,14 @@ export const uploadPage = {
         properties: {},
       },
       uploadedFile: fileInputSchema,
+      'view:alertTooManyPages': {
+        type: 'object',
+        properties: {},
+      },
+      'view:alertTooFewPages': {
+        type: 'object',
+        properties: {},
+      },
     },
     required: ['uploadedFile'],
   },

--- a/src/platform/forms-system/src/js/web-component-fields/VaFileInputField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaFileInputField.jsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { setData } from 'platform/forms-system/src/js/actions';
 import { VaFileInput } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { getOcrResults } from '~/applications/simple-forms/form-upload/helpers';
 import vaFileInputFieldMapping from './vaFileInputFieldMapping';
 import { areFilesEqual, uploadScannedForm } from './vaFileInputFieldHelpers';
 
@@ -43,9 +44,17 @@ const VaFileInputField = props => {
   const { fileUploadUrl } = mappedProps;
 
   const onFileUploaded = useCallback(
-    uploadedFile => {
-      if (uploadedFile.confirmationCode) {
-        props.childrenProps.onChange(uploadedFile);
+    async uploadedFile => {
+      const { confirmationCode } = uploadedFile;
+      if (confirmationCode) {
+        const ocrResults = await getOcrResults(uploadedFile.file);
+        const { name, size } = uploadedFile.file;
+        props.childrenProps.onChange({
+          name,
+          size,
+          confirmationCode,
+          ocrResults,
+        });
       }
     },
     [props.childrenProps],


### PR DESCRIPTION
## Summary
This is the second part of a two-part series of PRs. Part 1 is here: https://github.com/department-of-veterans-affairs/vets-website/pull/31047

This PR adds warning alerts in case the uploaded file has either too many or too few pages, per the expectation from the template PDF.

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1276
