### PR TITLE
Assets Review Error Handling

### DIFF
--- a/src/applications/financial-status-report/constants/reviewErrors.js
+++ b/src/applications/financial-status-report/constants/reviewErrors.js
@@ -87,11 +87,7 @@ export default {
       return errorMapping[errorKey];
     }
 
-    if (
-      fullError &&
-      fullError.__errors &&
-      fullError.__errors.some(str => str.includes('resolution amount'))
-    ) {
+    if (fullError?.__errors?.some(str => str.includes('resolution amount'))) {
       return {
         chapterKey: 'resolutionOptionsChapter',
         pageKey: 'resolutionComment',

--- a/src/applications/financial-status-report/constants/reviewErrors.js
+++ b/src/applications/financial-status-report/constants/reviewErrors.js
@@ -23,6 +23,14 @@ export default {
   },
   monthlyHousingExpenses:
     'Please enter a valid dollar amount for your monthly housing expenses',
+  // Household Assets error messages
+  monetaryAssets: 'Please provide valid information for all monetary assets',
+  realEstateValue:
+    'Please enter a valid dollar amount for your real estate value',
+  recVehicleAmount:
+    'Please enter a valid dollar amount for your recreational vehicle',
+  otherAssets: 'Please provide valid information for all other assets',
+
   _override: (error, fullError) => {
     if (error === 'questions') {
       return {
@@ -40,6 +48,30 @@ export default {
       return {
         chapterKey: 'resolutionOptionsChapter',
         pageKey: 'resolutionComment',
+      };
+    }
+    if (error.startsWith('assets.monetaryAssets')) {
+      return {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'monetaryValues',
+      };
+    }
+    if (error === 'assets.realEstateValue') {
+      return {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'enhancedRealEstateRecords',
+      };
+    }
+    if (error === 'assets.recVehicleAmount') {
+      return {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'recreationalVehicleRecords',
+      };
+    }
+    if (error.startsWith('assets.otherAssets')) {
+      return {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'otherAssetsSummary',
       };
     }
     // always return null for non-matches

--- a/src/applications/financial-status-report/constants/reviewErrors.js
+++ b/src/applications/financial-status-report/constants/reviewErrors.js
@@ -7,6 +7,11 @@ export default {
   hasBeenAdjudicatedBankrupt:
     "Please select whether you've declared bankruptcy (select yes or no)",
 
+  hasRecreationalVehicle:
+    'Please select whether you have a recreational vehicle (select yes or no)',
+  hasVehicle: 'Please select whether you own a vehicle (select yes or no)',
+  hasRealEstate: 'Please select whether you own real estate (select yes or no)',
+
   resolutionOption: index =>
     `Please select a resolution option for the ${numberToWords(
       index + 1,
@@ -59,13 +64,34 @@ export default {
         chapterKey: 'householdAssetsChapter',
         pageKey: 'otherAssetsSummary',
       },
+      hasRecreationalVehicle: {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'recreationalVehicleRecords',
+      },
+      hasVehicle: {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'enhancedVehicleRecords',
+      },
+      hasRealEstate: {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'enhancedRealEstateRecords',
+      },
     };
 
-    if (errorMapping[error]) {
-      return errorMapping[error];
+    // Extract the relevant key from the error
+    const errorKey = error.includes('selectedDebtsAndCopays')
+      ? 'selectedDebtsAndCopays'
+      : error.split('.').slice(-1)[0];
+
+    if (errorMapping[errorKey]) {
+      return errorMapping[errorKey];
     }
 
-    if (fullError?.__errors.some(str => str.includes('resolution amount'))) {
+    if (
+      fullError &&
+      fullError.__errors &&
+      fullError.__errors.some(str => str.includes('resolution amount'))
+    ) {
       return {
         chapterKey: 'resolutionOptionsChapter',
         pageKey: 'resolutionComment',

--- a/src/applications/financial-status-report/constants/reviewErrors.js
+++ b/src/applications/financial-status-report/constants/reviewErrors.js
@@ -6,23 +6,25 @@ import numberToWords from 'platform/forms-system/src/js/utilities/data/numberToW
 export default {
   hasBeenAdjudicatedBankrupt:
     "Please select whether you've declared bankruptcy (select yes or no)",
-  resolutionOption: index => {
-    return `Please select a resolution option for the ${numberToWords(
+
+  resolutionOption: index =>
+    `Please select a resolution option for the ${numberToWords(
       index + 1,
-    )} selected debt`;
-  },
-  resolutionComment: index => {
-    return `Please enter a resolution amount for the ${numberToWords(
+    )} selected debt`,
+
+  resolutionComment: index =>
+    `Please enter a resolution amount for the ${numberToWords(
       index + 1,
-    )} selected debt`;
-  },
-  resolutionWaiverCheck: index => {
-    return `Please select whether you agree to the waiver for the ${numberToWords(
+    )} selected debt`,
+
+  resolutionWaiverCheck: index =>
+    `Please select whether you agree to the waiver for the ${numberToWords(
       index + 1,
-    )} selected debt`;
-  },
+    )} selected debt`,
+
   monthlyHousingExpenses:
     'Please enter a valid dollar amount for your monthly housing expenses',
+
   // Household Assets error messages
   monetaryAssets: 'Please provide valid information for all monetary assets',
   realEstateValue:
@@ -32,49 +34,44 @@ export default {
   otherAssets: 'Please provide valid information for all other assets',
 
   _override: (error, fullError) => {
-    if (error === 'questions') {
-      return {
+    const errorMapping = {
+      questions: {
         chapterKey: 'bankruptcyAttestationChapter',
         pageKey: 'bankruptcyHistory',
-      };
-    }
-    if (error.includes('selectedDebtsAndCopays')) {
-      return {
+      },
+      selectedDebtsAndCopays: {
         chapterKey: 'resolutionOptionsChapter',
         pageKey: 'resolutionOption',
-      };
+      },
+      assetsMonetaryAssets: {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'monetaryValues',
+      },
+      assetsRealEstateValue: {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'enhancedRealEstateRecords',
+      },
+      assetsRecVehicleAmount: {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'recreationalVehicleRecords',
+      },
+      assetsOtherAssets: {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'otherAssetsSummary',
+      },
+    };
+
+    if (errorMapping[error]) {
+      return errorMapping[error];
     }
+
     if (fullError?.__errors.some(str => str.includes('resolution amount'))) {
       return {
         chapterKey: 'resolutionOptionsChapter',
         pageKey: 'resolutionComment',
       };
     }
-    if (error.startsWith('assets.monetaryAssets')) {
-      return {
-        chapterKey: 'householdAssetsChapter',
-        pageKey: 'monetaryValues',
-      };
-    }
-    if (error === 'assets.realEstateValue') {
-      return {
-        chapterKey: 'householdAssetsChapter',
-        pageKey: 'enhancedRealEstateRecords',
-      };
-    }
-    if (error === 'assets.recVehicleAmount') {
-      return {
-        chapterKey: 'householdAssetsChapter',
-        pageKey: 'recreationalVehicleRecords',
-      };
-    }
-    if (error.startsWith('assets.otherAssets')) {
-      return {
-        chapterKey: 'householdAssetsChapter',
-        pageKey: 'otherAssetsSummary',
-      };
-    }
-    // always return null for non-matches
+
     return null;
   },
 };


### PR DESCRIPTION
Description
This PR implements more helpful error handling on final review page for Household Assets Chapter

[Design ticket](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/67811)

Example of Review page error message that has been implemented:

https://github.com/department-of-veterans-affairs/va.gov-team/issues/21252

https://github.com/department-of-veterans-affairs/vets-website/pull/16431

- Given: Error handling isn't exactly clear on final review page
- When: A veteran attempts to submit a form with an error
- Then: Error alert links to set focus to the accordion where the error exists

<table>
  <tr>
    <th style="text-align: center;"> 
      <img src="https://github.com/user-attachments/assets/f240cda4-37e3-480a-8936-8e2f56f3ede0" alt="Default for null values" width="350">
    </th>
    <th style="text-align: center;">
      <img src="https://github.com/user-attachments/assets/0a72afcc-a9f8-4d70-8fba-f272d61950a3" alt="Questions (Missing Values)" width="350">
    </th>
  </tr>
  <tr>
    <td style="text-align: center;">Default for null values</td>
    <td style="text-align: center;">Questions (Missing Values)</td>
  </tr>
</table>

Tasks
Confirm functionality for the following pages:

-  enhancedRealEstate (hasRealEstate)
-  enhancedRealEstateRecords
-  recreationalVehicles (hasRecreationalVehicle)
-  recreationalVehicleRecords
-  monetaryValues
-  otherAssetsSummary
-  hasVehicle


Acceptance criteria

- [x]  Error messaging on final review page for Household Assets Chapter is clear and functioning as expected
- [x]  Works with current version of the form (post review navigation)

