### PR TITLE
Find a Rep: remove reference to fa svg

### DIFF
--- a/src/applications/representative-search/components/search/SearchControls.jsx
+++ b/src/applications/representative-search/components/search/SearchControls.jsx
@@ -235,12 +235,7 @@ const SearchControls = props => {
                   aria-label="Use my location"
                   style={{ order: 2 }}
                 >
-                  <va-icon
-                    size={4}
-                    icon="see name mappings here https://design.va.gov/foundation/icons"
-                    className="use-my-location-button"
-                    aria-hidden="true"
-                  />
+                  <va-icon size={4} icon="near_me" aria-hidden="true" />
                   Use my location
                 </button>
               )}

--- a/src/applications/representative-search/sass/find-a-representative.scss
+++ b/src/applications/representative-search/sass/find-a-representative.scss
@@ -101,15 +101,6 @@
           }
         }
 
-        .use-my-location-button {
-          width: 1.8rem;
-          height: 1.8rem;
-          background-image: url("/img/location-arrow-solid.svg");
-          background-repeat: no-repeat;
-          background-color: transparent;
-          padding: 0 2.4rem 0 0;
-        }
-
         .finding-your-location-loading {
           min-width: 22.4rem;
           text-decoration: none;


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**: Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
- _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR removes a reference to an icon that made use of font-awesome in accordance with the deprectaion of font awesome from vets-website. The PR also fixes a related va-icon instance.

## Related issue(s)

[2944](https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/2944)

## Testing done

local testing

## Screenshots

<img width="828" alt="Screenshot 2024-08-06 at 2 01 30 PM" src="https://github.com/user-attachments/assets/fd4b9165-f837-4acc-aa3e-7c6c72b2e938">


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
