### PR TITLE
Add Prepare for Appointment section for phone appointments

### DIFF
--- a/src/applications/vaos/components/layout/PhoneLayout.jsx
+++ b/src/applications/vaos/components/layout/PhoneLayout.jsx
@@ -3,12 +3,14 @@ import PropTypes from 'prop-types';
 import { shallowEqual } from 'recompose';
 import { useSelector } from 'react-redux';
 import { selectConfirmedAppointmentData } from '../../appointment-list/redux/selectors';
+import { selectFeatureMedReviewInstructions } from '../../redux/selectors';
 import DetailPageLayout, {
   Section,
   What,
   When,
   Who,
   ClinicOrFacilityPhone,
+  Prepare,
 } from './DetailPageLayout';
 import { APPOINTMENT_STATUS } from '../../utils/constants';
 import {
@@ -35,6 +37,11 @@ export default function PhoneLayout({ data: appointment }) {
     state => selectConfirmedAppointmentData(state, appointment),
     shallowEqual,
   );
+
+  const featureMedReviewInstructions = useSelector(
+    selectFeatureMedReviewInstructions,
+  );
+
   const [reason, otherDetails] = comment ? comment?.split(':') : [];
   const oracleHealthProviderName = null;
 
@@ -102,6 +109,16 @@ export default function PhoneLayout({ data: appointment }) {
         <br />
         <span>Other details: {`${otherDetails || 'Not available'}`}</span>
       </Section>
+      {featureMedReviewInstructions && (
+        <Prepare>
+          Bring your insurance cards, a list of medications, and other things to
+          share with your provider.
+          <br />
+          <NewTabAnchor href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/">
+            Find out what to bring to your appointment
+          </NewTabAnchor>
+        </Prepare>
+      )}
     </DetailPageLayout>
   );
 }

--- a/src/applications/vaos/components/tests/PhoneLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/PhoneLayout.unit.spec.js
@@ -30,6 +30,7 @@ describe('VAOS Component: PhoneLayout', () => {
     },
     featureToggles: {
       vaOnlineSchedulingAppointmentDetailsRedesign: true,
+      vaOnlineSchedulingMedReviewInstructions: true,
     },
   };
 
@@ -262,6 +263,23 @@ describe('VAOS Component: PhoneLayout', () => {
       expect(screen.getByText(/Other details:/i));
       expect(screen.getByText(/Additional information/i));
 
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Prepare for your appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /Bring your insurance cards, a list of medications, and other things to share with your provider./i,
+        ),
+      );
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"]',
+        ),
+      ).to.be.ok;
+
       expect(screen.container.querySelector('va-button[text="Print"]'));
       expect(
         screen.container.querySelector('va-button[text="Cancel appointment"]'),
@@ -345,6 +363,23 @@ describe('VAOS Component: PhoneLayout', () => {
       expect(screen.getByText(/This is a test/i));
       expect(screen.getByText(/Other details:/i));
       expect(screen.getByText(/Additional information/i));
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Prepare for your appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /Bring your insurance cards, a list of medications, and other things to share with your provider./i,
+        ),
+      );
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"]',
+        ),
+      ).to.be.ok;
 
       expect(screen.container.querySelector('va-button[text="Print"]'));
       expect(
@@ -434,6 +469,23 @@ describe('VAOS Component: PhoneLayout', () => {
       expect(screen.getByText(/This is a test/i));
       expect(screen.getByText(/Other details:/i));
       expect(screen.getByText(/Additional information/i));
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Prepare for your appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /Bring your insurance cards, a list of medications, and other things to share with your provider./i,
+        ),
+      );
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"]',
+        ),
+      ).to.be.ok;
 
       expect(screen.container.querySelector('va-button[text="Print"]')).to.be
         .ok;
