### PR TITLE
Add Prepare for Appointment for In-person and Video at VA appointments

### DIFF
--- a/src/applications/vaos/components/layout/InPersonLayout.jsx
+++ b/src/applications/vaos/components/layout/InPersonLayout.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { shallowEqual } from 'recompose';
 import { useSelector } from 'react-redux';
 import { getRealFacilityId } from '../../utils/appointment';
-
+import { selectFeatureMedReviewInstructions } from '../../redux/selectors';
 import {
   AppointmentDate,
   AppointmentTime,
@@ -16,6 +16,7 @@ import DetailPageLayout, {
   Section,
   Who,
   ClinicOrFacilityPhone,
+  Prepare,
 } from './DetailPageLayout';
 import { APPOINTMENT_STATUS } from '../../utils/constants';
 import FacilityDirectionsLink from '../FacilityDirectionsLink';
@@ -40,6 +41,10 @@ export default function InPersonLayout({ data: appointment }) {
   } = useSelector(
     state => selectConfirmedAppointmentData(state, appointment),
     shallowEqual,
+  );
+
+  const featureMedReviewInstructions = useSelector(
+    selectFeatureMedReviewInstructions,
   );
 
   if (!appointment) return null;
@@ -135,6 +140,16 @@ export default function InPersonLayout({ data: appointment }) {
         <br />
         <span>Other details: {`${otherDetails || 'Not available'}`}</span>
       </Section>
+      {featureMedReviewInstructions && (
+        <Prepare>
+          Bring your insurance cards, a list of medications, and other things to
+          share with your provider.
+          <br />
+          <NewTabAnchor href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/">
+            Find out what to bring to your appointment
+          </NewTabAnchor>
+        </Prepare>
+      )}
     </DetailPageLayout>
   );
 }

--- a/src/applications/vaos/components/layout/VideoLayoutVA.jsx
+++ b/src/applications/vaos/components/layout/VideoLayoutVA.jsx
@@ -9,8 +9,10 @@ import DetailPageLayout, {
   When,
   Who,
   ClinicOrFacilityPhone,
+  Prepare,
 } from './DetailPageLayout';
 import { APPOINTMENT_STATUS } from '../../utils/constants';
