### PR TITLE
Removes logic that was breaking the InfoAlert display on the CC request page

### DIFF
--- a/src/applications/vaos/components/StatusAlert.jsx
+++ b/src/applications/vaos/components/StatusAlert.jsx
@@ -52,11 +52,7 @@ export default function StatusAlert({ appointment, facility }) {
   ]);
   const { status } = appointment;
 
-  if (
-    featureAfterVisitSummary &&
-    featureAppointmentDetailsRedesign &&
-    APPOINTMENT_STATUS.proposed === status
-  ) {
+  if (APPOINTMENT_STATUS.proposed === status) {
     return (
       <InfoAlert backgroundOnly status={showConfirmMsg ? 'success' : 'info'}>
         <p>


### PR DESCRIPTION
## Summary


## Related issue(s)

N/A

## Testing done

Local testing

## Screenshots
N/A 

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
