### PR TITLE
Remove sign in from Form Upload widget

### DIFF
--- a/src/applications/static-pages/simple-forms/form-upload/App.js
+++ b/src/applications/static-pages/simple-forms/form-upload/App.js
@@ -1,25 +1,14 @@
 import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { isLoggedIn } from 'platform/user/selectors';
-import {
-  VaButton,
-  VaAlert,
-} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
-import { toggleLoginModal as toggleLoginModalAction } from '@department-of-veterans-affairs/platform-site-wide/actions';
 import './stylesheet.scss';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 
 export const App = ({ formNumber, hasOnlineTool }) => {
-  const dispatch = useDispatch();
-
-  // TODO: Confirm this accurately detects if the user is logged in.
-  const userLoggedIn = useSelector(state => isLoggedIn(state));
   const shouldShow = useSelector(
     state => toggleValues(state)[FEATURE_FLAG_NAMES.formUploadFlow],
   );
-  const onSignInClicked = () => dispatch(toggleLoginModalAction(true));
 
   if (shouldShow && hasOnlineTool === undefined) {
     return <va-loading-indicator message="Loading..." />;
@@ -30,28 +19,16 @@ export const App = ({ formNumber, hasOnlineTool }) => {
       <>
         <h3>Submit completed form</h3>
         <p>After you complete the form, you can upload and submit it here.</p>
-        {userLoggedIn ? (
-          <div className="action-bar-arrow">
-            <div className="vads-u-background-color--primary vads-u-padding--1">
-              <a
-                className="vads-c-action-link--white"
-                href={`/form-upload/${formNumber}/upload`}
-              >
-                Start uploading your form
-              </a>
-            </div>
+        <div className="action-bar-arrow">
+          <div className="vads-u-background-color--primary vads-u-padding--1">
+            <a
+              className="vads-c-action-link--white"
+              href={`/form-upload/${formNumber}/introduction`}
+            >
+              Start uploading your form
+            </a>
           </div>
-        ) : (
-          <VaAlert status="info" data-testid="form-upload-sign-in-alert" uswds>
-            <h2 slot="headline">Sign in now to submit a completed form</h2>
-            <p>By signing in you will be able to submit a completed PDF form</p>
-            <VaButton
-              onClick={onSignInClicked}
-              uswds
-              text="Sign in to upload your form"
-            />
-          </VaAlert>
-        )}
+        </div>
       </>
     );
   }


### PR DESCRIPTION
## Summary
This PR removes the authentication checks from the Form Upload widget on the find a form page. It also redirects to `/introduction` upon starting the form (the Introduction page will handle auth).

## Related issue(s)
https://app.zenhub.com/workspaces/vagov-product-team-forms-634853151f5c6000165942bc/issues/gh/department-of-veterans-affairs/va.gov-team-forms/1515

## Screenshot
This screenshot demonstrates that I am not logged in and I can still begin the form.
<img width="1052" alt="Screenshot 2024-08-07 at 1 20 37 PM" src="https://github.com/user-attachments/assets/442e4747-c2c2-4257-94c5-299799cfaee1">