+import { selectFeatureMedReviewInstructions } from '../../redux/selectors';
 import { selectConfirmedAppointmentData } from '../../appointment-list/redux/selectors';
 import {
   AppointmentDate,
@@ -38,6 +40,10 @@ export default function VideoLayoutVA({ data: appointment }) {
   } = useSelector(
     state => selectConfirmedAppointmentData(state, appointment),
     shallowEqual,
+  );
+
+  const featureMedReviewInstructions = useSelector(
+    selectFeatureMedReviewInstructions,
   );
 
   let heading = 'Video appointment at VA location';
@@ -124,6 +130,16 @@ export default function VideoLayoutVA({ data: appointment }) {
           facilityPhone={facilityPhone}
         />
       </Section>
+      {featureMedReviewInstructions && (
+        <Prepare>
+          Bring your insurance cards, a list of medications, and other things to
+          share with your provider.
+          <br />
+          <NewTabAnchor href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/">
+            Find out what to bring to your appointment
+          </NewTabAnchor>
+        </Prepare>
+      )}
       {APPOINTMENT_STATUS.booked === status &&
         !isPastAppointment && (
           <Section heading="Need to make changes?">

--- a/src/applications/vaos/components/tests/InPersonLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/InPersonLayout.unit.spec.js
@@ -30,6 +30,7 @@ describe('VAOS Component: InPersonLayout', () => {
     },
     featureToggles: {
       vaOnlineSchedulingAppointmentDetailsRedesign: true,
+      vaOnlineSchedulingMedReviewInstructions: true,
     },
   };
 
@@ -330,6 +331,24 @@ describe('VAOS Component: InPersonLayout', () => {
       expect(
         screen.getByRole('heading', {
           level: 2,
+          name: /Prepare for your appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /Bring your insurance cards, a list of medications, and other things to share with your provider./i,
+        ),
+      );
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"]',
+        ),
+      ).to.be.ok;
+      expect(screen.getByText(/Find out what to bring to your appointment/i));
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
           name: /Details you shared with your provider/i,
         }),
       );
@@ -410,6 +429,24 @@ describe('VAOS Component: InPersonLayout', () => {
       expect(
         screen.container.querySelector('va-telephone[contact="307-778-7550"]'),
       ).to.be.ok;
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Prepare for your appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /Bring your insurance cards, a list of medications, and other things to share with your provider./i,
+        ),
+      );
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"]',
+        ),
+      ).to.be.ok;
+      expect(screen.getByText(/Find out what to bring to your appointment/i));
 
       expect(
         screen.getByRole('heading', {
@@ -497,6 +534,24 @@ describe('VAOS Component: InPersonLayout', () => {
       expect(
         screen.container.querySelector('va-telephone[contact="500-500-5000"]'),
       ).to.be.ok;
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Prepare for your appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /Bring your insurance cards, a list of medications, and other things to share with your provider./i,
+        ),
+      );
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"]',
+        ),
+      ).to.be.ok;
+      expect(screen.getByText(/Find out what to bring to your appointment/i));
 
       expect(
         screen.getByRole('heading', {
@@ -590,6 +645,24 @@ describe('VAOS Component: InPersonLayout', () => {
       expect(
         screen.container.querySelector('va-telephone[contact="500-500-5000"]'),
       ).to.be.ok;
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Prepare for your appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /Bring your insurance cards, a list of medications, and other things to share with your provider./i,
+        ),
+      );
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"]',
+        ),
+      ).to.be.ok;
+      expect(screen.getByText(/Find out what to bring to your appointment/i));
 
       expect(
         screen.getByRole('heading', {

--- a/src/applications/vaos/components/tests/VideoLayoutVA.unit.spec.js
+++ b/src/applications/vaos/components/tests/VideoLayoutVA.unit.spec.js
@@ -30,6 +30,7 @@ describe('VAOS Component: VideoLayoutVA', () => {
     },
     featureToggles: {
       vaOnlineSchedulingAppointmentDetailsRedesign: true,
+      vaOnlineSchedulingMedReviewInstructions: true,
     },
   };
 
@@ -405,6 +406,24 @@ describe('VAOS Component: VideoLayoutVA', () => {
             'va-button[text="Cancel appointment"]',
           ),
         ).not.to.exist;
+
+        expect(
+          screen.getByRole('heading', {
+            level: 2,
+            name: /Prepare for your appointment/i,
+          }),
+        );
+        expect(
+          screen.getByText(
+            /Bring your insurance cards, a list of medications, and other things to share with your provider./i,
+          ),
+        );
+        expect(
+          screen.container.querySelector(
+            'a[href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"]',
+          ),
+        ).to.be.ok;
+        expect(screen.getByText(/Find out what to bring to your appointment/i));
       });
     });
 
@@ -526,6 +545,24 @@ describe('VAOS Component: VideoLayoutVA', () => {
             'va-button[text="Cancel appointment"]',
           ),
         ).not.to.exist;
+
+        expect(
+          screen.getByRole('heading', {
+            level: 2,
+            name: /Prepare for your appointment/i,
+          }),
+        );
+        expect(
+          screen.getByText(
+            /Bring your insurance cards, a list of medications, and other things to share with your provider./i,
+          ),
+        );
+        expect(
+          screen.container.querySelector(
+            'a[href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"]',
+          ),
+        ).to.be.ok;
+        expect(screen.getByText(/Find out what to bring to your appointment/i));
       });
     });
   });
@@ -652,6 +689,24 @@ describe('VAOS Component: VideoLayoutVA', () => {
       expect(
         screen.container.querySelector('va-button[text="Cancel appointment"]'),
       ).not.to.exist;
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Prepare for your appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /Bring your insurance cards, a list of medications, and other things to share with your provider./i,
+        ),
+      );
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"]',
+        ),
+      ).to.be.ok;
+      expect(screen.getByText(/Find out what to bring to your appointment/i));
     });
   });
 
@@ -777,6 +832,24 @@ describe('VAOS Component: VideoLayoutVA', () => {
       expect(
         screen.container.querySelector('va-telephone[contact="500-500-5000"]'),
       ).to.be.ok;
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Prepare for your appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /Bring your insurance cards, a list of medications, and other things to share with your provider./i,
+        ),
+      );
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"]',
+        ),
+      ).to.be.ok;
+      expect(screen.getByText(/Find out what to bring to your appointment/i));
 
       expect(screen.container.querySelector('va-button[text="Print"]')).to.be
         .ok;

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -2154,7 +2154,7 @@
           }
         }
       }
