### PR TITLE
Array Builder Summary Page Title UI

### DIFF
--- a/src/applications/pensions/components/ArrayTitle.jsx
+++ b/src/applications/pensions/components/ArrayTitle.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ArrayTitle = ({ title }) => (
+  <h3 className="vads-u-color--gray-dark vads-u-margin-top--0">{title}</h3>
+);
+
+ArrayTitle.propTypes = {
+  title: PropTypes.string.isRequired,
+};
+
+export default ArrayTitle;

--- a/src/applications/pensions/config/chapters/02-military-history/otherNamesPages.js
+++ b/src/applications/pensions/config/chapters/02-military-history/otherNamesPages.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   arrayBuilderItemFirstPageTitleUI,
   arrayBuilderYesNoSchema,
@@ -7,6 +8,7 @@ import {
 } from '~/platform/forms-system/src/js/web-component-patterns';
 
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
+import ArrayTitle from '../../../components/ArrayTitle';
 import { formatFullName, showMultiplePageResponse } from '../../../helpers';
 
 /** @type {ArrayBuilderOptions} */
@@ -14,6 +16,7 @@ const options = {
   arrayPath: 'previousNames',
   nounSingular: 'previous name',
   nounPlural: 'previous names',
+  customSummaryPageHeader: <ArrayTitle title="Other service names" />,
   required: false,
   isItemIncomplete: item =>
     !item?.previousFullName?.first || !item.previousFullName?.last, // include all required fields here
@@ -33,6 +36,7 @@ const summaryPage = {
       options,
       {
         title: 'Did you serve under another name?',
+        labelHeaderLevel: ' ',
         hint: null,
         labels: {
           Y: 'Yes, I have a previous name to report',

--- a/src/applications/pensions/config/chapters/04-household-information/dependentChildrenPages.js
+++ b/src/applications/pensions/config/chapters/04-household-information/dependentChildrenPages.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import merge from 'lodash/merge';
 import get from 'platform/utilities/data/get';
 
@@ -25,6 +26,7 @@ import {
 } from 'platform/forms-system/src/js/web-component-fields';
 import currencyUI from 'platform/forms-system/src/js/definitions/currency';
 import { arrayBuilderPages } from '~/platform/forms-system/src/js/patterns/array-builder';
+import ArrayTitle from '../../../components/ArrayTitle';
 import {
   DisabilityDocsAlert,
   SchoolAttendanceAlert,
@@ -42,6 +44,7 @@ const options = {
   arrayPath: 'dependents',
   nounSingular: 'dependent child',
   nounPlural: 'dependent children',
+  customSummaryPageHeader: <ArrayTitle title="Dependent children" />,
   required: false,
   isItemIncomplete: item =>
     !item?.fullName ||
@@ -77,6 +80,7 @@ const summaryPage = {
   uiSchema: {
     'view:isAddingDependents': arrayBuilderYesNoUI(options, {
       title: 'Do you have any dependent children?',
+      labelHeaderLevel: ' ',
       hint: null,
     }),
   },

--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -71,6 +71,8 @@ function getYesNoReviewErrorMessage(reviewErrors, hasItemsKey) {
  *   nounSingular: string,
  *   required: (formData) => boolean,
  *   titleHeaderLevel: string,
+ *   customSummaryPageHeader: string | React.node,
+ *   customSummaryPageDescription: string | React.node,
  * }} props
  * @returns {CustomPageType}
  */
@@ -87,6 +89,8 @@ export default function ArrayBuilderSummaryPage({
   nounSingular,
   required,
   titleHeaderLevel = '3',
+  customSummaryPageHeader,
+  customSummaryPageDescription,
 }) {
   /** @type {CustomPageType} */
   function CustomPage(props) {
@@ -111,6 +115,8 @@ export default function ArrayBuilderSummaryPage({
     const reviewErrorAlertRef = useRef(null);
     const { uiSchema, schema } = props;
     const Heading = `h${titleHeaderLevel}`;
+    const customHeader = customSummaryPageHeader;
+    const customDescription = customSummaryPageDescription;
     const isMaxItemsReached = arrayData?.length >= maxItems;
     const hasReviewError =
       isReviewPage && checkHasYesNoReviewError(props.reviewErrors, hasItemsKey);
@@ -431,8 +437,8 @@ export default function ArrayBuilderSummaryPage({
       // ensure new reference to trigger re-render
       uiSchema['ui:description'] = <Cards />;
     } else {
-      uiSchema['ui:title'] = undefined;
-      uiSchema['ui:description'] = undefined;
+      uiSchema['ui:title'] = customHeader || undefined;
+      uiSchema['ui:description'] = customDescription || undefined;
     }
 
     if (schema?.properties && maxItems && arrayData?.length >= maxItems) {
@@ -488,6 +494,14 @@ export default function ArrayBuilderSummaryPage({
     setData: PropTypes.func, // available regardless of review page or not
     setFormData: PropTypes.func, // not available on review page
     title: PropTypes.string,
+    customSummaryPageHeader: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element,
+    ]),
+    customSummaryPageDescription: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element,
+    ]),
     trackingPrefix: PropTypes.string,
   };
 

--- a/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/arrayBuilder.jsx
@@ -233,6 +233,8 @@ export function arrayBuilderPages(options, pageBuilderCallback) {
     text: userText = {},
     reviewPath = 'review-and-submit',
     required: userRequired,
+    customSummaryPageHeader,
+    customSummaryPageDescription,
   } = options;
 
   const getItemName = assignGetItemName(options);
@@ -401,6 +403,8 @@ export function arrayBuilderPages(options, pageBuilderCallback) {
       nounPlural,
       nounSingular,
       required,
+      customSummaryPageHeader,
+      customSummaryPageDescription,
     };
 
     return {

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.js
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.js
@@ -101,6 +101,8 @@ describe('ArrayBuilderSummaryPage', () => {
     urlParams = '',
     arrayData = [],
     title = 'Name and address of employer',
+    customSummaryPageHeader,
+    customSummaryPageDescription,
     required = () => false,
     maxItems = 5,
     isReviewPage = false,
@@ -151,6 +153,8 @@ describe('ArrayBuilderSummaryPage', () => {
       maxItems,
       nounPlural: 'employers',
       nounSingular: 'employer',
+      customSummaryPageHeader,
+      customSummaryPageDescription,
       required,
       summaryRoute: '/summary',
       introRoute: '/intro',
@@ -313,5 +317,40 @@ describe('ArrayBuilderSummaryPage', () => {
       'va-alert[name="employersReviewError"]',
     );
     expect($errorAlert).to.not.exist;
+  });
+
+  it('should display custom header and description when it is not the review page', () => {
+    const { container } = setupArrayBuilderSummaryPage({
+      title: 'Review your employers',
+      customSummaryPageHeader: 'Custom header text',
+      customSummaryPageDescription: 'Custom description text',
+      arrayData: [],
+      urlParams: '',
+      maxItems: 5,
+    });
+
+    const $fieldset = container.querySelector('fieldset');
+    expect($fieldset).to.exist;
+    const $legend = $fieldset.querySelector('legend');
+    expect($legend).to.exist;
+    expect($legend).to.include.text('Custom header text');
+    const description = $fieldset.querySelector('p');
+    expect(description).to.exist;
+    expect(description).to.include.text('Custom description text');
+  });
+
+  it('should not display custom header and description on the review page', () => {
+    const { container } = setupArrayBuilderSummaryPage({
+      title: 'Review your employers',
+      customSummaryPageHeader: 'Custom header text',
+      customSummaryPageDescription: 'Custom description text',
+      arrayData: [],
+      urlParams: '',
+      isReviewPage: true,
+      maxItems: 5,
+    });
+
+    const $fieldset = container.querySelector('fieldset');
+    expect($fieldset).not.to.exist;
   });
 });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes

## Summary
The [Array Builder Pattern(Multiple responses list & loop)](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/forms-system/src/js/patterns/array-builder/README.md) pattern summary page has dynamic titles based on the number of items. The title text is customizable for summary page as an 'intro' page and a 'review' page after an item is added. Some implementations may want to include a custom page title(h1-h5), description(with string or JSX) and the yes/no question with a default label. For example, the Pension Benefits form would like to implement the summary 'intro' page with a custom page title and description.

## Issue
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89286

## Associated Vets-api PR
n/a

## How to run in local environment
1. Check out this branch locally
2. Run `vets-website` and `vets-api`
3. Go to a vets-website page with an array builder summary page in your browser

## How to verify
1. Verify that a 'customSummaryPageHeader' can be passed into the `ArrayBuilderOptions`
2. Verify that a 'customSummaryPageDescription' can be passed into the `ArrayBuilderOptions`
3. Verify axe dev tools accessibility audit is passing

## What areas of the site does it impact?
Array Builder Pattern (Multiple responses list & loop)

## Screenshots
### Pensions Other Service Names Array Builder Summary Page
| Before | After |
| ------ | ----- |
|![localhost_3001_pension_apply-for-veteran-pension-form-21p-527ez_military_other-names_summary](https://github.com/user-attachments/assets/56127806-7af6-47cb-a351-ab34c4bdea8f)|![localhost_3001_pension_apply-for-veteran-pension-form-21p-527ez_military_other-names_summary (1)](https://github.com/user-attachments/assets/b4c280a8-ca37-421e-89e3-95e889ac93a3)

### Pensions Dependent Children Array Builder Summary Page
| Before | After |
| ------ | ----- |
|![localhost_3001_pension_apply-for-veteran-pension-form-21p-527ez_household_dependents_summary](https://github.com/user-attachments/assets/00ed8912-fe36-447e-b50b-174e96997b24)|![localhost_3001_pension_apply-for-veteran-pension-form-21p-527ez_household_dependents_summary (1)](https://github.com/user-attachments/assets/ba8c6ce8-e516-47de-b9ce-c9c9a8b75320)

### Quality Assurance & Testing
- [x] Existing unit tests and integration tests are passing
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling
- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
