### PR TITLE
VEBT-418 / VEBT-421 VA-approved hyphen and "Call us" section links

### DIFF
--- a/src/applications/sco/components/HubRail/AskQuestions/callUs.jsx
+++ b/src/applications/sco/components/HubRail/AskQuestions/callUs.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+
 import LiVaLinkAndVaTelephone from '../shared/liVaLinkAndVaTelephone';
 
 const CallUs = () => {
@@ -7,24 +9,23 @@ const CallUs = () => {
       <h4>Call us</h4>
       <ul className="va-nav-linkslist-list social">
         <LiVaLinkAndVaTelephone
-          phoneNumber="888-442-4551"
+          phoneNumber={CONTACTS.GI_BILL}
           text="VA Education Call Center:"
         />
         <LiVaLinkAndVaTelephone
-          phoneNumber="918-781-5678"
+          phoneNumber="9187815678"
           text="Outside the U.S.:"
           isInternational
         />
         <LiVaLinkAndVaTelephone
-          phoneNumber="800-698-2411"
+          phoneNumber={CONTACTS.VA_411}
           text="MyVA411 for main information line:"
         />
-        <li className="vads-u-margin-bottom--2 vads-u-margin-top--0">
-          <va-link href="tel:711" text="Telecommunications Relay Services" />
-
-          <br />
-          <va-telephone contact="+1TTY: 711"> TTY: 711 </va-telephone>
-        </li>
+        <LiVaLinkAndVaTelephone
+          phoneNumber={CONTACTS['711']}
+          text="Telecommunications Relay Services"
+          isTty
+        />
       </ul>
     </section>
   );

--- a/src/applications/sco/components/HubRail/shared/liVaLinkAndVaTelephone.jsx
+++ b/src/applications/sco/components/HubRail/shared/liVaLinkAndVaTelephone.jsx
@@ -5,11 +5,16 @@ const LiVaLinkAndVaTelephone = ({
   phoneNumber,
   text,
   isInternational = false,
+  isTty = false,
 }) => (
   <li className="vads-u-margin-bottom--2 vads-u-margin-top--0">
-    <va-link href={`tel:${phoneNumber}`} text={text} />
+    {text}
     <br />
-    <va-telephone contact={phoneNumber} international={isInternational} />
+    <va-telephone
+      contact={phoneNumber}
+      international={isInternational}
+      tty={isTty}
+    />
   </li>
 );
 
@@ -17,6 +22,7 @@ LiVaLinkAndVaTelephone.propTypes = {
   phoneNumber: PropTypes.string.isRequired,
   text: PropTypes.string.isRequired,
   isInternational: PropTypes.bool,
+  isTty: PropTypes.bool,
 };
 
 export default LiVaLinkAndVaTelephone;

--- a/src/applications/sco/components/MainContent/Update/OtherResources.jsx
+++ b/src/applications/sco/components/MainContent/Update/OtherResources.jsx
@@ -188,7 +188,7 @@ const OtherResources = () => {
         <LiSpanAndVaLinkAndPTag
           href="https://www.va.gov/education/gi-bill-comparison-tool/"
           hrefText="GI Bill Comparison Tool"
-          pText="Compare and calculate GI Bill benefits at VA approved schools."
+          pText="Compare and calculate GI Bill benefits at VA-approved schools."
         />
         <LiSpanAndVaLinkAndPTag
           href="https://www.va.gov/education/benefit-rates/"

--- a/src/applications/sco/tests/accessibility.cypress.spec.js
+++ b/src/applications/sco/tests/accessibility.cypress.spec.js
@@ -157,10 +157,6 @@ describe('Accessibility', () => {
     cy.realPress('Tab');
     cy.realPress('Tab');
     cy.realPress('Tab');
-    cy.realPress('Tab');
-    cy.realPress('Tab');
-    cy.realPress('Tab');
-    cy.realPress('Tab');
     // Tab to 'Connect with us' section
     cy.realPress('Tab');
     cy.focused().should('contain.text', 'Connect with us');


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary
- Slight wording change to _"Compare and calculate GI Bill Benefits at VA-approved schools"_ sentence
- _"Call us"_ section links updated to only have links on `va-telephone` component

## Related issue(s)
- https://jira.devops.va.gov/browse/VEBT-418
- https://jira.devops.va.gov/browse/VEBT-421

### VEBT-418

**Problem**

The links under the Call Us section display both the name of the entity that can be called, and its phone number. For each entity, both the name of the entity and the phone number are separate links to the same phone number. Some are using the va-telephone component, some are not.

**Recommended Solution**

Provide only one phone number link for each entity, and ensure that it uses the [va-telephone](https://design.va.gov/components/telephone) component. I recommend displaying the organization name as plain text and linking the digits of the phone number.

**Acceptance Criteria:**

[Vish Thinks]- Under the CALL-US section on the right side, all the titles have to be changed such that the hyperlinks are removed and only kept on the content under the titles such that the title is now non-clickable. 

 
**Technical Details:**

Dependencies: No

Feature Flag needed: No

Demo needed: No

UAT needed:  No

Additional Notes: Link to GitHub ticket - [Staging Review finding: Duplicate "Call us" section links in sidebar · Issue #90540 · department-of-veterans-affairs/va.gov-team · GitHub](https://github.com/department-of-veterans-affairs/va.gov-team/issues/90540)

**Testing Details:**

(  ) Quick Turn Around/Direct to Production

(  ) Remains in Staging

(  ) Staging Environment unavailable, coordinate w/ developer

(  ) Other, coordinate w/ developer

**Requested by and when:**

n/a

**Definition of Done:** 

(  )  Demo/UAT completed with EDU

(  )  Passed all internal testing in Staging

(  )  Passed all internal testing in Production

(  )  All work documented in Jira ticket

(  ) GitHub ticket closed

### VEBT-421

**Problem**

The sentence "Compare and calculate GI Bill benefits at VA approved schools" should have a hyphen between VA and approved, as the words are functioning as a single adjective.

**Recommended Solution**

Add a hyphen to make the sentence "Compare and calculate GI Bill benefits at VA-approved schools."

**Acceptance Criteria:**

Add a hyphen to make the sentence "Compare and calculate GI Bill benefits at VA-approved schools."
Technical Details:

Dependencies: No

Feature Flag needed: No

Demo needed: No

UAT needed:  No

Additional Notes: Link to GitHub ticket - [Staging Review finding: VA-approved should have a hyphen · Issue #90543 · department-of-veterans-affairs/va.gov-team · GitHub](https://github.com/department-of-veterans-affairs/va.gov-team/issues/90543)

**Testing Details:**

(  ) Quick Turn Around/Direct to Production

(  ) Remains in Staging

(  ) Staging Environment unavailable, coordinate w/ developer

(  ) Other, coordinate w/ developer

**Requested by and when:**

n/a

**Definition of Done:** 

(  )  Demo/UAT completed with EDU

(  )  Passed all internal testing in Staging

(  )  Passed all internal testing in Production

(  )  All work documented in Jira ticket

(  ) GitHub ticket closed

## Testing done
Manual testing done in local environment and unit tests re-run locally for the _sco_ page

## Screenshots
### VEBT-418
**Before:**

![Desktop (Before)](https://github.com/user-attachments/assets/f3c149d3-0f77-4c2b-b36f-eef1de5f7cfe)

**After:**

![Desktop (After)](https://github.com/user-attachments/assets/23b02f89-3966-4588-89fb-242e02c893c3)

### VEBT-421
**Before:**

![Desktop (Before)](https://github.com/user-attachments/assets/fb89f2fe-35da-416b-9aaa-9e8ff3531ee8)

**After:**

![Desktop (After)](https://github.com/user-attachments/assets/9c2d512b-1f66-4ad9-aa18-23472d877f26)

## What areas of the site does it impact?
Resources for Schools

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
N/A