### PR TITLE
VACMS-18460 Remove unneeded custom GA events in Find Forms

### DIFF
--- a/src/applications/discharge-wizard/components/AnswerReview.jsx
+++ b/src/applications/discharge-wizard/components/AnswerReview.jsx
@@ -47,7 +47,7 @@ const AnswerReview = ({ formValues, handleScrollTo }) => {
                   onClick={handleScrollTo}
                   name={k}
                   text="Edit"
-                  aria-label={reviewLabel}
+                  label={reviewLabel}
                 />
               </div>
             )

--- a/src/applications/find-forms/components/FindVaForms.jsx
+++ b/src/applications/find-forms/components/FindVaForms.jsx
@@ -4,17 +4,9 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { toggleValues } from '~/platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from '~/platform/utilities/feature-toggles/featureFlagNames';
-import recordEvent from '~/platform/monitoring/record-event';
 import SearchForm from '../containers/SearchForm';
 import SearchResults from '../containers/SearchResults';
 import PdfAlert from './PdfAlert';
-
-const onFeaturedContentClick = header => () => {
-  recordEvent({
-    event: 'nav-featured-content-link-click',
-    'featured-content-header': header,
-  });
-};
 
 export const FindVaForms = ({ showPdfWarningBanner = false }) => {
   return (
@@ -46,11 +38,9 @@ export const FindVaForms = ({ showPdfWarningBanner = false }) => {
           </p>
           <va-link
             active
-            aria-label="Apply online about filing a VA disability claim"
+            label="Apply online about filing a VA disability claim"
             className="vads-u-display--block vads-u-padding-top--1 vads-u-text-decoration--none"
-            disable-analytics
             href="/disability/file-disability-claim-form-21-526ez/"
-            onClick={onFeaturedContentClick('File a VA disability claim')}
             text="Apply online"
           />
         </li>
@@ -68,13 +58,9 @@ export const FindVaForms = ({ showPdfWarningBanner = false }) => {
           </p>
           <va-link
             active
-            aria-label="Learn how to apply online about applying for the GI Bill and other education benefits"
+            label="Learn how to apply online about applying for the GI Bill and other education benefits"
             className="vads-u-display--block vads-u-padding-top--1 vads-u-text-decoration--none"
-            disable-analytics
             href="/education/how-to-apply/"
-            onClick={onFeaturedContentClick(
-              'Apply for the GI Bill and other education benefits',
-            )}
             text="Learn how to apply online"
           />
         </li>
@@ -92,13 +78,9 @@ export const FindVaForms = ({ showPdfWarningBanner = false }) => {
           </p>
           <va-link
             active
-            aria-label="Apply online about applying for VA health care benefits"
+            label="Apply online about applying for VA health care benefits"
             className="vads-u-display--block vads-u-padding-top--1 vads-u-text-decoration--none"
-            disable-analytics
             href="/health-care/apply-for-health-care-form-10-10ez/"
-            onClick={onFeaturedContentClick(
-              'Apply for VA health care benefits',
-            )}
             text="Apply online"
           />
         </li>

--- a/src/applications/find-forms/components/FormTitle.jsx
+++ b/src/applications/find-forms/components/FormTitle.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const FormTitle = ({ id, formUrl, title, lang, recordGAEvent, formName }) => (
+const FormTitle = ({ id, formUrl, title, recordGAEvent, formName }) => (
   <div
     className="vads-u-margin--0 vads-u-font-weight--bold"
     data-e2e-id="result-title"
@@ -14,30 +14,24 @@ const FormTitle = ({ id, formUrl, title, lang, recordGAEvent, formName }) => (
         >
           Form {formName}
         </p>
-        <h3
-          aria-describedby={id}
-          className="vads-u-font-size--base vads-u-margin--0"
-        >
-          <a
+        <h3 aria-describedby={id} className="vads-u-margin--0">
+          <va-link
+            disable-analytics
             href={formUrl}
-            className="vads-u-font-family--serif vads-u-margin-top--1"
             onClick={() => recordGAEvent(title, formUrl, 'title')}
-            lang={lang}
-          >
-            {title}
-          </a>
+            text={title}
+          />
         </h3>
       </>
     ) : (
       <>
-        <p id={id} className="vads-u-font-weight--normal vads-u-margin--0">
+        <p
+          id={id}
+          className="vads-u-font-weight--normal vads-u-margin-top--0 vads-u-margin-bottom--1p5"
+        >
           Form {formName}
         </p>
-        <h3
-          aria-describedby={id}
-          className="vads-u-font-family--serif vads-u-font-size--base vads-u-margin--0 vads-u-margin-top--1p5"
-          lang={lang}
-        >
+        <h3 aria-describedby={id} className="vads-u-margin--0">
           {title}
         </h3>
       </>

--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -161,13 +161,6 @@ const SearchResult = ({
 
   const pdfDownloadHandler = () => {
     setPrevFocusedLink(`pdf-link-${id}`);
-
-    recordEvent({
-      event: 'int-modal-click',
-      'modal-status': 'opened',
-      'modal-title': 'Download this PDF and open it in Acrobat Reader',
-    });
-
     toggleModalState(formName, url, pdfLabel);
   };
 
@@ -176,7 +169,6 @@ const SearchResult = ({
       <FormTitle
         id={id}
         formUrl={regulateURL(formDetailsUrl)}
-        lang={language}
         title={title}
         recordGAEvent={recordGAEvent}
         formName={formName}
@@ -189,19 +181,14 @@ const SearchResult = ({
       {relatedTo}
       {relativeFormToolUrl ? (
         <div className="vads-u-margin-bottom--2p5">
-          <va-link
-            className="vads-c-action-link--green"
-            disable-analytics
+          <va-link-action
             href={relativeFormToolUrl}
-            lang={language}
-            onClick={() =>
-              recordGAEvent(`Go to online tool`, relativeFormToolUrl, 'cta')
-            }
             text={deriveLanguageTranslation(
               language,
               'goToOnlineTool',
               formName,
             )}
+            type="secondary"
           />
         </div>
       ) : null}

--- a/src/applications/find-forms/containers/SearchResults.jsx
+++ b/src/applications/find-forms/containers/SearchResults.jsx
@@ -109,11 +109,6 @@ export const SearchResults = ({
         ...modalState,
         isOpen: !modalState.isOpen,
       });
-      recordEvent({
-        event: 'int-modal-click',
-        'modal-status': 'closed',
-        'modal-title': 'Download this PDF and open it in Acrobat Reader',
-      });
     } else {
       setModalState({
         isOpen: !modalState.isOpen,

--- a/src/applications/find-forms/tests/components/FormTitle.unit.spec.jsx
+++ b/src/applications/find-forms/tests/components/FormTitle.unit.spec.jsx
@@ -12,7 +12,6 @@ describe('Find VA Forms <FormTitle />', () => {
     formDetailsUrl:
       'https://www.va.gov/health-care/about-information-for-pre-complaint-processing/',
     title: 'Information for Pre-Complaint Processing',
-    language: 'en',
     recordGAEvent: recordSpy,
     formName: 'VA10192',
   };
@@ -23,7 +22,6 @@ describe('Find VA Forms <FormTitle />', () => {
         id={props.id}
         formUrl={props.formDetailsUrl}
         recordGAEvent={props.recordGAEvent}
-        lang={props.language}
         title={props.title}
         formName={props.formName}
       />,
@@ -50,7 +48,6 @@ describe('Find VA Forms <FormTitle />', () => {
     const treeText = tree.text();
 
     // expecting result node tree text to include the following
-    expect(treeText).to.include(props.title);
     expect(treeText).to.include(props.formName);
     tree.unmount();
   });
@@ -80,7 +77,7 @@ describe('Find VA Forms <FormTitle />', () => {
         />,
       );
 
-      tree.find('a').simulate('click');
+      tree.find('va-link').simulate('click');
       expect(recordSpy.called).to.be.true;
 
       tree.unmount();

--- a/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFGuidance.js
+++ b/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFGuidance.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import recordEvent from '~/platform/monitoring/record-event';
 import DownloadPDFModal from './DownloadPDFModal';
 import InvalidFormDownload from './InvalidFormAlert';
 import { sentryLogger } from './index';
@@ -35,12 +34,6 @@ const DownloadPDFGuidance = ({
     );
 
     parentEl.insertBefore(div, link); // Insert modal on DOM
-
-    recordEvent({
-      event: 'int-modal-click',
-      'modal-status': 'opened',
-      'modal-title': 'Download this PDF and open it in Acrobat Reader',
-    });
   } else {
     let errorMessage = 'Find Forms - Form Detail - invalid PDF accessed';
 

--- a/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFModal.jsx
+++ b/src/applications/find-forms/widgets/createFindVaFormsPDFDownloadHelper/DownloadPDFModal.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { VaModal } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import recordEvent from '~/platform/monitoring/record-event';
 
 // DownloadPDFModal is state wrapper + modal for PDF guidance upon PDf being valid
 const DownloadPDFModal = ({ formNumber, removeNode, url }) => {
@@ -34,14 +33,7 @@ const DownloadPDFModal = ({ formNumber, removeNode, url }) => {
       }}
     >
       <VaModal
-        onCloseEvent={() => {
-          toggleModalState();
-          recordEvent({
-            event: 'int-modal-click',
-            'modal-status': 'closed',
-            'modal-title': 'Download this PDF and open it in Acrobat Reader',
-          });
-        }}
+        onCloseEvent={toggleModalState}
         modalTitle="Download this PDF and open it in Acrobat Reader"
         visible={isOpen}
         uswds

--- a/src/applications/static-pages/cta-widget/components/CallToActionAlert.jsx
+++ b/src/applications/static-pages/cta-widget/components/CallToActionAlert.jsx
@@ -22,7 +22,7 @@ export default function CallToActionAlert({
           <va-button
             onClick={primaryButtonHandler}
             text={primaryButtonText}
-            aria-label={ariaLabel}
+            label={ariaLabel}
             aria-describedby={ariaDescribedby}
             uswds
           />


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Removal of unneeded custom Google Analytics events in the Find Forms application.

I also discovered that we are using `aria-label` for `<va-link>` in a couple spots where we should be using `label`. I corrected that while I was in here.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18460

## Testing done


## Screenshots

Tested at `/discharge-upgrade-instructions`
<details><summary>DUW "Edit" link aria-label fix</summary>
<img width="527" alt="Screenshot 2024-07-29 at 12 17 47 PM" src="https://github.com/user-attachments/assets/cd91ead4-7561-4826-bf6c-80c993c5fea8">
<img width="492" alt="Screenshot 2024-07-29 at 12 17 42 PM" src="https://github.com/user-attachments/assets/63733673-2cfd-4c02-9d72-7e2f3fd32a9b">
</details>

Tested at `/health-care/refill-track-prescriptions`
<details><summary>CTA widget aria-label fix</summary>
<img width="701" alt="Screenshot 2024-07-29 at 1 03 37 PM" src="https://github.com/user-attachments/assets/87384e01-3817-403d-b7df-38796b6d27a9">
<img width="419" alt="Screenshot 2024-07-29 at 1 03 35 PM" src="https://github.com/user-attachments/assets/9681db3d-f683-4066-8399-0ed4bfab8f21">

</details>

Tested from `/find-forms` searching "1010"
<details><summary>BAKED-IN events for "Frequently used VA forms" links</summary>
<img width="702" alt="Screenshot 2024-07-29 at 12 53 02 PM" src="https://github.com/user-attachments/assets/b2464124-9075-4438-a75d-21f3a9d9af78">

#### File a VA disability claim
<img width="534" alt="Screenshot 2024-07-29 at 12 19 24 PM" src="https://github.com/user-attachments/assets/b162bb76-da2b-4e57-8f4e-55d583961136">
<img width="417" alt="Screenshot 2024-07-29 at 12 21 32 PM" src="https://github.com/user-attachments/assets/14ba8d8a-ae50-4ad5-b436-9a83a2a7afa2">

#### Apply for the GI Bill and other education benefits
<img width="521" alt="Screenshot 2024-07-29 at 12 19 48 PM" src="https://github.com/user-attachments/assets/a616cfc8-0492-4949-bb44-f7e646ab00b9">
<img width="424" alt="Screenshot 2024-07-29 at 12 21 40 PM" src="https://github.com/user-attachments/assets/b9837e45-0a40-46bf-822a-6ee0546f4f78">

#### Apply for VA health care
<img width="530" alt="Screenshot 2024-07-29 at 12 19 58 PM" src="https://github.com/user-attachments/assets/c2c2f697-5c2e-4a14-8155-e0d13a5c164c">
<img width="431" alt="Screenshot 2024-07-29 at 12 21 48 PM" src="https://github.com/user-attachments/assets/087c4040-744e-4a81-ad38-95fd0bedf878">


</details>

<details><summary>CUSTOM event for when search results are shown</summary>
<img width="642" alt="Screenshot 2024-07-29 at 12 07 52 PM" src="https://github.com/user-attachments/assets/140aea6b-982e-4c3e-bdcc-54efd2a3b31e">
</details>

<details><summary>BAKED-IN event for opening modal (clicking "Download VA Form ___" on search results page)</summary>
<img width="509" alt="Screenshot 2024-07-29 at 12 53 28 PM" src="https://github.com/user-attachments/assets/f636e03b-2781-459f-bb2d-33056d4061b7">

<img width="645" alt="Screenshot 2024-07-29 at 12 09 38 PM" src="https://github.com/user-attachments/assets/9980fa88-1da5-49ef-966b-15b8dce93846">
</details>

<details><summary>CUSTOM event for clicking a search result</summary>
<img width="252" alt="Screenshot 2024-07-30 at 9 41 10 AM" src="https://github.com/user-attachments/assets/deaf4aae-bc43-4d2d-a628-67c64ce8391a">
<img width="465" alt="Screenshot 2024-07-30 at 9 57 03 AM" src="https://github.com/user-attachments/assets/8391b471-925d-47b6-a0b7-eb4f896be6a1">



</details>

<details><summary>BAKED-IN event for clicking a form's tool link</summary>
<img width="341" alt="Screenshot 2024-07-30 at 9 38 59 AM" src="https://github.com/user-attachments/assets/0cf764cd-2d61-49d4-b421-12dfefcd0095">
<img width="469" alt="Screenshot 2024-07-30 at 9 39 44 AM" src="https://github.com/user-attachments/assets/cff3245f-b043-4b86-a98b-706dfe94238a">

</details>

<details><summary>CUSTOM event for using "Sort by" on the search results page</summary>
<img width="229" alt="Screenshot 2024-07-29 at 12 53 50 PM" src="https://github.com/user-attachments/assets/0c9357a7-e85d-44e5-957d-4d37bff4d711">

<img width="636" alt="Screenshot 2024-07-29 at 12 16 35 PM" src="https://github.com/user-attachments/assets/4e6fd879-2e18-4638-bb9c-be3d361125e5">
</details>