### PR TITLE
Add error for array builder review page + keep url params

### DIFF
--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-array-builder-review-errors.cypress.spec.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/mock-array-builder-review-errors.cypress.spec.js
@@ -1,0 +1,238 @@
+import path from 'path';
+import testForm from 'platform/testing/e2e/cypress/support/form-tester';
+import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
+import { introductionPageFlow } from 'applications/simple-forms/shared/tests/e2e/helpers';
+import featureToggles from '../../../shared/tests/e2e/fixtures/mocks/feature-toggles.json';
+import mockSubmit from '../../../shared/tests/e2e/fixtures/mocks/application-submit.json';
+import formConfig from '../../config/form';
+import manifest from '../../manifest.json';
+import pagePaths from './pagePaths';
+
+let nextState;
+
+function* stateSequence() {
+  yield '1_ADD_ITEM';
+  yield '2_GO_TO_REVIEW';
+  yield '3_DELETE_ITEM_FROM_REVIEW';
+  yield '4_CANCEL_ADDING';
+  yield '5_CONFIRM_ERROR';
+  yield '6_ADD_ANOTHER_ITEM';
+  yield '7_FINISH';
+}
+
+const stateMachine = stateSequence();
+
+function goNextState() {
+  const state = stateMachine.next();
+  if (!state.done) {
+    cy.log(`
+**********
+State change: ${state.value}
+**********
+`);
+    nextState = state.value;
+  }
+}
+
+function summaryAddMore(hasEmployment) {
+  cy.selectYesNoVaRadioOption('root_view:hasEmployment', hasEmployment);
+  cy.axeCheck();
+  cy.findByText(/continue/i, { selector: 'button' }).click();
+}
+
+function summaryFinishAdding() {
+  cy.selectYesNoVaRadioOption('root_view:hasEmployment', false);
+  cy.axeCheck();
+  cy.findByText(/continue/i, { selector: 'button' }).click();
+}
+
+function addItemPage1() {
+  cy.url().should('include', 'add=true');
+  cy.fillPage();
+  cy.selectVaSelect('root_address_state', 'AL');
+  cy.axeCheck();
+  cy.findByText(/continue/i, { selector: 'button' }).click();
+}
+
+function addItemPage2() {
+  cy.url().should('include', 'add=true');
+  cy.fillPage();
+  cy.axeCheck();
+  cy.findByText(/continue/i, { selector: 'button' }).click();
+}
+
+function addItemFromReviewPage() {
+  cy.get('va-button[name="employersAddButton"]').click();
+}
+
+/**
+ * @param {'add' | 'edit' | 'review'} type
+ */
+function cancelItemPage(type) {
+  cy.url().should('include', `${type}=true`);
+  cy.get('va-button[data-action="cancel"]').click();
+  cy.axeCheck();
+  cy.get('va-modal[status="warning"]')
+    .shadow()
+    .get('h2')
+    .should('include', /cancel/gi);
+  cy.get('va-modal[status="warning"]')
+    .shadow()
+    .get('.va-modal-alert-body va-button')
+    .first()
+    .click();
+}
+
+function removeItemFromReviewCard() {
+  cy.get('va-accordion-item[data-chapter="arrayMultiPageBuilder"]').click();
+  cy.get('va-card[name="employer_0"] [data-action="remove"]').click();
+  cy.get('va-modal[status="warning"]')
+    .shadow()
+    .get('h2')
+    .should('contain', 'Delete');
+  cy.get('va-modal[status="warning"]')
+    .shadow()
+    .get('.va-modal-alert-body va-button')
+    .first()
+    .click();
+}
+
+const routeItem1Page1 = 'array-multiple-page-builder/0/name-and-address';
+const routeItem1Page2 = 'array-multiple-page-builder/0/dates';
+
+const testConfig = createTestConfig(
+  {
+    useWebComponentFields: true,
+    dataPrefix: 'data',
+    dataSets: ['arrayBuilder'],
+    dataDir: path.join(__dirname, 'fixtures', 'data'),
+    pageHooks: {
+      introduction: ({ afterHook }) => {
+        afterHook(() => {
+          introductionPageFlow();
+        });
+      },
+      'chapter-select': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get(`va-button[text="Deselect all"]`).click();
+          cy.selectVaCheckbox('root_chapterSelect_arrayMultiPageBuilder', true);
+          goNextState();
+          cy.findByText(/continue/i, { selector: 'button' }).click();
+        });
+      },
+      [pagePaths.arrayMultiPageBuilderFlow]: ({ afterHook }) => {
+        cy.injectAxeThenAxeCheck();
+        afterHook(() => {
+          cy.get('@testData').then(() => {
+            cy.selectVaRadioOption(
+              'root_arrayBuilderPatternFlowType',
+              'required',
+            );
+            cy.findByText(/continue/i, { selector: 'button' }).click();
+          });
+        });
+      },
+      [pagePaths.arrayMultiPageBuilderIntro]: ({ afterHook }) => {
+        cy.injectAxeThenAxeCheck();
+        afterHook(() => {
+          cy.get('@testData').then(() => {
+            cy.findByText(/continue/i, { selector: 'button' }).click();
+          });
+        });
+      },
+      [pagePaths.arrayMultiPageBuilderSummary]: ({ afterHook }) => {
+        cy.injectAxeThenAxeCheck();
+        afterHook(() => {
+          cy.get('@testData').then(() => {
+            switch (nextState) {
+              case '1_ADD_ITEM':
+                summaryAddMore(true);
+                break;
+              case '2_GO_TO_REVIEW':
+                cy.get('va-card').should('have.length', 1);
+                summaryFinishAdding();
+                goNextState();
+                break;
+              case '7_FINISH':
+                cy.get('va-card').should('have.length', 1);
+                summaryFinishAdding();
+                break;
+              default:
+                throw new Error(`Unexpected nextState: ${nextState}`);
+            }
+          });
+        });
+      },
+      [routeItem1Page1]: ({ afterHook }) => {
+        cy.injectAxeThenAxeCheck();
+        afterHook(() => {
+          cy.get('@testData').then(() => {
+            switch (nextState) {
+              case '1_ADD_ITEM':
+              case '6_ADD_ANOTHER_ITEM':
+                addItemPage1();
+                break;
+              case '4_CANCEL_ADDING':
+                cancelItemPage('add');
+                goNextState();
+                break;
+              default:
+                throw new Error(`Unexpected nextState: ${nextState}`);
+            }
+          });
+        });
+      },
+      [routeItem1Page2]: ({ afterHook }) => {
+        cy.injectAxeThenAxeCheck();
+        afterHook(() => {
+          cy.get('@testData').then(() => {
+            switch (nextState) {
+              case '1_ADD_ITEM':
+              case '6_ADD_ANOTHER_ITEM':
+                addItemPage2();
+                goNextState();
+                break;
+              default:
+                throw new Error(`Unexpected nextState: ${nextState}`);
+            }
+          });
+        });
+      },
+      'review-and-submit': ({ afterHook }) => {
+        afterHook(() => {
+          cy.get('@testData').then(() => {
+            switch (nextState) {
+              case '3_DELETE_ITEM_FROM_REVIEW':
+                removeItemFromReviewCard();
+                goNextState();
+                break;
+              case '5_CONFIRM_ERROR':
+                cy.get(
+                  'va-alert[name="employersReviewError"][status="error"]',
+                ).should('exist');
+                addItemFromReviewPage();
+                goNextState();
+                break;
+              case '7_FINISH':
+                cy.findAllByText(/Submit application/i, {
+                  selector: 'button',
+                }).click();
+                break;
+              default:
+                throw new Error(`Unexpected nextState: ${nextState}`);
+            }
+          });
+        });
+      },
+    },
+    setupPerTest: () => {
+      cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
+      cy.intercept('POST', formConfig.submitUrl, mockSubmit);
+    },
+    skip: false,
+  },
+  manifest,
+  formConfig,
+);
+
+testForm(testConfig);

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderCards.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderCards.jsx
@@ -129,10 +129,13 @@ const ArrayBuilderCards = ({
       focusRemoveButton: false,
     });
     onRemove(removedIndex, removedItem);
+    // forceRerender should happen BEFORE onRemoveAll because
+    // we should handle any data manipulation before a potential
+    // change of URL
+    forceRerender(newData);
     if (arrayWithRemovedItem.length === 0) {
       onRemoveAll();
     }
-    forceRerender(newData);
   }
 
   const Card = ({ index, children }) => (

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -47,6 +47,16 @@ function filterEmptyItems(arrayData) {
     : arrayData;
 }
 
+function checkHasYesNoReviewError(reviewErrors, hasItemsKey) {
+  return reviewErrors?.errors?.some(obj => obj.name === hasItemsKey);
+}
+
+function getYesNoReviewErrorMessage(reviewErrors, hasItemsKey) {
+  // use the same error message as the yes/no field
+  const error = reviewErrors?.errors?.find(obj => obj.name === hasItemsKey);
+  return error?.message;
+}
+
 /**
  * @param {{
  *   arrayPath: string,
@@ -93,34 +103,43 @@ export default function ArrayBuilderSummaryPage({
 
     const [showUpdatedAlert, setShowUpdatedAlert] = useState(!!updatedItemData);
     const [showRemovedAlert, setShowRemovedAlert] = useState(false);
+    const [showReviewErrorAlert, setShowReviewErrorAlert] = useState(false);
     const [removedItemText, setRemovedItemText] = useState('');
     const [removedItemIndex, setRemovedItemIndex] = useState(null);
     const updatedAlertRef = useRef(null);
     const removedAlertRef = useRef(null);
+    const reviewErrorAlertRef = useRef(null);
     const { uiSchema, schema } = props;
     const Heading = `h${titleHeaderLevel}`;
     const isMaxItemsReached = arrayData?.length >= maxItems;
+    const hasReviewError =
+      isReviewPage && checkHasYesNoReviewError(props.reviewErrors, hasItemsKey);
 
     useEffect(() => {
-      // We may end up with empty items if the user navigates back
-      // from outside of the array scope, because of FormPage's
-      // prePopulateArrayData function which auto populates an
-      // array with empty initial values. This will remove any items
-      // with no array data.
-      if (arrayData?.length) {
-        const newArrayData = filterEmptyItems(arrayData);
-        if (newArrayData?.length !== arrayData.length) {
-          props.setData({ ...props.data, [arrayPath]: newArrayData });
+      const cleanupEmptyItems = () => {
+        // We may end up with empty items if the user navigates back
+        // from outside of the array scope, because of FormPage's
+        // prePopulateArrayData function which auto populates an
+        // array with empty initial values. This will remove any items
+        // with no array data.
+        if (arrayData?.length) {
+          const newArrayData = filterEmptyItems(arrayData);
+          if (newArrayData?.length !== arrayData.length) {
+            props.setData({ ...props.data, [arrayPath]: newArrayData });
+          }
         }
-      }
-    }, []);
+      };
 
-    useEffect(() => {
-      if (!isReviewPage && !arrayData?.length && required(props.data)) {
-        // We shouldn't be on this page if there are no items and its required
-        // because the required flow goes intro -> item page with no items
-        props.goToPath(introPath);
-      }
+      const redirectToIntroIfEmpty = () => {
+        if (!isReviewPage && !arrayData?.length && required(props.data)) {
+          // We shouldn't be on this page if there are no items and its required
+          // because the required flow goes intro -> item page with no items
+          props.goToPath(introPath);
+        }
+      };
+
+      cleanupEmptyItems();
+      redirectToIntroIfEmpty();
     }, []);
 
     useEffect(
@@ -182,6 +201,22 @@ export default function ArrayBuilderSummaryPage({
         },
       });
     }
+
+    useEffect(
+      () => {
+        setShowReviewErrorAlert(hasReviewError);
+        if (
+          props.recalculateErrors &&
+          props.name &&
+          (showUpdatedAlert || showRemovedAlert)
+        ) {
+          // Affects the red highlighting at the chapter level and
+          // error messages. This prop only exists on the review page.
+          props.recalculateErrors(props.name);
+        }
+      },
+      [hasReviewError, showUpdatedAlert, showRemovedAlert],
+    );
 
     function addAnotherItemButtonClick() {
       const index = arrayData ? arrayData.length : 0;
@@ -293,10 +328,31 @@ export default function ArrayBuilderSummaryPage({
       );
     };
 
+    const ReviewErrorAlert = ({ show }) => {
+      return (
+        <div ref={reviewErrorAlertRef}>
+          {show ? (
+            <div className="vads-u-margin-top--2">
+              <VaAlert
+                status="error"
+                slim
+                tabIndex={0}
+                visible
+                name={`${nounPlural}ReviewError`}
+              >
+                {getYesNoReviewErrorMessage(props.reviewErrors, hasItemsKey)}
+              </VaAlert>
+            </div>
+          ) : null}
+        </div>
+      );
+    };
+
     const Cards = () => (
       <div>
         <RemovedAlert show={showRemovedAlert} />
         <UpdatedAlert show={showUpdatedAlert} />
+        <ReviewErrorAlert show={showReviewErrorAlert} />
         <ArrayBuilderCards
           cardDescription={getText('cardDescription', updatedItemData)}
           arrayPath={arrayPath}
@@ -351,6 +407,7 @@ export default function ArrayBuilderSummaryPage({
                 data-action="add"
                 text={getText('reviewAddButtonText', updatedItemData)}
                 onClick={addAnotherItemButtonClick}
+                name={`${nounPlural}AddButton`}
                 primary
                 uswds
               />
@@ -426,18 +483,24 @@ export default function ArrayBuilderSummaryPage({
     onReviewPage: PropTypes.bool,
     onSubmit: PropTypes.func,
     pagePerItemIndex: PropTypes.number,
+    recalculateErrors: PropTypes.func,
+    reviewErrors: PropTypes.object,
     setData: PropTypes.func, // available regardless of review page or not
     setFormData: PropTypes.func, // not available on review page
     title: PropTypes.string,
     trackingPrefix: PropTypes.string,
   };
 
+  const mapStateToProps = state => ({
+    reviewErrors: state?.form?.formErrors,
+  });
+
   const mapDispatchToProps = {
     setData,
   };
 
   return connect(
-    null,
+    mapStateToProps,
     mapDispatchToProps,
   )(CustomPage);
 }

--- a/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
@@ -343,20 +343,26 @@ export function arrayBuilderPages(options, pageBuilderCallback) {
   };
 
   /** @type {FormConfigPage['onNavForward']} */
-  const navForwardIntro = ({ formData, goPath, goNextPath }) => {
+  const navForwardIntro = ({ formData, goPath, urlParams }) => {
+    let path;
     // required flow:
     // intro -> items -> summary -> items -> summary
     //
     // optional flow:
     // summary -> items -> summary
     if (required(formData) && !formData[arrayPath]?.length) {
-      const path = createArrayBuilderItemAddPath({
+      path = createArrayBuilderItemAddPath({
         path: firstItemPagePath,
         index: 0,
+        isReview: urlParams?.review,
       });
       goPath(path);
     } else {
-      goPath(summaryPath);
+      path = summaryPath;
+      if (urlParams?.review) {
+        path = `${path}?review=true`;
+      }
+      goPath(path);
     }
   };
 
@@ -408,6 +414,7 @@ export function arrayBuilderPages(options, pageBuilderCallback) {
       }),
       scrollAndFocusTarget: 'h3',
       onNavForward: navForwardSummary,
+      onNavBack: onNavBackKeepUrlParams,
       ...pageConfig,
     };
   };

--- a/src/platform/forms-system/src/js/patterns/array-builder/helpers.js
+++ b/src/platform/forms-system/src/js/patterns/array-builder/helpers.js
@@ -84,8 +84,10 @@ export function onNavBackRemoveAddingItem({
       setFormData(newData);
     }
 
-    const path =
-      introRoute && !newArrayData?.length ? introRoute : summaryRoute;
+    let path = introRoute && !newArrayData?.length ? introRoute : summaryRoute;
+    if (urlParams?.review) {
+      path = `${path}?review=true`;
+    }
     goPath(path);
   };
 }

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.js
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.js
@@ -12,12 +12,28 @@ import {
 import ArrayBuilderSummaryPage from '../ArrayBuilderSummaryPage';
 import * as helpers from '../helpers';
 
+const MOCK_REVIEW_ERRORS_EMPTY = {};
+const MOCK_REVIEW_ERRORS_AT_LEAST_ONE = {
+  errors: [
+    {
+      name: 'view:hasOption',
+      index: null,
+      message:
+        'You must add at least one employer for us to process this form.',
+      chapterKey: 'arrayMultiPageBuilder',
+      pageKey: 'multiPageBuilderSummary',
+    },
+  ],
+  rawErrors: [],
+};
+
 const mockRedux = ({
   review = false,
   submitted = false,
   formData = {},
   onChange = () => {},
   setFormData = () => {},
+  formErrors,
 } = {}) => {
   return {
     props: {
@@ -32,7 +48,10 @@ const mockRedux = ({
     },
     mockStore: {
       getState: () => ({
-        form: { data: formData },
+        form: {
+          data: formData,
+          formErrors,
+        },
         formContext: {
           onReviewPage: false,
           reviewMode: false,
@@ -85,6 +104,7 @@ describe('ArrayBuilderSummaryPage', () => {
     required = () => false,
     maxItems = 5,
     isReviewPage = false,
+    reviewErrors,
   }) {
     const setFormData = sinon.spy();
     const goToPath = sinon.spy();
@@ -101,9 +121,10 @@ describe('ArrayBuilderSummaryPage', () => {
     const { mockStore } = mockRedux({
       formData: data,
       setFormData,
+      formErrors: reviewErrors,
     });
 
-    const itemPage = {
+    const summaryPage = {
       uiSchema: {
         'view:hasOption': arrayBuilderYesNoUI({
           arrayPath: 'employers',
@@ -140,8 +161,8 @@ describe('ArrayBuilderSummaryPage', () => {
     const { container, getByText } = render(
       <Provider store={mockStore}>
         <CustomPage
-          schema={itemPage.schema}
-          uiSchema={itemPage.uiSchema}
+          schema={summaryPage.schema}
+          uiSchema={summaryPage.uiSchema}
           data={data}
           onChange={() => {}}
           onSubmit={() => {}}
@@ -260,5 +281,37 @@ describe('ArrayBuilderSummaryPage', () => {
 
     const $addButton = container.querySelector('va-button[data-action="add"]');
     expect($addButton).to.not.exist;
+  });
+
+  it('should show an error alert on the review page if reviewErrors are present', () => {
+    const { container } = setupArrayBuilderSummaryPage({
+      title: 'Review your employers',
+      arrayData: [],
+      urlParams: '',
+      isReviewPage: true,
+      maxItems: 5,
+      reviewErrors: MOCK_REVIEW_ERRORS_AT_LEAST_ONE,
+    });
+
+    const $errorAlert = container.querySelector(
+      'va-alert[name="employersReviewError"]',
+    );
+    expect($errorAlert).to.include.text('at least one employer');
+  });
+
+  it('should not show an error alert on the review page if reviewErrors are not present', () => {
+    const { container } = setupArrayBuilderSummaryPage({
+      title: 'Review your employers',
+      arrayData: [],
+      urlParams: '',
+      isReviewPage: true,
+      maxItems: 5,
+      reviewErrors: MOCK_REVIEW_ERRORS_EMPTY,
+    });
+
+    const $errorAlert = container.querySelector(
+      'va-alert[name="employersReviewError"]',
+    );
+    expect($errorAlert).to.not.exist;
   });
 });

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -393,6 +393,7 @@ class ReviewCollapsibleChapter extends React.Component {
               updatePage={() =>
                 this.handleEdit(page.pageKey, false, page.index)
               }
+              recalculateErrors={this.hasValidationError}
               pagePerItemIndex={page.index}
               schema={pageSchema}
               uiSchema={pageUiSchema}
@@ -418,6 +419,7 @@ class ReviewCollapsibleChapter extends React.Component {
             data={props.form.data}
             pagePerItemIndex={page.index}
             goToPath={this.goToPath}
+            recalculateErrors={this.hasValidationError}
           />
         </div>
       </React.Fragment>

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -173,28 +173,35 @@
  */
 
 /**
- * @typedef {({
- *   name,
- *   title,
- *   data,
- *   pagePerItemIndex,
- *   onReviewPage,
- *   trackingPrefix,
- *   uploadFile,
- *   schema,
- *   uiSchema,
- *   goBack,
- *   goForward,
- *   goToPath,
- *   onContinue,
- *   onChange,
- *   onSubmit,
- *   setFormData,
- *   contentBeforeButtons,
- *   contentAfterButtons,
- *   appStateData,
- *   formContext,
- * }) => React.ReactNode} CustomPageType
+ * @typedef {Object} CustomPageProps
+ * @property {string} name route.pageConfig.pageKey
+ * @property {string} title route.pageConfig.title
+ * @property {Object} data
+ * @property {number} pagePerItemIndex
+ * @property {boolean} onReviewPage
+ * @property {string} trackingPrefix
+ * @property {Function} uploadFile
+ * @property {Object} schema
+ * @property {Object} uiSchema
+ * @property {() => void} goBack
+ * @property {({ formData }) => void} goForward
+ * @property {(customPath: string, options?: { force: boolean }) => void} goToPath
+ * @property {() => void} onContinue
+ * @property {(formData) => void} onChange
+ * @property {({ formData }) => void} onSubmit
+ * @property {(pageName: string, index?: number) => boolean} recalculateErrors Only available
+ * on review page. Recalculates errors for the page including the red chapter level styling.
+ * Pass the prop.name to the pageName param. If the page is an array, pass the index as the second param.
+ * @property {Function} setFormData
+ * @property {React.ReactNode} contentBeforeButtons
+ * @property {React.ReactNode} contentAfterButtons
+ * @property {Object} appStateData
+ * @property {Object} formContext
+ * @property {Object} NavButtons Standard buttons at the bottom of the form e.g. back/continue
+ */
+
+/**
+ * @typedef {(props: CustomPageProps) => React.ReactNode} CustomPageType
  */
 
 /**


### PR DESCRIPTION
## Summary

- Show error on review page for array builder
- Keep URL params on navigating to intro page, which helps navigate back to review page if we accidentally clicked back
- Fix fields not loading field names and required properly, when removing all from review page -> force add new item

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#1436

## Testing done

- Regression tests
- New cypress tests
- New unit tests

## Screenshots

![image](https://github.com/user-attachments/assets/f16c6451-10c5-4a61-8b08-549e72fc8f46)

## What areas of the site does it impact?

code using array builder pattern

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
