### PR TITLE
89908 Remove extra marriage questions/uploads - form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -65,13 +65,13 @@ import {
   applicantOhiCardsConfig,
   applicantOtherInsuranceCertificationConfig,
   applicantMarriageCertConfig,
-  applicantSecondMarriageDivorceCertConfig,
+  // applicantSecondMarriageDivorceCertConfig,
   applicantBirthCertUploadUiSchema,
   applicantAdoptedUploadUiSchema,
   applicantStepChildUploadUiSchema,
   applicantMarriageCertUploadUiSchema,
-  applicantSecondMarriageCertUploadUiSchema,
-  applicantSecondMarriageDivorceCertUploadUiSchema,
+  // applicantSecondMarriageCertUploadUiSchema,
+  // applicantSecondMarriageDivorceCertUploadUiSchema,
   applicantMedicarePartAPartBCardsUploadUiSchema,
   applicantMedicarePartDCardsUploadUiSchema,
   appMedicareOver65IneligibleUploadUiSchema,
@@ -109,15 +109,15 @@ import {
   ApplicantDependentStatusReviewPage,
 } from '../pages/ApplicantDependentStatus';
 import {
-  ApplicantSponsorMarriageDetailsPage,
-  ApplicantSponsorMarriageDetailsReviewPage,
+  // ApplicantSponsorMarriageDetailsPage,
+  // ApplicantSponsorMarriageDetailsReviewPage,
   marriageDatesSchema,
-  remarriageDetailsSchema,
-  depends18f2,
+  // remarriageDetailsSchema,
+  // depends18f2,
   depends18f3,
-  depends18f4,
-  depends18f5,
-  depends18f6,
+  // depends18f4,
+  // depends18f5,
+  // depends18f6,
 } from '../pages/ApplicantSponsorMarriageDetailsPage';
 import { ApplicantAddressCopyPage } from '../../shared/components/applicantLists/ApplicantAddressPage';
 
@@ -973,6 +973,9 @@ const formConfig = {
             ),
           }),
         },
+        /*
+        // COMMENTED OUT AUGUST 2, 2024 - We don't want to collect any additional
+        // marriage info beyond whether or not the applicant is/was married to sponsor.
         page18f1: {
           path: 'applicant-marriage/:index',
           arrayPath: 'applicants',
@@ -1017,6 +1020,7 @@ const formConfig = {
           uiSchema: remarriageDetailsSchema.uiSchema,
           schema: remarriageDetailsSchema.schema,
         },
+        */
         // Marriage dates (sponsor living or dead) when applicant did not remarry
         page18f3: {
           path: 'applicant-marriage-date/:index',
@@ -1027,6 +1031,7 @@ const formConfig = {
           uiSchema: marriageDatesSchema.noRemarriageUiSchema,
           schema: marriageDatesSchema.noRemarriageSchema,
         },
+        /*
         // Applicant remarried after sponsor died
         page18f4: {
           path: 'applicant-remarriage-date/:index',
@@ -1047,7 +1052,7 @@ const formConfig = {
           uiSchema: marriageDatesSchema.remarriageSeparatedUiSchema,
           schema: marriageDatesSchema.remarriageSeparatedSchema,
         },
-        // Applicant separated from sponsor before sponsor's death
+        /* // Applicant separated from sponsor before sponsor's death
         page18f6: {
           path: 'applicant-information/married-separated-dates/:index',
           arrayPath: 'applicants',
@@ -1057,6 +1062,7 @@ const formConfig = {
           uiSchema: marriageDatesSchema.separatedUiSchema,
           schema: marriageDatesSchema.separatedSchema,
         },
+        */
         page18f: {
           path: 'applicant-marriage-upload/:index',
           arrayPath: 'applicants',
@@ -1068,7 +1074,8 @@ const formConfig = {
               get(
                 'applicantRelationshipToSponsor.relationshipToVeteran',
                 formData?.applicants?.[index],
-              ) === 'spouse' &&
+              ) ===
+              'spouse' /* &&
               ((get('sponsorIsDeceased', formData) &&
                 [
                   'marriedTillDeathNoRemarriage',
@@ -1079,7 +1086,7 @@ const formConfig = {
                     formData?.applicants?.[index],
                   ),
                 )) ||
-                !get('sponsorIsDeceased', formData))
+                !get('sponsorIsDeceased', formData)) */
             );
           },
           CustomPage: FileFieldWrapped,
@@ -1094,6 +1101,7 @@ const formConfig = {
             ),
           }),
         },
