### PR TITLE
VEBT-77, VEBT-68 VYE staging review - add headings

### DIFF
--- a/src/applications/verify-your-enrollment/components/PendingDocuments.jsx
+++ b/src/applications/verify-your-enrollment/components/PendingDocuments.jsx
@@ -28,9 +28,9 @@ const PendingDocuments = ({ loading, pendingDocuments }) => {
 
   return (
     <div id="vye-pending-documents">
-      <p className="vads-u-font-size--h2 vads-u-font-family--serif vads-u-font-weight--bold">
+      <h2 className="vads-u-margin-y--4 vads-u-font-family--serif">
         {PENDING_DOCUMENTS_TITLE}
-      </p>
+      </h2>
       {/* {PENDING_DOCUMENTS_STATEMENT} */}
       <div
         className="vads-u-border-color--gray-lighter

--- a/src/applications/verify-your-enrollment/components/VerifiedSuccessStatement.jsx
+++ b/src/applications/verify-your-enrollment/components/VerifiedSuccessStatement.jsx
@@ -9,16 +9,7 @@ const VerifiedSuccessStatement = () => {
         visible
         id="success-alert"
       >
-        <div
-          slot="headline"
-          className="
-            vads-u-font-size--h2
-            vads-u-font-weight--bold
-            vye-h2-style-as-h3
-          "
-        >
-          You have successfully verified your enrollment
-        </div>
+        <h2 slot="headline">You have successfully verified your enrollment</h2>
         <p className="vads-u-margin-top--2">
           Your verification will be submitted for processing during the next
           regular business day. Your payment will be deposited within 4 to 6

--- a/src/applications/verify-your-enrollment/tests/components/PendingDocuments.unit.spec.js
+++ b/src/applications/verify-your-enrollment/tests/components/PendingDocuments.unit.spec.js
@@ -59,7 +59,7 @@ describe('<PendingDocuments>', () => {
     const wrapper = mount(
       <PendingDocuments loading={false} pendingDocuments={[]} />,
     );
-    expect(wrapper.find('.vads-u-font-size--h2').text()).to.equal(
+    expect(wrapper.find('#vye-pending-documents > h2').text()).to.equal(
       PENDING_DOCUMENTS_TITLE,
     );
     wrapper.unmount();

--- a/src/applications/verify-your-enrollment/tests/components/VerifiedSuccessStatement.unit.spec.js
+++ b/src/applications/verify-your-enrollment/tests/components/VerifiedSuccessStatement.unit.spec.js
@@ -19,8 +19,6 @@ describe('<VerifiedSuccessStatement />', () => {
       'You have successfully verified your enrollment',
     );
     expect(headline).to.exist;
-    expect(headline.className).to.include('vads-u-font-size--h2');
-    expect(headline.className).to.include('vads-u-font-weight--bold');
   });
 
   it('Check for the paragraph content', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)

## Summary

Staging Review finding: Missing headings - Add headers to cards. Tickets had overlap.

## Related issue(s)

https://jira.devops.va.gov/browse/VEBT-77
https://jira.devops.va.gov/browse/VEBT-68

Problem:

On [/mgib-enrollments/benefits-profile/](https://staging.va.gov/education/verify-school-enrollment/mgib-enrollments/benefits-profile/), the "Pending documents" text is styled to look like an H2 heading but is coded as a p paragraph. Likewise, after submitting an enrollment verification, the success alert is styled as having a heading but the heading itself is just coded as a div.

Screen reader users often navigate the page via heading, in which they skip directly to the heading for the section of content they're looking for. When heading text isn't coded as a heading, it's not available for them as a navigational tool.

Solution:

Both of these should be H2 headings.

Acceptance Criteria:

The "Pending documents" text is coded as a heading instead of as a p paragraph 
The success alert is coded as a heading instead of as a div


Problem:

There are several cards on the “Your Montgomery GI Bill benefits information” page. Some of these cards are missing headers. Headers help organize and structure page content.

Solution:

Add missing headers to any cards.

Acceptance Criteria:

On the verify enrollment page there are cards with a block of information inside of them. This block of information has a left border similar to an [address block](https://design.va.gov/components/address-block). This border seem visually distracting and is not an address
Add headers to the cards on the "Your Montgomery GI Bill benefits information" page

## Testing done


## Screenshots
<img width="1721" alt="image" src="https://github.com/user-attachments/assets/29334819-0217-4639-966b-07e4747c3107">

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |
**_Before:_**
<img width="848" alt="image" src="https://github.com/user-attachments/assets/c0fbcba9-1394-44f6-b3ff-4d1b52caf87a">
<img width="848" alt="image" src="https://github.com/user-attachments/assets/7e2d2004-a472-4018-8015-2018a6e8546f">

**_After:_**
<img width="848" alt="image" src="https://github.com/user-attachments/assets/22d3c42c-7a18-44da-a21e-134862734649">
<img width="848" alt="image" src="https://github.com/user-attachments/assets/fb0d6921-5843-4ec1-ba26-3d49a9985e25">

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
