### PR TITLE
Update medication review language (part 2)

### DIFF
--- a/src/applications/vaos/components/layout/CCLayout.jsx
+++ b/src/applications/vaos/components/layout/CCLayout.jsx
@@ -108,8 +108,8 @@ export default function CCLayout({ data: appointment }) {
             APPOINTMENT_STATUS.cancelled === status) && (
             <Prepare>
               <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
-                Bring your insurance cards and a list of your medications and
-                other information to share with your provider.
+                Bring your insurance cards. And bring a list of your medications
+                and other information to share with your provider.
               </p>
               <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
                 <va-link

--- a/src/applications/vaos/components/layout/InPersonLayout.jsx
+++ b/src/applications/vaos/components/layout/InPersonLayout.jsx
@@ -146,8 +146,8 @@ export default function InPersonLayout({ data: appointment }) {
           APPOINTMENT_STATUS.cancelled === status) && (
           <Prepare>
             <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
-              Bring your insurance cards and a list of your medications and
-              other information to share with your provider.
+              Bring your insurance cards. And bring a list of your medications
+              and other information to share with your provider.
             </p>
             <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
               <va-link

--- a/src/applications/vaos/components/layout/PhoneLayout.jsx
+++ b/src/applications/vaos/components/layout/PhoneLayout.jsx
@@ -115,8 +115,8 @@ export default function PhoneLayout({ data: appointment }) {
           APPOINTMENT_STATUS.cancelled === status) && (
           <Prepare>
             <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
-              Bring your insurance cards and a list of your medications and
-              other information to share with your provider.
+              Bring your insurance cards. And bring a list of your medications
+              and other information to share with your provider.
             </p>
             <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
               <va-link

--- a/src/applications/vaos/components/layout/VideoLayout.jsx
+++ b/src/applications/vaos/components/layout/VideoLayout.jsx
@@ -121,8 +121,8 @@ export default function VideoLayout({ data: appointment }) {
           <Prepare>
             <ul className="vads-u-margin-top--0">
               <li>
-                Bring your insurance cards and a list of your medications and
-                other information to share with your provider.
+                Bring your insurance cards. And bring a list of your medications
+                and other information to share with your provider.
                 <br />
                 <va-link
                   text="Find a full list of things to bring to your appointment"

--- a/src/applications/vaos/components/layout/VideoLayoutAtlas.jsx
+++ b/src/applications/vaos/components/layout/VideoLayoutAtlas.jsx
@@ -139,8 +139,8 @@ export default function VideoLayoutAtlas({ data: appointment }) {
           <Prepare>
             <ul className="vads-u-margin-top--0">
               <li>
-                Bring your insurance cards and a list of your medications and
-                other information to share with your provider.
+                Bring your insurance cards. And bring a list of your medications
+                and other information to share with your provider.
                 <br />
                 <va-link
                   text="Find a full list of things to bring to your appointment"

--- a/src/applications/vaos/components/layout/VideoLayoutVA.jsx
+++ b/src/applications/vaos/components/layout/VideoLayoutVA.jsx
@@ -136,8 +136,8 @@ export default function VideoLayoutVA({ data: appointment }) {
           APPOINTMENT_STATUS.cancelled === status) && (
           <Prepare>
             <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
-              Bring your insurance cards and a list of your medications and
-              other information to share with your provider.
+              Bring your insurance cards. And bring a list of your medications
+              and other information to share with your provider.
             </p>
             <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
               <va-link

--- a/src/applications/vaos/components/tests/CCLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/CCLayout.unit.spec.js
@@ -175,7 +175,7 @@ describe('VAOS Component: CCLayout', () => {
       );
       expect(
         screen.getByText(
-          /Bring your insurance cards and a list of your medications and other information to share with your provider./i,
+          /Bring your insurance cards. And bring a list of your medications and other information to share with your provider./i,
         ),
       );
       expect(
@@ -423,7 +423,7 @@ describe('VAOS Component: CCLayout', () => {
       );
       expect(
         screen.getByText(
-          /Bring your insurance cards and a list of your medications and other information to share with your provider./i,
+          /Bring your insurance cards. And bring a list of your medications and other information to share with your provider./i,
         ),
       );
       expect(

--- a/src/applications/vaos/components/tests/InPersonLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/InPersonLayout.unit.spec.js
@@ -348,7 +348,7 @@ describe('VAOS Component: InPersonLayout', () => {
       );
       expect(
         screen.getByText(
-          /Bring your insurance cards and a list of your medications and other information to share with your provider./i,
+          /Bring your insurance cards. And bring a list of your medications and other information to share with your provider./i,
         ),
       );
       expect(
@@ -454,7 +454,7 @@ describe('VAOS Component: InPersonLayout', () => {
       );
       expect(
         screen.getByText(
-          /Bring your insurance cards and a list of your medications and other information to share with your provider./i,
+          /Bring your insurance cards. And bring a list of your medications and other information to share with your provider./i,
         ),
       );
       expect(
@@ -662,7 +662,7 @@ describe('VAOS Component: InPersonLayout', () => {
       );
       expect(
         screen.getByText(
-          /Bring your insurance cards and a list of your medications and other information to share with your provider./i,
+          /Bring your insurance cards. And bring a list of your medications and other information to share with your provider./i,
         ),
       );
       expect(

--- a/src/applications/vaos/components/tests/PhoneLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/PhoneLayout.unit.spec.js
@@ -278,7 +278,7 @@ describe('VAOS Component: PhoneLayout', () => {
       );
       expect(
         screen.getByText(
-          /Bring your insurance cards and a list of your medications and other information to share with your provider./i,
+          /Bring your insurance cards. And bring a list of your medications and other information to share with your provider./i,
         ),
       );
       expect(
@@ -384,7 +384,7 @@ describe('VAOS Component: PhoneLayout', () => {
       );
       expect(
         screen.getByText(
-          /Bring your insurance cards and a list of your medications and other information to share with your provider./i,
+          /Bring your insurance cards. And bring a list of your medications and other information to share with your provider./i,
         ),
       );
       expect(
@@ -596,7 +596,7 @@ describe('VAOS Component: PhoneLayout', () => {
       );
       expect(
         screen.getByText(
-          /Bring your insurance cards and a list of your medications and other information to share with your provider./i,
+          /Bring your insurance cards. And bring a list of your medications and other information to share with your provider./i,
         ),
       );
       expect(

--- a/src/applications/vaos/components/tests/VideoLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/VideoLayout.unit.spec.js
@@ -309,7 +309,7 @@ describe('VAOS Component: VideoLayout', () => {
       );
       expect(
         screen.getByText(
-          /Bring your insurance cards and a list of your medications and other information to share with your provider/i,
+          /Bring your insurance cards. And bring a list of your medications and other information to share with your provider./i,
         ),
       );
       expect(
@@ -602,7 +602,7 @@ describe('VAOS Component: VideoLayout', () => {
         );
         expect(
           screen.getByText(
-            /Bring your insurance cards and a list of your medications and other information to share with your provider/i,
+            /Bring your insurance cards. And bring a list of your medications and other information to share with your provider./i,
           ),
         );
         expect(
@@ -765,7 +765,7 @@ describe('VAOS Component: VideoLayout', () => {
         );
         expect(
           screen.getByText(
-            /Bring your insurance cards and a list of your medications and other information to share with your provider/i,
+            /Bring your insurance cards. And bring a list of your medications and other information to share with your provider./i,
           ),
         );
         expect(

--- a/src/applications/vaos/components/tests/VideoLayoutAtlas.unit.spec.js
+++ b/src/applications/vaos/components/tests/VideoLayoutAtlas.unit.spec.js
@@ -386,7 +386,7 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
       );
       expect(
         screen.getByText(
-          /Bring your insurance cards and a list of your medications and other information to share with your provider/i,
+          /Bring your insurance cards. And bring a list of your medications and other information to share with your provider./i,
         ),
       );
       expect(
@@ -698,7 +698,7 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
       );
       expect(
         screen.getByText(
-          /Bring your insurance cards and a list of your medications and other information to share with your provider/i,
+          /Bring your insurance cards. And bring a list of your medications and other information to share with your provider./i,
         ),
       );
       expect(

--- a/src/applications/vaos/components/tests/VideoLayoutVA.unit.spec.js
+++ b/src/applications/vaos/components/tests/VideoLayoutVA.unit.spec.js
@@ -415,7 +415,7 @@ describe('VAOS Component: VideoLayoutVA', () => {
         );
         expect(
           screen.getByText(
-            /Bring your insurance cards and a list of your medications and other information to share with your provider./i,
+            /Bring your insurance cards. And bring a list of your medications and other information to share with your provider./i,
           ),
         );
         expect(
@@ -558,7 +558,7 @@ describe('VAOS Component: VideoLayoutVA', () => {
         );
         expect(
           screen.getByText(
-            /Bring your insurance cards and a list of your medications and other information to share with your provider./i,
+            /Bring your insurance cards. And bring a list of your medications and other information to share with your provider./i,
           ),
         );
         expect(
@@ -837,7 +837,7 @@ describe('VAOS Component: VideoLayoutVA', () => {
       );
       expect(
         screen.getByText(
-          /Bring your insurance cards and a list of your medications and other information to share with your provider./i,
+          /Bring your insurance cards. And bring a list of your medications and other information to share with your provider./i,
         ),
       );
       expect(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- This PR updates the medication review language based on staging review feedback.
- Appointments (VAOS)

## Related issue(s)

- https://app.zenhub.com/workspaces/appointments-team-603fdef281af6500110a1691/issues/gh/department-of-veterans-affairs/va.gov-team/91709

## Testing done

- Updated unit tests to account for the updated language.

## Screenshots

|  | Confirmed | Canceled |
| - | - | - |
| In Person  | <img width="607" alt="image" src="https://github.com/user-attachments/assets/6662be7d-dfca-47ec-b43c-ff7454309945"> | <img width="608" alt="image" src="https://github.com/user-attachments/assets/4a2be144-5dc7-4df0-b67a-c4e99c9afbbf"> |
| Phone | <img width="614" alt="image" src="https://github.com/user-attachments/assets/5e89e59c-ee48-46de-afaf-7d5adc263f93"> | <img width="614" alt="image" src="https://github.com/user-attachments/assets/74103b11-b374-49ca-9ce4-41d4a7d5be2b"> |
| CC  | <img width="609" alt="image" src="https://github.com/user-attachments/assets/f632d185-3267-4888-82d8-ec7215ac60df"> | <img width="606" alt="image" src="https://github.com/user-attachments/assets/0839f55c-caba-43a8-ba9b-ab89434ae434"> |
| Video at home  | <img width="613" alt="image" src="https://github.com/user-attachments/assets/2f4fc5d6-9e4b-422e-8003-38f8b6e247ad"> | <img width="608" alt="image" src="https://github.com/user-attachments/assets/a9c5271c-9246-4953-af3a-3bd6a86424d3"> |
| Video at VA  | <img width="546" alt="image" src="https://github.com/user-attachments/assets/8b60a437-e9cd-4e60-8d3a-b399d9bfd090"> | <img width="540" alt="image" src="https://github.com/user-attachments/assets/30bbf94f-dba9-4b23-8424-0ed53e4d224e"> |
| Video at ATLAS  | <img width="543" alt="image" src="https://github.com/user-attachments/assets/e31493d2-9f49-4e95-8891-3620d6a030b2"> | <img width="543" alt="image" src="https://github.com/user-attachments/assets/1051fbba-0a2a-4e61-8105-da9f9219f0c3"> |

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

- [ ] Change the sentence: `Bring your insurance cards and a list of your medications and other information to share with your provider.`
to: `Bring your insurance cards. And bring a list of your medications and other information to share with your provider.`

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

