### PR TITLE
Update yeoman generator to 3.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@bahmutov/cypress-esbuild-preprocessor": "^2.2.0",
     "@cypress/code-coverage": "^3.11.0",
     "@department-of-veterans-affairs/eslint-plugin": "^1.18.2",
-    "@department-of-veterans-affairs/generator-vets-website": "^3.9.2",
+    "@department-of-veterans-affairs/generator-vets-website": "^3.10.0",
     "@octokit/rest": "^18.11.0",
     "@sentry/browser": "^6.13.2",
     "@testing-library/dom": "^7.26.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2910,10 +2910,10 @@
     element-closest "^3.0.1"
     foundation-sites "5"
 
-"@department-of-veterans-affairs/generator-vets-website@^3.9.2":
-  version "3.9.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/generator-vets-website/-/generator-vets-website-3.9.2.tgz#c6a094a89f3f5c322db8fdc55a49b89ed554c800"
-  integrity sha512-+n1bZuDcTPGlx4ua9NFtpg314uyvLarmbcnFN0Sssij+STTLkyAInFUsO5YKO1vi7onf9ILCl35aEO4aJylnKg==
+"@department-of-veterans-affairs/generator-vets-website@^3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/generator-vets-website/-/generator-vets-website-3.10.0.tgz#1a720e22b9250a7691c42d4f2fddebdd48452577"
+  integrity sha512-6+uOjLzCDfgMpEccwbeQ4E9vf8tJ7KebDGHvQ65jV3I9Or+Mor2EJUpDNz85szQfGqvlD+x8xeTRdF0oU1xMow==
   dependencies:
     chalk "^4.1.2"
     yeoman-generator "^5.6.1"


### PR DESCRIPTION
## Summary

- Update yeoman generator to 3.10.0
- New version asks different prompt, instead of blank simple and complex, we have 1 page, or 4 page starters

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#1567
https://github.com/department-of-veterans-affairs/generator-vets-website/pull/417

## Testing done

- Tested both paths

## Screenshots

See https://github.com/department-of-veterans-affairs/generator-vets-website/pull/417

## What areas of the site does it impact?

`yarn new:app`

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
