### PR TITLE
dependent ages refactor and dependent bug fixes

### DIFF
--- a/src/applications/financial-status-report/components/household/DependentAges.jsx
+++ b/src/applications/financial-status-report/components/household/DependentAges.jsx
@@ -11,7 +11,6 @@ import ButtonGroup from '../shared/ButtonGroup';
 const DependentAges = ({
   contentBeforeButtons,
   contentAfterButtons,
-  setFormData,
   goForward,
   goToPath,
   goBack,
@@ -127,15 +126,6 @@ const DependentAges = ({
 
   const handleGoBack = event => {
     event.preventDefault();
-    // Only save the hasDependents value when going back
-    const updatedFormData = {
-      ...formData,
-      questions: {
-        ...formData.questions,
-        hasDependents: formData.questions.hasDependents,
-      },
-    };
-    setFormData(updatedFormData);
     goBack();
   };
 
@@ -189,7 +179,7 @@ const DependentAges = ({
           buttons={[
             {
               label: 'Back',
-              onClick: handlers.handleGoBack,
+              onClick: goBack,
               isSecondary: true,
               isSubmitting: 'prevent',
             },

--- a/src/applications/financial-status-report/components/household/DependentAges.jsx
+++ b/src/applications/financial-status-report/components/household/DependentAges.jsx
@@ -215,6 +215,7 @@ const DependentAges = ({
               isSecondary: true,
             },
             {
+              isSubmitting: 'prevent',
               label: continueButtonText,
               onClick: handlers.onSubmit,
             },

--- a/src/applications/financial-status-report/components/household/DependentCount.jsx
+++ b/src/applications/financial-status-report/components/household/DependentCount.jsx
@@ -128,7 +128,6 @@ const DependentCount = ({
             label: 'Back',
             onClick: goBack,
             isSecondary: true,
-            isSubmitting: 'prevent',
           },
           {
             label: 'Continue',

--- a/src/applications/financial-status-report/components/household/DependentCount.jsx
+++ b/src/applications/financial-status-report/components/household/DependentCount.jsx
@@ -128,6 +128,7 @@ const DependentCount = ({
             label: 'Back',
             onClick: goBack,
             isSecondary: true,
+            isSubmitting: 'prevent',
           },
           {
             label: 'Continue',

--- a/src/applications/financial-status-report/components/shared/ButtonGroup.jsx
+++ b/src/applications/financial-status-report/components/shared/ButtonGroup.jsx
@@ -19,7 +19,7 @@ const Button = ({ label, onClick, isSubmitting, isSecondary }) => {
 };
 
 Button.defaultProps = {
-  isSubmitting: 'submit',
+  isSubmitting: 'prevent',
   isSecondary: false,
 };
 

--- a/src/applications/financial-status-report/components/shared/ButtonGroup.jsx
+++ b/src/applications/financial-status-report/components/shared/ButtonGroup.jsx
@@ -26,7 +26,7 @@ Button.defaultProps = {
 Button.propTypes = {
   label: PropTypes.string.isRequired,
   isSecondary: PropTypes.bool,
-  isSubmitting: PropTypes.bool || PropTypes.string,
+  isSubmitting: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   onClick: PropTypes.func,
 };
 
@@ -52,7 +52,7 @@ ButtonGroup.propTypes = {
     PropTypes.shape({
       label: PropTypes.string.isRequired,
       onClick: PropTypes.func.isRequired,
-      isSubmitting: PropTypes.bool,
+      isSubmitting: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
       isSecondary: PropTypes.bool,
     }),
   ).isRequired,

--- a/src/applications/financial-status-report/components/shared/ButtonGroup.jsx
+++ b/src/applications/financial-status-report/components/shared/ButtonGroup.jsx
@@ -7,19 +7,30 @@ import { VaButton } from '@department-of-veterans-affairs/component-library/dist
  */
 
 const Button = ({ label, onClick, isSubmitting, isSecondary }) => {
+  if (isSubmitting) {
+    return (
+      <VaButton
+        data-testid="custom-button-group-button"
+        text={label}
+        onClick={onClick}
+        submit={isSubmitting}
+        secondary={isSecondary}
+      />
+    );
+  }
+
   return (
     <VaButton
       data-testid="custom-button-group-button"
       text={label}
       onClick={onClick}
-      submit={isSubmitting}
       secondary={isSecondary}
     />
   );
 };
 
 Button.defaultProps = {
-  isSubmitting: 'prevent',
+  isSubmitting: false,
   isSecondary: false,
 };
 

--- a/src/applications/financial-status-report/components/shared/ButtonGroup.jsx
+++ b/src/applications/financial-status-report/components/shared/ButtonGroup.jsx
@@ -26,7 +26,7 @@ Button.defaultProps = {
 Button.propTypes = {
   label: PropTypes.string.isRequired,
   isSecondary: PropTypes.bool,
-  isSubmitting: PropTypes.string,
+  isSubmitting: PropTypes.bool || PropTypes.string,
   onClick: PropTypes.func,
 };
 

--- a/src/applications/financial-status-report/config/chapters/veteranInformationChapter.js
+++ b/src/applications/financial-status-report/config/chapters/veteranInformationChapter.js
@@ -18,7 +18,6 @@ import {
 } from '../../components/contactInfo/EditContactInfo';
 import DependentCount from '../../components/household/DependentCount';
 import DependentAges from '../../components/household/DependentAges';
-import DependentAgesReview from '../../components/household/DependentAgesReview';
 import SpouseTransitionExplainer from '../../components/householdIncome/SpouseTransitionExplainer';
 import { getGlobalState } from '../../utils/checkGlobalState';
 
@@ -104,7 +103,7 @@ export default {
         title: 'Spouse name',
         uiSchema: spouseName.uiSchema,
         schema: spouseName.schema,
-        depends: formData => formData.questions.isMarried,
+        depends: formData => formData.questions?.isMarried,
       },
       spouseTransition: {
         path: 'spouse-transition',
@@ -116,8 +115,8 @@ export default {
         depends: formData => {
           const globalState = getGlobalState();
           return (
-            formData.questions.isMarried &&
-            !formData.reviewNavigation &&
+            formData.questions?.isMarried &&
+            !formData?.reviewNavigation &&
             globalState.spouseChanged
           );
         },
@@ -125,7 +124,7 @@ export default {
       dependentCount: {
         path: 'dependents-count',
         title: 'Dependents count',
-        uiSchema: dependents.uiSchemaEnhanced,
+        uiSchema: {},
         schema: dependents.schemaEnhanced,
         CustomPage: DependentCount,
         CustomPageReview: null,
@@ -137,10 +136,9 @@ export default {
         schema: dependentRecords.schemaEnhanced,
         depends: formData =>
           formData.questions?.hasDependents &&
-          formData.questions.hasDependents !== '0' &&
+          formData.questions?.hasDependents !== '0' &&
           formData['view:streamlinedWaiver'],
         CustomPage: DependentAges,
-        CustomPageReview: DependentAgesReview,
         editModeOnReviewPage: false,
       },
     },

--- a/src/applications/financial-status-report/config/chapters/veteranInformationChapter.js
+++ b/src/applications/financial-status-report/config/chapters/veteranInformationChapter.js
@@ -139,6 +139,7 @@ export default {
           formData.questions?.hasDependents !== '0' &&
           formData['view:streamlinedWaiver'],
         CustomPage: DependentAges,
+        CustomPageReview: null,
         editModeOnReviewPage: false,
       },
     },

--- a/src/applications/financial-status-report/pages/income/dependents/index.js
+++ b/src/applications/financial-status-report/pages/income/dependents/index.js
@@ -1,29 +1,3 @@
-import React from 'react';
-import DependentExplainer from '../../../components/household/DependentExplainer';
-
-export const uiSchemaEnhanced = {
-  'ui:title': () => (
-    <>
-      <legend className="schemaform-block-title">
-        <h3 className="vads-u-margin--0">Your dependents</h3>
-      </legend>
-    </>
-  ),
-  questions: {
-    'ui:options': {
-      hideOnReview: false, // change this to true to hide this question on review page
-    },
-    hasDependents: {
-      'ui:title': 'Number of dependents',
-    },
-  },
-  'view:components': {
-    'view:dependentsAdditionalInfo': {
-      'ui:description': DependentExplainer,
-    },
-  },
-};
-
 export const schemaEnhanced = {
   type: 'object',
   properties: {

--- a/src/applications/financial-status-report/pages/income/dependents/records.js
+++ b/src/applications/financial-status-report/pages/income/dependents/records.js
@@ -1,22 +1,3 @@
-import React from 'react';
-import DependentAges from '../../../components/household/DependentAges';
-
-export const uiSchemaEnhanced = {
-  'ui:title': () => (
-    <>
-      <legend className="schemaform-block-title">
-        <h3 className="vads-u-margin--0">Your dependents</h3>
-      </legend>
-      <p>Enter each dependent’s age separately.</p>
-    </>
-  ),
-  personalData: {
-    dependents: {
-      'ui:field': DependentAges,
-    },
-  },
-};
-
 export const schemaEnhanced = {
   type: 'object',
   properties: {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)


## Summary

The current implementation of DependentAges has several conditionals that check the values of isReviewMode and isEditing. However, these variables are not being used now that editing takes place on a chapter level rather then directly on the review page. To improve maintainability and reduce unused code, we should remove all references to these conditionals

- [x] Remove all occurrences of isReviewMode and isEditing in the code.
- [x] Refactor the conditionals to use a more specific approach, such as checking the current page path or the user's input state.
- [x] Update any affected logic to be conditional on the new approach.


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#90488


## Testing done

- Manual verification and cypress

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |  
![image](https://github.com/user-attachments/assets/b52fcc64-0fe9-4764-a54b-198104045e74) |   ![image](https://github.com/user-attachments/assets/6ef595cd-e3bb-49f3-8982-3c46e5e715be) |

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added


### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
