### PR TITLE
89834 Custom error on submit - forms 10-10d, 10-7959c, 10-7959a, 10-7959f-1, 10-7959f-2

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -26,6 +26,7 @@ import {
 import VaTextInputField from 'platform/forms-system/src/js/web-component-fields/VaTextInputField';
 import get from '@department-of-veterans-affairs/platform-forms-system/get';
 import { blankSchema } from 'platform/forms-system/src/js/utilities/data/profile';
+import SubmissionError from '../../shared/components/SubmissionError';
 // import { fileUploadUi as fileUploadUI } from '../components/File/upload';
 
 import { ssnOrVaFileNumberCustomUI } from '../components/CustomSsnPattern';
@@ -168,6 +169,7 @@ const formConfig = {
       fullNamePath: formData => getNameKeyForSignature(formData),
     },
   },
+  submissionError: SubmissionError,
   formId: '10-10D',
   dev: {
     showNavLinks: false,

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -8,6 +8,7 @@ import transformForSubmit from './submitTransformer';
 import { nameWording } from '../helpers/utilities';
 import FileFieldWrapped from '../components/FileUploadWrapper';
 import { prefillTransformer } from './prefillTransformer';
+import SubmissionError from '../../shared/components/SubmissionError';
 
 import {
   applicantNameDobSchema,
@@ -81,6 +82,7 @@ const formConfig = {
   v3SegmentedProgressBar: true,
   showReviewErrors: !environment.isProduction(),
   footerContent: GetFormHelp,
+  submissionError: SubmissionError,
   formId: '10-7959C',
   dev: {
     showNavLinks: false,

--- a/src/applications/ivc-champva/10-7959a/config/form.js
+++ b/src/applications/ivc-champva/10-7959a/config/form.js
@@ -2,6 +2,7 @@
 import get from '@department-of-veterans-affairs/platform-forms-system/get';
 import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
+import SubmissionError from '../../shared/components/SubmissionError';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import { nameWording } from '../../shared/utilities';
 import { ApplicantAddressCopyPage } from '../../shared/components/applicantLists/ApplicantAddressPage';
@@ -49,6 +50,7 @@ const formConfig = {
   trackingPrefix: '10-7959a-',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
+  submissionError: SubmissionError,
   formId: '10-7959A',
   saveInProgress: {
     messages: {

--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -19,6 +19,7 @@ import {
 import transformForSubmit from './submitTransformer';
 import manifest from '../manifest.json';
 import prefillTransformer from './prefillTransformer';
+import SubmissionError from '../../shared/components/SubmissionError';
 
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
@@ -65,6 +66,7 @@ const formConfig = {
       fullNamePath: 'veteranFullName',
     },
   },
+  submissionError: SubmissionError,
   formId: '10-7959F-1',
   saveInProgress: {
     messages: {

--- a/src/applications/ivc-champva/10-7959f-2/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-2/config/form.js
@@ -17,6 +17,7 @@ import {
   yesNoSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
+import SubmissionError from '../../shared/components/SubmissionError';
 import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
@@ -42,6 +43,7 @@ const formConfig = {
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   v3SegmentedProgressBar: true,
+  submissionError: SubmissionError,
   formId: '10-7959F-2',
   saveInProgress: {
     // messages: {

--- a/src/applications/ivc-champva/shared/components/SubmissionError.jsx
+++ b/src/applications/ivc-champva/shared/components/SubmissionError.jsx
@@ -1,0 +1,59 @@
+import React, { useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+import { scrollTo, focusElement } from 'platform/utilities/ui';
+import recordEvent from 'platform/monitoring/record-event';
+
+const SubmissionError = ({ form }) => {
+  const alertRef = useRef(null);
+
+  useEffect(
+    () => {
+      if (alertRef?.current) {
+        scrollTo(alertRef.current);
+        focusElement('h3', {}, alertRef.current);
+      }
+    },
+    [alertRef],
+  );
+  recordEvent({
+    event: 'visible-alert-box',
+    'alert-box-type': 'error',
+    'alert-box-heading': `${
+      form?.formId
+    } - Your CHAMPVA submission didn’t go through`,
+    'error-key': 'submission_failure',
+    'alert-box-full-width': false,
+    'alert-box-background-only': false,
+    'alert-box-closeable': false,
+    'reason-for-alert': 'Submission failure',
+  });
+
+  return (
+    <va-alert
+      ref={alertRef}
+      id="submission-error"
+      status="error"
+      class="vads-u-margin-y--2"
+      uswds
+    >
+      <h3 slot="headline">We couldn’t submit your form</h3>
+      <p>
+        We’re sorry. There was a problem with our system. Try submitting your
+        form again.
+      </p>
+      <p>
+        If it still doesn’t work, call us at{' '}
+        <va-telephone contact="8006982411" /> (
+        <va-telephone contact="711" tty />
+        ). We’re here 24/7.
+      </p>
+    </va-alert>
+  );
+};
+
+SubmissionError.propTypes = {
+  form: PropTypes.shape({ formId: PropTypes.string }),
+};
+
+export default SubmissionError;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR adds a shared on submit error component that is used by all IVC CHAMPVA forms.

- Adds new error message component
- Adds import and usage of new message to all IVC form configs
- Team: IVC CHAMPVA
- Flipper: NA

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89834

## Testing done

- Manual
- Unit

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |<img width="730" alt="Screenshot 2024-08-02 at 14 28 33" src="https://github.com/user-attachments/assets/4ff83838-57f7-462e-b63a-5ba6567e1656">|<img width="808" alt="Screenshot 2024-08-02 at 14 16 08" src="https://github.com/user-attachments/assets/d404b2b0-cfbf-4208-805d-4231a3659707">|

## What areas of the site does it impact?

IVC CHAMPVA forms

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA