### PR TITLE
VAGOV-TEAM-87719: Adds initial features to the form-renderer app

### DIFF
--- a/src/applications/form-renderer/_config/formConfig.js
+++ b/src/applications/form-renderer/_config/formConfig.js
@@ -1,0 +1,183 @@
+/**
+ * This file - in its current form - is temporary. We want to temporarily define
+ * two `formConfig` objects that can be dynamically chosen based on the url.
+ * Eventually, the `formConfig` object that drives the application will
+ * be calculated after fetching configuration from Drupal.
+ *
+ * As such, we purposely do not name this file `form.js` so as to bypass
+ * unit testing that automatically takes place on all `config/form.js` files
+ * in `src/applications`.
+ */
+
+// import fullSchema from 'vets-json-schema/dist/-schema.json';
+import manifest from '../manifest.json';
+
+import IntroductionPage from '../containers/IntroductionPage';
+import ConfirmationPage from '../containers/ConfirmationPage';
+import { dependsOn } from '../utils/conditional';
+
+// const { } = fullSchema.properties;
+
+// const { } = fullSchema.definitions;
+
+export const formConfig1 = {
+  rootUrl: `${manifest.rootUrl}/123-abc`,
+  urlPrefix: '/123-abc/',
+  trackingPrefix: '123-abc-',
+  // eslint-disable-next-line no-console
+  submit: () => console.log('submit form 1'),
+  introduction: IntroductionPage,
+  confirmation: ConfirmationPage,
+  formId: '123-abc',
+  saveInProgress: {},
+  version: 0,
+  prefillEnabled: true,
+  savedFormMessages: {
+    notFound: 'Form 1 NOT FOUND',
+    noAuth: 'Please sign in again to continue Form 1.',
+  },
+  title: 'Form 123-ABC',
+  defaultDefinitions: {},
+  chapters: {
+    f1c1: {
+      title: 'Form 1 Chapter 1',
+      pages: {
+        f1c1p1: {
+          path: 'f1c1p1',
+          title: 'Form 1 Chapter 1 Page 1',
+          uiSchema: {
+            'ui:title': 'Eligibility',
+            'ui:description': 'Requirements',
+            isEligible1: {
+              'ui:title': 'Are you eligible for Item1?',
+              'ui:widget': 'yesNo',
+            },
+            isEligible2: {
+              'ui:title': 'Are you eligible for Item2?',
+              'ui:widget': 'yesNo',
+            },
+          },
+          schema: {
+            type: 'object',
+            required: ['isEligible1'],
+            properties: {
+              isEligible1: {
+                type: 'boolean',
+              },
+              isEligible2: {
+                type: 'boolean',
+              },
+            },
+          },
+        },
+        f1c1p2: {
+          depends: dependsOn({
+            operator: 'or',
+            conditions: [
+              {
+                field: 'isEligible1',
+                value: true,
+              },
+              {
+                field: 'isEligible2',
+                value: true,
+              },
+            ],
+          }),
+          path: 'f1c1p2',
+          title: 'Form 1 Chapter 1 Page 2',
+          uiSchema: {
+            'ui:title': 'Conditional Page',
+            'ui:description': 'Other',
+            isOtherEligible: {
+              'ui:title': 'Are you eligible for something else?',
+              'ui:widget': 'yesNo',
+            },
+          },
+          schema: {
+            type: 'object',
+            required: ['isOtherEligible'],
+            properties: {
+              isOtherEligible: {
+                type: 'boolean',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+export const formConfig2 = {
+  rootUrl: `${manifest.rootUrl}/456-xyz`,
+  urlPrefix: '/456-xyz/',
+  trackingPrefix: '456-xyz-',
+  // eslint-disable-next-line no-console
+  submit: () => console.log('submit form 2'),
+  introduction: IntroductionPage,
+  confirmation: ConfirmationPage,
+  formId: '456-xyz',
+  saveInProgress: {},
+  version: 0,
+  prefillEnabled: true,
+  savedFormMessages: {
+    notFound: 'Form 2 NOT FOUND',
+    noAuth: 'Please sign in again to continue Form 2.',
+  },
+  title: 'Form 456-XYZ',
+  defaultDefinitions: {},
+  chapters: {
+    f2c1: {
+      title: 'Form 2 Chapter 1',
+      pages: {
+        f2c1p1: {
+          path: 'f2c1p1',
+          title: 'Form 2 Chapter 1 Page 1',
+          uiSchema: {
+            favoriteFood: {
+              'ui:title': 'Favorite Food',
+              'ui:widget': 'radio',
+              'ui:options': {
+                labels: {
+                  P: 'Pizza',
+                  H: 'Hamburger',
+                  S: 'Salad',
+                },
+              },
+            },
+          },
+          schema: {
+            type: 'object',
+            required: [],
+            properties: {
+              favoriteFood: {
+                type: 'string',
+                enum: ['P', 'H', 'S'],
+              },
+            },
+          },
+        },
+        f2c1p2: {
+          path: 'f2c1p2',
+          title: 'Form 2 Chapter 1 Page 2',
+          uiSchema: {
+            otherInformation: {
+              'ui:title': 'Other Information',
+              'ui:widget': 'textarea',
+            },
+          },
+          schema: {
+            type: 'object',
+            required: [],
+            properties: {
+              otherInformation: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};

--- a/src/applications/form-renderer/actions/form-load/index.js
+++ b/src/applications/form-renderer/actions/form-load/index.js
@@ -1,0 +1,63 @@
+export const FORM_LOADING_INITIATED = 'FORM_RENDERER/FORM_LOADING_INITIATED';
+export const FORM_LOADING_SUCCEEDED = 'FORM_RENDERER/FORM_LOADING_SUCCEEDED';
+export const FORM_LOADING_FAILED = 'FORM_RENDERER/FORM_LOADING_FAILED';
+
+import { formConfig1, formConfig2 } from '../../_config/formConfig';
+
+export const formLoadingInitiated = formId => {
+  return {
+    type: FORM_LOADING_INITIATED,
+    formId,
+  };
+};
+
+export const formLoadingSucceeded = formConfig => {
+  return {
+    type: FORM_LOADING_SUCCEEDED,
+    formConfig,
+  };
+};
+
+export const formLoadingFailed = error => {
+  return {
+    type: FORM_LOADING_FAILED,
+    error,
+  };
+};
+
+/**
+ * This is a temporary mock fetch of a formConfig. Once we
+ * are ready to fetch for real, we'll update this and write
+ * proper tests for this code.
+ */
+export const fetchFormConfig = formId => {
+  /* eslint-disable-next-line no-shadow */
+  const mockFetchFormConfigByFormId = async formId => {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        const formConfig = {
+          '123-abc': formConfig1,
+          '456-xyz': formConfig2,
+        }?.[formId];
+
+        if (formConfig) {
+          resolve(formConfig);
+        } else {
+          reject(new Error(`Form config not found for form id '${formId}'`));
+        }
+      }, 200);
+    });
+  };
+
+  return async dispatch => {
+    dispatch(formLoadingInitiated(formId));
+    try {
+      const formConfig = await mockFetchFormConfigByFormId(formId);
+      dispatch(formLoadingSucceeded(formConfig));
+      return formConfig;
+    } catch (error) {
+      dispatch(formLoadingFailed(error));
+      return undefined;
+    }
+  };
+};

--- a/src/applications/form-renderer/app-entry.jsx
+++ b/src/applications/form-renderer/app-entry.jsx
@@ -1,14 +1,14 @@
 import 'platform/polyfills';
 import './sass/form-renderer.scss';
 
+import React from 'react';
 import startApp from 'platform/startup';
-
-import routes from './routes';
-import reducer from './reducers';
 import manifest from './manifest.json';
+import formLoadReducer from './reducers/form-load';
+import App from './containers/App';
 
 startApp({
   url: manifest.rootUrl,
-  reducer,
-  routes,
+  reducer: formLoadReducer,
+  component: <App />,
 });

--- a/src/applications/form-renderer/containers/App.jsx
+++ b/src/applications/form-renderer/containers/App.jsx
@@ -1,12 +1,75 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { Router, useRouterHistory } from 'react-router';
+import { useDispatch, useSelector, useStore } from 'react-redux';
+import { createHistory } from 'history';
+import manifest from '../manifest.json';
+import Error from './Error';
+import { getRoutesFromFormConfig } from '../routes';
+import { formLoadingFailed, fetchFormConfig } from '../actions/form-load';
+import { getFormIdFromUrl } from '../utils/url';
+import { getReducerFromFormConfig } from '../reducers/form-render';
 
-// import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+// eslint-disable-next-line react-hooks/rules-of-hooks
+const history = useRouterHistory(createHistory)({
+  basename: manifest.rootUrl,
+});
 
-export default function App() {
-  return (
-    <h1>Form Renderer</h1>
-    // <RoutedSavableApp formConfig={null} currentLocation={location}>
-    //   {children}
-    // </RoutedSavableApp>
+export default () => {
+  const dispatch = useDispatch();
+  const store = useStore();
+  const [routes, setRoutes] = useState(null);
+  const formId = useSelector(state => state.formLoad?.formId);
+  const formConfig = useSelector(state => state.formLoad?.formConfig);
+  const formLoadingError = useSelector(state => state.formLoad?.error);
+  const isFormLoading = useSelector(state => state.formLoad?.isLoading);
+
+  useEffect(
+    () => {
+      if (formConfig) {
+        // We can't create a reducer or know the routes until we have the formConfig loaded.
+        // After successfully loading formConfig, update the reducer and then calculate the routes.
+        const formReducer = getReducerFromFormConfig(formConfig);
+        store.injectReducer('form', formReducer.form);
+
+        // The routes cannot be set until after the reducer has been injected
+        const route = getRoutesFromFormConfig(formConfig);
+        setRoutes(route);
+      } else {
+        // On initial load, parse url for formId and attempt to fetch formConfig
+        const formIdFromUrl = getFormIdFromUrl(
+          window.location.pathname,
+          manifest.rootUrl,
+        );
+        if (formIdFromUrl) {
+          dispatch(fetchFormConfig(formIdFromUrl));
+        } else {
+          dispatch(formLoadingFailed('Bad URL - No form id'));
+        }
+      }
+    },
+    [formConfig, dispatch, store],
   );
-}
+
+  if (formLoadingError) {
+    return <Error error={formLoadingError} />;
+  }
+
+  if (routes) {
+    return (
+      <Router
+        history={history}
+        createElement={(Element, elementProps) => (
+          <Element {...elementProps} formConfig={formConfig} />
+        )}
+      >
+        {routes}
+      </Router>
+    );
+  }
+
+  if (isFormLoading) {
+    return <div>Loading Form: {formId}</div>;
+  }
+
+  return null;
+};

--- a/src/applications/form-renderer/containers/ConfirmationPage.jsx
+++ b/src/applications/form-renderer/containers/ConfirmationPage.jsx
@@ -1,0 +1,97 @@
+/**
+ *  NOTE: This is a placeholder. It will be replaced/updated.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { format, isValid } from 'date-fns';
+import { connect } from 'react-redux';
+
+import scrollToTop from 'platform/utilities/ui/scrollToTop';
+import { focusElement } from 'platform/utilities/ui';
+
+export class ConfirmationPage extends React.Component {
+  componentDidMount() {
+    focusElement('h2');
+    scrollToTop('topScrollElement');
+  }
+
+  render() {
+    const { form } = this.props;
+    const { submission, formId, data } = form;
+    const submitDate = new Date(submission?.timestamp);
+
+    const { fullName } = data;
+
+    return (
+      <div>
+        <div className="print-only">
+          <img
+            src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
+            alt="VA logo"
+            width="300"
+          />
+          <h2>Application for Mock Form</h2>
+        </div>
+        <h2 className="vads-u-font-size--h3">
+          Your application has been submitted
+        </h2>
+        <p>We may contact you for more information or documents.</p>
+        <p className="screen-only">Please print this page for your records.</p>
+        <div className="inset">
+          <h3 className="vads-u-margin-top--0 vads-u-font-size--h4">
+            Form Renderer Claim{' '}
+            <span className="vads-u-font-weight--normal">(Form {formId})</span>
+          </h3>
+          {fullName ? (
+            <span>
+              for {fullName.first} {fullName.middle} {fullName.last}
+              {fullName.suffix ? `, ${fullName.suffix}` : null}
+            </span>
+          ) : null}
+
+          {isValid(submitDate) ? (
+            <p>
+              <strong>Date submitted</strong>
+              <br />
+              <span>{format(submitDate, 'MMMM d, yyyy')}</span>
+            </p>
+          ) : null}
+          <va-button
+            type="button"
+            className="usa-button screen-only"
+            onClick={window.print}
+          >
+            Print this for your records
+          </va-button>
+        </div>
+      </div>
+    );
+  }
+}
+
+ConfirmationPage.propTypes = {
+  form: PropTypes.shape({
+    data: PropTypes.shape({
+      fullName: {
+        first: PropTypes.string,
+        middle: PropTypes.string,
+        last: PropTypes.string,
+        suffix: PropTypes.string,
+      },
+    }),
+    formId: PropTypes.string,
+    submission: PropTypes.shape({
+      timestamp: PropTypes.string,
+    }),
+  }),
+  name: PropTypes.string,
+};
+
+function mapStateToProps(state) {
+  return {
+    form: state.form,
+  };
+}
+
+export default connect(mapStateToProps)(ConfirmationPage);

--- a/src/applications/form-renderer/containers/Error.jsx
+++ b/src/applications/form-renderer/containers/Error.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Error = ({ error }) => {
+  const message =
+    typeof error === 'string' ? `Error: ${error}` : error.toString();
+
+  return <div>{message}</div>;
+};
+
+Error.propTypes = {
+  error: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
+};
+
+export default Error;

--- a/src/applications/form-renderer/containers/IntroductionPage.jsx
+++ b/src/applications/form-renderer/containers/IntroductionPage.jsx
@@ -1,0 +1,100 @@
+/**
+ *  NOTE: This is a placeholder. It will be replaced/updated.
+ */
+
+import React from 'react';
+
+import { focusElement } from 'platform/utilities/ui';
+// import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
+import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+
+class IntroductionPage extends React.Component {
+  componentDidMount() {
+    focusElement('.va-nav-breadcrumbs-list');
+  }
+
+  render() {
+    const { route } = this.props;
+    const { formConfig, pageList } = route;
+
+    return (
+      <article className="schemaform-intro">
+        <FormTitle title={formConfig.title} />
+        <SaveInProgressIntro
+          headingLevel={2}
+          prefillEnabled={formConfig.prefillEnabled}
+          messages={formConfig.savedFormMessages}
+          pageList={pageList}
+          startText="Start the Application"
+        >
+          Please complete the form to apply for benefits.
+        </SaveInProgressIntro>
+        <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
+          Follow the steps below to apply for benefits.
+        </h2>
+        <va-process-list>
+          <li>
+            <h3>Prepare</h3>
+            <h4>To fill out this application, you’ll need your:</h4>
+            <ul>
+              <li>Social Security number (required)</li>
+            </ul>
+            <p>
+              <strong>What if I need help filling out my application?</strong>{' '}
+              An accredited representative, like a Veterans Service Officer
+              (VSO), can help you fill out your claim.{' '}
+              <a href="/disability-benefits/apply/help/index.html">
+                Get help filing your claim
+              </a>
+            </p>
+          </li>
+          <li>
+            <h3>Apply</h3>
+            <p>Complete this benefits form.</p>
+            <p>
+              After submitting the form, you’ll get a confirmation message. You
+              can print this for your records.
+            </p>
+          </li>
+          <li>
+            <h3>VA Review</h3>
+            <p>
+              We process claims within a week. If more than a week has passed
+              since you submitted your application and you haven’t heard back,
+              please don’t apply again. Call us at.
+            </p>
+          </li>
+          <li>
+            <h3>Decision</h3>
+            <p>
+              Once we’ve processed your claim, you’ll get a notice in the mail
+              with our decision.
+            </p>
+          </li>
+        </va-process-list>
+        <SaveInProgressIntro
+          buttonOnly
+          headingLevel={2}
+          prefillEnabled={formConfig.prefillEnabled}
+          messages={formConfig.savedFormMessages}
+          pageList={pageList}
+          startText="Start the Application"
+        />
+        <p />
+        <va-omb-info exp-date="12/31/2025" omb-number="" res-burden={30}>
+          <p>
+            <strong>The Paperwork Reduction Act</strong> of 1995 requires us to
+            notify you that this information...
+          </p>
+          <p>
+            <strong>Privacy Act information:</strong> VA is asking you to
+            provide the information...
+          </p>
+        </va-omb-info>
+      </article>
+    );
+  }
+}
+
+export default IntroductionPage;

--- a/src/applications/form-renderer/manifest.json
+++ b/src/applications/form-renderer/manifest.json
@@ -3,5 +3,5 @@
   "entryFile": "./app-entry.jsx",
   "entryName": "form-renderer",
   "rootUrl": "/digital-form",
-  "productId": "8e41524c-d835-476c-ba0f-040037380911"
+  "productId": "d349beb0-9b3b-464c-844e-31e4778fa744"
 }

--- a/src/applications/form-renderer/reducers/form-load/index.js
+++ b/src/applications/form-renderer/reducers/form-load/index.js
@@ -1,0 +1,53 @@
+import {
+  FORM_LOADING_INITIATED,
+  FORM_LOADING_SUCCEEDED,
+  FORM_LOADING_FAILED,
+} from '../../actions/form-load';
+
+export const initialState = {
+  formId: null,
+  formConfig: null,
+  isLoading: false,
+  isError: false,
+  isSuccess: false,
+  error: null,
+};
+
+export default {
+  formLoad: (state = initialState, action) => {
+    switch (action.type) {
+      case FORM_LOADING_INITIATED:
+        return {
+          ...state,
+          isLoading: true,
+          isError: false,
+          isSuccess: false,
+          formId: action.formId,
+          formConfig: null,
+        };
+
+      case FORM_LOADING_SUCCEEDED:
+        return {
+          ...state,
+          isLoading: false,
+          isError: false,
+          isSuccess: true,
+          error: null,
+          formConfig: action.formConfig,
+        };
+
+      case FORM_LOADING_FAILED:
+        return {
+          ...state,
+          isLoading: false,
+          isError: true,
+          isSuccess: false,
+          error: action.error,
+          formConfig: null,
+        };
+
+      default:
+        return state;
+    }
+  },
+};

--- a/src/applications/form-renderer/reducers/form-render/index.js
+++ b/src/applications/form-renderer/reducers/form-render/index.js
@@ -1,0 +1,5 @@
+import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
+
+export const getReducerFromFormConfig = formConfig => ({
+  form: createSaveInProgressFormReducer(formConfig),
+});

--- a/src/applications/form-renderer/reducers/index.js
+++ b/src/applications/form-renderer/reducers/index.js
@@ -1,6 +1,0 @@
-// import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
-// import formConfig from '../config/form';
-
-export default {
-  form: null, // createSaveInProgressFormReducer(formConfig),
-};

--- a/src/applications/form-renderer/routes.jsx
+++ b/src/applications/form-renderer/routes.jsx
@@ -1,11 +1,24 @@
-import App from './containers/App';
+import React from 'react';
+import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
+import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import { removeTrailingSlash } from './utils/string';
 
-const route = {
-  path: '/',
-  component: App,
-  // indexRoute: { onEnter: (nextState, replace) => replace('/introduction') },
+export const getRoutesFromFormConfig = formConfig => {
+  const childRoutes = createRoutesWithSaveInProgress(formConfig);
+  const urlPrefix = removeTrailingSlash(formConfig.urlPrefix);
 
-  childRoutes: null,
+  return {
+    path: `${urlPrefix}(/)`,
+    component: ({ location, children }) => (
+      <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+        {children}
+      </RoutedSavableApp>
+    ),
+    indexRoute: {
+      onEnter: (nextState, replace) => {
+        return replace(`${urlPrefix}/introduction`);
+      },
+    },
+    childRoutes,
+  };
 };
-
-export default route;

--- a/src/applications/form-renderer/tests/e2e/form-renderer.cypress.spec.js
+++ b/src/applications/form-renderer/tests/e2e/form-renderer.cypress.spec.js
@@ -3,8 +3,8 @@
 // import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 // import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
 
-// import formConfig from '../config/form';
-// import manifest from '../manifest.json';
+// import formConfig from '../../config/form';
+// import manifest from '../../manifest.json';
 
 // const testConfig = createTestConfig(
 //   {

--- a/src/applications/form-renderer/tests/unit/containers/App.unit.spec.js
+++ b/src/applications/form-renderer/tests/unit/containers/App.unit.spec.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { expect } from 'chai';
+import thunk from 'redux-thunk';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
+
+import App from '../../../containers/App';
+import formLoadReducer from '../../../reducers/form-load';
+
+const renderApp = store => {
+  return render(
+    <Provider store={store}>
+      <App />
+    </Provider>,
+  );
+};
+
+describe('<App /> component', () => {
+  const mockStore = configureStore([thunk]);
+
+  it('renders error message if error', () => {
+    const store = mockStore({
+      formLoad: {
+        isLoading: false,
+        isError: true,
+        isSuccess: false,
+        error: 'Bad URL',
+      },
+    });
+    const { getByText } = renderApp(store);
+    expect(getByText(/Error:.*Bad URL/)).to.exist;
+  });
+
+  it('renders loading message if loading', () => {
+    const store = mockStore({
+      formLoad: {
+        isLoading: true,
+        isError: false,
+        isSuccess: false,
+        formId: '123-abc',
+      },
+    });
+    const { getByText } = renderApp(store);
+    expect(getByText(/Loading.*123-abc/)).to.exist;
+  });
+});
+
+describe('<App /> integration', () => {
+  const rootReducer = combineReducers({
+    formLoad: formLoadReducer.formLoad,
+  });
+
+  it('renders error message if no form id in url', async () => {
+    const store = createStore(rootReducer, applyMiddleware(thunk));
+    window.history.pushState({}, '', `/digital-form`);
+    const { getByText } = renderApp(store);
+    await waitFor(() => {
+      expect(getByText(/Error.*Bad URL - No form id/)).to.exist;
+    });
+  });
+
+  it('renders loading message if form id present in url', async () => {
+    const store = createStore(rootReducer, applyMiddleware(thunk));
+    window.history.pushState({}, '', `/digital-form/some-form-id`);
+    const { getByText } = renderApp(store);
+    await waitFor(() => {
+      expect(getByText(/Loading.*some-form-id/)).to.exist;
+    });
+  });
+
+  /* This will eventually require mocking the call to fetch the CMS form config */
+  it('renders not-found error message if form id in url does not map to real form', async () => {
+    const store = createStore(rootReducer, applyMiddleware(thunk));
+    window.history.pushState({}, '', `/digital-form/bad-form-id`);
+    const { getByText } = renderApp(store);
+    await waitFor(() => {
+      expect(getByText(/Error.*config not found/)).to.exist;
+    });
+  });
+});

--- a/src/applications/form-renderer/tests/unit/containers/Error.unit.spec.js
+++ b/src/applications/form-renderer/tests/unit/containers/Error.unit.spec.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+
+import ErrorComponent from '../../../containers/Error';
+
+describe('<Error/> component', () => {
+  const errorString = 'This is an error message';
+  const errorDisplayed = `Error: ${errorString}`;
+
+  it('renders the error message when error is a string', () => {
+    const { getByText } = render(<ErrorComponent error={errorString} />);
+    expect(getByText(errorDisplayed)).to.exist;
+  });
+
+  it('renders the error message when error is an object', () => {
+    const errorObject = new Error(errorString);
+    const { getByText } = render(<ErrorComponent error={errorObject} />);
+    expect(getByText(errorDisplayed)).to.exist;
+  });
+});

--- a/src/applications/form-renderer/tests/unit/reducers/form-load.unit.spec.js
+++ b/src/applications/form-renderer/tests/unit/reducers/form-load.unit.spec.js
@@ -1,0 +1,76 @@
+import { expect } from 'chai';
+
+import reducer, { initialState } from '../../../reducers/form-load';
+import {
+  formLoadingInitiated,
+  formLoadingSucceeded,
+  formLoadingFailed,
+} from '../../../actions/form-load';
+
+describe('form-load reducer', () => {
+  it('should return the initial state', () => {
+    expect(reducer.formLoad(undefined, {})).to.deep.equal(initialState);
+  });
+
+  it('should handle FORM_LOADING_INITIATED', () => {
+    const action = formLoadingInitiated('123-abc');
+    const expectedState = {
+      ...initialState,
+      isLoading: true,
+      isError: false,
+      error: null,
+      isSuccess: false,
+      formId: action.formId,
+      formConfig: null,
+    };
+    expect(reducer.formLoad(initialState, action)).to.deep.equal(expectedState);
+  });
+
+  it('should handle FORM_LOADING_SUCCEEDED', () => {
+    const action = formLoadingSucceeded({
+      someKey: 'someValue',
+    });
+    const currentState = {
+      ...initialState,
+      isLoading: true,
+      isError: false,
+      isSuccess: false,
+      error: null,
+      formId: '123-abc',
+      formConfig: null,
+    };
+    const expectedState = {
+      ...currentState,
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      error: null,
+      formId: '123-abc',
+      formConfig: action.formConfig,
+    };
+    expect(reducer.formLoad(currentState, action)).to.deep.equal(expectedState);
+  });
+
+  it('should handle FORM_LOADING_FAILED', () => {
+    const action = formLoadingFailed('some error');
+    const currentState = {
+      ...initialState,
+      isLoading: true,
+      isError: false,
+      isSuccess: false,
+      error: null,
+      formId: 'bad-form-id',
+      formConfig: null,
+    };
+    const expectedState = {
+      ...currentState,
+      isLoading: false,
+      isError: true,
+      isSuccess: false,
+      error: action.error,
+      formId: 'bad-form-id',
+      formConfig: null,
+    };
+    expect(reducer.formLoad(currentState, action)).to.deep.equal(expectedState);
+  });
+});

--- a/src/applications/form-renderer/tests/unit/utils/conditional.unit.spec.js
+++ b/src/applications/form-renderer/tests/unit/utils/conditional.unit.spec.js
@@ -1,0 +1,130 @@
+import { expect } from 'chai';
+
+import { dependsOn } from '../../../utils/conditional';
+
+describe('dependsOn', () => {
+  const formData = {
+    booleanVal: true,
+    stringVal: 'a',
+    numberVal: 1,
+  };
+
+  describe('`and` operator', () => {
+    it('returns true with all true conditions and an `and` operator.', () => {
+      const dependsObject = {
+        operator: 'and',
+        conditions: [
+          {
+            field: 'booleanVal',
+            value: true,
+          },
+          {
+            field: 'stringVal',
+            value: 'a',
+          },
+          {
+            field: 'numberVal',
+            value: 1,
+          },
+        ],
+      };
+
+      const result = dependsOn(dependsObject)(formData);
+      expect(result).to.be.true;
+    });
+
+    it('returns false with at least one false condition and an `and` operator.', () => {
+      const dependsObject = {
+        operator: 'and',
+        conditions: [
+          {
+            field: 'booleanVal',
+            value: false, // This is not the actual value of `booleanVal`, so this check should be false
+          },
+          {
+            field: 'stringVal',
+            value: 'a',
+          },
+          {
+            field: 'numberVal',
+            value: 1,
+          },
+        ],
+      };
+
+      const result = dependsOn(dependsObject)(formData);
+      expect(result).to.be.false;
+    });
+  });
+
+  describe('`or` operator', () => {
+    it('returns true with all true conditions and an `or` operator.', () => {
+      const dependsObject = {
+        operator: 'or',
+        conditions: [
+          {
+            field: 'booleanVal',
+            value: true,
+          },
+          {
+            field: 'stringVal',
+            value: 'a',
+          },
+          {
+            field: 'numberVal',
+            value: 1,
+          },
+        ],
+      };
+
+      const result = dependsOn(dependsObject)(formData);
+      expect(result).to.be.true;
+    });
+
+    it('returns true with at least one true condition and an `or` operator.', () => {
+      const dependsObject = {
+        operator: 'or',
+        conditions: [
+          {
+            field: 'booleanVal',
+            value: false, // This is not the actual value of `booleanVal`, so this check should be false
+          },
+          {
+            field: 'stringVal',
+            value: 'b', // This is not the actual value of `stringVal`, so this check should be false
+          },
+          {
+            field: 'numberVal',
+            value: 1, // This IS the actual value of `numberVal`, so this check should be true
+          },
+        ],
+      };
+
+      const result = dependsOn(dependsObject)(formData);
+      expect(result).to.be.true;
+    });
+
+    it('returns false with no true condition and an `or` operator.', () => {
+      const dependsObject = {
+        operator: 'or',
+        conditions: [
+          {
+            field: 'booleanVal',
+            value: false, // This is not the actual value of `booleanVal`, so this check should be false
+          },
+          {
+            field: 'stringVal',
+            value: 'b', // This is not the actual value of `stringVal`, so this check should be false
+          },
+          {
+            field: 'numberVal',
+            value: 2, // This is not the actual value of `numberVal`, so this check should be false
+          },
+        ],
+      };
+
+      const result = dependsOn(dependsObject)(formData);
+      expect(result).to.be.false;
+    });
+  });
+});

--- a/src/applications/form-renderer/tests/unit/utils/string.unit.spec.js
+++ b/src/applications/form-renderer/tests/unit/utils/string.unit.spec.js
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+
+import { removeLeadingSlash, removeTrailingSlash } from '../../../utils/string';
+
+describe('removeLeadingSlash', () => {
+  it('removes the leading slash when present', () => {
+    const url = '/path/to/page/';
+    const removed = removeLeadingSlash(url);
+    expect(removed).to.equal('path/to/page/');
+  });
+
+  it('removes only one leading slash if multiple are present', () => {
+    const url = '//path/to/page/';
+    const removed = removeLeadingSlash(url);
+    expect(removed).to.equal('/path/to/page/');
+  });
+
+  it('has no effect with leading slash not present', () => {
+    const url = 'path/to/page/';
+    const removed = removeLeadingSlash(url);
+    expect(removed).to.equal('path/to/page/');
+  });
+});
+
+describe('removeTrailingSlash', () => {
+  it('removes the trailing slash when present', () => {
+    const url = '/path/to/page/';
+    const removed = removeTrailingSlash(url);
+    expect(removed).to.equal('/path/to/page');
+  });
+
+  it('removes only one trailing slash if multiple are present', () => {
+    const url = '/path/to/page//';
+    const removed = removeTrailingSlash(url);
+    expect(removed).to.equal('/path/to/page/');
+  });
+
+  it('has no effect with trailing slash not present', () => {
+    const url = '/path/to/page';
+    const removed = removeTrailingSlash(url);
+    expect(removed).to.equal('/path/to/page');
+  });
+});

--- a/src/applications/form-renderer/tests/unit/utils/url.unit.spec.js
+++ b/src/applications/form-renderer/tests/unit/utils/url.unit.spec.js
@@ -1,0 +1,55 @@
+import { expect } from 'chai';
+
+import { getFormIdFromUrl } from '../../../utils/url';
+
+describe('getFormIdFromUrl', () => {
+  const rootUrl = 'root/url';
+
+  it('successfully parses the formId when present at the end of the url', () => {
+    const formId = '123-abc';
+    const url = `https://www.va.gov/${rootUrl}/${formId}`;
+    const parsedFormId = getFormIdFromUrl(url, rootUrl);
+    expect(parsedFormId).to.equal(formId);
+  });
+
+  it('successfully parses the formId when present at the end of the url', () => {
+    const formId = '123-abc';
+    const url = `https://www.va.gov/${rootUrl}/${formId}`;
+    const parsedFormId = getFormIdFromUrl(url, rootUrl);
+    expect(parsedFormId).to.equal(formId);
+  });
+
+  it('successfully parses the formId when present in the middle of the url', () => {
+    const formId = '123-abc';
+    const url = `https://www.va.gov/${rootUrl}/${formId}/some/more`;
+    const parsedFormId = getFormIdFromUrl(url, rootUrl);
+    expect(parsedFormId).to.equal(formId);
+  });
+
+  it('returns undefined when not properly formed', () => {
+    const url = `https://www.va.gov/${rootUrl}`;
+    const parsedFormId = getFormIdFromUrl(url, rootUrl);
+    expect(parsedFormId).to.be.undefined;
+  });
+
+  it('successfully handles rootUrl with leading slash', () => {
+    const formId = '123-abc';
+    const url = `https://www.va.gov/${rootUrl}/${formId}/some/more`;
+    const parsedFormId = getFormIdFromUrl(url, `/${rootUrl}`);
+    expect(parsedFormId).to.equal(formId);
+  });
+
+  it('successfully handles rootUrl with trailing slash', () => {
+    const formId = '123-abc';
+    const url = `https://www.va.gov/${rootUrl}/${formId}/some/more`;
+    const parsedFormId = getFormIdFromUrl(url, `${rootUrl}/`);
+    expect(parsedFormId).to.equal(formId);
+  });
+
+  it('successfully handles rootUrl with leading and trailing slash', () => {
+    const formId = '123-abc';
+    const url = `https://www.va.gov/${rootUrl}/${formId}/some/more`;
+    const parsedFormId = getFormIdFromUrl(url, `/${rootUrl}/`);
+    expect(parsedFormId).to.equal(formId);
+  });
+});

--- a/src/applications/form-renderer/utils/conditional.js
+++ b/src/applications/form-renderer/utils/conditional.js
@@ -1,0 +1,10 @@
+export const dependsOn = ({ operator, conditions }) => formData => {
+  return conditions.reduce((acc, condition) => {
+    const { field, value } = condition;
+    const isConditionSatisfied = formData[field] === value;
+
+    return operator === 'and'
+      ? acc && isConditionSatisfied
+      : acc || isConditionSatisfied;
+  }, operator === 'and');
+};

--- a/src/applications/form-renderer/utils/string.js
+++ b/src/applications/form-renderer/utils/string.js
@@ -1,0 +1,2 @@
+export const removeLeadingSlash = path => path.replace(/^\//, '');
+export const removeTrailingSlash = path => path.replace(/\/$/, '');

--- a/src/applications/form-renderer/utils/url.js
+++ b/src/applications/form-renderer/utils/url.js
@@ -1,0 +1,6 @@
+import { removeLeadingSlash, removeTrailingSlash } from './string';
+
+export const getFormIdFromUrl = (url, rootUrl) => {
+  const noSlashRootUrl = removeLeadingSlash(removeTrailingSlash(rootUrl));
+  return url.match(new RegExp(`${noSlashRootUrl}/([a-zA-Z0-9-_]+)/?`))?.[1];
+};


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary
This PR moves the form-renderer app from a mere shell to including its initial functionality and structure. Most notably, this PR creates an `<App />` component whose purpose is to search for a form id in the url and then bootstrap the form. 

### Important considerations
Apps in `vets-website` are bootstrapped by calling `startApp`. This utility abstracts away the setup of functionality common to all apps, which is extremely helpful. Two critical pieces that are handled by this are:
1. Creating a Redux store and combining app-specific reducers with the common reducer. 
2. Configuring the routes the app defines.

Both of these are accomplished by allowing properties on the options parameter the function accepts (`reducer` and `routes`, respectively). For most form applications, the `reducer` and `routes` objects that are passed in are calculated from the static `formConfig` object, as shown in the example below:

```
import formConfig from '../config/form';

startApp({
  entryName: manifest.entryName,
  url: manifest.rootUrl,
  reducer: createSaveInProgressFormReducer(formConfig),
  routes: {
    path: '/',
    component: App,
    indexRoute: { onEnter: (nextState, replace) => replace('/introduction') },

    childRoutes: createRoutesWithSaveInProgress(formConfig),
  },
});
```

Our app presents an interesting use case wherein we do not have the `formConfig` object at the time we want to bootstrap the application because the `formConfig` depends on the url (the form id is defined in the url).  Part of our app's functionality is to first examine the url, try to parse a form id, and then try to find that id in a list of form-configuration objects fetched from Drupal. That is to say, we can't call `startApp` like shown above because we don't have the `reducer` or the `routes`. 

Instead, the challenge addressed in this PR is to bootstrap an application using `startApp` that first does the work of parsing the url for a form id and fetching the matching configuration, _and then calculates the `reducer` and `routes` and renders the form appropriately_. That work is done in in [src/applications/form-renderer/containers/App.jsx](https://github.com/department-of-veterans-affairs/vets-website/blob/8193db4f889c699789b0a62c4d7a10996237d708/src/applications/form-renderer/containers/App.jsx), largely in the `useEffect` hook.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/87719

## QA Steps
- [ ] `/form-renderer/digital-form` should produce error indicating no form id found.
- [ ] `/form-renderer/digital-form/some-bad-form-id` should produce error indicating no form configuration found for `some-bad-form-id`.
- [ ] `/form-renderer/digital-form/123-abc` should render a form.
  - [ ] Test utility for conditional page rendering:
    - [ ] Click through and select 'Yes' to at least one of ['Are you eligible for Item1?', 'Are you eligible for Item 2?']. Click 'next' and confirm the Conditional Page displays.
    - [ ] Go back to previous page and select 'No' for both requirement questions. Click 'next' and confirm the Conditional Page does not display.
- [ ] `/form-renderer/digital-form/456-xyz` should render a different form.

## Testing done
- Added unit tests for newly added components and utils.
- Manually tested locally.

## Screenshots
![image](https://github.com/user-attachments/assets/dead652b-1d6c-4fdc-a587-b7f4bafc5f8b)
![image](https://github.com/user-attachments/assets/6601cf04-2a9b-447f-a2a5-0c6864d0fbd1)

## What areas of the site does it impact?

This PR touches only our team-owned application (form-renderer). Notably, the app is not yet live.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
N/A
