### PR TITLE
91344 Consistency in use of singular versus plural in the term "Toxic Exposure"

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
@@ -21,7 +21,7 @@ export const conditionsDescription = (
   >
     <div>
       <p className="vads-u-margin-top--0">
-        Toxic exposures include exposures to substances like Agent Orange, burn
+        Toxic exposure includes exposure to substances like Agent Orange, burn
         pits, radiation, asbestos, or contaminated water.
       </p>
       <p className="vads-u-margin-bottom--0">


### PR DESCRIPTION
## Summary

- Update content in additional info component for Consistency in use of singular versus plural in the term "Toxic Exposure"

team: @department-of-veterans-affairs/dbex-trex 
toggle cleanup: department-of-veterans-affairs/va.gov-team#65089

## Related issue(s)
department-of-veterans-affairs/va.gov-team#91344


## Testing done
Unit and e2e tests still passing (regression). Manual test with screen reader.

## Screenshots
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/aeb81b86-4850-4177-9c7a-11cbaa37d8e9">


## What areas of the site does it impact?
526ez

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [n/a] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [n/a] Events are being sent to the appropriate logging solution
- [n/a] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
