### PR TITLE
Update claims filter text as filters get applied.

### DIFF
--- a/src/applications/travel-pay/containers/TravelPayStatusApp.jsx
+++ b/src/applications/travel-pay/containers/TravelPayStatusApp.jsx
@@ -180,6 +180,41 @@ export default function App({ children }) {
     displayedClaims = displayedClaims.slice(pageStart - 1, pageEnd);
   }
 
+  const resultsText = () => {
+    let sortAndFilterText;
+
+    if (orderClaimsBy === 'mostRecent') {
+      sortAndFilterText = 'date (most recent)';
+    }
+
+    if (orderClaimsBy === 'oldest') {
+      sortAndFilterText = 'date (oldest)';
+    }
+
+    let appliedFiltersLength = appliedStatusFilters.length;
+    if (appliedDateFilter !== 'all') {
+      appliedFiltersLength += 1;
+    }
+
+    if (appliedFiltersLength > 0) {
+      sortAndFilterText += `, with ${appliedFiltersLength} ${
+        appliedFiltersLength === 1 ? 'filter' : 'filters'
+      } applied`;
+    }
+
+    if (numResults === 0 && appliedFiltersLength > 0) {
+      // Note that appliedFiltersLength === 1 should never be true here, since
+      // 0 claims matching a single filter should mean the filter isn't shown
+      return `Showing 0 claims with ${appliedFiltersLength} ${
+        appliedFiltersLength === 1 ? 'filter' : 'filters'
+      } applied`;
+    }
+
+    return numResults === 0
+      ? `Showing ${numResults} claims`
+      : `Showing ${pageStart} ‒ ${pageEnd} of ${numResults} claims, sorted by ${sortAndFilterText}.`;
+  };
+
   const onPageSelect = useCallback(
     selectedPage => {
       setCurrentPage(selectedPage);
@@ -285,9 +320,7 @@ export default function App({ children }) {
                 </div>
 
                 <h2 tabIndex={-1} ref={filterInfoRef} id="pagination-info">
-                  {numResults === 0
-                    ? `Showing ${numResults} events`
-                    : `Showing ${pageStart} ‒ ${pageEnd} of ${numResults} events`}
+                  {resultsText()}
                 </h2>
 
                 <section

--- a/src/applications/travel-pay/tests/containers/TravelPayStatusApp.unit.spec.jsx
+++ b/src/applications/travel-pay/tests/containers/TravelPayStatusApp.unit.spec.jsx
@@ -283,7 +283,6 @@ describe('App', () => {
       });
     });
 
-    await userEvent.click(screen.getByTestId('status-filter_Incomplete'));
     userEvent.click($('va-button[text="Apply filters"]'));
 
     expect(screen.getAllByTestId('travel-claim-details').length).to.eq(1);
@@ -325,6 +324,70 @@ describe('App', () => {
         document.querySelector('va-button[text="Apply filters"]'),
       );
 
+      expect(
+        screen.findByText(
+          'Showing 1 ‒ 10 of 31 claims, sorted by date (most recent), with 1 filter applied.',
+        ),
+      ).to.exist;
+      expect(screen.getAllByTestId('travel-claim-details').length).to.eq(1);
+      expect(
+        screen.getAllByTestId('travel-claim-details')[0].textContent,
+      ).to.eq(`${date} at ${time} appointment`);
+    });
+
+    fireEvent.click(document.querySelector('va-button[text="Reset search"]'));
+    expect(screen.getAllByTestId('travel-claim-details').length).to.eq(3);
+  });
+
+  it('filters by status and date together', async () => {
+    const screen = renderWithStoreAndRouter(<App />, {
+      initialState: getData({
+        areFeatureTogglesLoading: false,
+        hasFeatureFlag: true,
+        isLoggedIn: true,
+      }),
+      path: `/`,
+      reducers: reducer,
+    });
+
+    await waitFor(async () => {
+      const [date, time] = formatDateTime(previousYearDate);
+
+      userEvent.click(
+        document.querySelector(
+          'va-accordion-item[header="Filter travel claims"]',
+        ),
+      );
+
+      const dateSelect = screen.getByTestId('claimsDates');
+      dateSelect.__events.vaSelect({
+        target: {
+          value: 'All of 2023',
+        },
+      });
+
+      userEvent.selectOptions(dateSelect, ['All of 2023']);
+
+      expect(screen.getByRole('option', { name: 'All of 2023' }).selected).to
+        .true;
+
+      const checkboxGroup = $('#status-checkboxes');
+      checkboxGroup.__events.vaChange({
+        target: {
+          name: 'Saved',
+          checked: true,
+        },
+      });
+
+      userEvent.click(
+        document.querySelector('va-button[text="Apply filters"]'),
+      );
+
+      expect(
+        await screen.findByText(
+          'Showing 1 ‒ 1 of 1 claims, sorted by date (most recent), with 2 filters applied.',
+        ),
+      ).to.exist;
       expect(screen.getAllByTestId('travel-claim-details').length).to.eq(1);
       expect(
         screen.getAllByTestId('travel-claim-details')[0].textContent,
@@ -350,7 +413,11 @@ describe('App', () => {
     });
 
     await waitFor(async () => {
-      expect(await screen.findByText('Showing 1 ‒ 10 of 31 events')).to.exist;
+      expect(
+        await screen.findByText(
+          'Showing 1 ‒ 10 of 31 claims, sorted by date (most recent).',
+        ),
+      ).to.exist;
       // RTL doesn't support shadow DOM elements, so best we can do here is
       // check that the top-level pagination element gets rendered
       expect(await screen.container.querySelectorAll('va-card').length).to.eq(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**: Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
- _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updates the paginated results description as filters and sorting are changed/applied

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87886

## Testing done

- Added unit tests to assert proper UI appearance, as well as fixed/updated existing tests 

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

**Single Filter**

<img width="698" alt="Screenshot 2024-07-30 at 5 25 08 PM" src="https://github.com/user-attachments/assets/608a47b6-2f07-44b5-8255-d7565b8b16ed">

**Multiple Filters**

<img width="698" alt="Screenshot 2024-07-30 at 5 25 54 PM" src="https://github.com/user-attachments/assets/d8da9721-ad14-4f66-adcd-f9c4b3b4a608">

**Zero claims with chosen filters**

<img width="574" alt="Screenshot 2024-07-30 at 5 23 25 PM" src="https://github.com/user-attachments/assets/cf6f4897-440d-4633-ba3a-4179b05b187f">


## What areas of the site does it impact?

Travel Pay

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
