### PR TITLE
90752 Add PEGA maintenance window wrappers - forms 10-7959c, 10-7959a, 10-7959f-1, 10-7959f-2

### DIFF
--- a/src/applications/ivc-champva/10-7959C/config/form.js
+++ b/src/applications/ivc-champva/10-7959C/config/form.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import { externalServices } from 'platform/monitoring/DowntimeNotification';
 import get from 'platform/utilities/data/get';
 import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
@@ -87,6 +88,9 @@ const formConfig = {
   dev: {
     showNavLinks: false,
     collapsibleNavLinks: true,
+  },
+  downtime: {
+    dependencies: [externalServices.pega],
   },
   preSubmitInfo: {
     required: true,

--- a/src/applications/ivc-champva/10-7959C/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959C/containers/App.jsx
@@ -3,6 +3,10 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import {
+  DowntimeNotification,
+  externalServices,
+} from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
 import { Toggler } from 'platform/utilities/feature-toggles';
 import formConfig from '../config/form';
 import WIP from '../../shared/components/WIP';
@@ -41,7 +45,12 @@ export default function App({ location, children }) {
         <Toggler.Enabled>
           <VaBreadcrumbs breadcrumbList={breadcrumbList} />
           <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-            {children}
+            <DowntimeNotification
+              appTitle={`CHAMPVA Form ${formConfig.formId}`}
+              dependencies={[externalServices.pega]}
+            >
+              {children}
+            </DowntimeNotification>
           </RoutedSavableApp>
         </Toggler.Enabled>
         <Toggler.Disabled>

--- a/src/applications/ivc-champva/10-7959a/config/form.js
+++ b/src/applications/ivc-champva/10-7959a/config/form.js
@@ -1,4 +1,5 @@
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import { externalServices } from 'platform/monitoring/DowntimeNotification';
 import get from '@department-of-veterans-affairs/platform-forms-system/get';
 import GetFormHelp from '../../shared/components/GetFormHelp';
 import manifest from '../manifest.json';
@@ -69,6 +70,9 @@ const formConfig = {
     appType: 'form',
     continueAppButtonText: 'Continue your form',
     startNewAppButtonText: 'Start a new form',
+  },
+  downtime: {
+    dependencies: [externalServices.pega],
   },
   preSubmitInfo: {
     statementOfTruth: {

--- a/src/applications/ivc-champva/10-7959a/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959a/containers/App.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { VaBreadcrumbs } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import {
+  DowntimeNotification,
+  externalServices,
+} from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from '../config/form';
 
@@ -21,7 +25,12 @@ export default function App({ location, children }) {
     <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
       <VaBreadcrumbs breadcrumbList={breadcrumbList} />
       <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-        {children}
+        <DowntimeNotification
+          appTitle={`CHAMPVA Form ${formConfig.formId}`}
+          dependencies={[externalServices.pega]}
+        >
+          {children}
+        </DowntimeNotification>
       </RoutedSavableApp>
     </div>
   );

--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -1,4 +1,5 @@
 import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import { externalServices } from 'platform/monitoring/DowntimeNotification';
 import { cloneDeep } from 'lodash';
 
 import {
@@ -53,6 +54,9 @@ const formConfig = {
   customText: {
     reviewPageTitle: 'Review and sign',
     submitButtonText: 'Submit',
+  },
+  downtime: {
+    dependencies: [externalServices.pega],
   },
   preSubmitInfo: {
     statementOfTruth: {

--- a/src/applications/ivc-champva/10-7959f-1/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/App.jsx
@@ -1,4 +1,8 @@
 import React from 'react';
+import {
+  DowntimeNotification,
+  externalServices,
+} from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
 import PropTypes from 'prop-types';
 import { Toggler } from 'platform/utilities/feature-toggles';
 
@@ -26,7 +30,12 @@ export default function App({ location, children }) {
         <Toggler.Enabled>
           <va-breadcrumbs breadcrumb-list={bcString} />
           <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-            {children}
+            <DowntimeNotification
+              appTitle={`CHAMPVA Form ${formConfig.formId}`}
+              dependencies={[externalServices.pega]}
+            >
+              {children}
+            </DowntimeNotification>
           </RoutedSavableApp>
         </Toggler.Enabled>
         <Toggler.Disabled>

--- a/src/applications/ivc-champva/10-7959f-2/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-2/config/form.js
@@ -1,4 +1,5 @@
 import { cloneDeep } from 'lodash';
+import { externalServices } from 'platform/monitoring/DowntimeNotification';
 
 import {
   ssnOrVaFileNumberSchema,
@@ -54,6 +55,9 @@ const formConfig = {
   },
   version: 0,
   prefillEnabled: true,
+  downtime: {
+    dependencies: [externalServices.pega],
+  },
   savedFormMessages: {
     notFound: 'Please start over to apply for health care benefits.',
     noAuth:

--- a/src/applications/ivc-champva/10-7959f-2/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959f-2/containers/App.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import {
+  DowntimeNotification,
+  externalServices,
+} from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from '../config/form';
 
@@ -20,7 +23,12 @@ export default function App({ location, children }) {
     <>
       <va-breadcrumbs breadcrumb-list={bcString} />
       <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-        {children}
+        <DowntimeNotification
+          appTitle={`CHAMPVA Form ${formConfig.formId}`}
+          dependencies={[externalServices.pega]}
+        >
+          {children}
+        </DowntimeNotification>
       </RoutedSavableApp>
     </>
   );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR adds a downtime warning to IVC CHAMPVA forms. It is part of an ongoing effort to add PEGA maintenance warnings based on a new external PEGA service (see related PRs https://github.com/department-of-veterans-affairs/vets-api/pull/18063 and https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3068).

- Configures IVC CHAMPVA forms to show maintenance warnings on review and intro page when PEGA service has a maintenance window

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90752

## Testing done

- NA - need to be in staging to test this maintenance window (service: `staging: external: pega`)

## Screenshots
NA

## What areas of the site does it impact?

IVC CHAMPVA forms

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA