### PR TITLE
10-7959f-1 Staging Updates

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -100,6 +100,7 @@ const formConfig = {
             veteranFullName: veteranFullNameUI,
             veteranDateOfBirth: dateOfBirthUI({ required: true }),
           },
+          messageAriaDescribedby: 'Name and date of birth',
           schema: {
             type: 'object',
             required: ['veteranFullName', 'veteranDateOfBirth'],
@@ -174,9 +175,9 @@ const formConfig = {
       pages: {
         page4: {
           path: 'same-as-mailing-address',
-          title: 'Home address ',
+          title: 'Home address status ',
           uiSchema: {
-            ...titleUI('Home address'),
+            ...titleUI('Home address status'),
             sameMailingAddress: yesNoUI({
               title: 'Is your home address the same as your mailing address?',
               labels: {

--- a/src/applications/ivc-champva/10-7959f-1/helpers/CustomSSN.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/helpers/CustomSSN.jsx
@@ -58,7 +58,6 @@ export function CustomSSNReviewPage(props) {
           secondary
           onClick={props?.editPage}
           text="Edit"
-          uswds
         />
       </div>
       <dl className="review">

--- a/src/applications/ivc-champva/10-7959f-1/helpers/CustomSSN.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/helpers/CustomSSN.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { validateSSN } from 'platform/forms-system/src/js/validation';
-import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import SSNReviewWidget from 'platform/forms-system/src/js/review/SSNWidget';
 import get from 'platform/utilities/data/get';
 import { vaFileNumberUI } from 'platform/forms-system/src/js/web-component-patterns';
@@ -54,7 +53,13 @@ export function CustomSSNReviewPage(props) {
         <h4 className="form-review-panel-page-header vads-u-font-size--h5">
           {props?.title}
         </h4>
-        <VaButton secondary onClick={props?.editPage} text="Edit" uswds />
+        <va-button
+          label="You must enter either a Social Security number or VA file number."
+          secondary
+          onClick={props?.editPage}
+          text="Edit"
+          uswds
+        />
       </div>
       <dl className="review">
         <div className="review-row">

--- a/src/applications/ivc-champva/10-7959f-1/manifest.json
+++ b/src/applications/ivc-champva/10-7959f-1/manifest.json
@@ -1,5 +1,5 @@
 {
-  "appName": "Foreign Medical Program (FMP) Registration Form",
+  "appName": "Register for the Foreign Medical Program (FMP)",
   "entryFile": "./app-entry.jsx",
   "entryName": "10-7959f-1-FMP",
   "rootUrl": "/health-care/foreign-medical-program/register-form-10-7959f-1",


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR makes several updates requested after staging review:

1. Update title of app to match h1
2. Add aria-label to id info page
3. Update home address pages to have different titles

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/91905
https://github.com/department-of-veterans-affairs/va.gov-team/issues/91904
https://github.com/department-of-veterans-affairs/va.gov-team/issues/91903

## Testing done
unit tests
e2e

## Screenshots
![Screenshot 2024-09-03 at 9 54 44 AM](https://github.com/user-attachments/assets/1954bb8e-6ec4-4ae1-b4d3-2dbffc2e4cd1)
![Screenshot 2024-09-03 at 10 13 44 AM](https://github.com/user-attachments/assets/9aefda03-e134-4f29-81e7-f91f4f6af3a2)
![Screenshot 2024-09-03 at 10 34 15 AM](https://github.com/user-attachments/assets/0933f7bb-bf51-48db-9fec-84622accb574)

## What areas of the site does it impact?
this form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
NA