### PR TITLE
MHV-61206 Fixed Pathology fields and made PDF & TXT match

### DIFF
--- a/src/applications/mhv-medical-records/components/LabsAndTests/PathologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/PathologyDetails.jsx
@@ -129,7 +129,7 @@ ${record.results} \n`;
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Date completed
         </h3>
-        <p data-testid="pathology-lab-comments">{record.date}</p>
+        <p data-testid="date-completed">{record.date}</p>
       </div>
       <div className="test-results-container">
         <h2>Results</h2>

--- a/src/applications/mhv-medical-records/components/LabsAndTests/PathologyDetails.jsx
+++ b/src/applications/mhv-medical-records/components/LabsAndTests/PathologyDetails.jsx
@@ -80,8 +80,8 @@ ${formatName(user.userFullName)}\n
 Date of birth: ${formatDateLong(user.dob)}\n
 Details about this test: \n
 ${txtLine} \n
-Sample tested: ${record.sampleTested} \n
-Lab location: ${record.labLocation} \n
+Site or sample tested: ${record.sampleTested} \n
+Location: ${record.labLocation} \n
 Date completed: ${record.date} \n
 Results: \n
 ${record.results} \n`;
@@ -102,7 +102,7 @@ ${record.results} \n`;
         {record.name}
       </h1>
       <DateSubheading
-        date={record.date}
+        date={record.dateCollected}
         id="pathology-date"
         label="Date and time collected"
         labelClass="vads-font-weight-regular"
@@ -123,17 +123,13 @@ ${record.results} \n`;
         </h3>
         <p data-testid="pathology-sample-tested">{record.sampleTested}</p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Ordered by
-        </h3>
-        <p data-testid="pathology-ordered-by">{record.orderedBy}</p>
-        <h3 className="vads-u-font-size--base vads-u-font-family--sans">
           Location
         </h3>
         <p data-testid="pathology-location">{record.labLocation}</p>
         <h3 className="vads-u-font-size--base vads-u-font-family--sans">
-          Lab comments
+          Date completed
         </h3>
-        <p data-testid="pathology-lab-comments">{record.labComments}</p>
+        <p data-testid="pathology-lab-comments">{record.date}</p>
       </div>
       <div className="test-results-container">
         <h2>Results</h2>