+        /*
         page18f7: {
           path: 'applicant-remarriage-upload/:index',
           arrayPath: 'applicants',
@@ -1158,6 +1166,7 @@ const formConfig = {
             ),
           }),
         },
+        */
         page19: {
           path: 'applicant-medicare/:index',
           arrayPath: 'applicants',

--- a/src/applications/ivc-champva/10-10D/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-10D/config/submitTransformer.js
@@ -42,8 +42,8 @@ function transformApplicants(applicants) {
       vetRelationship: transformRelationship(
         app.applicantRelationshipToSponsor || 'NA',
       ),
-      sponsorMarriageDetails:
-        app?.applicantSponsorMarriageDetails?.relationshipToVeteran || 'NA',
+      // sponsorMarriageDetails:
+      // app?.applicantSponsorMarriageDetails?.relationshipToVeteran || 'NA',
       isEnrolledInMedicare:
         app?.applicantMedicareStatus?.eligibility === 'enrolled',
       hasOtherHealthInsurance: app?.applicantHasOhi?.hasOhi === 'yes',
@@ -57,8 +57,8 @@ function transformApplicants(applicants) {
         app?.applicantAdoptionPapers,
         app?.applicantStepMarriageCert,
         app?.applicantMarriageCert,
-        app?.applicantSecondMarriageCert,
-        app?.applicantSecondMarriageDivorceCert,
+        // app?.applicantSecondMarriageCert,
+        // app?.applicantSecondMarriageDivorceCert,
         app?.applicantMedicarePartAPartBCard,
         app?.applicantMedicarePartDCard,
         app?.applicantMedicareIneligibleProof,

--- a/src/applications/ivc-champva/10-10D/pages/ApplicantSponsorMarriageDetailsPage.jsx
+++ b/src/applications/ivc-champva/10-10D/pages/ApplicantSponsorMarriageDetailsPage.jsx
@@ -119,12 +119,13 @@ export function depends18f3(formData, index) {
     get(
       'applicantRelationshipToSponsor.relationshipToVeteran',
       formData?.applicants?.[index],
-    ) === 'spouse' &&
+    ) ===
+    'spouse' /* &&
     (get(
       'applicantSponsorMarriageDetails.relationshipToVeteran',
       formData?.applicants?.[index],
     ) === 'marriedTillDeathNoRemarriage' ||
-      !get('sponsorIsDeceased', formData))
+      !get('sponsorIsDeceased', formData)) */
   );
 }
 

--- a/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/10-10D.cypress.spec.js
@@ -269,6 +269,7 @@ const testConfig = createTestConfig(
           });
         });
       },
+      /*
       [ALL_PAGES.page18f1.path]: ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
@@ -285,6 +286,7 @@ const testConfig = createTestConfig(
           });
         });
       },
+      */
       [ALL_PAGES.page18f3.path]: ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
@@ -300,6 +302,7 @@ const testConfig = createTestConfig(
           });
         });
       },
+      /*
       [ALL_PAGES.page18f6.path]: ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(() => {
@@ -319,6 +322,7 @@ const testConfig = createTestConfig(
           });
         });
       },
+      */
       [ALL_PAGES.page19.path]: ({ afterHook }) => {
         cy.injectAxeThenAxeCheck();
         afterHook(() => {

--- a/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/cert-sd-spoused.json
+++ b/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/cert-sd-spoused.json
@@ -28,9 +28,6 @@
         "applicantRelationshipToSponsor": {
           "relationshipToVeteran": "spouse"
         },
-        "applicantSponsorMarriageDetails": {
-          "relationshipToVeteran": "marriageDissolved"
-        },
         "applicantMedicareStatus": {
           "eligibility": "ineligible"
         },

--- a/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/vet-2a-spouse-child-medabd-ohi.json
+++ b/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/vet-2a-spouse-child-medabd-ohi.json
@@ -27,9 +27,6 @@
         "applicantRelationshipToSponsor": {
           "relationshipToVeteran": "spouse"
         },
-        "applicantSponsorMarriageDetails": {
-          "relationshipToVeteran": "marriedTillDeathNoRemarriage"
-        },
         "missingUploads": [
           {
             "name": "applicantMarriageCert",

--- a/src/applications/ivc-champva/10-10D/tests/unit/config/form.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-10D/tests/unit/config/form.unit.spec.jsx
@@ -231,6 +231,7 @@ testNumberOfWebComponentFields(
   { ...mockData.data },
 );
 
+/*
 // marriageData.data.sponsorIsDeceased = true;
 testNumberOfWebComponentFields(
   formConfig,
@@ -249,6 +250,7 @@ testNumberOfWebComponentFields(
   'Applicant - remarriage status',
   { ...mockData.data },
 );
+*/
 
 testNumberOfWebComponentFields(
   formConfig,
@@ -259,6 +261,7 @@ testNumberOfWebComponentFields(
   { ...marriageData.data },
 );
 
+/*
 testNumberOfWebComponentFields(
   formConfig,
   formConfig.chapters.applicantInformation.pages.page18f4.schema,
@@ -303,6 +306,7 @@ testNumberOfWebComponentFields(
   'Applicant - second marriage divorce documents',
   { ...mockData.data },
 );
+*/
 
 testNumberOfWebComponentFields(
   formConfig,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR comments out some extra questions/uploads surrounding an applicant's divorce from sponsor and subsequent remarriage/divorce. We don't need to collect this extra information, so for the time being the pages are being commented out. It's possible we may need it in the future though, so they haven't been fully removed.

- Commented out extra question/upload pages
- Commented out unit tests pertaining to those pages
- Removed E2E test data for those pages

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89908

## Testing done

- Unit
- E2E

## Screenshots

NA

## What areas of the site does it impact?

This form

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA