### PR TITLE
[CDP] Removing deprecated feature flags

### DIFF
--- a/src/applications/combined-debt-portal/combined/tests/e2e/fixtures/mocks/feature-toggles.json
+++ b/src/applications/combined-debt-portal/combined/tests/e2e/fixtures/mocks/feature-toggles.json
@@ -6,8 +6,7 @@
         "name": "combined_debt_portal_access",
         "value": true
       },
-      { "name": "debt_letters_show_letters_vbms", "value": true },
-      { "name": "show_medical_copays", "value": true }
+      { "name": "debt_letters_show_letters_vbms", "value": true }
     ]
   }
 }

--- a/src/applications/combined-debt-portal/combined/utils/helpers.js
+++ b/src/applications/combined-debt-portal/combined/utils/helpers.js
@@ -49,11 +49,6 @@ export const currency = amount => {
 export const mcpFeatureToggle = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.showMedicalCopays];
 
-export const mcpHTMLStatementToggle = state =>
-  toggleValues(state)[
-    FEATURE_FLAG_NAMES.medicalCopaysHtmlMedicalStatementsViewEnabled
-  ];
-
 export const cdpAccessToggle = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.combinedDebtPortalAccess];
 

--- a/src/applications/combined-debt-portal/combined/utils/helpers.js
+++ b/src/applications/combined-debt-portal/combined/utils/helpers.js
@@ -46,9 +46,6 @@ export const currency = amount => {
   return formatter.format(parseFloat(amount));
 };
 
-export const mcpFeatureToggle = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.showMedicalCopays];
-
 export const cdpAccessToggle = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.combinedDebtPortalAccess];
 

--- a/src/applications/combined-debt-portal/combined/utils/helpers.js
+++ b/src/applications/combined-debt-portal/combined/utils/helpers.js
@@ -24,9 +24,6 @@ export const API_RESPONSES = Object.freeze({
 export const combinedPortalAccess = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.combinedDebtPortalAccess];
 
-export const debtLettersShowLetters = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.debtLettersShowLetters];
-
 export const debtLettersShowLettersVBMS = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.debtLettersShowLettersVBMS];
 

