### PR TITLE
#vebt-229 #comment Added h2 sr-only to gi bill name search results

### DIFF
--- a/src/applications/gi/containers/search/LocationSearchResults.jsx
+++ b/src/applications/gi/containers/search/LocationSearchResults.jsx
@@ -601,6 +601,7 @@ function LocationSearchResults({
           id="location-search-results-container"
           className={containerClassNames}
         >
+          <h2 className="sr-only">Search results</h2>
           {resultCards}
         </div>
       );

--- a/src/applications/gi/containers/search/NameSearchResults.jsx
+++ b/src/applications/gi/containers/search/NameSearchResults.jsx
@@ -156,6 +156,7 @@ export function NameSearchResults({
                 </div>
               )} */}
             <div className="column small-12 medium-8 name-search-cards-padding">
+              <h2 className="sr-only">Search results</h2>
               {inProgress && (
                 <VaLoadingIndicator
                   data-testid="loading-indicator"


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

### - _(Summarize the changes that have been made to the platform)_
- In search by name and location for the GI Bill Comparison Tool, adding an h2 sr-only element between the filters and search results for screen readers to tell users they are now viewing search results.
### - _(If bug, how to reproduce)_ N/A
### - _(What is the solution, why is this the solution)_ 
- Added an h2 sr-only element to let screen readers read out they are now viewing search results
### - _(Which team do you work for, does your team own the maintenance of this component?)_
- GovCIO, we are the code owners.
### - _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_ N/A

## Related issue(s)

Jira -> https://jira.devops.va.gov/browse/VEBT-229

Problem:

When results cards are displayed, the heading structure of the page doesn't quite make sense. Each card is described by an H3 heading, and they're all nested under the H2 "Filter your results." The cards aren't properly subsections beneath that heading — in other words, they're not peers of "Type of instituiton" and "Location," they're something different. They should be grouped under a different H2 heading.

Screen reader users often have their computers announce a list of headings on the page with the heading level hierarchy as a way of scanning the page to jump to the appropriate section. This interaction pattern depends on the heading level being faithfully communicated to the user via their screen reader; otherwise, they may lose track of how different groupings of content are related to each other.

Recommended action

Best recommendation here is that you add some additional H2 between the filters and the search results, with a heading like "Search results" or similar. This heading can be visible text, or it can be visually hidden using sr-only which will still expose it to screen reader users.

## Testing done

### - _Describe what the old behavior was prior to the change_
- Screen reader will not read out an h2 sr-only element between filters and search results in search by name and location
### - _Describe the steps required to verify your changes are working as expected_
- Screen reader will now read out 'Search results' header between filters and search results in search by name and location
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
