### PR TITLE
Update submit documents page

### DIFF
--- a/src/applications/pensions/PensionsApp.jsx
+++ b/src/applications/pensions/PensionsApp.jsx
@@ -21,6 +21,9 @@ export default function PensionEntry({ location, children }) {
   const pensionMedicalEvidenceClarification = useToggleValue(
     TOGGLE_NAMES.pensionMedicalEvidenceClarification,
   );
+  const pensionDocumentUploadUpdate = useToggleValue(
+    TOGGLE_NAMES.pensionDocumentUploadUpdate,
+  );
   const pensionModuleEnabled = useToggleValue(
     TOGGLE_NAMES.pensionModuleEnabled,
   );
@@ -52,6 +55,10 @@ export default function PensionEntry({ location, children }) {
           'showPensionEvidenceClarification',
           !!pensionMedicalEvidenceClarification,
         );
+        window.sessionStorage.setItem(
+          'showUploadDocuments',
+          !!pensionDocumentUploadUpdate,
+        );
       }
     },
     [
@@ -59,6 +66,7 @@ export default function PensionEntry({ location, children }) {
       pensionMultiplePageResponse,
       pensionIncomeAndAssetsClarification,
       pensionMedicalEvidenceClarification,
+      pensionDocumentUploadUpdate,
     ],
   );
 

--- a/src/applications/pensions/config/chapters/06-additional-information/documentUpload.js
+++ b/src/applications/pensions/config/chapters/06-additional-information/documentUpload.js
@@ -3,6 +3,12 @@ import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
 import environment from 'platform/utilities/environment';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
 import { files } from '../../definitions';
+import { showUploadDocuments } from '../../../helpers';
+
+// TODO: Remove this page when pension_document_upload_update flipper is removed
+const path = !showUploadDocuments()
+  ? 'additional-information/document-upload'
+  : 'temporarily-hidden-document-upload';
 
 const Description = (
   <div className="vads-u-color--gray-dark">
@@ -68,7 +74,8 @@ const UploadMessage = (
 
 export default {
   title: 'Document upload',
-  path: 'additional-information/document-upload',
+  path,
+  depends: () => !showUploadDocuments(),
   uiSchema: {
     ...titleUI('Submit your supporting documents'),
     'ui:description': Description,

--- a/src/applications/pensions/config/chapters/06-additional-information/index.js
+++ b/src/applications/pensions/config/chapters/06-additional-information/index.js
@@ -3,6 +3,7 @@ import accountInformation from './accountInformation';
 import otherPaymentOptions from './otherPaymentOptions';
 import supportingDocuments from './supportingDocuments';
 import documentUpload from './documentUpload';
+import uploadDocuments from './uploadDocuments';
 import fasterClaimProcessing from './fasterClaimProcessing';
 
 export default {
@@ -13,6 +14,7 @@ export default {
     otherPaymentOptions,
     supportingDocuments, // aidAttendance
     documentUpload,
+    uploadDocuments,
     fasterClaimProcessing,
   },
 };

--- a/src/applications/pensions/config/chapters/06-additional-information/uploadDocuments.js
+++ b/src/applications/pensions/config/chapters/06-additional-information/uploadDocuments.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
+import environment from 'platform/utilities/environment';
+import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
+import { files } from '../../definitions';
+import { showUploadDocuments } from '../../../helpers';
+
+// TODO: Remove path ternary when pension_document_upload_update flipper is removed
+const path = showUploadDocuments()
+  ? 'additional-information/upload-documents'
+  : 'temporarily-hidden-upload-documents';
+
+const Description = (
+  <>
+    <p>
+      You can submit your supporting documents and additional evidence with your
+      pension claim.
+    </p>
+    <p>Guidelines to upload a file:</p>
+    <ul>
+      <li>You can upload a .pdf, .jpeg, or .png file</li>
+      <li>Your file should be no larger than 20MB</li>
+    </ul>
+  </>
+);
+
+const UploadMessage = (
+  <p>
+    <strong>Note:</strong> You can choose to submit your supporting documents
+    and additional evidence after submitting your pension claim. You’ll need to
+    submit them by mail or upload them using the Claim Status Tool.
+  </p>
+);
+
+export default {
+  title: 'Upload documents',
+  path,
+  depends: () => showUploadDocuments(),
+  uiSchema: {
+    ...titleUI('Submit your supporting documents'),
+    'ui:description': Description,
+    files: fileUploadUI('', {
+      fileUploadUrl: `${environment.API_URL}/v0/claim_attachments`,
+      hideLabelText: true,
+    }),
+    'view:uploadMessage': {
+      'ui:description': UploadMessage,
+    },
+  },
+  schema: {
+    type: 'object',
+    properties: {
+      files,
+      'view:uploadMessage': {
+        type: 'object',
+        properties: {},
+      },
+    },
+  },
+};

--- a/src/applications/pensions/helpers.jsx
+++ b/src/applications/pensions/helpers.jsx
@@ -128,3 +128,6 @@ export const showIncomeAndAssetsClarification = () =>
 // TODO: Remove when pensions_medical_evidence_clarification flipper is removed
 export const showMedicalEvidenceClarification = () =>
   window.sessionStorage.getItem('showPensionEvidenceClarification') === 'true';
+
+export const showUploadDocuments = () =>
+  window.sessionStorage.getItem('showUploadDocuments') === 'true';

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -149,6 +149,7 @@
   "pensionIntroductionUpdate": "pension_introduction_update",
   "pensionConfirmationUpdate": "pension_confirmation_update",
   "pensionSupportingDocumentsUpdate": "pension_supporting_documents_update",
+  "pensionDocumentUploadUpdate": "pension_document_upload_update",
   "pensionMultiplePageResponse": "pension_multiple_page_response",
   "pensionIncomeAndAssetsClarification": "pension_income_and_assets_clarification",
   "pensionsBrowserMonitoringEnabled": "pension_browser_monitoring_enabled",


### PR DESCRIPTION
## Summary
Update the submit documents page on the Pension Benefits form (21P-527EZ)

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89519

## Associated Vets-api PR
- https://github.com/department-of-veterans-affairs/vets-api/pull/17854

## How to run in local environment
1. Check out this branch locally
2. In your local environment, set the `pension_document_upload_update` flipper to 'enabled' at http://localhost:3000/flipper/features/pension_document_upload_update
3. Run `vets-website` and `vets-api`
4. Go to `http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/` in your browser

## How to verify
1. Go to '/additional-information/upload-documents' 
2. Verify the 'submit documents' page style, layout and content matches the design references
3. Verify that upload functionality is not broken
4. Verify axe dev tools accessibility audit is passing

## What areas of the site does it impact?
Pension Benefits Application

## Screenshots
| Before | After |
| ------ | ------ |
|![localhost_3001_pension_apply-for-veteran-pension-form-21p-527ez_form-saved (21)](https://github.com/user-attachments/assets/dabfd502-e29a-4552-84ea-7cc5f645d9ad)|![localhost_3001_pension_apply-for-veteran-pension-form-21p-527ez_ (5)](https://github.com/user-attachments/assets/05c8a7e3-106f-4e8b-888b-8b22e0fd458f)





### Quality Assurance & Testing
- [x] Existing unit tests and integration tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
