### PR TITLE
Update the alert message for request flow when the services is down

### DIFF
--- a/src/applications/vaos/new-appointment/components/ReviewPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/index.jsx
@@ -53,6 +53,9 @@ export default function ReviewPage() {
 
   const isDirectSchedule = flowType === FLOW_TYPES.DIRECT;
   const submissionType = isDirectSchedule ? 'appointment' : 'request';
+  const alertHeadline = isDirectSchedule
+    ? 'We couldn’t schedule this appointment'
+    : 'We can’t submit your request';
   const facilityDetails = facility || parentFacility;
 
   return (
@@ -92,10 +95,7 @@ export default function ReviewPage() {
       </div>
       {submitStatus === FETCH_STATUS.failed && (
         <div className="info-alert" role="alert">
-          <InfoAlert
-            status="error"
-            headline="We couldn’t schedule this appointment"
-          >
+          <InfoAlert status="error" headline={alertHeadline}>
             <>
               {submitStatusVaos409 && (
                 <p>

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.cc-request.unit.spec.js
@@ -273,7 +273,7 @@ describe('VAOS Page: ReviewPage CC request with VAOS service', () => {
 
     userEvent.click(screen.getByText(/Submit request/i));
 
-    await screen.findByText('We couldn’t schedule this appointment');
+    await screen.findByText('We can’t submit your request');
 
     expect(screen.baseElement).contain.text(
       'Something went wrong when we tried to submit your request. You can try again later, or call your VA medical center to help with your request.',

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.va-request.unit.spec.js
@@ -234,7 +234,7 @@ describe('VAOS Page: ReviewPage VA request with VAOS service', () => {
 
     userEvent.click(screen.getByText(/Submit request/i));
 
-    await screen.findByText('We couldn’t schedule this appointment');
+    await screen.findByText('We can’t submit your request');
 
     expect(screen.baseElement).contain.text(
       'Something went wrong when we tried to submit your request. You can try again later, or call your VA medical center to help with your request.',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- This PR updates the alert message for failure during request workflows to be more accurate.
- Appointments (VAOS) team

## Related issue(s)

- https://app.zenhub.com/workspaces/appointments-team-603fdef281af6500110a1691/issues/gh/department-of-veterans-affairs/va.gov-team/79613

## Testing done

- Local testing, see screenshot

## Screenshots

Old screenshot is seen in the linked issue. 
New screenshot:
<img width="280" alt="image" src="https://github.com/user-attachments/assets/a96d7e6d-e647-4ed9-aaa1-3d022f2eedd3">


## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
