### PR TITLE
Add currency to text patterns

### DIFF
--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -218,7 +218,7 @@
 
 /**
  * Icon - any value from https://design.va.gov/storybook/?path=/docs/uswds-va-icon--docs
- * @typedef {'credit_card' | 'comment'| 'attach_money' | OrAnyString} Icon
+ * @typedef {'credit_card' | 'comment' | 'attach_money' | OrAnyString} Icon
  */
 
 /**

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -217,6 +217,11 @@
  */
 
 /**
+ * Icon - any value from https://design.va.gov/storybook/?path=/docs/uswds-va-icon--docs
+ * @typedef {'credit_card' | 'comment'| 'attach_money' | OrAnyString} Icon
+ */
+
+/**
  * @typedef {Array<{
  *    pageKey: string,
  *    path: string,
@@ -271,6 +276,7 @@
  * @property {string} [classNames] additional CSS classes to add to the field
  * @property {boolean} [confirmRemove] For arrays. If true, will show a confirmation modal when removing an item.
  * @property {string} [confirmRemoveDescription] For arrays. Description for the confirmation modal when removing an item.
+ * @property {boolean} [currency] For textUI / vaTextInputField. If true, will show a currency symbol in the input field.
  * @property {string} [customTitle] For the review page, for arrays and some widgets. This doesn't appear to change any text, but is just used for a hack to prevent an outer DL wrapper. Often set to `' '`, and used with `useDlWrap: true` to get a11y issues to pass. Will format field title and body vertically instead of horizontally. `useDlWrap` will format text horizontally.
  * @property {number} [debounceRate] Used for AutoSuggest widget
  * @property {boolean} [displayEmptyObjectOnReview] For objects with empty properties object. This will display ui:title and ui:description on the review page.
@@ -304,6 +310,10 @@
  * @property {'' | '1' | '2' | '3' | '4' | '5'} [labelHeaderLevelStyle] The header style level for the label. For web components such as radio buttons or checkboxes.
  * @property {string} [messageAriaDescribedby] For web components. An optional message that will be read by screen readers when the input is focused.
  * @property {boolean} [monthSelect] For VaMemorableDate web component. If true, will use a select dropdown for the month instead of an input.
+ * @property {string} [inputPrefix] For textUI / VaTextInputField. Displays a fixed prefix string at the start of the input field.
+ * @property {Icon} [inputIconPrefix] For textUI / VaTextInputField. This property displays a prefix that accepts a string which represents icon name.
+ * @property {string} [inputSuffix] For textUI / VaTextInputField. Displays a fixed suffix string at the start of the input field.
+ * @property {Icon} [inputIconSuffix] For textUI / VaTextInputField. This property displays a suffix that accepts a string which represents icon name.
  * @property {(formData: any, schema: SchemaOptions, uiSchema: UISchemaOptions, index, path: string[]) => SchemaOptions} [replaceSchema] Replace the entire `schema` based on `formData`. Must provide the entire `schema` in the return. Recalculates on every form data change.
  *
  * Also accepts `title` one-off property to update `'ui:title'` as long as `'ui:title'` it is not defined. (can be useful if you are working inside of an array where `updateUiSchema` is not supported).

--- a/src/platform/forms-system/src/js/web-component-fields/vaTextInputFieldMapping.jsx
+++ b/src/platform/forms-system/src/js/web-component-fields/vaTextInputFieldMapping.jsx
@@ -39,6 +39,11 @@ export default function vaTextInputFieldMapping(props) {
     type: inputType,
     width: uiOptions?.width,
     charcount: uiOptions?.charcount,
+    currency: uiOptions?.currency,
+    inputSuffix: uiOptions?.inputSuffix,
+    inputIconSuffix: uiOptions?.inputIconSuffix,
+    inputPrefix: uiOptions?.inputPrefix,
+    inputIconPrefix: uiOptions?.inputIconPrefix,
     onInput: (event, value) => {
       // redux value or input value
       let newVal = value || event.target.value;


### PR DESCRIPTION
## Summary

- Update text patterns to use currency, inputPrefix, inputIconPrefix, inputSuffix, inputIconSuffix

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#1591

## Testing done

- Browser testing

## Screenshots

![image](https://github.com/user-attachments/assets/0104cc78-7b55-4b92-a867-a53250763714)

## What areas of the site does it impact?

Allows user to pass new props to textUI and numberUI

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
