### PR TITLE
Remove aria-label from Add to Calendar button

### DIFF
--- a/src/applications/vaos/components/AddToCalendarButton.jsx
+++ b/src/applications/vaos/components/AddToCalendarButton.jsx
@@ -51,7 +51,6 @@ export default function AddToCalendarButton({ appointment, facility }) {
   );
 
   const filename = `${summary.replace(/\s/g, '_')}.ics`;
-  const formattedDate = moment.parseZone(startDate).format('MMMM D, YYYY');
 
   return (
     <>
@@ -64,7 +63,6 @@ export default function AddToCalendarButton({ appointment, facility }) {
       </a>
       <VaButton
         text="Add to calendar"
-        label={`Add ${formattedDate} appointment to your calendar`}
         secondary
         onClick={handleClick({
           filename,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- As part of the staging review, it was decided that the aria label for the Add to Calendar button should be removed. Instead Voice Over will use the text of the button instead.
- This is not hidden behind a feature flag
- Appointments (VAOS) team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/91735

## Testing done

- Tested manually with Voice Over and tab navigation ensuring the button still works as intended. See screenshot for more details.

## Screenshots

After:
<img width="1143" alt="image" src="https://github.com/user-attachments/assets/c8824d59-9051-4409-a30e-e795c5235334">


## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria
- [ ] Remove aria-label from Add to Calendar button

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
