### PR TITLE
switch the order of Go back to edit and Update button

### DIFF
--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -145,7 +145,7 @@ class AddressValidationView extends React.Component {
       confirmedSuggestions,
     } = this.props;
 
-    let buttonText = 'Update';
+    let buttonText = 'Use this address';
 
     if (confirmedSuggestions.length === 0 && validationKey) {
       buttonText = 'Use this address';
@@ -173,7 +173,7 @@ class AddressValidationView extends React.Component {
     return (
       <LoadingButton
         isLoading={isLoading}
-        className="usa-button-primary"
+        className="usa-button-secondary"
         data-testid="confirm-address-button"
         aria-label={isLoading ? 'Loading' : buttonText}
       >
@@ -300,15 +300,16 @@ class AddressValidationView extends React.Component {
             </div>
           )}
 
-          {this.renderPrimaryButton()}
-
-          {!isLoading && (
-            <va-button
-              secondary
-              onClick={this.onEditClick}
-              text="Go back to edit"
-            />
-          )}
+          <div className="vads-u-display--flex small-screen:vads-u-display--block vads-u-flex-direction--column">
+            {!isLoading && (
+              <va-button
+                primary
+                onClick={this.onEditClick}
+                text="Go back to edit"
+              />
+            )}
+            {this.renderPrimaryButton()}
+          </div>
         </form>
       </>
     );

--- a/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vap-svc/containers/AddressValidationView.jsx
@@ -160,13 +160,7 @@ class AddressValidationView extends React.Component {
       (!confirmedSuggestions.length && !validationKey)
     ) {
       return (
-        <button
-          type="button"
-          className="usa-button-primary"
-          onClick={this.onEditClick}
-        >
-          Edit Address
-        </button>
+        <va-button primary onClick={this.onEditClick} text="Edit Address" />
       );
     }
 
@@ -214,6 +208,7 @@ class AddressValidationView extends React.Component {
               checked={selectedAddressId === id}
             />
           )}
+        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
         <label
           htmlFor={id}
           className="vads-u-margin-top--2 vads-u-display--flex vads-u-align-items--center"
@@ -382,8 +377,12 @@ AddressValidationView.propTypes = {
       addressPou: PropTypes.string.isRequired,
     }),
   ),
+  isLoading: PropTypes.bool,
+  refreshTransaction: PropTypes.func,
   selectedAddress: PropTypes.object,
   selectedAddressId: PropTypes.string,
+  transaction: PropTypes.string,
+  transactionRequest: PropTypes.object,
   userHasBadAddress: PropTypes.bool,
   validationKey: PropTypes.number,
 };

--- a/src/platform/user/profile/vap-svc/tests/containers/AddressValidationView.unit.spec.jsx
+++ b/src/platform/user/profile/vap-svc/tests/containers/AddressValidationView.unit.spec.jsx
@@ -83,7 +83,7 @@ describe('<AddressValidationView/>', () => {
     const component = enzyme.mount(<AddressValidationView store={fakeStore} />);
 
     expect(component.find('LoadingButton').text()).to.equal('Use this address');
-    expect(component.find('va-button[secondary]').props().text).to.equal(
+    expect(component.find('va-button[primary]').props().text).to.equal(
       'Go back to edit',
     );
     component.unmount();
@@ -126,12 +126,18 @@ describe('<AddressValidationView/>', () => {
       <AddressValidationView store={newFakeStore} />,
     );
 
-    expect(component.find('.usa-button-primary').text()).to.equal(
-      'Edit Address',
-    );
-    expect(component.find('va-button[secondary]').props().text).to.equal(
-      'Go back to edit',
-    );
+    expect(
+      component
+        .find('va-button[primary]')
+        .at(0)
+        .prop('text'),
+    ).to.equal('Go back to edit');
+    expect(
+      component
+        .find('va-button[primary]')
+        .at(1)
+        .prop('text'),
+    ).to.equal('Edit Address');
     component.unmount();
   });
 
@@ -270,8 +276,8 @@ describe('<AddressValidationView/>', () => {
       <AddressValidationView store={newFakeStore} />,
     );
 
-    expect(component.find('LoadingButton').text()).to.equal('Update');
-    expect(component.find('va-button[secondary]').props().text).to.equal(
+    expect(component.find('LoadingButton').text()).to.equal('Use this address');
+    expect(component.find('va-button[primary]').props().text).to.equal(
       'Go back to edit',
     );
     component.unmount();
@@ -361,7 +367,7 @@ describe('<AddressValidationView/>', () => {
     expect(component.find('LoadingButton').text()).to.equal(
       'Use suggested address',
     );
-    expect(component.find('va-button[secondary]').props().text).to.equal(
+    expect(component.find('va-button[primary]').props().text).to.equal(
       'Go back to edit',
     );
     component.unmount();


### PR DESCRIPTION
### Summary of Changes

- On the "Contact Information" page, within the Address group, there are two sections: **Mailing** and **Home**. When a user clicks the edit button for either section and then saves their changes, the **"Go back to edit"** button does not take up the full width of the container when the screen size is 481px or smaller (mobile size). Additionally, after the user saves, the button label, which previously read **Update**, should now say **Use this address**. The order of the buttons has also been updated: **Use this address** should be on the right side, and **Go back to edit** should be on the left side. This behavior causes a visual inconsistency and affects the user experience on smaller devices.


## Steps to Reproduce:
1. Navigate to the **Contact Information** page.
2. Locate the **Address** group, which contains the **Mailing** and **Home** sections.
3. Click the **Edit** button on either the **Mailing** or **Home** section.
4. Make any changes in the edit form.
5. Save the changes.
6. After saving, observe that the address the user entered is displayed, and there may be a suggested address displayed as well.
7. Underneath the displayed address(es), note the **Update** button and the **Go back to edit** button.
8. As per the new design changes:
   - The **Update** button label has been changed to **Use this address**.
   - The button order has been switched so that **Use this address** is on the right side, and **Go back to edit** is on the left side.


## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#89516
department-of-veterans-affairs/va.gov-team#91076


## Expected Result:
- The **"Go back to edit"** button should take up the full width of the container on screen sizes smaller than 481px
- The button label should be **Use this address** instead of **Update**
- The button order should place **Use this address** on the right side and **Go back to edit** on the left side

## Actual Result:
- The **"Go back to edit"** button does not take up the full width of the container on screen sizes 481px or smaller
- The button label still displays as **Update**
- The button order remains unchanged

## Acceptance Criteria:
- [x] The **"Go back to edit"** button should take up the full width of the container when viewed on screen sizes 481px or smaller (mobile size)
- [x] The styling should remain consistent with the rest of the page, ensuring that the button reverts to its default styling on screen sizes larger than 481px
- [x] The button label should be updated to **Use this address** instead of **Update**
- [x] The button order should be switched, with **Use this address** on the right and **Go back to edit** on the left

## Testing Done:
- I have run the application locally and followed the steps to reproduce to verify the changes

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Desktop | ![desktop-before](https://github.com/user-attachments/assets/1ad7245a-181f-43c1-a673-4cb1ca584d6f) | ![desktop-after](https://github.com/user-attachments/assets/9302d29b-acf2-42d0-851c-e74014d3dd36) | 
Mobile  | ![mobile-before](https://github.com/user-attachments/assets/0ae1393b-8cc8-4046-8c18-ea9b680af064) | ![mobile-after](https://github.com/user-attachments/assets/7dea1870-4a31-431f-8e21-0e63df6f5b78) | 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

