### PR TITLE
Remove outdated CE prep section

### DIFF
--- a/src/applications/vaos/components/layout/ClaimExamLayout.jsx
+++ b/src/applications/vaos/components/layout/ClaimExamLayout.jsx
@@ -56,16 +56,6 @@ export default function ClaimExamLayout({ data: appointment }) {
 
   return (
     <DetailPageLayout heading={heading} data={appointment}>
-      {APPOINTMENT_STATUS.booked === status &&
-        !isPastAppointment && (
-          <Section heading="How to prepare for this exam">
-            <span>
-              This appointment is for disability rating purposes only. It
-              doesn’t include treatment. If you have medical evidence to support
-              your claim, bring copies to this appointment.
-            </span>
-          </Section>
-        )}
       <When>
         <AppointmentDate date={startDate} />
         <br />

--- a/src/applications/vaos/components/tests/ClaimExamLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/ClaimExamLayout.unit.spec.js
@@ -298,9 +298,6 @@ describe('VAOS Component: ClaimExamLayout', () => {
           name: /claim exam/i,
         }),
       );
-      expect(
-        screen.getByRole('heading', { level: 2, name: /How to prepare/i }),
-      );
       expect(screen.getByRole('heading', { level: 2, name: /When/i }));
       expect(
         screen.container.querySelector('va-button[text="Add to calendar"]'),


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Removing the duplicated and outdated claims exam preparation section
- Appointments (VAOS) team

## Related issue(s)

- https://app.zenhub.com/workspaces/appointments-team-603fdef281af6500110a1691/issues/gh/department-of-veterans-affairs/va.gov-team/90070

## Testing done

- Tested locally see screenshots below
- Updated unit tests

## Screenshots

New screenshot of CE exam
<img width="301" alt="image" src="https://github.com/user-attachments/assets/99adc626-d839-40f0-b0b0-e531a70f8bfd">


## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
