### PR TITLE
updated alert message to be per app.

### DIFF
--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -294,11 +294,9 @@ const AppointmentDetails = props => {
                     {/* Slotted p tags can't have margin for some reason. */}
                     <br />
                     <p>
-                      {t('find-all-appointment-information', {
-                        type: APP_NAMES.PRE_CHECK_IN
-                          ? t('reviewing-information-first')
-                          : t('checking-in-first'),
-                      })}
+                      {APP_NAMES.PRE_CHECK_IN
+                        ? t('find-all-appointment-information-check-in')
+                        : t('find-all-appointment-information-pre-check-in')}
                     </p>
                   </va-alert-expandable>
                 )}

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -293,7 +293,13 @@ const AppointmentDetails = props => {
                     <p>{t('some-appointment-information-not-available')}</p>
                     {/* Slotted p tags can't have margin for some reason. */}
                     <br />
-                    <p>{t('find-all-appointment-information')}</p>
+                    <p>
+                      {t('find-all-appointment-information', {
+                        type: APP_NAMES.PRE_CHECK_IN
+                          ? t('reviewing-information-first')
+                          : t('checking-in-first'),
+                      })}
+                    </p>
                   </va-alert-expandable>
                 )}
               {app === APP_NAMES.PRE_CHECK_IN &&

--- a/src/applications/check-in/components/pages/UpcomingAppointments/UpcomingAppointmentsPage.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/UpcomingAppointments/UpcomingAppointmentsPage.unit.spec.jsx
@@ -178,5 +178,33 @@ describe('unified check-in experience', () => {
       sandbox.assert.calledOnce(v2.getUpcomingAppointmentsData);
       sandbox.restore();
     });
+    it('shows alert message when there are upcoming appointments', () => {
+      const { getByTestId } = render(
+        <CheckInProvider
+          store={{
+            upcomingAppointments: multipleAppointments,
+            features: appointmentsOn,
+          }}
+        >
+          <UpcomingAppointmentsPage />
+        </CheckInProvider>,
+      );
+
+      expect(getByTestId('info-warning')).to.exist;
+    });
+    it('does not show alert message when there are upcoming appointments', () => {
+      const { queryByTestId } = render(
+        <CheckInProvider
+          store={{
+            upcomingAppointments: [],
+            features: appointmentsOn,
+          }}
+        >
+          <UpcomingAppointmentsPage />
+        </CheckInProvider>,
+      );
+
+      expect(queryByTestId('info-warning')).to.not.exist;
+    });
   });
 });

