### PR TITLE
#93-Fixed phone number clearing issue in task purple

### DIFF
--- a/src/applications/_mock-form-ae-design-patterns/components/task-purple/SchemaForm.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/components/task-purple/SchemaForm.jsx
@@ -4,7 +4,7 @@ import { merge, once } from 'lodash';
 import Form from '@department-of-veterans-affairs/react-jsonschema-form';
 import { deepEquals } from '@department-of-veterans-affairs/react-jsonschema-form/lib/utils';
 import set from 'platform/utilities/data/set';
-
+import { connect } from 'react-redux';
 import {
   uiSchemaValidate,
   transformErrors,
@@ -197,9 +197,22 @@ class SchemaForm extends React.Component {
       safeRenderCompletion,
       name,
       addNameAttribute,
+      profile,
     } = this.props;
 
     const useReviewMode = reviewMode && !editModeOnReviewPage;
+
+    const profileData = profile || {};
+    const contactInfo = profileData.vapContactInfo || {};
+
+    const inputPhoneNumber = document.querySelector(
+      'va-text-input[name="root_inputPhoneNumber"]',
+    );
+    const initialValue = contactInfo.homePhone.phoneNumber;
+
+    if (inputPhoneNumber?.value.includes(initialValue)) {
+      inputPhoneNumber.value = '';
+    }
 
     return (
       <Form
@@ -228,6 +241,9 @@ class SchemaForm extends React.Component {
     );
   }
 }
+const mapStateToProps = state => ({
+  profile: state.user.profile,
+});
 
 SchemaForm.propTypes = {
   name: PropTypes.string.isRequired,
@@ -239,6 +255,7 @@ SchemaForm.propTypes = {
   data: PropTypes.any,
   editModeOnReviewPage: PropTypes.bool,
   hideTitle: PropTypes.bool,
+  profile: PropTypes.object,
   reviewMode: PropTypes.bool,
   onChange: PropTypes.func,
   onSubmit: PropTypes.func,
@@ -256,4 +273,4 @@ SchemaForm.defaultProps = {
   addNameAttribute: false,
 };
 
-export default SchemaForm;
+export default connect(mapStateToProps)(SchemaForm);

--- a/src/applications/_mock-form-ae-design-patterns/utils/data/task-purple/formValues.js
+++ b/src/applications/_mock-form-ae-design-patterns/utils/data/task-purple/formValues.js
@@ -63,24 +63,19 @@ export const getInitialFormValues = options => {
       inputPhoneNumber: '',
     };
 
-    initialFormValues = {
-      extension: '',
-      inputPhoneNumber: '',
-    };
+    if (data) {
+      const { extension, areaCode, phoneNumber } = data;
+      const inputPhoneNumber =
+        areaCode && phoneNumber
+          ? `${areaCode}${phoneNumber}`
+          : `${phoneNumber}`;
 
-    // if (data) {
-    //   const { extension, areaCode, phoneNumber } = data;
-    //   const inputPhoneNumber =
-    //     areaCode && phoneNumber
-    //       ? `${areaCode}${phoneNumber}`
-    //       : `${phoneNumber}`;
-
-    //   initialFormValues = {
-    //     ...data,
-    //     extension: extension || '',
-    //     inputPhoneNumber: '',
-    //   };
-    // }
+      initialFormValues = {
+        ...data,
+        extension: extension || '',
+        inputPhoneNumber,
+      };
+    }
 
     return initialFormValues;
   }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No

## Summary
Fixed the issue with clearing the existing phone number in the edit field on the edit page. 
Checked the Network tab, and `telephones` endpoint now uses PUT method instead of POST.

### Steps to view task purple fix
1) Pull down branch. In one terminal, run mock server `yarn mock-api --responses src/applications/_mock-form-ae-design-patterns/mocks/server.js`
2) Open another terminal, run `yarn watch --env entry=mock-form-ae-design-patterns`
3) Go to "http://localhost:3001/mock-form-ae-design-patterns/task-purple/introduction". Click on "Start the Board Appeal request".
4) Go through the form as shown in [Figma](https://www.figma.com/design/2j01RTqCSJRy4lX3eUOiod/AE-Design-Patterns---Prefill?node-id=62-8608&m=dev&t=ByZUN5cb3ULxHBYU-1)
5) Once you get to the Edit phone number page, you should see the existing phone number is cleared out. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/tmf-auth-exp-design-patterns/issues/93

## Testing done
Testing done locally. No additional testing is needed as this is an experimental app that does not touch other areas of the website.

## Screenshots
<img width="578" alt="Screenshot 2024-08-21 at 11 24 01 AM" src="https://github.com/user-attachments/assets/42d3b14b-ecaf-4cd2-af6a-0efd3abef2fb">
<img width="616" alt="Screenshot 2024-08-21 at 11 23 50 AM" src="https://github.com/user-attachments/assets/a1e4fa8c-37e9-4482-8c79-61928217de3f">


## What areas of the site does it impact?
N/A. this is an experimental app that does not touch other areas of the website.

## Acceptance criteria
[ ] Existing Phone number is cleared from the edit phone number field on the edit page.
[ ] After user enters a new phone number and clicks "Save", phone number should still stay on screen. 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
