### PR TITLE
Add Prepare for Appointment section for cc appointments

### DIFF
--- a/src/applications/vaos/components/layout/CCLayout.jsx
+++ b/src/applications/vaos/components/layout/CCLayout.jsx
@@ -2,9 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { shallowEqual } from 'recompose';
 import { useSelector } from 'react-redux';
-import DetailPageLayout, { Section, What, When } from './DetailPageLayout';
+import DetailPageLayout, {
+  Section,
+  What,
+  When,
+  Prepare,
+} from './DetailPageLayout';
 import { APPOINTMENT_STATUS } from '../../utils/constants';
 import { selectConfirmedAppointmentData } from '../../appointment-list/redux/selectors';
+import { selectFeatureMedReviewInstructions } from '../../redux/selectors';
 import {
   AppointmentDate,
   AppointmentTime,
@@ -26,6 +32,10 @@ export default function CCLayout({ data: appointment }) {
   } = useSelector(
     state => selectConfirmedAppointmentData(state, appointment),
     shallowEqual,
+  );
+
+  const featureMedReviewInstructions = useSelector(
+    selectFeatureMedReviewInstructions,
   );
 
   if (!appointment) return null;
@@ -92,6 +102,23 @@ export default function CCLayout({ data: appointment }) {
           <br />
           <span>Other details: {`${otherDetails || 'Not available'}`}</span>
         </Section>
+        {featureMedReviewInstructions &&
+          !isPastAppointment &&
+          (APPOINTMENT_STATUS.booked === status ||
+            APPOINTMENT_STATUS.cancelled === status) && (
+            <Prepare>
+              <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
+                Bring your insurance cards, a list of medications, and other
+                things to share with your provider.
+              </p>
+              <a
+                target="_self"
+                href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"
+              >
+                Find out what to bring to your appointment
+              </a>
+            </Prepare>
+          )}
         {APPOINTMENT_STATUS.booked === status &&
           !isPastAppointment && (
             <Section heading="Need to make changes?">

--- a/src/applications/vaos/components/tests/CCLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/CCLayout.unit.spec.js
@@ -11,6 +11,7 @@ describe('VAOS Component: CCLayout', () => {
   const initialState = {
     featureToggles: {
       vaOnlineSchedulingAppointmentDetailsRedesign: true,
+      vaOnlineSchedulingMedReviewInstructions: true,
     },
   };
 
@@ -79,7 +80,7 @@ describe('VAOS Component: CCLayout', () => {
     });
   });
 
-  describe('When viewing upcomming appointment details', () => {
+  describe('When viewing upcoming appointment details', () => {
     it('should display CC layout', async () => {
       // Arrange
       const store = createTestStore(initialState);
@@ -165,6 +166,24 @@ describe('VAOS Component: CCLayout', () => {
       expect(screen.getByText(/This is a test/i));
       expect(screen.getByText(/Other details:/i));
       expect(screen.getByText(/Additional information/i));
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Prepare for your appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /Bring your insurance cards, a list of medications, and other things to share with your provider./i,
+        ),
+      );
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"]',
+        ),
+      ).to.be.ok;
+      expect(screen.getByText(/Find out what to bring to your appointment/i));
 
       expect(screen.getByText(/Need to make changes/i));
 
@@ -273,6 +292,12 @@ describe('VAOS Component: CCLayout', () => {
       expect(screen.getByText(/This is a test/i));
       expect(screen.getByText(/Other details:/i));
       expect(screen.getByText(/Additional information/i));
+
+      expect(
+        screen.queryByRole('heading', {
+          name: /Prepare for your appointment/i,
+        }),
+      ).not.to.exist;
 
       expect(screen.container.querySelector('va-button[text="Print"]')).to.be
         .ok;
@@ -385,6 +410,24 @@ describe('VAOS Component: CCLayout', () => {
       expect(screen.getByText(/This is a test/i));
       expect(screen.getByText(/Other details:/i));
       expect(screen.getByText(/Additional information/i));
+
+      expect(
+        screen.getByRole('heading', {
+          level: 2,
+          name: /Prepare for your appointment/i,
+        }),
+      );
+      expect(
+        screen.getByText(
+          /Bring your insurance cards, a list of medications, and other things to share with your provider./i,
+        ),
+      );
+      expect(
+        screen.container.querySelector(
+          'a[href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"]',
+        ),
+      ).to.be.ok;
+      expect(screen.getByText(/Find out what to bring to your appointment/i));
 
       expect(screen.container.querySelector('va-button[text="Print"]')).to.be
         .ok;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Add "Prepare for your appointment" section to cc appointments.
- This feature is toggled by the Flipper flag `va_online_scheduling_med_review_instructions `
- Appointments (VAOS) team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89495

## Testing done

- Unit tests updated to account for the new content
- The new content (text and link) is verified locally with the feature toggle enabled

## Screenshots

New screenshots:

| Confirmed Appointment | Cancelled Appointment | 
| - | - |
| <img width="409" alt="image" src="https://github.com/user-attachments/assets/7f7cdea4-18b1-4a29-92da-718ff0fc25f4"> | <img width="409" alt="image" src="https://github.com/user-attachments/assets/d146e86d-3002-4331-9a53-e9cd70061230"> |


## What areas of the site does it impact?

N/A

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
