### PR TITLE
Remove group role from state abbreviation

### DIFF
--- a/src/applications/vaos/components/State.jsx
+++ b/src/applications/vaos/components/State.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 export const stateNames = {
@@ -76,3 +77,7 @@ export default function State({ state }) {
     </span>
   );
 }
+
+State.propTypes = {
+  state: PropTypes.string,
+};

--- a/src/applications/vaos/components/State.jsx
+++ b/src/applications/vaos/components/State.jsx
@@ -71,10 +71,10 @@ export default function State({ state }) {
   }
 
   return (
-    <span>
+    <>
       <span className="sr-only">{stateName}</span>
       <span aria-hidden="true">{state}</span>
-    </span>
+    </>
   );
 }
 

--- a/src/applications/vaos/components/State.jsx
+++ b/src/applications/vaos/components/State.jsx
@@ -70,7 +70,7 @@ export default function State({ state }) {
   }
 
   return (
-    <span role="group">
+    <span>
       <span className="sr-only">{stateName}</span>
       <span aria-hidden="true">{state}</span>
     </span>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- As part of the staging review, it was decided that the group role is not needed for the state abbreviation in addresses.
- Text size will be addressed separately for all detail page components.
- This is not hidden behind a feature flag
- Appointments (VAOS) team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/91722

## Testing done

- Tested locally, see screenshot

## Screenshots

After:
<img width="1072" alt="image" src="https://github.com/user-attachments/assets/923223b0-fc2b-4103-a2fa-54ea398e1032">

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

For all affected appointment types:
- [ ] Remove `role=group` from the span that wraps the state abbreviation
- [ ] ~~Font size for the content under "Where to attend" section should be 16.96px~~

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
