### PR TITLE
[10-10CG] - Facility page: Create confirmation screen for selected facility and render parent facility if selected does not offer caregiver services

### DIFF
--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -118,7 +118,7 @@ const FacilitySearch = props => {
 
   return (
     <>
-      <va-card role="search">
+      <va-card role="search" background>
         <label
           htmlFor="facility-search"
           id="facility-search-label"

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -17,10 +17,41 @@ const FacilitySearch = props => {
 
   const facilityListProps = useMemo(
     () => {
+      const caregiverSupport = async facility => {
+        const offersCaregiverSupport = facility.services?.health?.some(
+          service => service.serviceId === 'caregiverSupport',
+        );
+
+        if (offersCaregiverSupport) {
+          return facility;
+        }
+
+        const loadedParent = facilities.find(
+          entry => entry.id === facility.parentId,
+        );
+        if (loadedParent) {
+          return loadedParent;
+        }
+
+        const parentFacilityResponse = await fetchFacilities({
+          id: facility.parentId,
+        });
+        if (parentFacilityResponse.errorMessage) {
+          setError(parentFacilityResponse.errorMessage);
+          return null;
+        }
+
+        return parentFacilityResponse;
+      };
+
       const { onChange, ...restOfProps } = props;
-      const setSelectedFacilities = facilityId => {
+      const setSelectedFacilities = async facilityId => {
         const facility = facilities.find(f => f.id === facilityId);
-        onChange({ veteranSelected: facility });
+        const caregiverSupportFacility = await caregiverSupport(facility);
+        onChange({
+          veteranSelected: facility,
+          caregiverSupport: caregiverSupportFacility,
+        });
       };
       return {
         ...restOfProps,
@@ -118,7 +149,6 @@ const FacilitySearch = props => {
 FacilitySearch.propTypes = {
   onChange: PropTypes.func.isRequired,
   value: PropTypes.string,
-  onChange: PropTypes.func.isRequired,
 };
 
 export default FacilitySearch;

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -118,6 +118,7 @@ const FacilitySearch = props => {
 FacilitySearch.propTypes = {
   onChange: PropTypes.func.isRequired,
   value: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
 };
 
 export default FacilitySearch;

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -27,14 +27,14 @@ const FacilitySearch = props => {
         }
 
         const loadedParent = facilities.find(
-          entry => entry.id === facility.parentId,
+          entry => entry.id === facility.parent.id,
         );
         if (loadedParent) {
           return loadedParent;
         }
 
         const parentFacilityResponse = await fetchFacilities({
-          id: facility.parentId,
+          id: facility.parent.id,
         });
         if (parentFacilityResponse.errorMessage) {
           setError(parentFacilityResponse.errorMessage);

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -11,6 +11,7 @@ import content from '../../locales/en/content.json';
 
 const FacilitySearch = props => {
   const [query, setQuery] = useState('');
+  const [submittedQuery, setSubmittedQuery] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [facilities, setFacilities] = useState([]);
@@ -58,10 +59,10 @@ const FacilitySearch = props => {
         value: restOfProps?.formData?.veteranSelected?.id,
         onChange: setSelectedFacilities,
         facilities,
-        query,
+        query: submittedQuery,
       };
     },
-    [facilities, props],
+    [facilities, submittedQuery, props],
   );
 
   const handleChange = e => {
@@ -97,6 +98,7 @@ const FacilitySearch = props => {
     }
 
     setFacilities(facilitiesResponse);
+    setSubmittedQuery(query);
     setLoading(false);
   };
 

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -61,7 +61,7 @@ const FacilitySearch = props => {
         query,
       };
     },
-    [facilities, props, query],
+    [facilities, props],
   );
 
   const handleChange = e => {

--- a/src/applications/caregivers/components/FormPages/FacilityConfirmation.jsx
+++ b/src/applications/caregivers/components/FormPages/FacilityConfirmation.jsx
@@ -5,6 +5,34 @@ import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButto
 const FacilityConfirmation = props => {
   const { data, goBack, goForward } = props;
   const selectedFacility = data['view:plannedClinic'].veteranSelected;
+  const selectedCaregiverSupportFacility =
+    data['view:plannedClinic'].caregiverSupport;
+
+  const addressText = facility => {
+    return (
+      <>
+        {facility.name}
+        {facility?.address?.physical?.address1 && (
+          <>
+            <br />
+            {facility.address.physical.address1}
+          </>
+        )}
+        {facility?.address?.physical?.address2 && (
+          <>
+            <br />
+            {facility.address.physical.address2}
+          </>
+        )}
+        {facility?.address?.physical?.address3 && (
+          <>
+            <br />
+            {facility.address.physical.address3}
+          </>
+        )}
+      </>
+    );
+  };
 
   return (
     <div>
@@ -14,26 +42,16 @@ const FacilityConfirmation = props => {
         This is the facility where you told us the Veteran receives or plans to
         receive treatment.
       </p>
+      <p className="va-address-block">{addressText(selectedFacility)}</p>
+      <h4>Your assigned caregiver support facility</h4>
+      <p>
+        This is the facility we’ve assigned to support you in the application
+        process and has a caregiver support coordinator on staff. The
+        coordinator at this facility will support you through the application
+        process.
+      </p>
       <p className="va-address-block">
-        {selectedFacility.name}
-        {selectedFacility?.address?.physical?.address1 && (
-          <>
-            <br />
-            {selectedFacility.address.physical.address1}
-          </>
-        )}
-        {selectedFacility?.address?.physical?.address2 && (
-          <>
-            <br />
-            {selectedFacility.address.physical.address2}
-          </>
-        )}
-        {selectedFacility?.address?.physical?.address3 && (
-          <>
-            <br />
-            {selectedFacility.address.physical.address3}
-          </>
-        )}
+        {addressText(selectedCaregiverSupportFacility)}
       </p>
       <FormNavButtons goBack={goBack} goForward={goForward} />
     </div>

--- a/src/applications/caregivers/components/FormPages/FacilityConfirmation.jsx
+++ b/src/applications/caregivers/components/FormPages/FacilityConfirmation.jsx
@@ -11,24 +11,23 @@ const FacilityConfirmation = props => {
   const addressText = facility => {
     return (
       <>
-        {facility.name}
+        <h5 className="vads-u-font-size--h4 vads-u-margin-top--0">
+          {facility.name}
+        </h5>
         {facility?.address?.physical?.address1 && (
           <>
-            <br />
             {facility.address.physical.address1}
+            <br />
           </>
         )}
         {facility?.address?.physical?.address2 && (
           <>
-            <br />
             {facility.address.physical.address2}
+            <br />
           </>
         )}
         {facility?.address?.physical?.address3 && (
-          <>
-            <br />
-            {facility.address.physical.address3}
-          </>
+          <>{facility.address.physical.address3}</>
         )}
       </>
     );

--- a/src/applications/caregivers/components/FormPages/FacilityConfirmation.jsx
+++ b/src/applications/caregivers/components/FormPages/FacilityConfirmation.jsx
@@ -42,7 +42,7 @@ const FacilityConfirmation = props => {
         This is the facility where you told us the Veteran receives or plans to
         receive treatment.
       </p>
-      <p className="va-address-block">{addressText(selectedFacility)}</p>
+      <va-card>{addressText(selectedFacility)}</va-card>
       <h4>Your assigned caregiver support facility</h4>
       <p>
         This is the facility we’ve assigned to support you in the application

--- a/src/applications/caregivers/components/FormPages/FacilityConfirmation.jsx
+++ b/src/applications/caregivers/components/FormPages/FacilityConfirmation.jsx
@@ -17,13 +17,13 @@ const FacilityConfirmation = props => {
         {facility?.address?.physical?.address1 && (
           <>
             {facility.address.physical.address1}
-            <br />
+            <br role="presentation" />
           </>
         )}
         {facility?.address?.physical?.address2 && (
           <>
             {facility.address.physical.address2}
-            <br />
+            <br role="presentation" />
           </>
         )}
         {facility?.address?.physical?.address3 && (

--- a/src/applications/caregivers/config/form.js
+++ b/src/applications/caregivers/config/form.js
@@ -9,6 +9,7 @@ import {
   primaryHasDifferentMailingAddress,
   secondaryOneHasDifferentMailingAddress,
   secondaryTwoHasDifferentMailingAddress,
+  showFacilityConfirmation,
 } from '../utils/helpers/form-config';
 import submitTransformer from './submit-transformer';
 import IntroductionPage from '../containers/IntroductionPage';
@@ -153,7 +154,7 @@ const formConfig = {
         vetFacilityConfirmation: {
           path: 'veteran-information/va-medical-center/confirmation',
           title: content['vet-info-title--facility'],
-          depends: formData => formData['view:useFacilitiesAPI'],
+          depends: showFacilityConfirmation,
           CustomPage: FacilityConfirmation,
           CustomPageReview: null,
           uiSchema: {},

--- a/src/applications/caregivers/config/form.js
+++ b/src/applications/caregivers/config/form.js
@@ -151,8 +151,8 @@ const formConfig = {
           uiSchema: vetMedicalCenterApiPage.uiSchema,
           schema: vetMedicalCenterApiPage.schema,
         },
-        vetFacilityConfirmation: {
-          path: 'veteran-information/va-medical-center/confirmation',
+        vetMedicalCenterConfirmation: {
+          path: 'veteran-information/va-medical-center/confirm',
           title: content['vet-info-title--facility'],
           depends: showFacilityConfirmation,
           CustomPage: FacilityConfirmation,

--- a/src/applications/caregivers/config/submit-transformer.js
+++ b/src/applications/caregivers/config/submit-transformer.js
@@ -12,7 +12,9 @@ const submitTransformer = (formConfig, form) => {
     : null;
 
   if (formData['view:useFacilitiesAPI']) {
-    const plannedClinicId = formData['view:plannedClinic'].id.split('_').pop();
+    const plannedClinicId = formData['view:plannedClinic'].caregiverSupport.id
+      .split('_')
+      .pop();
 
     formData.veteranPlannedClinic = plannedClinicId;
   }

--- a/src/applications/caregivers/tests/mocks/responses.js
+++ b/src/applications/caregivers/tests/mocks/responses.js
@@ -67,6 +67,7 @@ export const mockFacilitiesResponse = [
         city: 'Columbus',
         state: 'OH',
         address1: '420 North James Road',
+        address3: '33',
       },
     },
     classification: 'Health Care Center (HCC)',

--- a/src/applications/caregivers/tests/mocks/responses.js
+++ b/src/applications/caregivers/tests/mocks/responses.js
@@ -511,7 +511,7 @@ const fetchParentFacility = {
   address: {
     physical: {
       address1: '420 North James Road',
-      address2: '',
+      address2: '33',
       address3: 'Columbus, OH, 43219-1834',
     },
   },

--- a/src/applications/caregivers/tests/mocks/responses.js
+++ b/src/applications/caregivers/tests/mocks/responses.js
@@ -35,7 +35,9 @@ export const mockFacilitiesResponse = [
       code: 'NORMAL',
     },
     operationalHoursSpecialInstructions: null,
-    parentId: 'vha_757',
+    parent: {
+      id: 'vha_757',
+    },
     phone: {
       fax: '614-388-7565',
       main: '614-388-7650',
@@ -101,7 +103,9 @@ export const mockFacilitiesResponse = [
     operationalHoursSpecialInstructions: [
       'Normal business hours are Monday through Friday, 8:00 a.m. to 4:30 p.m.',
     ],
-    parentId: 'vha_757',
+    parent: {
+      id: 'vha_757',
+    },
     phone: {
       fax: '614-257-5460',
       main: '614-257-5200',
@@ -460,7 +464,9 @@ const fetchChildFacilityWithoutCaregiverSupport = {
     code: 'NORMAL',
   },
   operationalHoursSpecialInstructions: null,
-  parentId: 'vha_757',
+  parent: {
+    id: 'vha_757',
+  },
   phone: {
     fax: '614-388-7565',
     main: '614-388-7650',
@@ -543,7 +549,9 @@ const fetchParentFacility = {
   operationalHoursSpecialInstructions: [
     'Normal business hours are Monday through Friday, 8:00 a.m. to 4:30 p.m.',
   ],
-  parentId: 'vha_757',
+  parent: {
+    id: 'vha_757',
+  },
   phone: {
     fax: '614-257-5460',
     main: '614-257-5200',

--- a/src/applications/caregivers/tests/mocks/responses.js
+++ b/src/applications/caregivers/tests/mocks/responses.js
@@ -35,6 +35,7 @@ export const mockFacilitiesResponse = [
       code: 'NORMAL',
     },
     operationalHoursSpecialInstructions: null,
+    parentId: 'vha_757',
     phone: {
       fax: '614-388-7565',
       main: '614-388-7650',
@@ -100,6 +101,7 @@ export const mockFacilitiesResponse = [
     operationalHoursSpecialInstructions: [
       'Normal business hours are Monday through Friday, 8:00 a.m. to 4:30 p.m.',
     ],
+    parentId: 'vha_757',
     phone: {
       fax: '614-257-5460',
       main: '614-257-5200',
@@ -424,425 +426,456 @@ export const mockFacilitiesResponse = [
   },
 ];
 
-export const mockFetchFacilitiesResponse = [
-  {
-    access: null,
-    activeStatus: null,
-    address: {
-      physical: {
-        address1: '2720 Airport Drive',
-        address2: 'Suite 100',
-        address3: 'Columbus, OH, 43219-2219',
-      },
+const fetchChildFacilityWithoutCaregiverSupport = {
+  access: null,
+  activeStatus: null,
+  address: {
+    physical: {
+      address1: '2720 Airport Drive',
+      address2: 'Suite 100',
+      address3: 'Columbus, OH, 43219-2219',
     },
-    classification: 'Other Outpatient Services (OOS)',
-    detailedServices: null,
-    distance: 7.14,
-    facilityType: 'va_health_facility',
-    facilityTypePrefix: 'vha',
-    feedback: null,
-    hours: {
-      monday: '800AM-430PM',
-      tuesday: '800AM-430PM',
-      wednesday: '800AM-430PM',
-      thursday: '800AM-430PM',
-      friday: '800AM-430PM',
-      saturday: 'Closed',
-      sunday: 'Closed',
-    },
-    id: 'vha_757QC',
-    lat: 39.996592,
-    long: -82.93310921,
-    mobile: false,
-    name: 'Columbus VA Clinic',
-    operatingStatus: {
-      code: 'NORMAL',
-    },
-    operationalHoursSpecialInstructions: null,
-    phone: {
-      fax: '614-388-7565',
-      main: '614-388-7650',
-      pharmacy: '614-257-5230',
-      afterHours: '888-838-6446',
-      patientAdvocate: '614-257-5449',
-      mentalHealthClinic: '614-257-5631',
-      enrollmentCoordinator: '614-257-5628',
-    },
-    services: {
-      link:
-        'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757QC/services',
-      lastUpdated: '2024-08-18',
-    },
-    type: 'va_facilities',
-    uniqueId: '757QC',
-    visn: '10',
-    website:
-      'https://www.va.gov/central-ohio-health-care/locations/columbus-va-clinic/',
   },
-  {
-    access: null,
-    activeStatus: null,
-    address: {
-      physical: {
-        address1: '420 North James Road',
-        address2: '',
-        address3: 'Columbus, OH, 43219-1834',
+  classification: 'Other Outpatient Services (OOS)',
+  detailedServices: null,
+  distance: 7.14,
+  facilityType: 'va_health_facility',
+  facilityTypePrefix: 'vha',
+  feedback: null,
+  hours: {
+    monday: '800AM-430PM',
+    tuesday: '800AM-430PM',
+    wednesday: '800AM-430PM',
+    thursday: '800AM-430PM',
+    friday: '800AM-430PM',
+    saturday: 'Closed',
+    sunday: 'Closed',
+  },
+  id: 'vha_757QC',
+  lat: 39.996592,
+  long: -82.93310921,
+  mobile: false,
+  name: 'Columbus VA Clinic',
+  operatingStatus: {
+    code: 'NORMAL',
+  },
+  operationalHoursSpecialInstructions: null,
+  parentId: 'vha_757',
+  phone: {
+    fax: '614-388-7565',
+    main: '614-388-7650',
+    pharmacy: '614-257-5230',
+    afterHours: '888-838-6446',
+    patientAdvocate: '614-257-5449',
+    mentalHealthClinic: '614-257-5631',
+    enrollmentCoordinator: '614-257-5628',
+  },
+  services: {
+    link:
+      'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757QC/services',
+    lastUpdated: '2024-08-18',
+  },
+  type: 'va_facilities',
+  uniqueId: '757QC',
+  visn: '10',
+  website:
+    'https://www.va.gov/central-ohio-health-care/locations/columbus-va-clinic/',
+};
+
+const fetchChildFacilityWithCaregiverSupport = {
+  ...fetchChildFacilityWithoutCaregiverSupport,
+  services: {
+    health: [
+      {
+        name: 'CaregiverSupport',
+        serviceId: 'caregiverSupport',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/caregiverSupport',
       },
-    },
-    classification: 'Health Care Center (HCC)',
-    detailedServices: null,
-    distance: 8.44,
-    facilityType: 'va_health_facility',
-    facilityTypePrefix: 'vha',
-    feedback: {
-      health: {
-        primaryCareUrgent: 0.800000011920929,
-        primaryCareRoutine: 0.8700000047683716,
-        specialtyCareUrgent: 0.7599999904632568,
-        specialtyCareRoutine: 0.8399999737739563,
-      },
-      effectiveDate: '2024-02-08',
-    },
-    hours: {
-      monday: '730AM-600PM',
-      tuesday: '730AM-600PM',
-      wednesday: '730AM-600PM',
-      thursday: '730AM-600PM',
-      friday: '730AM-600PM',
-      saturday: '800AM-400PM',
-      sunday: '800AM-400PM',
-    },
-    id: 'vha_757',
-    lat: 39.98048191,
-    long: -82.91230307,
-    mobile: false,
-    name: 'Chalmers P. Wylie Veterans Outpatient Clinic',
-    operatingStatus: {
-      code: 'NORMAL',
-    },
-    operationalHoursSpecialInstructions: [
-      'Normal business hours are Monday through Friday, 8:00 a.m. to 4:30 p.m.',
     ],
-    phone: {
-      fax: '614-257-5460',
-      main: '614-257-5200',
-      pharmacy: '614-257-5230',
-      afterHours: '614-257-5512',
-      patientAdvocate: '614-257-5290',
-      mentalHealthClinic: '614-257-5631',
-      enrollmentCoordinator: '614-257-5628',
-    },
-    services: {
-      health: [
-        {
-          name: 'Allergy, asthma and immunology',
-          serviceId: 'allergy',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/allergy',
-        },
-        {
-          name: 'Audiology and speech',
-          serviceId: 'audiology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/audiology',
-        },
-        {
-          name: 'Cardiology',
-          serviceId: 'cardiology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/cardiology',
-        },
-        {
-          name: 'CaregiverSupport',
-          serviceId: 'caregiverSupport',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/caregiverSupport',
-        },
-        {
-          name: 'COVID-19 vaccines',
-          serviceId: 'covid19Vaccine',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/covid19Vaccine',
-        },
-        {
-          name: 'Dental/oral surgery',
-          serviceId: 'dental',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/dental',
-        },
-        {
-          name: 'Dermatology',
-          serviceId: 'dermatology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/dermatology',
-        },
-        {
-          name: 'Diabetic care',
-          serviceId: 'diabetic',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/diabetic',
-        },
-        {
-          name: 'Endocrinology',
-          serviceId: 'endocrinology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/endocrinology',
-        },
-        {
-          name: 'Gastroenterology',
-          serviceId: 'gastroenterology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/gastroenterology',
-        },
-        {
-          name: 'Geriatrics',
-          serviceId: 'geriatrics',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/geriatrics',
-        },
-        {
-          name: 'Gynecology',
-          serviceId: 'gynecology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/gynecology',
-        },
-        {
-          name: 'Hematology/oncology',
-          serviceId: 'hematology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/hematology',
-        },
-        {
-          name: 'Homeless Veteran care',
-          serviceId: 'homeless',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/homeless',
-        },
-        {
-          name: 'Palliative and hospice care',
-          serviceId: 'hospice',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/hospice',
-        },
-        {
-          name: 'Laboratory and pathology',
-          serviceId: 'laboratory',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/laboratory',
-        },
-        {
-          name: 'LGBTQ+ Veteran care',
-          serviceId: 'lgbtq',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/lgbtq',
-        },
-        {
-          name: 'Minority Veteran care',
-          serviceId: 'minorityCare',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/minorityCare',
-        },
-        {
-          name: 'Nephrology',
-          serviceId: 'nephrology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/nephrology',
-        },
-        {
-          name: 'Neurology',
-          serviceId: 'neurology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/neurology',
-        },
-        {
-          name: 'Nutrition, food, and dietary care',
-          serviceId: 'nutrition',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/nutrition',
-        },
-        {
-          name: 'Ophthalmology',
-          serviceId: 'ophthalmology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/ophthalmology',
-        },
-        {
-          name: 'Optometry',
-          serviceId: 'optometry',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/optometry',
-        },
-        {
-          name: 'Orthopedics',
-          serviceId: 'orthopedics',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/orthopedics',
-        },
-        {
-          name: 'Otolaryngology',
-          serviceId: 'otolaryngology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/otolaryngology',
-        },
-        {
-          name: 'Pain management',
-          serviceId: 'painManagement',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/painManagement',
-        },
-        {
-          name: 'Patient advocates',
-          serviceId: 'patientAdvocates',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/patientAdvocates',
-        },
-        {
-          name: 'Pharmacy',
-          serviceId: 'pharmacy',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/pharmacy',
-        },
-        {
-          name: 'Physical medicine and rehabilitation',
-          serviceId: 'physicalMedicine',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/physicalMedicine',
-        },
-        {
-          name: 'Plastic and reconstructive surgery',
-          serviceId: 'plasticSurgery',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/plasticSurgery',
-        },
-        {
-          name: 'Podiatry',
-          serviceId: 'podiatry',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/podiatry',
-        },
-        {
-          name: 'Primary care',
-          serviceId: 'primaryCare',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/primaryCare',
-        },
-        {
-          name: 'Prosthetics and rehabilitation',
-          serviceId: 'prosthetics',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/prosthetics',
-        },
-        {
-          name: 'PTSD care',
-          serviceId: 'ptsd',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/ptsd',
-        },
-        {
-          name: 'Pulmonary medicine',
-          serviceId: 'pulmonaryMedicine',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/pulmonaryMedicine',
-        },
-        {
-          name: 'Radiology',
-          serviceId: 'radiology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/radiology',
-        },
-        {
-          name: 'Rheumatology',
-          serviceId: 'rheumatology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/rheumatology',
-        },
-        {
-          name: 'Smoking and tobacco cessation',
-          serviceId: 'smoking',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/smoking',
-        },
-        {
-          name: 'Social work',
-          serviceId: 'socialWork',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/socialWork',
-        },
-        {
-          name: 'Spinal cord injuries and disorders',
-          serviceId: 'spinalInjury',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/spinalInjury',
-        },
-        {
-          name: 'Suicide prevention',
-          serviceId: 'suicidePrevention',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/suicidePrevention',
-        },
-        {
-          name: 'Surgery',
-          serviceId: 'surgery',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/surgery',
-        },
-        {
-          name: 'Returning service member care',
-          serviceId: 'transitionCounseling',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/transitionCounseling',
-        },
-        {
-          name: 'Urgent care',
-          serviceId: 'urgentCare',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/urgentCare',
-        },
-        {
-          name: 'Urology',
-          serviceId: 'urology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/urology',
-        },
-        {
-          name: 'Vascular surgery',
-          serviceId: 'vascularSurgery',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/vascularSurgery',
-        },
-        {
-          name: 'Blind and low vision rehabilitation',
-          serviceId: 'vision',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/vision',
-        },
-        {
-          name: 'MOVE! weight management',
-          serviceId: 'weightManagement',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/weightManagement',
-        },
-        {
-          name: 'Women Veteran care',
-          serviceId: 'womensHealth',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/womensHealth',
-        },
-        {
-          name: 'Wound care and ostomy',
-          serviceId: 'wound',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/wound',
-        },
-      ],
-      link:
-        'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services',
-      lastUpdated: '2024-08-18',
-    },
-    type: 'va_facilities',
-    uniqueId: '757',
-    visn: '10',
-    website:
-      'https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/',
+    link:
+      'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757QC/services',
+    lastUpdated: '2024-08-18',
   },
+};
+
+const fetchParentFacility = {
+  access: null,
+  activeStatus: null,
+  address: {
+    physical: {
+      address1: '420 North James Road',
+      address2: '',
+      address3: 'Columbus, OH, 43219-1834',
+    },
+  },
+  classification: 'Health Care Center (HCC)',
+  detailedServices: null,
+  distance: 8.44,
+  facilityType: 'va_health_facility',
+  facilityTypePrefix: 'vha',
+  feedback: {
+    health: {
+      primaryCareUrgent: 0.800000011920929,
+      primaryCareRoutine: 0.8700000047683716,
+      specialtyCareUrgent: 0.7599999904632568,
+      specialtyCareRoutine: 0.8399999737739563,
+    },
+    effectiveDate: '2024-02-08',
+  },
+  hours: {
+    monday: '730AM-600PM',
+    tuesday: '730AM-600PM',
+    wednesday: '730AM-600PM',
+    thursday: '730AM-600PM',
+    friday: '730AM-600PM',
+    saturday: '800AM-400PM',
+    sunday: '800AM-400PM',
+  },
+  id: 'vha_757',
+  lat: 39.98048191,
+  long: -82.91230307,
+  mobile: false,
+  name: 'Chalmers P. Wylie Veterans Outpatient Clinic',
+  operatingStatus: {
+    code: 'NORMAL',
+  },
+  operationalHoursSpecialInstructions: [
+    'Normal business hours are Monday through Friday, 8:00 a.m. to 4:30 p.m.',
+  ],
+  parentId: 'vha_757',
+  phone: {
+    fax: '614-257-5460',
+    main: '614-257-5200',
+    pharmacy: '614-257-5230',
+    afterHours: '614-257-5512',
+    patientAdvocate: '614-257-5290',
+    mentalHealthClinic: '614-257-5631',
+    enrollmentCoordinator: '614-257-5628',
+  },
+  services: {
+    health: [
+      {
+        name: 'Allergy, asthma and immunology',
+        serviceId: 'allergy',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/allergy',
+      },
+      {
+        name: 'Audiology and speech',
+        serviceId: 'audiology',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/audiology',
+      },
+      {
+        name: 'Cardiology',
+        serviceId: 'cardiology',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/cardiology',
+      },
+      {
+        name: 'CaregiverSupport',
+        serviceId: 'caregiverSupport',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/caregiverSupport',
+      },
+      {
+        name: 'COVID-19 vaccines',
+        serviceId: 'covid19Vaccine',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/covid19Vaccine',
+      },
+      {
+        name: 'Dental/oral surgery',
+        serviceId: 'dental',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/dental',
+      },
+      {
+        name: 'Dermatology',
+        serviceId: 'dermatology',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/dermatology',
+      },
+      {
+        name: 'Diabetic care',
+        serviceId: 'diabetic',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/diabetic',
+      },
+      {
+        name: 'Endocrinology',
+        serviceId: 'endocrinology',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/endocrinology',
+      },
+      {
+        name: 'Gastroenterology',
+        serviceId: 'gastroenterology',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/gastroenterology',
+      },
+      {
+        name: 'Geriatrics',
+        serviceId: 'geriatrics',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/geriatrics',
+      },
+      {
+        name: 'Gynecology',
+        serviceId: 'gynecology',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/gynecology',
+      },
+      {
+        name: 'Hematology/oncology',
+        serviceId: 'hematology',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/hematology',
+      },
+      {
+        name: 'Homeless Veteran care',
+        serviceId: 'homeless',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/homeless',
+      },
+      {
+        name: 'Palliative and hospice care',
+        serviceId: 'hospice',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/hospice',
+      },
+      {
+        name: 'Laboratory and pathology',
+        serviceId: 'laboratory',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/laboratory',
+      },
+      {
+        name: 'LGBTQ+ Veteran care',
+        serviceId: 'lgbtq',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/lgbtq',
+      },
+      {
+        name: 'Minority Veteran care',
+        serviceId: 'minorityCare',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/minorityCare',
+      },
+      {
+        name: 'Nephrology',
+        serviceId: 'nephrology',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/nephrology',
+      },
+      {
+        name: 'Neurology',
+        serviceId: 'neurology',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/neurology',
+      },
+      {
+        name: 'Nutrition, food, and dietary care',
+        serviceId: 'nutrition',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/nutrition',
+      },
+      {
+        name: 'Ophthalmology',
+        serviceId: 'ophthalmology',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/ophthalmology',
+      },
+      {
+        name: 'Optometry',
+        serviceId: 'optometry',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/optometry',
+      },
+      {
+        name: 'Orthopedics',
+        serviceId: 'orthopedics',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/orthopedics',
+      },
+      {
+        name: 'Otolaryngology',
+        serviceId: 'otolaryngology',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/otolaryngology',
+      },
+      {
+        name: 'Pain management',
+        serviceId: 'painManagement',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/painManagement',
+      },
+      {
+        name: 'Patient advocates',
+        serviceId: 'patientAdvocates',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/patientAdvocates',
+      },
+      {
+        name: 'Pharmacy',
+        serviceId: 'pharmacy',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/pharmacy',
+      },
+      {
+        name: 'Physical medicine and rehabilitation',
+        serviceId: 'physicalMedicine',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/physicalMedicine',
+      },
+      {
+        name: 'Plastic and reconstructive surgery',
+        serviceId: 'plasticSurgery',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/plasticSurgery',
+      },
+      {
+        name: 'Podiatry',
+        serviceId: 'podiatry',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/podiatry',
+      },
+      {
+        name: 'Primary care',
+        serviceId: 'primaryCare',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/primaryCare',
+      },
+      {
+        name: 'Prosthetics and rehabilitation',
+        serviceId: 'prosthetics',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/prosthetics',
+      },
+      {
+        name: 'PTSD care',
+        serviceId: 'ptsd',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/ptsd',
+      },
+      {
+        name: 'Pulmonary medicine',
+        serviceId: 'pulmonaryMedicine',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/pulmonaryMedicine',
+      },
+      {
+        name: 'Radiology',
+        serviceId: 'radiology',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/radiology',
+      },
+      {
+        name: 'Rheumatology',
+        serviceId: 'rheumatology',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/rheumatology',
+      },
+      {
+        name: 'Smoking and tobacco cessation',
+        serviceId: 'smoking',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/smoking',
+      },
+      {
+        name: 'Social work',
+        serviceId: 'socialWork',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/socialWork',
+      },
+      {
+        name: 'Spinal cord injuries and disorders',
+        serviceId: 'spinalInjury',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/spinalInjury',
+      },
+      {
+        name: 'Suicide prevention',
+        serviceId: 'suicidePrevention',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/suicidePrevention',
+      },
+      {
+        name: 'Surgery',
+        serviceId: 'surgery',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/surgery',
+      },
+      {
+        name: 'Returning service member care',
+        serviceId: 'transitionCounseling',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/transitionCounseling',
+      },
+      {
+        name: 'Urgent care',
+        serviceId: 'urgentCare',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/urgentCare',
+      },
+      {
+        name: 'Urology',
+        serviceId: 'urology',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/urology',
+      },
+      {
+        name: 'Vascular surgery',
+        serviceId: 'vascularSurgery',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/vascularSurgery',
+      },
+      {
+        name: 'Blind and low vision rehabilitation',
+        serviceId: 'vision',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/vision',
+      },
+      {
+        name: 'MOVE! weight management',
+        serviceId: 'weightManagement',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/weightManagement',
+      },
+      {
+        name: 'Women Veteran care',
+        serviceId: 'womensHealth',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/womensHealth',
+      },
+      {
+        name: 'Wound care and ostomy',
+        serviceId: 'wound',
+        link:
+          'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/wound',
+      },
+    ],
+    link:
+      'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services',
+    lastUpdated: '2024-08-18',
+  },
+  type: 'va_facilities',
+  uniqueId: '757',
+  visn: '10',
+  website:
+    'https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/',
+};
+
+export const mockFetchChildFacilityResponse = [
+  fetchChildFacilityWithoutCaregiverSupport,
+];
+export const mockFetchChildFacilityWithCaregiverSupportResponse = [
+  fetchChildFacilityWithCaregiverSupport,
+];
+export const mockFetchParentFacilityResponse = [fetchParentFacility];
+
+export const mockFetchFacilitiesResponse = [
+  fetchChildFacilityWithoutCaregiverSupport,
+  fetchParentFacility,
 ];

--- a/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch.unit.spec.js
@@ -30,14 +30,14 @@ describe('CG <FacilitySearch>', () => {
     },
   });
   const subject = ({ props }) => {
-    const { container } = render(<FacilitySearch {...props} />);
+    const { container, getByText } = render(<FacilitySearch {...props} />);
     const selectors = () => ({
       button: container.querySelector('va-button'),
       input: container.querySelector('va-text-input'),
       loader: container.querySelector('va-loading-indicator'),
       radioList: container.querySelector('va-radio'),
     });
-    return { container, selectors };
+    return { container, selectors, getByText };
   };
 
   context('when the component renders on the form page', () => {
@@ -89,6 +89,27 @@ describe('CG <FacilitySearch>', () => {
         expect(selectors().radioList).to.exist;
         expect(selectors().loader).to.not.exist;
         expect(selectors().input).to.not.have.attr('error');
+      });
+    });
+
+    it('only renders query value that was searched for', async () => {
+      const { props } = getData({});
+      const { container, getByText, selectors } = subject({ props });
+      mapboxStub.resolves(successResponse);
+      facilitiesStub.resolves(mockFetchFacilitiesResponse);
+
+      await waitFor(() => {
+        inputVaTextInput(container, 'Tampa', selectors().input);
+        userEvent.click(selectors().button);
+        expect(selectors().loader).to.exist;
+      });
+
+      await waitFor(() => {
+        inputVaTextInput(container, 'Denver', selectors().input);
+      });
+
+      await waitFor(() => {
+        expect(getByText('“Tampa”')).to.exist;
       });
     });
 

--- a/src/applications/caregivers/tests/unit/components/FormPages/FacilityConfirmation.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormPages/FacilityConfirmation.unit.spec.js
@@ -9,6 +9,7 @@ import FacilityConfirmation from '../../../../components/FormPages/FacilityConfi
 describe('CG <FacilityConfirmation>', () => {
   const facilities = mockFetchFacilitiesResponse;
   const selectedFacility = facilities[0];
+  const caregiverFacility = facilities[1];
 
   const goBack = sinon.spy();
   const goForward = sinon.spy();
@@ -16,7 +17,8 @@ describe('CG <FacilityConfirmation>', () => {
   const defaultProps = {
     data: {
       'view:plannedClinic': {
-        veteranSelected: facilities[0],
+        veteranSelected: selectedFacility,
+        caregiverSupport: caregiverFacility,
       },
     },
     goBack,
@@ -28,6 +30,7 @@ describe('CG <FacilityConfirmation>', () => {
       <FacilityConfirmation {...props} />,
     );
     const selectedFacilityAddress = selectedFacility.address.physical;
+    const caregiverFacilityAddress = caregiverFacility.address.physical;
 
     const selectors = () => ({
       pageDescription: {
@@ -39,6 +42,12 @@ describe('CG <FacilityConfirmation>', () => {
         address1: getByText(new RegExp(selectedFacilityAddress.address1)),
         address2: getByText(new RegExp(selectedFacilityAddress.address2)),
         address3: getByText(new RegExp(selectedFacilityAddress.address3)),
+      },
+      caregiverFacility: {
+        name: getByText(new RegExp(caregiverFacility.name)),
+        address1: getByText(new RegExp(caregiverFacilityAddress.address1)),
+        address2: getByText(new RegExp(caregiverFacilityAddress.address2)),
+        address3: getByText(new RegExp(caregiverFacilityAddress.address3)),
       },
       formNavButtons: {
         back: getByText('Back'),
@@ -94,5 +103,18 @@ describe('CG <FacilityConfirmation>', () => {
     expect(selectors().selectedFacility.address1).to.exist;
     expect(selectors().selectedFacility.address2).to.exist;
     expect(selectors().selectedFacility.address3).to.exist;
+  });
+
+  it('should render caregiver facility name', () => {
+    const { selectors } = subject();
+    expect(selectors().caregiverFacility.name).to.exist;
+  });
+
+  it('should render caregiver facility address', () => {
+    const { selectors } = subject();
+
+    expect(selectors().caregiverFacility.address1).to.exist;
+    expect(selectors().caregiverFacility.address2).to.exist;
+    expect(selectors().caregiverFacility.address3).to.exist;
   });
 });

--- a/src/applications/caregivers/tests/unit/components/FormPages/FacilityConfirmation.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormPages/FacilityConfirmation.unit.spec.js
@@ -33,10 +33,6 @@ describe('CG <FacilityConfirmation>', () => {
     const caregiverFacilityAddress = caregiverFacility.address.physical;
 
     const selectors = () => ({
-      pageDescription: {
-        confirmHeader: getByRole('heading', { level: 3 }),
-        veteranSelectedHeader: getByRole('heading', { level: 4 }),
-      },
       selectedFacility: {
         name: getByText(new RegExp(selectedFacility.name)),
         address1: getByText(new RegExp(selectedFacilityAddress.address1)),
@@ -78,13 +74,19 @@ describe('CG <FacilityConfirmation>', () => {
   });
 
   it('renders selected facility description text', () => {
-    const { selectors, getByText } = subject();
-    expect(selectors().pageDescription.confirmHeader).to.have.text(
-      'Confirm your health care facilities',
-    );
-    expect(selectors().pageDescription.veteranSelectedHeader).to.have.text(
-      'The Veteran’s Facility you selected',
-    );
+    const { getByRole, getByText } = subject();
+    expect(
+      getByRole('heading', {
+        level: 3,
+        name: /Confirm your health care facilities/i,
+      }),
+    ).to.be.visible;
+    expect(
+      getByRole('heading', {
+        level: 4,
+        name: /The Veteran’s Facility you selected/i,
+      }),
+    ).to.be.visible;
     expect(
       getByText(
         /This is the facility where you told us the Veteran receives or plans to receive treatment/i,
@@ -103,6 +105,21 @@ describe('CG <FacilityConfirmation>', () => {
     expect(selectors().selectedFacility.address1).to.exist;
     expect(selectors().selectedFacility.address2).to.exist;
     expect(selectors().selectedFacility.address3).to.exist;
+  });
+
+  it('renders caregive facility description text', () => {
+    const { getByRole, getByText } = subject();
+    expect(
+      getByRole('heading', {
+        level: 4,
+        name: /Your assigned caregiver support facility/i,
+      }),
+    ).to.be.visible;
+    expect(
+      getByText(
+        /This is the facility we’ve assigned to support you in the application process and has a caregiver support coordinator on staff. The coordinator at this facility will support you through the application process./i,
+      ),
+    ).to.be.visible;
   });
 
   it('should render caregiver facility name', () => {

--- a/src/applications/caregivers/tests/unit/components/FormPages/FacilityConfirmation.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormPages/FacilityConfirmation.unit.spec.js
@@ -53,6 +53,11 @@ describe('CG <FacilityConfirmation>', () => {
     return { selectors, getByRole, getByText };
   };
 
+  afterEach(() => {
+    goBack.reset();
+    goForward.reset();
+  });
+
   context('formNavButtons', () => {
     it('renders back and forward buttons', () => {
       const { selectors } = subject();

--- a/src/applications/caregivers/tests/unit/config/submit-transformer.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/config/submit-transformer.unit.spec.js
@@ -273,7 +273,9 @@ describe('CG `submitTransformer` method', () => {
       const requiredOnlyFormData = {
         ...requiredOnly,
         'view:useFacilitiesAPI': true,
-        'view:plannedClinic': veteranSelectedPlannedClinic,
+        'view:plannedClinic': {
+          caregiverSupport: veteranSelectedPlannedClinic,
+        },
       };
 
       const formData = { data: requiredOnlyFormData };

--- a/src/applications/caregivers/tests/unit/utils/helpers/form-config.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/utils/helpers/form-config.unit.spec.js
@@ -5,6 +5,7 @@ import {
   primaryHasDifferentMailingAddress,
   secondaryOneHasDifferentMailingAddress,
   secondaryTwoHasDifferentMailingAddress,
+  showFacilityConfirmation,
 } from '../../../../utils/helpers/form-config';
 
 describe('CG `hideCaregiverRequiredAlert` method', () => {
@@ -126,5 +127,61 @@ describe('CG `secondaryTwoHasDifferentMailingAddress` method', () => {
       'view:secondaryTwoHomeSameAsMailingAddress': false,
     };
     expect(secondaryTwoHasDifferentMailingAddress(formData)).to.be.true;
+  });
+});
+
+describe('CG `hasPlannedMedicalCenter` method', () => {
+  it('should return `false` when useFacilitiesAPI is off', () => {
+    const formData = { 'view:useFacilitiesAPI': false };
+    expect(showFacilityConfirmation(formData)).to.be.false;
+  });
+
+  context('useFacilitiesAPI is on', () => {
+    it('should return `false` when veteranSelected and caregiverSupport are the same facility', () => {
+      const formData = {
+        'view:useFacilitiesAPI': true,
+        'view:plannedClinic': {
+          veteranSelected: { id: 'my-id' },
+          caregiverSupport: { id: 'my-id' },
+        },
+      };
+      expect(showFacilityConfirmation(formData)).to.be.false;
+    });
+
+    it('should return `false` when view:plannedClinic is undefined', () => {
+      const formData = {
+        'view:useFacilitiesAPI': true,
+      };
+      expect(showFacilityConfirmation(formData)).to.be.false;
+    });
+
+    it('should return `false` when view:plannedClinic is empty object', () => {
+      const formData = {
+        'view:useFacilitiesAPI': true,
+        'view:plannedClinic': {},
+      };
+      expect(showFacilityConfirmation(formData)).to.be.false;
+    });
+
+    it('should return `false` when veteranSelected is empty object', () => {
+      const formData = {
+        'view:useFacilitiesAPI': true,
+        'view:plannedClinic': {
+          veteranSelected: {},
+        },
+      };
+      expect(showFacilityConfirmation(formData)).to.be.false;
+    });
+
+    it('should return `true` when veteranSelected and caregiverSupport are different facilities', () => {
+      const formData = {
+        'view:useFacilitiesAPI': true,
+        'view:plannedClinic': {
+          veteranSelected: { id: 'my-id' },
+          caregiverSupport: { id: 'not-my-id' },
+        },
+      };
+      expect(showFacilityConfirmation(formData)).to.be.true;
+    });
   });
 });

--- a/src/applications/caregivers/utils/helpers/form-config.js
+++ b/src/applications/caregivers/utils/helpers/form-config.js
@@ -87,3 +87,23 @@ export const secondaryTwoHasDifferentMailingAddress = formData => {
     formData['view:secondaryTwoHomeSameAsMailingAddress'] === false;
   return hasCaregiver && hasDifferentMailingAddress;
 };
+
+export const showFacilityConfirmation = formData => {
+  if (!formData['view:useFacilitiesAPI']) {
+    return false;
+  }
+
+  const plannedClinic = formData['view:plannedClinic'];
+  const hasPlannedClinic =
+    plannedClinic &&
+    typeof plannedClinic === 'object' &&
+    Object.keys(plannedClinic).length > 0;
+
+  if (!hasPlannedClinic) {
+    return false;
+  }
+
+  return (
+    plannedClinic?.veteranSelected?.id !== plannedClinic?.caregiverSupport?.id
+  );
+};


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- When a Veteran selects a health care facility, we validate if the facility offers caregiver services. If it does, the `veteranPlannedClinic` value is set with the facility id. If it does not, the parent facility is found and both facilities are rendered on a confirmation page notifying that the submission will be processed at the parent facility. 
- This functionality is currently behind a flipper toggle. (`caregiver_use_facilities_API`)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90381
- This PR needs the changes in https://github.com/department-of-veterans-affairs/vets-api/pull/18140 to add the parent object to the request response body.

## Testing done

- Unit tests updated

## Screenshots

[
![Screenshot 2024-08-27 at 3 58 15 PM](https://github.com/user-attachments/assets/9352665f-c4e2-4223-a233-f08977018e3b)
![Screenshot 2024-08-27 at 3 39 25 PM](https://github.com/user-attachments/assets/e4723e03-907f-4e0f-9d9a-1ad6c5c2af40)
](url)

## What areas of the site does it impact?

- 10-10CG

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
