### PR TITLE
Removes duplicate mocks for mhv-landing-page

### DIFF
--- a/src/applications/mhv-landing-page/mocks/api/index.js
+++ b/src/applications/mhv-landing-page/mocks/api/index.js
@@ -1,11 +1,11 @@
-const commonResponses = require('../../../../platform/testing/local-dev-mock-api/common');
 const { generateFeatureToggles } = require('./feature-toggles/index');
 const { USER_MOCKS } = require('./user/index');
 const folders = require('./mhv-api/messaging/folders/index');
 const personalInformation = require('../../tests/fixtures/personal-information.json');
 
 const responses = (userMock = USER_MOCKS.DEFAULT) => ({
-  ...commonResponses,
+  'OPTIONS /v0/maintenance_windows': 'OK',
+  'GET /v0/maintenance_windows': { data: [] },
   'GET /v0/user': userMock,
   '/v0/feature_toggles(.*)': generateFeatureToggles(),
   // '/v0/feature_toggles(.*)': generateFeatureToggles({ enableAll: true }),


### PR DESCRIPTION
## Summary

I ran into an issue where mocks defined by `commonResponses` were overriding mocks defined for the mhv-landing-page app.

- removes `commonResponses` from mocks, removing duplicate mocks for `/v0/user` and `/v0/feature_toggles` that were overriding our mocks
- adds mocks for `/v0/maintenance_windows`

## Related issue(s)

n/a

## Testing done

- localhost

## Screenshots

no ui changes

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

