### PR TITLE
fixed action link not showing on todays appointments and added tests.

### DIFF
--- a/src/applications/check-in/components/UpcomingAppointmentsListItem.jsx
+++ b/src/applications/check-in/components/UpcomingAppointmentsListItem.jsx
@@ -1,5 +1,4 @@
-import React, { useMemo } from 'react';
-import { useSelector } from 'react-redux';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 
@@ -9,7 +8,6 @@ import {
   getAppointmentId,
 } from '../utils/appointment';
 import { APP_NAMES } from '../utils/appConstants';
-import { makeSelectFeatureToggles } from '../utils/selectors/feature-toggles';
 import { useFormRouting } from '../hooks/useFormRouting';
 
 import AppointmentMessage from './AppointmentDisplay/AppointmentMessage';
@@ -17,15 +15,12 @@ import UpcomingAppointmentsListItemAction from './UpcomingAppointmentsListItemAc
 
 const UpcomingAppointmentsListItem = props => {
   const { app, appointment, goToDetails, router, border, count } = props;
-  const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
-  const { isUpcomingAppointmentsEnabled } = useSelector(selectFeatureToggles);
   const { t } = useTranslation();
   const { getCurrentPageFromRouter } = useFormRouting(router);
   const page = getCurrentPageFromRouter();
   const appointmentDateTime = new Date(appointment.startTime);
   const clinic = clinicName(appointment);
   const isCancelled = appointment.status?.includes('CANCELLED');
-
   const appointmentInfo = () => {
     if (appointment?.kind === 'vvc') {
       return <div data-testid="appointment-info-vvc">{t('video')}</div>;
@@ -111,7 +106,7 @@ const UpcomingAppointmentsListItem = props => {
           {t('details')}
         </a>
         {app === APP_NAMES.CHECK_IN &&
-          !isUpcomingAppointmentsEnabled && (
+          page === 'appointments' && (
             <div data-testid="appointment-action">
               <AppointmentMessage appointment={appointment} page={page} />
               <UpcomingAppointmentsListItemAction

--- a/src/applications/check-in/components/tests/UpcomingAppointmentsListItem.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/UpcomingAppointmentsListItem.unit.spec.jsx
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import UpcomingAppointmentsListItem from '../UpcomingAppointmentsListItem';
 import CheckInProvider from '../../tests/unit/utils/CheckInProvider';
 import { setupI18n, teardownI18n } from '../../utils/i18n/i18n';
+import { APP_NAMES } from '../../utils/appConstants';
 
 const appointments = [
   {
@@ -66,10 +67,7 @@ const appointments = [
 ];
 
 const mockRouter = {
-  location: {
-    basename: 'https://localhost:3001/health-care/appointment-check-in',
-  },
-  currentPage: '/health-care/appointment-check-in',
+  currentPage: '/appointments',
 };
 
 describe('unified check-in experience', () => {
@@ -205,6 +203,48 @@ describe('unified check-in experience', () => {
         </CheckInProvider>,
       );
       expect(screen.queryByRole('listitem')).to.not.exist;
+    });
+    it('should render an action link on day-of appointments page', () => {
+      const screen = render(
+        <CheckInProvider router={mockRouter}>
+          <UpcomingAppointmentsListItem
+            app={APP_NAMES.CHECK_IN}
+            appointment={appointments[0]}
+            goToDetails={() => {}}
+            count={1}
+          />
+        </CheckInProvider>,
+      );
+      expect(screen.getByTestId('appointment-action')).to.exist;
+    });
+    it('should not render an action link on pre-check-in appointments page', () => {
+      const screen = render(
+        <CheckInProvider router={mockRouter}>
+          <UpcomingAppointmentsListItem
+            app={APP_NAMES.PRE_CHECK_IN}
+            appointment={appointments[0]}
+            goToDetails={() => {}}
+            count={1}
+          />
+        </CheckInProvider>,
+      );
+      expect(screen.queryByTestId('appointment-action')).to.not.exist;
+    });
+    it('should not render an action link on upcoming appointments page', () => {
+      const upcomingRouter = {
+        currentPage: '/upcoming-appointments',
+      };
+      const screen = render(
+        <CheckInProvider router={upcomingRouter}>
+          <UpcomingAppointmentsListItem
+            app={APP_NAMES.CHECK_IN}
+            appointment={appointments[0]}
+            goToDetails={() => {}}
+            count={1}
+          />
+        </CheckInProvider>,
+      );
+      expect(screen.queryByTestId('appointment-action')).to.not.exist;
     });
   });
 });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Allows the action link to show in `<UpcomingAppointmentsListItem>` on day-of Today's appointments section, but not the upcoming-appointments page.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#90985

## Testing done

Added additional unit tests

## Screenshots

![localhost_3001_health-care_appointment-check-in_upcoming-appointments](https://github.com/user-attachments/assets/23b58b38-0c28-4c4c-8825-d5bef6345303)

## What areas of the site does it impact?

day-of check-in

## Acceptance criteria
 - [ ] action link shows on eligible appointments in the "Today’s appointments at this facility" section
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

