### PR TITLE
[DR-91508] use v1 NOD contestable issues endpoint

### DIFF
--- a/src/applications/appeals/10182/actions/index.js
+++ b/src/applications/appeals/10182/actions/index.js
@@ -12,7 +12,7 @@ export const getContestableIssues = () => {
   return dispatch => {
     dispatch({ type: FETCH_CONTESTABLE_ISSUES_INIT });
 
-    return apiRequest(CONTESTABLE_ISSUES_API)
+    return apiRequest(CONTESTABLE_ISSUES_API, { apiVersion: 'v1' })
       .then(response =>
         dispatch({
           type: FETCH_CONTESTABLE_ISSUES_SUCCEEDED,

--- a/src/applications/appeals/10182/tests/10182-downtime-notification.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-downtime-notification.cypress.spec.js
@@ -8,7 +8,7 @@ import downtimeTesting from '../../shared/tests/cypress.downtime';
 
 downtimeTesting({
   baseUrl: NOD_BASE_URL,
-  contestableApi: `/v0${CONTESTABLE_ISSUES_API}`,
+  contestableApi: `/v1${CONTESTABLE_ISSUES_API}`,
   formId: '10182',
   inProgressVersion: 2,
   data: mockData.data,

--- a/src/applications/appeals/10182/tests/10182-keyboard-only.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-keyboard-only.cypress.spec.js
@@ -26,7 +26,7 @@ describe.skip('Notice of Disagreement keyboard only navigation', () => {
     cy.get('@testData').then(data => {
       const { chapters } = formConfig;
 
-      cy.intercept('GET', `/v0${CONTESTABLE_ISSUES_API}`, {
+      cy.intercept('GET', `/v1${CONTESTABLE_ISSUES_API}`, {
         data: fixDecisionDates(data.contestedIssues, { unselected: true }),
       }).as('getIssues');
       cy.visit(

--- a/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
@@ -125,7 +125,7 @@ const testConfig = createTestConfig(
       cy.get('@testData').then(data => {
         cy.intercept('GET', '/v0/in_progress_forms/10182', mockPrefill);
         cy.intercept('PUT', 'v0/in_progress_forms/10182', mockInProgress);
-        cy.intercept('GET', `/v0${CONTESTABLE_ISSUES_API}`, {
+        cy.intercept('GET', `/v1${CONTESTABLE_ISSUES_API}`, {
           data: fixDecisionDates(data.contestedIssues, { unselected: true }),
         }).as('getIssues');
       });

--- a/src/applications/appeals/shared/tests/mock-api.js
+++ b/src/applications/appeals/shared/tests/mock-api.js
@@ -67,7 +67,7 @@ const responses = {
 
   'GET /v0/intent_to_file': itf,
 
-  'GET /v0/notice_of_disagreements/contestable_issues': issues,
+  'GET /v1/notice_of_disagreements/contestable_issues': issues,
   'GET /v1/supplemental_claims/contestable_issues/compensation': issues,
   'GET /v1/higher_level_reviews/contestable_issues/compensation': hlrIssues,
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder


Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
We are switching over to the v1 NOD contestable issues endpoint as a part of our effort to switch everything over from v0. The version of the Lighthouse endpoint that v0 uses has been marked as deprecated, so we should be using the newer endpoint anyway. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/91508

## Testing done
The other Decision Review forms are already using the newer LH contestable issues endpoint, so this shouldn't be a breaking change. Works fine locally.

## What areas of the site does it impact?

Appeals (Notice of Disagreement)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
