### PR TITLE
DR | Update Cypress commands

### DIFF
--- a/src/applications/appeals/10182/tests/10182-contact-loop.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-contact-loop.cypress.spec.js
@@ -2,7 +2,7 @@ import { CONTESTABLE_ISSUES_API } from '../constants';
 
 import mockData from './fixtures/data/maximal-test.json';
 
-import { NOD_BASE_URL } from '../../shared/constants';
+import { NOD_BASE_URL, CONTACT_INFO_PATH } from '../../shared/constants';
 
 import { mockContestableIssues } from '../../shared/tests/cypress.helpers';
 import cypressSetup from '../../shared/tests/cypress.setup';
@@ -12,6 +12,8 @@ const checkOpt = {
 };
 
 describe('NOD contact info loop', () => {
+  const MAIN_CONTACT_PATH = `${NOD_BASE_URL}${CONTACT_INFO_PATH}`;
+
   beforeEach(() => {
     cypressSetup();
     window.dataLayer = [];
@@ -56,10 +58,9 @@ describe('NOD contact info loop', () => {
 
   it('should edit info on a new page & cancel returns to contact info page', () => {
     getToContactPage();
-    const contactPageUrl = `${NOD_BASE_URL}/contact-information`;
 
     // Contact info
-    cy.location('pathname').should('eq', contactPageUrl);
+    cy.location('pathname').should('eq', MAIN_CONTACT_PATH);
     cy.injectAxe();
     cy.axeCheck();
 
@@ -67,71 +68,71 @@ describe('NOD contact info loop', () => {
     cy.get('a[href$="phone"]').click();
     cy.location('pathname').should(
       'eq',
-      `${NOD_BASE_URL}/contact-information/edit-mobile-phone`,
+      `${MAIN_CONTACT_PATH}/edit-mobile-phone`,
     );
     cy.injectAxe();
     cy.axeCheck();
 
     // cancel phone change
     cy.get('va-button[text="Cancel"]').click();
-    cy.location('pathname').should('eq', contactPageUrl);
+    cy.location('pathname').should('eq', MAIN_CONTACT_PATH);
 
     // update phone
     /*
     cy.get('a[href$="phone"]').click();
-    cy.location('pathname').should('eq', `${NOD_BASE_URL}/edit-mobile-phone`);
+    cy.location('pathname').should('eq', `${MAIN_CONTACT_PATH}/edit-mobile-phone`);
     cy.findByLabelText(/extension/i)
       .clear()
       .type('12345');
     cy.findByText(/^update$/i, { selector: 'button' })
       .first()
       .click();
-    cy.location('pathname').should('eq', contactPageUrl);
+    cy.location('pathname').should('eq', MAIN_CONTACT_PATH);
     */
 
     // Email loops *****
     cy.get('a[href$="email-address"]').click();
     cy.location('pathname').should(
       'eq',
-      `${NOD_BASE_URL}/contact-information/edit-email-address`,
+      `${MAIN_CONTACT_PATH}/edit-email-address`,
     );
     cy.injectAxe();
     cy.axeCheck();
 
     // cancel email change
     cy.get('va-button[text="Cancel"]').click();
-    cy.location('pathname').should('eq', contactPageUrl);
+    cy.location('pathname').should('eq', MAIN_CONTACT_PATH);
 
     // update email
     /*
     cy.get('a[href$="email-address"]').click();
-    cy.location('pathname').should('eq', `${NOD_BASE_URL}/edit-email-address`);
+    cy.location('pathname').should('eq', `${MAIN_CONTACT_PATH}/edit-email-address`);
     cy.findByLabelText(/email address/i)
       .clear()
       .type('test@test.com');
     cy.findByText(/^update$/i, { selector: 'button' })
       .first()
       .click();
-    cy.location('pathname').should('eq', contactPageUrl);
+    cy.location('pathname').should('eq', MAIN_CONTACT_PATH);
     */
 
     // Mailing address loops *****
     cy.get('a[href$="mailing-address"]').click();
     cy.location('pathname').should(
       'eq',
-      `${NOD_BASE_URL}/contact-information/edit-mailing-address`,
+      `${MAIN_CONTACT_PATH}/edit-mailing-address`,
     );
     cy.injectAxe();
     cy.axeCheck();
 
     // cancel address change
     cy.get('va-button[text="Cancel"]').click();
-    cy.location('pathname').should('eq', contactPageUrl);
+    cy.location('pathname').should('eq', MAIN_CONTACT_PATH);
 
     // update address
     /*
     cy.get('a[href$="mailing-address"]').click();
-    cy.location('pathname').should('eq', `${NOD_BASE_URL}/edit-mailing-address`);
+    cy.location('pathname').should('eq', `${MAIN_CONTACT_PATH}/edit-mailing-address`);
     cy.findByLabelText(/address line 2/i).clear(); // remove "c/o Pixar"
     cy.findByText(/^update$/i, { selector: 'button' })
       .first()
@@ -145,6 +146,32 @@ describe('NOD contact info loop', () => {
       .first()
       .click();
     */
-    cy.location('pathname').should('eq', contactPageUrl);
+    cy.location('pathname').should('eq', MAIN_CONTACT_PATH);
+  });
+
+  // eslint-disable-next-line @department-of-veterans-affairs/axe-check-required
+  it('should edit info on a new page, update & return to contact info page ', () => {
+    getToContactPage();
+
+    // Contact info
+
+    // Mobile phone
+    cy.get('a[href$="mobile-phone"]').click();
+    cy.contains('Edit mobile phone number').should('be.visible');
+    cy.location('pathname').should(
+      'eq',
+      `${MAIN_CONTACT_PATH}/edit-mobile-phone`,
+    );
+
+    cy.get('va-text-input[value="5109224444"]');
+
+    cy.findAllByText(/save/i, { selector: 'button' })
+      .first()
+      .click({ waitForAnimations: true });
+
+    cy.wait('@telephones');
+    cy.location('pathname').should('eq', MAIN_CONTACT_PATH);
+
+    // Skipping AXE-check; already done in previous test.
   });
 });

--- a/src/applications/appeals/10182/tests/10182-contact-loop.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-contact-loop.cypress.spec.js
@@ -169,7 +169,6 @@ describe('NOD contact info loop', () => {
       .first()
       .click({ waitForAnimations: true });
 
-    cy.wait('@telephones');
     cy.location('pathname').should('eq', MAIN_CONTACT_PATH);
 
     // Skipping AXE-check; already done in previous test.

--- a/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
@@ -66,10 +66,7 @@ const testConfig = createTestConfig(
                 cy.get('.add-new-issue').click();
                 cy.url().should('include', `${NOD_BASE_URL}/add-issue?index=`);
                 cy.axeCheck();
-                cy.get('#issue-name')
-                  .shadow()
-                  .find('input')
-                  .type(additionalIssue.issue);
+                cy.fillVaTextInput('issue-name', additionalIssue.issue);
                 cy.fillDate('decision-date', getRandomDate());
                 cy.get('#submit').click();
               }

--- a/src/applications/appeals/995/tests/995-contact-loop.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-contact-loop.cypress.spec.js
@@ -151,7 +151,6 @@ describe('995 contact info loop', () => {
       .first()
       .click();
 
-    cy.wait('@telephones');
     cy.location('pathname').should('eq', MAIN_CONTACT_PATH);
 
     // Skipping AXE-check; already done in previous test.

--- a/src/applications/appeals/995/tests/995-contact-loop.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-contact-loop.cypress.spec.js
@@ -69,12 +69,7 @@ describe('995 contact info loop', () => {
       .should('be.visible')
       .then(() => {
         // Click past the ITF message
-        cy.get('va-button-pair')
-          .shadow()
-          .find('va-button[back]')
-          .shadow()
-          .find('button')
-          .click();
+        cy.selectVaButtonPairSecondary();
       });
     cy.location('pathname').should('eq', `${BASE_URL}/introduction`);
   });
@@ -147,22 +142,16 @@ describe('995 contact info loop', () => {
     cy.contains('Edit mobile phone number').should('be.visible');
     cy.location('pathname').should(
       'eq',
-      `${BASE_URL}/contact-information/edit-mobile-phone`,
+      `${MAIN_CONTACT_PATH}/edit-mobile-phone`,
     );
 
-    cy.get('va-text-input[label^="Mobile phone"]')
-      .shadow()
-      .find('input')
-      .clear();
-    cy.get('va-text-input[label^="Mobile phone"]')
-      .shadow()
-      .find('input')
-      .type('8885551212');
+    cy.get('va-text-input[value="5109224444"]');
 
     cy.findAllByText(/save/i, { selector: 'button' })
       .first()
       .click();
 
+    cy.wait('@telephones');
     cy.location('pathname').should('eq', MAIN_CONTACT_PATH);
 
     // Skipping AXE-check; already done in previous test.

--- a/src/applications/appeals/995/tests/995.cypress.helpers.js
+++ b/src/applications/appeals/995/tests/995.cypress.helpers.js
@@ -127,12 +127,7 @@ export const getPastItf = cy => {
     .should('be.visible')
     .then(() => {
       // Click past the ITF message
-      cy.get('va-button-pair')
-        .shadow()
-        .find('va-button[continue]')
-        .shadow()
-        .find('button')
-        .click();
+      cy.selectVaButtonPairPrimary();
     });
 };
 

--- a/src/applications/appeals/996/tests/hlr-contact-loop.cypress.spec.js
+++ b/src/applications/appeals/996/tests/hlr-contact-loop.cypress.spec.js
@@ -121,14 +121,7 @@ describe('HLR contact info loop', () => {
       `${BASE_URL}/contact-information/edit-mobile-phone`,
     );
 
-    cy.get('va-text-input[label^="Mobile phone"]')
-      .shadow()
-      .find('input')
-      .clear();
-    cy.get('va-text-input[label^="Mobile phone"]')
-      .shadow()
-      .find('input')
-      .type('8885551212');
+    cy.get('va-text-input[value="5109224444"]');
 
     cy.findAllByText(/save/i, { selector: 'button' })
       .first()

--- a/src/applications/appeals/996/tests/hlr-keyboard-only.cypress.spec.js
+++ b/src/applications/appeals/996/tests/hlr-keyboard-only.cypress.spec.js
@@ -60,7 +60,7 @@ describe('Higher-Level Review keyboard only navigation', () => {
 
       // Homelessness radios
       cy.url().should('include', chapters.infoPages.pages.homeless.path);
-      cy.tabToElement('input[name="root_homeless"]');
+      cy.tabToElement('input#root_homelessYesinput');
       cy.chooseRadio(data.homeless ? 'Y' : 'N');
       cy.tabToContinueForm();
 
@@ -78,6 +78,8 @@ describe('Higher-Level Review keyboard only navigation', () => {
         'include',
         chapters.conditions.pages.contestableIssues.path,
       );
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      cy.wait(100);
       cy.tabToElement('#root_contestedIssues_0'); // Tinnitus
       cy.realPress('Space');
       cy.tabToContinueForm();
@@ -112,7 +114,7 @@ describe('Higher-Level Review keyboard only navigation', () => {
         chapters.informalConference.pages.requestConference.path,
       );
       // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(250); // wait for H3 focus before tabbing to radios
+      // cy.wait(250); // wait for H3 focus before tabbing to radios
       cy.tabToElement('input[name="informalConference"]');
       cy.chooseRadio('rep');
       cy.tabToContinueForm();

--- a/src/applications/appeals/996/tests/hlr-keyboard-only.cypress.spec.js
+++ b/src/applications/appeals/996/tests/hlr-keyboard-only.cypress.spec.js
@@ -78,8 +78,6 @@ describe('Higher-Level Review keyboard only navigation', () => {
         'include',
         chapters.conditions.pages.contestableIssues.path,
       );
-      // eslint-disable-next-line cypress/no-unnecessary-waiting
-      cy.wait(100);
       cy.tabToElement('#root_contestedIssues_0'); // Tinnitus
       cy.realPress('Space');
       cy.tabToContinueForm();
@@ -114,7 +112,7 @@ describe('Higher-Level Review keyboard only navigation', () => {
         chapters.informalConference.pages.requestConference.path,
       );
       // eslint-disable-next-line cypress/no-unnecessary-waiting
-      // cy.wait(250); // wait for H3 focus before tabbing to radios
+      cy.wait(250); // wait for H3 focus before tabbing to radios
       cy.tabToElement('input[name="informalConference"]');
       cy.chooseRadio('rep');
       cy.tabToContinueForm();

--- a/src/applications/appeals/996/tests/hlr-v3.cypress.spec.js
+++ b/src/applications/appeals/996/tests/hlr-v3.cypress.spec.js
@@ -72,10 +72,7 @@ const testConfig = createTestConfig(
                 cy.get('.add-new-issue').click();
                 cy.url().should('include', `${BASE_URL}/add-issue?index=`);
                 cy.axeCheck();
-                cy.get('#issue-name')
-                  .shadow()
-                  .find('input')
-                  .type(additionalIssue.issue);
+                cy.fillVaTextInput('issue-name', additionalIssue.issue);
                 cy.fillDate('decision-date', getRandomDate());
                 cy.get('#submit').click();
               }

--- a/src/applications/appeals/996/tests/hlr.cypress.spec.js
+++ b/src/applications/appeals/996/tests/hlr.cypress.spec.js
@@ -72,10 +72,7 @@ const testConfig = createTestConfig(
                 cy.get('.add-new-issue').click();
                 cy.url().should('include', `${BASE_URL}/add-issue?index=`);
                 cy.axeCheck();
-                cy.get('#issue-name')
-                  .shadow()
-                  .find('input')
-                  .type(additionalIssue.issue);
+                cy.fillVaTextInput('issue-name', additionalIssue.issue);
                 cy.fillDate('decision-date', getRandomDate());
                 cy.get('#submit').click();
               }

--- a/src/applications/appeals/shared/tests/cypress.setup.js
+++ b/src/applications/appeals/shared/tests/cypress.setup.js
@@ -24,7 +24,9 @@ export default function cypressSetup({ user = mockUser } = {}) {
   cy.intercept('GET', '/v0/profile/status*', mockStatus);
   cy.intercept('GET', '/v0/user?now=*', mockUserUpdate);
   cy.intercept('GET', '/v0/user_transition_availabilities', mockUserAvail);
-  cy.intercept('PUT', '/v0/profile/telephones', mockProfilePhone);
+  cy.intercept('PUT', '/v0/profile/telephones', mockProfilePhone).as(
+    'telephones',
+  );
   cy.intercept('PUT', '/v0/profile/email_addresses', mockProfileEmail);
   cy.intercept('PUT', '/v0/profile/addresses', mockProfileAddress);
   cy.intercept(

--- a/src/applications/appeals/shared/tests/cypress.setup.js
+++ b/src/applications/appeals/shared/tests/cypress.setup.js
@@ -24,9 +24,7 @@ export default function cypressSetup({ user = mockUser } = {}) {
   cy.intercept('GET', '/v0/profile/status*', mockStatus);
   cy.intercept('GET', '/v0/user?now=*', mockUserUpdate);
   cy.intercept('GET', '/v0/user_transition_availabilities', mockUserAvail);
-  cy.intercept('PUT', '/v0/profile/telephones', mockProfilePhone).as(
-    'telephones',
-  );
+  cy.intercept('PUT', '/v0/profile/telephones', mockProfilePhone);
   cy.intercept('PUT', '/v0/profile/email_addresses', mockProfileEmail);
   cy.intercept('PUT', '/v0/profile/addresses', mockProfileAddress);
   cy.intercept(

--- a/src/applications/appeals/shared/tests/fixtures/mocks/profile-phone.json
+++ b/src/applications/appeals/shared/tests/fixtures/mocks/profile-phone.json
@@ -4,7 +4,7 @@
     "type": "async_transaction_va_profile_telephone_transactions",
     "attributes": {
       "transactionId": "c049d895-ecdf-40a4-ac0f-7947a06ea0c2",
-      "transactionStatus": "COMPLETED_SUCCESS",
+      "transactionStatus": "COMPLETED_NO_CHANGES_DETECTED",
       "type": "AsyncTransaction::VAProfile::TelephoneTransaction",
       "metadata": []
     }

--- a/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
+++ b/src/platform/testing/e2e/cypress/support/commands/keyboardNavigation.js
@@ -17,7 +17,8 @@ const removeLeadingHash = name => name.replace(leadingHashRegex, '');
 // Use chooseSelectOptionUsingValue or chooseSelectOptionByTyping instead.
 Cypress.Commands.add('findOption', value => {
   cy.get(':focus').then($el => {
-    if ($el.val() !== value) {
+    // Check that an input is focused
+    if ($el[0].tagName === 'INPUT' && $el.val() !== value) {
       cy.realPress('ArrowDown', { pressDelay: timeoutDuration });
       cy.findOption(value);
     }

--- a/src/platform/testing/e2e/cypress/support/commands/webComponents.js
+++ b/src/platform/testing/e2e/cypress/support/commands/webComponents.js
@@ -1,6 +1,24 @@
 const FORCE_OPTION = { force: true };
 const DELAY_OPTION = { force: true, delay: 100 };
 
+Cypress.Commands.add('selectVaButtonPairPrimary', field => {
+  const selector = `va-button-pair${field ? `[name="${field}"]` : ''}`;
+  cy.get(selector)
+    .shadow()
+    .find('va-button:not([secondary]):not([back])')
+    .first()
+    .click();
+});
+
+Cypress.Commands.add('selectVaButtonPairSecondary', field => {
+  const selector = `va-button-pair${field ? `[name="${field}"]` : ''}`;
+  cy.get(selector)
+    .shadow()
+    .find('va-button[secondary], va-button[back]')
+    .first()
+    .click();
+});
+
 Cypress.Commands.add('fillVaTextInput', (field, value) => {
   if (typeof value !== 'undefined') {
     const strValue = value.toString();

--- a/src/platform/testing/e2e/cypress/support/commands/webComponents.js
+++ b/src/platform/testing/e2e/cypress/support/commands/webComponents.js
@@ -227,10 +227,18 @@ Cypress.Commands.add(
 
         // day and year
         if (isChrome) {
-          cy.realPress('Tab')
-            .realType(day)
-            .realPress('Tab')
-            .realType(year);
+          cy.wrap(el)
+            .find(getSelectors('day'))
+            .shadow()
+            .find('input')
+            .focus();
+          cy.realType(day);
+          cy.wrap(el)
+            .find(getSelectors('year'))
+            .shadow()
+            .find('input')
+            .focus();
+          cy.realType(year);
         } else {
           cy.wrap(el)
             .find(getSelectors('day'))


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > - Add `selectVaButtonPairPrimary` & `selectVaButtonPairSecondary` Cypress commands for `va-button-pair`
  > - Update Cypress `fillVaMemorableDate` command to not use tabs to navigate to the day & year inputs (focus was being shifted to header in some cases)
  > - Update Decision Review contact loop e2e tests
  > - Update Decision Review e2e tests to use Cypress web component commands
  > - Update `findOption` to check that an input is focused before looping (prevents infinite loops if focus is on a header)
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/90112

## Testing done

- _Describe what the old behavior was prior to the change_
  > In e2e tests:
  > - Supplemental Claims VA evidence second memorable date input was consistently losing focus while data was being filled.
  > - Notice of Disagreement contact loop e2e test was not testing telephone edit & save
  > - Higher-Level Review e2e tests would time out after 40 minutes due to header focus instead of radio input focus
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

N/A

## What areas of the site does it impact?

Decision Review e2e tests & any other e2e tests that fill in memorable date web components

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
