### PR TITLE
Ask-VA/radio-button-name

### DIFF
--- a/src/applications/ask-va/containers/SubTopicSelectPage.jsx
+++ b/src/applications/ask-va/containers/SubTopicSelectPage.jsx
@@ -88,12 +88,13 @@ const SubTopicSelectPage = props => {
           label-header-level={CHAPTER_1.PAGE_3.QUESTION_1}
           error={validationError}
           required
+          name="select_subtopic"
           uswds
         >
           {apiData.map(subTopic => (
             <VaRadioOption
               key={subTopic.id}
-              name={subTopic.attributes.name}
+              name="select_subtopic"
               id={subTopic.id}
               value={subTopic.attributes.name}
               label={subTopic.attributes.name}

--- a/src/applications/ask-va/containers/TopicSelectPage.jsx
+++ b/src/applications/ask-va/containers/TopicSelectPage.jsx
@@ -106,13 +106,14 @@ const TopicSelectPage = props => {
           label={CHAPTER_1.PAGE_2.QUESTION_1}
           label-header-level={CHAPTER_1.PAGE_2.QUESTION_1}
           error={validationError}
+          name="select_topic"
           required
           uswds
         >
           {apiData.map(topic => (
             <VaRadioOption
               key={topic.id}
-              name={topic.attributes.name}
+              name="select_topic"
               id={topic.id}
               value={topic.attributes.name}
               label={topic.attributes.name}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Updating names for radio buttons to get ready for testing
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- No ticket fixing a bug

## Testing done

- Manual testing
- Testing the topic and subtopic page
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

no change

## What areas of the site does it impact?

Only impacts Ask va form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

