### PR TITLE
89946 Update intro page text and footer - form 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959a/config/form.js
+++ b/src/applications/ivc-champva/10-7959a/config/form.js
@@ -65,6 +65,9 @@ const formConfig = {
       saved: 'Your CHAMPVA claim form application has been saved.',
     },
   },
+  appType: 'form',
+  continueAppButtonText: 'Continue your form',
+  startNewAppButtonText: 'Start a new form',
   preSubmitInfo: {
     statementOfTruth: {
       body:

--- a/src/applications/ivc-champva/10-7959a/config/form.js
+++ b/src/applications/ivc-champva/10-7959a/config/form.js
@@ -1,5 +1,6 @@
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
 import get from '@department-of-veterans-affairs/platform-forms-system/get';
+import GetFormHelp from '../../shared/components/GetFormHelp';
 import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
 import SubmissionError from '../../shared/components/SubmissionError';
@@ -49,6 +50,7 @@ const formConfig = {
   transformForSubmit,
   // submit: () =>
   //   Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
+  footerContent: GetFormHelp,
   trackingPrefix: '10-7959a-',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,

--- a/src/applications/ivc-champva/10-7959a/config/form.js
+++ b/src/applications/ivc-champva/10-7959a/config/form.js
@@ -65,9 +65,11 @@ const formConfig = {
       saved: 'Your CHAMPVA claim form application has been saved.',
     },
   },
-  appType: 'form',
-  continueAppButtonText: 'Continue your form',
-  startNewAppButtonText: 'Start a new form',
+  customText: {
+    appType: 'form',
+    continueAppButtonText: 'Continue your form',
+    startNewAppButtonText: 'Start a new form',
+  },
   preSubmitInfo: {
     statementOfTruth: {
       body:

--- a/src/applications/ivc-champva/10-7959a/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959a/containers/IntroductionPage.jsx
@@ -9,6 +9,7 @@ import { VaLink } from '@department-of-veterans-affairs/component-library/dist/r
 export default function IntroductionPage(props) {
   const { route } = props;
   const { formConfig, pageList } = route;
+  const { appType } = formConfig?.customText || 'application';
 
   useEffect(() => {
     focusElement('.va-nav-breadcrumbs-list');
@@ -21,12 +22,12 @@ export default function IntroductionPage(props) {
         subTitle="CHAMPVA Claim Form (VA Form 10-7959a)"
       />
       <p>
-        Use this form if you’re currently enrolled in The Civilian Health and
-        Medical Program of the Department of Veterans Affairs (CHAMPVA) and want
-        to file a claim for reimbursement.
+        Use this {appType} if you’re currently enrolled in The Civilian Health
+        and Medical Program of the Department of Veterans Affairs (CHAMPVA) and
+        want to file a claim for reimbursement.
       </p>
       <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
-        What to know before you fill out this form
+        What to know before you fill out this {appType}
       </h2>
       <ul>
         <li>
@@ -35,8 +36,8 @@ export default function IntroductionPage(props) {
           1 year of when you left the hospital.
         </li>
         <li>
-          Each claim needs its own form. If you need to submit more than one
-          claim, you’ll need to submit a new form for each claim.
+          Each claim needs its own {appType}. If you need to submit more than
+          one claim, you’ll need to submit a new {appType} for each claim.
         </li>
         <li>
           You’ll need to submit separate claims for each beneficiary, even if

--- a/src/applications/ivc-champva/10-7959a/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959a/containers/IntroductionPage.jsx
@@ -60,7 +60,15 @@ export default function IntroductionPage(props) {
         prefillEnabled={formConfig.prefillEnabled}
         messages={formConfig.savedFormMessages}
         pageList={pageList}
-        startText="Start the Application"
+        startText="Start the form"
+        unauthStartText="Sign in to start your form"
+        formConfig={{
+          customText: {
+            appType: 'form',
+            continueAppButtonText: 'Continue your form',
+            startNewAppButtonText: 'Start a new form',
+          },
+        }}
       >
         Please complete the 10-7959A form to apply for CHAMPVA claim form.
       </SaveInProgressIntro>

--- a/src/applications/ivc-champva/10-7959a/containers/IntroductionPage.jsx
+++ b/src/applications/ivc-champva/10-7959a/containers/IntroductionPage.jsx
@@ -62,13 +62,7 @@ export default function IntroductionPage(props) {
         pageList={pageList}
         startText="Start the form"
         unauthStartText="Sign in to start your form"
-        formConfig={{
-          customText: {
-            appType: 'form',
-            continueAppButtonText: 'Continue your form',
-            startNewAppButtonText: 'Start a new form',
-          },
-        }}
+        formConfig
       >
         Please complete the 10-7959A form to apply for CHAMPVA claim form.
       </SaveInProgressIntro>

--- a/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/test-data.json
+++ b/src/applications/ivc-champva/10-7959a/tests/e2e/fixtures/data/test-data.json
@@ -11,6 +11,7 @@
       "first": "Beneficiary",
       "last": "Jones"
     },
+    "applicantPhone": "1231231234",
     "applicantMemberNumber": "222111123",
     "applicantDOB": "2000-10-25",
     "applicantAddress": {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR updates the prompt text on the intro page and adds the "Get Help" footer.

- Update buttons and link to Sign in to start your form" and "Start your form without signing in" (change to "form" instead of "application")
- Add the Need help footer 

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89946

## Testing done

- Manual

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![Screenshot 2024-08-14 at 12 04 16](https://github.com/user-attachments/assets/c113f269-4040-4760-99fe-74293cf6a95c)|![after](https://github.com/user-attachments/assets/2c20e8e5-427d-4a43-9ab3-9acd6c944166)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA