### PR TITLE
wrapped reloading upcoming in feature flag.

### DIFF
--- a/src/applications/check-in/components/layout/ReloadWrapper.jsx
+++ b/src/applications/check-in/components/layout/ReloadWrapper.jsx
@@ -27,7 +27,6 @@ const ReloadWrapper = props => {
   const currentForm = useSelector(selectForm);
   const { updateError } = useUpdateError();
   const progressState = getProgressState(window);
-
   const { checkInDataError, refreshCheckInData, isLoading } = useGetCheckInData(
     {
       refreshNeeded: false,

--- a/src/applications/check-in/components/layout/ReloadWrapper.jsx
+++ b/src/applications/check-in/components/layout/ReloadWrapper.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 
 import { makeSelectCurrentContext, makeSelectForm } from '../../selectors';
+import { makeSelectFeatureToggles } from '../../utils/selectors/feature-toggles';
 import { setForm } from '../../actions/universal';
 import { createSetSession } from '../../actions/authentication';
 import { useStorage } from '../../hooks/useStorage';
@@ -27,6 +28,9 @@ const ReloadWrapper = props => {
   const currentForm = useSelector(selectForm);
   const { updateError } = useUpdateError();
   const progressState = getProgressState(window);
+  const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
+  const { isUpcomingAppointmentsEnabled } = useSelector(selectFeatureToggles);
+
   const { checkInDataError, refreshCheckInData, isLoading } = useGetCheckInData(
     {
       refreshNeeded: false,
@@ -71,7 +75,9 @@ const ReloadWrapper = props => {
             }),
           );
           refreshCheckInData();
-          refreshUpcomingData();
+          if (isUpcomingAppointmentsEnabled) {
+            refreshUpcomingData();
+          }
         } else {
           setRefreshData(false);
         }

--- a/src/applications/check-in/components/layout/ReloadWrapper.jsx
+++ b/src/applications/check-in/components/layout/ReloadWrapper.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { useSelector, useDispatch } from 'react-redux';
 
 import { makeSelectCurrentContext, makeSelectForm } from '../../selectors';
-import { makeSelectFeatureToggles } from '../../utils/selectors/feature-toggles';
 import { setForm } from '../../actions/universal';
 import { createSetSession } from '../../actions/authentication';
 import { useStorage } from '../../hooks/useStorage';
@@ -28,8 +27,6 @@ const ReloadWrapper = props => {
   const currentForm = useSelector(selectForm);
   const { updateError } = useUpdateError();
   const progressState = getProgressState(window);
-  const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
-  const { isUpcomingAppointmentsEnabled } = useSelector(selectFeatureToggles);
 
   const { checkInDataError, refreshCheckInData, isLoading } = useGetCheckInData(
     {
@@ -75,9 +72,7 @@ const ReloadWrapper = props => {
             }),
           );
           refreshCheckInData();
-          if (isUpcomingAppointmentsEnabled) {
-            refreshUpcomingData();
-          }
+          refreshUpcomingData();
         } else {
           setRefreshData(false);
         }

--- a/src/applications/check-in/components/tests/UpcomingAppointments.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/UpcomingAppointments.unit.spec.jsx
@@ -18,6 +18,9 @@ describe('unified check-in experience', () => {
     afterEach(() => {
       teardownI18n();
     });
+    const features = {
+      check_in_experience_upcoming_appointments_enabled: true,
+    };
     it('displays the upcoming appointments list component', () => {
       // Mock the return value for the useGetUpcomingAppointmentsData hook
       const useGetUpcomingAppointmentsDataStub = sinon
@@ -30,7 +33,7 @@ describe('unified check-in experience', () => {
         });
 
       const { getByTestId } = render(
-        <CheckInProvider>
+        <CheckInProvider store={{ features }}>
           <UpcomingAppointments />
         </CheckInProvider>,
       );
@@ -55,7 +58,7 @@ describe('unified check-in experience', () => {
           upcomingAppointmentsDataError: false,
         });
       const screen = render(
-        <CheckInProvider store={{ upcomingAppointments: [] }}>
+        <CheckInProvider store={{ upcomingAppointments: [], features }}>
           <UpcomingAppointments />
         </CheckInProvider>,
       );
@@ -77,7 +80,7 @@ describe('unified check-in experience', () => {
           upcomingAppointmentsDataError: true,
         });
       const screen = render(
-        <CheckInProvider>
+        <CheckInProvider store={{ features }}>
           <UpcomingAppointments />
         </CheckInProvider>,
       );
@@ -96,7 +99,7 @@ describe('unified check-in experience', () => {
       const { v2 } = api;
       sandbox.stub(v2, 'getUpcomingAppointmentsData').resolves({});
       const screen = render(
-        <CheckInProvider store={{ upcomingAppointments: [] }}>
+        <CheckInProvider store={{ upcomingAppointments: [], features }}>
           <UpcomingAppointments refresh={false} />
         </CheckInProvider>,
       );
@@ -111,7 +114,12 @@ describe('unified check-in experience', () => {
       const { v2 } = api;
       sandbox.stub(v2, 'getUpcomingAppointmentsData').resolves({});
       const screen = render(
-        <CheckInProvider store={{ upcomingAppointments: multipleAppointments }}>
+        <CheckInProvider
+          store={{
+            upcomingAppointments: multipleAppointments,
+            features,
+          }}
+        >
           <UpcomingAppointments refresh={false} />
         </CheckInProvider>,
       );
@@ -126,7 +134,12 @@ describe('unified check-in experience', () => {
       const { v2 } = api;
       sandbox.stub(v2, 'getUpcomingAppointmentsData').resolves({});
       const screen = render(
-        <CheckInProvider store={{ upcomingAppointments: multipleAppointments }}>
+        <CheckInProvider
+          store={{
+            upcomingAppointments: multipleAppointments,
+            features,
+          }}
+        >
           <UpcomingAppointments refresh />
         </CheckInProvider>,
       );

--- a/src/applications/check-in/hooks/useGetUpcomingAppointmentsData.jsx
+++ b/src/applications/check-in/hooks/useGetUpcomingAppointmentsData.jsx
@@ -2,10 +2,13 @@ import { useLayoutEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { api } from '../api';
 import { makeSelectCurrentContext } from '../selectors';
+import { makeSelectFeatureToggles } from '../utils/selectors/feature-toggles';
 
 import { recievedUpcomingAppointments } from '../actions/universal';
 
 const useGetUpcomingAppointmentsData = ({ refreshNeeded }) => {
+  const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
+  const { isUpcomingAppointmentsEnabled } = useSelector(selectFeatureToggles);
   const [isComplete, setIsComplete] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isStale, setIsStale] = useState(refreshNeeded);
@@ -23,10 +26,9 @@ const useGetUpcomingAppointmentsData = ({ refreshNeeded }) => {
   };
 
   const dispatch = useDispatch();
-
   useLayoutEffect(
     () => {
-      if (token && !isComplete && isStale) {
+      if (isUpcomingAppointmentsEnabled && token && !isComplete && isStale) {
         setIsLoading(true);
         api.v2
           .getUpcomingAppointmentsData(token)
@@ -43,7 +45,7 @@ const useGetUpcomingAppointmentsData = ({ refreshNeeded }) => {
           });
       }
     },
-    [token, isComplete, isStale, dispatch],
+    [token, isComplete, isStale, dispatch, isUpcomingAppointmentsEnabled],
   );
 
   return {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**: Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
- _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Hotfix to prevent reload from calling upcoming appointments endpoint when the feature is off.

## Related issue(s)

Hotfix

## Testing done

Local testing

## What areas of the site does it impact?

pre-check-in and day-of check-in

## Acceptance criteria
 - [ ] upcoming appointments is not called on reload with the feature off
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
