### PR TITLE
DR | Fix breadcrumb horizontal padding on narrow screens

### DIFF
--- a/src/applications/appeals/shared/components/Breadcrumbs.jsx
+++ b/src/applications/appeals/shared/components/Breadcrumbs.jsx
@@ -34,6 +34,7 @@ export const wrapWithBreadcrumb = (id, component) => (
   <>
     <div className="row">
       <VaBreadcrumbs
+        class="va-nav-breadcrumbs"
         wrapping
         label="Breadcrumb"
         breadcrumbList={[


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Adding a "va-nav-breadcrumbs" class to the `va-breadcrumb` web component fixes the horizontal padding issues seen on narrow screens
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > The `.va-nav-breadcrumbs` class is already defined in media queries inside the `shame.scss` file
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/90568

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Narrow screen | <img width="500" alt="browser width at 465px with no padding" src="https://github.com/user-attachments/assets/616880f8-9872-4c69-a8e1-dde513947d63"> | <img width="500" alt="browser width at 465px with some padding" src="https://github.com/user-attachments/assets/b9654f15-83be-494b-b14b-8d128b9fe46d"> |
| Mid-sized | <img width="663" alt="browser width at 600px with no padding" src="https://github.com/user-attachments/assets/c24819b2-8923-4a18-b150-f4a29e7ef297"> | <img width="645" alt="browser width at 600px with some padding" src="https://github.com/user-attachments/assets/1f122a2f-fc3b-44ef-b2fb-a386271176df"> |
| Wider sized | <img width="849" alt="browser width at 790px with no padding" src="https://github.com/user-attachments/assets/8a60fd26-0db7-4a47-9a4f-8ebfbbcef790"> | <img width="836" alt="browser width at 790px with some padding" src="https://github.com/user-attachments/assets/2da28103-a1c7-456e-9e0d-8cc6a53001ad"> |

## What areas of the site does it impact?

All Decision Reviews apps

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
