### PR TITLE
MBMS-66254 Platform change to not allow encrypted files as ui option

### DIFF
--- a/src/applications/pre-need-integration/utils/upload.js
+++ b/src/applications/pre-need-integration/utils/upload.js
@@ -5,6 +5,7 @@ import VaSelectField from '~/platform/forms-system/src/js/web-component-fields/V
 export function fileUploadUi(content) {
   return {
     ...fileUiSchema(content.label, {
+      allowEncryptedFiles: false,
       buttonText: 'Upload file',
       addAnotherLabel: 'Upload another file',
       itemDescription: content.description,

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -29,7 +29,10 @@ import {
   FILE_TYPE_MISMATCH_ERROR,
 } from '../utilities/file';
 import { usePreviousValue } from '../helpers';
-import { MISSING_PASSWORD_ERROR } from '../validation';
+import {
+  MISSING_PASSWORD_ERROR,
+  UNSUPPORTED_ENCRYPTED_FILE_ERROR,
+} from '../validation';
 
 /**
  * Modal content callback
@@ -111,6 +114,7 @@ const FileField = props => {
   const content = {
     upload: uiOptions.buttonText || 'Upload',
     uploadAnother: uiOptions.addAnotherLabel || 'Upload another',
+    allowEncryptedFiles: uiOptions.allowEncryptedFiles ?? true,
     ariaLabelAdditionalText: uiOptions.ariaLabelAdditionalText || '',
     passwordLabel: fileName => `Add a password for ${fileName}`,
     tryAgain: 'Try again',
@@ -434,6 +438,14 @@ const FileField = props => {
               errorSchema?.[index]?.__errors ||
               [file.errorMessage].filter(error => error);
 
+            if (file.isEncrypted && !content.allowEncryptedFiles) {
+              if (errors[0] === MISSING_PASSWORD_ERROR) {
+                errors[0] = UNSUPPORTED_ENCRYPTED_FILE_ERROR;
+              } else {
+                errors.push(UNSUPPORTED_ENCRYPTED_FILE_ERROR);
+              }
+            }
+
             // Don't show missing password error in the card (above the input
             // label), but we are adding an error for missing password to
             // prevent page submission without adding an error; see #71406
@@ -457,9 +469,13 @@ const FileField = props => {
             );
             const attachmentNameErrors = get([index, 'name'], errorSchema);
             const showPasswordInput =
-              file.isEncrypted && !file.confirmationCode;
+              file.isEncrypted &&
+              !file.confirmationCode &&
+              content.allowEncryptedFiles;
             const showPasswordSuccess =
-              file.isEncrypted && file.confirmationCode;
+              file.isEncrypted &&
+              file.confirmationCode &&
+              content.allowEncryptedFiles;
             const description =
               (!file.uploading && uiOptions.itemDescription) || '';
 

--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -572,6 +572,8 @@ export function validateDateRangeAllowSameMonth(
 export const UPLOADING_FILE = 'Uploading file...';
 export const NOT_UPLOADED = 'We couldn’t upload your file';
 export const MISSING_PASSWORD_ERROR = 'Missing password';
+export const UNSUPPORTED_ENCRYPTED_FILE_ERROR =
+  "We weren't able to upload your file. Make sure the file is not encrypted and an accepted format.";
 export function getFileError(file) {
   if (file.errorMessage) {
     return file.errorMessage;


### PR DESCRIPTION
## Summary

- As a Veteran and/or family member, I need the Supporting documents section to provide clear guidance on what is NOT accepted so that I am aware of the necessary materials needed to provide to get a quick determination on possible eligibility.

## Related issue(s)

- https://jira.devops.va.gov/browse/MBMS-66254

## Testing done

- [x] POR/UI/UX Review
- [x] QA
- [x] Unit Tests Passing
- [x] Internal Review
- [x] External Review

## Screenshots

https://github.com/user-attachments/assets/45b85f5a-4e29-4c92-9eac-309aef501815

## What areas of the site does it impact?

- Pre-need-integration supporting files. 
- Platform file upload 

## Acceptance criteria

![image](https://github.com/user-attachments/assets/1041fefd-a208-45f8-bc1e-261574334d77)
