### PR TITLE
[10-10CG] Update Abbr component prop

### DIFF
--- a/src/applications/caregivers/components/Abbreviation.jsx
+++ b/src/applications/caregivers/components/Abbreviation.jsx
@@ -2,16 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import content from '../locales/en/content.json';
 
-const Abbr = ({ key }) => (
+const Abbr = ({ abbrKey }) => (
   <dfn>
-    <abbr title={content[`dfn--${key}-title`]}>
-      {content[`dfn--${key}-abbr`]}
+    <abbr title={content[`dfn--${abbrKey}-title`]}>
+      {content[`dfn--${abbrKey}-abbr`]}
     </abbr>
   </dfn>
 );
 
 Abbr.propTypes = {
-  key: PropTypes.string,
+  abbrKey: PropTypes.string,
 };
 
 export default Abbr;

--- a/src/applications/caregivers/components/ConfirmationPage/ConfirmationScreenView.jsx
+++ b/src/applications/caregivers/components/ConfirmationPage/ConfirmationScreenView.jsx
@@ -43,7 +43,7 @@ const ConfirmationScreenView = ({ name, timestamp }) => {
 
         <h4>{content['confirmation--print-heading']}</h4>
         <p>
-          {content['confirmation--print-text']} <Abbr key="pdf" />.
+          {content['confirmation--print-text']} <Abbr abbrKey="pdf" />.
         </p>
 
         <div className="vads-u-margin-y--2">

--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -68,8 +68,9 @@ const ConfirmationPage = () => {
         </p>
         <p>
           Or call us at <va-telephone contact={CONTACTS.CAREGIVER} />. We’re
-          here Monday through Friday, 8:00 a.m. to 10:00 p.m. <Abbr key="et" />,
-          and Saturday, 8:00 a.m. to 5:00 p.m. <Abbr key="et" />.
+          here Monday through Friday, 8:00 a.m. to 10:00 p.m.{' '}
+          <Abbr abbrKey="et" />, and Saturday, 8:00 a.m. to 5:00 p.m.{' '}
+          <Abbr abbrKey="et" />.
         </p>
         <p className="no-print">
           <a

--- a/src/applications/caregivers/tests/unit/components/Abbreviation.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/Abbreviation.unit.spec.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import Abbr from '../../../components/Abbreviation';
+import content from '../../../locales/en/content.json';
+
+describe('CG <Abbr>', () => {
+  const subject = props => {
+    return render(<Abbr {...props} />);
+  };
+
+  it('renders abbrKey text', () => {
+    const { queryByText } = subject({ abbrKey: 'pdf' });
+    expect(queryByText(content['dfn--pdf-abbr'])).to.exist;
+  });
+
+  it('renders the correct title attribute in the abbr tag', () => {
+    const { container } = subject({ abbrKey: 'pdf' });
+    const abbrElement = container.querySelector('abbr');
+
+    expect(abbrElement).to.have.attribute('title', content['dfn--pdf-title']);
+  });
+});

--- a/src/applications/caregivers/tests/unit/components/ConfirmationPage/ConfirmationScreenView.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/ConfirmationPage/ConfirmationScreenView.unit.spec.js
@@ -36,15 +36,23 @@ describe('CG <ConfirmationScreenView>', () => {
 
   it('should render with default props', () => {
     const { mockStore, props } = getData({});
-    const { container } = subject({ mockStore, props });
+    const { container, getByText, getByTitle } = subject({ mockStore, props });
+
     const selectors = {
       veteranName: container.querySelector(
         '[data-testid="cg-veteran-fullname"]',
       ),
       download: container.querySelector('.caregiver-application--download'),
+      printDescription: getByText(
+        /You can print this confirmation page for your records. You can also download your completed application as a/,
+      ),
+      abbreviation: getByTitle('Portable Document Format'),
     };
     expect(selectors.veteranName).to.contain.text('John Marjorie Smith Sr.');
     expect(selectors.download).to.not.be.empty;
+    expect(selectors.printDescription).to.exist;
+    expect(selectors.abbreviation).to.exist;
+    expect(selectors.abbreviation).to.have.text('PDF');
   });
 
   it('should not render timestamp in `application information` section when not provided', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**: Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
- _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update the `Abbr` component to accept a prop named `abbrKey` instead of `key`, since `key` is a reserved prop by React. 
- Currently, setting the `key` on the component renders the value as empty, since it is not using the supplied value in the component as the expected custom prop. 
- Renamed the prop so it does not use the reserved prop. 
- 1010 Health Apps

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89810

## Testing done

- Add unit tests for the `Abbr` component. Updated specs where the component is being used to validate the values are being properly rendered.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

Before:
<img width="742" alt="Screenshot 2024-08-02 at 9 01 05 AM" src="https://github.com/user-attachments/assets/17d8d79b-d940-493c-bbcd-cf0df02ec1fd">
After
<img width="921" alt="Screenshot 2024-08-02 at 9 15 03 AM" src="https://github.com/user-attachments/assets/068b5bc3-16a3-4f32-9593-823906ed227d">

## What areas of the site does it impact?

10-10 CG

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
