### PR TITLE
Fix heading for accessibility

### DIFF
--- a/src/applications/vaos/components/VideoLink.jsx
+++ b/src/applications/vaos/components/VideoLink.jsx
@@ -38,9 +38,9 @@ export default function VideoLink({ appointment }) {
               status="error"
               visible
             >
-              <h2 slot="headline">
+              <h3 slot="headline">
                 We're sorry, we couldn't load the link to join your appointment
-              </h2>
+              </h3>
               <p className="vads-u-margin-y--0">
                 Please contact your facility for help joining this appointment.
               </p>

--- a/src/applications/vaos/components/tests/VideoLink.unit.spec.js
+++ b/src/applications/vaos/components/tests/VideoLink.unit.spec.js
@@ -126,7 +126,7 @@ describe('VAOS Component: VideoLink', () => {
     expect(screen.queryByText('Join appointment')).not.to.exist;
     expect(
       screen.queryByRole('heading', {
-        level: 2,
+        level: 3,
         name: /We're sorry, we couldn't load the link to join your appointment/,
       }),
     ).to.exist;


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


## Summary

This PR fixes the alert message heading from h2 to h3 for accessibility.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#90713


## Testing done

n/a

## Acceptance criteria

- [ ] Change default heading from h2 to h3 on the alert message

## Screenshots


![Screenshot 2024-08-20 at 10 10 25 AM](https://github.com/user-attachments/assets/282c43f5-99d5-4bd1-95e5-f02aaa95c176)


## What areas of the site does it impact?
Accessibility

*(Describe what parts of the site are impacted **if** code touched other areas)*


### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