--- a/src/applications/mhv-medical-records/reducers/labsAndTests.js
+++ b/src/applications/mhv-medical-records/reducers/labsAndTests.js
@@ -258,6 +258,9 @@ const convertPathologyRecord = record => {
     date: record.effectiveDateTime
       ? dateFormatWithoutTimezone(record.effectiveDateTime)
       : EMPTY_FIELD,
+    dateCollected: specimen?.collection?.collectedDateTime
+      ? dateFormatWithoutTimezone(specimen.collection.collectedDateTime)
+      : EMPTY_FIELD,
     sampleTested: specimen?.type?.text || EMPTY_FIELD,
     labLocation,
     collectingLocation: labLocation,

--- a/src/applications/mhv-medical-records/tests/components/PathologyDetails.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/components/PathologyDetails.unit.spec.jsx
@@ -50,7 +50,7 @@ describe('Pathology details component', () => {
   });
 
   it('should display the formatted date', () => {
-    const formattedDate = screen.getByText('august', {
+    const formattedDate = screen.getAllByText('august', {
       exact: false,
     });
     expect(formattedDate).to.exist;

--- a/src/applications/mhv-medical-records/tests/e2e/medical-records-view-pathology-details.cypress.spec.js
+++ b/src/applications/mhv-medical-records/tests/e2e/medical-records-view-pathology-details.cypress.spec.js
@@ -14,12 +14,17 @@ describe('Medical Records View Labs And Tests', () => {
     LabsAndTestsListPage.clickLabsAndTestsDetailsLink(5, labsAndTests.entry[8]);
     PathologyDetailsPage.verifyLabName(record.code.text);
     PathologyDetailsPage.verifyLabDate(
-      moment(record.effectiveDateTime).format('MMMM D, YYYY'),
+      moment(record.contained[0].collection.collectedDateTime).format(
+        'MMMM D, YYYY',
+      ),
     );
     PathologyDetailsPage.verifySampleTested(record.contained[0].type.text);
     PathologyDetailsPage.verifyLabLocation('None noted');
-    PathologyDetailsPage.verifyLabComments('None noted');
     PathologyDetailsPage.verifyReport('None noted');
+    PathologyDetailsPage.verifyDateCompleted(
+      moment(record.effectiveDateTime).format('MMMM D, YYYY'),
+    );
+
     // Axe check
     cy.injectAxe();
     cy.axeCheck('main');

--- a/src/applications/mhv-medical-records/tests/e2e/pages/PathologyDetailsPage.js
+++ b/src/applications/mhv-medical-records/tests/e2e/pages/PathologyDetailsPage.js
@@ -29,6 +29,10 @@ class PathologyDetailsPage extends BaseDetailsPage {
     );
   };
 
+  verifyDateCompleted = dateCompleted => {
+    cy.get('[data-testid="date-completed"]').should('contain', dateCompleted);
+  };
+
   verifyComposeMessageLink = composeMessageLink => {
     // verify compose a message on the My Healthvet website
     cy.get('[data-testid="compose-message-Link"]').should('be.visible');

--- a/src/applications/mhv-medical-records/util/helpers.js
+++ b/src/applications/mhv-medical-records/util/helpers.js
@@ -24,13 +24,19 @@ export const dateFormat = (timestamp, format = null) => {
 };
 
 /**
- * @param {*} datetime (2017-08-02T09:50:57-04:00)
+ * @param {*} datetime (2017-08-02T09:50:57-04:00 or 2000-08-09)
  * @returns {String} formatted datetime (August 2, 2017, 9:50 a.m.)
  */
 export const dateFormatWithoutTimezone = datetime => {
   let withoutTimezone = datetime;
   if (typeof datetime === 'string' && datetime.includes('-')) {
-    withoutTimezone = datetime.substring(0, datetime.lastIndexOf('-'));
+    // Check if datetime has a timezone and strip it off if present
+    if (datetime.includes('T')) {
+      withoutTimezone = datetime.substring(0, datetime.lastIndexOf('-'));
+    } else {
+      // Handle the case where the datetime is just a date (e.g., "2000-08-09")
+      return moment(datetime).format('MMMM D, YYYY');
+    }
   }
   return moment(withoutTimezone).format('MMMM D, YYYY, h:mm a');
 };

--- a/src/applications/mhv-medical-records/util/helpers.js
+++ b/src/applications/mhv-medical-records/util/helpers.js
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/browser';
 import { snakeCase } from 'lodash';
 import { generatePdf } from '@department-of-veterans-affairs/platform-pdf/exports';
 import { formatDateLong } from '@department-of-veterans-affairs/platform-utilities/exports';
-import { format as dateFnsFormat, parseISO } from 'date-fns';
+import { format as dateFnsFormat, parseISO, isValid } from 'date-fns';
 import {
   EMPTY_FIELD,
   interpretationMap,
@@ -35,12 +35,20 @@ export const dateFormatWithoutTimezone = datetime => {
       withoutTimezone = datetime.substring(0, datetime.lastIndexOf('-'));
     } else {
       // Handle the case where the datetime is just a date (e.g., "2000-08-09")
-      return moment(datetime).format('MMMM D, YYYY');
+      const parsedDate = parseISO(datetime);
+      if (isValid(parsedDate)) {
+        return dateFnsFormat(parsedDate, 'MMMM d, yyyy');
+      }
     }
   }
-  return moment(withoutTimezone).format('MMMM D, YYYY, h:mm a');
-};
 
+  const parsedDateTime = parseISO(withoutTimezone);
+  if (isValid(parsedDateTime)) {
+    return dateFnsFormat(parsedDateTime, 'MMMM d, yyyy, h:mm a');
+  }
+
+  return null;
+};
 /**
  * @param {Object} nameObject {first, middle, last, suffix}
  * @returns {String} formatted timestamp

--- a/src/applications/mhv-medical-records/util/helpers.js
+++ b/src/applications/mhv-medical-records/util/helpers.js
@@ -44,7 +44,10 @@ export const dateFormatWithoutTimezone = datetime => {
 
   const parsedDateTime = parseISO(withoutTimezone);
   if (isValid(parsedDateTime)) {
-    return dateFnsFormat(parsedDateTime, 'MMMM d, yyyy, h:mm a');
+    const formattedDate = dateFnsFormat(parsedDateTime, 'MMMM d, yyyy, h:mm a');
+    return formattedDate.replace(/AM|PM/, match =>
+      match.toLowerCase().replace('m', '.m.'),
+    );
   }
 
   return null;

--- a/src/applications/mhv-medical-records/util/pdfHelpers/labsAndTests.js
+++ b/src/applications/mhv-medical-records/util/pdfHelpers/labsAndTests.js
@@ -136,12 +136,12 @@ export const generatePathologyContent = record => ({
     header: 'Details about this test',
     items: [
       {
-        title: 'Sample tested',
+        title: 'Site or sample tested',
         value: record.sampleTested,
         inline: true,
       },
       {
-        title: 'Lab location',
+        title: 'Location',
         value: record.labLocation,
         inline: true,
       },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Found more issues -- we had the wrong set of fields in Pathology.
- Additionally we were using the wrong date for date collected.
- Updated PDF and TXT labels to match latest designs.

## Related issue(s)

### [MHV-61206](https://jira.devops.va.gov/browse/MHV-61206) - Implement fixes from UAT session ###

> We identified several issues during Labs & Tests UAT:
> 
> Pathology - Remove "Type of Test" field
> Radiology - Clinical History didn’t say “None Noted” in radiology if blank
> Chem/Hem - Should say "None Noted" for no results
> Chem/Hem - Interpretation should be Lab Comments
> Microbiology - Use title for H1, but if not present, use "Microbiology". Also, there should be a "Lab type" field if the title is the H1.


## Testing done

- Fixed existing tests

## Screenshots

<img width="300" alt="image" src="https://github.com/user-attachments/assets/ff50392e-b36b-4fb1-b7fe-e5b45508385d">


## What areas of the site does it impact?

MHV Medical Records

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
