### PR TITLE
Check in/91028/upcoming tests

### DIFF
--- a/src/applications/check-in/README.md
+++ b/src/applications/check-in/README.md
@@ -52,6 +52,7 @@ There are several different mock UUIDs that can be used as a value for the `id` 
   - missingUUID: `a5895713-ca42-4244-9f38-f8b5db020d04`
   - noFacilityAddressUUID: `5d5a26cd-fb0b-4c5b-931e-2957bfc4b9d3`
   - demographicsConfirmedUUID: `3f93c0e0-319a-4642-91b3-750e0aec0388`
+  - noUpcomingAppointments: `34de41ed-014c-4734-a4a4-3a4738f5e0d8`
 
 ### Pre-check-in
   - defaultUUID: `46bebc0a-b99c-464f-a5c5-560bc9eae287`
@@ -67,6 +68,7 @@ There are several different mock UUIDs that can be used as a value for the `id` 
   - noFacilityAddressUUID: `5d5a26cd-fb0b-4c5b-931e-2957bfc4b9d3`
   - allDemographicsCurrentUUID: `e544c217-6fe8-44c5-915f-6c3d9908a678`
   - onlyDemographicsCurrentUUID: `7397abc0-fb4d-4238-a3e2-32b0e47a1527` (NoK and Emergency Contact not current)
+  - noUpcomingAppointments: `34de41ed-014c-4734-a4a4-3a4738f5e0d8`
 
 ### Travel-claim
   - defaultUUID: `46bebc0a-b99c-464f-a5c5-560bc9eae287`

--- a/src/applications/check-in/api/local-mock-api/index.js
+++ b/src/applications/check-in/api/local-mock-api/index.js
@@ -22,6 +22,8 @@ const demographicsConfirmedUUID = '3f93c0e0-319a-4642-91b3-750e0aec0388';
 const upcomingAppointmentsDataGetErrorUUID =
   'b5895713-ca42-4244-9f38-f8b5db020d04';
 
