### PR TITLE
Check in/89004/no list for one item

### DIFF
--- a/src/applications/check-in/components/AppointmentBlock.jsx
+++ b/src/applications/check-in/components/AppointmentBlock.jsx
@@ -7,6 +7,7 @@ import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring
 
 import { createAnalyticsSlug } from '../utils/analytics';
 import AppointmentListItem from './AppointmentDisplay/AppointmentListItem';
+import ListWrapper from './ListWrapper';
 import { makeSelectApp } from '../selectors';
 import { useFormRouting } from '../hooks/useFormRouting';
 import {
@@ -31,38 +32,17 @@ const AppointmentBlock = props => {
   };
 
   const sortedAppointments = sortAppointmentsByStartTime(appointments);
-  const AppointmentWrapper = wrapperProps => {
-    const { children, count } = wrapperProps;
-    if (count === 1) {
-      return (
-        <div
-          className="vads-u-border-top--1px vads-u-border-color--gray-light vads-u-margin-bottom--4 check-in--appointment-list appointment-list"
-          data-testid="appointment-list"
-        >
-          {children}
-        </div>
-      );
-    }
-    return (
-      <ul
-        className="vads-u-border-top--1px vads-u-border-color--gray-light vads-u-margin-bottom--4 check-in--appointment-list appointment-list"
-        data-testid="appointment-list"
-      >
-        {children}
-      </ul>
-    );
-  };
-  AppointmentWrapper.propTypes = {
-    children: PropTypes.node.isRequired,
-    count: PropTypes.number.isRequired,
-  };
 
   return (
     <div>
       <h2 className="vads-u-margin-top--0" data-testid="appointment-text">
         {t('your-appointments', { count: sortedAppointments.length })}
       </h2>
-      <AppointmentWrapper count={sortedAppointments.length}>
+      <ListWrapper
+        count={sortedAppointments.length}
+        className="vads-u-border-top--1px vads-u-border-color--gray-light vads-u-margin-bottom--4 check-in--appointment-list appointment-list"
+        testId="appointment-list"
+      >
         {sortedAppointments.map(appointment => {
           return (
             <AppointmentListItem
@@ -76,7 +56,7 @@ const AppointmentBlock = props => {
             />
           );
         })}
-      </AppointmentWrapper>
+      </ListWrapper>
     </div>
   );
 };

--- a/src/applications/check-in/components/AppointmentBlock.jsx
+++ b/src/applications/check-in/components/AppointmentBlock.jsx
@@ -31,16 +31,38 @@ const AppointmentBlock = props => {
   };
 
   const sortedAppointments = sortAppointmentsByStartTime(appointments);
+  const AppointmentWrapper = wrapperProps => {
+    const { children, count } = wrapperProps;
+    if (count === 1) {
+      return (
+        <div
+          className="vads-u-border-top--1px vads-u-border-color--gray-light vads-u-margin-bottom--4 check-in--appointment-list appointment-list"
+          data-testid="appointment-list"
+        >
+          {children}
+        </div>
+      );
+    }
+    return (
+      <ul
+        className="vads-u-border-top--1px vads-u-border-color--gray-light vads-u-margin-bottom--4 check-in--appointment-list appointment-list"
+        data-testid="appointment-list"
+      >
+        {children}
+      </ul>
+    );
+  };
+  AppointmentWrapper.propTypes = {
+    children: PropTypes.node.isRequired,
+    count: PropTypes.number.isRequired,
+  };
 
   return (
     <div>
       <h2 className="vads-u-margin-top--0" data-testid="appointment-text">
         {t('your-appointments', { count: sortedAppointments.length })}
       </h2>
-      <ul
-        className="vads-u-border-top--1px vads-u-border-color--gray-light vads-u-margin-bottom--4 check-in--appointment-list appointment-list"
-        data-testid="appointment-list"
-      >
+      <AppointmentWrapper count={sortedAppointments.length}>
         {sortedAppointments.map(appointment => {
           return (
             <AppointmentListItem
@@ -50,10 +72,11 @@ const AppointmentBlock = props => {
               goToDetails={handleDetailClick}
               app={app}
               router={router}
+              count={sortedAppointments.length}
             />
           );
         })}
-      </ul>
+      </AppointmentWrapper>
     </div>
   );
 };

--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentListItem.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentListItem.jsx
@@ -11,7 +11,7 @@ import {
 import { APP_NAMES } from '../../utils/appConstants';
 
 const AppointmentListItem = props => {
-  const { appointment, goToDetails, router, app, page } = props;
+  const { appointment, goToDetails, router, app, page, count } = props;
   const { t } = useTranslation();
   const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
   const { isMedicationReviewContentEnabled } = useSelector(
@@ -111,12 +111,8 @@ const AppointmentListItem = props => {
       </div>
     );
   };
-
-  return (
-    <li
-      className="vads-u-border-bottom--1px vads-u-border-color--gray-light check-in--appointment-item"
-      data-testid="appointment-list-item"
-    >
+  const appointmentItem = (
+    <>
       <div className="check-in--appointment-summary vads-u-margin-bottom--2 vads-u-margin-top--2p5">
         {page === 'confirmation' && (
           <div className="vads-u-font-family--serif vads-u-font-size--lg vads-u-line-height--2 vads-u-margin-bottom--1">
@@ -179,6 +175,24 @@ const AppointmentListItem = props => {
             <div>{infoBlockMessage()}</div>
           </va-alert>
         )}
+    </>
+  );
+  if (count === 1) {
+    return (
+      <div
+        className="vads-u-border-bottom--1px vads-u-border-color--gray-light check-in--appointment-item"
+        data-testid="appointment-list-item"
+      >
+        {appointmentItem}
+      </div>
+    );
+  }
+  return (
+    <li
+      className="vads-u-border-bottom--1px vads-u-border-color--gray-light check-in--appointment-item"
+      data-testid="appointment-list-item"
+    >
+      {appointmentItem}
     </li>
   );
 };
@@ -186,6 +200,7 @@ const AppointmentListItem = props => {
 AppointmentListItem.propTypes = {
   app: PropTypes.string.isRequired,
   appointment: PropTypes.object.isRequired,
+  count: PropTypes.number.isRequired,
   page: PropTypes.string.isRequired,
   goToDetails: PropTypes.func,
   router: PropTypes.object,

--- a/src/applications/check-in/components/AppointmentDisplay/AppointmentListItem.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/AppointmentListItem.jsx
@@ -181,7 +181,7 @@ const AppointmentListItem = props => {
     return (
       <div
         className="vads-u-border-bottom--1px vads-u-border-color--gray-light check-in--appointment-item"
-        data-testid="appointment-list-item"
+        data-testid="appointment-item"
       >
         {appointmentItem}
       </div>

--- a/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentListItem.unit.spec.jsx
+++ b/src/applications/check-in/components/AppointmentDisplay/tests/AppointmentListItem.unit.spec.jsx
@@ -73,6 +73,7 @@ describe('AppointmentListItem', () => {
               app="preCheckIn"
               appointment={appointments[0]}
               page="intro"
+              count={3}
             />
           </CheckInProvider>,
         );
@@ -92,6 +93,7 @@ describe('AppointmentListItem', () => {
               appointment={appointments[0]}
               page="confirmation"
               goToDetails={() => {}}
+              count={3}
             />
           </CheckInProvider>,
         );
@@ -105,6 +107,7 @@ describe('AppointmentListItem', () => {
               app="preCheckIn"
               appointment={appointments[0]}
               page="intro"
+              count={3}
             />
           </CheckInProvider>,
         );
@@ -119,6 +122,7 @@ describe('AppointmentListItem', () => {
               appointment={appointments[0]}
               page="details"
               goToDetails={() => {}}
+              count={3}
             />
           </CheckInProvider>,
         );
@@ -136,6 +140,7 @@ describe('AppointmentListItem', () => {
               app="preCheckIn"
               appointment={appointments[1]}
               page="intro"
+              count={3}
             />
           </CheckInProvider>,
         );
@@ -154,6 +159,7 @@ describe('AppointmentListItem', () => {
               app="preCheckIn"
               appointment={appointments[1]}
               page="confirmation"
+              count={3}
             />
           </CheckInProvider>,
         );
@@ -168,6 +174,7 @@ describe('AppointmentListItem', () => {
               appointment={appointments[1]}
               page="confirmation"
               goToDetails={() => {}}
+              count={3}
             />
           </CheckInProvider>,
         );
@@ -186,6 +193,7 @@ describe('AppointmentListItem', () => {
               appointment={appointments[2]}
               page="confirmation"
               goToDetails={() => {}}
+              count={3}
             />
           </CheckInProvider>,
         );
@@ -207,6 +215,7 @@ describe('AppointmentListItem', () => {
               appointment={appointments[3]}
               page="confirmation"
               goToDetails={() => {}}
+              count={3}
             />
           </CheckInProvider>,
         );
@@ -228,6 +237,7 @@ describe('AppointmentListItem', () => {
               appointment={appointments[0]}
               goToDetails={() => {}}
               page="intro"
+              count={3}
             />
           </CheckInProvider>,
         );
@@ -241,6 +251,7 @@ describe('AppointmentListItem', () => {
               appointment={appointments[0]}
               goToDetails={() => {}}
               page="details"
+              count={3}
             />
           </CheckInProvider>,
         );
@@ -255,11 +266,40 @@ describe('AppointmentListItem', () => {
               appointment={appointments[0]}
               goToDetails={goToDetails}
               page="details"
+              count={3}
             />
           </CheckInProvider>,
         );
         fireEvent.click(screen.getByTestId('details-link'));
         expect(goToDetails.calledOnce).to.be.true;
+      });
+      it('renders as a list item when more than one', () => {
+        const screen = render(
+          <CheckInProvider router={mockRouter}>
+            <AppointmentListItem
+              app="preCheckIn"
+              appointment={appointments[0]}
+              goToDetails={() => {}}
+              page="details"
+              count={3}
+            />
+          </CheckInProvider>,
+        );
+        expect(screen.queryByRole('listitem')).to.exist;
+      });
+      it('does not render as a list item when only one', () => {
+        const screen = render(
+          <CheckInProvider router={mockRouter}>
+            <AppointmentListItem
+              app="preCheckIn"
+              appointment={appointments[0]}
+              goToDetails={() => {}}
+              page="details"
+              count={1}
+            />
+          </CheckInProvider>,
+        );
+        expect(screen.queryByRole('listitem')).to.not.exist;
       });
     });
   });

--- a/src/applications/check-in/components/ListWrapper.jsx
+++ b/src/applications/check-in/components/ListWrapper.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ListWrapper = props => {
+  const { children, count, className, testId } = props;
+  if (count === 1) {
+    return (
+      <div className={className} data-testid={testId}>
+        {children}
+      </div>
+    );
+  }
+  return (
+    <ul className={className} data-testid={testId}>
+      {children}
+    </ul>
+  );
+};
+
+ListWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+  count: PropTypes.number.isRequired,
+  className: PropTypes.string,
+  testId: PropTypes.string,
+};
+
+export default ListWrapper;

--- a/src/applications/check-in/components/PrepareContent.jsx
+++ b/src/applications/check-in/components/PrepareContent.jsx
@@ -38,7 +38,7 @@ const PrepareContent = props => {
             href={`${router.location.basename}/what-to-bring/`}
             hrefLang="en"
             onClick={onPrepareClick}
-            data-testId="what-to-bring-link"
+            data-testid="what-to-bring-link"
           >
             {t('find-out-what-to-bring')}
           </a>

--- a/src/applications/check-in/components/UpcomingAppointmentsList.jsx
+++ b/src/applications/check-in/components/UpcomingAppointmentsList.jsx
@@ -11,6 +11,7 @@ import {
   organizeAppointmentsByYearMonthDay,
 } from '../utils/appointment';
 
+import ListWrapper from './ListWrapper';
 import UpcomingAppointmentsListItem from './UpcomingAppointmentsListItem';
 
 const UpcomingAppointmentsList = props => {
@@ -87,9 +88,10 @@ const UpcomingAppointmentsList = props => {
                       </h4>
                     </div>
                     <div className="vads-l-col--10 vads-u-border-top--1px vads-u-border-color--gray-light">
-                      <ul
+                      <ListWrapper
+                        count={appointments.length}
                         className="vads-u-margin-bottom--3 check-in--appointment-list appointment-list"
-                        data-testid="appointment-list"
+                        testId="appointment-list"
                       >
                         {appointments.map((appointment, number) => {
                           return (
@@ -100,10 +102,11 @@ const UpcomingAppointmentsList = props => {
                               router={router}
                               border={number !== appointments.length - 1}
                               app={app}
+                              count={appointments.length}
                             />
                           );
                         })}
-                      </ul>
+                      </ListWrapper>
                     </div>
                   </div>
                 </div>

--- a/src/applications/check-in/components/UpcomingAppointmentsListItem.jsx
+++ b/src/applications/check-in/components/UpcomingAppointmentsListItem.jsx
@@ -16,7 +16,7 @@ import AppointmentMessage from './AppointmentDisplay/AppointmentMessage';
 import UpcomingAppointmentsListItemAction from './UpcomingAppointmentsListItemAction';
 
 const UpcomingAppointmentsListItem = props => {
-  const { app, appointment, goToDetails, router, border } = props;
+  const { app, appointment, goToDetails, router, border, count } = props;
   const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
   const { isUpcomingAppointmentsEnabled } = useSelector(selectFeatureToggles);
   const { t } = useTranslation();
@@ -87,13 +87,8 @@ const UpcomingAppointmentsListItem = props => {
       </div>
     );
   };
-
-  return (
-    <li
-      className={`check-in--appointment-item ${border &&
-        'vads-u-border-bottom--1px vads-u-border-color--gray-light'}`}
-      data-testid="appointment-list-item"
-    >
+  const appointmentItem = (
+    <>
       {isCancelled ? (
         <del>{appointmentDetails('appointment-details-cancelled')}</del>
       ) : (
@@ -127,6 +122,26 @@ const UpcomingAppointmentsListItem = props => {
             </div>
           )}
       </div>
+    </>
+  );
+  if (count === 1) {
+    return (
+      <div
+        className={`check-in--appointment-item ${border &&
+          'vads-u-border-bottom--1px vads-u-border-color--gray-light'}`}
+        data-testid="appointment-item"
+      >
+        {appointmentItem}
+      </div>
+    );
+  }
+  return (
+    <li
+      className={`check-in--appointment-item ${border &&
+        'vads-u-border-bottom--1px vads-u-border-color--gray-light'}`}
+      data-testid="appointment-list-item"
+    >
+      {appointmentItem}
     </li>
   );
 };
@@ -135,6 +150,7 @@ UpcomingAppointmentsListItem.propTypes = {
   app: PropTypes.string.isRequired,
   appointment: PropTypes.object.isRequired,
   border: PropTypes.bool.isRequired,
+  count: PropTypes.number.isRequired,
   goToDetails: PropTypes.func,
   router: PropTypes.object,
 };

--- a/src/applications/check-in/components/tests/AppointmentBlock.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/AppointmentBlock.unit.spec.jsx
@@ -59,9 +59,7 @@ describe('AppointmentBlock', () => {
           </CheckInProvider>,
         );
 
-        expect(screen.getAllByTestId('appointment-list-item').length).to.equal(
-          1,
-        );
+        expect(screen.getAllByTestId('appointment-item').length).to.equal(1);
       });
     });
   });

--- a/src/applications/check-in/components/tests/ListWrapper.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/ListWrapper.unit.spec.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';

--- a/src/applications/check-in/components/tests/ListWrapper.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/ListWrapper.unit.spec.jsx
@@ -1,0 +1,19 @@
+/* eslint-disable camelcase */
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+
+import ListWrapper from '../ListWrapper';
+
+describe('ListWrapper', () => {
+  it('Renders as a list when there is more than one item', () => {
+    const screen = render(<ListWrapper count={2} testId="test-wrapper" />);
+    expect(screen.getByTestId('test-wrapper')).to.exist;
+    expect(screen.getByRole('list')).to.exist;
+  });
+  it('Renders without a list when there is one item', () => {
+    const screen = render(<ListWrapper count={1} testId="test-wrapper" />);
+    expect(screen.getByTestId('test-wrapper')).to.exist;
+    expect(screen.queryByRole('list')).to.not.exist;
+  });
+});

--- a/src/applications/check-in/components/tests/UpcomingAppointmentsListItem.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/UpcomingAppointmentsListItem.unit.spec.jsx
@@ -88,6 +88,7 @@ describe('unified check-in experience', () => {
             appointment={appointments[0]}
             goToDetails={goToDetails}
             router={mockRouter}
+            count={5}
           />
         </CheckInProvider>,
       );
@@ -115,6 +116,7 @@ describe('unified check-in experience', () => {
             goToDetails={goToDetails}
             dayKey=""
             router={mockRouter}
+            count={5}
           />
         </CheckInProvider>,
       );
@@ -130,6 +132,7 @@ describe('unified check-in experience', () => {
             goToDetails={goToDetails}
             dayKey=""
             router={mockRouter}
+            count={5}
           />
         </CheckInProvider>,
       );
@@ -143,6 +146,7 @@ describe('unified check-in experience', () => {
             goToDetails={goToDetails}
             dayKey=""
             router={mockRouter}
+            count={5}
           />
         </CheckInProvider>,
       );
@@ -155,6 +159,7 @@ describe('unified check-in experience', () => {
             appointment={appointments[1]}
             goToDetails={goToDetails}
             router={mockRouter}
+            count={5}
           />
         </CheckInProvider>,
       );
@@ -169,10 +174,37 @@ describe('unified check-in experience', () => {
             appointment={appointments[4]}
             goToDetails={goToDetails}
             router={mockRouter}
+            count={5}
           />
         </CheckInProvider>,
       );
       expect(screen.getByTestId('appointment-details-cancelled')).to.exist;
+    });
+    it('renders as a list item when more than one', () => {
+      const screen = render(
+        <CheckInProvider>
+          <UpcomingAppointmentsListItem
+            appointment={appointments[0]}
+            goToDetails={() => {}}
+            router={mockRouter}
+            count={5}
+          />
+        </CheckInProvider>,
+      );
+      expect(screen.queryByRole('listitem')).to.exist;
+    });
+    it('does not render as a list item when only one', () => {
+      const screen = render(
+        <CheckInProvider>
+          <UpcomingAppointmentsListItem
+            appointment={appointments[0]}
+            goToDetails={() => {}}
+            router={mockRouter}
+            count={1}
+          />
+        </CheckInProvider>,
+      );
+      expect(screen.queryByRole('listitem')).to.not.exist;
     });
   });
 });

--- a/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
+++ b/src/applications/check-in/day-of/pages/Confirmation/CheckInConfirmation.jsx
@@ -142,7 +142,7 @@ const CheckInConfirmation = props => {
           </p>
         </div>
         <h2>{t('your-appointments', { count: 1 })}</h2>
-        <ul
+        <div
           className="vads-u-border-top--1px vads-u-margin-bottom--4 check-in--appointment-list"
           data-testid="appointment-list"
         >
@@ -154,8 +154,9 @@ const CheckInConfirmation = props => {
             router={router}
             page="confirmation"
             app={APP_NAMES.CHECK_IN}
+            count={1}
           />
-        </ul>
+        </div>
         {isTravelReimbursementEnabled ? (
           <>
             <h2 data-testid="travel-reimbursement-heading">


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Refactors appointment lists and list-items to not be list if there is only a single instance of an appointment.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#31393

## Testing done

Updates and adds unit tests.

## Screenshots

<img width="1401" alt="Screenshot 2024-08-14 at 11 57 21 AM" src="https://github.com/user-attachments/assets/48811816-0e57-4387-9b49-5c77af5ca390">

## What areas of the site does it impact?

day-of and pre-check-in

## Acceptance criteria
 - [ ] appointment lists are not lists when there is only one appointment
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