--- a/src/applications/check-in/components/pages/UpcomingAppointments/index.jsx
+++ b/src/applications/check-in/components/pages/UpcomingAppointments/index.jsx
@@ -94,22 +94,22 @@ const UpcomingAppointmentsPage = props => {
   } else {
     body = (
       <>
-        <va-alert-expandable
-          status="warning"
-          trigger={t('we-cant-show-all-information')}
-        >
-          <p>{t('some-appointment-information-not-available')}</p>
-          {/* Slotted p tags can't have margin for some reason. */}
-          <br />
-          <p>
-            {t('find-all-appointment-information', {
-              type:
-                app === APP_NAMES.PRE_CHECK_IN
-                  ? t('reviewing-information-first')
-                  : t('checking-in-first'),
-            })}
-          </p>
-        </va-alert-expandable>
+        {upcomingAppointments.length && (
+          <va-alert-expandable
+            status="warning"
+            trigger={t('we-cant-show-all-information')}
+            data-testid="info-warning"
+          >
+            <p>{t('some-appointment-information-not-available')}</p>
+            {/* Slotted p tags can't have margin for some reason. */}
+            <br />
+            <p>
+              {APP_NAMES.PRE_CHECK_IN
+                ? t('find-all-appointment-information-check-in')
+                : t('find-all-appointment-information-pre-check-in')}
+            </p>
+          </va-alert-expandable>
+        )}
         <UpcomingAppointmentsList
           router={router}
           app={app}

--- a/src/applications/check-in/components/pages/UpcomingAppointments/index.jsx
+++ b/src/applications/check-in/components/pages/UpcomingAppointments/index.jsx
@@ -101,7 +101,14 @@ const UpcomingAppointmentsPage = props => {
           <p>{t('some-appointment-information-not-available')}</p>
           {/* Slotted p tags can't have margin for some reason. */}
           <br />
-          <p>{t('find-all-appointment-information')}</p>
+          <p>
+            {t('find-all-appointment-information', {
+              type:
+                app === APP_NAMES.PRE_CHECK_IN
+                  ? t('reviewing-information-first')
+                  : t('checking-in-first'),
+            })}
+          </p>
         </va-alert-expandable>
         <UpcomingAppointmentsList
           router={router}

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -440,7 +440,6 @@
   "find-out-how-to-check-in-opens-in-new-tab": "Find out how to check in (opens in new tab)",
   "we-cant-show-all-information": "We can’t show all your information right now",
   "some-appointment-information-not-available": "Some of your appointment information is not available right now.",
-  "find-all-appointment-information": "To find all your appointment information, finish {{ type }} first. Then go to appointments on VA.gov.",
-  "checking-in-first": "checking in for this appointment",
-  "reviewing-information-first": "reviewing your contact information"
+  "find-all-appointment-information-check-in": "To find all your appointment information, finish checking in for this appointment first. Then go to appointments on VA.gov.",
+  "find-all-appointment-information-pre-check-in": "To find all your appointment information, finish reviewing your contact information first. Then go to appointments on VA.gov."
 }

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -440,5 +440,7 @@
   "find-out-how-to-check-in-opens-in-new-tab": "Find out how to check in (opens in new tab)",
   "we-cant-show-all-information": "We can’t show all your information right now",
   "some-appointment-information-not-available": "Some of your appointment information is not available right now.",
-  "find-all-appointment-information": "To find all your appointment information, finish checking in for this appointment first. Then go to appointments on VA.gov."
+  "find-all-appointment-information": "To find all your appointment information, finish {{ type }} first. Then go to appointments on VA.gov.",
+  "checking-in-first": "checking in for this appointment",
+  "reviewing-information-first": "reviewing your contact information"
 }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Make alert message specific to each app

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#90926

## Testing done

visual

## Screenshots

![localhost_3001_health-care_appointment-pre-check-in__id=46bebc0a-b99c-464f-a5c5-560bc9eae287 (8)](https://github.com/user-attachments/assets/1f10047f-e7d1-413d-a6a9-d7bd67e0949f)
![localhost_3001_health-care_appointment-check-in__id=46bebc0a-b99c-464f-a5c5-560bc9eae287 (5)](https://github.com/user-attachments/assets/e9e90c49-1165-48c5-966d-eb650b7c7f1e)
![localhost_3001_health-care_appointment-check-in__id=46bebc0a-b99c-464f-a5c5-560bc9eae287 (4)](https://github.com/user-attachments/assets/d760ece7-4d62-4dd9-ae4e-ab51f1b746e0)
![localhost_3001_health-care_appointment-check-in__id=46bebc0a-b99c-464f-a5c5-560bc9eae287 (3)](https://github.com/user-attachments/assets/e9338725-c432-4629-985c-fd016e6cb302)
![localhost_3001_health-care_appointment-check-in__id=46bebc0a-b99c-464f-a5c5-560bc9eae287 (2)](https://github.com/user-attachments/assets/9c9d2514-fb58-41d0-a7ad-da194148573a)
![localhost_3001_health-care_appointment-pre-check-in__id=46bebc0a-b99c-464f-a5c5-560bc9eae287 (11)](https://github.com/user-attachments/assets/4bad9b97-5d6f-4d7c-8feb-0b5c288c5813)
![localhost_3001_health-care_appointment-pre-check-in__id=46bebc0a-b99c-464f-a5c5-560bc9eae287 (10)](https://github.com/user-attachments/assets/d9cdceb7-c126-4022-b540-b4c9456dcc80)
![localhost_3001_health-care_appointment-pre-check-in__id=46bebc0a-b99c-464f-a5c5-560bc9eae287 (9)](https://github.com/user-attachments/assets/28aa4f59-0843-4a1e-a0c3-a0669faa55ff)


## What areas of the site does it impact?

day-of and pre-check-in

## Acceptance criteria
 - [ ] the alert message makes sense to each app as out lined in the figma files.
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

