### PR TITLE
MHV-61186 Include reportText and impressionText in results

### DIFF
--- a/src/applications/mhv-medical-records/reducers/labsAndTests.js
+++ b/src/applications/mhv-medical-records/reducers/labsAndTests.js
@@ -314,6 +314,15 @@ const convertEkgRecord = record => {
 //   };
 // };
 
+export const buildResults = record => {
+  return `Report:${record.reportText
+    .replace(/\r\n|\r/g, '\n')
+    .replace(/^/gm, '   ')}  
+Impression:${record.impressionText
+    .replace(/\r\n|\r/g, '\n')
+    .replace(/^/gm, '   ')}`;
+};
+
 export const convertMhvRadiologyRecord = record => {
   return {
     id: `r${record.id}`,
@@ -330,7 +339,7 @@ export const convertMhvRadiologyRecord = record => {
       : EMPTY_FIELD,
     sortDate: record.eventDate,
     imagingProvider: record.radiologist || EMPTY_FIELD,
-    results: record.impressionText,
+    results: buildResults(record),
     images: [],
   };
 };

--- a/src/applications/mhv-medical-records/reducers/labsAndTests.js
+++ b/src/applications/mhv-medical-records/reducers/labsAndTests.js
@@ -314,13 +314,11 @@ const convertEkgRecord = record => {
 //   };
 // };
 
-export const buildResults = record => {
-  return `Report:${record.reportText
-    .replace(/\r\n|\r/g, '\n')
-    .replace(/^/gm, '   ')}  
-Impression:${record.impressionText
-    .replace(/\r\n|\r/g, '\n')
-    .replace(/^/gm, '   ')}`;
+export const buildRadiologyResults = record => {
+  const reportText = record?.reportText || '\n';
+  const impressionText = record?.impressionText || '\n';
+  return `Report:${reportText.replace(/\r\n|\r/g, '\n').replace(/^/gm, '   ')}  
+Impression:${impressionText.replace(/\r\n|\r/g, '\n').replace(/^/gm, '   ')}`;
 };
 
 export const convertMhvRadiologyRecord = record => {
@@ -339,7 +337,7 @@ export const convertMhvRadiologyRecord = record => {
       : EMPTY_FIELD,
     sortDate: record.eventDate,
     imagingProvider: record.radiologist || EMPTY_FIELD,
-    results: buildResults(record),
+    results: buildRadiologyResults(record),
     images: [],
   };
 };

--- a/src/applications/mhv-medical-records/tests/reducers/labsAndTests.unit.spec.js
+++ b/src/applications/mhv-medical-records/tests/reducers/labsAndTests.unit.spec.js
@@ -163,22 +163,22 @@ describe('buildRadiologyResults', () => {
       impressionText: IMPRESSION,
     };
     const report = buildRadiologyResults(record);
-    expect(buildRadiologyResults(record)).to.include(REPORT);
-    expect(buildRadiologyResults(record)).to.include(IMPRESSION);
+    expect(report).to.include(REPORT);
+    expect(report).to.include(IMPRESSION);
   });
 
   it('builds the result without impression', () => {
     const record = { reportText: REPORT };
     const report = buildRadiologyResults(record);
-    expect(buildRadiologyResults(record)).to.include(REPORT);
-    expect(buildRadiologyResults(record)).to.not.include(IMPRESSION);
+    expect(report).to.include(REPORT);
+    expect(report).to.not.include(IMPRESSION);
   });
 
   it('builds the result without report', () => {
     const record = { impressionText: IMPRESSION };
     const report = buildRadiologyResults(record);
-    expect(buildRadiologyResults(record)).to.not.include(REPORT);
-    expect(buildRadiologyResults(record)).to.include(IMPRESSION);
+    expect(report).to.not.include(REPORT);
+    expect(report).to.include(IMPRESSION);
   });
 });
 

--- a/src/applications/mhv-medical-records/tests/reducers/labsAndTests.unit.spec.js
+++ b/src/applications/mhv-medical-records/tests/reducers/labsAndTests.unit.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import {
+  buildRadiologyResults,
   extractOrderedBy,
   extractOrderedTest,
   extractOrderedTests,
@@ -149,6 +150,35 @@ describe('extractOrderedBy', () => {
   };
   it('gets the performing lab location', () => {
     expect(extractOrderedBy(record)).to.eq('Practitioner Name');
+  });
+});
+
+describe('buildRadiologyResults', () => {
+  const REPORT = 'The report.';
+  const IMPRESSION = 'The impression.';
+
+  it('builds the full result', () => {
+    const record = {
+      reportText: REPORT,
+      impressionText: IMPRESSION,
+    };
+    const report = buildRadiologyResults(record);
+    expect(buildRadiologyResults(record)).to.include(REPORT);
+    expect(buildRadiologyResults(record)).to.include(IMPRESSION);
+  });
+
+  it('builds the result without impression', () => {
+    const record = { reportText: REPORT };
+    const report = buildRadiologyResults(record);
+    expect(buildRadiologyResults(record)).to.include(REPORT);
+    expect(buildRadiologyResults(record)).to.not.include(IMPRESSION);
+  });
+
+  it('builds the result without report', () => {
+    const record = { impressionText: IMPRESSION };
+    const report = buildRadiologyResults(record);
+    expect(buildRadiologyResults(record)).to.not.include(REPORT);
+    expect(buildRadiologyResults(record)).to.include(IMPRESSION);
   });
 });
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Now including both impressionText and reportText in the report, to achieve parity with MHV Classic
- Slack thread: https://dsva.slack.com/archives/C04ER7MHX5E/p1723126310452439

## Related issue(s)

### [MHV-61186](https://jira.devops.va.gov/browse/MHV-61186) - Include both reportText and impressionText in radiology reports ###

> Currently we are just showing impressionText, but MHV classic shows both blocks of text. (In the future, when using FHIR, we will get the full radiologist's report, as we do for other domains with reports.)

## Testing done

- Added new unit tests for the new function

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

### Before ###
<img width="300" alt="image" src="https://github.com/user-attachments/assets/f2f43290-4c37-48ae-ab7d-7af24ad9e3cb">

### After ###
<img width="300" alt="image" src="https://github.com/user-attachments/assets/e145ce65-9e34-4d3d-a880-4a8a327502fe">

## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