--- a/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersDownload.jsx
+++ b/src/applications/combined-debt-portal/debt-letters/containers/DebtLettersDownload.jsx
@@ -85,7 +85,7 @@ const DebtLettersDownload = () => {
             For medical copay debt, please go to
             <a
               className="vads-u-margin-x--0p5"
-              href="/health-care/pay-copay-bill/"
+              href="/manage-va-debt/summary/copay-balances"
             >
               pay your VA copay bill
             </a>

--- a/src/applications/combined-debt-portal/debt-letters/tests/e2e/debt-alerts.cypress.spec.js
+++ b/src/applications/combined-debt-portal/debt-letters/tests/e2e/debt-alerts.cypress.spec.js
@@ -12,7 +12,6 @@ describe('CDP - VBA Debt Alerts', () => {
     cy.intercept('GET', '/v0/feature_toggles*', {
       data: {
         features: [
-          { name: 'debt_letters_show_letters', value: true },
           { name: 'combined_debt_portal_access', value: true },
           { name: 'debt_letters_show_letters_vbms', value: true },
         ],

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/disabled.json
@@ -99,10 +99,6 @@
         "value": false
       },
       {
-        "name": "debtLettersShowLetters",
-        "value": false
-      },
-      {
         "name": "gibctCh33BenefitRateUpdate",
         "value": false
       },

--- a/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
+++ b/src/applications/static-pages/health-care-manage-benefits/fixtures/feature-toggles/enabled.json
@@ -99,10 +99,6 @@
         "value": true
       },
       {
-        "name": "debtLettersShowLetters",
-        "value": true
-      },
-      {
         "name": "gibctCh33BenefitRateUpdate",
         "value": true
       },

--- a/src/applications/static-pages/medical-copays-cta/components/App/index.js
+++ b/src/applications/static-pages/medical-copays-cta/components/App/index.js
@@ -9,11 +9,7 @@ import ServiceProvidersText, {
   ServiceProvidersTextCreateAcct,
 } from 'platform/user/authentication/components/ServiceProvidersText';
 
-export const App = ({ loggedIn, show, toggleLoginModal }) => {
-  if (!show) {
-    return null;
-  }
-
+export const App = ({ loggedIn, toggleLoginModal }) => {
   return (
     <va-alert status={loggedIn ? 'info' : 'continue'}>
       {/* Title */}
@@ -61,12 +57,10 @@ App.propTypes = {
   toggleLoginModal: PropTypes.func.isRequired,
   // From mapStateToProps.
   loggedIn: PropTypes.bool,
-  show: PropTypes.bool,
 };
 
 const mapStateToProps = state => ({
   loggedIn: state?.user?.login?.currentlyLoggedIn || false,
-  show: state?.featureToggles?.showMedicalCopays,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/applications/static-pages/medical-copays-cta/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/medical-copays-cta/components/App/index.unit.spec.js
@@ -7,12 +7,6 @@ import { Provider } from 'react-redux';
 import { App } from '.';
 
 describe('Medical Copays CTA <App>', () => {
-  it('does not render when feature toggle is falsey', () => {
-    const wrapper = shallow(<App show={false} />);
-    expect(wrapper.type()).to.equal(null);
-    wrapper.unmount();
-  });
-
   it('renders what we expect when unauthenticated', () => {
     const mockStore = {
       getState: () => ({}),

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -116,7 +116,6 @@
   "manageDependents": "dependents_management",
   "mebAutoPopulateRelinquishmentDate": "meb_auto_populate_relinquishment_date",
   "mebExclusionPeriodEnabled": "meb_exclusion_period_enabled",
-  "medicalCopaysHtmlMedicalStatementsViewEnabled": "medical_copays_html_medical_statements_view_enabled",
   "merge1995And5490": "merge_1995_and_5490",
   "mgibVerificationsMaintenance": "mgib_verifications_maintenance",
   "mhvLandingPagePersonalization": "mhv_landing_page_personalization",

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -219,7 +219,6 @@
   "showMebInternationalAddressPrefill": "show_meb_international_address_prefill",
   "showMebLettersMaintenanceAlert": "show_meb_letters_maintenance_alert",
   "showMebServiceHistoryCategorizeDisagreement": "show_meb_service_history_categorize_disagreement",
-  "showMedicalCopays": "show_medical_copays",
   "showNewRefillTrackPrescriptionsPage": "show_new_refill_track_prescriptions_page",
   "showNewScheduleViewAppointmentsPage": "show_new_schedule_view_appointments_page",
   "showPaymentAndDebtSection": "show_payment_and_debt_section",

--- a/src/platform/utilities/feature-toggles/featureFlagNames.json
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.json
@@ -51,7 +51,6 @@
   "cstUseLighthouse#5103": "cst_use_lighthouse_5103",
   "cstUseLighthouse#index": "cst_use_lighthouse_index",
   "cstUseLighthouse#show": "cst_use_lighthouse_show",
-  "debtLettersShowLetters": "debt_letters_show_letters",
   "debtLettersShowLettersVBMS": "debt_letters_show_letters_vbms",
   "dependencyVerification": "dependency_verification",
   "dgiRudisillHideBenefitsSelectionStep": "dgi_rudisill_hide_benefits_selection_step",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)

## Summary
Removing old/unused feature flags from the Combined Debt Portal. Most of these were around prior to the merge from the separate medical copays and debt letters applications. 
### Flags being removed
- `show_medical_copays`
- `debt_letters_show_letters`
- `medical_copays_html_medical_statements_view_enabled`

There will be a corresponding `vets-api` PR to remove references and the feature flags there. 


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#90559
- _Associated vets-api PR_
department-of-veterans-affairs/vets-api/pull/18104

## Testing done
All tests still passing

## Screenshots
N/A

## What areas of the site does it impact?
FSR only
*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
