### PR TITLE
91216 Add "over 65" boolean in submit transformer - form 10-10d

### DIFF
--- a/src/applications/ivc-champva/10-10D/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-10D/config/submitTransformer.js
@@ -1,6 +1,10 @@
 import { transformForSubmit as formsSystemTransformForSubmit } from 'platform/forms-system/src/js/helpers';
 import { REQUIRED_FILES, OPTIONAL_FILES } from './constants';
-import { adjustYearString, concatStreets } from '../../shared/utilities';
+import {
+  adjustYearString,
+  concatStreets,
+  getAgeInYears,
+} from '../../shared/utilities';
 
 // Rearranges date string from YYYY-MM-DD to MM-DD-YYYY
 function fmtDate(date) {
@@ -188,6 +192,11 @@ export default function transformForSubmit(formConfig, form) {
       });
     }
   });
+
+  // Set a top-level boolean indicating if any applicants are over 65
+  dataPostTransform.hasApplicantOver65 = dataPostTransform.applicants.some(
+    app => getAgeInYears(app.applicantDob) >= 65,
+  );
 
   dataPostTransform.supportingDocs = dataPostTransform.supportingDocs
     .flat()

--- a/src/applications/ivc-champva/10-10D/tests/unit/config/submitTransformer.unit.spec.js
+++ b/src/applications/ivc-champva/10-10D/tests/unit/config/submitTransformer.unit.spec.js
@@ -171,4 +171,27 @@ describe('transform for submit', () => {
       appCert.data.applicants[1].applicantEmailAddress,
     );
   });
+  it('should set `hasApplicantOver65` to false if all applicants are under 65', () => {
+    const tmpData = JSON.parse(JSON.stringify(mockData));
+    tmpData.data.applicants.forEach(app => {
+      // eslint-disable-next-line no-param-reassign
+      app.applicantDob = '2003-01-01'; // None over 65
+    });
+
+    const transformed = JSON.parse(transformForSubmit(formConfig, tmpData));
+    expect(transformed.hasApplicantOver65).to.be.false;
+  });
+  it('should set `hasApplicantOver65` to true if any applicant is 65 or over', () => {
+    const tmpData = JSON.parse(JSON.stringify(mockData));
+    tmpData.data.applicants.forEach(app => {
+      // eslint-disable-next-line no-param-reassign
+      app.applicantDob = '2003-01-01'; // None over 65
+    });
+
+    // One is over 65
+    tmpData.data.applicants[0].applicantDob = '1947-01-01';
+
+    const transformed = JSON.parse(transformForSubmit(formConfig, tmpData));
+    expect(transformed.hasApplicantOver65).to.be.true;
+  });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adds flag to submit transformer if any applicant is over 65
- Adds unit tests for this behavior

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/91216

## Testing done

- Unit

## Screenshots

NA

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA