### PR TITLE
Updates spacing around new join video appointment link

### DIFF
--- a/src/applications/vaos/components/VideoLink.jsx
+++ b/src/applications/vaos/components/VideoLink.jsx
@@ -19,8 +19,6 @@ export default function VideoLink({ appointment }) {
         <>
           We'll add the link to join this appointment 30 minutes before your
           appointment time.
-          <br />
-          <br />
         </>
       )}
 
@@ -28,10 +26,9 @@ export default function VideoLink({ appointment }) {
         <>
           Join the video appointment using the link.
           <br />
-          <br />
           <NewTabAnchor
             href={url}
-            className="vads-c-action-link--green vaos-hide-for-print vads-u-margin-bottom--3"
+            className="vads-c-action-link--green vaos-hide-for-print vads-u-margin-top--2"
             aria-describedby={`description-join-link-${appointment.id}`}
             onClick={e => e.preventDefault()}
           >


### PR DESCRIPTION

## Summary

Fixes spacing issues around join video appointment link on new appointment details page design within VAOS. This only updates styles/spacing.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/88731#issuecomment-2266128982

## Testing done
- Local testing

## Screenshots

| Before | After |
| ------ | ----- |
|<img width="763" alt="Screenshot 2024-08-06 at 6 17 22 AM" src="https://github.com/user-attachments/assets/f24709ca-db61-40f0-82c7-ec51b8705aa9">|<img width="729" alt="Screenshot 2024-08-06 at 6 18 12 AM" src="https://github.com/user-attachments/assets/4d95dd2d-8a9d-47e8-b241-8367ced0695c">|
|<img width="788" alt="Screenshot 2024-08-06 at 6 20 04 AM" src="https://github.com/user-attachments/assets/dce683e0-e776-4b46-8a51-f910b220f0d0">|<img width="785" alt="Screenshot 2024-08-06 at 6 22 01 AM" src="https://github.com/user-attachments/assets/ffc8c852-c682-4d22-b14a-9ad1c09dd401">|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- Should show correct spcing

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

