### PR TITLE
URGENT - Fix failing unit test in form app 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959a/tests/unit/containers/ConfirmationPage.unit.spec.js
+++ b/src/applications/ivc-champva/10-7959a/tests/unit/containers/ConfirmationPage.unit.spec.js
@@ -73,7 +73,7 @@ describe('Confirmation page', () => {
 
   it('should render name without suffix if none present', () => {
     const tmpStore = storeBaseTruncated;
-    delete tmpStore.form.data.fullName.suffix;
+    delete tmpStore.form.data.applicantName.suffix;
     const { container } = render(
       <Provider store={mockStore(tmpStore)}>
         <ConfirmationPage />


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR fixes a failing unit test that made it to main. A property access was breaking because the property didn't actually exist in the test data object (`fullName` -> should be `applicantName`).

## Related issue(s)

- NA

## Testing done

- Unit

## Screenshots


|         | Results | 
| ------- | ------ |
| 10-7959a tests |<img width="1227" alt="Screenshot 2024-08-23 at 12 30 37" src="https://github.com/user-attachments/assets/3eb28fe5-879e-46a0-8082-1f0772f67b90">|

## What areas of the site does it impact?

Site-wide unit test success status

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA