### PR TITLE
Add month/year date UI patterns

### DIFF
--- a/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockDate.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/pages/mockDate.js
@@ -7,6 +7,10 @@ import {
   dateOfBirthUI,
   currentOrPastDateRangeUI,
   currentOrPastDateRangeSchema,
+  currentOrPastMonthYearDateUI,
+  currentOrPastMonthYearDateRangeUI,
+  currentOrPastMonthYearDateSchema,
+  currentOrPastMonthYearDateRangeSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 /** @type {PageSchema} */
@@ -23,6 +27,20 @@ export default {
       'End date',
       'End date must be after start date',
     ),
+    'view:monthYearDates': {
+      'ui:description': <h4>Month year only</h4>,
+    },
+    dateMonthYear: currentOrPastMonthYearDateUI('Month and year only'),
+    dateMonthYearRange: currentOrPastMonthYearDateRangeUI(
+      {
+        title: 'Start date',
+        hint: 'Start date must be before end date',
+      },
+      {
+        title: 'End date',
+        hint: 'End date must be after start date',
+      },
+    ),
   },
   schema: {
     type: 'object',
@@ -34,7 +52,13 @@ export default {
         properties: {},
       },
       dateRange: currentOrPastDateRangeSchema,
+      'view:monthYearDates': {
+        type: 'object',
+        properties: {},
+      },
+      dateMonthYear: currentOrPastMonthYearDateSchema,
+      dateMonthYearRange: currentOrPastMonthYearDateRangeSchema,
     },
-    required: ['dateWCV3'],
+    required: ['dateWCV3', 'dateMonthYear'],
   },
 };

--- a/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/fixtures/data/default.json
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/tests/e2e/fixtures/data/default.json
@@ -6,6 +6,11 @@
       "from": "1999-01-03",
       "to": "1999-01-03"
     },
+    "dateMonthYear": "1999-02",
+    "dateMonthYearRange": {
+      "from": "1999-01",
+      "to": "1999-01"
+    },
     "vaCompensationType": "none",
     "isCurrentlyActiveDuty": false,
     "wcv3VaCompensationType": "highDisability",

--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -191,6 +191,14 @@ function formatYear(val) {
   return val;
 }
 
