### PR TITLE
10-7959f-1 Content Updates

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/ConfirmationPage.jsx
@@ -33,7 +33,7 @@ export class ConfirmationPage extends React.Component {
         </div>
         <VaAlert uswds status="success">
           <h2 className="vads-u-font-size--h3">
-            You've submitted your registration for FMP (VA Form 10-7959f-1)
+            You've submitted your registration for FMP
           </h2>
         </VaAlert>
 
@@ -69,7 +69,7 @@ export class ConfirmationPage extends React.Component {
         </div>
         <h2>What to expect after you submit your form</h2>
         <p>
-          We'll review your registration form, which can take up to 60 days. If
+          We'll review your registration form. This can take up to 60 days. If
           you're eligible for this program, we'll send you a benefits
           authorization letter. This letter will list your service-connected
           conditions that we'll cover.
@@ -84,8 +84,9 @@ export class ConfirmationPage extends React.Component {
         <div>
           <p>
             If you have questions about your registration or an FMP claim, call
-            the FMP office at <va-telephone contact="8773458179" />. We're here
-            Monday through Friday, 8:05 a.m. to 6:45 p.m. ET.
+            the FMP office at <va-telephone contact="8773458179" /> (
+            <va-telephone tty contact="711" />
+            ). We're here Monday through Friday, 8:05 a.m. to 6:45 p.m. ET.
           </p>
           <p>You can also contact us online through our Ask VA tool.</p>
           <a href="https://ask.va.gov/">Go to Ask VA</a>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**: Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
- _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR made updates to a few places on the confirmation page:

- Added TTY
- Changed first two sentences of what to expect section
- Removed form number from submission approval message

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/89887

## Testing done
unit tests
e2e
## Screenshots
![Screenshot 2024-08-02 at 2 47 06 PM](https://github.com/user-attachments/assets/18322a95-6590-4e6d-b126-d942fa1f1f88)
![Screenshot 2024-08-02 at 2 47 15 PM](https://github.com/user-attachments/assets/b7fb335d-4c5b-4490-b2e5-16a10caf135f)

## What areas of the site does it impact?
this form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
NA