### PR TITLE
Add Registration Only pages for auth users in the Health Care Application

### DIFF
--- a/src/applications/hca/components/FormFooter/index.jsx
+++ b/src/applications/hca/components/FormFooter/index.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import GetFormHelp from '../GetFormHelp';
+
+const FormFooter = () => (
+  <div className="vads-u-margin-bottom--2">
+    <va-need-help>
+      <div slot="content">
+        <GetFormHelp />
+      </div>
+    </va-need-help>
+  </div>
+);
+
+export default FormFooter;

--- a/src/applications/hca/components/IdentityPage/VerificationPageDescription.jsx
+++ b/src/applications/hca/components/IdentityPage/VerificationPageDescription.jsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
+import content from '../../locales/en/content.json';
 
 const VerificationPageDescription = ({ onLogin }) => (
   <>
-    <FormTitle title="Before you start your application" />
+    <FormTitle
+      title={content['page-title--before-you-begin']}
+      subTitle={content['form-subtitle']}
+    />
     <p>
       We need some information before you can start your application. This will
-      help us fit your application to your specific needs.
+      help us fit your application to your specific needs. Then you can fill out
+      the VA health care application (10-10EZ).
     </p>
-    <p>Then you can fill out the VA health care application (10-10EZ).</p>
     <p className="vads-u-font-weight--bold">Sign in and save time</p>
     <p>
       You can sign in and confirm that the information we have for you is up to

--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -11,13 +11,16 @@ import { prefillTransformer, transform } from '../utils/helpers';
 import {
   isLoggedOut,
   isSigiEnabled,
+  isRegOnlyEnabled,
   isMissingVeteranDob,
   hasDifferentHomeAddress,
   hasLowDisabilityRating,
   hasNoCompensation,
   hasHighCompensation,
   notShortFormEligible,
+  includeRegOnlyAuthQuestions,
   includeRegOnlyGuestQuestions,
+  showRegOnlyAuthConfirmation,
   showRegOnlyGuestConfirmation,
   dischargePapersRequired,
   includeTeraInformation,
@@ -37,13 +40,18 @@ import {
 import { SHARED_PATHS } from '../utils/constants';
 import migrations from './migrations';
 import manifest from '../manifest.json';
-import IdentityPage from '../containers/IdentityPage';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import SubmissionErrorAlert from '../components/FormAlerts/SubmissionErrorAlert';
 import DowntimeWarning from '../components/FormAlerts/DowntimeWarning';
 import PreSubmitNotice from '../components/PreSubmitNotice';
 import GetFormHelp from '../components/GetFormHelp';
+
+// Before you begin
+import IdentityPage from '../containers/IdentityPage';
+import PersonalInformationPage from '../containers/PersonalInformationPage';
+import AuthBenefitsPackagePage from '../containers/AuthBenefitsPackagePage';
+import AuthRegistrationOnlyPage from '../containers/AuthRegistrationOnlyPage';
 
 // chapter 1 Veteran Information
 import VeteranInformation from '../components/FormPages/VeteranInformation';
@@ -152,6 +160,24 @@ const formConfig = {
       pageKey: 'id-form',
       depends: isLoggedOut,
     },
+    {
+      path: 'check-your-personal-information',
+      component: PersonalInformationPage,
+      pageKey: 'verify-personal-information',
+      depends: isRegOnlyEnabled,
+    },
+    {
+      path: 'select-benefits-package',
+      component: AuthBenefitsPackagePage,
+      pageKey: 'medical-benefits-package',
+      depends: includeRegOnlyAuthQuestions,
+    },
+    {
+      path: 'care-for-service-connected-conditions',
+      component: AuthRegistrationOnlyPage,
+      pageKey: 'auth-reg-only',
+      depends: showRegOnlyAuthConfirmation,
+    },
   ],
   confirmation: ConfirmationPage,
   submissionError: SubmissionErrorAlert,
@@ -176,6 +202,7 @@ const formConfig = {
           CustomPageReview: null,
           uiSchema: {},
           schema: { type: 'object', properties: {} },
+          depends: formData => !isRegOnlyEnabled(formData),
         },
         dobInformation: {
           path: 'veteran-information/profile-information-dob',

--- a/src/applications/hca/containers/AuthBenefitsPackagePage.jsx
+++ b/src/applications/hca/containers/AuthBenefitsPackagePage.jsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  getNextPagePath,
+  getPreviousPagePath,
+} from 'platform/forms-system/src/js/routing';
+import { focusElement } from 'platform/utilities/ui';
+import { setData } from 'platform/forms-system/src/js/actions';
+import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
+import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
+import definition from '../config/chapters/vaBenefits/benefitsPackage';
+import RegistrationOnlyDescription from '../components/FormDescriptions/RegistrationOnlyDescription';
+import FormFooter from '../components/FormFooter';
+import content from '../locales/en/content.json';
+
+const AuthBenefitsPackagePage = props => {
+  const { location, route, router } = props;
+  const { pathname } = location;
+  const { pageList } = route;
+  const { schema } = definition;
+  const uiSchema = {
+    ...definition.uiSchema,
+    ...titleUI({
+      title: content['benefits--reg-only-title'],
+      description: RegistrationOnlyDescription,
+      headerLevel: 2,
+      headerStyleLevel: 3,
+    }),
+  };
+
+  const { data: formData } = useSelector(state => state.form);
+  const [localData, setLocalData] = useState({});
+  const dispatch = useDispatch();
+
+  const handlers = {
+    goBack: () => {
+      const prevPagePath = getPreviousPagePath(pageList, formData, pathname);
+      router.push(prevPagePath);
+    },
+    onChange: data => {
+      setLocalData(data);
+      dispatch(
+        setData({
+          ...formData,
+          'view:vaBenefitsPackage': data['view:vaBenefitsPackage'],
+        }),
+      );
+    },
+    onSubmit: () => {
+      const nextPagePath = getNextPagePath(pageList, formData, pathname);
+      router.push(nextPagePath);
+    },
+  };
+
+  useEffect(() => {
+    focusElement('.va-nav-breadcrumbs-list');
+  }, []);
+
+  return (
+    <>
+      <FormTitle
+        title={content['page-title--before-you-begin']}
+        subTitle={content['form-subtitle']}
+      />
+      <div className="progress-box progress-box-schemaform vads-u-padding-x--0">
+        <div className="vads-u-margin-y--2 form-panel">
+          <SchemaForm
+            name="Benefits package form"
+            title="Benefits package form"
+            schema={schema}
+            uiSchema={uiSchema}
+            onSubmit={handlers.onSubmit}
+            onChange={handlers.onChange}
+            data={localData}
+          >
+            <FormNavButtons goBack={handlers.goBack} submitToContinue />
+          </SchemaForm>
+        </div>
+      </div>
+      <FormFooter />
+    </>
+  );
+};
+
+AuthBenefitsPackagePage.propTypes = {
+  location: PropTypes.object,
+  route: PropTypes.object,
+  router: PropTypes.object,
+};
+
+export default AuthBenefitsPackagePage;

--- a/src/applications/hca/containers/AuthRegistrationOnlyPage.jsx
+++ b/src/applications/hca/containers/AuthRegistrationOnlyPage.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import { getPreviousPagePath } from 'platform/forms-system/src/js/routing';
+import ProgressButton from 'platform/forms-system/src/js/components/ProgressButton';
+import RegistrationOnlyAlert from '../components/FormAlerts/RegistrationOnlyAlert';
+import FormFooter from '../components/FormFooter';
+import content from '../locales/en/content.json';
+
+const AuthRegistrationOnlyPage = props => {
+  const { location, route, router } = props;
+  const { data: formData } = useSelector(state => state.form);
+  const goBack = () => {
+    const { pathname } = location;
+    const { pageList } = route;
+    const prevPagePath = getPreviousPagePath(pageList, formData, pathname);
+    router.push(prevPagePath);
+  };
+  return (
+    <>
+      <div className="progress-box progress-box-schemaform vads-u-padding-x--0">
+        <RegistrationOnlyAlert headingLevel={1} />
+        <div className="row form-progress-buttons schemaform-buttons vads-u-margin-y--2">
+          <div className="small-6 medium-5 columns">
+            <ProgressButton
+              buttonClass="hca-button-progress usa-button-secondary"
+              onButtonClick={goBack}
+              buttonText={content['button-back']}
+              beforeText="«"
+            />
+          </div>
+        </div>
+      </div>
+      <FormFooter />
+    </>
+  );
+};
+
+AuthRegistrationOnlyPage.propTypes = {
+  location: PropTypes.object,
+  route: PropTypes.object,
+  router: PropTypes.object,
+};
+
+export default AuthRegistrationOnlyPage;

--- a/src/applications/hca/containers/PersonalInformationPage.jsx
+++ b/src/applications/hca/containers/PersonalInformationPage.jsx
@@ -1,0 +1,68 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import {
+  getNextPagePath,
+  getPreviousPagePath,
+} from 'platform/forms-system/src/js/routing';
+import { focusElement } from 'platform/utilities/ui';
+import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
+import FormNavButtons from 'platform/forms-system/src/js/components/FormNavButtons';
+import AuthProfileInformation from '../components/VeteranInformation/AuthProfileInformation';
+import GuestVerifiedInformation from '../components/VeteranInformation/GuestVerifiedInformation';
+import FormFooter from '../components/FormFooter';
+import content from '../locales/en/content.json';
+
+const PersonalInformationPage = props => {
+  const { location, route, router } = props;
+  const { pathname } = location;
+  const { pageList } = route;
+  const { data: formData } = useSelector(state => state.form);
+  const { userFullName, dob } = useSelector(state => state.user.profile);
+  const authUser = {
+    veteranFullName: userFullName,
+    veteranDateOfBirth: dob,
+    totalDisabilityRating: formData['view:totalDisabilityRating'],
+  };
+  const guestUser = formData['view:veteranInformation'];
+  const goBack = () => {
+    const prevPagePath = getPreviousPagePath(pageList, formData, pathname);
+    router.push(prevPagePath);
+  };
+  const goForward = () => {
+    const nextPagePath = getNextPagePath(pageList, formData, pathname);
+    router.push(nextPagePath);
+  };
+
+  useEffect(() => {
+    focusElement('.va-nav-breadcrumbs-list');
+  }, []);
+
+  return (
+    <>
+      <FormTitle
+        title={content['page-title--check-your-information']}
+        subTitle={content['form-subtitle']}
+      />
+      <div className="progress-box progress-box-schemaform vads-u-padding-x--0">
+        <div className="vads-u-margin-y--2 form-panel">
+          {formData['view:isLoggedIn'] ? (
+            <AuthProfileInformation user={authUser} />
+          ) : (
+            <GuestVerifiedInformation user={guestUser} />
+          )}
+          <FormNavButtons goBack={goBack} goForward={goForward} />
+        </div>
+      </div>
+      <FormFooter />
+    </>
+  );
+};
+
+PersonalInformationPage.propTypes = {
+  location: PropTypes.object,
+  route: PropTypes.object,
+  router: PropTypes.object,
+};
+
+export default PersonalInformationPage;

--- a/src/applications/hca/locales/en/content.json
+++ b/src/applications/hca/locales/en/content.json
@@ -26,6 +26,8 @@
   "insurance-info--facility-title": "VA facility",
   "load-app": "Loading application...",
   "load-enrollment-status": "Verifying your enrollment status...",
+  "page-title--before-you-begin" : "Before you start your application",
+  "page-title--check-your-information" : "Check your personal information",
   "sip-start-form-text": "Start the health care application",
   "vet-info--birthplace-title" :"Your place of birth",
   "vet-info--birthplace-description" :"Enter your place of birth, including city and state, province or region.",

--- a/src/applications/hca/tests/unit/containers/AuthBenefitsPackagePage.unit.spec.js
+++ b/src/applications/hca/tests/unit/containers/AuthBenefitsPackagePage.unit.spec.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { expect } from 'chai';
+import { fireEvent, render } from '@testing-library/react';
+import sinon from 'sinon';
+import { simulateInputChange } from '../../helpers';
+import formConfig from '../../../config/form';
+import AuthBenefitsPackagePage from '../../../containers/AuthBenefitsPackagePage';
+
+describe('hca AuthBenefitsPackagePage', () => {
+  const getData = () => ({
+    props: {
+      router: { push: sinon.spy() },
+      route: {
+        pageList: [
+          { path: '/previous', formConfig },
+          { path: '/current-page' },
+          { path: '/next', formConfig },
+        ],
+      },
+      location: {
+        pathname: '/current-page',
+      },
+    },
+    mockStore: {
+      getState: () => ({
+        form: { data: {} },
+        user: {
+          login: { currentlyLoggedIn: true },
+          profile: { loading: false },
+        },
+      }),
+      subscribe: () => {},
+      dispatch: sinon.stub(),
+    },
+  });
+  const subject = ({ props, mockStore }) => {
+    const { container } = render(
+      <Provider store={mockStore}>
+        <AuthBenefitsPackagePage {...props} />
+      </Provider>,
+    );
+    const selectors = () => ({
+      form: container.querySelector('.rjsf'),
+      primaryBtn: container.querySelector('.usa-button-primary'),
+      secondaryBtn: container.querySelector('.usa-button-secondary'),
+    });
+    return { container, selectors };
+  };
+
+  it('should render form and navigation buttons', () => {
+    const { props, mockStore } = getData();
+    const { selectors } = subject({ props, mockStore });
+    const { form, primaryBtn, secondaryBtn } = selectors();
+    expect(form).to.exist;
+    expect(primaryBtn).to.exist;
+    expect(secondaryBtn).to.exist;
+  });
+
+  it('should fire the routers `push` method with the correct path when the `back` button is clicked', () => {
+    const { props, mockStore } = getData();
+    const { selectors } = subject({ props, mockStore });
+    const { router } = props;
+    fireEvent.click(selectors().secondaryBtn);
+    expect(router.push.calledWith('/previous')).to.be.true;
+  });
+
+  it('should fire the routers `push` method with the correct path when the `continue` button is clicked', () => {
+    const { props, mockStore } = getData();
+    const { selectors } = subject({ props, mockStore });
+    const { router } = props;
+    fireEvent.click(selectors().primaryBtn);
+    expect(router.push.calledWith('/next')).to.be.true;
+  });
+
+  it('should fire the `setData` dispatch with the correct data', () => {
+    const { props, mockStore } = getData();
+    const { container } = subject({ props, mockStore });
+    const { dispatch } = mockStore;
+    const expectedData = { 'view:vaBenefitsPackage': 'regOnly' };
+    simulateInputChange(
+      container,
+      '#root_view\\3A vaBenefitsPackage_1',
+      'regOnly',
+    );
+    expect(dispatch.firstCall.args[0].type).to.eq('SET_DATA');
+    expect(dispatch.firstCall.args[0].data).to.deep.eq(expectedData);
+  });
+});

--- a/src/applications/hca/tests/unit/containers/AuthRegistrationOnlyPage.unit.spec.js
+++ b/src/applications/hca/tests/unit/containers/AuthRegistrationOnlyPage.unit.spec.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { expect } from 'chai';
+import { fireEvent, render } from '@testing-library/react';
+import sinon from 'sinon';
+import formConfig from '../../../config/form';
+import AuthRegistrationOnlyPage from '../../../containers/AuthRegistrationOnlyPage';
+
+describe('hca AuthRegistrationOnlyPage', () => {
+  const getData = () => ({
+    props: {
+      router: { push: sinon.spy() },
+      route: {
+        pageList: [
+          { path: '/previous', formConfig },
+          { path: '/current-page' },
+          { path: '/next', formConfig },
+        ],
+      },
+      location: {
+        pathname: '/current-page',
+      },
+    },
+    mockStore: {
+      getState: () => ({
+        form: { data: {} },
+        user: {
+          login: { currentlyLoggedIn: true },
+          profile: { loading: false },
+        },
+      }),
+      subscribe: () => {},
+      dispatch: () => {},
+    },
+  });
+  const subject = ({ props, mockStore }) => {
+    const { container } = render(
+      <Provider store={mockStore}>
+        <AuthRegistrationOnlyPage {...props} />
+      </Provider>,
+    );
+    const selectors = () => ({
+      vaAlert: container.querySelector('va-alert'),
+      secondaryBtn: container.querySelector('.usa-button-secondary'),
+    });
+    return { selectors };
+  };
+
+  it('should render `va-alert` and back button', () => {
+    const { props, mockStore } = getData();
+    const { selectors } = subject({ props, mockStore });
+    const { vaAlert, secondaryBtn } = selectors();
+    expect(secondaryBtn).to.exist;
+    expect(vaAlert).to.exist;
+    expect(vaAlert).to.have.attr('status', 'info');
+  });
+
+  it('should fire the routers `push` method with the correct path when the `back` button is clicked', () => {
+    const { props, mockStore } = getData();
+    const { selectors } = subject({ props, mockStore });
+    const { router } = props;
+    fireEvent.click(selectors().secondaryBtn);
+    expect(router.push.calledWith('/previous')).to.be.true;
+  });
+});

--- a/src/applications/hca/tests/unit/containers/IdentityPage.unit.spec.js
+++ b/src/applications/hca/tests/unit/containers/IdentityPage.unit.spec.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { expect } from 'chai';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import sinon from 'sinon';
 
-import { toggleLoginModal } from '~/platform/site-wide/user-nav/actions';
+import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { HCA_ENROLLMENT_STATUSES } from '../../../utils/constants';
 import { simulateInputChange } from '../../helpers';
 import formConfig from '../../../config/form';
@@ -12,22 +12,21 @@ import IdentityPage from '../../../containers/IdentityPage';
 
 describe('hca IdentityPage', () => {
   const getData = ({
-    push = () => {},
-    dispatch = () => {},
     status = '',
     loggedIn = false,
+    recordFound = false,
     fetchingStatus = false,
     fetchAttempted = false,
   }) => ({
     props: {
       router: {
-        push,
+        push: sinon.spy(),
       },
       route: {
-        pageList: [{ path: '/id-form' }, { path: '/next', formConfig }],
+        pageList: [{ path: '/current-page' }, { path: '/next', formConfig }],
       },
       location: {
-        pathname: '/id-form',
+        pathname: '/current-page',
       },
     },
     mockStore: {
@@ -35,7 +34,7 @@ describe('hca IdentityPage', () => {
         hcaEnrollmentStatus: {
           statusCode: status,
           isUserInMPI: false,
-          vesRecordFound: false,
+          vesRecordFound: recordFound,
           hasServerError: false,
           loading: fetchingStatus,
           fetchAttempted,
@@ -53,128 +52,118 @@ describe('hca IdentityPage', () => {
         },
       }),
       subscribe: () => {},
-      dispatch,
+      dispatch: sinon.stub(),
     },
   });
-
-  context('when the user is logged in', () => {
-    it('should call the router to redirect to the intro page', () => {
-      const push = sinon.spy();
-      const { mockStore, props } = getData({ push, loggedIn: true });
-      render(
-        <Provider store={mockStore}>
-          <IdentityPage {...props} />
-        </Provider>,
-      );
-      expect(push.calledWith('/')).to.be.true;
+  const subject = ({ props, mockStore }) => {
+    const { container, rerender } = render(
+      <Provider store={mockStore}>
+        <IdentityPage {...props} />
+      </Provider>,
+    );
+    const selectors = () => ({
+      form: container.querySelector('.rjsf'),
+      buttons: {
+        login: container.querySelector('[data-testid="hca-login-button"]'),
+        submit: container.querySelector('.hca-idform-submit-button'),
+      },
     });
+    return { container, rerender, selectors };
+  };
+
+  it('should render the sign-in button and form when the page renders', () => {
+    const { props, mockStore } = getData({});
+    const { selectors } = subject({ props, mockStore });
+    const { form, buttons } = selectors();
+    expect(form).to.exist;
+    expect(buttons.login).to.exist;
+    expect(buttons.submit).to.exist;
   });
 
-  context('when the page renders', () => {
-    it('should show the signin button and form', () => {
-      const { mockStore } = getData({});
-      const { container } = render(
-        <Provider store={mockStore}>
-          <IdentityPage />
-        </Provider>,
-      );
-      const selectors = {
-        form: container.querySelector('.rjsf'),
-        buttons: {
-          login: container.querySelector('[data-testid="hca-login-button"]'),
-          submit: container.querySelector('.hca-idform-submit-button'),
-        },
-      };
-      expect(selectors.form).to.exist;
-      expect(selectors.buttons.login).to.exist;
-      expect(selectors.buttons.submit).to.exist;
-    });
+  it('should fire the routers `push` method with the correct path when the user is logged in', () => {
+    const { props, mockStore } = getData({ loggedIn: true });
+    const { router } = props;
+    subject({ props, mockStore });
+    expect(router.push.calledWith('/')).to.be.true;
   });
 
-  context('when user attempts to sign in', () => {
-    it('should call the `toggleLoginModal` action', () => {
-      const dispatch = sinon.stub();
-      const { mockStore } = getData({ dispatch });
-      const { container } = render(
-        <Provider store={mockStore}>
-          <IdentityPage />
-        </Provider>,
-      );
-      const selector = container.querySelector(
-        '[data-testid="hca-login-button"]',
-      );
-
-      fireEvent.click(selector);
-      expect(dispatch.called).to.be.true;
-      expect(dispatch.calledWithMatch(toggleLoginModal(true))).to.be.true;
-    });
+  it('should fire the `toggleLoginModal` action when user attempts to sign in', () => {
+    const { props, mockStore } = getData({});
+    const { selectors } = subject({ props, mockStore });
+    const { dispatch } = mockStore;
+    fireEvent.click(selectors().buttons.login);
+    expect(dispatch.called).to.be.true;
+    expect(dispatch.calledWithMatch(toggleLoginModal(true))).to.be.true;
   });
 
-  context('when the form is submitted', () => {
-    const fillForm = container => {
+  it('should fire the `fetchEnrollmentStatus` action when the form is submitted', async () => {
+    const { props, mockStore } = getData({});
+    const { container, selectors } = subject({ props, mockStore });
+    const { dispatch } = mockStore;
+    await waitFor(() => {
       simulateInputChange(container, '#root_firstName', 'Diane');
       simulateInputChange(container, '#root_lastName', 'Smith');
       simulateInputChange(container, '#root_dobMonth', '1');
       simulateInputChange(container, '#root_dobDay', '1');
       simulateInputChange(container, '#root_dobYear', '1990');
       simulateInputChange(container, '#root_ssn', '211111111');
-    };
-
-    it('should call the dispatch action', () => {
-      const dispatch = sinon.stub();
-      const { mockStore } = getData({ dispatch });
-      const { container } = render(
-        <Provider store={mockStore}>
-          <IdentityPage />
-        </Provider>,
-      );
-      const selector = container.querySelector('.hca-idform-submit-button');
-
-      fillForm(container);
-      fireEvent.click(selector);
+      fireEvent.click(selectors().buttons.submit);
       expect(dispatch.called).to.be.true;
     });
+  });
 
-    it('should go to the next page when user can fill out the application', () => {
-      const push = sinon.spy();
-      const dispatch = sinon.stub();
-      const { mockStore, props } = getData({ push, dispatch });
-      const { rerender } = render(
-        <Provider store={mockStore}>
-          <IdentityPage {...props} />
-        </Provider>,
-      );
-
-      const { mockStore: newMockStore } = getData({ fetchAttempted: true });
-      rerender(
-        <Provider store={newMockStore}>
-          <IdentityPage {...props} />
-        </Provider>,
-      );
-
-      expect(dispatch.called).to.be.true;
-      expect(push.calledWith('/next')).to.be.true;
+  it('should not fire the `setData` action or router `push` method when existing record is found in VES', () => {
+    const { props, mockStore } = getData({});
+    const { rerender } = subject({ props, mockStore });
+    const { props: newProps, mockStore: newMockStore } = getData({
+      status: HCA_ENROLLMENT_STATUSES.enrolled,
+      fetchAttempted: true,
+      recordFound: true,
     });
+    const { dispatch } = newMockStore;
+    const { router } = newProps;
+    rerender(
+      <Provider store={newMockStore}>
+        <IdentityPage {...newProps} />
+      </Provider>,
+    );
+    expect(dispatch.called).to.be.false;
+    expect(router.push.calledWith('/next')).to.be.false;
+  });
 
-    it('should not go to the next page when user cannot fill out the application', () => {
-      const push = sinon.spy();
-      const { mockStore, props } = getData({ push });
-      const { rerender } = render(
-        <Provider store={mockStore}>
-          <IdentityPage {...props} />
-        </Provider>,
-      );
-
-      const { mockStore: newMockStore } = getData({
-        status: HCA_ENROLLMENT_STATUSES.enrolled,
-      });
-      rerender(
-        <Provider store={newMockStore}>
-          <IdentityPage {...props} />
-        </Provider>,
-      );
-
-      expect(push.calledWith('/next')).to.be.false;
+  it('should fire the `setData` action and router `push` method, with correct path, when no record is found in VES', () => {
+    const { props, mockStore } = getData({});
+    const { rerender } = subject({ props, mockStore });
+    const { props: newProps, mockStore: newMockStore } = getData({
+      fetchAttempted: true,
     });
+    const { dispatch } = newMockStore;
+    const { router } = newProps;
+    rerender(
+      <Provider store={newMockStore}>
+        <IdentityPage {...newProps} />
+      </Provider>,
+    );
+    expect(dispatch.firstCall.args[0].type).to.eq('SET_DATA');
+    expect(router.push.calledWith('/next')).to.be.true;
+  });
+
+  it('should fire the `setData` action and router `push` method, with correct path, when enrollment status code is `none_of_the_above`', () => {
+    const { props, mockStore } = getData({});
+    const { rerender } = subject({ props, mockStore });
+    const { props: newProps, mockStore: newMockStore } = getData({
+      status: HCA_ENROLLMENT_STATUSES.noneOfTheAbove,
+      fetchAttempted: true,
+      recordFound: true,
+    });
+    const { dispatch } = newMockStore;
+    const { router } = newProps;
+    rerender(
+      <Provider store={newMockStore}>
+        <IdentityPage {...newProps} />
+      </Provider>,
+    );
+    expect(dispatch.firstCall.args[0].type).to.eq('SET_DATA');
+    expect(router.push.calledWith('/next')).to.be.true;
   });
 });

--- a/src/applications/hca/tests/unit/containers/PersonalInformationPage.unit.spec.js
+++ b/src/applications/hca/tests/unit/containers/PersonalInformationPage.unit.spec.js
@@ -1,0 +1,128 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { expect } from 'chai';
+import { fireEvent, render } from '@testing-library/react';
+import sinon from 'sinon';
+import formConfig from '../../../config/form';
+import PersonalInformationPage from '../../../containers/PersonalInformationPage';
+
+describe('hca PersonalInformationPage', () => {
+  const authUser = {
+    login: {
+      currentlyLoggedIn: true,
+    },
+    profile: {
+      userFullName: {
+        first: 'John',
+        middle: 'Marjorie',
+        last: 'Smith',
+        suffix: 'Sr.',
+      },
+      dob: '1986-01-01',
+    },
+  };
+  const guestUser = {
+    login: {
+      currentlyLoggedIn: false,
+    },
+    profile: {},
+  };
+  const mockData = {
+    'view:isLoggedIn': false,
+    'view:veteranInformation': {
+      veteranFullName: {
+        first: 'John',
+        middle: 'Marjorie',
+        last: 'Smith',
+        suffix: 'Sr.',
+      },
+      veteranDateOfBirth: '1986-01-01',
+      veteranSocialSecurityNumber: '211557777',
+    },
+  };
+  const getData = ({ formData = {}, user = {} }) => ({
+    props: {
+      router: { push: sinon.spy() },
+      route: {
+        pageList: [
+          { path: '/previous', formConfig },
+          { path: '/current-page' },
+          { path: '/next', formConfig },
+        ],
+      },
+      location: {
+        pathname: '/current-page',
+      },
+    },
+    mockStore: {
+      getState: () => ({
+        form: { data: formData },
+        user,
+      }),
+      subscribe: () => {},
+      dispatch: () => {},
+    },
+  });
+  const subject = ({ props, mockStore }) => {
+    const { container } = render(
+      <Provider store={mockStore}>
+        <PersonalInformationPage {...props} />
+      </Provider>,
+    );
+    const selectors = () => ({
+      primaryBtn: container.querySelector('.usa-button-primary'),
+      secondaryBtn: container.querySelector('.usa-button-secondary'),
+      profileCard: container.querySelector('[data-testid="hca-profile-card"]'),
+      guestCard: container.querySelector('[data-testid="hca-guest-card"]'),
+    });
+    return { container, selectors };
+  };
+
+  it('should render Veteran information from profile when the user is logged in', () => {
+    const { mockStore, props } = getData({
+      user: authUser,
+      formData: {
+        ...mockData,
+        'view:totalDisabilityRating': 0,
+        'view:isLoggedIn': true,
+      },
+    });
+    const { selectors } = subject({ mockStore, props });
+    const { guestCard, profileCard } = selectors();
+    expect(profileCard).to.exist;
+    expect(guestCard).to.not.exist;
+  });
+
+  it('should render Veteran information from identity verification form when the user is not logged in', () => {
+    const { mockStore, props } = getData({
+      user: guestUser,
+      formData: mockData,
+    });
+    const { selectors } = subject({ mockStore, props });
+    const { guestCard, profileCard } = selectors();
+    expect(profileCard).to.not.exist;
+    expect(guestCard).to.exist;
+  });
+
+  it('should fire the routers `push` method with the correct path when the `back` button is clicked', () => {
+    const { mockStore, props } = getData({
+      user: guestUser,
+      formData: mockData,
+    });
+    const { selectors } = subject({ mockStore, props });
+    const { router } = props;
+    fireEvent.click(selectors().secondaryBtn);
+    expect(router.push.calledWith('/previous')).to.be.true;
+  });
+
+  it('should fire the routers `push` method with the correct path the `continue` button is clicked', () => {
+    const { mockStore, props } = getData({
+      user: guestUser,
+      formData: mockData,
+    });
+    const { selectors } = subject({ mockStore, props });
+    const { router } = props;
+    fireEvent.click(selectors().primaryBtn);
+    expect(router.push.calledWith('/next')).to.be.true;
+  });
+});

--- a/src/applications/hca/tests/unit/utils/helpers/form-config.unit.spec.js
+++ b/src/applications/hca/tests/unit/utils/helpers/form-config.unit.spec.js
@@ -7,7 +7,9 @@ import {
   hasLowCompensation,
   hasNoCompensation,
   notShortFormEligible,
+  includeRegOnlyAuthQuestions,
   includeRegOnlyGuestQuestions,
+  showRegOnlyAuthConfirmation,
   showRegOnlyGuestConfirmation,
   dischargePapersRequired,
   isMissingVeteranDob,
@@ -200,6 +202,38 @@ describe('hca form config helpers', () => {
     });
   });
 
+  context('when `includeRegOnlyAuthQuestions` executes', () => {
+    const getData = ({
+      enabled = true,
+      loggedIn = true,
+      totalRating = 30,
+    }) => ({
+      'view:isLoggedIn': loggedIn,
+      'view:isRegOnlyEnabled': enabled,
+      'view:totalDisabilityRating': totalRating,
+    });
+
+    it('should return `true` when all data values are correct', () => {
+      const formData = getData({});
+      expect(includeRegOnlyAuthQuestions(formData)).to.be.true;
+    });
+
+    it('should return `false` when user is logged out', () => {
+      const formData = getData({ loggedIn: false });
+      expect(includeRegOnlyAuthQuestions(formData)).to.be.false;
+    });
+
+    it('should return `false` when feature toggle is disabled', () => {
+      const formData = getData({ enabled: false });
+      expect(includeRegOnlyAuthQuestions(formData)).to.be.false;
+    });
+
+    it('should return `false` when user has no disability rating', () => {
+      const formData = getData({ totalRating: 0 });
+      expect(includeRegOnlyAuthQuestions(formData)).to.be.false;
+    });
+  });
+
   context('when `includeRegOnlyGuestQuestions` executes', () => {
     const getData = ({
       enabled = true,
@@ -229,6 +263,33 @@ describe('hca form config helpers', () => {
     it('should return `false` when user does not have a `lowDisability` rating', () => {
       const formData = getData({ compensationType: 'none' });
       expect(includeRegOnlyGuestQuestions(formData)).to.be.false;
+    });
+  });
+
+  context('when `showRegOnlyAuthConfirmation` executes', () => {
+    const getData = ({ loggedIn = true, selectedPackage = 'regOnly' }) => ({
+      'view:isLoggedIn': loggedIn,
+      'view:vaBenefitsPackage': selectedPackage,
+    });
+
+    it('should return `true` when all data values are correct', () => {
+      const formData = getData({});
+      expect(showRegOnlyAuthConfirmation(formData)).to.be.true;
+    });
+
+    it('should return `false` when user is logged out', () => {
+      const formData = getData({ loggedIn: false });
+      expect(showRegOnlyAuthConfirmation(formData)).to.be.false;
+    });
+
+    it('should return `false` when user skips the question', () => {
+      const formData = getData({ selectedPackage: '' });
+      expect(showRegOnlyAuthConfirmation(formData)).to.be.false;
+    });
+
+    it('should return `false` when selects a non-`regOnly` value', () => {
+      const formData = getData({ selectedPackage: 'fullPackage' });
+      expect(showRegOnlyAuthConfirmation(formData)).to.be.false;
     });
   });
 

--- a/src/applications/hca/utils/helpers/form-config.js
+++ b/src/applications/hca/utils/helpers/form-config.js
@@ -1,3 +1,4 @@
+import { inRange } from 'lodash';
 import { DEPENDENT_VIEW_FIELDS, HIGH_DISABILITY_MINIMUM } from '../constants';
 
 /**
@@ -111,6 +112,21 @@ export function hasDifferentHomeAddress(formData) {
 }
 
 /**
+ * Helper that determines if the registration-only questions should be show to authenticated users
+ * @param {Object} formData - the current data object passed from the form
+ * @returns {Boolean} - true if the user is logged in, feature flag is active & total disability
+ * rating is 10-40%
+ */
+export function includeRegOnlyAuthQuestions(formData) {
+  const { 'view:totalDisabilityRating': totalRating } = formData;
+  return (
+    !isLoggedOut(formData) &&
+    isRegOnlyEnabled(formData) &&
+    inRange(totalRating, 10, 40)
+  );
+}
+
+/**
  * Helper that determines if the registration-only questions should be show to guest users
  * @param {Object} formData - the current data object passed from the form
  * @returns {Boolean} - true if the user is logged out, feature flag is active & VA
@@ -122,6 +138,18 @@ export function includeRegOnlyGuestQuestions(formData) {
     isRegOnlyEnabled(formData) &&
     hasLowCompensation(formData)
   );
+}
+
+/**
+ * Helper that determines if the registration-only alert should be shown to
+ * authenticated users
+ * @param {Object} formData - the current data object passed from the form
+ * @returns {Boolean} - true if the user is logged in and users selected the
+ * `regOnly` package
+ */
+export function showRegOnlyAuthConfirmation(formData) {
+  const { 'view:vaBenefitsPackage': vaBenefitsPackage } = formData;
+  return !isLoggedOut(formData) && vaBenefitsPackage === 'regOnly';
 }
 
 /**


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR adds pages for the registration only pathway in the Health Care Application. These pages are targeted at authenticated users as they attempt to begin the form.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#81103

## Acceptance criteria

- Pages are available when the the appropriate auth & feature toggle statuses are in place 

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution