### PR TITLE
[DR-91508] Switch to v1 endpoint for decision review evidence upload

### DIFF
--- a/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-notice-of-disagreement.cypress.spec.js
@@ -118,7 +118,7 @@ const testConfig = createTestConfig(
     setupPerTest: () => {
       cypressSetup();
 
-      cy.intercept('POST', 'v0/decision_review_evidence', mockUpload);
+      cy.intercept('POST', 'v1/decision_review_evidence', mockUpload);
       cy.intercept('POST', `v0/${formConfig.submitUrl}`, mockSubmit);
       cy.intercept('POST', `v1/${formConfig.submitUrl}`, mockSubmit);
 

--- a/src/applications/appeals/10182/utils/upload.js
+++ b/src/applications/appeals/10182/utils/upload.js
@@ -15,7 +15,7 @@ import { createPayload, parseResponse } from '../../shared/utils/upload';
 
 export const evidenceUploadUI = {
   ...fileUiSchema(EvidenceUploadLabel, {
-    fileUploadUrl: `${environment.API_URL}/v0/decision_review_evidence`,
+    fileUploadUrl: `${environment.API_URL}/v1/decision_review_evidence`,
     fileTypes: SUPPORTED_UPLOAD_TYPES,
     maxSize: MAX_FILE_SIZE_BYTES,
     maxSizeText: `${MAX_FILE_SIZE_MB}MB`,

--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -36,7 +36,7 @@ export const CONTESTABLE_ISSUES_API =
 export const ITF_API = '/intent_to_file';
 
 // Evidence upload API - same endpoint as NOD
-export const EVIDENCE_UPLOAD_API = '/v0/decision_review_evidence';
+export const EVIDENCE_UPLOAD_API = '/v1/decision_review_evidence';
 
 export const SUBMIT_URL = '/v1/supplemental_claims';
 

--- a/src/applications/appeals/testing/nod-new/utils/additionalInfoUpload.js
+++ b/src/applications/appeals/testing/nod-new/utils/additionalInfoUpload.js
@@ -26,7 +26,7 @@ const focusFileCard = name => {
 
 export const additionalInfoUploadUI = {
   ...fileUiSchema(AdditionalInfoUploadLabel, {
-    fileUploadUrl: `${environment.API_URL}/v0/decision_review_evidence`,
+    fileUploadUrl: `${environment.API_URL}/v1/decision_review_evidence`,
     addAnotherLabel: 'Add another document',
     buttonText: 'Upload document',
     fileTypes: SUPPORTED_UPLOAD_TYPES,

--- a/src/applications/appeals/testing/nod-new/utils/evidenceUpload.js
+++ b/src/applications/appeals/testing/nod-new/utils/evidenceUpload.js
@@ -26,7 +26,7 @@ const focusFileCard = name => {
 
 export const evidenceUploadUI = {
   ...fileUiSchema(EvidenceUploadLabel, {
-    fileUploadUrl: `${environment.API_URL}/v0/decision_review_evidence`,
+    fileUploadUrl: `${environment.API_URL}/v1/decision_review_evidence`,
     addAnotherLabel: 'Add another document',
     buttonText: 'Upload document',
     fileTypes: SUPPORTED_UPLOAD_TYPES,

--- a/src/applications/appeals/testing/sc/constants.js
+++ b/src/applications/appeals/testing/sc/constants.js
@@ -36,7 +36,7 @@ export const CONTESTABLE_ISSUES_API =
 export const ITF_API = '/intent_to_file';
 
 // Evidence upload API - same endpoint as NOD
-export const EVIDENCE_UPLOAD_API = '/v0/decision_review_evidence';
+export const EVIDENCE_UPLOAD_API = '/v1/decision_review_evidence';
 
 export const SUBMIT_URL = '/v1/supplemental_claims';
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Follow up to [this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/18253) in vets-api to switch over to a v1 endpoint for decision review evidence uploads — there's no actual functional change to the endpoint; we're just cleaning up unused v0 endpoints and want a clean cutover to v1 for all of our requests

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/91508

## Testing done
- Unit tests updated
- Local manual testing to check that we can still upload files using v1 endpoint

## What areas of the site does it impact?

Decision Reviews (SC and NOD for evidence uploads)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).


### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

