### PR TITLE
88484: remove controlInformation from the directDeposit PUT request

### DIFF
--- a/src/applications/personalization/profile/hooks/useDirectDeposit.js
+++ b/src/applications/personalization/profile/hooks/useDirectDeposit.js
@@ -114,11 +114,10 @@ export const useDirectDeposit = () => {
           accountNumber: formData.accountNumber,
           routingNumber: formData.routingNumber,
         },
-        controlInformation,
       };
       dispatch(saveDirectDeposit(payload));
     },
-    [dispatch, formData, controlInformation],
+    [dispatch, formData],
   );
 
   const {


### PR DESCRIPTION
## Summary

- remove `controlInformation` data that was getting passed down in the `directDeposit`'s `PUT` request
- Not a bug, just a clean up
- backend wasn't using the `controlInformation` so there was no point on passing `controlInformation` in the body
- Authenticated Profile and yes my team own the maintenance of this component

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#88484
- _Link to epic if not included in ticket_
department-of-veterans-affairs/va.gov-team#76202

## Testing done

- Tested locally by making a directDeposit request and verified that the `controlInformation` in `directDeposit`'s `PUT` request's payload didn't exist


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*
- Direct Deposit page in the VA Profile 

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

