### PR TITLE
90728 Combine street text fields in submit transformer - forms 10-7959c, 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959C/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959C/config/submitTransformer.js
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import { transformForSubmit as formsSystemTransformForSubmit } from 'platform/forms-system/src/js/helpers';
 import { getObjectsWithAttachmentId } from '../helpers/utilities';
+import { concatStreets } from '../../shared/utilities';
 
 function getPrimaryContact(data) {
   // For callback API we need to know what data in the form should be
@@ -29,6 +30,11 @@ export default function transformForSubmit(formConfig, form) {
     copyOfData.applicantName.middle =
       copyOfData.applicantName?.middle?.charAt(0) ?? '';
   }
+
+  // Combine all street strings for main address into one
+  copyOfData.applicantAddress.streetCombined = concatStreets(
+    copyOfData.applicantAddress,
+  );
 
   // Get today's date as YYYY-MM-DD
   copyOfData.certificationDate = new Date().toISOString().replace(/T.*/, '');

--- a/src/applications/ivc-champva/10-7959C/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959C/config/submitTransformer.js
@@ -32,9 +32,10 @@ export default function transformForSubmit(formConfig, form) {
   }
 
   // Combine all street strings for main address into one
-  copyOfData.applicantAddress.streetCombined = concatStreets(
-    copyOfData.applicantAddress,
-  );
+  if (copyOfData.applicantAddress)
+    copyOfData.applicantAddress.streetCombined = concatStreets(
+      copyOfData.applicantAddress,
+    );
 
   // Get today's date as YYYY-MM-DD
   copyOfData.certificationDate = new Date().toISOString().replace(/T.*/, '');

--- a/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/minimal-test.json
+++ b/src/applications/ivc-champva/10-7959C/tests/e2e/fixtures/data/minimal-test.json
@@ -8,6 +8,7 @@
     "applicantAddress": {
       "country": "USA",
       "street": "123 Circle Street",
+      "street2": "Apt 1C",
       "city": "Cityburg",
       "state": "CA",
       "postalCode": "12312"

--- a/src/applications/ivc-champva/10-7959C/tests/helpers/utilities.unit.spec.js
+++ b/src/applications/ivc-champva/10-7959C/tests/helpers/utilities.unit.spec.js
@@ -5,6 +5,7 @@ import {
   getObjectsWithAttachmentId,
 } from '../../helpers/utilities';
 import { requiredFiles } from '../../config/constants';
+import { concatStreets } from '../../../shared/utilities';
 
 describe('isRequiredFile', () => {
   it("should return '(Required)' if required file in formContext", () => {
@@ -60,5 +61,26 @@ describe('getObjectsWithAttachmentId', () => {
       [{ attachmentId: '2' }],
     ];
     expect(getObjectsWithAttachmentId(objectList).length).to.equal(2);
+  });
+});
+
+describe('concatStreets function', () => {
+  it('should concatenate all streets together', () => {
+    const addr = {
+      street: '123 St',
+      street2: 'Unit 1C',
+      street3: 'Apt A',
+      state: 'MD',
+    };
+    expect(concatStreets(addr).trim()).to.equal(
+      `${addr.street} ${addr.street2} ${addr.street3}`,
+    );
+  });
+  it('should return single street(1) value if no 2 and 3 are present', () => {
+    const addr = {
+      street: '123 St',
+      state: 'MD',
+    };
+    expect(concatStreets(addr).trim()).to.equal(`${addr.street}`);
   });
 });

--- a/src/applications/ivc-champva/10-7959a/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959a/config/submitTransformer.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import { transformForSubmit as formsSystemTransformForSubmit } from 'platform/forms-system/src/js/helpers';
-import { adjustYearString } from '../../shared/utilities';
+import { adjustYearString, concatStreets } from '../../shared/utilities';
 
 function getPrimaryContact(data) {
   // For callback API we need to know what data in the form should be
@@ -42,17 +42,15 @@ export default function transformForSubmit(formConfig, form) {
   // ---
 
   // Combine all three street strings into one
-  copyOfData.applicantAddress.streetCombined = `${
-    copyOfData.applicantAddress.street
-  } ${copyOfData.applicantAddress.street2 ?? ''} ${copyOfData.applicantAddress
-    .street3 ?? ''}`;
+  copyOfData.applicantAddress.streetCombined = concatStreets(
+    copyOfData.applicantAddress,
+  );
 
   if (copyOfData.certifierAddress) {
     // Combine streets for 3rd party certifier
-    copyOfData.certifierAddress.streetCombined = `${
-      copyOfData.certifierAddress.street
-    } ${copyOfData.certifierAddress.street2 ?? ''} ${copyOfData.certifierAddress
-      .street3 ?? ''}`;
+    copyOfData.certifierAddress.streetCombined = concatStreets(
+      copyOfData.certifierAddress.streetCombined,
+    );
   }
 
   // Date of signature

--- a/src/applications/ivc-champva/shared/utilities.js
+++ b/src/applications/ivc-champva/shared/utilities.js
@@ -146,8 +146,10 @@ export function adjustYearString(data) {
  */
 export function concatStreets(addr) {
   let res = '';
-  for (const [k, v] of Object.entries(addr)) {
-    res += k.includes('street') ? `${v} ` : '';
+  if (addr) {
+    for (const [k, v] of Object.entries(addr)) {
+      res += k.includes('street') ? `${v} ` : '';
+    }
   }
   return res;
 }

--- a/src/applications/ivc-champva/shared/utilities.js
+++ b/src/applications/ivc-champva/shared/utilities.js
@@ -138,3 +138,16 @@ export function adjustYearString(data) {
   });
   return copy;
 }
+
+/**
+ * Combine all street fields from an address into a single string.
+ * @param {Object} addr Standard form address object containing one or more `street` properties (e.g., street, street1, street2)
+ * @returns String of all street fields combined.
+ */
+export function concatStreets(addr) {
+  let res = '';
+  for (const [k, v] of Object.entries(addr)) {
+    res += k.includes('street') ? `${v} ` : '';
+  }
+  return res;
+}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR adds a helper function that takes an address as input and returns a concatenated list of all "streetX" properties. This was added because multiple IVC forms only have a single text field for street on the actual PDF, while the digital forms have been designed to allow users to enter more than one street field.

This helper function was then used on forms 10-7959c and 10-7959a (which previously had its own version of this functionality).

- Adds street concatenation helper
- Adds unit tests for street concat helper
- Updates submit transformers for 10-7959c/a to use the street concatenator

## Related issue(s)

- vets-api sister PR: https://github.com/department-of-veterans-affairs/vets-api/pull/18033
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90728

## Testing done

- Manual
- Verified unit tests run and pass

## Screenshots

| |form|pdf|
|-|------|-----|
|streets|<img width="630" alt="address" src="https://github.com/user-attachments/assets/af49a14d-bd26-43b1-983b-c7736ec7b5e1">|<img width="246" alt="ohi_pdf" src="https://github.com/user-attachments/assets/68932da1-afbf-4bf1-a69e-2c5b75d70dce">|

## What areas of the site does it impact?

Forms 10-7959c and 10-7959a (via re-factor)

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA