### PR TITLE
MBMS-58071 Array Field Review Page Formatting Changes

### DIFF
--- a/src/applications/pre-need/config/pages/currentlyBuriedPersons.jsx
+++ b/src/applications/pre-need/config/pages/currentlyBuriedPersons.jsx
@@ -49,6 +49,8 @@ export const uiSchema = {
         viewField: EligibleBuriedView,
         keepInPageOnReview: true,
         itemName: 'Name of deceased',
+        useCardStyling: true,
+        useCardStylingJustOnReviewPage: true,
       },
       items: {
         name: merge({}, fullNameUI),

--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -403,7 +403,13 @@ export default class ArrayField extends React.Component {
               uiItemName;
             const multipleRows = items.length > 1;
             const notLastOrMultipleRows = showSave || !isLast || multipleRows;
-            const useCardStyling = notLastOrMultipleRows;
+            const shouldUseCardStyling =
+              uiOptions.useCardStyling || notLastOrMultipleRows;
+
+            const useCardStyling = uiOptions.useCardStylingJustOnReviewPage
+              ? this.props.formContext.onReviewPage && shouldUseCardStyling
+              : shouldUseCardStyling;
+
             const CardOrDiv = useVaCards && useCardStyling ? VaCard : 'div';
 
             if (isReviewMode ? isEditing : isLast || isEditing) {


### PR DESCRIPTION
## Summary

- The `Deceased's first name` and `Deceased's last name` fields have incorrect error formatting in the review sections.
- The error formatting design is incorrect and missing a red line on the left for the text input fields.

## Related issue(s)

- https://jira.devops.va.gov/browse/MBMS-58071

## Testing done

- [ ] POR/UI/UX
- [x] Unit Tests Passing
- [ ] QA
- [ ] Internal Review
- [ ] External Review
- [ ] Platform Review (There are platform file changes `vets-website/src/platform/forms-system/src/js/fields/ArrayField.jsx`)

## Screenshots
| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/9853370c-45d5-4875-9d1d-facd6218e65c) | ![image](https://github.com/user-attachments/assets/a33d0360-5079-4f21-945a-6d7420a695f5) |


## What areas of the site does it impact?

- Pre-need Burial Benefits on the review page

## Steps to reproduce
Sign into the pre-need application, select ‘Applicant is the service member or Veteran’ for the relationship question, fill out the form up to the review page. Go to the burial benefits section and click the ‘Edit’ button. For “Is there anyone currently buried in a VA national cemetery under your eligibility?”, select ‘Yes’ and without filling out the ‘Deceased's first name’ and ‘Deceased's last name’ fields, click ‘Update page’. 

- Expected results: The ‘Deceased's first name' and ‘Deceased's last name' text input fields are formatted correctly with red vertical bars distributed correctly on the left side of the fields.

- Actual Results: The ‘Deceased's first name' and Deceased's last name' text input fields do not have the correct formatting without red vertical bar to the left of the fields.

# Documentation

### Added functionality for the platform form-systems `vets-website/src/platform/forms-system/src/js/fields/ArrayField.jsx`

- When dealing with uiSchema that utilizes the form-systems array field, if you want to force the use of card styling which you can see in the after screenshot above, add ```useCardStyling: true``` to your uiOptions. 
- If you want to only want to see that functionality on the review page, additionally add ```useCardStylingJustOnReviewPage: true``` to your uiOptions.
- ```useCardStyling``` can be used independently, but ```useCardStylingJustOnReviewPage``` will only impact the ArrayField component if ```useCardStyling``` is set to **true**

![image](https://github.com/user-attachments/assets/6fd47a64-6e43-4fd9-91af-459467b11f21)
