### PR TITLE
Add <p> tags to text areas on details page to inherit base font size.

### DIFF
--- a/src/applications/check-in/components/AddressBlock.jsx
+++ b/src/applications/check-in/components/AddressBlock.jsx
@@ -41,13 +41,14 @@ const AddressBlock = ({ address, showDirections = false, placeName }) => {
 
   return (
     <div data-testid="address-block">
-      <span data-testid="address-line-street1">{address.street1}</span>
+      <p className="vads-u-margin--0" data-testid="address-line-street1">
+        {address.street1}
+      </p>
       {lineTwo}
       {lineThree}
-      <br aria-hidden="true" />
-      <span data-testid="address-city-state-and-zip">
+      <p className="vads-u-margin--0" data-testid="address-city-state-and-zip">
         {`${address.city}, ${address.state} ${address.zip.substring(0, 5)}`}
-      </span>
+      </p>
       {showDirections &&
         placeName && (
           <div

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -293,17 +293,23 @@ const AppointmentDetails = props => {
                 )}
               <div data-testid="appointment-details--when">
                 <h2 className="vads-u-font-size--sm">{t('when')}</h2>
-                <div data-testid="appointment-details--date-value">
+                <p
+                  className="vads-u-margin--0"
+                  data-testid="appointment-details--date-value"
+                >
                   {isValid(appointmentDay) &&
                     t('appointment-day', { date: appointmentDay })}
-                </div>
+                </p>
               </div>
               {appointment.doctorName && (
                 <div data-testid="appointment-details--provider">
                   <h2 className="vads-u-font-size--sm">{t('who')}</h2>
-                  <div data-testid="appointment-details--provider-value">
+                  <p
+                    className="vads-u-margin--0"
+                    data-testid="appointment-details--provider-value"
+                  >
                     {appointment.doctorName}
-                  </div>
+                  </p>
                 </div>
               )}
 
@@ -312,7 +318,10 @@ const AppointmentDetails = props => {
                   <h2 className="vads-u-font-size--sm">
                     {t('where-to-attend')}
                   </h2>
-                  <div data-testid="appointment-details--facility-value">
+                  <p
+                    className="vads-u-margin--0"
+                    data-testid="appointment-details--facility-value"
+                  >
                     {appointment.facility}
                     {appointment.facilityAddress?.street1 && (
                       <div className="vads-u-margin-bottom--2">
@@ -323,7 +332,7 @@ const AppointmentDetails = props => {
                         />
                       </div>
                     )}
-                  </div>
+                  </p>
                 </div>
               )}
               {(isPhoneAppointment || isVvcAppointment) && (
@@ -340,21 +349,27 @@ const AppointmentDetails = props => {
               {(isPhoneAppointment || isVvcAppointment) && (
                 <div data-testid="appointment-details--facility-info">
                   {appointment.facility && (
-                    <div data-testid="appointment-details--facility-value">
+                    <p
+                      className="vads-u-margin--0"
+                      data-testid="appointment-details--facility-value"
+                    >
                       {appointment.facility}
-                    </div>
+                    </p>
                   )}
                   {appointment.facilityAddress?.city &&
                     appointment.facilityAddress?.state && (
-                      <div data-testid="appointment-details--facility-address">
+                      <p
+                        className="vads-u-margin--0"
+                        data-testid="appointment-details--facility-address"
+                      >
                         {`${appointment.facilityAddress.city}, ${
                           appointment.facilityAddress.state
                         }`}
-                      </div>
+                      </p>
                     )}
                 </div>
               )}
-              <div className="vads-u-margin-top--2">
+              <p className="vads-u-margin-top--2">
                 {clinic && (
                   <div data-testid="appointment-details--clinic-value">
                     {`${t('clinic')}:`} {clinic}
@@ -384,7 +399,7 @@ const AppointmentDetails = props => {
                     </div>
                   </div>
                 )}
-              </div>
+              </p>
               {app === APP_NAMES.CHECK_IN && link}
               {app === APP_NAMES.PRE_CHECK_IN && (
                 <PrepareContent

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -369,21 +369,30 @@ const AppointmentDetails = props => {
                     )}
                 </div>
               )}
-              <p className="vads-u-margin-top--2">
+              <div className="vads-u-margin-top--2">
                 {clinic && (
-                  <div data-testid="appointment-details--clinic-value">
+                  <p
+                    className="vads-u-margin--0"
+                    data-testid="appointment-details--clinic-value"
+                  >
                     {`${t('clinic')}:`} {clinic}
-                  </div>
+                  </p>
                 )}
                 {(isInPersonAppointment || isCvtAppointment) &&
                   appointment.clinicLocation && (
-                    <div data-testid="appointment-details--location-value">
+                    <p
+                      className="vads-u-margin--0"
+                      data-testid="appointment-details--location-value"
+                    >
                       {`${t('location')}: ${appointment.clinicLocation}`}
-                    </div>
+                    </p>
                   )}
                 {appointment.clinicPhoneNumber && (
                   <div data-testid="appointment-details--phone">
-                    <div data-testid="appointment-details--phone-value">
+                    <p
+                      className="vads-u-margin--0"
+                      data-testid="appointment-details--phone-value"
+                    >
                       {`${t('clinic-phone')}: `}
                       <va-telephone
                         onClick={handlePhoneNumberClick}
@@ -396,10 +405,10 @@ const AppointmentDetails = props => {
                         ariaLabel="7 1 1."
                       />
                       )
-                    </div>
+                    </p>
                   </div>
                 )}
-              </p>
+              </div>
               {app === APP_NAMES.CHECK_IN && link}
               {app === APP_NAMES.PRE_CHECK_IN && (
                 <PrepareContent

--- a/src/applications/check-in/tests/e2e/pages/AppointmentDetails.js
+++ b/src/applications/check-in/tests/e2e/pages/AppointmentDetails.js
@@ -14,17 +14,17 @@ class AppointmentDetails {
   };
 
   validateWhen = () => {
-    cy.get('div[data-testid="appointment-details--when"]').should('be.visible');
-    cy.get('div[data-testid="appointment-details--date-value"]').should(
+    cy.get('[data-testid="appointment-details--when"]').should('be.visible');
+    cy.get('[data-testid="appointment-details--date-value"]').should(
       'be.visible',
     );
   };
 
   validateProvider = () => {
-    cy.get('div[data-testid="appointment-details--provider"]').should(
+    cy.get('[data-testid="appointment-details--provider"]').should(
       'be.visible',
     );
-    cy.get('div[data-testid="appointment-details--provider-value"]').should(
+    cy.get('[data-testid="appointment-details--provider-value"]').should(
       'be.visible',
     );
   };
@@ -39,45 +39,41 @@ class AppointmentDetails {
 
   validateFacilityAddress = visible => {
     if (visible) {
-      cy.get('div[data-testid="address-block"]').should('be.visible');
+      cy.get('[data-testid="address-block"]').should('be.visible');
     } else {
-      cy.get('div[data-testid="address-block"]').should('not.exist');
+      cy.get('[data-testid="address-block"]').should('not.exist');
     }
   };
 
   validateNeedToMakeChanges = () => {
-    cy.get(
-      'div[data-testid="appointment-details--need-to-make-changes"]',
-    ).should('be.visible');
+    cy.get('[data-testid="appointment-details--need-to-make-changes"]').should(
+      'be.visible',
+    );
   };
 
   validateWhere = () => {
-    cy.get('div[data-testid="appointment-details--where"]').should(
+    cy.get('[data-testid="appointment-details--where"]').should('be.visible');
+    cy.get('[data-testid="appointment-details--clinic-value"]').should(
       'be.visible',
     );
-    cy.get('div[data-testid="appointment-details--clinic-value"]').should(
-      'be.visible',
-    );
-    cy.get('div[data-testid="appointment-details--facility-value"]').should(
+    cy.get('[data-testid="appointment-details--facility-value"]').should(
       'be.visible',
     );
 
-    cy.get('div[data-testid="appointment-details--location-value"]').should(
+    cy.get('[data-testid="appointment-details--location-value"]').should(
       'be.visible',
     );
   };
 
   validatePhone = () => {
-    cy.get('div[data-testid="appointment-details--phone"]').should(
-      'be.visible',
-    );
-    cy.get('div[data-testid="appointment-details--phone-value"]').should(
+    cy.get('[data-testid="appointment-details--phone"]').should('be.visible');
+    cy.get('[data-testid="appointment-details--phone-value"]').should(
       'be.visible',
     );
   };
 
   validateAppointmentMessage = () => {
-    cy.get('div[data-testid="appointment-message"]').should('be.visible');
+    cy.get('[data-testid="appointment-message"]').should('be.visible');
   };
 
   validateCheckedInMessage = () => {
@@ -87,7 +83,7 @@ class AppointmentDetails {
   };
 
   validateNoAppointmentMessage = () => {
-    cy.get('div[data-testid="appointment-message"]').should('not.exist');
+    cy.get('[data-testid="appointment-message"]').should('not.exist');
   };
 
   validateCheckInButton = () => {


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

adds `<p>` tags around text that were just in `<div>` to inherit the base font size.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#90154

## Testing done

Updates Details page test class to more generically look for testids.

## Screenshots

![localhost_3001_health-care_appointment-pre-check-in_appointment-details_0001-0001 (4)](https://github.com/user-attachments/assets/d4adcf4e-f472-43ec-8861-01beef0dc04d)

## What areas of the site does it impact?

day-of and pre-check-in

## Acceptance criteria
 - [ ] all body text on details page inherits the 16.96px computed text size.
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

