### PR TITLE
#89526: Update reason code identifier in reasonCode.text field [Direct Schedule]

### DIFF
--- a/src/applications/vaos/new-appointment/redux/helpers/getReasonCode.js
+++ b/src/applications/vaos/new-appointment/redux/helpers/getReasonCode.js
@@ -47,7 +47,7 @@ export function getReasonCode({ data, isCC, isDS }) {
     appointmentInfo = `${facility}|${modality}|${phone}|${email}|${preferredDates}|${reasonCode}`;
   }
   if (isDS) {
-    appointmentInfo = `reasonCode:${apptReasonCode}`;
+    appointmentInfo = `reason code:${apptReasonCode}`;
     reasonText = `comments:${data.reasonAdditionalInfo.slice(0, 250)}`;
   }
   return {

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -175,7 +175,7 @@ function getReasonCodeDS(appt, key) {
   const reasonCode = appt.reasonCode?.text?.split('|');
   if (reasonCode && key === 'code') {
     data = reasonCode
-      .filter(item => item.includes('reasonCode:'))[0]
+      .filter(item => item.includes('reason code:'))[0]
       ?.split(':')[1]
       ?.trim();
   }

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.direct.unit.spec.js
@@ -193,7 +193,7 @@ describe('VAOS Page: ReviewPage direct scheduling with v2 api', () => {
       locationId: '983',
       clinic: '455',
       reasonCode: {
-        text: 'reasonCode:ROUTINEVISIT|comments:I need an appt',
+        text: 'reason code:ROUTINEVISIT|comments:I need an appt',
       },
       extension: {
         desiredDate: '2021-05-06T00:00:00+00:00',


### PR DESCRIPTION
## Summary
Update reason code identifier in `reasonCode.text` field to match the reason code identifier for Requests. 
Identifier should be 'reason code:'



## Related issue(s)

- https://app.zenhub.com/workspaces/appointments-team-603fdef281af6500110a1691/issues/gh/department-of-veterans-affairs/va.gov-team/89526

## Testing done
Tested with Mock data and updated unit tests.



## Acceptance criteria

- [x]  -  reason code identifier is updated from 'reasonCode:' to  'reason code:'
- [x] - Tests updated
