### PR TITLE
Update ATLAS video appointment details

### DIFF
--- a/src/applications/vaos/components/layout/VideoLayoutAtlas.jsx
+++ b/src/applications/vaos/components/layout/VideoLayoutAtlas.jsx
@@ -60,11 +60,10 @@ export default function VideoLayoutAtlas({ data: appointment }) {
       {APPOINTMENT_STATUS.booked === status &&
         !isPastAppointment && (
           <Section heading="How to join">
-            You will use this appointment code to find your appointment using
-            the computer provided at the site:
+            You’ll use this appointment code to find your appointment using the
+            computer provided at the site:
             <br />
             {atlasConfirmationCode}
-            <br />
             <br />
           </Section>
         )}

--- a/src/applications/vaos/components/tests/VideoLayoutAtlas.unit.spec.js
+++ b/src/applications/vaos/components/tests/VideoLayoutAtlas.unit.spec.js
@@ -311,7 +311,7 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
       );
       expect(
         screen.getByText(
-          /You'll use this appointment code to find your appointment using the computer provided at the site:/i,
+          /You’ll use this appointment code to find your appointment using the computer provided at the site:/i,
         ),
       );
 

--- a/src/applications/vaos/components/tests/VideoLayoutAtlas.unit.spec.js
+++ b/src/applications/vaos/components/tests/VideoLayoutAtlas.unit.spec.js
@@ -311,7 +311,7 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
       );
       expect(
         screen.getByText(
-          /You will use this appointment code to find your appointment using the computer provided at the site:/i,
+          /You'll use this appointment code to find your appointment using the computer provided at the site:/i,
         ),
       );
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- As part of the staging review, the text and spacing for Video appointments at an ATLAS location details page need to be updated.
- Text size will be addressed separately for all detail page components.
- This is not hidden behind a feature flag
- Appointments (VAOS) team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/91713

## Testing done

- Tested locally, see screenshot

## Screenshots

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/15a2a1ba-070f-4d8d-857a-b18cae500040) | ![image](https://github.com/user-attachments/assets/520a57c3-3d7c-43de-bdda-bc6409bf8fc8) |

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

For all affected appointment types:
- [ ] Under “How to join” change this text: `You will use this appointment code`
To `You’ll use this appointment code`
- [ ] Remove the extra space under the “How to join” section (see screenshot). 
- [ ] ~~The text under “How to join” is the standard 16.96 base font size.~~

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
