### PR TITLE
91534 Update shared address behavior for mailing and physical addresses - form 10-7959f-1

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/submitTransformer.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/submitTransformer.js
@@ -10,13 +10,15 @@ export default function transformForSubmit(formConfig, form) {
     veteran: {
       date_of_birth: transformedData.veteranDateOfBirth,
       full_name: transformedData?.veteranFullName,
-      physical_address: transformedData.physicalAddress || {
-        country: 'NA',
-        street: 'NA',
-        city: 'NA',
-        state: 'NA',
-        postalCode: 'NA',
-      },
+      physical_address: transformedData.sameMailingAddress
+        ? transformedData.veteranAddress
+        : transformedData.physicalAddress || {
+            country: 'NA',
+            street: 'NA',
+            city: 'NA',
+            state: 'NA',
+            postalCode: 'NA',
+          },
       mailing_address: transformedData.veteranAddress || {
         country: 'NA',
         street: 'NA',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Updates behavior when a user selects that their mailing and physical addresses are the same vs when they're different.

- Updates shared addresses so that when they're the same, the PDF shows that address text in both locations

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/91534

## Testing done

- Manual
- Verified unit tests pass

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Desktop |![Screenshot 2024-08-26 at 15 52 55](https://github.com/user-attachments/assets/9c7fcc27-b9b4-444a-9821-20a991247d9a)|![Screenshot 2024-08-26 at 16 14 30](https://github.com/user-attachments/assets/40f0a86a-5ae5-49b8-92d5-d77cc2092444)|

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA