### PR TITLE
Skip failing VAOS test

### DIFF
--- a/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/RequestedAppointmentDetailsPage.unit.spec.js
@@ -42,7 +42,8 @@ describe('VAOS Page: RequestedAppointmentDetailsPage', () => {
     MockDate.reset();
   });
 
-  it('should render VA request details with a VAOS appointment', async () => {
+  // Test failure: https://github.com/department-of-veterans-affairs/va.gov-team/issues/89798
+  it.skip('should render VA request details with a VAOS appointment', async () => {
     // Arrange
     const response = new MockAppointmentResponse({
       status: APPOINTMENT_STATUS.proposed,


### PR DESCRIPTION
Skipping failing test. Fix pending: https://github.com/department-of-veterans-affairs/va.gov-team/issues/89798.