+const noUpcomingAppointmentsUUID = `34de41ed-014c-4734-a4a4-3a4738f5e0d8`;
+
 const responses = {
   ...commonResponses,
   'GET /v0/feature_toggles': featureToggles.generateFeatureToggles({
@@ -123,6 +125,9 @@ const responses = {
     }
     if (uuid === upcomingAppointmentsDataGetErrorUUID) {
       return res.status(404).json(sharedData.get.createMockFailedResponse());
+    }
+    if (uuid === noUpcomingAppointmentsUUID) {
+      return res.json({ data: [] });
     }
     return res.json(sharedData.get.createUpcomingAppointments(uuid));
   },

--- a/src/applications/check-in/api/local-mock-api/mocks/v2/shared/get.js
+++ b/src/applications/check-in/api/local-mock-api/mocks/v2/shared/get.js
@@ -16,6 +16,7 @@ const aboutToExpireUUID = '25165847-2c16-4c8b-8790-5de37a7f427f';
 const pacificTimezoneUUID = '6c72b801-74ac-47fe-82af-cfe59744b45f';
 const allAppointmentTypesUUID = 'bb48c558-7b35-44ec-8ab7-32b7d49364fc';
 const checkInTooLateUUID = '127c6f75-ea5f-4986-b0f5-d411d9d5e55c';
+const noUpcomingAppointments = '34de41ed-014c-4734-a4a4-3a4738f5e0d8';
 
 // travel-claim UUIDS
 const multiOHAppointmentsUUID = 'd80ade2e-7a96-4a30-9edc-efc08b4d157d';
@@ -344,32 +345,36 @@ const createAppointments = (
 };
 
 const createUpcomingAppointments = (token, number = 4) => {
-  const appointments = [
-    createUpcomingAppointment({
-      id: '123123',
-      clincFriendlyName: `HEART CLINIC-1`,
-      start: dateFns.addDays(new Date('2023-09-26T14:00:00'), 1),
-    }),
-  ];
-  for (let i = 0; i < number; i += 1) {
+  let appointments;
+  if (token === noUpcomingAppointments) {
+    appointments = [];
+  } else {
+    appointments = [
+      createUpcomingAppointment({
+        id: '123123',
+        clincFriendlyName: `HEART CLINIC-1`,
+        start: dateFns.addDays(new Date('2023-09-26T14:00:00'), 1),
+      }),
+    ];
+    for (let i = 0; i < number; i += 1) {
+      appointments.push(
+        createUpcomingAppointment({
+          id: `12300${i + 1}`,
+          clincFriendlyName: `HEART CLINIC-${i}`,
+          start: dateFns.addHours(new Date('2023-09-26T14:00:00'), i),
+          kind: kinds[i],
+        }),
+      );
+    }
     appointments.push(
       createUpcomingAppointment({
-        id: `12300${i + 1}`,
-        clincFriendlyName: `HEART CLINIC-${i}`,
-        start: dateFns.addHours(new Date('2023-09-26T14:00:00'), i),
-        kind: kinds[i],
+        id: `123456`,
+        clincFriendlyName: `HEART CLINIC-E`,
+        start: dateFns.addMonths(new Date('2023-09-26T14:00:00'), 2),
+        status: 'CANCELLED BY CLINIC',
       }),
     );
   }
-  appointments.push(
-    createUpcomingAppointment({
-      id: `123456`,
-      clincFriendlyName: `HEART CLINIC-E`,
-      start: dateFns.addMonths(new Date('2023-09-26T14:00:00'), 2),
-      status: 'CANCELLED BY CLINIC',
-    }),
-  );
-
   return {
     data: appointments,
   };

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -295,8 +295,8 @@ const AppointmentDetails = props => {
                     <br />
                     <p>
                       {APP_NAMES.PRE_CHECK_IN
-                        ? t('find-all-appointment-information-check-in')
-                        : t('find-all-appointment-information-pre-check-in')}
+                        ? t('find-all-appointment-information-pre-check-in')
+                        : t('find-all-appointment-information-check-in')}
                     </p>
                   </va-alert-expandable>
                 )}

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -301,7 +301,7 @@ const AppointmentDetails = props => {
                   </va-alert-expandable>
                 )}
               {app === APP_NAMES.PRE_CHECK_IN &&
-                !getPreCheckinComplete(window)?.complete && (
+                link && (
                   <>
                     <h2 className="vads-u-font-size--sm">
                       {t('review-contact-information')}

--- a/src/applications/check-in/components/pages/UpcomingAppointments/index.jsx
+++ b/src/applications/check-in/components/pages/UpcomingAppointments/index.jsx
@@ -94,7 +94,7 @@ const UpcomingAppointmentsPage = props => {
   } else {
     body = (
       <>
-        {upcomingAppointments.length && (
+        {upcomingAppointments.length > 0 && (
           <va-alert-expandable
             status="warning"
             trigger={t('we-cant-show-all-information')}

--- a/src/applications/check-in/components/pages/UpcomingAppointments/index.jsx
+++ b/src/applications/check-in/components/pages/UpcomingAppointments/index.jsx
@@ -105,8 +105,8 @@ const UpcomingAppointmentsPage = props => {
             <br />
             <p>
               {APP_NAMES.PRE_CHECK_IN
-                ? t('find-all-appointment-information-check-in')
-                : t('find-all-appointment-information-pre-check-in')}
+                ? t('find-all-appointment-information-pre-check-in')
+                : t('find-all-appointment-information-check-in')}
             </p>
           </va-alert-expandable>
         )}

--- a/src/applications/check-in/day-of/tests/e2e/complete.check.in.go.back.cypress.spec.js
+++ b/src/applications/check-in/day-of/tests/e2e/complete.check.in.go.back.cypress.spec.js
@@ -123,8 +123,67 @@ describe('Check In Experience | Day Of |', () => {
 
       UpcomingAppointmentsPage.validatePageLoaded();
       UpcomingAppointmentsPage.validateUpcomingAppointmentsList();
+      cy.createScreenshots('Day-of-check-in--Pages--Upcoming-Appointments');
+      cy.injectAxeThenAxeCheck();
+    });
+  });
+  describe('Patient who completes check-in and navigates back to upcoming appointments but has none', () => {
+    const {
+      initializeFeatureToggle,
+      initializeSessionGet,
+      initializeSessionPost,
+      initializeUpcomingAppointmentsDataGet,
+      initializeCheckInDataGet,
+      initializeCheckInDataPost,
+    } = ApiInitializer;
+    beforeEach(() => {
+      const appointments = [
+        {
+          appointmentIen: '0001',
+        },
+      ];
+      initializeFeatureToggle.withAllFeatures();
+      initializeSessionGet.withSuccessfulNewSession();
+      initializeSessionPost.withValidation();
+      initializeUpcomingAppointmentsDataGet.withSuccess({
+        uuid: '34de41ed-014c-4734-a4a4-3a4738f5e0d8',
+      });
+      initializeCheckInDataGet.withSuccessAndUpdate({
+        appointments,
+        demographicsNeedsUpdate: false,
+        demographicsConfirmedAt: dateFns.format(
+          new Date(),
+          "yyyy-LL-dd'T'HH:mm:ss",
+        ),
+        nextOfKinNeedsUpdate: false,
+        nextOfKinConfirmedAt: dateFns.format(
+          new Date(),
+          "yyyy-LL-dd'T'HH:mm:ss",
+        ),
+        emergencyContactNeedsUpdate: false,
+        emergencyContactConfirmedAt: dateFns.format(
+          new Date(),
+          "yyyy-LL-dd'T'HH:mm:ss",
+        ),
+      });
+      initializeCheckInDataPost.withSuccess();
+      cy.visitWithUUID();
+      ValidateVeteran.validateVeteran();
+      ValidateVeteran.attemptToGoToNextPage();
+      AppointmentsPage.validatePageLoaded();
+      AppointmentsPage.attemptCheckIn();
+      Arrived.validateArrivedPage();
+      Arrived.attemptToGoToNextPage();
+      TravelPages.validatePageLoaded();
+      TravelPages.attemptToGoToNextPage('no');
+      Confirmation.validatePageLoaded();
+    });
+    it('should see a list of upcoming appointments', () => {
+      Confirmation.attemptGoBackToUpcomingAppointments();
+
+      UpcomingAppointmentsPage.validatePageLoaded();
       cy.createScreenshots(
-        'Day-of-check-in--Pages--Upcoming-Appointments-from-confirmation',
+        'Day-of-check-in--Pages--Upcoming-Appointments--no-appointments',
       );
       cy.injectAxeThenAxeCheck();
     });

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -440,6 +440,6 @@
   "find-out-how-to-check-in-opens-in-new-tab": "Find out how to check in (opens in new tab)",
   "we-cant-show-all-information": "We can’t show all your information right now",
   "some-appointment-information-not-available": "Some of your appointment information is not available right now.",
-  "find-all-appointment-information-check-in": "To find all your appointment information, finish checking in for this appointment first. Then go to appointments on VA.gov.",
+  "find-all-appointment-information-check-in": "To find all your appointment information, finish checking in for your appointment first. Then go to appointments on VA.gov.",
   "find-all-appointment-information-pre-check-in": "To find all your appointment information, finish reviewing your contact information first. Then go to appointments on VA.gov."
 }

--- a/src/applications/check-in/pre-check-in/tests/e2e/demographics.needs.to.confirm.cypress.spec.js
+++ b/src/applications/check-in/pre-check-in/tests/e2e/demographics.needs.to.confirm.cypress.spec.js
@@ -9,6 +9,7 @@ import EmergencyContact from '../../../tests/e2e/pages/EmergencyContact';
 import NextOfKin from '../../../tests/e2e/pages/NextOfKin';
 import Confirmation from './pages/Confirmation';
 import AppointmentResources from './pages/AppointmentResources';
+import UpcomingAppointmentsPage from '../../../tests/e2e/pages/UpcomingAppointmentsPage';
 
 const dateFns = require('date-fns');
 
@@ -377,6 +378,55 @@ describe('Check In Experience | Pre-Check-In |', () => {
             emergencyContactUpToDate: true,
             checkInType: 'preCheckIn',
           });
+        Confirmation.validatePageLoaded();
+      });
+    });
+    describe('A patient who looks at upcoming appointments before finishing pre-check-in', () => {
+      beforeEach(() => {
+        initializeFeatureToggle.withAllFeatures();
+        initializeSessionGet.withSuccessfulNewSession();
+        initializeSessionPost.withValidation();
+        initializePreCheckInDataPost.withSuccess();
+        initializeDemographicsPatch.withSuccess();
+        initializePreCheckInDataGet.withSuccess();
+        cy.visitPreCheckInWithUUID('47fa6bad-62b4-440d-a4e1-50e7f7b92d27');
+        ValidateVeteran.validateVeteran();
+        ValidateVeteran.attemptToGoToNextPage();
+      });
+      it('should view the upcoming appointments page then go back and complete', () => {
+        initializeUpcomingAppointmentsDataGet.withSuccess();
+        AppointmentsPage.attemptGoToUpcomingAppointmentsPage();
+        cy.createScreenshots('Pre-check-in--Pages--Upcoming-Appointments');
+        cy.injectAxeThenAxeCheck();
+        UpcomingAppointmentsPage.attemptToGoBack();
+        AppointmentsPage.validatePageLoaded();
+        AppointmentsPage.attemptCheckIn();
+        Demographics.validatePageLoaded();
+        Demographics.attemptToGoToNextPage();
+        EmergencyContact.validatePageLoaded();
+        EmergencyContact.attemptToGoToNextPage();
+        NextOfKin.validatePageLoaded();
+        NextOfKin.attemptToGoToNextPage();
+        Confirmation.validatePageLoaded();
+      });
+      it('should view the upcoming appointments page with no upcoming appointments then go back and complete', () => {
+        initializeUpcomingAppointmentsDataGet.withSuccess({
+          uuid: '34de41ed-014c-4734-a4a4-3a4738f5e0d8',
+        });
+        AppointmentsPage.attemptGoToUpcomingAppointmentsPage();
+        cy.createScreenshots(
+          'Pre-check-in--Pages--Upcoming-Appointments--no-appointments',
+        );
+        cy.injectAxeThenAxeCheck();
+        UpcomingAppointmentsPage.attemptToGoBack();
+        AppointmentsPage.validatePageLoaded();
+        AppointmentsPage.attemptCheckIn();
+        Demographics.validatePageLoaded();
+        Demographics.attemptToGoToNextPage();
+        EmergencyContact.validatePageLoaded();
+        EmergencyContact.attemptToGoToNextPage();
+        NextOfKin.validatePageLoaded();
+        NextOfKin.attemptToGoToNextPage();
         Confirmation.validatePageLoaded();
       });
     });

--- a/src/applications/check-in/tests/e2e/commands/index.js
+++ b/src/applications/check-in/tests/e2e/commands/index.js
@@ -57,38 +57,50 @@ Cypress.Commands.add('createScreenshots', filename => {
     cy.wait(1000);
     // Back to english
     cy.get('[data-testid="translate-button-en"]').click();
-    const screenshotHiddenItem = (item, type) => {
+    const expandHiddenItem = item => {
       item.each((i, v) => {
         cy.get(v)
           .shadow()
           .find('[aria-expanded="false"]')
           .click();
       });
-      cy.screenshot(`english/${filename}-${type}-expanded`);
       cy.wait(1000);
-      // Capture Spanish
-      cy.get('[data-testid="translate-button-es"]').click();
-      cy.wait(1000);
-      cy.screenshot(`spanish/${filename}-${type}-expanded-spanish`);
-      cy.wait(1000);
-      // Capture Tagalog
-      cy.get('[data-testid="translate-button-tl"]').click();
-      cy.wait(1000);
-      cy.screenshot(`tagalog/${filename}-${type}-expanded-tagalog`);
-      cy.wait(1000);
-      // Back to english
-      cy.get('[data-testid="translate-button-en"]').click();
     };
     // Expand additional info if it exists and make more screenshots
     // eslint-disable-next-line cypress/no-assigning-return-values
     const additionalInfo = cy.$$('va-additional-info');
     // eslint-disable-next-line cypress/no-assigning-return-values
     const accordion = cy.$$('va-accordion-item');
+    // eslint-disable-next-line cypress/no-assigning-return-values
+    const alert = cy.$$('va-alert-expandable');
+    let hiddenItems = false;
     if (additionalInfo.length) {
-      screenshotHiddenItem(additionalInfo, 'info');
+      expandHiddenItem(additionalInfo);
+      hiddenItems = true;
     }
     if (accordion.length) {
-      screenshotHiddenItem(accordion, 'accordion');
+      expandHiddenItem(accordion);
+      hiddenItems = true;
+    }
+    if (alert.length) {
+      expandHiddenItem(alert);
+      hiddenItems = true;
+    }
+    if (hiddenItems) {
+      cy.screenshot(`english/${filename}-items-expanded`);
+      cy.wait(1000);
+      // Capture Spanish
+      cy.get('[data-testid="translate-button-es"]').click();
+      cy.wait(1000);
+      cy.screenshot(`spanish/${filename}-items-expanded-spanish`);
+      cy.wait(1000);
+      // Capture Tagalog
+      cy.get('[data-testid="translate-button-tl"]').click();
+      cy.wait(1000);
+      cy.screenshot(`tagalog/${filename}-items-expanded-tagalog`);
+      cy.wait(1000);
+      // Back to english
+      cy.get('[data-testid="translate-button-en"]').click();
     }
   }
 });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Adds e2e tests and screenshots for pre-check-in upcoming appointments and adds a no-appointments test and screenshot for day-of. Also fixes a couple of bugs and a text change for another ticket.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#91028
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#90926

## Testing done

Adds tests


## What areas of the site does it impact?

day-of check-in and pre-check-in

## Acceptance criteria

 - [ ] We test upcoming appointments in e2e and take screenshots
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)