-    }, 
+    },
     {
       "id": "193059",
       "type": "appointments",
@@ -2284,7 +2284,7 @@
           }
         }
       }
-    },          
+    },
     {
       "id": "115069",
       "type": "appointments",
@@ -3477,6 +3477,99 @@
         "clinic": "945",
         "start": "2024-08-29T02:30:00Z",
         "end": "2024-06-22T14:00:00Z",
+        "created": "2024-03-17T00:00:00Z",
+        "cancellable": false,
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [
+            "NO ACTION TAKEN"
+          ]
+        },
+        "serviceName": "FTC C&P AUDIO BEV",
+        "physicalLocation": "FORT COLLINS AUDIO",
+        "friendlyName": "C&P BEV AUDIO FTC",
+        "location": {
+          "id": "983GC",
+          "type": "appointments",
+          "attributes": {
+            "id": "983GC",
+            "vistaSite": "983",
+            "vastParent": "983",
+            "type": "va_facilities",
+            "name": "Fort Collins VA Clinic",
+            "classification": "Multi-Specialty CBOC",
+            "timezone": {
+              "timeZoneId": "Asia/Manila"
+            },
+            "lat": 40.553875,
+            "long": -105.08795,
+            "website": "https://www.cheyenne.va.gov/locations/Fort_Collins_VA_CBOC.asp",
+            "phone": {
+              "main": "970-224-1550"
+            },
+            "physicalAddress": {
+              "line": [
+                "2509 Research Boulevard"
+              ],
+              "city": "Fort Collins",
+              "state": "CO",
+              "postalCode": "80526-8108"
+            },
+            "healthService": [
+              "Audiology",
+              "EmergencyCare",
+              "MentalHealthCare",
+              "PrimaryCare",
+              "SpecialtyCare"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "167312",
+      "type": "appointments",
+      "attributes": {
+        "id": "167312",
+        "identifier": [
+          {
+            "system": "Appointment/",
+            "value": "4139383339353233"
+          }
+        ],
+        "kind": "clinic",
+        "status": "cancelled",
+        "serviceType": "audiology",
+        "serviceTypes": [
+          {
+            "coding": [
+              {
+                "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                "code": "audiology"
+              }
+            ]
+          }
+        ],
+        "serviceCategory": [
+          {
+            "coding": [
+              {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                "code": "COMPENSATION & PENSION",
+                "display": "COMPENSATION & PENSION"
+              }
+            ],
+            "text": "COMPENSATION & PENSION"
+          }
+        ],
+        "patientIcn": "1013120826V646496",
+        "locationId": "983GC",
+        "localStartTime": "2024-08-29T11:30:00.000+08:00",
+        "clinic": "945",
+        "start": "2024-08-29T03:30:00Z",
+        "end": "2024-08-29T04:30:00Z",
         "created": "2024-03-17T00:00:00Z",
         "cancellable": false,
         "extension": {

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -621,14 +621,161 @@
     }
 },
 {
-    "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44cf",
+    "id": "aa6bb54b5f8ba22a82720a30abdfa3efe0805cc0dc1b6b248815e942ad61847f",
     "type": "appointments",
     "attributes": {
-        "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44cf",
+        "id": "aa6bb54b5f8ba22a82720a30abdfa3efe0805cc0dc1b6b248815e942ad61847f",
+        "identifier": [
+            {
+                "system": "Appointment/",
+                "value": "413938333133353534"
+            },
+            {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+                "value": "983:13553"
+            }
+        ],
+        "kind": "clinic",
+        "status": "cancelled",
+        "serviceType": "covid",
+        "serviceTypes": [
+            {
+                "coding": [
+                    {
+                        "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                        "code": "covid"
+                    }
+                ]
+            }
+        ],
+        "serviceCategory": [
+            {
+                "coding": [
+                    {
+                        "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                        "code": "REGULAR",
+                        "display": "REGULAR"
+                    }
+                ],
+                "text": "REGULAR"
+            }
+        ],
+        "patientIcn": "1012846043V576341",
+        "locationId": "983",
+        "clinic": "1038",
+        "practitioners": [
+            {
+                "identifier": [
+                    {
+                        "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
+                        "value": null
+                    }
+                ],
+                "name": {
+                    "family": "BERNARDO",
+                    "given": [
+                        "KENNETH J"
+                    ]
+                }
+            }
+        ],
+        "start": "2024-12-01T15:00:00Z",
+        "end": "2024-08-01T15:15:00Z",
+        "minutesDuration": 15,
+        "slot": {
+            "id": "3230323430383031313430303A323032343038303131343135",
+            "start": "2024-12-01T15:00:00Z",
+            "end": "2024-12-01T15:15:00Z"
+        },
+        "created": "2024-12-09T00:00:00Z",
+        "cancellable": false,
+        "extension": {
+            "ccLocation": {
+                "address": {}
+            },
+            "vistaStatus": [
+                "FUTURE"
+            ],
+            "preCheckinAllowed": true,
+            "eCheckinAllowed": true,
+            "clinic": {
+                "physicalLocation": "MHC"
+            }
+        },
+        "localStartTime": "2024-12-01T09:00:00.000-06:00",
+        "serviceName": "COVID VACCINE CLIN1",
+        "friendlyName": "COVID VACCINE CLIN1",
+        "physicalLocation": "MHC",
+        "location": {
+            "id": "983",
+            "type": "appointments",
+            "attributes": {
+                "id": "983",
+                "vistaSite": "983",
+                "vastParent": "983",
+                "type": "va_facilities",
+                "name": "Cheyenne VA Medical Center",
+                "classification": "VA Medical Center (VAMC)",
+                "timezone": {
+                    "timeZoneId": "America/Denver"
+                },
+                "lat": 39.744507,
+                "long": -104.830956,
+                "website": "https://www.denver.va.gov/locations/directions.asp",
+                "phone": {
+                    "main": "307-778-7550",
+                    "fax": "307-778-7381",
+                    "pharmacy": "866-420-6337",
+                    "afterHours": "307-778-7550",
+                    "patientAdvocate": "307-778-7550 x7517",
+                    "mentalHealthClinic": "307-778-7349",
+                    "enrollmentCoordinator": "307-778-7550 x7579"
+                },
+                "physicalAddress": {
+                    "type": "physical",
+                    "line": [
+                        "2360 East Pershing Boulevard"
+                    ],
+                    "city": "Cheyenne",
+                    "state": "WY",
+                    "postalCode": "82001-5356"
+                },
+                "mobile": false,
+                "healthService": [
+                    "Audiology",
+                    "Cardiology",
+                    "DentalServices",
+                    "EmergencyCare",
+                    "Gastroenterology",
+                    "Gynecology",
+                    "MentalHealthCare",
+                    "Nutrition",
+                    "Ophthalmology",
+                    "Optometry",
+                    "Orthopedics",
+                    "Podiatry",
+                    "PrimaryCare",
+                    "SpecialtyCare",
+                    "UrgentCare",
+                    "Urology",
+                    "WomensHealth"
+                ],
+                "operatingStatus": {
+                    "code": "NORMAL"
+                }
+            }
+        }
+    }
+},
+{
+    "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44ce",
+    "type": "appointments",
+    "attributes": {
+        "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44ce",
         "identifier": [
             {
                 "system": "urn:va.gov:masv2:cerner:appointment",
-                "value": "Appointment/52499028"
+                "value": "Appointment/52499027"
             }
         ],
         "kind": "clinic",
@@ -670,6 +817,191 @@
         },
         "requestedPeriods": null,
         "localStartTime": "2024-12-23T09:30:00.000-04:00",
+        "location": {
+            "id": "757",
+            "type": "appointments",
+            "attributes": {
+                "id": "757",
+                "facilitiesApiId": "vha_757",
+                "vistaSite": "757",
+                "vastParent": "757",
+                "type": "va_health_facility",
+                "name": "Chalmers P. Wylie Veterans CERNER Clinic",
+                "classification": "Health Care Center (HCC)",
+                "timezone": {
+                    "timeZoneId": "America/New_York"
+                },
+                "lat": 39.98048,
+                "long": -82.9123,
+                "website": "https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/",
+                "phone": {
+                    "main": "614-257-5200",
+                    "fax": "614-257-5460",
+                    "pharmacy": "614-257-5230",
+                    "afterHours": "614-257-5512",
+                    "patientAdvocate": "614-257-5290",
+                    "mentalHealthClinic": "614-257-5631",
+                    "enrollmentCoordinator": "614-257-5628"
+                },
+                "hoursOfOperation": [
+                    {
+                        "daysOfWeek": "sun",
+                        "openingTime": "800AM",
+                        "closingTime": "400PM"
+                    },
+                    {
+                        "daysOfWeek": "mon",
+                        "openingTime": "730AM",
+                        "closingTime": "600PM"
+                    },
+                    {
+                        "daysOfWeek": "tue",
+                        "openingTime": "730AM",
+                        "closingTime": "600PM"
+                    },
+                    {
+                        "daysOfWeek": "wed",
+                        "openingTime": "730AM",
+                        "closingTime": "600PM"
+                    },
+                    {
+                        "daysOfWeek": "thu",
+                        "openingTime": "730AM",
+                        "closingTime": "600PM"
+                    },
+                    {
+                        "daysOfWeek": "fri",
+                        "openingTime": "730AM",
+                        "closingTime": "600PM"
+                    },
+                    {
+                        "daysOfWeek": "sat",
+                        "openingTime": "800AM",
+                        "closingTime": "400PM"
+                    }
+                ],
+                "physicalAddress": {
+                    "type": "physical",
+                    "line": [
+                        "420 North James Road",
+                        null,
+                        null
+                    ],
+                    "city": "Columbus",
+                    "state": "OH",
+                    "postalCode": "43219-1834"
+                },
+                "mobile": false,
+                "healthService": [
+                    "Allergy",
+                    "Audiology",
+                    "Cardiology",
+                    "CaregiverSupport",
+                    "Covid19Vaccine",
+                    "Dental",
+                    "Dermatology",
+                    "Diabetic",
+                    "Endocrinology",
+                    "Gastroenterology",
+                    "Geriatrics",
+                    "Gynecology",
+                    "Hematology",
+                    "Homeless",
+                    "Hospice",
+                    "Laboratory",
+                    "Lgbtq",
+                    "MinorityCare",
+                    "Nephrology",
+                    "Neurology",
+                    "Nutrition",
+                    "Ophthalmology",
+                    "Optometry",
+                    "Orthopedics",
+                    "Otolaryngology",
+                    "PainManagement",
+                    "PatientAdvocates",
+                    "Pharmacy",
+                    "PhysicalMedicine",
+                    "PlasticSurgery",
+                    "Podiatry",
+                    "PrimaryCare",
+                    "Prosthetics",
+                    "Ptsd",
+                    "PulmonaryMedicine",
+                    "Radiology",
+                    "Rheumatology",
+                    "Smoking",
+                    "SocialWork",
+                    "SpinalInjury",
+                    "SuicidePrevention",
+                    "Surgery",
+                    "TransitionCounseling",
+                    "UrgentCare",
+                    "Urology",
+                    "VascularSurgery",
+                    "Vision",
+                    "WeightManagement",
+                    "WomensHealth",
+                    "Wound"
+                ],
+                "operatingStatus": {
+                    "code": "NORMAL"
+                },
+                "visn": "10"
+            }
+        }
+    }
+},
+{
+    "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44cf",
+    "type": "appointments",
+    "attributes": {
+        "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44cf",
+        "identifier": [
+            {
+                "system": "urn:va.gov:masv2:cerner:appointment",
+                "value": "Appointment/52499028"
+            }
+        ],
+        "kind": "clinic",
+        "status": "cancelled",
+        "serviceTypes": [
+            {
+                "coding": [
+                    {
+                        "system": "https://fhir.cerner.com/d45741b3-8335-463d-ab16-8c5f0bcf78ed/codeSet/14249",
+                        "code": "381456583"
+                    }
+                ]
+            }
+        ],
+        "description": "PC Established Patient",
+        "patientIcn": "1012845331V153043",
+        "locationId": "757",
+        "practitioners": [
+            {
+                "name": {
+                    "family": "Everett",
+                    "given": [
+                        "CERNER",
+                        "DO"
+                    ]
+                }
+            }
+        ],
+        "start": "2024-12-23T14:30:00Z",
+        "end": "2024-12-23T15:00:00Z",
+        "minutesDuration": 30,
+        "comment": "\nContact preference: Secure message",
+        "cancellable": false,
+        "patientInstruction": "Preparations:\n- If you have any new non-VA medical records since your last visit, please bring them.\r\nIf you need to cancel or reschedule your appointment, please call our Contact Center at 614-257-5200 or visit the patient portal.",
+        "extension": {
+            "ccLocation": {
+                "address": {}
+            }
+        },
+        "requestedPeriods": null,
+        "localStartTime": "2024-12-23T10:30:00.000-04:00",
         "location": {
             "id": "757",
             "type": "appointments",
@@ -3103,11 +3435,11 @@
           ]
         },
         "description": "Upcoming VA location telehealth appointment",
-        "end": "2024-07-22T14:00:00Z",
+        "end": "2024-08-22T14:00:00Z",
         "id": "05aa456vvc",
         "kind": "telehealth",
         "locationId": "983",
-        "localStartTime": "2024-07-22T09:00:00.000-06:00",
+        "localStartTime": "2024-08-22T09:00:00.000-06:00",
         "physicalLocation": "PHYSICAL LOCATION TESTING",
         "minutesDuration": 30,
         "patientIcn": null,
@@ -3118,9 +3450,50 @@
         "requestedPeriods": null,
         "serviceType": "foodAndNutrition",
         "slot": null,
-        "created": "2024-07-22T13:00:00Z",
-        "start": "2024-07-22T13:00:00Z",
+        "created": "2024-08-22T13:00:00Z",
+        "start": "2024-08-22T13:00:00Z",
         "status": "booked",
+        "telehealth": {
+          "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#",
+          "atlas": null,
+          "vvsKind": "CLINIC_BASED"
+        }
+      }
+    },
+    {
+      "id": "05aa456vvd",
+      "type": "Appointment",
+      "attributes": {
+        "cancelationReason": null,
+        "clinic": "848",
+        "comment": null,
+        "contact": {
+          "telecom": [
+            {
+              "type": "email",
+              "value": null
+            }
+          ]
+        },
+        "description": "Upcoming VA location telehealth appointment",
+        "end": "2024-08-22T15:00:00Z",
+        "id": "05aa456vvd",
+        "kind": "telehealth",
+        "locationId": "983",
+        "localStartTime": "2024-08-22T10:00:00.000-06:00",
+        "physicalLocation": "PHYSICAL LOCATION TESTING",
+        "minutesDuration": 30,
+        "patientIcn": null,
+        "practitioners": [],
+        "preferredTimesForPhoneCall": [],
+        "priority": 0,
+        "reasonCode": {},
+        "requestedPeriods": null,
+        "serviceType": "foodAndNutrition",
+        "slot": null,
+        "created": "2024-08-22T14:00:00Z",
+        "start": "2024-08-22T14:00:00Z",
+        "status": "cancelled",
         "telehealth": {
           "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#",
           "atlas": null,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Add "Prepare for your appointment" section to In-person and Video at VA.
- This feature is toggled by the Flipper flag `va_online_scheduling_med_review_instructions `
- Appointments (VAOS) team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/85118

## Testing done

- Unit tests updated to account for the new content
- The new content (text and link) is verified locally with the feature toggle enabled

## Screenshots

New screenshots:

| Type | Confirmed Appointment | Cancelled Appointment |
| - | ------ | ----- |
| In-person | <img width="343" alt="image" src="https://github.com/user-attachments/assets/96700b17-d2d6-4f24-8694-f146e07228ae"> | <img width="343" alt="image" src="https://github.com/user-attachments/assets/414c4032-44e3-4170-b2ca-8d263dfb1f63"> |
| In-person Vaccine | <img width="328" alt="image" src="https://github.com/user-attachments/assets/8932272c-57fe-4cfc-88ba-ebaa77b6f754"> | <img width="337" alt="image" src="https://github.com/user-attachments/assets/dd8dffd1-e88c-4e08-a958-3b5a3a6fe50a"> |
| Video at VA | <img width="342" alt="image" src="https://github.com/user-attachments/assets/164a9dc1-4794-40c0-8dc6-4c96dabd12e5"> | <img width="338" alt="image" src="https://github.com/user-attachments/assets/9a02af10-cced-4387-8216-706286bd5cef"> |

## What areas of the site does it impact?

N/A

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
