### PR TITLE
Check in/90926/upcoming alert

### DIFF
--- a/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
@@ -3,10 +3,10 @@ const generateFeatureToggles = (toggles = {}) => {
     checkInExperienceEnabled = true,
     preCheckInEnabled = true,
     checkInExperienceTranslationDisclaimerSpanishEnabled = true,
-    checkInExperienceTranslationDislaimerTagalogEnabled = true,
+    checkInExperienceTranslationDisclaimerTagalogEnabled = true,
     checkInExperienceTravelReimbursement = true,
     checkInExperienceBrowserMonitoring = false,
-    checkInExperienceUpcomingAppointmentsEnabled = false,
+    checkInExperienceUpcomingAppointmentsEnabled = true,
     checkInExperienceMedicationReviewContent = true,
   } = toggles;
 
@@ -28,7 +28,7 @@ const generateFeatureToggles = (toggles = {}) => {
         },
         {
           name: 'check_in_experience_translation_disclaimer_tagalog_enabled',
-          value: checkInExperienceTranslationDislaimerTagalogEnabled,
+          value: checkInExperienceTranslationDisclaimerTagalogEnabled,
         },
         {
           name: 'check_in_experience_travel_reimbursement',

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/feature-toggles/index.js
@@ -6,7 +6,7 @@ const generateFeatureToggles = (toggles = {}) => {
     checkInExperienceTranslationDisclaimerTagalogEnabled = true,
     checkInExperienceTravelReimbursement = true,
     checkInExperienceBrowserMonitoring = false,
-    checkInExperienceUpcomingAppointmentsEnabled = true,
+    checkInExperienceUpcomingAppointmentsEnabled = false,
     checkInExperienceMedicationReviewContent = true,
   } = toggles;
 

--- a/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/AppointmentDetails.unit.spec.jsx
@@ -402,6 +402,17 @@ describe('check-in experience', () => {
           );
           expect(getByTestId('prepare-content')).to.exist;
         });
+        it('should not display the incomplete info warning', () => {
+          const { queryByTestId } = render(
+            <CheckInProvider
+              store={preCheckInStore}
+              router={appointmentTwoRoute}
+            >
+              <AppointmentDetails />
+            </CheckInProvider>,
+          );
+          expect(queryByTestId('info-warning')).to.not.exist;
+        });
       });
       describe('CVT pre-check-in appointment', () => {
         it('renders correct heading for appointment type', () => {
@@ -567,6 +578,17 @@ describe('check-in experience', () => {
           );
           expect(queryByTestId('prepare-content')).to.not.exist;
         });
+        it('should not display the incomplete info warning', () => {
+          const { queryByTestId } = render(
+            <CheckInProvider
+              store={dayOfCheckInStore}
+              router={appointmentTwoRoute}
+            >
+              <AppointmentDetails />
+            </CheckInProvider>,
+          );
+          expect(queryByTestId('info-warning')).to.not.exist;
+        });
       });
       describe('Day-of check-in eligible appointment', () => {
         it('Renders the check-in button and no message', () => {
@@ -621,6 +643,17 @@ describe('check-in experience', () => {
           expect(queryByTestId('appointment-action-message')).to.not.exist;
           expect(queryByTestId('check-in-button')).to.not.exist;
         });
+        it('should display the incomplete info warning', () => {
+          const { getByTestId } = render(
+            <CheckInProvider
+              store={dayOfCheckInStore}
+              router={upcomingAppointmentTwoRoute}
+            >
+              <AppointmentDetails />
+            </CheckInProvider>,
+          );
+          expect(getByTestId('info-warning')).to.exist;
+        });
         describe('Canceled appointments', () => {
           it('Renders the canceled alert', () => {
             const { getByTestId } = render(
@@ -667,6 +700,17 @@ describe('check-in experience', () => {
             );
             expect(queryByTestId('canceled-by-patient')).to.not.exist;
             expect(queryByTestId('canceled-by-faciity')).to.not.exist;
+          });
+          it('should not display the incomplete info warning', () => {
+            const { queryByTestId } = render(
+              <CheckInProvider
+                store={dayOfCheckInStore}
+                router={upcomingAppointmentFiveRoute}
+              >
+                <AppointmentDetails />
+              </CheckInProvider>,
+            );
+            expect(queryByTestId('info-warning')).to.not.exist;
           });
         });
       });

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -282,6 +282,20 @@ const AppointmentDetails = props => {
                   </div>
                 </va-alert>
               )}
+              {isUpcoming &&
+                !isCanceled && (
+                  <va-alert-expandable
+                    status="warning"
+                    trigger={t('we-cant-show-all-information')}
+                    class="vads-u-margin-top--3"
+                    data-testid="info-warning"
+                  >
+                    <p>{t('some-appointment-information-not-available')}</p>
+                    {/* Slotted p tags can't have margin for some reason. */}
+                    <br />
+                    <p>{t('find-all-appointment-information')}</p>
+                  </va-alert-expandable>
+                )}
               {app === APP_NAMES.PRE_CHECK_IN &&
                 !getPreCheckinComplete(window)?.complete && (
                   <>

--- a/src/applications/check-in/components/pages/UpcomingAppointments/index.jsx
+++ b/src/applications/check-in/components/pages/UpcomingAppointments/index.jsx
@@ -94,6 +94,15 @@ const UpcomingAppointmentsPage = props => {
   } else {
     body = (
       <>
+        <va-alert-expandable
+          status="warning"
+          trigger={t('we-cant-show-all-information')}
+        >
+          <p>{t('some-appointment-information-not-available')}</p>
+          {/* Slotted p tags can't have margin for some reason. */}
+          <br />
+          <p>{t('find-all-appointment-information')}</p>
+        </va-alert-expandable>
         <UpcomingAppointmentsList
           router={router}
           app={app}

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -437,5 +437,8 @@
   "were-having-trouble-getting-your-upcoming-appointments": "We’re having trouble getting your upcoming appointments. Please try again later.",
   "to-file-another-claim-for-different-date": "To file another claim for a different date, you can visit the Beneficiary Travel Self-Service System (BTSSS). You must file within 30 days of the appointment.",
   "find-a-full-list-of-things-to-bring": "Find a full list of things to bring to your appointment",
-  "find-out-how-to-check-in-opens-in-new-tab": "Find out how to check in (opens in new tab)"
+  "find-out-how-to-check-in-opens-in-new-tab": "Find out how to check in (opens in new tab)",
+  "we-cant-show-all-information": "We can’t show all your information right now",
+  "some-appointment-information-not-available": "Some of your appointment information is not available right now.",
+  "find-all-appointment-information": "To find all your appointment information, finish checking in for this appointment first. Then go to appointments on VA.gov."
 }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adds an alert to the upcoming appointments page and on appointment details pages.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#90926

## Testing done

Adds unit tests

## Screenshots

![localhost_3001_health-care_appointment-pre-check-in_upcoming-appointments](https://github.com/user-attachments/assets/7a499895-16ef-4c9f-9b77-d52bebb30225)
![localhost_3001_health-care_appointment-pre-check-in_upcoming-appointments (1)](https://github.com/user-attachments/assets/05ddfe01-66d5-47ec-9c69-d714ca50df5e)
![localhost_3001_health-care_appointment-pre-check-in_upcoming-appointment-details_123001-983](https://github.com/user-attachments/assets/b306a923-bb4b-4847-ae26-97cd88e15939)
![localhost_3001_health-care_appointment-pre-check-in_upcoming-appointment-details_123001-983 (1)](https://github.com/user-attachments/assets/e89885ed-fd4d-4f89-b3ee-42bf08d4bc7d)


## What areas of the site does it impact?

day-of and pre-check-in

## Acceptance criteria
 - [ ] the warning displays on upcoming appointments page
 - [ ] the warning displays on appointment details for upcoming appointments
 - [ ] the warning does not display on other appointment details pages
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
