### PR TITLE
90786 Update remarriage file upload - form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/components/Applicant/applicantFileUpload.js
+++ b/src/applications/ivc-champva/10-10D/components/Applicant/applicantFileUpload.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
+import { fileUploadBlurbCustom } from 'applications/ivc-champva/shared/components/fileUploads/attachments';
 import { applicantWording } from '../../../shared/utilities';
 import ApplicantField from '../../../shared/components/applicantLists/ApplicantField';
 import { fileUploadUi as fileUploadUI } from '../../../shared/components/fileUploads/upload';
@@ -38,6 +39,21 @@ const marriageDocumentList = (
         A document showing proof of a civil union, <b>or</b>
       </li>
       <li>Common-law marriage affidavit</li>
+    </ul>
+  </>
+);
+
+const divorceDocumentList = (
+  <>
+    <b>If the remarriage has ended</b>, upload a copy of one of these documents:
+    <ul>
+      <li>
+        Divorce decree, <b>or</b>
+      </li>
+      <li>
+        Annulment decree, <b>or</b>
+      </li>
+      <li>Death certificate</li>
     </ul>
   </>
 );
@@ -430,9 +446,9 @@ export const applicantOtherInsuranceCertificationUploadUiSchema = {
   },
 };
 
-export const applicantMarriageCertConfig = uploadWithInfoComponent(
+export const applicantRemarriageCertConfig = uploadWithInfoComponent(
   undefined, // acceptableFiles.spouseCert,
-  'marriage certificates',
+  'remarriage certificates',
 );
 
 // When in list loop, formData is just the list element's data, but when editing
@@ -444,13 +460,19 @@ export function getTopLevelFormData(formContext) {
     : formContext.contentAfterButtons.props.form.data;
 }
 
-export const applicantMarriageCertUploadUiSchema = {
+// If the beneficiary remarried, collect proof of that remarriage
+// and any other marital docs they want to include
+export const applicantRemarriageCertUploadUiSchema = {
   applicants: {
     'ui:options': { viewField: ApplicantField },
     items: {
       ...titleUI(
-        ({ _formData, formContext }) =>
-          `Upload proof of marriage or legal union ${isRequiredFile(
+        ({ formData, formContext }) =>
+          `If ${applicantWording(
+            formData,
+            false,
+            false,
+          )} remarried, upload proof of remarriage ${isRequiredFile(
             formContext,
           )}`,
         ({ formData, formContext }) => {
@@ -460,22 +482,24 @@ export const applicantMarriageCertUploadUiSchema = {
           const vetName = getTopLevelFormData(formContext)?.veteransFullName;
           return (
             <>
-              You’ll need to submit a document showing proof of the marriage or
-              legal union between <b>{nonPosessive}</b> and{' '}
-              <b>
-                {vetName?.first ?? ''} {vetName?.last ?? ''}
-              </b>
-              .<br />
+              If {nonPosessive} remarried after the death of{' '}
+              {vetName?.first ?? ''} {vetName?.last ?? ''}, you can help us
+              process your application by submitting documents showing proof of
+              that remarriage.
+              <br />
               <br />
               {marriageDocumentList}
-              {mailOrFaxLaterMsg}
+              {divorceDocumentList}
             </>
           );
         },
       ),
-      ...applicantMarriageCertConfig.uiSchema,
-      applicantMarriageCert: fileUploadUI({
-        label: 'Upload proof of marriage or legal union',
+      ...fileUploadBlurbCustom(
+        <li>You can upload more than one file here.</li>,
+        'You can also upload all your supporting documents at the end of this form. Or you can send copies by mail or fax.',
+      ),
+      applicantRemarriageCert: fileUploadUI({
+        label: 'Upload proof of remarriage',
       }),
     },
   },
@@ -505,7 +529,7 @@ export const applicantSecondMarriageCertUploadUiSchema = {
           );
         },
       ),
-      ...applicantMarriageCertConfig.uiSchema,
+      ...applicantRemarriageCertConfig.uiSchema,
       applicantSecondMarriageCert: fileUploadUI({
         label: 'Upload proof of marriage or legal union',
       }),

--- a/src/applications/ivc-champva/10-10D/components/Sponsor/sponsorFileUploads.js
+++ b/src/applications/ivc-champva/10-10D/components/Sponsor/sponsorFileUploads.js
@@ -6,6 +6,9 @@ const marriagePapers = [
   'Marriage certificate',
   'Civil union papers',
   'Affidavit of common law marriage',
+  'Divorce decree',
+  'Annulment decree',
+  'Death certificate',
 ];
 
 export const acceptableFiles = {

--- a/src/applications/ivc-champva/10-10D/config/constants.js
+++ b/src/applications/ivc-champva/10-10D/config/constants.js
@@ -40,7 +40,7 @@ export const OPTIONAL_FILES = {
   applicantBirthCertOrSocialSecCard:
     'Birth Certificate or Social Security Card',
   applicantHelplessCert: 'VBA Rating (Helpless Child)',
-  applicantMarriageCert: 'Proof of Marriage or Legal Union to Sponsor',
+  applicantRemarriageCert: 'Proof of Remarriage or Legal Union, or separation',
   applicantSecondMarriageCert: 'Proof of Marriage or Legal Union to Other',
   applicantSecondMarriageDivorceCert:
     'Proof of Legal Separation from Marriage Or Legal Union to Other',

--- a/src/applications/ivc-champva/10-10D/config/form.js
+++ b/src/applications/ivc-champva/10-10D/config/form.js
@@ -65,11 +65,10 @@ import {
   appMedicareOver65IneligibleConfig,
   applicantOhiCardsConfig,
   applicantOtherInsuranceCertificationConfig,
-  applicantMarriageCertConfig,
   applicantBirthCertUploadUiSchema,
   applicantAdoptedUploadUiSchema,
   applicantStepChildUploadUiSchema,
-  applicantMarriageCertUploadUiSchema,
+  applicantRemarriageCertUploadUiSchema,
   applicantMedicarePartAPartBCardsUploadUiSchema,
   applicantMedicarePartDCardsUploadUiSchema,
   appMedicareOver65IneligibleUploadUiSchema,
@@ -986,17 +985,17 @@ const formConfig = {
               get(
                 'applicantRelationshipToSponsor.relationshipToVeteran',
                 formData?.applicants?.[index],
-              ) === 'spouse'
+              ) === 'spouse' && get('sponsorIsDeceased', formData)
             );
           },
           CustomPage: FileFieldWrapped,
           CustomPageReview: null,
           customPageUsesPagePerItemData: true,
-          uiSchema: applicantMarriageCertUploadUiSchema,
+          uiSchema: applicantRemarriageCertUploadUiSchema,
           schema: applicantListSchema([], {
             titleSchema,
-            ...applicantMarriageCertConfig.schema,
-            applicantMarriageCert: fileWithMetadataSchema(
+            'view:fileUploadBlurb': blankSchema,
+            applicantRemarriageCert: fileWithMetadataSchema(
               acceptableFiles.spouseCert,
             ),
           }),

--- a/src/applications/ivc-champva/10-10D/containers/App.jsx
+++ b/src/applications/ivc-champva/10-10D/containers/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import PropTypes from 'prop-types';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
@@ -6,6 +6,7 @@ import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library
 import { Toggler } from 'platform/utilities/feature-toggles';
 import formConfig from '../config/form';
 import WIP from '../../shared/components/WIP';
+import { addStyleToShadowDomOnPages } from '../../shared/utilities';
 
 const breadcrumbList = [
   { href: '/', label: 'Home' },
@@ -24,6 +25,16 @@ const breadcrumbList = [
 ];
 
 export default function App({ location, children }) {
+  useEffect(() => {
+    // Insert CSS to hide 'For example: January 19 2000' hint on memorable dates
+    // (can't be overridden by passing 'hint' to uiOptions):
+    addStyleToShadowDomOnPages(
+      [''],
+      ['va-memorable-date'],
+      '#dateHint {display: none}',
+    );
+  });
+
   return (
     <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
       <Toggler toggleName={Toggler.TOGGLE_NAMES.form1010d}>

--- a/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/maximal-test.json
@@ -80,7 +80,7 @@
             "uploaded": false
           },
           {
-            "name": "applicantMarriageCert",
+            "name": "applicantRemarriageCert",
             "path": "applicant-marriage-file/:index",
             "required": false,
             "uploaded": false

--- a/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/vet-2a-spouse-child-medabd-ohi.json
+++ b/src/applications/ivc-champva/10-10D/tests/e2e/fixtures/data/vet-2a-spouse-child-medabd-ohi.json
@@ -29,7 +29,7 @@
         },
         "missingUploads": [
           {
-            "name": "applicantMarriageCert",
+            "name": "applicantRemarriageCert",
             "path": "applicant-marriage-file/:index",
             "required": false,
             "uploaded": false


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR changes the applicant/sponsor marriage file upload to only show when sponsor is deceased, and to collect remarriage/separation information.

- Updated content of marriage file upload screen and changed key to `remarriage...`
- Changed conditional flow so this upload screen only shows when sponsor is deceased.
- Added style workaround to hide extra date hint on date fields (waiting on [fix PR](https://github.com/department-of-veterans-affairs/va.gov-team/issues/86478) for removing that hint in the mean time).

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90786

## Testing done

- Manual
- Verified unit and E2E tests pass

## Screenshots

|         | Before | After |
| ------- |  ----- | ----- |
| Upload screen |<img width="500" alt="Screenshot 2024-08-15 at 19 15 56" src="https://github.com/user-attachments/assets/67eb8b40-f0c7-4106-8c0b-6ab10bcb05ba">|<img width="491" alt="Screenshot 2024-08-15 at 18 57 57" src="https://github.com/user-attachments/assets/ca23d95e-a3bd-420d-9da1-321c87039723">|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA