### PR TITLE
91991 Update confirmation page - form 10-7959a

### DIFF
--- a/src/applications/ivc-champva/10-7959a/containers/ConfirmationPage.jsx
+++ b/src/applications/ivc-champva/10-7959a/containers/ConfirmationPage.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { focusElement } from 'platform/utilities/ui';
+import { applicantWording } from '../../shared/utilities';
 
 export class ConfirmationPage extends React.Component {
   componentDidMount() {
@@ -16,10 +17,6 @@ export class ConfirmationPage extends React.Component {
     const { form } = this.props;
     const { submission, data } = form;
     const submitDate = new Date(submission?.timestamp);
-
-    const fullName = Object.values(data?.applicantName || {})
-      .filter(el => el)
-      .join(' ');
 
     return (
       <div>
@@ -38,13 +35,21 @@ export class ConfirmationPage extends React.Component {
 
         <div className="inset">
           <h3 className="vads-u-margin-top--0">Your submission information</h3>
-          {fullName && (
-            <span className="veterans-full-name">
-              <strong>CHAMPVA claim (Form 10-7959a)</strong>
+          {data.applicantName && (
+            <>
+              <span className="veterans-full-name">
+                <strong>Applicant’s name</strong>
+                <br />
+                {applicantWording(form.data, false, false, false)}
+              </span>
               <br />
-              For {fullName}
               <br />
-            </span>
+              <span className="signer-name">
+                <strong>Who submitted this form</strong>
+                <br />
+                {data.statementOfTruthSignature || data.signature}
+              </span>
+            </>
           )}
           {isValid(submitDate) && (
             <p className="date-submitted">
@@ -67,18 +72,15 @@ export class ConfirmationPage extends React.Component {
         </div>
 
         <h2>What to expect next</h2>
+        <p>It will take about 90 days to process your claim.</p>
         <p>
-          It will take approximately 90 days to process your claim once received
-          by CHAMPVA.
-          <br />
-          <br />
-          We’ll review your documents. If we need more information, we’ll
-          contact you.
+          If we have any questions or need additional information, we'll contact
+          you.
         </p>
         <h3>If we decide we can cover this claim under CHAMPVA</h3>
         <p>
-          We’ll send you an explanation of benefits. This document explains the
-          amount we’ll cover and the amount you’ll need to pay.
+          We’ll send you an explanation of benefits. This document explains
+          details about the amount we'll cover.
         </p>
         <h3>If we decide we can’t cover this claim under CHAMPVA</h3>
         <p>
@@ -100,7 +102,7 @@ export class ConfirmationPage extends React.Component {
         </p>
         <h2>How to contact us about CHAMPVA claims</h2>
         <p>
-          If you have any questions about your form you can call us at at{' '}
+          If you have any questions about your claim, call us at{' '}
           <va-telephone contact="8007338387" /> (TTY: 711). We’re here Monday
           through Friday, 8:05 a.m. to 7:30 p.m. ET.
           <br />
@@ -119,13 +121,8 @@ export class ConfirmationPage extends React.Component {
             <br />
           </p>
           <p>You can also contact us online through Ask VA.</p>
-          <va-link
-            href="https://ask.va.gov/"
-            text="Contact us online through Ask VA"
-          />
+          <va-link href="https://ask.va.gov/" text="Go to Ask VA" />
         </p>
-        <br />
-        <br />
         <va-link-action href="/" text="Go back to VA.gov" />
       </div>
     );
@@ -141,6 +138,8 @@ ConfirmationPage.propTypes = {
         last: PropTypes.string,
         suffix: PropTypes.string,
       },
+      statementOfTruthSignature: PropTypes.string,
+      signature: PropTypes.string,
     }),
     submission: PropTypes.shape({
       timestamp: PropTypes.string,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the confirmation page for form 10-7959a.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/91991

## Testing done

- Manual

## Screenshots

|         |  After |
| ------- |  ----- |
| Desktop |<img width="406" alt="Screenshot 2024-09-03 at 13 37 29" src="https://github.com/user-attachments/assets/a0b1ed52-918b-4718-916c-f91be6dd9e09">|       |

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA