### PR TITLE
Add Reg-Only feature flag to Health Care Application

### DIFF
--- a/src/applications/hca/containers/App.jsx
+++ b/src/applications/hca/containers/App.jsx
@@ -28,6 +28,7 @@ const App = props => {
   const {
     isLoadingFeatureFlags,
     isFacilitiesApiEnabled,
+    isRegOnlyEnabled,
     isSigiEnabled,
   } = useSelector(selectFeatureToggles);
   const { dob: veteranDob } = useSelector(selectProfile);
@@ -66,6 +67,7 @@ const App = props => {
       const defaultViewFields = {
         'view:isLoggedIn': isLoggedIn,
         'view:isSigiEnabled': isSigiEnabled,
+        'view:isRegOnlyEnabled': isRegOnlyEnabled,
         'view:isFacilitiesApiEnabled': isFacilitiesApiEnabled,
         'view:totalDisabilityRating': parseInt(totalRating, 10) || 0,
       };
@@ -90,6 +92,7 @@ const App = props => {
       veteranDob,
       veteranFullName,
       isSigiEnabled,
+      isRegOnlyEnabled,
       isFacilitiesApiEnabled,
       totalRating,
     ],

--- a/src/applications/hca/tests/unit/utils/selectors/feature-toggles.unit.spec.js
+++ b/src/applications/hca/tests/unit/utils/selectors/feature-toggles.unit.spec.js
@@ -6,6 +6,7 @@ describe('hca FeatureToggles selector', () => {
     featureToggles: {
       /* eslint-disable camelcase */
       hca_sigi_enabled: false,
+      hca_reg_only_enabled: true,
       hca_browser_monitoring_enabled: true,
       hca_enrollment_status_override_enabled: false,
       hca_use_facilities_API: false,
@@ -20,6 +21,7 @@ describe('hca FeatureToggles selector', () => {
         isBrowserMonitoringEnabled: true,
         isESOverrideEnabled: false,
         isFacilitiesApiEnabled: false,
+        isRegOnlyEnabled: true,
         isSigiEnabled: false,
       });
     });

--- a/src/applications/hca/utils/selectors/feature-toggles.js
+++ b/src/applications/hca/utils/selectors/feature-toggles.js
@@ -10,6 +10,7 @@ export const selectFeatureToggles = state => {
     isESOverrideEnabled:
       toggles[FEATURE_FLAG_NAMES.hcaEnrollmentStatusOverrideEnabled],
     isFacilitiesApiEnabled: toggles[FEATURE_FLAG_NAMES.hcaUseFacilitiesApi],
+    isRegOnlyEnabled: toggles[FEATURE_FLAG_NAMES.hcaRegOnlyEnabled],
     isSigiEnabled: toggles[FEATURE_FLAG_NAMES.hcaSigiEnabled],
   };
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR adds the Registration Only feature flag status to the form data in the Health Care Application.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#81103

## Acceptance criteria

- Feature flag data is available for use for future conditional logic in the application

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution