### PR TITLE
MHV-60735 + MHV-60736: Spacing changes - Detail page (VA + Non-VA) & Refill page

### DIFF
--- a/src/applications/mhv-medications/components/PrescriptionDetails/NonVaPrescription.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/NonVaPrescription.jsx
@@ -8,7 +8,7 @@ const NonVaPrescription = prescription => {
     const status = prescription?.dispStatus?.toString();
     return (
       <div className="medication-details-div vads-u-border-top--1px vads-u-border-color--gray-lighter vads-u-margin-top--3 medium-screen:vads-u-margin-top--4 vads-u-margin-bottom--3">
-        <h2 className="vads-u-margin-top--2 medium-screen:vads-u-margin-top--3 vads-u-margin-bottom--2 no-print">
+        <h2 className="vads-u-margin-top--3 medium-screen:vads-u-margin-top--4 vads-u-margin-bottom--2 no-print">
           About this medication or supply
         </h2>
         {prescription && <ExtraDetails {...prescription} />}

--- a/src/applications/mhv-medications/components/PrescriptionDetails/NonVaPrescription.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/NonVaPrescription.jsx
@@ -7,8 +7,8 @@ const NonVaPrescription = prescription => {
   const content = () => {
     const status = prescription?.dispStatus?.toString();
     return (
-      <div className="medication-details-div vads-u-border-top--1px vads-u-border-color--gray-lighter vads-u-margin-top--2 vads-u-margin-bottom--3">
-        <h2 className="vads-u-margin-y--2 no-print">
+      <div className="medication-details-div vads-u-border-top--1px vads-u-border-color--gray-lighter vads-u-margin-top--3 medium-screen:vads-u-margin-top--4 vads-u-margin-bottom--3">
+        <h2 className="vads-u-margin-top--2 medium-screen:vads-u-margin-top--3 vads-u-margin-bottom--2 no-print">
           About this medication or supply
         </h2>
         {prescription && <ExtraDetails {...prescription} />}

--- a/src/applications/mhv-medications/components/PrescriptionDetails/VaPrescription.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/VaPrescription.jsx
@@ -41,14 +41,16 @@ const VaPrescription = prescription => {
       const dispStatus = prescription.dispStatus?.toString();
       return (
         <>
-          <div className="medication-details-div vads-u-border-top--1px vads-u-border-color--gray-lighter vads-u-margin-top--2 vads-u-margin-bottom--3">
+          <div className="medication-details-div vads-u-border-top--1px vads-u-border-color--gray-lighter vads-u-margin-top--3 medium-screen:vads-u-margin-top--4 vads-u-margin-bottom--3">
             {latestTrackingStatus && (
               <TrackingInfo
                 {...latestTrackingStatus}
                 prescriptionName={prescription.prescriptionName}
               />
             )}
-            <h2 className="vads-u-margin-y--2">About your prescription</h2>
+            <h2 className="vads-u-margin-top--2 medium-screen:vads-u-margin-top--3 vads-u-margin-bottom--2">
+              About your prescription
+            </h2>
             {prescription && <ExtraDetails {...prescription} />}
             {showRefillContent && prescription?.isRefillable ? (
               <Link

--- a/src/applications/mhv-medications/components/PrescriptionDetails/VaPrescription.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/VaPrescription.jsx
@@ -48,7 +48,7 @@ const VaPrescription = prescription => {
                 prescriptionName={prescription.prescriptionName}
               />
             )}
-            <h2 className="vads-u-margin-top--2 medium-screen:vads-u-margin-top--3 vads-u-margin-bottom--2">
+            <h2 className="vads-u-margin-top--3 medium-screen:vads-u-margin-top--4 vads-u-margin-bottom--2">
               About your prescription
             </h2>
             {prescription && <ExtraDetails {...prescription} />}

--- a/src/applications/mhv-medications/components/RefillPrescriptions/RenewablePrescriptions.jsx
+++ b/src/applications/mhv-medications/components/RefillPrescriptions/RenewablePrescriptions.jsx
@@ -120,7 +120,7 @@ const RenewablePrescriptions = ({ renewablePrescriptionsList = [] }) => {
           return (
             <div
               key={idx}
-              className={`vads-u-margin-top--${idx !== 0 ? '5' : '2p5'}`}
+              className={`vads-u-margin-top--${idx !== 0 ? '3' : '2p5'}`}
             >
               <Link
                 data-testid={`medication-details-page-link-${idx}`}

--- a/src/applications/mhv-medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv-medications/containers/PrescriptionDetails.jsx
@@ -346,7 +346,7 @@ const PrescriptionDetails = () => {
               <>
                 <p
                   id="last-filled"
-                  className="title-last-filled-on vads-u-font-family--sans vads-u-margin-top--1 medium-screen:vads-u-margin-bottom--4 vads-u-margin-bottom--3"
+                  className="title-last-filled-on vads-u-font-family--sans vads-u-margin-top--2 medium-screen:vads-u-margin-bottom--4 vads-u-margin-bottom--3"
                   data-testid="rx-last-filled-date"
                 >
                   {filledEnteredDate()}

--- a/src/applications/mhv-medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv-medications/containers/PrescriptionDetails.jsx
@@ -346,7 +346,7 @@ const PrescriptionDetails = () => {
               <>
                 <p
                   id="last-filled"
-                  className="title-last-filled-on vads-u-font-family--sans vads-u-margin-top--0p5"
+                  className="title-last-filled-on vads-u-font-family--sans vads-u-margin-top--1 medium-screen:vads-u-margin-bottom--4 vads-u-margin-bottom--3"
                   data-testid="rx-last-filled-date"
                 >
                   {filledEnteredDate()}


### PR DESCRIPTION
## Summary

Updated spacing on Medication Details and Refill pages using vads-u class names

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-60735
https://jira.devops.va.gov/browse/MHV-60736

<img width="1075" alt="image" src="https://github.com/user-attachments/assets/4269928b-6070-467b-a9cf-4ee3e0e2f7ee">
<img width="968" alt="image" src="https://github.com/user-attachments/assets/14a01a95-451a-4850-abae-b71f77aaf6d4">

## Screenshots

![image](https://github.com/user-attachments/assets/a5827c51-1d2b-4c1d-9ef5-f89648627e1a)
![image](https://github.com/user-attachments/assets/a04e13d2-1a57-4785-8be8-b9e32f2c37a3)
![image](https://github.com/user-attachments/assets/34596c6a-0de0-4449-9b00-a2e7c069bee9)
![image](https://github.com/user-attachments/assets/db2d1de0-15d2-4c88-87ce-4d6e9cf48678)
![image](https://github.com/user-attachments/assets/86e3d8a6-a774-4233-8fb8-59257fb005b1)
![image](https://github.com/user-attachments/assets/cf79d31b-ec67-44cc-a2e9-7b08622233cd)
![image](https://github.com/user-attachments/assets/4a71f574-9920-410d-b4be-9ccd6f180104)
![image](https://github.com/user-attachments/assets/3c36175c-e05e-4019-af33-51c9849ae7d2)

## Testing done

- Manual testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Not filled spacing is 4px above and 17px below margins but should be 16px above and 32 px below for desktop and 16px above and 24 px below for mobile
AC2: Solid line between What to know before you print or download and About your prescription should be 32 px on either side for desktop and 24 px for mobile

AC1: Between Select all and first refill should be 16px for desktop and mobile (comment from UCD: Actually, the way I see it in staging now is fine.)
AC2: Between all prescription you may need to renew it should have 24px margins for desktop and mobile
AC3: Between Refills requested success message and Ready to refill it should be 32px margins on desktop (comment from UCD:  That's fine with me [the way it is now]. We normally don't count the line height spacing, but I'll make an exception because we're rethinking the way we are working with headers soon.)

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
