### PR TITLE
Check in/91083/back to appts link

### DIFF
--- a/src/applications/check-in/components/LinkList.jsx
+++ b/src/applications/check-in/components/LinkList.jsx
@@ -79,14 +79,14 @@ const LinkList = ({ router }) => {
   let body = null;
   if (page === URLS.APPOINTMENTS) {
     body = (
-      <p className="vads-u-margin-bottom--4">
+      <p data-testid="link-wrapper" className="vads-u-margin-bottom--4">
         <UpcomingAppointmentsLink />
       </p>
     );
   }
   if (page === URLS.UPCOMING_APPOINTMENTS) {
     body = (
-      <p className="vads-u-margin-bottom--4">
+      <p data-testid="link-wrapper" className="vads-u-margin-bottom--4">
         <AppointmentsLink />
       </p>
     );
@@ -97,16 +97,16 @@ const LinkList = ({ router }) => {
         {isUpcomingAppointmentsEnabled && (
           <>
             {app === APP_NAMES.CHECK_IN && (
-              <p className="vads-u-margin-bottom--2">
+              <p data-testid="link-wrapper" className="vads-u-margin-bottom--2">
                 <UpcomingAppointmentsLink />
               </p>
             )}
-            <p className="vads-u-margin-bottom--2">
+            <p data-testid="link-wrapper" className="vads-u-margin-bottom--2">
               <AppointmentsLink />
             </p>
           </>
         )}
-        <p className="vads-u-margin-bottom--4">
+        <p data-testid="link-wrapper" className="vads-u-margin-bottom--4">
           <ExternalLink href={apptLink} hrefLang="en">
             {t('sign-in-to-vagov-and-schedule')}
           </ExternalLink>

--- a/src/applications/check-in/components/LinkList.jsx
+++ b/src/applications/check-in/components/LinkList.jsx
@@ -9,10 +9,12 @@ import PropTypes from 'prop-types';
 import { recordEvent } from '@department-of-veterans-affairs/platform-monitoring/exports';
 import { useFeatureToggle } from '~/platform/utilities/feature-toggles';
 import { makeSelectFeatureToggles } from '../utils/selectors/feature-toggles';
+import { makeSelectApp } from '../selectors';
 
 import { createAnalyticsSlug } from '../utils/analytics';
 import { useFormRouting } from '../hooks/useFormRouting';
 
+import { APP_NAMES } from '../utils/appConstants';
 import { URLS } from '../utils/navigation';
 import ExternalLink from './ExternalLink';
 
@@ -25,6 +27,9 @@ const LinkList = ({ router }) => {
   const selectFeatureToggles = useMemo(makeSelectFeatureToggles, []);
   const featureToggles = useSelector(selectFeatureToggles);
   const { isUpcomingAppointmentsEnabled } = featureToggles;
+
+  const selectApp = useMemo(makeSelectApp, []);
+  const { app } = useSelector(selectApp);
 
   const handleClick = (e, location) => {
     e.preventDefault();
@@ -42,13 +47,20 @@ const LinkList = ({ router }) => {
     : 'https://va.gov/health-care/schedule-view-va-appointments/appointments/';
 
   const AppointmentsLink = () => {
+    let linkText = t('review-todays-appointments');
+    let testId = 'go-to-appointments-link';
+
+    if (app === APP_NAMES.PRE_CHECK_IN) {
+      linkText = t('review-your-appointments');
+      testId = 'go-to-appointments-link-pre-check-in';
+    }
     return (
       <Link
         onClick={e => handleClick(e, URLS.APPOINTMENTS)}
         to={URLS.APPOINTMENTS}
-        data-testid="go-to-appointments-link"
+        data-testid={testId}
       >
-        {t('review-todays-appointments')}
+        {linkText}
       </Link>
     );
   };
@@ -84,9 +96,11 @@ const LinkList = ({ router }) => {
       <>
         {isUpcomingAppointmentsEnabled && (
           <>
-            <p className="vads-u-margin-bottom--2">
-              <UpcomingAppointmentsLink />
-            </p>
+            {app === APP_NAMES.CHECK_IN && (
+              <p className="vads-u-margin-bottom--2">
+                <UpcomingAppointmentsLink />
+              </p>
+            )}
             <p className="vads-u-margin-bottom--2">
               <AppointmentsLink />
             </p>

--- a/src/applications/check-in/components/tests/LinkList.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/LinkList.unit.spec.jsx
@@ -32,6 +32,7 @@ describe('LinkList', () => {
     );
     expect(screen.getByTestId('go-to-appointments-link-pre-check-in')).to.exist;
     expect(screen.getByTestId('external-link')).to.exist;
+    expect(screen.queryAllByTestId('link-wrapper')).to.have.length(2);
   });
   it('renders correct for Pre-check-in upcoming appointments page', () => {
     const screen = render(
@@ -47,6 +48,7 @@ describe('LinkList', () => {
     );
     expect(screen.getByTestId('go-to-appointments-link-pre-check-in')).to.exist;
     expect(screen.queryByTestId('external-link')).to.not.exist;
+    expect(screen.queryAllByTestId('link-wrapper')).to.have.length(1);
   });
   it('renders correct for Day-of confirmation', () => {
     const screen = render(
@@ -63,6 +65,7 @@ describe('LinkList', () => {
     expect(screen.getByTestId('go-to-upcoming-appointments-link')).to.exist;
     expect(screen.getByTestId('go-to-appointments-link')).to.exist;
     expect(screen.getByTestId('external-link')).to.exist;
+    expect(screen.queryAllByTestId('link-wrapper')).to.have.length(3);
   });
   it('renders correct for Day-of upcoming appointments page', () => {
     const screen = render(
@@ -78,6 +81,7 @@ describe('LinkList', () => {
     );
     expect(screen.getByTestId('go-to-appointments-link')).to.exist;
     expect(screen.queryByTestId('external-link')).to.not.exist;
+    expect(screen.queryAllByTestId('link-wrapper')).to.have.length(1);
   });
   it('renders correct for pre-check-in appointments page', () => {
     const screen = render(
@@ -92,6 +96,7 @@ describe('LinkList', () => {
       </CheckInProvider>,
     );
     expect(screen.getByTestId('go-to-upcoming-appointments-link')).to.exist;
+    expect(screen.queryAllByTestId('link-wrapper')).to.have.length(1);
   });
   it('renders correct for day-of appointments page', () => {
     const screen = render(
@@ -106,5 +111,6 @@ describe('LinkList', () => {
       </CheckInProvider>,
     );
     expect(screen.getByTestId('go-to-upcoming-appointments-link')).to.exist;
+    expect(screen.queryAllByTestId('link-wrapper')).to.have.length(1);
   });
 });

--- a/src/applications/check-in/components/tests/LinkList.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/LinkList.unit.spec.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { setupI18n, teardownI18n } from '../../utils/i18n/i18n';
+import CheckInProvider from '../../tests/unit/utils/CheckInProvider';
+import LinkList from '../LinkList';
+import { APP_NAMES } from '../../utils/appConstants';
+import { URLS } from '../../utils/navigation';
+
+describe('LinkList', () => {
+  beforeEach(() => {
+    setupI18n();
+  });
+  afterEach(() => {
+    teardownI18n();
+  });
+  const appointmentsOn = {
+    // eslint-disable-next-line camelcase
+    check_in_experience_upcoming_appointments_enabled: true,
+  };
+  it('renders correct for Pre-check-in confirmation', () => {
+    const screen = render(
+      <CheckInProvider
+        store={{
+          app: APP_NAMES.PRE_CHECK_IN,
+          features: appointmentsOn,
+        }}
+        router={{ currentPage: URLS.COMPLETE }}
+      >
+        <LinkList />
+      </CheckInProvider>,
+    );
+    expect(screen.getByTestId('go-to-appointments-link-pre-check-in')).to.exist;
+    expect(screen.getByTestId('external-link')).to.exist;
+  });
+  it('renders correct for Pre-check-in upcoming appointments page', () => {
+    const screen = render(
+      <CheckInProvider
+        store={{
+          app: APP_NAMES.PRE_CHECK_IN,
+          features: appointmentsOn,
+        }}
+        router={{ currentPage: URLS.UPCOMING_APPOINTMENTS }}
+      >
+        <LinkList />
+      </CheckInProvider>,
+    );
+    expect(screen.getByTestId('go-to-appointments-link-pre-check-in')).to.exist;
+    expect(screen.queryByTestId('external-link')).to.not.exist;
+  });
+  it('renders correct for Day-of confirmation', () => {
+    const screen = render(
+      <CheckInProvider
+        store={{
+          app: APP_NAMES.CHECK_IN,
+          features: appointmentsOn,
+        }}
+        router={{ currentPage: URLS.COMPLETE }}
+      >
+        <LinkList />
+      </CheckInProvider>,
+    );
+    expect(screen.getByTestId('go-to-upcoming-appointments-link')).to.exist;
+    expect(screen.getByTestId('go-to-appointments-link')).to.exist;
+    expect(screen.getByTestId('external-link')).to.exist;
+  });
+  it('renders correct for Day-of upcoming appointments page', () => {
+    const screen = render(
+      <CheckInProvider
+        store={{
+          app: APP_NAMES.CHECK_IN,
+          features: appointmentsOn,
+        }}
+        router={{ currentPage: URLS.UPCOMING_APPOINTMENTS }}
+      >
+        <LinkList />
+      </CheckInProvider>,
+    );
+    expect(screen.getByTestId('go-to-appointments-link')).to.exist;
+    expect(screen.queryByTestId('external-link')).to.not.exist;
+  });
+  it('renders correct for pre-check-in appointments page', () => {
+    const screen = render(
+      <CheckInProvider
+        store={{
+          app: APP_NAMES.PRE_CHECK_IN,
+          features: appointmentsOn,
+        }}
+        router={{ currentPage: URLS.APPOINTMENTS }}
+      >
+        <LinkList />
+      </CheckInProvider>,
+    );
+    expect(screen.getByTestId('go-to-upcoming-appointments-link')).to.exist;
+  });
+  it('renders correct for day-of appointments page', () => {
+    const screen = render(
+      <CheckInProvider
+        store={{
+          app: APP_NAMES.CHECK_IN,
+          features: appointmentsOn,
+        }}
+        router={{ currentPage: URLS.APPOINTMENTS }}
+      >
+        <LinkList />
+      </CheckInProvider>,
+    );
+    expect(screen.getByTestId('go-to-upcoming-appointments-link')).to.exist;
+  });
+});

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -441,5 +441,6 @@
   "we-cant-show-all-information": "We can’t show all your information right now",
   "some-appointment-information-not-available": "Some of your appointment information is not available right now.",
   "find-all-appointment-information-check-in": "To find all your appointment information, finish checking in for your appointment first. Then go to appointments on VA.gov.",
-  "find-all-appointment-information-pre-check-in": "To find all your appointment information, finish reviewing your contact information first. Then go to appointments on VA.gov."
+  "find-all-appointment-information-pre-check-in": "To find all your appointment information, finish reviewing your contact information first. Then go to appointments on VA.gov.",
+  "review-your-appointments": "Review your appointments"
 }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Tweaks the link logic a bit for pre-check-in and adds a unit test.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#91083

## Testing done

Added unit test for component

## Screenshots

![localhost_3001_health-care_appointment-pre-check-in_complete (2)](https://github.com/user-attachments/assets/051afe48-b4d3-4239-bdf3-8997113858ca)

## What areas of the site does it impact?

check-in apps

## Acceptance criteria
 - [ ] manage your appointments looks like the [figma](https://www.figma.com/design/mVg6S9xgiQpWbAOAvptQOZ/Pre-check-in-%7C-PCI?node-id=393-18714&t=SEKiCdClczX8a9n2-0)
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)


