### PR TITLE
This is how we would connect the Facilities API to the Preneed Cemete…

### DIFF
--- a/src/applications/pre-need-integration/utils/helpers.js
+++ b/src/applications/pre-need-integration/utils/helpers.js
@@ -19,7 +19,6 @@ import {
   filterViewFields,
 } from 'platform/forms-system/src/js/helpers';
 
-import environment from 'platform/utilities/environment';
 import { useSelector } from 'react-redux';
 import { fetchAndUpdateSessionExpiration as fetch } from 'platform/utilities/api';
 import * as autosuggest from 'platform/forms-system/src/js/definitions/autosuggest';
@@ -1278,13 +1277,15 @@ export function DesiredCemeteryNoteDescription() {
 }
 
 export function getCemeteries() {
-  return fetch(`${environment.API_URL}/v0/preneeds/cemeteries`, {
-    credentials: 'include',
-    headers: {
-      'X-Key-Inflection': 'camel',
-      'Source-App-Name': window.appName,
+  return fetch(
+    `https://sandbox-api.va.gov/services/va_facilities/v1/facilities?type=cemetery`,
+    {
+      headers: {
+        apikey: 'jyWCYkoohpBvZ0C6weiyfxTsgC8uQMS7',
+        accept: 'application/json',
+      },
     },
-  })
+  )
     .then(res => {
       if (!res.ok) {
         return Promise.reject(res);
@@ -1292,20 +1293,18 @@ export function getCemeteries() {
 
       return res.json();
     })
-    .then(res =>
-      res.data.map(item => ({
+    .then(res => {
+      return res.data.map(item => ({
         label: item.attributes.name,
         id: item.id,
-      })),
-    )
+      }));
+    })
     .catch(res => {
       if (res instanceof Error) {
         Sentry.captureException(res);
         Sentry.captureMessage('vets_preneed_cemeteries_error');
       }
 
-      // May change this to a reject later, depending on how we want
-      // to surface errors in autosuggest field
       return Promise.resolve([]);
     });
 }


### PR DESCRIPTION
## Summary

- This is a research story looking into how the pre-need / pre-need-integration would access the facilities api in order to retrieve cemeteries data.
- The code changes in this PR demonstrate this with the sandbox version of the API.

## Related issue(s)

- https://jira.devops.va.gov/browse/MBMS-72246

## Relevant Information
- Here is the link to facilities api: https://developer.va.gov/explore/api/va-facilities
- Here is where I received my sandbox api key: https://developer.va.gov/explore/api/va-facilities/sandbox-access

## Moving to production
- Request production access to the api: https://developer.va.gov/production-access/request-prod-access
- Update the api endpoint to the code from the sandbox uri to `https://api.va.gov/services/va_facilities/v1/facilities?type=cemetery`

### Things to consider
- My sandbox api key is hardcoded into the facilities API request. If moved into production, the apikey should be stored more securly. 