### PR TITLE
Temporarily skip flakey VAOS unit test for COVID appointments

### DIFF
--- a/src/applications/vaos/tests/covid-19-vaccine/components/SelectDate1Page.unit.spec.js
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/SelectDate1Page.unit.spec.js
@@ -323,7 +323,7 @@ describe('VAOS vaccine flow: SelectDate1Page', () => {
     expect(screen.history.push.called).not.to.be.true;
   });
 
-  it('should fetch slots when moving between months', async () => {
+  it.skip('should fetch slots when moving between months', async () => {
     mockEligibilityFetches({
       facilityId: '983',
       typeOfCareId: TYPE_OF_CARE_ID,

--- a/src/applications/vaos/tests/covid-19-vaccine/components/SelectDate1Page.unit.spec.js
+++ b/src/applications/vaos/tests/covid-19-vaccine/components/SelectDate1Page.unit.spec.js
@@ -35,6 +35,7 @@ describe('VAOS vaccine flow: SelectDate1Page', () => {
     stationId: '983',
     friendlyName: 'Green team clinic',
   });
+
   const clinic2 = createMockClinic({
     id: '309',
     stationId: '983',


### PR DESCRIPTION

## Summary
Temporarily skips flakey unit test mentioned [here](https://dsva.slack.com/archives/CMNQT72LX/p1722440006566879)

## Related issue(s)

(will to issue shortly)

## Testing done

N/A

## Acceptance criteria

### Quality Assurance & Testing

- [ ] The skipped test allows all unit tests to pass 

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
