### PR TITLE
VEBT-330 CT text alignment is off center when an error is thrown

### DIFF
--- a/src/applications/gi/components/ServiceError.jsx
+++ b/src/applications/gi/components/ServiceError.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 export const ServiceError = () => (
-  <div className="backenderror">
-    <h3 className="backend-error-bold"> We’ve run into a problem. </h3>
+  <div className="row vads-u-padding-x--2p5 small-screen:vads-u-padding-x--0">
+    <h3> We’ve run into a problem. </h3>
 
-    <div className="backend-error vads-u-padding-bottom--5">
-      We're sorry. Something went wrong on our end. Please refresh this page or
+    <div className="vads-u-padding-bottom--5">
+      We’re sorry. Something went wrong on our end. Please refresh this page or
       check back soon.
     </div>
   </div>

--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -116,10 +116,7 @@ export function ProfilePage({
       name="profilePage"
       className="profile-page vads-u-padding-top--3"
     >
-      <div className="row">
-        {profile.error && <ServiceError />}
-        {!profile.error && content}
-      </div>
+      {profile.error ? <ServiceError /> : <div className="row">{content}</div>}
     </ScrollElement>
   );
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary
Minor styling improvements done to the _ServiceError_ component in the GI Bill Comparison Tool
- Updated to make use of VA.gov Design System responsive classes
- Alignment issues fixed
- _ProfilePage_ row div rendered only when error component isn't present
- Unused classes removed

## Related issue(s)
https://jira.devops.va.gov/browse/VEBT-330

**Problem:**

When the Comparison Tool has an error, the error message displays to the left of the page instead of the center.  The message needs to be moved to the center of the page.

**Acceptance Criteria:**

When the Comparison Tool has an error and is unable to load properly an error message should appear and display as "We've run into a problem.  We're sorry.  Something went wrong on our end.  Please refresh this page or check back soon."
The error message should appear in the center of the page

**Technical Details:**

Dependencies: No

Feature Flag needed: No

Demo needed: No

UAT needed: No

Additional Notes:  n/a

**Testing Details:**

( X ) Quick Turn Around/Direct to Production

(  ) Remains in Staging

(  ) Staging Environment unavailable, coordinate w/ developer

If needed, the development team can recreate the error message on their local machine for testing so that we can avoid taking down production
Requires regular & mobile view testing and ensuring JAWS/NVDA still reads correctly after fix has been deployed to production

**Requested by and when:**

Jarred/Content Team on 7/25

**Definition of Done:**

( n/a )  Demo/UAT completed with EDU

(  )  Passed all internal testing in Staging

(  )  Passed all internal testing in Production

(  )  All work documented in Jira ticket

## Testing done

Manual testing by dispatching errors on fetch and unit tests re-run locally as well as testing that the _ComparePage_ still renders properly with no errors

## Screenshots

**Before (Mobile):**
![Mobile (Before)](https://github.com/user-attachments/assets/99435e8a-e949-4608-baec-92282214a00a)

**After (Mobile):**
![Mobile (After)](https://github.com/user-attachments/assets/9d232391-1047-452c-8cf0-88b464ab7a5a)

**Before (Desktop):**
![Desktop (Before)](https://github.com/user-attachments/assets/c1c9674a-9cf0-4162-9495-b8633d133466)

**After (Desktop):**
![Desktop (After)](https://github.com/user-attachments/assets/ac24b238-7028-4b1f-b2ab-7d6d05659c92)

## What areas of the site does it impact?
GI Bill Comparison Tool when it comes back with an error
- Landing Page
- Institution Compare Page
- Institution Profile Page

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
N/A