### PR TITLE
Add isLinkData util, check lists for non-link data values

### DIFF
--- a/src/applications/mhv-landing-page/tests/utilities/data.unit.spec.js
+++ b/src/applications/mhv-landing-page/tests/utilities/data.unit.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { expect } from 'chai';
-import { countUnreadMessages } from './index';
+import { countUnreadMessages, isLinkData } from '../../utilities/data/index';
 import manifest from '../../manifest.json';
 
 describe(manifest.appName, () => {
@@ -90,6 +90,25 @@ describe(manifest.appName, () => {
           ],
         });
         expect(count).to.equal(10);
+      });
+    });
+    describe('isLinkData', () => {
+      it('checks that inputs are objects have href and text properties', () => {
+        const validLinkData = {
+          href: '/link',
+          text: 'text',
+        };
+        expect(isLinkData(validLinkData)).to.be.true;
+
+        const missingHref = { text: 'foo' };
+        expect(isLinkData(missingHref)).to.be.false;
+
+        const missingText = { href: '/link' };
+        expect(isLinkData(missingText)).to.be.false;
+
+        // Test non-objects, since
+        expect(isLinkData(null)).to.be.false;
+        expect(isLinkData(false)).to.be.false;
       });
     });
   });

--- a/src/applications/mhv-landing-page/utilities/data/index.js
+++ b/src/applications/mhv-landing-page/utilities/data/index.js
@@ -3,6 +3,8 @@ import { mhvUrl } from '@department-of-veterans-affairs/platform-site-wide/utili
 // Links to MHV subdomain need to use `mhvUrl`. Va.gov links can just be paths
 import { HEALTH_TOOL_HEADINGS, HEALTH_TOOL_LINKS } from '../../constants';
 
+const isLinkData = x => x?.href !== undefined && x?.text !== undefined;
+
 const countUnreadMessages = folders => {
   if (Array.isArray(folders?.data)) {
     return folders.data.reduce((accumulator, currentFolder) => {
@@ -88,7 +90,7 @@ const resolveLandingPageLinks = (
     //   href: '#FIXME-need-link',
     //   text: 'Download my IRS 1095-B form',
     // },
-  ];
+  ].filter(isLinkData);
 
   const moreResourcesLinks = [
     featureToggles[FEATURE_FLAG_NAMES.mhvVaHealthChatEnabled] && {
@@ -123,7 +125,7 @@ const resolveLandingPageLinks = (
       href: mhvUrl(authdWithSSOe, 'ss20200320-va-video-connect'),
       text: 'How to use VA Video Connect',
     },
-  ];
+  ].filter(isLinkData);
 
   const spotlightLinks = [
     {
@@ -194,6 +196,7 @@ const resolveLandingPageLinks = (
 
 export {
   countUnreadMessages,
+  isLinkData,
   resolveLandingPageLinks,
   resolveUnreadMessageAriaLabel,
 };


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Add isLinkData util for checking for valid link data when some expressions may resolve to non-link-data values



## Related issue(s)

- None

## Testing done

- While running `yarn mock-api --responses src/platform/mhv/api/mocks` and visiting `/my-health`, I noticed errors due to values in `myVaHealthBenefitsLinks` and `moreResourcesLinks` that weren't link-data objects.
- Added a `isLinkData` function, filtered arrays and re-ran locally
- Wrote tests for various values that would and would not count as links.

## What areas of the site does it impact?

MHV landing page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
