### PR TITLE
84192 Update confirmation page copy - form 10-7959c

### DIFF
--- a/src/applications/ivc-champva/10-7959C/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-7959C/containers/ConfirmationPage.jsx
@@ -7,6 +7,8 @@ import { focusElement } from 'platform/utilities/ui';
 import {
   VaAlert,
   VaLinkAction,
+  VaLink,
+  VaTelephone,
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import {
   requiredFiles,
@@ -140,9 +142,26 @@ export function ConfirmationPage(props) {
       </div>
       <h2 className="vads-u-font-size--h3">What to expect next</h2>
       <p>
-        We’ll contact the number you listed on this form by mail or phone if we
-        have questions or need more information.
+        It will take approximately 60 days to process your form once received by
+        CHAMPVA.
       </p>
+      <p>
+        If we have any questions, need additional information, or encounter any
+        issues, we will contact you.
+      </p>
+
+      <h2 className="vads-u-font-size--h3">
+        How to contact us about your form
+      </h2>
+      <p>
+        If you have any questions about your application you can call the
+        CHAMPVA call center at <VaTelephone contact="800-733-8387" />. We’re
+        here Monday through Friday, 8:05 a.m. to 7:30 p.m. ET.
+      </p>
+      <p>You can also contact us online through our Ask VA tool.</p>
+      <VaLink text="Go to Ask VA" href="https://ask.va.gov/" />
+      <br />
+      <br />
       <VaLinkAction href="/" text="Go back to VA.gov" />
     </div>
   );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR updates the copy on the confirmation screen for form 10-7959c.

- Adds "How to contact us" section
- Updates "what to expect next" text

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/84192

## Testing done

- Manual

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| All attachments uploaded |![Screenshot 2024-08-14 at 13 15 10](https://github.com/user-attachments/assets/30f1d60a-31f2-4fe5-9b37-d4ce1f8f6626)|![after_complete](https://github.com/user-attachments/assets/d46dc8bd-8b3e-4eaa-aae6-0732e709f62e)|
| Missing attachments |![before_missing](https://github.com/user-attachments/assets/6206b92c-65a7-464d-a78d-2310f5359125)|![after_missing](https://github.com/user-attachments/assets/2ef78a65-64ff-4f80-8ecf-08ca82f68699)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA