### PR TITLE
Household Income Review Page Error Messages

### DIFF
--- a/src/applications/financial-status-report/constants/reviewErrors.js
+++ b/src/applications/financial-status-report/constants/reviewErrors.js
@@ -6,43 +6,142 @@ import numberToWords from 'platform/forms-system/src/js/utilities/data/numberToW
 export default {
   hasBeenAdjudicatedBankrupt:
     "Please select whether you've declared bankruptcy (select yes or no)",
-  resolutionOption: index => {
-    return `Please select a resolution option for the ${numberToWords(
+
+  hasRecreationalVehicle:
+    'Please select whether you have a recreational vehicle (select yes or no)',
+  hasVehicle: 'Please select whether you own a vehicle (select yes or no)',
+  hasRealEstate: 'Please select whether you own real estate (select yes or no)',
+
+  resolutionOption: index =>
+    `Please select a resolution option for the ${numberToWords(
       index + 1,
-    )} selected debt`;
-  },
-  resolutionComment: index => {
-    return `Please enter a resolution amount for the ${numberToWords(
+    )} selected debt`,
+
+  resolutionComment: index =>
+    `Please enter a resolution amount for the ${numberToWords(
       index + 1,
-    )} selected debt`;
-  },
-  resolutionWaiverCheck: index => {
-    return `Please select whether you agree to the waiver for the ${numberToWords(
+    )} selected debt`,
+
+  resolutionWaiverCheck: index =>
+    `Please select whether you agree to the waiver for the ${numberToWords(
       index + 1,
-    )} selected debt`;
-  },
+    )} selected debt`,
+
   monthlyHousingExpenses:
     'Please enter a valid dollar amount for your monthly housing expenses',
+
+  // Household Assets error messages
+  monetaryAssets: 'Please provide valid information for all monetary assets',
+  realEstateValue:
+    'Please enter a valid dollar amount for your real estate value',
+  recVehicleAmount:
+    'Please enter a valid dollar amount for your recreational vehicle',
+  otherAssets: 'Please provide valid information for all other assets',
+
+  // Household Income error messages
+  grossMonthlyIncome:
+    'Please enter a valid dollar amount for your gross monthly income',
+  additionalIncome:
+    'Please provide valid information for all additional income sources',
+  spouseGrossMonthlyIncome:
+    'Please enter a valid dollar amount for your spouse’s gross monthly income',
+
   _override: (error, fullError) => {
-    if (error === 'questions') {
-      return {
+    const errorMapping = {
+      questions: {
         chapterKey: 'bankruptcyAttestationChapter',
         pageKey: 'bankruptcyHistory',
-      };
-    }
-    if (error.includes('selectedDebtsAndCopays')) {
-      return {
+      },
+      selectedDebtsAndCopays: {
         chapterKey: 'resolutionOptionsChapter',
         pageKey: 'resolutionOption',
-      };
+      },
+      assetsMonetaryAssets: {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'monetaryValues',
+      },
+      assetsRealEstateValue: {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'enhancedRealEstateRecords',
+      },
+      assetsRecVehicleAmount: {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'recreationalVehicleRecords',
+      },
+      assetsOtherAssets: {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'otherAssetsSummary',
+      },
+      hasRecreationalVehicle: {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'recreationalVehicleRecords',
+      },
+      hasVehicle: {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'enhancedVehicleRecords',
+      },
+      hasRealEstate: {
+        chapterKey: 'householdAssetsChapter',
+        pageKey: 'enhancedRealEstateRecords',
+      },
+      grossMonthlyIncome: {
+        chapterKey: 'householdIncomeChapter',
+        pageKey: 'grossMonthlyIncome',
+      },
+      additionalIncome: {
+        chapterKey: 'householdIncomeChapter',
+        pageKey: 'additionalIncomeValues',
+      },
+      spouseGrossMonthlyIncome: {
+        chapterKey: 'householdIncomeChapter',
+        pageKey: 'enhancedSpouseGrossMonthlyIncome',
+      },
+    };
+
+    // Extract the relevant key from the error
+    const errorKey = error.includes('selectedDebtsAndCopays')
+      ? 'selectedDebtsAndCopays'
+      : error.split('.').slice(-1)[0];
+
+    if (errorMapping[errorKey]) {
+      return errorMapping[errorKey];
     }
-    if (fullError?.__errors.some(str => str.includes('resolution amount'))) {
+
+    if (fullError?.__errors?.some(str => str.includes('resolution amount'))) {
       return {
         chapterKey: 'resolutionOptionsChapter',
         pageKey: 'resolutionComment',
       };
     }
-    // always return null for non-matches
+
+    // Household Income specific errors
+    if (
+      fullError?.__errors?.some(str => str.includes('gross monthly income'))
+    ) {
+      return {
+        chapterKey: 'householdIncomeChapter',
+        pageKey: 'grossMonthlyIncome',
+      };
+    }
+
+    if (fullError?.__errors?.some(str => str.includes('additional income'))) {
+      return {
+        chapterKey: 'householdIncomeChapter',
+        pageKey: 'additionalIncomeValues',
+      };
+    }
+
+    if (
+      fullError?.__errors?.some(str =>
+        str.includes('spouse’s gross monthly income'),
+      )
+    ) {
+      return {
+        chapterKey: 'householdIncomeChapter',
+        pageKey: 'enhancedSpouseGrossMonthlyIncome',
+      };
+    }
+
     return null;
   },
 };


### PR DESCRIPTION
Description
This PR implements more helpful error handling on final review page for the Household Income Chapter

[Design ticket](https://app.zenhub.com/workspaces/vsa---debt-607736a6c8b7e2001084e3ab/issues/gh/department-of-veterans-affairs/va.gov-team/67811)

Example of Review page error message that has been implemented:

https://github.com/department-of-veterans-affairs/va.gov-team/issues/21252

https://github.com/department-of-veterans-affairs/vets-website/pull/16431

- Given: Error handling isn't exactly clear on final review page
- When: A veteran attempts to submit a form with an error
- Then: Error alert links to set focus to the accordion where the error exists

<table>
  <tr>
    <th style="text-align: center;"> 
 coming soon
    </th>
    <th style="text-align: center;">
    coming soon
    </th>
  </tr>
  <tr>
    <td style="text-align: center;">Default for null values</td>
    <td style="text-align: center;">Questions (Missing Values)</td>
  </tr>
</table>

Tasks
Confirm functionality for the following pages:

-  grossMonthlyIncome (Veteran)
-  additionalIncome
-  spouseGrossMonthlyIncome

Acceptance criteria

- [x]  Error messaging on final review page for Household Assets Chapter is clear and functioning as expected
- [x]  Works with current version of the form (post review navigation)

