### PR TITLE
VACMS-18861: Update breadcrumb default for DUW

### DIFF
--- a/src/applications/discharge-wizard/components/Breadcrumbs.jsx
+++ b/src/applications/discharge-wizard/components/Breadcrumbs.jsx
@@ -13,7 +13,7 @@ const Breadcrumbs = () => (
       },
       {
         href: '/discharge-upgrade-instructions',
-        label: 'Discharge upgrade',
+        label: 'How to apply for a discharge upgrade',
       },
     ]}
   />

--- a/src/applications/discharge-wizard/components/InstructionsPage.jsx
+++ b/src/applications/discharge-wizard/components/InstructionsPage.jsx
@@ -8,7 +8,7 @@ const InstructionsPage = () => {
       itemScope
       itemType="http://schema.org/FAQPage"
     >
-      <h1 itemProp="name">How to Apply for a Discharge Upgrade</h1>
+      <h1 itemProp="name">How to apply for a discharge upgrade</h1>
       <div className="row vads-u-margin--0">
         <article className="usa-content columns xsmall-screen:vads-u-padding--0">
           <div className="va-introtext">

--- a/src/applications/discharge-wizard/components/v2/BreadcrumbsV2.jsx
+++ b/src/applications/discharge-wizard/components/v2/BreadcrumbsV2.jsx
@@ -11,7 +11,7 @@ const BreadcrumbsV2 = () => (
       },
       {
         href: '/discharge-upgrade-instructions/introduction',
-        label: 'Discharge upgrade',
+        label: 'How to apply for a discharge upgrade',
       },
     ]}
   />

--- a/src/applications/discharge-wizard/constants/question-data-map.js
+++ b/src/applications/discharge-wizard/constants/question-data-map.js
@@ -1,5 +1,5 @@
 export const QUESTION_MAP = Object.freeze({
-  HOME: 'How to Apply for a Discharge Upgrade',
+  HOME: 'How to apply for a discharge upgrade',
   SERVICE_BRANCH: 'What was your branch of service?',
   DISCHARGE_YEAR: 'What year were you discharged from the military?',
   DISCHARGE_MONTH: 'What month were you discharged?',

--- a/src/applications/discharge-wizard/containers/FormPage.jsx
+++ b/src/applications/discharge-wizard/containers/FormPage.jsx
@@ -10,7 +10,7 @@ import FormQuestions from '../components/FormQuestions';
 export const FormPage = ({ formValues, updateFormField }) => {
   return (
     <div>
-      <h1>How to Apply for a Discharge Upgrade</h1>
+      <h1>How to apply for a discharge upgrade</h1>
       <div className="medium-8">
         <FormQuestions
           formValues={formValues}

--- a/src/applications/discharge-wizard/tests/components/InstructionsPage.unit.spec.js
+++ b/src/applications/discharge-wizard/tests/components/InstructionsPage.unit.spec.js
@@ -11,7 +11,7 @@ describe('Discharge Wizard <InstructionsPage /> ', () => {
     const tree = mount(<InstructionsPage />);
     const html = tree.html();
     expect(html).to.contain('Get started');
-    expect(html).to.contain('How to Apply for a Discharge Upgrade');
+    expect(html).to.contain('How to apply for a discharge upgrade');
     expect(tree.find('p[itemProp="description"]')).to.be.lengthOf(1);
     tree.unmount();
   });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Updating the DUW breadcrumb based on a11y and CAIA guidance

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18861

## Testing done
Tested locally both DUW and v2 for the new breadcrumb

DUW: `/discharge-upgrade-instructions/`
DUW v2: `/discharge-upgrade-instructions/introduction/`

## Screenshots
![How_To_Apply_For_A_Discharge_Upgrade___Veterans_Affairs](https://github.com/user-attachments/assets/8cf28866-592e-4444-9fde-e34cefe3f263)


## What areas of the site does it impact?

DUW

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

