### PR TITLE
VACMS-89623 Verify Your Enrollment Tool redirects

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -1180,6 +1180,16 @@
     "dest": "/life-insurance/options-eligibility/valife"
   },
   {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/isaksonroe/verification_of_enrollment.asp",
+    "dest": "/resources/gi-bill-enrollment-verification-faqs/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/isaksonRoe/EV_FAQs.asp",
+    "dest": "/resources/gi-bill-enrollment-verification-faqs/"
+  },
+  {
     "domain": "www.altoona.va.gov",
     "src": "/",
     "dest": "/altoona-health-care/",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Cross-domain redirects for Verify Your Enrollment Tool (CAIA request).

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89623

## Testing done
Cannot test in lower environments.