+export function formatMonthYearISOPartialDate({ month, year }) {
+  if (month || year) {
+    return `${formatYear(year)}-${formatDayMonth(month)}`;
+  }
+
+  return undefined;
+}
+
 export function formatISOPartialDate({ month, day, year }) {
   if (month || day || year) {
     return `${formatYear(year)}-${formatDayMonth(month)}-${formatDayMonth(

--- a/src/platform/forms-system/src/js/utilities/validations/index.js
+++ b/src/platform/forms-system/src/js/utilities/validations/index.js
@@ -77,6 +77,11 @@ export function isValidCurrentOrPastYear(value) {
   return Number(value) >= minYear && Number(value) < moment().year() + 1;
 }
 
+export function isValidCurrentOrPastMonthYear(month, year) {
+  const momentDate = moment({ month: parseInt(month, 10) - 1, year });
+  return momentDate.isSameOrBefore(moment().endOf('month'), 'month');
+}
+
 export function isValidCurrentOrFutureMonthYear(month, year) {
   const momentDate = moment({ month: parseInt(month, 10) - 1, year });
   return momentDate.isSameOrAfter(moment(), 'month');

--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -437,7 +437,7 @@ export function validateCurrentOrPastMemorableDate(
     new Date().getFullYear(),
   );
   const { day, month, year } = parseISODate(dateString);
-  if (!day || !year || !day || !isValidCurrentOrPastDate(day, month, year)) {
+  if (!day || !month || !year || !isValidCurrentOrPastDate(day, month, year)) {
     errors.addError(futureDate);
   }
 }

--- a/src/platform/forms-system/src/js/web-component-fields/VaDateField.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/VaDateField.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { VaMemorableDate } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { VaDate } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { useVaDateCommon } from './useVaDateCommon';
 
 /**
  * @param {WebComponentFieldProps} props
  */
-export default function VaMemorableDateField(props) {
+export default function VaDateField(props) {
   const {
     mappedProps,
     formattedValue,
@@ -14,9 +14,9 @@ export default function VaMemorableDateField(props) {
   } = useVaDateCommon(props);
 
   return (
-    <VaMemorableDate
+    <VaDate
       {...mappedProps}
-      monthSelect={props.uiOptions?.monthSelect ?? true}
+      monthYearOnly={props.uiOptions?.monthYearOnly ?? false}
       onDateChange={onDateChange}
       onDateBlur={onDateBlur}
       value={formattedValue}

--- a/src/platform/forms-system/src/js/web-component-fields/useVaDateCommon.js
+++ b/src/platform/forms-system/src/js/web-component-fields/useVaDateCommon.js
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+import vaDateCommonFieldMapping from './vaDateCommonFieldMapping';
+import {
+  formatISOPartialDate,
+  formatMonthYearISOPartialDate,
+  parseISODate,
+} from '../helpers';
+
+export function useVaDateCommon(props) {
+  const mappedProps = vaDateCommonFieldMapping(props);
+  const [values, setValues] = useState(parseISODate(props.value));
+  const monthYearOnly = props?.uiOptions?.monthYearOnly;
+
+  const formatter = monthYearOnly
+    ? formatMonthYearISOPartialDate
+    : formatISOPartialDate;
+
+  /**
+   * We store the value in redux as this format: XXXX-03-XX, with X and 0 padding.
+   * The component expects the value in this format: '--', '19--', '1999--', '1999-3-', '1999-3-1', '1999-03-12'
+   * During user input, we want to make sure there is no leading zero
+   *   so that they can type two digits for day/month.
+   *
+   * parseISODate(XXXX-03-XX) => { year: 1999, month: '', day: '01' }
+   * formatISOPartialDate({ day, month, year }) => XXXX-03-XX
+   */
+  const formattedValue = formatISOPartialDate(values)
+    ?.replace(/X/g, '')
+    ?.replace(/-0(\d)/g, '-$1');
+
+  const isIncomplete = (vals = {}) => {
+    return (
+      !vals.year ||
+      !vals.month ||
+      Number(vals.month) === 0 ||
+      Number(vals.year) === 0 ||
+      (!monthYearOnly && (!vals.day || Number(vals.day) === 0))
+    );
+  };
+
+  function onDateChange(event, newValue) {
+    const date = newValue ?? event.target.value ?? undefined;
+    const newValues = parseISODate(date);
+    setValues(newValues);
+
+    if (isIncomplete(newValues)) {
+      props.childrenProps.onChange(undefined);
+    } else {
+      props.childrenProps.onChange(formatter(newValues));
+    }
+  }
+
+  function onDateBlur(event) {
+    const newValues = parseISODate(event.target.value);
+
+    if (isIncomplete(newValues)) {
+      props.childrenProps.onChange(formatter(newValues));
+    }
+
+    props.childrenProps.onBlur(props.childrenProps.idSchema.$id);
+  }
+
+  return {
+    mappedProps,
+    formattedValue,
+    onDateChange,
+    onDateBlur,
+  };
+}

--- a/src/platform/forms-system/src/js/web-component-fields/useVaDateCommon.js
+++ b/src/platform/forms-system/src/js/web-component-fields/useVaDateCommon.js
@@ -8,7 +8,7 @@ import {
 
 export function useVaDateCommon(props) {
   const mappedProps = vaDateCommonFieldMapping(props);
-  const [values, setValues] = useState(parseISODate(props.value));
+  const [values, setValues] = useState(parseISODate(mappedProps.value));
   const monthYearOnly = props?.uiOptions?.monthYearOnly;
 
   const formatter = monthYearOnly
@@ -24,7 +24,7 @@ export function useVaDateCommon(props) {
    * parseISODate(XXXX-03-XX) => { year: 1999, month: '', day: '01' }
    * formatISOPartialDate({ day, month, year }) => XXXX-03-XX
    */
-  const formattedValue = formatISOPartialDate(values)
+  const formattedValue = formatter(values)
     ?.replace(/X/g, '')
     ?.replace(/-0(\d)/g, '-$1');
 

--- a/src/platform/forms-system/src/js/web-component-fields/vaDateCommonFieldMapping.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/vaDateCommonFieldMapping.jsx
@@ -3,7 +3,7 @@ import commonFieldMapping from './commonFieldMapping';
 import formsPatternFieldMapping from './formsPatternFieldMapping';
 
 /** @param {WebComponentFieldProps} props */
-export default function vaMemorableDateFieldMapping(props) {
+export default function vaDateCommonFieldMapping(props) {
   const {
     description,
     textDescription,
@@ -24,7 +24,6 @@ export default function vaMemorableDateFieldMapping(props) {
       typeof childrenProps.formData === 'undefined'
         ? ''
         : childrenProps.formData,
-    'month-select': uiOptions?.monthSelect ?? true,
     children: (
       <>
         {formDescriptionSlot}

--- a/src/platform/forms-system/src/js/web-component-patterns/datePatterns.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/datePatterns.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import commonDefinitions from 'vets-json-schema/dist/definitions.json';
 import VaMemorableDateField from '../web-component-fields/VaMemorableDateField';
+import VaDateField from '../web-component-fields/VaDateField';
 import {
   validateCurrentOrPastMemorableDate,
+  validateCurrentOrPastMonthYear,
   validateDateRange,
 } from '../validation';
 
@@ -22,18 +24,34 @@ import {
  * @param {string | UIOptions & {
  *   title?: UISchemaOptions['ui:title'],
  *   hint?: string,
+ *   errorMessages?: {
+ *     pattern?: string,
+ *     required?: string
+ *   },
  * }} [options] accepts a single string for title, or an object of options
  * @returns {UISchemaOptions} uiSchema
  */
 const currentOrPastDateUI = options => {
   const { title, errorMessages, ...uiOptions } =
     typeof options === 'object' ? options : { title: options };
+
+  // if monthYearOnly is used, the schema pattern also needs
+  // to be updated, so prefer to use currentOrPastMonthYearDateUI
+  // and currentOrPastMonthYearDateSchema rather than passing
+  // monthYearOnly option to this directly
+  const monthYearOnly = uiOptions?.monthYearOnly;
+
   const uiTitle = title ?? 'Date';
+  const localeDateStringOptions = monthYearOnly
+    ? { year: 'numeric', month: 'long' }
+    : { year: 'numeric', month: 'long', day: 'numeric' };
 
   return {
     'ui:title': uiTitle,
-    'ui:webComponentField': VaMemorableDateField,
-    'ui:validations': [validateCurrentOrPastMemorableDate],
+    'ui:webComponentField': monthYearOnly ? VaDateField : VaMemorableDateField,
+    'ui:validations': monthYearOnly
+      ? [validateCurrentOrPastMonthYear]
+      : [validateCurrentOrPastMemorableDate],
     'ui:errorMessages': {
       pattern:
         errorMessages?.pattern || 'Please enter a valid current or past date',
@@ -50,17 +68,43 @@ const currentOrPastDateUI = options => {
             <>
               {new Date(
                 `${children.props.formData}T00:00:00`,
-              ).toLocaleDateString('en-us', {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-              })}
+              ).toLocaleDateString('en-us', localeDateStringOptions)}
             </>
           )}
         </dd>
       </div>
     ),
   };
+};
+
+/**
+ * Web component v3 uiSchema for current or past month and year only dates
+ *
+ * ```js
+ * exampleDate: currentOrPastDateUI('Date of event')
+ * exampleDate: currentOrPastDateUI({
+ *  title: 'Date of event',
+ *  hint: 'This is a hint'
+ * })
+ * exampleDate: {
+ *  ...currentOrPastDateUI('Date of event')
+ * }
+ * ```
+ * @param {string | UIOptions & {
+ *   title?: UISchemaOptions['ui:title'],
+ *   hint?: string,
+ *   errorMessages?: {
+ *     pattern?: string,
+ *     required?: string
+ *   },
+ * }} [options] accepts a single string for title, or an object of options
+ * @returns {UISchemaOptions} uiSchema
+ */
+const currentOrPastMonthYearDateUI = options => {
+  return currentOrPastDateUI({
+    ...options,
+    monthYearOnly: true,
+  });
 };
 
 /**
@@ -130,6 +174,53 @@ const currentOrPastDateRangeUI = (fromOptions, toOptions, errorMessage) => {
     to: currentOrPastDateUI({ title: toLabel, ...toCustomOptions }),
     ...(errorMessage && { 'ui:errorMessages': { pattern: errorMessage } }),
   };
+};
+
+/**
+ * Web component v3 uiSchema for month and year only date range
+ *
+ * ```js
+ * // Simple usage:
+ * exampleDateRange: currentOrPastDateRangeUI(
+ *   'Start date of event',
+ *   'End date of event',
+ *   'Custom error message'
+ * )
+ *
+ * // Advanced usage:
+ * exampleDateRange: currentOrPastDateRangeUI(
+ *   { title: 'Start date of event', ... },
+ *   { title: 'End date of event', hint: 'This is a hint' },
+ *   'Custom error message'
+ * })
+ * ```
+ * @param {string | UIOptions & {
+ *   title?: UISchemaOptions['ui:title'],
+ *   hint?: string,
+ * }} [options] accepts a single string for start/from date title, or an object of options
+ * @param {string | UIOptions & {
+ *   title?: UISchemaOptions['ui:title'],
+ *   hint?: string,
+ * }} [options] accepts a single string for to/end date title, or an object of options
+ * @param {string} [errorMessage] - Optional custom error message for the date range validation
+ * @returns {UISchemaOptions} uiSchema
+ */
+const currentOrPastMonthYearDateRangeUI = (
+  fromOptions,
+  toOptions,
+  errorMessage,
+) => {
+  return currentOrPastDateRangeUI(
+    {
+      ...fromOptions,
+      monthYearOnly: true,
+    },
+    {
+      ...toOptions,
+      monthYearOnly: true,
+    },
+    errorMessage,
+  );
 };
 
 /**
@@ -229,6 +320,13 @@ const dateOfDeathUI = options => {
  */
 const currentOrPastDateSchema = commonDefinitions.date;
 
+const monthYearDateSchema = {
+  type: 'string',
+  pattern: '^(\\d{4}|XXXX)-(0[1-9]|1[0-2]|XX)$',
+};
+
+const currentOrPastMonthYearDateSchema = monthYearDateSchema;
+
 /**
  * @returns `commonDefinitions.date`
  */
@@ -263,15 +361,38 @@ const currentOrPastDateRangeSchema = {
   required: ['from', 'to'],
 };
 
+/**
+ * Usage:
+ * ```
+ * dateRange: currentOrPastMonthYearDateRangeSchema
+ * dateRange: {
+ *   ...currentOrPastMonthYearDateRangeSchema
+ *   required: []
+ * }
+ * ```
+ */
+const currentOrPastMonthYearDateRangeSchema = {
+  type: 'object',
+  properties: {
+    from: currentOrPastMonthYearDateSchema,
+    to: currentOrPastMonthYearDateSchema,
+  },
+  required: ['from', 'to'],
+};
+
 export {
   currentOrPastDateUI,
   currentOrPastDateDigitsUI,
+  currentOrPastDateRangeUI,
+  currentOrPastMonthYearDateUI,
+  currentOrPastMonthYearDateRangeUI,
   dateOfBirthUI,
   dateOfDeathUI,
-  currentOrPastDateRangeUI,
   currentOrPastDateRangeSchema,
   currentOrPastDateSchema,
   currentOrPastDateDigitsSchema,
+  currentOrPastMonthYearDateSchema,
+  currentOrPastMonthYearDateRangeSchema,
   dateOfBirthSchema,
   dateOfDeathSchema,
 };

--- a/src/platform/forms-system/test/js/utilities/validations.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/validations.unit.spec.js
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
 
-import { getValidationErrors } from '../../../src/js/utilities/validations';
+import {
+  getValidationErrors,
+  isValidCurrentOrPastMonthYear,
+} from '../../../src/js/utilities/validations';
 
 describe('getValidationErrors', () => {
   // simple validation functions
@@ -29,5 +32,19 @@ describe('getValidationErrors', () => {
     expect(
       getValidationErrors([check1, check2], { foo: '123', bar: '456' }),
     ).to.deep.equal([]);
+  });
+});
+
+describe('validations', () => {
+  it('isValidCurrentOrPastMonthYear', () => {
+    expect(isValidCurrentOrPastMonthYear('10', '2000')).to.be.true;
+    expect(isValidCurrentOrPastMonthYear('10', '3000')).to.be.false;
+    expect(isValidCurrentOrPastMonthYear('0', '3000')).to.be.false;
+    const today = new Date();
+    const todaysMonth = today.getMonth() + 1; // 0 based index
+    const todaysYear = today.getFullYear();
+    expect(isValidCurrentOrPastMonthYear(todaysMonth, todaysYear)).to.be.true;
+    expect(isValidCurrentOrPastMonthYear(todaysMonth + 1, todaysYear)).to.be
+      .false;
   });
 });

--- a/src/platform/testing/e2e/cypress/support/commands/webComponents.js
+++ b/src/platform/testing/e2e/cypress/support/commands/webComponents.js
@@ -106,22 +106,10 @@ Cypress.Commands.add('selectVaCheckbox', (field, isChecked) => {
   }
 });
 
-Cypress.Commands.add('fillVaDate', (field, dateString, monthYearOnly) => {
-  if (dateString) {
-    const element =
-      typeof field === 'string'
-        ? cy.get(`va-date[name="${field}"]`)
-        : cy.wrap(field);
-
-    const [year, month, day] = dateString.split('-').map(
-      dateComponent =>
-        // eslint-disable-next-line no-restricted-globals
-        isFinite(dateComponent)
-          ? parseInt(dateComponent, 10).toString()
-          : dateComponent,
-    );
-
-    element.shadow().then(el => {
+function fillVaDateFields(year, month, day, monthYearOnly) {
+  cy.get('@currentElement')
+    .shadow()
+    .then(el => {
       cy.wrap(el)
         .find('va-select.select-month')
         .shadow()
@@ -140,6 +128,31 @@ Cypress.Commands.add('fillVaDate', (field, dateString, monthYearOnly) => {
         .find('input')
         .type(year);
     });
+}
+
+Cypress.Commands.add('fillVaDate', (field, dateString, isMonthYearOnly) => {
+  if (dateString) {
+    const element =
+      typeof field === 'string'
+        ? cy.get(`va-date[name="${field}"]`)
+        : cy.wrap(field);
+    element.as('currentElement');
+
+    const [year, month, day] = dateString.split('-').map(
+      dateComponent =>
+        // eslint-disable-next-line no-restricted-globals
+        isFinite(dateComponent)
+          ? parseInt(dateComponent, 10).toString()
+          : dateComponent,
+    );
+
+    if (isMonthYearOnly == null) {
+      element.invoke('attr', 'month-year-only').then(monthYearOnlyAttr => {
+        fillVaDateFields(year, month, day, monthYearOnlyAttr === 'true');
+      });
+    } else {
+      fillVaDateFields(year, month, day, isMonthYearOnly === 'true');
+    }
   }
 });
 

--- a/src/platform/testing/e2e/cypress/support/commands/webComponents.js
+++ b/src/platform/testing/e2e/cypress/support/commands/webComponents.js
@@ -151,7 +151,7 @@ Cypress.Commands.add('fillVaDate', (field, dateString, isMonthYearOnly) => {
         fillVaDateFields(year, month, day, monthYearOnlyAttr === 'true');
       });
     } else {
-      fillVaDateFields(year, month, day, isMonthYearOnly === 'true');
+      fillVaDateFields(year, month, day, isMonthYearOnly);
     }
   }
 });

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -9,7 +9,7 @@ const ARRAY_ITEM_SELECTOR =
   'div[name^="topOfTable_"] ~ div.va-growable-background';
 const FIELD_SELECTOR = 'input, select, textarea';
 const WEB_COMPONENT_SELECTORS =
-  'va-text-input, va-select, va-textarea, va-radio-option, va-checkbox, va-memorable-date';
+  'va-text-input, va-select, va-textarea, va-radio-option, va-checkbox, va-date, va-memorable-date';
 
 const LOADING_SELECTOR = 'va-loading-indicator';
 


### PR DESCRIPTION
## Summary

Added:
```js
currentOrPastMonthYearDateUI,
currentOrPastMonthYearDateRangeUI,
currentOrPastMonthYearDateSchema,
currentOrPastMonthYearDateRangeSchema
```
and added `VaDateField` to support this

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#86478

## Testing done

- Unit and Cypress test, regression tests

## Screenshots

![image](https://github.com/user-attachments/assets/4c2ce430-cba5-4817-ada1-a8d8f5f16cdb)
![image](https://github.com/user-attachments/assets/1f3ce259-dcfb-47ae-80aa-efaecdaab79c)
![image](https://github.com/user-attachments/assets/bd8e499f-4418-4702-a29d-dcbd10ab4be7)

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
