### PR TITLE
MHV-60626 SM Folder filter - redundant aria tags

### DIFF
--- a/src/applications/mhv-secure-messaging/components/Search/SearchForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/Search/SearchForm.jsx
@@ -244,10 +244,8 @@ const SearchForm = props => {
                 id="filter-input"
                 label={filterLabelBody}
                 class="filter-input-box"
-                message-aria-describedby="filter text input"
                 value={searchTerm}
                 onInput={e => setSearchTerm(e.target.value)}
-                aria-label={filterLabelHeading + filterLabelBody}
                 data-testid="keyword-search-input"
                 onKeyPress={e => {
                   if (e.key === 'Enter') handleSearch();

--- a/src/applications/mhv-secure-messaging/components/Search/SearchForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/Search/SearchForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useLocation } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
@@ -6,7 +6,12 @@ import moment from 'moment';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { clearSearchResults, runAdvancedSearch } from '../../actions/search';
 import FilterBox from './FilterBox';
-import { ErrorMessages, Paths, filterDescription } from '../../util/constants';
+import {
+  DefaultFolders,
+  ErrorMessages,
+  Paths,
+  filterDescription,
+} from '../../util/constants';
 import { DateRangeOptions, DateRangeValues } from '../../util/inputContants';
 import { dateFormat } from '../../util/helpers';
 
@@ -202,19 +207,23 @@ const SearchForm = props => {
     );
   };
 
-  const handleFolderName = () => {
-    if (folder.name === 'Deleted') {
-      return 'Trash';
-    }
-    return folder.name;
-  };
-  const filterLabelHeading = `Filter messages in ${handleFolderName()} `;
-  let filterLabelBody;
-  if (location.pathname.includes('/drafts')) {
-    filterLabelBody = filterDescription.noMsgId;
-  } else {
-    filterLabelBody = filterDescription.withMsgId;
-  }
+  const filterLabelHeading = useMemo(
+    () => {
+      return `Filter messages in ${
+        folder.name === 'Deleted' ? 'Trash' : folder.name
+      } `;
+    },
+    [folder.name],
+  );
+
+  const filterLabelBody = useMemo(
+    () => {
+      return folder.folderId === DefaultFolders.DRAFTS.id
+        ? filterDescription.noMsgId
+        : filterDescription.withMsgId;
+    },
+    [folder.folderId],
+  );
 
   return (
     <>

--- a/src/applications/mhv-secure-messaging/tests/components/MessageListComponents/folderHeader.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/MessageListComponents/folderHeader.unit.spec.jsx
@@ -131,12 +131,6 @@ describe('Folder Header component', () => {
       expect(filterInputElement.getAttribute('label')).to.equal(
         filterDescription.withMsgId,
       );
-
-      expect(filterInputElement.getAttribute('aria-label')).to.equal(
-        `Filter messages in ${customFolder.name} ${
-          filterDescription.withMsgId
-        }`,
-      );
     });
 
     it('does not render FilterBox w/o `threadCount` on CUSTOM FOLDER', () => {
@@ -199,9 +193,6 @@ describe('Folder Header component', () => {
       const filterInputElement = screen.queryByTestId('keyword-search-input');
       expect(filterInputElement.getAttribute('label')).to.equal(
         filterDescription.withMsgId,
-      );
-      expect(filterInputElement.getAttribute('aria-label')).to.equal(
-        `Filter messages in ${inbox.name} ${filterDescription.withMsgId}`,
       );
     });
 
@@ -309,9 +300,6 @@ describe('Folder Header component', () => {
       expect(filterInputElement.getAttribute('label')).to.equal(
         'Enter information from one of these fields: To, from, or subject',
       );
-      expect(filterInputElement.getAttribute('aria-label')).to.equal(
-        `Filter messages in ${drafts.name} ${filterDescription.noMsgId}`,
-      );
     });
 
     it('does not render FilterBox w/o `threadCount` on DRAFTS FOLDER', () => {
@@ -354,9 +342,6 @@ describe('Folder Header component', () => {
       const filterInputElement = screen.queryByTestId('keyword-search-input');
       expect(filterInputElement.getAttribute('label')).to.equal(
         filterDescription.withMsgId,
-      );
-      expect(filterInputElement.getAttribute('aria-label')).to.equal(
-        `Filter messages in ${sent.name} ${filterDescription.withMsgId}`,
       );
     });
 
@@ -412,9 +397,6 @@ describe('Folder Header component', () => {
       const filterInputElement = screen.queryByTestId('keyword-search-input');
       expect(filterInputElement.getAttribute('label')).to.equal(
         filterDescription.withMsgId,
-      );
-      expect(filterInputElement.getAttribute('aria-label')).to.equal(
-        `Filter messages in ${trash.name} ${filterDescription.withMsgId}`,
       );
     });
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [x] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**: Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
- _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

**Finding 1** – MEDIUM
**Summary**: Screen reader announces filter input label twice on Inbox page
**Where**: Inbox page
**Area**: Filter messages in Inbox
**Problem**: When navigating element by element using a screen reader, the text "Enter information from one of these fields: To, from, message ID, or subject" is announced twice. This causes confusion for screen reader users, as the next logical element should be the input field.
Code Snippet: 
```
<va-text-input
   id="filter-input"
   label="Enter information from one of these fields: To, from, message ID, or subject"
   class="filter-input-box hydrated"
   message-aria-describedby="filter text input"
   value=""
   aria-label="Filter messages in Inbox Enter information from one of these fields: To, from, message ID, or subject"
   data-testid="keyword-search-input"
   data-dd-privacy="mask"
   uswds="">
</va-text-input>
```
Investigation: * When the attribute `message-aria-describedby="filter text input"` is removed, the repetition issue is resolved.

The purpose of the `aria-label="Filter messages in Inbox Enter information from one of these fields: To, from, message ID, or subject"` attribute is unclear and may be redundant.

Recommendation: * Review and remove unnecessary ARIA attributes to ensure the label is only announced once.

Clarify the purpose of the aria-label attribute and determine if it can be simplified to avoid redundancy.

## Related issue(s)

- https://jira.devops.va.gov/browse/MHV-60626
![image](https://github.com/user-attachments/assets/4b331fec-362d-4e7d-8a92-2723e69e53b6)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
