### PR TITLE
Remove DST indicators from additional timezones

### DIFF
--- a/src/applications/vaos/tests/utils/timezone.unit.spec.js
+++ b/src/applications/vaos/tests/utils/timezone.unit.spec.js
@@ -1,24 +1,74 @@
 import { expect } from 'chai';
-import { getTimezoneAbbrByFacilityId, stripDST } from '../../utils/timezone';
+import {
+  getTimezoneAbbrByFacilityId,
+  getTimezoneNameFromAbbr,
+  stripDST,
+} from '../../utils/timezone';
 
 describe('VAOS Utils: timezone', () => {
-  it('should return the correct abbreviation', () => {
-    const abbr = getTimezoneAbbrByFacilityId(605);
-    expect(abbr).to.equal('PT');
-  });
+  describe('getTimezoneAbbrByFacilityId', () => {
+    it('should return the correct abbreviation', () => {
+      expect(getTimezoneAbbrByFacilityId(402)).to.equal('ET'); // America/New_York
+      expect(getTimezoneAbbrByFacilityId(437)).to.equal('CT'); // America/Chicago
+      expect(getTimezoneAbbrByFacilityId(442)).to.equal('MT'); // America/Denver
+      expect(getTimezoneAbbrByFacilityId(570)).to.equal('PT'); // America/Los_Angeles
+      expect(getTimezoneAbbrByFacilityId(463)).to.equal('AKT'); // America/Anchorage
+      expect(getTimezoneAbbrByFacilityId(459)).to.equal('HT'); // Pacific/Honolulu
+      expect(getTimezoneAbbrByFacilityId('459GE')).to.equal('ChT'); // Pacific/Guam
+      expect(getTimezoneAbbrByFacilityId('459GF')).to.equal('ST'); // Pacific/Pago_Pago
+      expect(getTimezoneAbbrByFacilityId(672)).to.equal('AT'); // America/Puerto_Rico
+    });
 
-  it('should not strip middle char if not an american zone', () => {
-    const abbr = getTimezoneAbbrByFacilityId(358); // manila
-    expect(abbr.length).to.equal(3);
+    it('should not strip middle char if not an american zone', () => {
+      const abbr = getTimezoneAbbrByFacilityId(358); // manila
+      expect(abbr.length).to.equal(3);
+    });
   });
 
   describe('stripDST', () => {
     it('should convert lower-48 tz to two chars', () => {
-      let tz = stripDST('MST');
-      expect(tz).to.equal('MT');
+      expect(stripDST('EST')).to.equal('ET');
+      expect(stripDST('EDT')).to.equal('ET');
+      expect(stripDST('MST')).to.equal('MT');
+      expect(stripDST('MDT')).to.equal('MT');
+      expect(stripDST('CST')).to.equal('CT');
+      expect(stripDST('CDT')).to.equal('CT');
+      expect(stripDST('PST')).to.equal('PT');
+      expect(stripDST('PDT')).to.equal('PT');
+      expect(stripDST('AKST')).to.equal('AKT');
+      expect(stripDST('AKDT')).to.equal('AKT');
+      expect(stripDST('HST')).to.equal('HT');
+      expect(stripDST('SST')).to.equal('ST');
+      expect(stripDST('ChST')).to.equal('ChT');
+      expect(stripDST('AST')).to.equal('AT');
+    });
 
-      tz = stripDST('AKST');
-      expect(tz).to.equal('AKT');
+    it('should return original abbreviation if it is already stripped or unrecognized', () => {
+      expect(stripDST('HKT')).to.equal('HKT');
+      expect(stripDST('PHT')).to.equal('PHT');
+      expect(stripDST('ET')).to.equal('ET');
+      expect(stripDST('MT')).to.equal('MT');
+      expect(stripDST('CT')).to.equal('CT');
+      expect(stripDST('PT')).to.equal('PT');
+    });
+  });
+
+  describe('getTimezoneNameFromAbbr', () => {
+    it('should return the correct timezone', () => {
+      expect(getTimezoneNameFromAbbr('PHT')).to.equal('Philippine time');
+      expect(getTimezoneNameFromAbbr('ET')).to.equal('Eastern time');
+      expect(getTimezoneNameFromAbbr('CT')).to.equal('Central time');
+      expect(getTimezoneNameFromAbbr('MT')).to.equal('Mountain time');
+      expect(getTimezoneNameFromAbbr('PT')).to.equal('Pacific time');
+      expect(getTimezoneNameFromAbbr('AKT')).to.equal('Alaska time');
+      expect(getTimezoneNameFromAbbr('HT')).to.equal('Hawaii time');
+      expect(getTimezoneNameFromAbbr('ST')).to.equal('Samoa time');
+      expect(getTimezoneNameFromAbbr('ChT')).to.equal('Chamorro time');
+      expect(getTimezoneNameFromAbbr('AT')).to.equal('Atlantic time');
+    });
+
+    it('should return abbreviation if no match', () => {
+      expect(getTimezoneNameFromAbbr('HKT')).to.equal('HKT');
     });
   });
 });

--- a/src/applications/vaos/tests/utils/timezone.unit.spec.js
+++ b/src/applications/vaos/tests/utils/timezone.unit.spec.js
@@ -17,6 +17,7 @@ describe('VAOS Utils: timezone', () => {
       expect(getTimezoneAbbrByFacilityId('459GE')).to.equal('ChT'); // Pacific/Guam
       expect(getTimezoneAbbrByFacilityId('459GF')).to.equal('ST'); // Pacific/Pago_Pago
       expect(getTimezoneAbbrByFacilityId(672)).to.equal('AT'); // America/Puerto_Rico
+      expect(getTimezoneAbbrByFacilityId('672GA')).to.equal('AT'); // America/St_Thomas
     });
 
     it('should not strip middle char if not an american zone', () => {

--- a/src/applications/vaos/utils/timezone.js
+++ b/src/applications/vaos/utils/timezone.js
@@ -8,10 +8,14 @@ const TIMEZONE_LABELS = {
   MT: 'Mountain time',
   PT: 'Pacific time',
   AKT: 'Alaska time',
+  HT: 'Hawaii time',
+  ST: 'Samoa time',
+  ChT: 'Chamorro time',
+  AT: 'Atlantic time',
 };
 
 export function stripDST(abbr) {
-  if (/^[PMCE][DS]T$|^AK[DS]T$/.test(abbr)) {
+  if (/^[PMCEHSA][DS]T$|^AK[DS]T$|^ChST$/.test(abbr)) {
     return abbr?.replace('ST', 'T').replace('DT', 'T');
   }
 
@@ -39,7 +43,10 @@ export function getTimezoneAbbrFromApi(appointment) {
     : null;
 
   // Strip out middle char in abbreviation so we can ignore DST
-  if (appointmentTZ?.includes('America')) {
+  if (
+    appointmentTZ?.includes('America') ||
+    appointmentTZ?.includes('Pacific')
+  ) {
     timeZoneAbbr = stripDST(timeZoneAbbr);
   }
   return timeZoneAbbr;
@@ -55,7 +62,7 @@ export function getTimezoneAbbrByFacilityId(id) {
   let abbreviation = moment.tz.zone(matchingZone).abbr(moment());
 
   // Strip out middle char in abbreviation so we can ignore DST
-  if (matchingZone.includes('America')) {
+  if (matchingZone.includes('America') || matchingZone.includes('Pacific')) {
     abbreviation = stripDST(abbreviation);
   }
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- This change updates the timezone logic to remove S/D indicator of DST from additional US timezones:
  - Hawaii - tz: Pacific/Honolulu, abbreviation: HST
  - American Samoa - tz: Pacific/Pago_Pago, abbreviation: SST
  - Guam - tz: Pacific/Guam, abbreviation: ChST
  - Puerto Rico - tz: America/Puerto_Rico, abbreviation: AST
  - US Virgin Islands - tz: America/St_Thomas, abbreviation: AST
- Appointments (VAOS) team
- This change is not behind a Flipper toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/89802

## Testing done

- Unit tests and tested with a mock appointment locally, see screenshot

## Screenshots

Before:
<img width="610" alt="image" src="https://github.com/user-attachments/assets/92653363-1d17-43b6-bb7c-bca579b1e00c">

After:
<img width="612" alt="image" src="https://github.com/user-attachments/assets/62fe965c-a5d6-43fe-bfef-c255a2cd97bb">

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

- [ ] Sets Hawaii Time to display HT, and not include S/D
- [ ] Checks that we're not showing S/D in any other timezone

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

