### PR TITLE
91345 Move subtitles into the titles

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ToxicExposureSummary.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ToxicExposureSummary.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
-import { formSubtitle } from '../utils';
 import {
   datesDescription,
   getOtherFieldDescription,
@@ -30,8 +29,7 @@ export function ToxicExposureSummary({
 
   return (
     <>
-      {formSubtitle('Summary')}
-      <ul>
+      <ul className="vads-u-margin-top--0">
         {Object.keys(checkboxes)
           .filter(item => item !== 'none' && item !== 'notsure')
           .map(item => {

--- a/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
@@ -3,6 +3,7 @@ import { checkboxGroupSchema } from 'platform/forms-system/src/js/web-component-
 import {
   capitalizeEachWord,
   formSubtitle,
+  formTitle,
   formatMonthYearDate,
   isClaimingNew,
   sippableId,
@@ -107,7 +108,7 @@ export const notSureHazardDetails = (
  * @param {number} totalItems - total number of selected items
  * @param {string} itemName - Display name of the location or hazard
  * @param {string} itemType - Name of the item. Defaults to 'Location'
- * @returns
+ * @returns {string} subtitle
  */
 export function teSubtitle(
   currentItem,
@@ -120,36 +121,6 @@ export function teSubtitle(
       totalItems > 0 &&
       `${itemType} ${currentItem} of ${totalItems}: ${itemName}`) ||
     itemName
-  );
-}
-
-/**
- * Create the markup for page description including the subtitle and date range description text
- *
- * @param {number} currentItem - Current item being viewed
- * @param {number} totalItems - Total items for this group
- * @param {string} itemName - Display name of the location or hazard
- * @param {string} itemName - Name of the item to display
- * @returns h4 subtitle and p description
- */
-export function dateRangePageDescription(
-  currentItem,
-  totalItems,
-  itemName,
-  itemType = 'Location',
-) {
-  const subtitle = formSubtitle(
-    teSubtitle(currentItem, totalItems, itemName, itemType),
-  );
-  return (
-    <>
-      {subtitle}
-      <p>
-        {itemType === 'Location'
-          ? dateRangeDescriptionWithLocation
-          : dateRangeDescriptionWithHazard}
-      </p>
-    </>
   );
 }
 
@@ -481,4 +452,44 @@ export function datesDescription(dates) {
     formatMonthYearDate(dates?.startDate) || 'No start date entered';
   const endDate = formatMonthYearDate(dates?.endDate) || 'No end date entered';
   return `${startDate} - ${endDate}`;
+}
+
+/**
+ * Create a title and subtitle for a page which will be passed into ui:title so that
+ * they are grouped in the same legend
+ * @param {string} title - the title for the page, which displays below the stepper
+ * @param {string} subTitle - the subtitle for the page, which displays below the title
+ * @returns {JSX.Element} markup with title and subtitle. example below.
+ *
+ * <h3 class="...">Service after August 2, 1990</h3>
+ * <h4 class="...">Location 2 of 2: Iraq</h4>
+ */
+export function titleWithSubtitle(title, subTitle) {
+  return (
+    <>
+      {formTitle(title)}
+      {formSubtitle(subTitle)}
+    </>
+  );
+}
+
+/**
+ * Group together the title, subtitle and description for the details page
+ * @param {string} title - the title for the page, which displays below the stepper
+ * @param {string} subTitle - markup for the page that displays in between the title and rest of the page
+ * @param {string} type - the type of page to generate for, locations or hazards
+ * @returns {JSX.Element} legend for the fieldset
+ */
+export function detailsPageBegin(title, subTitle, type = 'locations') {
+  return (
+    <legend>
+      {formTitle(title)}
+      {formSubtitle(subTitle)}
+      <p className="vads-u-color--base vads-u-font-weight--normal vads-u-margin-bottom--0">
+        {type === 'locations'
+          ? dateRangeDescriptionWithLocation
+          : dateRangeDescriptionWithHazard}
+      </p>
+    </legend>
+  );
 }

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposuresDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposuresDetails.js
@@ -2,11 +2,10 @@ import {
   currentOrPastDateUI,
   currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { formTitle } from '../../utils';
 import {
   additionalExposuresPageTitle,
   dateRangeAdditionalInfo,
-  dateRangePageDescription,
+  detailsPageBegin,
   exposureEndDateApproximate,
   exposureStartDateApproximate,
   getKeyIndex,
@@ -24,13 +23,16 @@ import { ADDITIONAL_EXPOSURES, TE_URL_PREFIX } from '../../constants';
  */
 function makeUiSchema(itemId) {
   return {
-    'ui:title': formTitle(additionalExposuresPageTitle),
-    'ui:description': ({ formData }) =>
-      dateRangePageDescription(
-        getKeyIndex(itemId, 'otherExposures', formData),
-        getSelectedCount('otherExposures', formData, 'specifyOtherExposures'),
-        ADDITIONAL_EXPOSURES[itemId],
-        'Hazard',
+    'ui:title': ({ formData }) =>
+      detailsPageBegin(
+        additionalExposuresPageTitle,
+        teSubtitle(
+          getKeyIndex(itemId, 'otherExposures', formData),
+          getSelectedCount('otherExposures', formData, 'specifyOtherExposures'),
+          ADDITIONAL_EXPOSURES[itemId],
+          'Hazard',
+        ),
+        'hazards',
       ),
     toxicExposure: {
       otherExposuresDetails: {

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposuresSummary.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposuresSummary.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { ADDITIONAL_EXPOSURES, TE_URL_PREFIX } from '../../constants';
 import { ToxicExposureSummary } from '../../components/ToxicExposureSummary';
-import { additionalExposuresPageTitle } from '../../content/toxicExposure';
-import { formTitle } from '../../utils';
+import {
+  additionalExposuresPageTitle,
+  titleWithSubtitle,
+} from '../../content/toxicExposure';
 
 export const uiSchema = {
-  'ui:title': formTitle(additionalExposuresPageTitle),
+  'ui:title': titleWithSubtitle(additionalExposuresPageTitle, 'Summary'),
   'ui:description': ({ formData }) => (
     <ToxicExposureSummary
       formData={formData}

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
@@ -2,9 +2,7 @@ import {
   currentOrPastDateUI,
   currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { formTitle } from '../../utils';
 import {
-  dateRangePageDescription,
   endDateApproximate,
   getKeyIndex,
   getSelectedCount,
@@ -14,6 +12,7 @@ import {
   startDateApproximate,
   teSubtitle,
   notSureDatesDetails,
+  detailsPageBegin,
 } from '../../content/toxicExposure';
 import { GULF_WAR_1990_LOCATIONS, TE_URL_PREFIX } from '../../constants';
 
@@ -24,12 +23,14 @@ import { GULF_WAR_1990_LOCATIONS, TE_URL_PREFIX } from '../../constants';
  */
 function makeUiSchema(locationId) {
   return {
-    'ui:title': formTitle(gulfWar1990PageTitle),
-    'ui:description': ({ formData }) =>
-      dateRangePageDescription(
-        getKeyIndex(locationId, 'gulfWar1990', formData),
-        getSelectedCount('gulfWar1990', formData),
-        GULF_WAR_1990_LOCATIONS[locationId],
+    'ui:title': ({ formData }) =>
+      detailsPageBegin(
+        gulfWar1990PageTitle,
+        teSubtitle(
+          getKeyIndex(locationId, 'gulfWar1990', formData),
+          getSelectedCount('gulfWar1990', formData),
+          GULF_WAR_1990_LOCATIONS[locationId],
+        ),
       ),
     toxicExposure: {
       gulfWar1990Details: {

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Summary.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Summary.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { GULF_WAR_1990_LOCATIONS, TE_URL_PREFIX } from '../../constants';
 import { ToxicExposureSummary } from '../../components/ToxicExposureSummary';
-import { gulfWar1990PageTitle } from '../../content/toxicExposure';
-import { formTitle } from '../../utils';
+import {
+  gulfWar1990PageTitle,
+  titleWithSubtitle,
+} from '../../content/toxicExposure';
 
 export const uiSchema = {
-  'ui:title': formTitle(gulfWar1990PageTitle),
+  'ui:title': titleWithSubtitle(gulfWar1990PageTitle, 'Summary'),
   'ui:description': ({ formData }) => (
     <ToxicExposureSummary
       formData={formData}

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
@@ -2,9 +2,7 @@ import {
   currentOrPastDateUI,
   currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { formTitle } from '../../utils';
 import {
-  dateRangePageDescription,
   endDateApproximate,
   getKeyIndex,
   getSelectedCount,
@@ -14,6 +12,7 @@ import {
   showCheckboxLoopDetailsPage,
   teSubtitle,
   notSureDatesDetails,
+  detailsPageBegin,
 } from '../../content/toxicExposure';
 import { GULF_WAR_2001_LOCATIONS, TE_URL_PREFIX } from '../../constants';
 
@@ -24,12 +23,14 @@ import { GULF_WAR_2001_LOCATIONS, TE_URL_PREFIX } from '../../constants';
  */
 function makeUiSchema(locationId) {
   return {
-    'ui:title': formTitle(gulfWar2001PageTitle),
-    'ui:description': ({ formData }) =>
-      dateRangePageDescription(
-        getKeyIndex(locationId, 'gulfWar2001', formData),
-        getSelectedCount('gulfWar2001', formData),
-        GULF_WAR_2001_LOCATIONS[locationId],
+    'ui:title': ({ formData }) =>
+      detailsPageBegin(
+        gulfWar2001PageTitle,
+        teSubtitle(
+          getKeyIndex(locationId, 'gulfWar2001', formData),
+          getSelectedCount('gulfWar2001', formData),
+          GULF_WAR_2001_LOCATIONS[locationId],
+        ),
       ),
     toxicExposure: {
       gulfWar2001Details: {

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Summary.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Summary.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { GULF_WAR_2001_LOCATIONS, TE_URL_PREFIX } from '../../constants';
-import { gulfWar2001PageTitle } from '../../content/toxicExposure';
+import {
+  gulfWar2001PageTitle,
+  titleWithSubtitle,
+} from '../../content/toxicExposure';
 import { ToxicExposureSummary } from '../../components/ToxicExposureSummary';
-import { formTitle } from '../../utils';
 
 export const uiSchema = {
-  'ui:title': formTitle(gulfWar2001PageTitle),
+  'ui:title': titleWithSubtitle(gulfWar2001PageTitle, 'Summary'),
   'ui:description': ({ formData }) => (
     <ToxicExposureSummary
       formData={formData}

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
@@ -2,10 +2,9 @@ import {
   currentOrPastDateUI,
   currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import { formTitle } from '../../utils';
 import {
   dateRangeAdditionalInfo,
-  dateRangePageDescription,
+  detailsPageBegin,
   endDateApproximate,
   getKeyIndex,
   getSelectedCount,
@@ -24,12 +23,14 @@ import { HERBICIDE_LOCATIONS, TE_URL_PREFIX } from '../../constants';
  */
 function makeUiSchema(locationId) {
   return {
-    'ui:title': formTitle(herbicidePageTitle),
-    'ui:description': ({ formData }) =>
-      dateRangePageDescription(
-        getKeyIndex(locationId, 'herbicide', formData),
-        getSelectedCount('herbicide', formData, 'otherHerbicideLocations'),
-        HERBICIDE_LOCATIONS[locationId],
+    'ui:title': ({ formData }) =>
+      detailsPageBegin(
+        herbicidePageTitle,
+        teSubtitle(
+          getKeyIndex(locationId, 'herbicide', formData),
+          getSelectedCount('herbicide', formData, 'otherHerbicideLocations'),
+          HERBICIDE_LOCATIONS[locationId],
+        ),
       ),
     toxicExposure: {
       herbicideDetails: {

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
@@ -4,28 +4,30 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import {
   dateRangeAdditionalInfo,
-  dateRangePageDescription,
+  detailsPageBegin,
   endDateApproximate,
   getOtherFieldDescription,
   getSelectedCount,
   herbicidePageTitle,
   notSureDatesDetails,
   startDateApproximate,
+  teSubtitle,
 } from '../../content/toxicExposure';
-import { formTitle } from '../../utils';
 
 export const uiSchema = {
-  'ui:title': formTitle(herbicidePageTitle),
-  'ui:description': ({ formData }) => {
+  'ui:title': ({ formData }) => {
     const indexAndSelectedCount = getSelectedCount(
       'herbicide',
       formData,
       'otherHerbicideLocations',
     );
-    return dateRangePageDescription(
-      indexAndSelectedCount,
-      indexAndSelectedCount,
-      getOtherFieldDescription(formData, 'otherHerbicideLocations'),
+    return detailsPageBegin(
+      herbicidePageTitle,
+      teSubtitle(
+        indexAndSelectedCount,
+        indexAndSelectedCount,
+        getOtherFieldDescription(formData, 'otherHerbicideLocations'),
+      ),
     );
   },
   toxicExposure: {

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideSummary.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideSummary.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { HERBICIDE_LOCATIONS, TE_URL_PREFIX } from '../../constants';
 import { ToxicExposureSummary } from '../../components/ToxicExposureSummary';
-import { herbicidePageTitle } from '../../content/toxicExposure';
-import { formTitle } from '../../utils';
+import {
+  herbicidePageTitle,
+  titleWithSubtitle,
+} from '../../content/toxicExposure';
 
 export const uiSchema = {
-  'ui:title': formTitle(herbicidePageTitle),
+  'ui:title': titleWithSubtitle(herbicidePageTitle, 'Summary'),
   'ui:description': ({ formData }) => (
     <ToxicExposureSummary
       formData={formData}

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/specifyOtherExposures.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/specifyOtherExposures.js
@@ -5,30 +5,34 @@ import {
 import {
   additionalExposuresPageTitle,
   dateRangeAdditionalInfo,
-  dateRangePageDescription,
+  detailsPageBegin,
   exposureEndDateApproximate,
   exposureStartDateApproximate,
   getOtherFieldDescription,
   getSelectedCount,
   notSureDatesDetails,
+  teSubtitle,
 } from '../../content/toxicExposure';
-import { formTitle } from '../../utils';
 
 export const uiSchema = {
-  'ui:title': formTitle(additionalExposuresPageTitle),
-  'ui:description': ({ formData }) => {
+  'ui:title': ({ formData }) => {
     const indexAndSelectedCount = getSelectedCount(
       'otherExposures',
       formData,
       'specifyOtherExposures',
     );
-    return dateRangePageDescription(
-      indexAndSelectedCount,
-      indexAndSelectedCount,
-      getOtherFieldDescription(formData, 'specifyOtherExposures'),
-      'Hazard',
+    return detailsPageBegin(
+      additionalExposuresPageTitle,
+      teSubtitle(
+        indexAndSelectedCount,
+        indexAndSelectedCount,
+        getOtherFieldDescription(formData, 'specifyOtherExposures'),
+        'Hazard',
+      ),
+      'hazards',
     );
   },
+
   toxicExposure: {
     specifyOtherExposures: {
       startDate: currentOrPastDateUI({

--- a/src/applications/disability-benefits/all-claims/tests/components/ToxicExposureSummary.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ToxicExposureSummary.unit.spec.jsx
@@ -29,8 +29,6 @@ describe('toxicExposureSummary', () => {
       <ToxicExposureSummary formData={formData} {...props} />,
     );
 
-    tree.getByText('Summary');
-
     tree.getByText(GULF_WAR_1990_LOCATIONS.afghanistan);
     tree.getByText(noDatesEntered);
 
@@ -59,7 +57,6 @@ describe('toxicExposureSummary', () => {
       <ToxicExposureSummary formData={formData} {...props} />,
     );
 
-    tree.getByText('Summary');
     tree.getByText(GULF_WAR_1990_LOCATIONS.waters);
     tree.getByText('January 2000 - January 2004');
   });
@@ -93,7 +90,6 @@ describe('toxicExposureSummary', () => {
       <ToxicExposureSummary formData={formData} {...props} />,
     );
 
-    tree.getByText('Summary');
     tree.getByText(GULF_WAR_1990_LOCATIONS.afghanistan);
     tree.getByText(noDatesEntered);
 

--- a/src/applications/disability-benefits/all-claims/tests/content/toxicExposure.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/content/toxicExposure.unit.spec.jsx
@@ -1,9 +1,6 @@
-import { render } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import {
-  dateRangeDescriptionWithLocation,
-  dateRangePageDescription,
   datesDescription,
   getKeyIndex,
   getOtherFieldDescription,
@@ -378,20 +375,6 @@ describe('toxicExposure', () => {
 
       validateTEConditions(errors, formData);
       expect(errors.toxicExposure.conditions.addError.called).to.be.false;
-    });
-  });
-
-  describe('dateRangePageDescription', () => {
-    it('displays description when counts specified', () => {
-      const tree = render(dateRangePageDescription(1, 5, 'Egypt'));
-      tree.getByText('Location 1 of 5: Egypt', { exact: false });
-      tree.getByText(dateRangeDescriptionWithLocation);
-    });
-
-    it('displays description when counts not specified', () => {
-      const tree = render(dateRangePageDescription(0, 0, 'Egypt'));
-      tree.getByText('Egypt');
-      tree.getByText(dateRangeDescriptionWithLocation);
     });
   });
 

--- a/src/applications/disability-benefits/all-claims/utils/index.jsx
+++ b/src/applications/disability-benefits/all-claims/utils/index.jsx
@@ -754,9 +754,7 @@ export const formTitle = title => (
  * @returns {string} markup with h4 tag and consistent styling
  */
 export const formSubtitle = subtitle => (
-  <h4 className="vads-u-font-size--h5 vads-u-margin-top--2 vads-u-color--gray-dark">
-    {subtitle}
-  </h4>
+  <h4 className="vads-u-font-size--h5 vads-u-color--gray-dark">{subtitle}</h4>
 );
 
 /**


### PR DESCRIPTION
## Summary
- For toxic exposure details and summary pages, move the subtitle and description into the `ui:title` so that they can be grouped together within a `<fieldset>`'s `<legend>`
- No significant visual changes, but when using a screen reader you can now hear the title, subtitle (location or hazard name) and description (instructions) announced together before going into the group

team: @department-of-veterans-affairs/dbex-trex 
toggle cleanup: department-of-veterans-affairs/va.gov-team#65089

## Related issue(s)
department-of-veterans-affairs/va.gov-team#91345

## Testing done
- Updated unit tests, verified e2e tests still successful, manually tested for visual regression and with voiceover
- _Describe what the old behavior was prior to the change_
Prior to change, only the title was in the fieldset legend. subtitle and instructions were outside of the legend

**Manual test setup**
1. Enable toggle `disability_526_toxic_exposure`
2. Start a new claim with new conditions
3. On the toxic-exposure/conditions page, select at least one new condition
4. For the gulf war 1990, gulf war 2001 and herbicide pages select one or more locations. For the additional exposures page, select one or more hazards. For the last two pages also enter other locations or hazards.
5. **Verify**: Make sure on each of the details and summary pages that the title, subtitle and description are grouped together in the `<legend>` and also screen reader announces all of these items when tabbing into the group

## Screenshots
n/a no visual changes, but verify no breaking visual changes, aka regression

## What areas of the site does it impact?
526ez

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [n/a] Documentation has been updated ([link to documentation](#) \*if necessary)
- [n/a] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [n/a] Events are being sent to the appropriate logging solution
- [n/a] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
