### PR TITLE
[CDP] Added links to error alerts for better screenreader experience

### DIFF
--- a/src/applications/combined-debt-portal/combined/components/AlertCard.jsx
+++ b/src/applications/combined-debt-portal/combined/components/AlertCard.jsx
@@ -16,7 +16,7 @@ const AlertCard = ({ appType }) => {
           We can’t access your{' '}
           {`${appType === APP_TYPES.DEBT ? 'debt' : 'copay'}`} records right now
         </h2>
-        <p className="vads-u-font-size--base vads-u-font-family--sans">
+        <p>
           We’re sorry. Information about{' '}
           {`${appType === APP_TYPES.DEBT ? 'debts' : 'copays'}`} you might have
           is unavailable because something went wrong on our end. Please check

--- a/src/applications/combined-debt-portal/combined/components/ComboAlerts.jsx
+++ b/src/applications/combined-debt-portal/combined/components/ComboAlerts.jsx
@@ -26,7 +26,7 @@ ComboAlert.Error = () => {
         debts and bills, contact us online through{' '}
         <a href="https://ask.va.gov">Ask VA</a>.
       </p>
-      <p>
+      <p className="vads-u-margin-bottom--0">
         <va-link active text="Contact us at Ask VA" url="https://ask.va.gov" />
       </p>
     </va-alert>
@@ -64,6 +64,9 @@ ComboAlert.Zero = () => {
           ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
         </li>
       </ul>
+      <p className="vads-u-margin-bottom--0">
+        <va-link active text="Return to VA.gov" url="https://va.gov" />
+      </p>
     </va-alert>
   );
 };

--- a/src/applications/combined-debt-portal/combined/components/ComboAlerts.jsx
+++ b/src/applications/combined-debt-portal/combined/components/ComboAlerts.jsx
@@ -8,14 +8,14 @@ const ComboAlert = ({ children }) => children;
 ComboAlert.Error = () => {
   return (
     <va-alert
-      class="row vads-u-margin-bottom--5"
+      class="row vads-u-margin-y--4"
       status="error"
       data-testid="balance-card-combo-alert-error"
     >
-      <h2 slot="headline" className="vads-u-font-size--h3">
+      <h2 slot="headline">
         We can’t access your debt and copay records right now
       </h2>
-      <p className="vads-u-font-size--base vads-u-font-family--sans">
+      <p>
         We’re sorry. Information about debts and copays you might have is
         unavailable because something went wrong on our end. Please check back
         soon.
@@ -25,6 +25,9 @@ ComboAlert.Error = () => {
         If you continue having trouble viewing information about your current
         debts and bills, contact us online through{' '}
         <a href="https://ask.va.gov">Ask VA</a>.
+      </p>
+      <p>
+        <va-link active text="Contact us at Ask VA" url="https://ask.va.gov" />
       </p>
     </va-alert>
   );
@@ -40,7 +43,7 @@ ComboAlert.Zero = () => {
       <h2 slot="headline" className="vads-u-font-size--h3">
         You don’t have any current VA debt or copay bills
       </h2>
-      <p className="vads-u-font-size--base vads-u-font-family--sans">
+      <p>
         Our records show you don’t have any current VA benefit debt and you
         haven’t received a copay bill in the past 6 months.
       </p>

--- a/src/applications/combined-debt-portal/combined/components/MCPAlerts.jsx
+++ b/src/applications/combined-debt-portal/combined/components/MCPAlerts.jsx
@@ -53,7 +53,7 @@ Alert.PastDue = ({ copay }) => {
       data-testid="past-due-balance-alert"
     >
       <h2 slot="headline">Your balance may be overdue</h2>
-      <p className="vads-u-font-size--base vads-u-font-family--sans">
+      <p>
         Your balance on
         <time dateTime={statementDate} className="vads-u-margin-x--0p5">
           {statementDate}
@@ -94,7 +94,7 @@ Alert.ZeroBalance = ({ copay }) => {
       data-testid="zero-balance-alert"
     >
       <h2 slot="headline">You don’t need to make a payment at this time</h2>
-      <p className="vads-u-font-size--base vads-u-font-family--sans">
+      <p>
         Your balance is $0 and was updated on
         <time dateTime={statementDate} className="vads-u-margin-x--0p5">
           {statementDate}
@@ -130,7 +130,7 @@ Alert.NoHealthcare = () => (
     data-testid="no-healthcare-alert"
   >
     <h2 slot="headline">You’re not enrolled in VA health care</h2>
-    <p className="vads-u-font-size--base vads-u-font-family--sans">
+    <p>
       You can’t check copay balances at this time because our records show that
       you’re not enrolled in VA health care.
       <a
@@ -160,7 +160,7 @@ Alert.NoHistory = () => (
     <h2 slot="headline">
       You haven’t received a copay bill in the past 6 months
     </h2>
-    <p className="vads-u-font-size--base vads-u-font-family--sans">
+    <p>
       You can’t check copay balances at this time because our records show that
       you haven’t received a copay bill in the past 6 months.
     </p>

--- a/src/applications/combined-debt-portal/combined/components/OtherVADebts.jsx
+++ b/src/applications/combined-debt-portal/combined/components/OtherVADebts.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 import { APP_TYPES } from '../utils/helpers';
 
 const OtherVADebts = ({ module, subHeading }) => {
@@ -41,15 +40,13 @@ const OtherVADebts = ({ module, subHeading }) => {
         )}
       </p>
 
-      <Link
-        className="vads-u-font-weight--bold"
-        aria-label="View all your VA debt and bills"
-        to="/manage-va-debt/summary"
+      <va-link
+        href="/manage-va-debt/summary/"
         data-testid="other-va-debts-link"
-      >
-        View all your VA debt and bills
-        <va-icon icon="navigate_next" size={3} />
-      </Link>
+        active
+        text="View all your VA debt and bills"
+        class="vads-u-margin-top--2"
+      />
     </>
   );
 };

--- a/src/applications/combined-debt-portal/combined/utils/alert-messages.jsx
+++ b/src/applications/combined-debt-portal/combined/utils/alert-messages.jsx
@@ -10,7 +10,7 @@ const alertMessage = (alertType, appType) => {
         header: `You don’t have any current VA debt or copay bills`,
         body: (
           <>
-            <p className="vads-u-font-size--base vads-u-font-family--sans">
+            <p>
               Our records show you don’t have any current VA benefit debt and
               you haven’t received a copay bill in the past 6 months.
             </p>
@@ -46,7 +46,7 @@ const alertMessage = (alertType, appType) => {
           <>
             {appType === APP_TYPES.DEBT ? (
               <>
-                <p className="vads-u-font-size--base vads-u-font-family--sans">
+                <p>
                   We’re sorry. Information about{' '}
                   {`${appType === APP_TYPES.DEBT ? 'debts' : 'copays'}`} you
                   might have is unavailable because something went wrong on our
@@ -106,7 +106,7 @@ const alertMessage = (alertType, appType) => {
         header: `We can’t access your debt and copay records right now`,
         body: (
           <>
-            <p className="vads-u-font-size--base vads-u-font-family--sans">
+            <p>
               We’re sorry. Information about debts and copays you might have is
               unavailable because something went wrong on our end. Please check
               back soon.
@@ -115,12 +115,19 @@ const alertMessage = (alertType, appType) => {
         ),
         secondHeader: `What you can do`,
         secondBody: (
-          <p className="vads-u-font-family--sans">
-            If you continue having trouble viewing information about your
-            current debts and bills, contact us online through{' '}
-            <a href="https://ask.va.gov">Ask VA</a>
-            ..
-          </p>
+          <>
+            <p className="vads-u-font-family--sans">
+              If you continue hav ing trouble viewing information about your
+              current debts and bills, contact us online through{' '}
+              <a href="https://ask.va.gov">Ask VA</a>.
+            </p>
+            <va-link
+              href="https://ask.va.gov"
+              active
+              text="Contact us at Ask VA"
+              class="vads-u-margin-top--2"
+            />
+          </>
         ),
       };
   }

--- a/src/applications/combined-debt-portal/combined/utils/alert-messages.jsx
+++ b/src/applications/combined-debt-portal/combined/utils/alert-messages.jsx
@@ -82,21 +82,13 @@ const alertMessage = (alertType, appType) => {
             : `You haven't received a copay bill in the past 6 months`,
         body:
           appType === APP_TYPES.DEBT ? (
-            <>
-              <p>
-                Our records show you don’t have any current debt related to VA
-                benefits. If you think this is incorrect, call the Debt
-                Management Center (DMC) at <va-telephone contact="8008270648" />{' '}
-                (<va-telephone tty contact="711" />
-                ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
-              </p>
-              <va-link
-                href="https://va.gov"
-                active
-                text="Return to VA.gov"
-                class="vads-u-margin-top--2"
-              />
-            </>
+            <p>
+              Our records show you don’t have any current debt related to VA
+              benefits. If you think this is incorrect, call the Debt Management
+              Center (DMC) at <va-telephone contact="8008270648" /> (
+              <va-telephone tty contact="711" />
+              ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
+            </p>
           ) : (
             <p>
               If you think this is incorrect, contact the VA Health Resource

--- a/src/applications/combined-debt-portal/combined/utils/alert-messages.jsx
+++ b/src/applications/combined-debt-portal/combined/utils/alert-messages.jsx
@@ -19,13 +19,13 @@ const alertMessage = (alertType, appType) => {
         secondHeader: `What to do if you think you have a VA debt or copay bill:`,
         secondBody: (
           <ul>
-            <li className="vads-u-font-family--sans">
+            <li>
               <strong>For benefit debts</strong>, call the Debt Management
               Center (DMC) at <va-telephone contact="8008270648" /> (
               <va-telephone tty contact="711" />
               ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
             </li>
-            <li className="vads-u-font-family--sans">
+            <li>
               <strong>For medical copay bills</strong>, call the VA Health
               Resource Center at <va-telephone contact="8664001238" /> (
               <va-telephone tty contact="711" />
@@ -52,7 +52,7 @@ const alertMessage = (alertType, appType) => {
                   might have is unavailable because something went wrong on our
                   end. Please check back soon.
                 </p>
-                <p className="vads-u-font-family--sans">
+                <p>
                   If you continue having trouble viewing information about your{' '}
                   {`${appType === APP_TYPES.DEBT ? 'debts' : 'copays'}`},
                   contact us online through{' '}
@@ -60,7 +60,7 @@ const alertMessage = (alertType, appType) => {
                 </p>
               </>
             ) : (
-              <p className="vads-u-font-family--sans">
+              <p>
                 Please check back soon. If you continue having trouble viewing
                 information about your copays, call the VA Health Resource
                 Center at <va-telephone contact="8664001238" /> (
@@ -82,15 +82,23 @@ const alertMessage = (alertType, appType) => {
             : `You haven't received a copay bill in the past 6 months`,
         body:
           appType === APP_TYPES.DEBT ? (
-            <p className="vads-u-font-family--sans">
-              Our records show you don’t have any current debt related to VA
-              benefits. If you think this is incorrect, call the Debt Management
-              Center (DMC) at <va-telephone contact="8008270648" /> (
-              <va-telephone tty contact="711" />
-              ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
-            </p>
+            <>
+              <p>
+                Our records show you don’t have any current debt related to VA
+                benefits. If you think this is incorrect, call the Debt
+                Management Center (DMC) at <va-telephone contact="8008270648" />{' '}
+                (<va-telephone tty contact="711" />
+                ). We’re here Monday through Friday, 7:30 a.m. to 7:00 p.m. ET.
+              </p>
+              <va-link
+                href="https://va.gov"
+                active
+                text="Return to VA.gov"
+                class="vads-u-margin-top--2"
+              />
+            </>
           ) : (
-            <p className="vads-u-font-family--sans">
+            <p>
               If you think this is incorrect, contact the VA Health Resource
               Center at <va-telephone contact="8664001238" /> (
               <va-telephone tty contact="711" />
@@ -116,8 +124,8 @@ const alertMessage = (alertType, appType) => {
         secondHeader: `What you can do`,
         secondBody: (
           <>
-            <p className="vads-u-font-family--sans">
-              If you continue hav ing trouble viewing information about your
+            <p>
+              If you continue having trouble viewing information about your
               current debts and bills, contact us online through{' '}
               <a href="https://ask.va.gov">Ask VA</a>.
             </p>

--- a/src/applications/combined-debt-portal/debt-letters/components/Alerts.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/Alerts.jsx
@@ -8,12 +8,12 @@ export const DownloadLettersAlert = () => (
     <h3 slot="headline">
       Downloadable letters have incorrect repayment plan terms
     </h3>
-    <p className="vads-u-font-size--base vads-u-font-family--sans">
+    <p>
       We’re sorry. The length of time listed for repayment plans in these
       letters is too short. Use the letters you get in the mail to find the
       correct repayment plan terms.
     </p>
-    <p className="vads-u-font-size--base vads-u-font-family--sans">
+    <p>
       If you have any questions, call us at{' '}
       <va-telephone contact={CONTACTS.DMC} /> (or{' '}
       <va-telephone contact={CONTACTS.DMC_OVERSEAS} international /> from
@@ -21,7 +21,7 @@ export const DownloadLettersAlert = () => (
       you have hearing loss, call TTY:{' '}
       <va-telephone contact={CONTACTS['711']} />.
     </p>
-    <p className="vads-u-font-size--base vads-u-font-family--sans">
+    <p>
       We’re working to fix this problem as fast as we can. Check back soon for
       updates.
     </p>
@@ -32,25 +32,21 @@ export const DowntimeMessage = () => {
   return (
     <va-alert status="error">
       <h3 slot="headline">Nightly tool maintenance</h3>
-      <p className="vads-u-font-size--base vads-u-font-family--sans">
+      <p>
         We’re working on this tool right now. If you have trouble signing in or
         using this tool, check back after we’re finished.
       </p>
-      <p className="vads-u-font-size--base vads-u-font-family--sans">
+      <p>
         Please note that we’ll be doing maintenance at this time each night from
         12:30 a.m. to 3 a.m. ET. Thank you for your patience.
       </p>
 
-      <p className="vads-u-font-size--base vads-u-font-family--sans">
-        Date: {moment().format('dddd, MMMM D, YYYY')}
-      </p>
-      <p className="vads-u-font-size--base vads-u-font-family--sans">
-        Start/End time: 12:30 a.m. to 3:00 a.m. ET
-      </p>
+      <p>Date: {moment().format('dddd, MMMM D, YYYY')}</p>
+      <p>Start/End time: 12:30 a.m. to 3:00 a.m. ET</p>
 
       <h4>What can you do</h4>
 
-      <p className="vads-u-font-size--base vads-u-font-family--sans">
+      <p>
         You can still
         <Link to="/debt-balances/letters" className="vads-u-margin-x--0p5">
           download your debt letters.

--- a/src/applications/combined-debt-portal/debt-letters/components/Alerts.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/components/Alerts.jsx
@@ -84,48 +84,69 @@ export const DebtLetterDownloadDisabled = () => (
 export const ErrorAlert = () => (
   <va-alert status="error">
     <h3 slot="headline">Your debt letters are currently unavailable.</h3>
-    <p className="vads-u-font-family--sans">
+    <p>
       You can’t download your debt letters because something went wrong on our
       end.
     </p>
     <h4>What you can do</h4>
-    <p className="vads-u-font-family--sans vads-u-margin-y--0">
+    <p>
       You can check back later or call the Debt Management Center at{' '}
       <va-telephone contact="8008270648" /> to find out more information about
       how to resolve your debt.
     </p>
+    <va-link
+      href="/manage-va-debt/summary/debt-balances/"
+      icon-name="navigate_before"
+      icon-size={3}
+      text="Back to current debts"
+      class="vads-u-font-weight--bold vads-u-margin-left--neg0p5 vads-u-margin-top--2"
+    />
   </va-alert>
 );
 
 export const DependentDebt = () => (
   <va-alert status="error">
     <h3 slot="headline">Your debt letters are currently unavailable.</h3>
-    <p className="vads-u-font-family--sans">
+    <p>
       You can’t download your debt letters because something went wrong on our
       end.
     </p>
     <h4>What you can do</h4>
-    <p className="vads-u-font-family--sans vads-u-margin-y--0">
+    <p>
       If you need to access debt letters that were mailed to you, call the Debt
       Management Center at <va-telephone contact="8008270648" />.
     </p>
+    <va-link
+      href="/manage-va-debt/summary/debt-balances/"
+      icon-name="navigate_before"
+      icon-size={3}
+      text="Back to current debts"
+      class="vads-u-font-weight--bold vads-u-margin-left--neg0p5 vads-u-margin-top--2"
+    />
   </va-alert>
 );
 
 export const NoDebtLinks = () => (
   <va-alert status="error">
     <h3 slot="headline">You don’t have any VA debt letters</h3>
-    <p className="vads-u-font-family--sans">
+    <p>
       Our records show you don’t have any debt letters related to VA benefits.
       If you think this is an error, please contact the Debt Management Center
       at <va-telephone contact="8008270648" />.
     </p>
-    <p className="vads-u-font-family--sans vads-u-margin-y--0">
+    <p>
       If you have VA health care copay debt, go to our
       <Link className="vads-u-margin-x--0p5" to="/copay-balances/">
         Pay your VA copay bill
       </Link>
       page to learn about your payment options.
     </p>
+    <va-link
+      href="/manage-va-debt/summary/debt-balances/"
+      icon-name="navigate_before"
+      icon-size={3}
+      text="Back to current debts"
+      class="vads-u-font-weight--bold vads-u-margin-left--neg0p5 vads-u-margin-top--2"
+    />
   </va-alert>
 );

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
@@ -82,6 +82,8 @@ const DebtLettersSummary = () => {
     isProfileUpdating,
   } = debtLetters;
   const { statements: mcpStatements, error: mcpError } = mcp;
+  const allDebtsEmpty =
+    !debtError && debts.length === 0 && debtLinks.length === 0;
 
   useEffect(() => {
     setPageFocus('h1');
@@ -96,9 +98,64 @@ const DebtLettersSummary = () => {
     );
   }
 
-  const allDebtsEmpty =
-    !debtError && debts.length === 0 && debtLinks.length === 0;
+  const renderContent = () => {
+    if (debtError) {
+      return renderAlert(
+        mcpError ? ALERT_TYPES.ALL_ERROR : ALERT_TYPES.ERROR,
+        mcpStatements?.length,
+      );
+    }
 
+    if (allDebtsEmpty) {
+      return renderAlert(ALERT_TYPES.ZERO, mcpStatements?.length);
+    }
+
+    return (
+      <>
+        <DebtCardsList />
+        {renderOtherVA(mcpStatements?.length, mcpError)}
+        {showDebtLetterDownload ? (
+          <section>
+            <h3
+              id="downloadDebtLetters"
+              className="vads-u-margin-top--4 vads-u-font-size--h2"
+            >
+              Download debt letters
+            </h3>
+            <p className="vads-u-margin-bottom--0 vads-u-font-family--sans">
+              You can download some of your letters for education, compensation
+              and pension debt.
+            </p>
+
+            <Link
+              to="/debt-balances/letters"
+              className="vads-u-margin-top--1 vads-u-font-family--sans"
+              data-testid="download-letters-link"
+            >
+              Download letters related to your VA debt
+            </Link>
+          </section>
+        ) : null}
+        <va-need-help id="needHelp" class="vads-u-margin-top--4">
+          <div slot="content">
+            <p>
+              If you have any questions about your benefit overpayment or if you
+              think your debt was created in an error, you can dispute it.
+              Contact us online through <a href="https://ask.va.gov/">Ask VA</a>{' '}
+              or call the Debt Management Center at{' '}
+              <va-telephone contact="8008270648" /> (
+              <va-telephone contact="711" tty="true" />
+              ). For international callers, use{' '}
+              <va-telephone contact="6127136415" />. We’re here Monday through
+              Friday, 7:30 a.m. to 7:00 p.m. ET.
+            </p>
+          </div>
+        </va-need-help>
+      </>
+    );
+  };
+
+  // Render common header content
   return (
     <>
       <VaBreadcrumbs
@@ -134,65 +191,7 @@ const DebtLettersSummary = () => {
           disability compensation, or pension benefits. Find out how to pay your
           debt and what to do if you need financial assistance.
         </p>
-        <>
-          {debtError || allDebtsEmpty ? (
-            <>
-              {debtError &&
-                renderAlert(
-                  mcpError ? ALERT_TYPES.ALL_ERROR : ALERT_TYPES.ERROR,
-                  mcpStatements?.length,
-                )}
-
-              {allDebtsEmpty &&
-                renderAlert(ALERT_TYPES.ZERO, mcpStatements?.length)}
-            </>
-          ) : (
-            <>
-              <DebtCardsList />
-
-              {renderOtherVA(mcpStatements?.length, mcpError)}
-
-              {showDebtLetterDownload ? (
-                <section>
-                  <h3
-                    id="downloadDebtLetters"
-                    className="vads-u-margin-top--4 vads-u-font-size--h2"
-                  >
-                    Download debt letters
-                  </h3>
-                  <p className="vads-u-margin-bottom--0 vads-u-font-family--sans">
-                    You can download some of your letters for education,
-                    compensation and pension debt.
-                  </p>
-
-                  <Link
-                    to="/debt-balances/letters"
-                    className="vads-u-margin-top--1 vads-u-font-family--sans"
-                    data-testid="download-letters-link"
-                  >
-                    Download letters related to your VA debt
-                  </Link>
-                </section>
-              ) : null}
-
-              <va-need-help id="needHelp" class="vads-u-margin-top--4">
-                <div slot="content">
-                  <p>
-                    If you have any questions about your benefit overpayment or
-                    if you think your debt was created in an error, you can
-                    dispute it. Contact us online through{' '}
-                    <a href="https://ask.va.gov/">Ask VA</a> or call the Debt
-                    Management Center at <va-telephone contact="8008270648" /> (
-                    <va-telephone contact="711" tty="true" />
-                    ). For international callers, use{' '}
-                    <va-telephone contact="6127136415" />. We’re here Monday
-                    through Friday, 7:30 a.m. to 7:00 p.m. ET.
-                  </p>
-                </div>
-              </va-need-help>
-            </>
-          )}
-        </>
+        {renderContent()}
       </div>
     </>
   );

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersSummary.jsx
@@ -16,6 +16,7 @@ import alertMessage from '../../combined/utils/alert-messages';
 const renderAlert = (alertType, statements) => {
   const alertInfo = alertMessage(alertType, APP_TYPES.DEBT);
   const showOther = statements > 0;
+  const showVAReturnLink = !showOther && alertType !== ALERT_TYPES.ALL_ERROR;
 
   return (
     <va-alert data-testid={alertInfo.testID} status={alertInfo.alertStatus}>
@@ -30,6 +31,15 @@ const renderAlert = (alertType, statements) => {
           {alertInfo.secondBody}
         </>
       )}
+      {showVAReturnLink ? (
+        <va-link
+          active
+          class="vads-u-margin-top--2"
+          data-testid="return-to-va-link"
+          href="https://va.gov"
+          text="Return to VA.gov"
+        />
+      ) : null}
     </va-alert>
   );
 };

--- a/src/applications/combined-debt-portal/medical-copays/containers/OverviewPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/OverviewPage.jsx
@@ -22,6 +22,7 @@ const renderAlert = (alertType, debts) => {
   const alertInfo = alertMessage(alertType, APP_TYPES.COPAY);
   const showOther = debts > 0;
   const showVAReturnLink = !showOther && alertType !== ALERT_TYPES.ALL_ERROR;
+
   return (
     <va-alert data-testid={alertInfo.testID} status={alertInfo.alertStatus}>
       <h2 className="vads-u-font-size--h3" slot="headline">
@@ -37,11 +38,11 @@ const renderAlert = (alertType, debts) => {
       )}
       {showVAReturnLink ? (
         <va-link
-          href="/manage-va-debt/summary/"
-          data-testid="other-va-debts-link"
           active
-          text="View all your VA debt and bills"
           class="vads-u-margin-top--2"
+          data-testid="return-to-va-link"
+          href="https://va.gov"
+          text="Return to VA.gov"
         />
       ) : null}
     </va-alert>

--- a/src/applications/combined-debt-portal/medical-copays/containers/OverviewPage.jsx
+++ b/src/applications/combined-debt-portal/medical-copays/containers/OverviewPage.jsx
@@ -21,7 +21,7 @@ import MCPAlerts from '../../combined/components/MCPAlerts';
 const renderAlert = (alertType, debts) => {
   const alertInfo = alertMessage(alertType, APP_TYPES.COPAY);
   const showOther = debts > 0;
-
+  const showVAReturnLink = !showOther && alertType !== ALERT_TYPES.ALL_ERROR;
   return (
     <va-alert data-testid={alertInfo.testID} status={alertInfo.alertStatus}>
       <h2 className="vads-u-font-size--h3" slot="headline">
@@ -35,6 +35,15 @@ const renderAlert = (alertType, debts) => {
           {alertInfo.secondBody}
         </>
       )}
+      {showVAReturnLink ? (
+        <va-link
+          href="/manage-va-debt/summary/"
+          data-testid="other-va-debts-link"
+          active
+          text="View all your VA debt and bills"
+          class="vads-u-margin-top--2"
+        />
+      ) : null}
     </va-alert>
   );
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Added active links to either return to va.gov homepage or Ask VA or go to overview page depending on the alert state 
- Added links specifically for 404 or empty states for debts and coapys to overview, copay and debt summary pages

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#88882


## Testing done

- Tested locally in the browser by forcing error/empty states to show up 

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Overview Empy state  |        |  <img width="711" alt="Screenshot 2024-07-30 at 11 59 31 AM" src="https://github.com/user-attachments/assets/2d619a1a-3631-4fa6-93b6-219e0248880f">  |
| Overview 404 |    | <img width="725" alt="Screenshot 2024-07-31 at 1 21 59 PM" src="https://github.com/user-attachments/assets/191d8a71-a45e-4a34-af16-9a39e79d9661"> |
| Debt Summary Empty state + copays available   |        | <img width="400" alt="image" src="https://github.com/user-attachments/assets/4ec3a0a2-2665-4d41-8e94-24bfad7ed5be"> |
| Debt Summary Empty state + no copays (or copays 404) |        | <img width="400" alt="image" src="https://github.com/user-attachments/assets/0de55c4f-41f7-4c77-9c29-ed73840ae5c9"> |
| Debt Summary both 404 |        | <img width="400" alt="image" src="https://github.com/user-attachments/assets/696f96cb-675a-43c9-9c97-1062abe86542"> |
| Debt Summary debt 404 + copays available  |        | <img width="400" alt="image" src="https://github.com/user-attachments/assets/c09cefad-ff5d-4278-ba94-c297456ce19b"> |
| Debt Summary debt 404 + no copays available  |        | <img width="400" alt="image" src="https://github.com/user-attachments/assets/c4727d5b-1942-408c-bf18-04f7d98ea1f4"> |
| Copay Summary Empty state + debt available   |        | <img width="400" alt="image" src="https://github.com/user-attachments/assets/36014c4d-d3df-40c5-b814-d7e6bbedf0c8"> |
| Copay Summary Empty state + no debts (or debt 404) |        | <img width="400" alt="image" src="https://github.com/user-attachments/assets/c3b798bd-4778-4e37-bf67-56911847911c"> |
| Copay Summary both 404 |        | <img width="400" alt="image" src="https://github.com/user-attachments/assets/8e5b7796-0cb2-4bde-81e2-f349958d392b"> |
| Copay Summary copay 404 + debts available  |        | <img width="400" alt="image" src="https://github.com/user-attachments/assets/6c1b8985-62d6-4f9a-9289-5d37bc120618"> |
| Copay Summary copay 404 + no debts available  |        | <img width="400" alt="image" src="https://github.com/user-attachments/assets/985e8284-458d-4825-a040-5b706dfcf465"> |

## What areas of the site does it impact?

Combined debt portal

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
