### PR TITLE
Remove the flipper code and update the default route.

### DIFF
--- a/src/applications/pensions/PensionsApp.jsx
+++ b/src/applications/pensions/PensionsApp.jsx
@@ -7,7 +7,6 @@ import { useFeatureToggle } from 'platform/utilities/feature-toggles';
 import formConfig from './config/form';
 import { NoFormPage } from './components/NoFormPage';
 import { useBrowserMonitoring } from './hooks/useBrowserMonitoring';
-import { submit } from './config/submit';
 
 export default function PensionEntry({ location, children }) {
   const { useToggleValue, TOGGLE_NAMES } = useFeatureToggle();
@@ -23,9 +22,6 @@ export default function PensionEntry({ location, children }) {
   );
   const pensionDocumentUploadUpdate = useToggleValue(
     TOGGLE_NAMES.pensionDocumentUploadUpdate,
-  );
-  const pensionModuleEnabled = useToggleValue(
-    TOGGLE_NAMES.pensionModuleEnabled,
   );
   const isLoadingFeatures = useSelector(
     state => state?.featureToggles?.loading,
@@ -68,15 +64,6 @@ export default function PensionEntry({ location, children }) {
       pensionMedicalEvidenceClarification,
       pensionDocumentUploadUpdate,
     ],
-  );
-
-  useEffect(
-    () => {
-      if (pensionModuleEnabled) {
-        formConfig.submit = (f, fc) => submit(f, fc, '/pensions/v0/claims');
-      }
-    },
-    [pensionModuleEnabled],
   );
 
   if (isLoadingFeatures !== false || redirectToHowToPage) {

--- a/src/applications/pensions/config/submit.js
+++ b/src/applications/pensions/config/submit.js
@@ -36,7 +36,7 @@ export function transform(formConfig, form) {
   });
 }
 
-export function submit(form, formConfig, apiPath = '/v0/pension_claims') {
+export function submit(form, formConfig, apiPath = '/pensions/v0/claims') {
   const headers = { 'Content-Type': 'application/json' };
   const body = transform(formConfig, form);
 

--- a/src/applications/pensions/tests/e2e/cypress.setup.js
+++ b/src/applications/pensions/tests/e2e/cypress.setup.js
@@ -7,7 +7,7 @@ import mockVamc from '../fixtures/mocks/vamc-ehr.json';
 const TEST_URL =
   '/pension/apply-for-veteran-pension-form-21p-527ez/introduction';
 const IN_PROGRESS_URL = '/v0/in_progress_forms/21P-527EZ';
-const PENSIONS_CLAIMS_URL = '/v0/pension_claims';
+const PENSIONS_CLAIMS_URL = '/pensions/v0/claims';
 const SUBMISSION_DATE = new Date().toISOString();
 
 const SUBMISSION_CONFIRMATION_NUMBER = '01e77e8d-79bf-4991-a899-4e2defff11e0';


### PR DESCRIPTION

- Remove the flipper module code
- Update the route to the new pension module default
- Update unit tests to use this new route and behavior.

When we are ready to remove flipper flag, we should shut it down in the front end by merging this PR first