### PR TITLE
Vebt-363 Add new code to religiousAffiliations for GI Bill Comparison Tool

### DIFF
--- a/src/applications/gi/utils/data/religiousAffiliations.js
+++ b/src/applications/gi/utils/data/religiousAffiliations.js
@@ -65,4 +65,5 @@ export const religiousAffiliations = {
   105: 'General Baptist',
   106: 'Muslim',
   107: 'Plymouth Brethren',
+  108: 'Non-Denominational',
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

Update file for religious affiliation codes such that GI Bill Comparison Tool results show "Non-Denominational" in their results

## Related issue(s)

https://jira.devops.va.gov/browse/VEBT-363

Problem:

In the Comparison Tool we show religious affiliation types for institutions using the community focus filter. Presently, for “Non-Denomination” institutions we are not showing this label. For example – Brian verified Westmont College as being a “Non-Denominational” school and it should be showing as such in the school result card header, same as “School: Roman Catholic” would for a result with Roman Catholic religious affiliation.

To resolve: FE needs to add code 108 for “Non-Denominational” to religiousAffiliations.js in vets-website

Add the “108” and display Non-Denominational to religious affiliations mappings in religiousAffiliations.js (vets-website)

Acceptance Criteria:

Search Results

If Religious Affiliation = 108 (Non-Denominational) then the verbiage "Non-Denominational" should appear at the top of the school card in the blue bar
On the Institution page

If Religious Affiliation = 108 (Non-Denominational) then the verbiage "Non-Denominational" should appear at the top of the school card in the blue bar
On the Institution Comparison page

If Religious Affiliation = 108 (Non-Denominational) then the verbiage "Non-Denominational" should appear in the box for "Community Focus"

## Testing done

Manual testing, re-ran tests to ensure 100% passing

## Screenshots
**Before/After**
<img width="1475" alt="Screenshot 2024-08-14 at 9 54 06 AM" src="https://github.com/user-attachments/assets/0af40b7d-f494-449c-92e4-5db456da96b0">

**Other Locations After**
<img width="1001" alt="Screenshot 2024-08-14 at 9 41 12 AM" src="https://github.com/user-attachments/assets/2beab861-f7e2-41a6-bc03-8ea7bfd57b50">
<img width="508" alt="Screenshot 2024-08-14 at 9 41 58 AM" src="https://github.com/user-attachments/assets/947b3e4d-f445-4674-841c-c91e742a0c21">

## What areas of the site does it impact?

Only GI Bill Comparison Tool

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
