### PR TITLE
VACMS 12070 - wait times widget h3 -> h4

### DIFF
--- a/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
@@ -52,7 +52,7 @@ export class FacilityAppointmentWaitTimesWidget extends React.Component {
     if (serviceExists && (serviceExists.new || serviceExists.established)) {
       return (
         <div>
-          <h3>Average number of days to get an appointment</h3>
+          <h4>Average number of days to get an appointment</h4>
           <p>
             We’ll work with you to schedule an appointment with the shortest
             wait time. In some cases, we may schedule your appointment at

--- a/src/applications/static-pages/facilities/tests/FacilityAppointmentWaitTimesWidget.unit.spec.jsx
+++ b/src/applications/static-pages/facilities/tests/FacilityAppointmentWaitTimesWidget.unit.spec.jsx
@@ -23,7 +23,7 @@ describe('facilities <FacilityAppointmentWaitTimesWidget>', () => {
 
     expect(tree.find('va-loading-indicator').exists()).to.be.false;
 
-    const appointmentWaitTimesHeader = tree.find('h3');
+    const appointmentWaitTimesHeader = tree.find('h4');
     expect(appointmentWaitTimesHeader.text()).to.contain(
       'Average number of days to get an appointment',
     );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Changed h3 to h4 in Wait Times Widget, due to accessibility/logical incorrectness
- Sitewide team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-cms/issues/12070

## Testing done

- Wait times displayed in section with h3 heading, now h4
- Manual testing of VAMC with wait times displaying (only location used)

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |    <img width="1386" alt="Screenshot 2024-08-12 at 3 34 19 PM" src="https://github.com/user-attachments/assets/7aa53f23-d671-4a68-8b72-822330b782ac">    | <img width="1390" alt="Screenshot 2024-08-12 at 3 33 48 PM" src="https://github.com/user-attachments/assets/e2029bfd-aef1-4b7a-9b03-5828851fea4f">      |
| Desktop |    <img width="1459" alt="Screenshot 2024-08-12 at 3 31 21 PM" src="https://github.com/user-attachments/assets/03f3c2c5-b515-46e6-be6e-a1f578659b3c">    | <img width="1440" alt="Screenshot 2024-08-12 at 3 33 35 PM" src="https://github.com/user-attachments/assets/7d2e6232-bb07-4036-87da-1f8dd9ec03b8"> |

## What areas of the site does it impact?

VAMC pages service locations with wait times

## Acceptance criteria

- [x] Update "Average number of days to get an appointment" heading to be an H4
- [ ] Accessibility review

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user (unauthenticated)

## Requested Feedback

Go to: RI/boston-health-care/locations/brockton-va-medical-center/#dermatology