### PR TITLE
Update 'Other Toxic Exposure' error message for Health Care Application

### DIFF
--- a/src/applications/hca/config/chapters/militaryService/otherToxicExposureDetails.js
+++ b/src/applications/hca/config/chapters/militaryService/otherToxicExposureDetails.js
@@ -15,7 +15,7 @@ export default {
       'ui:title': 'Enter any toxins or hazards you\u2019ve been exposed to',
       'ui:errorMessages': {
         pattern:
-          'You entered a character we can\u2019t accept. Remove any special characters other than these: . ? ! ,',
+          'You entered a character we can\u2019t accept. You can use only these characters: . , ! ?',
       },
     },
   },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR makes a small content update to one of the error messages in the TERA section of the Health Care Application. This is a CAIA request to update this content.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#82212

## Testing done

- Navigate through the application until you get to the military section.
- Indicate you have been exposed to Toxins during combat.
- Indicate you have been exposed to "Other" in the option list.
- Attempt to fill in the field with any of the accepted characters--you should not get an error
- Attempt to fill in the field with an unaccepted character--you should get an error

## Acceptance criteria

 - Error messaging is CAIA-approved for the application.

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution