### PR TITLE
88731 - Adds new VideoLink component to appointment details redesign video details page

### DIFF
--- a/src/applications/vaos/components/VideoLink.jsx
+++ b/src/applications/vaos/components/VideoLink.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+// import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import moment from 'moment-timezone';
+import NewTabAnchor from './NewTabAnchor';
+
+export default function VideoLink({ appointment }) {
+  const { url } = appointment.videoData;
+  const diff = moment().diff(moment(appointment.start), 'minutes');
+
+  // Button is enabled 30 minutes prior to start time, until 4 hours after start time
+  // NOTE: If the moment is earlier than the moment you are passing to moment.fn.diff,
+  // the return value will be negative. So checking to see if the appointment start
+  // time is before or after the current time.
+  let disableVideoLink;
+  if (diff > 0) {
+    disableVideoLink = diff > 30;
+  } else {
+    disableVideoLink = diff < -240;
+  }
+
+  return (
+    <div className="vaos-appts__video-visit">
+      {disableVideoLink && (
+        <>
+          We'll add the link to join this appointment 30 minutes before your
+          appointment time.
+        </>
+      )}
+
+      {!!disableVideoLink && (
+        <>
+          <NewTabAnchor
+            href={url}
+            className="vads-c-action-link--green vaos-hide-for-print vads-u-margin-bottom--2p5"
+            aria-describedby={`description-join-link-${appointment.id}`}
+            onClick={e => e.preventDefault()}
+          >
+            Join appointment
+          </NewTabAnchor>
+        </>
+      )}
+    </div>
+  );
+}
+
+VideoLink.propTypes = {
+  appointment: PropTypes.shape({
+    start: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    videoData: PropTypes.shape({
+      url: PropTypes.string.isRequired,
+    }),
+  }),
+};
+VideoLink.defaultProps = {
+  appointment: {
+    start: '',
+    videoData: {
+      url: '',
+    },
+  },
+};

--- a/src/applications/vaos/components/VideoLink.jsx
+++ b/src/applications/vaos/components/VideoLink.jsx
@@ -18,18 +18,22 @@ export default function VideoLink({ appointment }) {
   } else {
     disableVideoLink = diff < -240;
   }
-
+  disableVideoLink = true;
   return (
     <div className="vaos-appts__video-visit">
       {disableVideoLink && (
         <>
           We'll add the link to join this appointment 30 minutes before your
           appointment time.
+          <br />
+          <br />
         </>
       )}
 
-      {!!disableVideoLink && (
+      {!disableVideoLink && (
         <>
+          Join the video appointment using the link.
+          <br />
           <NewTabAnchor
             href={url}
             className="vads-c-action-link--green vaos-hide-for-print vads-u-margin-bottom--2p5"

--- a/src/applications/vaos/components/VideoLink.jsx
+++ b/src/applications/vaos/components/VideoLink.jsx
@@ -11,12 +11,7 @@ export default function VideoLink({ appointment }) {
   // NOTE: If the moment is earlier than the moment you are passing to moment.fn.diff,
   // the return value will be negative. So checking to see if the appointment start
   // time is before or after the current time.
-  let disableVideoLink;
-  if (diff > 0) {
-    disableVideoLink = diff > 30;
-  } else {
-    disableVideoLink = diff < -240;
-  }
+  const disableVideoLink = diff > 30 || diff < -240;
 
   return (
     <div className="vaos-appts__video-visit">

--- a/src/applications/vaos/components/VideoLink.jsx
+++ b/src/applications/vaos/components/VideoLink.jsx
@@ -34,9 +34,10 @@ export default function VideoLink({ appointment }) {
         <>
           Join the video appointment using the link.
           <br />
+          <br />
           <NewTabAnchor
             href={url}
-            className="vads-c-action-link--green vaos-hide-for-print vads-u-margin-bottom--2p5"
+            className="vads-c-action-link--green vaos-hide-for-print vads-u-margin-bottom--3"
             aria-describedby={`description-join-link-${appointment.id}`}
             onClick={e => e.preventDefault()}
           >

--- a/src/applications/vaos/components/VideoLink.jsx
+++ b/src/applications/vaos/components/VideoLink.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-// import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import moment from 'moment-timezone';
 import NewTabAnchor from './NewTabAnchor';

--- a/src/applications/vaos/components/VideoLink.jsx
+++ b/src/applications/vaos/components/VideoLink.jsx
@@ -18,7 +18,7 @@ export default function VideoLink({ appointment }) {
   } else {
     disableVideoLink = diff < -240;
   }
-  disableVideoLink = true;
+
   return (
     <div className="vaos-appts__video-visit">
       {disableVideoLink && (

--- a/src/applications/vaos/components/layout/VideoLayout.jsx
+++ b/src/applications/vaos/components/layout/VideoLayout.jsx
@@ -16,6 +16,7 @@ import DetailPageLayout, {
   Who,
   ClinicOrFacilityPhone,
 } from './DetailPageLayout';
+import VideoLink from '../VideoLink';
 import { APPOINTMENT_STATUS } from '../../utils/constants';
 import {
   AppointmentDate,
@@ -60,9 +61,7 @@ export default function VideoLayout({ data: appointment }) {
       {APPOINTMENT_STATUS.booked === status &&
         !isPastAppointment && (
           <Section heading="How to join">
-            We'll add the link to join this appointment 30 minutes before your
-            appointment time.
-            <br />
+            <VideoLink appointment={appointment} />
             <br />
             <va-additional-info trigger="How to setup your device" uswds>
               <div>

--- a/src/applications/vaos/components/layout/VideoLayout.jsx
+++ b/src/applications/vaos/components/layout/VideoLayout.jsx
@@ -62,7 +62,6 @@ export default function VideoLayout({ data: appointment }) {
         !isPastAppointment && (
           <Section heading="How to join">
             <VideoLink appointment={appointment} />
-            <br />
             <va-additional-info trigger="How to setup your device" uswds>
               <div>
                 <h4 className="vads-u-font-size--base vads-u-font-family--sans">

--- a/src/applications/vaos/components/tests/VideoLink.unit.spec.js
+++ b/src/applications/vaos/components/tests/VideoLink.unit.spec.js
@@ -16,7 +16,7 @@ afterEach(() => {
 });
 
 describe('VAOS Component: VideoLink', () => {
-  it('does not render join appoinment link when not 30 minutes before or 4 hours after start time', () => {
+  it('does not render join appoinment link when not 30 minutes after start time', () => {
     const now = moment();
     const appointment = {
       location: {
@@ -24,6 +24,29 @@ describe('VAOS Component: VideoLink', () => {
         locationId: '983',
       },
       start: moment.tz(now, 'America/New_York').subtract(600, 'minutes'),
+      videoData: {
+        url: 'test.com',
+      },
+    };
+
+    const wrapper = render(<VideoLink appointment={appointment} />);
+
+    expect(wrapper.queryByText('Join appointment')).not.to.exist;
+    expect(
+      wrapper.queryByText(
+        "/We'll add the link to join this appointment 30 minutes before your appointment time/i",
+      ),
+    );
+  });
+
+  it('does not render join appoinment link when not 4 hours after start time', () => {
+    const now = moment();
+    const appointment = {
+      location: {
+        vistaId: '983',
+        locationId: '983',
+      },
+      start: moment.tz(now, 'America/New_York').add(600, 'minutes'),
       videoData: {
         url: 'test.com',
       },

--- a/src/applications/vaos/components/tests/VideoLink.unit.spec.js
+++ b/src/applications/vaos/components/tests/VideoLink.unit.spec.js
@@ -1,8 +1,19 @@
 import React from 'react';
 import { expect } from 'chai';
-import { render, fireEvent } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import MockDate from 'mockdate';
 import moment from 'moment-timezone';
+import { getTestDate } from '../../tests/mocks/setup';
+
 import VideoLink from '../VideoLink';
+
+beforeEach(() => {
+  MockDate.set(getTestDate());
+});
+
+afterEach(() => {
+  MockDate.reset();
+});
 
 describe('VAOS Component: VideoLink', () => {
   it('does not render join appoinment link when not 30 minutes before or 4 hours after start time', () => {
@@ -12,84 +23,53 @@ describe('VAOS Component: VideoLink', () => {
         vistaId: '983',
         locationId: '983',
       },
-      start: moment.tz(now, 'America/Anchorage').add(240, 'minutes'),
+      start: moment.tz(now, 'America/New_York').subtract(600, 'minutes'),
       videoData: {
         url: 'test.com',
       },
     };
-    const props = { appointment };
-    const wrapper = render(<VideoLink {...props} />);
-    expect(wrapper.queryByText('Join appointment')).to.exist;
-    expect(wrapper.container.querySelector('.usa-button')).to.exist;
-    expect(wrapper.container.querySelector('.usa-button-disabled')).to.not
-      .exist;
-    // fireEvent.click returns false if event is cancelable, and at least one of the event
-    // handlers which received event called Event.preventDefault(). Otherwise true.
-    // We do not expect preventDefault() to be called if the link is active.
-    expect(fireEvent.click(wrapper.container.querySelector('.usa-button'))).to
-      .be.true;
-  });
-  it('renders disabled join appoinment link 30 minutes prior to start time', () => {
-    // const now = moment();
-    // const appointment = {
-    //   location: {
-    //     vistaId: '983',
-    //     locationId: '983',
-    //   },
-    //   start: moment.tz(now, 'America/New_York').subtract(35, 'minutes'),
-    //   videoData: {
-    //     url: 'test.com',
-    //   },
-    // };
-    // const props = { appointment };
-    // const wrapper = render(<VideoLink {...props} />);
-    // expect(wrapper.queryByText('Join appointment')).to.exist;
-    // expect(wrapper.container.querySelector('.usa-button')).to.exist;
-    // expect(wrapper.container.querySelector('.usa-button-disabled')).to.exist;
-    return true;
-  });
-  it('renders join appoinment link 4 hours after start time', () => {
-    // const now = moment();
-    // const appointment = {
-    //   location: {
-    //     vistaId: '983',
-    //     locationId: '983',
-    //   },
-    //   start: moment(now).add(242, 'minutes'),
-    //   videoData: {
-    //     url: 'test.com',
-    //   },
-    // };
-    // const props = { appointment };
-    // const wrapper = render(<VideoLink {...props} />);
-    // expect(wrapper.queryByText('Join appointment')).to.exist;
-    // expect(wrapper.container.querySelector('.usa-button')).to.exist;
-    // expect(wrapper.container.querySelector('.usa-button-disabled')).to.exist;
-    return true;
+
+    const wrapper = render(<VideoLink appointment={appointment} />);
+
+    expect(wrapper.queryByText('Join appointment')).not.to.exist;
+    expect(
+      wrapper.queryByText(
+        "/We'll add the link to join this appointment 30 minutes before your appointment time/i",
+      ),
+    );
   });
 
-  it('call preventDefault function', () => {
-    // const now = moment();
-    // const appointment = {
-    //   location: {
-    //     vistaId: '983',
-    //     locationId: '983',
-    //   },
-    //   start: moment(now).subtract(35, 'minutes'),
-    //   videoData: {
-    //     url: 'test.com',
-    //   },
-    // };
-    // const props = { appointment };
-    // const wrapper = render(<VideoLink {...props} />);
-    // expect(wrapper.queryByText('Join appointment')).to.exist;
-    // expect(wrapper.container.querySelector('.usa-button')).to.exist;
-    // expect(wrapper.container.querySelector('.usa-button-disabled')).to.exist;
-    // // fireEvent.click returns false if event is cancelable, and at least one of the event
-    // // handlers which received event called Event.preventDefault(). Otherwise true.
-    // // We expect preventDefault() to be called if the link is disabled.
-    // expect(fireEvent.click(wrapper.container.querySelector('.usa-button'))).to
-    //   .be.false;
-    return true;
+  it('renders join appoinment link 30 minutes prior to start time', () => {
+    const now = moment();
+    const appointment = {
+      location: {
+        vistaId: '983',
+        locationId: '983',
+      },
+      start: moment.tz(now, 'America/New_York').subtract(30, 'minutes'),
+      videoData: {
+        url: 'test.com',
+      },
+    };
+
+    const wrapper = render(<VideoLink appointment={appointment} />);
+    expect(wrapper.queryByText('Join appointment')).to.exist;
+  });
+
+  it('renders join appoinment link 4 hours after start time', () => {
+    const now = moment();
+    const appointment = {
+      location: {
+        vistaId: '983',
+        locationId: '983',
+      },
+      start: moment(now).add(240, 'minutes'),
+      videoData: {
+        url: 'test.com',
+      },
+    };
+
+    const wrapper = render(<VideoLink appointment={appointment} />);
+    expect(wrapper.queryByText('Join appointment')).to.exist;
   });
 });

--- a/src/applications/vaos/components/tests/VideoLink.unit.spec.js
+++ b/src/applications/vaos/components/tests/VideoLink.unit.spec.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render, fireEvent } from '@testing-library/react';
+import moment from 'moment-timezone';
+import VideoLink from '../VideoLink';
+
+describe('VAOS Component: VideoLink', () => {
+  it('does not render join appoinment link when not 30 minutes before or 4 hours after start time', () => {
+    const now = moment();
+    const appointment = {
+      location: {
+        vistaId: '983',
+        locationId: '983',
+      },
+      start: moment.tz(now, 'America/Anchorage').add(240, 'minutes'),
+      videoData: {
+        url: 'test.com',
+      },
+    };
+    const props = { appointment };
+    const wrapper = render(<VideoLink {...props} />);
+    expect(wrapper.queryByText('Join appointment')).to.exist;
+    expect(wrapper.container.querySelector('.usa-button')).to.exist;
+    expect(wrapper.container.querySelector('.usa-button-disabled')).to.not
+      .exist;
+    // fireEvent.click returns false if event is cancelable, and at least one of the event
+    // handlers which received event called Event.preventDefault(). Otherwise true.
+    // We do not expect preventDefault() to be called if the link is active.
+    expect(fireEvent.click(wrapper.container.querySelector('.usa-button'))).to
+      .be.true;
+  });
+  it('renders disabled join appoinment link 30 minutes prior to start time', () => {
+    // const now = moment();
+    // const appointment = {
+    //   location: {
+    //     vistaId: '983',
+    //     locationId: '983',
+    //   },
+    //   start: moment.tz(now, 'America/New_York').subtract(35, 'minutes'),
+    //   videoData: {
+    //     url: 'test.com',
+    //   },
+    // };
+    // const props = { appointment };
+    // const wrapper = render(<VideoLink {...props} />);
+    // expect(wrapper.queryByText('Join appointment')).to.exist;
+    // expect(wrapper.container.querySelector('.usa-button')).to.exist;
+    // expect(wrapper.container.querySelector('.usa-button-disabled')).to.exist;
+    return true;
+  });
+  it('renders join appoinment link 4 hours after start time', () => {
+    // const now = moment();
+    // const appointment = {
+    //   location: {
+    //     vistaId: '983',
+    //     locationId: '983',
+    //   },
+    //   start: moment(now).add(242, 'minutes'),
+    //   videoData: {
+    //     url: 'test.com',
+    //   },
+    // };
+    // const props = { appointment };
+    // const wrapper = render(<VideoLink {...props} />);
+    // expect(wrapper.queryByText('Join appointment')).to.exist;
+    // expect(wrapper.container.querySelector('.usa-button')).to.exist;
+    // expect(wrapper.container.querySelector('.usa-button-disabled')).to.exist;
+    return true;
+  });
+
+  it('call preventDefault function', () => {
+    // const now = moment();
+    // const appointment = {
+    //   location: {
+    //     vistaId: '983',
+    //     locationId: '983',
+    //   },
+    //   start: moment(now).subtract(35, 'minutes'),
+    //   videoData: {
+    //     url: 'test.com',
+    //   },
+    // };
+    // const props = { appointment };
+    // const wrapper = render(<VideoLink {...props} />);
+    // expect(wrapper.queryByText('Join appointment')).to.exist;
+    // expect(wrapper.container.querySelector('.usa-button')).to.exist;
+    // expect(wrapper.container.querySelector('.usa-button-disabled')).to.exist;
+    // // fireEvent.click returns false if event is cancelable, and at least one of the event
+    // // handlers which received event called Event.preventDefault(). Otherwise true.
+    // // We expect preventDefault() to be called if the link is disabled.
+    // expect(fireEvent.click(wrapper.container.querySelector('.usa-button'))).to
+    //   .be.false;
+    return true;
+  });
+});


### PR DESCRIPTION
## Summary

- Added new separate `VideoLink` component for the appointment details redesign. When we are confident with the redesign and it's been deployed to 100% of production users, it will be easier to remove the old component.
- Added new unit tests for the new component

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/88731

## Testing done

- Local testing
- Unit testing


## Screenshots





|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |![Screenshot 2024-08-01 at 06-13-45 VA appointment on Sunday September 22 2024 Veterans Affairs](https://github.com/user-attachments/assets/e9859029-0c45-4791-89eb-0ed5553fcdfe)|![Screenshot 2024-08-01 at 06-14-47 VA appointment on Sunday September 22 2024 Veterans Affairs](https://github.com/user-attachments/assets/6b319d7e-7064-4f73-93c4-302a742ecc76)|
| Desktop |![Screenshot 2024-08-01 at 06-13-14 VA appointment on Sunday September 22 2024 Veterans Affairs](https://github.com/user-attachments/assets/eead139d-24f3-4492-a818-a4e6429ebbf8)|![Screenshot 2024-08-01 at 06-14-34 VA appointment on Sunday September 22 2024 Veterans Affairs](https://github.com/user-attachments/assets/fc08537c-a464-4e4e-b9b0-7358035b0155)|


## Acceptance criteria
Background: the `va_online_scheduling_appointment_details_redesign` toggle is on
- [ ] Given when it is 30 minutes before an at home video appointment or 4 hours after the start time
- [ ] Then the front end will display the _Join appointment_ button
- [ ] And page design matches the [design spec](https://www.figma.com/design/eonNJsp57eqfPqx7ydsJY9/Feature-Reference-%7C-Appointments-FE?node-id=756-20952&t=IjUEbMHzkxesIHMX-4)
### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
