### PR TITLE
90041 Removed applicant date of birth field - form 10-7959c

### DIFF
--- a/src/applications/ivc-champva/10-7959C/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/applicantInformation.js
@@ -2,8 +2,6 @@ import { cloneDeep } from 'lodash';
 import {
   addressUI,
   addressSchema,
-  dateOfBirthUI,
-  dateOfBirthSchema,
   fullNameUI,
   fullNameSchema,
   phoneUI,
@@ -26,18 +24,12 @@ export const applicantNameDobSchema = {
   uiSchema: {
     ...titleUI('Beneficiary’s name and date of birth'),
     applicantName: fullNameMiddleInitialUI,
-    applicantDOB: dateOfBirthUI({
-      required: true,
-      hint: 'For example: January 19 2000',
-    }),
   },
   schema: {
     type: 'object',
-    required: ['applicantDOB'],
     properties: {
       titleSchema,
       applicantName: fullNameSchema,
-      applicantDOB: dateOfBirthSchema,
     },
   },
 };

--- a/src/applications/ivc-champva/10-7959C/chapters/applicantInformation.js
+++ b/src/applications/ivc-champva/10-7959C/chapters/applicantInformation.js
@@ -22,7 +22,7 @@ fullNameMiddleInitialUI.middle['ui:title'] = 'Middle initial';
 
 export const applicantNameDobSchema = {
   uiSchema: {
-    ...titleUI('Beneficiary’s name and date of birth'),
+    ...titleUI('Beneficiary’s name'),
     applicantName: fullNameMiddleInitialUI,
   },
   schema: {

--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -127,7 +127,7 @@ const formConfig = {
         applicantNameDob: {
           // initialData: mockdata.data,
           path: 'applicant-info',
-          title: 'Beneficiary’s name and date of birth',
+          title: 'Beneficiary’s name',
           ...applicantNameDobSchema,
         },
         applicantIdentity: {

--- a/src/applications/ivc-champva/10-7959C/tests/config/form.unit.spec.jsx
+++ b/src/applications/ivc-champva/10-7959C/tests/config/form.unit.spec.jsx
@@ -60,7 +60,7 @@ describe('Applicant Name/DOB page title', () => {
     formConfig,
     formConfig.chapters.applicantInformation.pages.applicantNameDob.schema,
     formConfig.chapters.applicantInformation.pages.applicantNameDob.uiSchema,
-    5,
+    4,
     'Applicant name/DOB',
     { ...mockData.data },
   );

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/maximal-test.json
@@ -45,7 +45,6 @@
       "last": "Jones",
       "suffix": "Jr."
     },
-    "applicantDOB": "1950-01-02",
     "missingUploads": [
       {
         "name": "applicantMedicarePartAPartBCard",

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/minimal-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/minimal-test.json
@@ -19,7 +19,6 @@
       "last": "Jones",
       "suffix": "III"
     },
-    "applicantDOB": "2000-02-01",
     "certifierRole": "other",
     "signature": "Certifier Jones"
   }

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/no-medicare-yes-ohi.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/no-medicare-yes-ohi.json
@@ -38,7 +38,6 @@
       "last": "Jones",
       "suffix": "Sr."
     },
-    "applicantDOB": "1950-02-03",
     "missingUploads": [
       {
         "name": "primaryInsuranceCard",

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/no-medicare-yes-primary.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/no-medicare-yes-primary.json
@@ -28,7 +28,6 @@
       "suffix": "IV"
     },
     "applicantNewAddress": "yes",
-    "applicantDOB": "1950-01-01",
     "missingUploads": [
       {
         "name": "primaryInsuranceCard",

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/test-data.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/test-data.json
@@ -7,7 +7,6 @@
       "middle": "Quincy",
       "last": "Alvin"
     },
-    "applicantDOB": "1958-01-01",
     "applicantAddress": {
       "country": "USA",
       "street": "456 Street Circle",

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/yes-medicare-no-ohi.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/yes-medicare-no-ohi.json
@@ -28,7 +28,6 @@
       "last": "Jones",
       "suffix": "II"
     },
-    "applicantDOB": "1950-08-02",
     "consentToMailMissingRequiredFiles": true,
     "certifierRole": "other",
     "signature": "Certifier Jones"

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/yes-medicare-yes-primary.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/yes-medicare-yes-primary.json
@@ -6,7 +6,6 @@
       "first": "Jimmy",
       "last": "Alvin"
     },
-    "applicantDOB": "1958-01-01",
     "applicantAddress": {
       "country": "USA",
       "street": "456 Street Circle",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Remove applicant date of birth from ui
- Remove references to this data from E2E test files

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90041
- https://github.com/department-of-veterans-affairs/vets-api/pull/17986

## Testing done

- Manual
- Verified unit and e2e tests pass

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![before](https://github.com/user-attachments/assets/95bd331a-3cfc-4692-be38-d035a6c61d4f)|![after](https://github.com/user-attachments/assets/ac08ad4e-3bc1-4640-9393-d82f1455f4a2)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA