### PR TITLE
Move need to make changes section of video appointments

### DIFF
--- a/src/applications/vaos/components/layout/VideoLayout.jsx
+++ b/src/applications/vaos/components/layout/VideoLayout.jsx
@@ -90,6 +90,55 @@ export default function VideoLayout({ data: appointment }) {
       <What>{typeOfCareName}</What>
 
       <Who>{videoProviderName}</Who>
+
+      {((APPOINTMENT_STATUS.booked === status && isPastAppointment) ||
+        isCanceledAppointment) && (
+        <Section heading="Scheduling facility">
+          {!!facility && (
+            <>
+              {facility.name}
+              <br />
+              <span>
+                {address.city}, <State state={address.state} />
+              </span>
+            </>
+          )}
+          <br />
+          {clinicName ? `Clinic: ${clinicName}` : 'Clinic not available'}
+          <br />
+          <ClinicOrFacilityPhone
+            clinicPhone={clinicPhone}
+            clinicPhoneExtension={clinicPhoneExtension}
+            facilityPhone={facilityPhone}
+          />
+        </Section>
+      )}
+
+      {featureMedReviewInstructions &&
+        !isPastAppointment &&
+        (APPOINTMENT_STATUS.booked === status ||
+          APPOINTMENT_STATUS.cancelled === status) && (
+          <Prepare>
+            <ul className="vads-u-margin-top--0">
+              <li>
+                Bring your insurance cards, a list of medications, and other
+                things to share with your provider
+                <br />
+                <a
+                  target="_self"
+                  href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"
+                >
+                  Find out what to bring to your appointment
+                </a>
+              </li>
+              <li>
+                Get your device ready to join.
+                <VideoInstructions />
+              </li>
+            </ul>
+          </Prepare>
+        )}
+
       {APPOINTMENT_STATUS.booked === status &&
         !isPastAppointment && (
           <Section heading="Need to make changes?">
@@ -117,52 +166,6 @@ export default function VideoLayout({ data: appointment }) {
               facilityPhone={facilityPhone}
             />
           </Section>
-        )}
-      {((APPOINTMENT_STATUS.booked === status && isPastAppointment) ||
-        isCanceledAppointment) && (
-        <Section heading="Scheduling facility">
-          {!!facility && (
-            <>
-              {facility.name}
-              <br />
-              <span>
-                {address.city}, <State state={address.state} />
-              </span>
-            </>
-          )}
-          <br />
-          {clinicName ? `Clinic: ${clinicName}` : 'Clinic not available'}
-          <br />
-          <ClinicOrFacilityPhone
-            clinicPhone={clinicPhone}
-            clinicPhoneExtension={clinicPhoneExtension}
-            facilityPhone={facilityPhone}
-          />
-        </Section>
-      )}
-      {featureMedReviewInstructions &&
-        !isPastAppointment &&
-        (APPOINTMENT_STATUS.booked === status ||
-          APPOINTMENT_STATUS.cancelled === status) && (
-          <Prepare>
-            <ul className="vads-u-margin-top--0">
-              <li>
-                Bring your insurance cards, a list of medications, and other
-                things to share with your provider
-                <br />
-                <a
-                  target="_self"
-                  href="https://www.va.gov/resources/what-should-i-bring-to-my-health-care-appointments/"
-                >
-                  Find out what to bring to your appointment
-                </a>
-              </li>
-              <li>
-                Get your device ready to join.
-                <VideoInstructions />
-              </li>
-            </ul>
-          </Prepare>
         )}
     </DetailPageLayout>
   );


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- We need to move the "need to make changes" section to the bottom of the details page for video appointments.
- Appointments (VAOS) team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/91036

## Testing done

- Visual inspection

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |     <img width="288" alt="image" src="https://github.com/user-attachments/assets/4a1a0b2e-5b89-426c-bf06-b7eaea3f45fe">   |   <img width="287" alt="image" src="https://github.com/user-attachments/assets/871c2cf6-6863-45cf-b734-83cfe52fb55b">    |
| Desktop |     <img width="690" alt="image" src="https://github.com/user-attachments/assets/924fb77f-f454-4666-810c-f17a5e8534cb">   |   <img width="683" alt="image" src="https://github.com/user-attachments/assets/cb88035e-f8c6-4a83-bc57-9a4133370ebe">    |

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