@@ -529,6 +581,23 @@ describe('VAOS Component: PhoneLayout', () => {
       expect(screen.getByText(/This is a test/i));
       expect(screen.getByText(/Other details:/i));
       expect(screen.getByText(/Additional information/i));
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Prepare for your appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /Bring your insurance cards, a list of medications, and other things to share with your provider./i,
+        ),
+      );
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"]',
+        ),
+      ).to.be.ok;
 
       expect(screen.container.querySelector('va-button[text="Print"]')).to.be
         .ok;

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -132,14 +132,141 @@
     }
 },
 {
-    "id": "e01555000d5c7ce9b754ea7ad8fa1d481298fec531ff43919734d31eb34ceb46",
+  "id": "e01555000d5c7ce9b754ea7ad8fa1d481298fec531ff43919734d31eb34ceb46",
+  "type": "appointments",
+  "attributes": {
+      "id": "e01555000d5c7ce9b754ea7ad8fa1d481298fec531ff43919734d31eb34ceb46",
+      "identifier": [
+          {
+              "system": "Appointment/",
+              "value": "4139383436333437"
+          },
+          {
+              "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+              "value": "984:6347"
+          }
+      ],
+      "kind": "phone",
+      "status": "booked",
+      "serviceCategory": [
+          {
+              "coding": [
+                  {
+                      "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                      "code": "REGULAR",
+                      "display": "REGULAR"
+                  }
+              ],
+              "text": "REGULAR"
+          }
+      ],
+      "patientIcn": "1013678363V916823",
+      "locationId": "984",
+      "clinic": "4570",
+      "practitioners": [
+          {
+              "identifier": [
+                  {
+                      "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
+                      "value": null
+                  }
+              ],
+              "name": {
+                  "family": "ISS",
+                  "given": [
+                      "PROVIDERONE"
+                  ]
+              }
+          }
+      ],
+      "start": "2024-12-05T18:00:00Z",
+      "end": "2024-12-05T18:15:00Z",
+      "minutesDuration": 15,
+      "slot": {
+          "id": "3230323331323035313830303A323032333132303531383135",
+          "start": "2024-12-05T18:00:00Z",
+          "end": "2024-12-05T18:15:00Z"
+      },
+      "created": "2024-11-28T00:00:00Z",
+      "cancellable": true,
+      "extension": {
+          "ccLocation": {
+              "address": {}
+          },
+          "vistaStatus": [
+              "NO ACTION TAKEN"
+          ],
+          "preCheckinAllowed": false,
+          "eCheckinAllowed": false,
+          "clinic": {
+              "physicalLocation": "DAYTSHR PHONE Provider",
+              "phoneNumber": "555-555-6551",
+              "phoneNumberExtension": "6001"
+          }
+      },
+      "localStartTime": "2024-12-05T13:00:00.000-05:00",
+      "serviceName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
+      "friendlyName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
+      "physicalLocation": "DAYTSHR PHONE Provider",
+      "location": {
+          "id": "984",
+          "type": "appointments",
+          "attributes": {
+              "id": "984",
+              "vistaSite": "984",
+              "vastParent": "984",
+              "type": "va_health_facility",
+              "name": "Dayton VA Medical Center",
+              "classification": "VA Medical Center (VAMC)",
+              "timezone": {
+                  "timeZoneId": "America/New_York"
+              },
+              "lat": 39.74935,
+              "long": -84.2532,
+              "website": "https://www.dayton.va.gov/locations/directions.asp",
+              "phone": {
+                  "main": "937-268-6511"
+              },
+              "physicalAddress": {
+                  "type": "physical",
+                  "line": [
+                      "4100 West Third Street"
+                  ],
+                  "city": "Dayton",
+                  "state": "OH",
+                  "postalCode": "45428-9000"
+              },
+              "healthService": [
+                  "Audiology",
+                  "Cardiology",
+                  "DentalServices",
+                  "Dermatology",
+                  "Gastroenterology",
+                  "Gynecology",
+                  "MentalHealthCare",
+                  "Nutrition",
+                  "Ophthalmology",
+                  "Optometry",
+                  "Orthopedics",
+                  "Podiatry",
+                  "PrimaryCare",
+                  "SpecialtyCare",
+                  "Urology",
+                  "WomensHealth"
+              ]
+          }
+      }
+  }
+},
+{
+    "id": "e01555000d5c7ce9b754ea7ad8fa1d481298fec531ff43919734d31eb34ceb47",
     "type": "appointments",
     "attributes": {
-        "id": "e01555000d5c7ce9b754ea7ad8fa1d481298fec531ff43919734d31eb34ceb46",
+        "id": "e01555000d5c7ce9b754ea7ad8fa1d481298fec531ff43919734d31eb34ceb47",
         "identifier": [
             {
                 "system": "Appointment/",
-                "value": "4139383436333437"
+                "value": "4139383436333438"
             },
             {
                 "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
@@ -147,7 +274,7 @@
             }
         ],
         "kind": "phone",
-        "status": "booked",
+        "status": "cancelled",
         "serviceCategory": [
             {
                 "coding": [
@@ -179,16 +306,16 @@
                 }
             }
         ],
-        "start": "2024-12-05T18:00:00Z",
-        "end": "2024-12-05T18:15:00Z",
+        "start": "2024-12-05T19:00:00Z",
+        "end": "2024-12-05T19:15:00Z",
         "minutesDuration": 15,
         "slot": {
             "id": "3230323331323035313830303A323032333132303531383135",
-            "start": "2024-12-05T18:00:00Z",
-            "end": "2024-12-05T18:15:00Z"
+            "start": "2024-12-05T19:00:00Z",
+            "end": "2024-12-05T19:15:00Z"
         },
         "created": "2024-11-28T00:00:00Z",
-        "cancellable": true,
+        "cancellable": false,
         "extension": {
             "ccLocation": {
                 "address": {}
@@ -204,7 +331,7 @@
                 "phoneNumberExtension": "6001"
             }
         },
-        "localStartTime": "2024-12-05T13:00:00.000-05:00",
+        "localStartTime": "2024-12-05T14:00:00.000-05:00",
         "serviceName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
         "friendlyName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
         "physicalLocation": "DAYTSHR PHONE Provider",
@@ -2154,7 +2281,7 @@
           }
         }
       }
-    }, 
+    },
     {
       "id": "193059",
       "type": "appointments",
@@ -2284,7 +2411,7 @@
           }
         }
       }
-    },          
+    },
     {
       "id": "115069",
       "type": "appointments",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Add "Prepare for your appointment" section to phone appointments.
- This feature is toggled by the Flipper flag `va_online_scheduling_med_review_instructions `
- Appointments (VAOS) team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/86473

## Testing done

- Unit tests updated to account for the new content
- The new content (text and link) is verified locally with the feature toggle enabled

## Screenshots

New screenshots:

| Confirmed Phone Appointment | Cancelled Phone Appointment |
| ------ | ----- |
| <img width="312" alt="image" src="https://github.com/user-attachments/assets/47ccfa9e-e425-4b83-9eb7-dde15a2ae169"> | <img width="311" alt="image" src="https://github.com/user-attachments/assets/0914da6b-7125-430f-8323-a63e296e481a"> |

## What areas of the site does it impact?

N/A

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
