### PR TITLE
[91108] Update appoint a rep intro page to match design

### DIFF
--- a/src/applications/representative-appoint/components/GetFormHelp.jsx
+++ b/src/applications/representative-appoint/components/GetFormHelp.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+
+const GetFormHelp = () => (
+  <div className="row footer-section vads-u-padding-bottom--4">
+    <h2 className="help-heading" style={{ margin: 0 }}>
+      How to contact us if you have questions
+    </h2>
+    <p className="help-talk">
+      You can call us at{' '}
+      <va-telephone contact={CONTACTS.VA_411} extension={0} /> (
+      <va-telephone contact={CONTACTS['711']} tty />
+      ). We’re here 24/7.
+    </p>
+  </div>
+);
+
+export default GetFormHelp;

--- a/src/applications/representative-appoint/config/form.js
+++ b/src/applications/representative-appoint/config/form.js
@@ -46,6 +46,7 @@ const formConfig = {
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
   customText: {
+    appType: 'form',
     submitButtonText: 'Continue',
   },
   submit: (form, _formConfig) => Promise.resolve(form), // This function will have to be updated when we're ready to call the create PDF endpoint
@@ -89,9 +90,6 @@ const formConfig = {
     date,
     dateRange,
     usaPhone,
-  },
-  customText: {
-    appType: 'form',
   },
   chapters: {
     formToggle: {

--- a/src/applications/representative-appoint/config/form.js
+++ b/src/applications/representative-appoint/config/form.js
@@ -90,6 +90,9 @@ const formConfig = {
     dateRange,
     usaPhone,
   },
+  customText: {
+    appType: 'form',
+  },
   chapters: {
     formToggle: {
       title: ' ',

--- a/src/applications/representative-appoint/containers/IntroductionPage.jsx
+++ b/src/applications/representative-appoint/containers/IntroductionPage.jsx
@@ -1,92 +1,146 @@
-import React from 'react';
-
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { focusElement } from 'platform/utilities/ui';
-// import OMBInfo from '@department-of-veterans-affairs/component-library/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import repStatusLoader from 'applications/static-pages/representative-status';
+import { useStore } from 'react-redux';
+import GetFormHelp from '../components/GetFormHelp';
 
-class IntroductionPage extends React.Component {
-  componentDidMount() {
+const IntroductionPage = props => {
+  const { route } = props;
+  const { formConfig, pageList } = route;
+  const store = useStore();
+
+  useEffect(() => {
     focusElement('.va-nav-breadcrumbs-list');
-  }
+  }, []);
 
-  render() {
-    const { route } = this.props;
-    const { formConfig, pageList } = route;
+  // search from query params on page load
+  useEffect(() => {
+    repStatusLoader(store, 'representative-status', 2, false);
+  }, []);
 
-    return (
-      <article className="schemaform-intro">
+  return (
+    <article className="schemaform-intro">
+      <div className="title-section">
         <FormTitle
-          title="Fill out your form to appoint a VA accredited representative or VSO"
-          subtitle="Equal to VA Form 21-22 (Fill out your form to appoint a VA accredited representative or VSO)"
+          title="Request help from a VA accredited representative or VSO"
+          subTitle="VA Form 21-22 and VA Form 21-22a"
         />
-        <SaveInProgressIntro
-          headingLevel={2}
-          prefillEnabled={formConfig.prefillEnabled}
-          messages={formConfig.savedFormMessages}
-          pageList={pageList}
-          startText="Start the Application"
-        >
-          Please complete the 21-22 form to apply for accredited representative
-          appointment.
-        </SaveInProgressIntro>
-        <h2 className="vads-u-font-size--h3 vad-u-margin-top--0">
-          Follow the steps below to apply for accredited representative
-          appointment.
-        </h2>
-        <va-process-list>
-          <li>
-            <h3>Prepare</h3>
-            <h4>To fill out this application, you’ll need your:</h4>
+        <p>
+          A VA accredited representative can help you file a claim or request a
+          decision review.
+        </p>
+        <p>
+          Use our online tool to pre-fill your VA Form 21-22 to appoint a
+          Veteran Service Organization (VSO). Or, use our online tool to
+          pre-fill your VA Form 21-22a to appoint a VA accredited attorney or
+          claims agent.
+        </p>
+        <>
+          <div tabIndex="-1">
+            <div data-widget-type="representative-status" />
+          </div>
+        </>
+      </div>
+      <h2>Follow these steps to pre-fill your form</h2>
+      <div className="vads-u-padding-left--2">
+        <va-process-list uswds>
+          <va-process-list-item
+            header="Contact the accredited representative"
+            level="3"
+          >
+            <p>
+              You’ll need to contact the accredited representative you’d like to
+              appoint to ask if they’re available to help you.
+            </p>
+            <p>
+              If you’d like to work with an accredited VSO representative,
+              you’ll need to appoint their organization. You should contact them
+              to confirm which organization they’re accredited by. You’ll need
+              to select this organization on your form.
+            </p>
+            <va-additional-info trigger="If you don't know who you'd like to appoint">
+              <p>
+                You can use our search tool to find an accredited
+                representative.
+              </p>
+              <p />
+              <a
+                href="/get-help-from-accredited-representative/find-rep"
+                target="_blank"
+              >
+                Find an accredited representative or VSO
+              </a>
+            </va-additional-info>
+          </va-process-list-item>
+          <va-process-list-item header="Gather your information" level="3">
+            <p>Here’s what you’ll need to complete this form:</p>
             <ul>
-              <li>Social Security number (required)</li>
+              <li>Your Social Security number or VA file number</li>
+              <li>Your date of birth</li>
+              <li>Your mailing address and phone number</li>
+              <li>
+                Your branch of service (only if you’d like to appoint a VSO)
+              </li>
+              <li>
+                The name of the organization you’d like to appoint, if you’d
+                like to work with an accredited VSO representative
+              </li>
             </ul>
             <p>
-              <strong>What if I need help filling out my application?</strong>{' '}
-              An accredited representative, like a Veterans Service Officer
-              (VSO), can help you fill out your claim.{' '}
-              <a href="/disability-benefits/apply/help/index.html">
-                Get help filing your claim
-              </a>
+              If you’re a dependent or surviving spouse, we’ll ask you for some
+              personal information about the Veteran or service member you’re
+              connected to.
             </p>
-          </li>
-          <li>
-            <h3>Apply</h3>
-            <p>Complete this accredited representative appointment form.</p>
+          </va-process-list-item>
+          <va-process-list-item header="Start your form" level="3">
             <p>
-              After submitting the form, you’ll get a confirmation message. You
-              can print this for your records.
+              We’ll take you through each step of our online tool. It should
+              take about 5 minutes.
             </p>
-          </li>
-          <li>
-            <h3>VA Review</h3>
             <p>
-              We process claims within a week. If more than a week has passed
-              since you submitted your application and you haven’t heard back,
-              please don’t apply again. Call us at.
+              After you complete your form, you’ll need to download, print, and
+              sign it. Then mail or bring your form to the accredited
+              representative you’re appointing. The accredited representative
+              will sign your form and submit it for you.
             </p>
-          </li>
-          <li>
-            <h3>Decision</h3>
-            <p>
-              Once we’ve processed your claim, you’ll get a notice in the mail
-              with our decision.
-            </p>
-          </li>
+          </va-process-list-item>
         </va-process-list>
-        <SaveInProgressIntro
-          buttonOnly
-          headingLevel={2}
-          prefillEnabled={formConfig.prefillEnabled}
-          messages={formConfig.savedFormMessages}
-          pageList={pageList}
-          startText="Start the Application"
-        />
-        <p />
-        {/* <OMBInfo resBurden={5} ombNumber="2900-0321" expDate="07/31/2026" /> */}
-      </article>
-    );
-  }
-}
+      </div>
+      <SaveInProgressIntro
+        alertTitle="Sign in with a verified account to request help from a VA accredited representative"
+        formConfig={formConfig}
+        headingLevel={2}
+        messages={formConfig.savedFormMessages}
+        prefillEnabled={formConfig.prefillEnabled}
+        pageList={pageList}
+        unauthStartText="Sign in or create an account"
+      />
+      <p />
+      <va-omb-info
+        exp-date="07/31/2026"
+        omb-number="2900-0321"
+        res-burden="5"
+      />
+      <p />
+      <GetFormHelp />
+    </article>
+  );
+};
+
+IntroductionPage.propTypes = {
+  route: PropTypes.shape({
+    formConfig: PropTypes.shape({
+      prefillEnabled: PropTypes.bool,
+      savedFormMessages: PropTypes.object,
+      customText: PropTypes.shape({
+        appType: PropTypes.string,
+      }),
+    }),
+    pageList: PropTypes.array,
+  }),
+};
 
 export default IntroductionPage;

--- a/src/applications/static-pages/representative-status/components/App/index.jsx
+++ b/src/applications/static-pages/representative-status/components/App/index.jsx
@@ -16,6 +16,7 @@ export const App = ({
   toggleLoginModal,
   authenticatedWithSSOe,
   authenticatedWithOAuth,
+  verbose,
 }) => {
   const DynamicHeader = `h${baseHeader}`;
   const DynamicSubheader = `h${baseHeader + 1}`;
@@ -56,6 +57,7 @@ export const App = ({
           <Unauth
             toggleLoginModal={toggleLoginModal}
             DynamicHeader={DynamicHeader}
+            verbose={verbose}
           />
         </>
       )}
@@ -69,6 +71,7 @@ App.propTypes = {
   authenticatedWithSSOe: PropTypes.bool,
   baseHeader: PropTypes.number,
   hasRepresentative: PropTypes.bool,
+  verbose: PropTypes.bool,
 };
 
 const mapStateToProps = state => ({

--- a/src/applications/static-pages/representative-status/components/States/Unauth.jsx
+++ b/src/applications/static-pages/representative-status/components/States/Unauth.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export const Unauth = ({ toggleLoginModal, DynamicHeader }) => {
+export const Unauth = ({ toggleLoginModal, DynamicHeader, verbose }) => {
   return (
     <>
       <va-alert
@@ -13,13 +13,15 @@ export const Unauth = ({ toggleLoginModal, DynamicHeader }) => {
           Sign in to check if you have an accredited representative
         </DynamicHeader>
         <React.Fragment key=".1">
-          <p>
-            Sign in with your existing{' '}
-            <strong>Login.gov, ID.me, DS Logon,</strong> or{' '}
-            <strong>My HealtheVet</strong> account. If you don’t have any of
-            these accounts, you can create a free <strong>Login.gov</strong> or{' '}
-            <strong>ID.me</strong> account now.
-          </p>
+          {verbose && (
+            <p>
+              Sign in with your existing{' '}
+              <strong>Login.gov, ID.me, DS Logon,</strong> or{' '}
+              <strong>My HealtheVet</strong> account. If you don’t have any of
+              these accounts, you can create a free <strong>Login.gov</strong>{' '}
+              or <strong>ID.me</strong> account now.
+            </p>
+          )}
           <va-button
             primary-alternate
             text="Sign in or create an account"
@@ -35,4 +37,5 @@ export const Unauth = ({ toggleLoginModal, DynamicHeader }) => {
 Unauth.propTypes = {
   DynamicHeader: PropTypes.string,
   toggleLoginModal: PropTypes.func,
+  verbose: PropTypes.bool,
 };

--- a/src/applications/static-pages/representative-status/index.jsx
+++ b/src/applications/static-pages/representative-status/index.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
-import './stylesheet.scss';
+
+// We don't want to import the stylesheet in unit tests when the widget
+//   is imported into other apps. Mocha and Babel will try to load the
+//   file as if it's a js file and throw syntax errors.
+if (process.env.NODE_ENV !== 'test') {
+  require('./stylesheet.scss');
+}
 
 export default (store, widgetType, baseHeader = 3, verbose = true) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);

--- a/src/applications/static-pages/representative-status/index.jsx
+++ b/src/applications/static-pages/representative-status/index.jsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import './stylesheet.scss';
 
-export default (store, widgetType, baseHeader = 3) => {
+export default (store, widgetType, baseHeader = 3, verbose = true) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
     import(/* webpackChunkName: "representative-status" */
@@ -12,7 +12,7 @@ export default (store, widgetType, baseHeader = 3) => {
 
       ReactDOM.render(
         <Provider store={store}>
-          <App baseHeader={baseHeader} />
+          <App baseHeader={baseHeader} verbose={verbose} />
         </Provider>,
         root,
       );


### PR DESCRIPTION
## Summary

- This pr updates the placeholder intro page for Appoint a Rep to match designs

## Related issue(s)

- [91108](https://app.zenhub.com/workspaces/accredited-representation-management-team-64d0dc51d3e8f4788ac6ef96/issues/gh/department-of-veterans-affairs/va.gov-team/91108)

## Screenshots
|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |![image](https://github.com/user-attachments/assets/9f84fee1-716c-40f3-bee5-b6b6f3d33b60)|![image](https://github.com/user-attachments/assets/438cbb44-cc3c-4d70-a3d3-088e648e6ace)|
| Desktop |![image](https://github.com/user-attachments/assets/14d12db5-c885-4824-ab1c-05c62d8634a0) |![image](https://github.com/user-attachments/assets/3dfa2a97-8c15-499f-9baf-1e838f4e0764)|

## What areas of the site does it impact?

Appoint a Rep

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user