### PR TITLE
Allow devs to get past intro page even if loading

### DIFF
--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -377,6 +377,12 @@ class SaveInProgressIntro extends React.Component {
             message={`Checking to see if you have a saved version of this ${appType} ...`}
           />
           <br />
+          {devOnlyForceShowFormControls && (
+            <>
+              <div>dev only:</div>
+              <div>{this.getFormControls(savedForm)}</div>
+            </>
+          )}
         </div>
       );
     }
@@ -398,7 +404,8 @@ class SaveInProgressIntro extends React.Component {
         {buttonOnly && !login.currentlyLoggedIn && alert}
         {showFormControls && this.getFormControls(savedForm)}
         {!showFormControls &&
-          devOnlyForceShowFormControls && (
+          devOnlyForceShowFormControls &&
+          savedForm && (
             <>
               <div>dev only:</div>
               <div>{this.getFormControls(savedForm)}</div>

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -404,8 +404,7 @@ class SaveInProgressIntro extends React.Component {
         {buttonOnly && !login.currentlyLoggedIn && alert}
         {showFormControls && this.getFormControls(savedForm)}
         {!showFormControls &&
-          devOnlyForceShowFormControls &&
-          savedForm && (
+          devOnlyForceShowFormControls && (
             <>
               <div>dev only:</div>
               <div>{this.getFormControls(savedForm)}</div>


### PR DESCRIPTION
## Summary

- Allow `devOnly.forceShowFormControls` option to work even if the form is loading

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#1564

## Testing done

- Test in the browser

## Screenshots

![image](https://github.com/user-attachments/assets/89a33c1b-4515-4e82-a9e0-6017e0cd8400)

## What areas of the site does it impact?

Helps new forms being developed quickly start working on the form without setting up everything for save in progress

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
