### PR TITLE
VACMS-18798 Homepage redesign modal: remove custom analytics

### DIFF
--- a/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
+++ b/src/platform/site-wide/announcements/components/HomepageRedesignModal.jsx
@@ -2,7 +2,6 @@ import { VaModal } from '@department-of-veterans-affairs/component-library/dist/
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import recordEvent from 'platform/monitoring/record-event';
 
 function HomepageRedesignModal({ dismiss }) {
   const noscriptElements = document.getElementsByTagName('noscript');
@@ -25,11 +24,6 @@ function HomepageRedesignModal({ dismiss }) {
           cssClass="va-modal announcement-brand-consolidation"
           visible
           onCloseEvent={() => {
-            recordEvent({
-              event: 'int-modal-click',
-              'modal-status': 'closed',
-              'modal-title': 'Try our new VA.gov homepage',
-            });
             dismiss();
           }}
           id="modal-announcement"
@@ -39,11 +33,6 @@ function HomepageRedesignModal({ dismiss }) {
           aria-labelledby="homepage-modal-label-title"
           secondary-button-text="Not today, go to the current homepage"
           onSecondaryButtonClick={() => {
-            recordEvent({
-              event: 'cta-button-click',
-              'button-type': 'secondary',
-              'button-click-label': 'Not today, go to the current homepage',
-            });
             dismiss();
           }}
         >
@@ -73,11 +62,6 @@ function HomepageRedesignModal({ dismiss }) {
               href="/new-home-page"
               onClick={() => {
                 dismiss();
-                recordEvent({
-                  event: 'cta-button-click',
-                  'button-click-label': 'Try the new home page',
-                  'button-type': 'link',
-                });
               }}
             >
               Try the new home page


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Remove the custom analytics from the elements in the homepage redesign modal **which is currently disabled in production** ([see config here](https://github.com/department-of-veterans-affairs/vets-website/blob/9a0554f2542b94809bd3240dd3829085aa803645/src/platform/site-wide/announcements/config/index.js#L12)). This modal, when it is active, only exists on the `new-homepage` path which is also inactive at the moment.

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18798

## Testing done
None of this code is used and the URL on which it would live is not used; I don't think testing is needed here outside of passing CI.