### PR TITLE
89641- Removes MHV schedule link on facilities page for food and nutrition appointments

### DIFF
--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
@@ -4,7 +4,10 @@ import { shallowEqual, useSelector } from 'react-redux';
 import { getCernerURL } from 'platform/utilities/cerner';
 import { VaSelect } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import recordEvent from '@department-of-veterans-affairs/platform-monitoring/record-event';
-import { selectFacilitiesRadioWidget } from '../../redux/selectors';
+import {
+  selectFacilitiesRadioWidget,
+  getFacilityPageV2Info,
+} from '../../redux/selectors';
 import State from '../../../components/State';
 import InfoAlert from '../../../components/InfoAlert';
 import {
@@ -16,8 +19,9 @@ import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import { isCernerLocation } from '../../../services/location';
 import NoAddressNote from '../NoAddressNote';
 
-const INITIAL_FACILITY_DISPLAY_COUNT = 5;
+import { selectFeatureOHDirectSchedule } from '../../../redux/selectors';
 
+const INITIAL_FACILITY_DISPLAY_COUNT = 5;
 /*
  * This is a copy of the form system RadioWidget, but with custom
  * code to disable certain options. This isn't currently supported by the
@@ -36,6 +40,17 @@ export default function FacilitiesRadioWidget({
     sortMethod,
     loadingEligibility,
   } = useSelector(state => selectFacilitiesRadioWidget(state), shallowEqual);
+
+  const { typeOfCare } = useSelector(
+    state => getFacilityPageV2Info(state),
+    shallowEqual,
+  );
+
+  const featureOHDirectSchedule = useSelector(selectFeatureOHDirectSchedule);
+
+  const OHDirectScheduleEnabled =
+    featureOHDirectSchedule && typeOfCare.idV2 === 'foodAndNutrition';
+
   const { hasUserAddress, sortOptions, updateFacilitySortMethod } = formContext;
   const { enumOptions } = options;
   const selectedIndex = enumOptions.findIndex(o => o.value === value);
@@ -168,11 +183,12 @@ export default function FacilitiesRadioWidget({
                     {distance} miles
                   </span>
                 )}
-                {isCerner && (
-                  <a href={getCernerURL('/pages/scheduling/upcoming')}>
-                    Schedule online at <strong>My VA Health</strong>
-                  </a>
-                )}
+                {isCerner &&
+                  !OHDirectScheduleEnabled && (
+                    <a href={getCernerURL('/pages/scheduling/upcoming')}>
+                      Schedule online at <strong>My VA Health</strong>
+                    </a>
+                  )}
               </label>
             </div>
           );

--- a/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
+++ b/src/applications/vaos/new-appointment/components/VAFacilityPage/FacilitiesRadioWidget.jsx
@@ -4,10 +4,7 @@ import { shallowEqual, useSelector } from 'react-redux';
 import { getCernerURL } from 'platform/utilities/cerner';
 import { VaSelect } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import recordEvent from '@department-of-veterans-affairs/platform-monitoring/record-event';
-import {
-  selectFacilitiesRadioWidget,
-  getFacilityPageV2Info,
-} from '../../redux/selectors';
+import { selectFacilitiesRadioWidget } from '../../redux/selectors';
 import State from '../../../components/State';
 import InfoAlert from '../../../components/InfoAlert';
 import {
@@ -18,8 +15,7 @@ import {
 import { scrollAndFocus } from '../../../utils/scrollAndFocus';
 import { isCernerLocation } from '../../../services/location';
 import NoAddressNote from '../NoAddressNote';
-
-import { selectFeatureOHDirectSchedule } from '../../../redux/selectors';
+import { useOHDirectScheduling } from '../../hooks/useOHDirectScheduling';
 
 const INITIAL_FACILITY_DISPLAY_COUNT = 5;
 /*
@@ -40,16 +36,6 @@ export default function FacilitiesRadioWidget({
     sortMethod,
     loadingEligibility,
   } = useSelector(state => selectFacilitiesRadioWidget(state), shallowEqual);
-
-  const { typeOfCare } = useSelector(
-    state => getFacilityPageV2Info(state),
-    shallowEqual,
-  );
-
-  const featureOHDirectSchedule = useSelector(selectFeatureOHDirectSchedule);
-
-  const OHDirectScheduleEnabled =
-    featureOHDirectSchedule && typeOfCare.idV2 === 'foodAndNutrition';
 
   const { hasUserAddress, sortOptions, updateFacilitySortMethod } = formContext;
   const { enumOptions } = options;
@@ -84,6 +70,8 @@ export default function FacilitiesRadioWidget({
       </option>
     );
   });
+
+  const useOHDirectSchedule = useOHDirectScheduling();
 
   useEffect(
     () => {
@@ -184,7 +172,7 @@ export default function FacilitiesRadioWidget({
                   </span>
                 )}
                 {isCerner &&
-                  !OHDirectScheduleEnabled && (
+                  !useOHDirectSchedule && (
                     <a href={getCernerURL('/pages/scheduling/upcoming')}>
                       Schedule online at <strong>My VA Health</strong>
                     </a>

--- a/src/applications/vaos/new-appointment/hooks/useOHDirectScheduling.js
+++ b/src/applications/vaos/new-appointment/hooks/useOHDirectScheduling.js
@@ -1,0 +1,19 @@
+import { shallowEqual, useSelector } from 'react-redux';
+import { getFacilityPageV2Info } from '../redux/selectors';
+import { selectFeatureOHDirectSchedule } from '../../redux/selectors';
+
+const OH_DIRECT_SCHEDULE_ENABLED_TYPES_OF_CARE = ['foodAndNutrition'];
+
+export function useOHDirectScheduling() {
+  const featureOHDirectSchedule = useSelector(selectFeatureOHDirectSchedule);
+
+  const { typeOfCare } = useSelector(
+    state => getFacilityPageV2Info(state),
+    shallowEqual,
+  );
+
+  return (
+    featureOHDirectSchedule &&
+    OH_DIRECT_SCHEDULE_ENABLED_TYPES_OF_CARE.includes(typeOfCare.idV2)
+  );
+}

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.js
@@ -1389,8 +1389,130 @@ describe('VAOS Page: VAFacilityPage', () => {
   });
 
   describe('when OH Direct Scheduling is enabled', () => {
+    beforeEach(() => mockFetch());
+
+    const initialState = {
+      drupalStaticData: {
+        vamcEhrData: {
+          loading: false,
+          data: {
+            ehrDataByVhaId: {
+              '442': {
+                vhaId: '442',
+                vamcFacilityName: 'Cheyenne VA Medical Center',
+                vamcSystemName: 'VA Cheyenne health care',
+                ehr: 'cerner',
+              },
+              '552': {
+                vhaId: '552',
+                vamcFacilityName: 'Dayton VA Medical Center',
+                vamcSystemName: 'VA Dayton health care',
+                ehr: 'cerner',
+              },
+            },
+            cernerFacilities: [
+              {
+                vhaId: '442',
+                vamcFacilityName: 'Cheyenne VA Medical Center',
+                vamcSystemName: 'VA Cheyenne health care',
+                ehr: 'cerner',
+              },
+              {
+                vhaId: '552',
+                vamcFacilityName: 'Dayton VA Medical Center',
+                vamcSystemName: 'VA Dayton health care',
+                ehr: 'cerner',
+              },
+            ],
+            vistaFacilities: [],
+          },
+        },
+      },
+      featureToggles: {
+        vaOnlineSchedulingDirect: true,
+        vaOnlineSchedulingUseDsot: true,
+        vaOnlineSchedulingFacilitiesServiceV2: true,
+        vaOnlineSchedulingOHDirectSchedule: true,
+      },
+      user: {
+        profile: {
+          facilities: [
+            {
+              facilityId: '442', // Must use real facility id when using DSOT
+              isCerner: false, // Not used when using DSOT
+            },
+            { facilityId: '552', isCerner: false },
+          ],
+        },
+      },
+    };
+
     it('should not display MHV scheduling link for foodAndNutrition appointments', async () => {
-      return true;
+      mockFacilitiesFetch({
+        children: true,
+        facilities: [
+          createMockFacility({
+            id: '983',
+            name: 'First cerner facility',
+            lat: 39.1362562,
+            long: -83.1804804,
+          }),
+          createMockFacility({
+            id: '984',
+            name: 'Second Cerner facility',
+            lat: 39.1362562,
+            long: -83.1804804,
+          }),
+        ],
+      });
+
+      mockSchedulingConfigurations([
+        getSchedulingConfigurationMock({
+          id: '983',
+          typeOfCareId: 'primaryCare',
+          directEnabled: true,
+        }),
+        getSchedulingConfigurationMock({
+          id: '984',
+          typeOfCareId: 'foodAndNutrition',
+          directEnabled: true,
+        }),
+      ]);
+
+      const store = createTestStore({
+        ...initialState,
+        user: {
+          ...initialState.user,
+          profile: {
+            ...initialState.user.profile,
+            vapContactInfo: {
+              residentialAddress: {
+                latitude: 39.1362562,
+                longitude: -84.6804804,
+              },
+            },
+          },
+        },
+      });
+
+      await setTypeOfCare(store, /nutrition and food/i);
+
+      const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
+        store,
+      });
+
+      // Make sure Cerner facilities show up
+      expect(await screen.findByText(/First Cerner facility/i)).to.be.ok;
+      expect(await screen.getByText(/Second Cerner facility/i)).to.be.ok;
+
+      // Make sure Cerner link shows up for primaryCare
+      const cernerSiteLabel = document.querySelector(
+        `label[for="${screen.getByLabelText(/First Cerner facility/i).id}"]`,
+      );
+
+      expect(
+        within(cernerSiteLabel).queryByRole('link', { name: /My VA Health/ }),
+      ).not.to.exist;
     });
   });
 });

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.js
@@ -1387,4 +1387,10 @@ describe('VAOS Page: VAFacilityPage', () => {
       );
     });
   });
+
+  describe('when OH Direct Scheduling is enabled', () => {
+    it('should not display MHV scheduling link for foodAndNutrition appointments', async () => {
+      return true;
+    });
+  });
 });

--- a/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.js
+++ b/src/applications/vaos/tests/new-appointment/components/VAFacilityPage/index.unit.spec.js
@@ -1469,7 +1469,7 @@ describe('VAOS Page: VAFacilityPage', () => {
       mockSchedulingConfigurations([
         getSchedulingConfigurationMock({
           id: '983',
-          typeOfCareId: 'primaryCare',
+          typeOfCareId: 'foodAndNutrition',
           directEnabled: true,
         }),
         getSchedulingConfigurationMock({
@@ -1505,7 +1505,7 @@ describe('VAOS Page: VAFacilityPage', () => {
       expect(await screen.findByText(/First Cerner facility/i)).to.be.ok;
       expect(await screen.getByText(/Second Cerner facility/i)).to.be.ok;
 
-      // Make sure Cerner link shows up for primaryCare
+      // Make sure Cerner link does not show up for foodAndNutrition
       const cernerSiteLabel = document.querySelector(
         `label[for="${screen.getByLabelText(/First Cerner facility/i).id}"]`,
       );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


## Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds a custom hook ([`useOHDirectScheduling`](https://github.com/department-of-veterans-affairs/vets-website/blob/d92a90045982d82c084a6f48e5aa57e4afc076f2/src/applications/vaos/new-appointment/hooks/useOHDirectScheduling.js)) to the new appointment flow that will allow for controlling OH Direct Scheduling functionality when the `vaOnlineSchedulingOHDirectSchedule` feature toggle is `true`
- Removes the `Schedule online at My VA Health` link on the facilities page when _Nutrition and Food_ is the chosen type of care. This allows users to proceed forward in the direct schedule flow for OH facilities for _Nutrition and Food_ appointments.

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/89641

## Testing done

- Local testing by replacing responses within Chrome developer tools
- Updated unit tests

## Screenshots
See screenshots in [original issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/89641)

## What areas of the site does it impact?
N/A

## Acceptance criteria

### Quality Assurance & Testing

- [X] I added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [X] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user
