### PR TITLE
Mhv 61207 contact list navigate away

### DIFF
--- a/src/applications/mhv-secure-messaging/containers/EditContactList.jsx
+++ b/src/applications/mhv-secure-messaging/containers/EditContactList.jsx
@@ -22,7 +22,6 @@ import { updateTriageTeamRecipients } from '../actions/recipients';
 import { addAlert } from '../actions/alerts';
 import SmRouteNavigationGuard from '../components/shared/SmRouteNavigationGuard';
 import { focusOnErrorField } from '../util/formHelpers';
-import { resetUserSession } from '../util/helpers';
 
 const EditContactList = () => {
   const dispatch = useDispatch();
@@ -51,24 +50,6 @@ const EditContactList = () => {
   } = recipients;
 
   const ehrDataByVhaId = useSelector(selectEhrDataByVhaId);
-
-  const localStorageValues = useMemo(() => {
-    return {
-      atExpires: localStorage.atExpires,
-      hasSession: localStorage.hasSession,
-      sessionExpiration: localStorage.sessionExpiration,
-      userFirstName: localStorage.userFirstName,
-    };
-  }, []);
-
-  const { signOutMessage, timeoutId } = resetUserSession(localStorageValues);
-
-  const noTimeout = useCallback(
-    () => {
-      clearTimeout(timeoutId);
-    },
-    [timeoutId],
-  );
 
   const isContactListChanged = useMemo(
     () => !_.isEqual(allRecipients, allTriageTeams),
@@ -104,17 +85,6 @@ const EditContactList = () => {
       ),
     );
   };
-
-  const beforeUnloadHandler = useCallback(
-    e => {
-      if (isContactListChanged) {
-        e.preventDefault();
-        window.onbeforeunload = () => signOutMessage;
-        e.returnValue = signOutMessage;
-      }
-    },
-    [isContactListChanged, signOutMessage],
-  );
 
   const handleSaveAndExit = async (e, forceSave) => {
     e.preventDefault();
@@ -182,23 +152,6 @@ const EditContactList = () => {
       }
     },
     [isMinimumSelected],
-  );
-
-  useEffect(
-    () => {
-      if (isContactListChanged) {
-        window.addEventListener('beforeunload', beforeUnloadHandler);
-      } else {
-        window.removeEventListener('beforeunload', beforeUnloadHandler);
-        noTimeout();
-      }
-      return () => {
-        window.removeEventListener('beforeunload', beforeUnloadHandler);
-        window.onbeforeunload = null;
-        noTimeout();
-      };
-    },
-    [beforeUnloadHandler, isContactListChanged, noTimeout],
   );
 
   return (

--- a/src/applications/mhv-secure-messaging/tests/containers/EditContactList.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/EditContactList.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { expect } from 'chai';
 import { cleanup, fireEvent, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
 import noBlockedRecipients from '../fixtures/json-triage-mocks/triage-teams-mock.json';
 import oneBlockedRecipient from '../fixtures/json-triage-mocks/triage-teams-one-blocked-mock.json';
 import oneBlockedFacility from '../fixtures/json-triage-mocks/triage-teams-facility-blocked-mock.json';
@@ -262,5 +263,46 @@ describe('Edit Contact List container', async () => {
     expect(checkboxInputError).to.equal(
       ErrorMessages.ContactList.MINIMUM_SELECTION,
     );
+  });
+
+  it('adds eventListener if path is /contact-list', async () => {
+    const screen = setup();
+
+    const addEventListenerSpy = sinon.spy(window, 'addEventListener');
+    expect(addEventListenerSpy.calledWith('beforeunload')).to.be.false;
+
+    const checkbox = await screen.findByTestId(
+      'contact-list-select-team-1013155',
+    );
+
+    checkVaCheckbox(checkbox, false);
+
+    await waitFor(() => {
+      expect(addEventListenerSpy.calledWith('beforeunload')).to.be.true;
+    });
+  });
+
+  it('removes eventListener if contact list changes are reverted', async () => {
+    const screen = setup();
+
+    const addEventListenerSpy = sinon.spy(window, 'addEventListener');
+    const removeEventListenerSpy = sinon.spy(window, 'removeEventListener');
+    expect(addEventListenerSpy.calledWith('beforeunload')).to.be.false;
+
+    const checkbox = await screen.findByTestId(
+      'contact-list-select-team-1013155',
+    );
+
+    checkVaCheckbox(checkbox, false);
+
+    await waitFor(() => {
+      expect(addEventListenerSpy.calledWith('beforeunload')).to.be.true;
+    });
+
+    checkVaCheckbox(checkbox, true);
+
+    await waitFor(() => {
+      expect(removeEventListenerSpy.calledWith('beforeunload')).to.be.true;
+    });
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-interface.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-interface.cypress.spec.js
@@ -1,11 +1,11 @@
-import SecureMessagingSite from './sm_site/SecureMessagingSite';
-import PatientInboxPage from './pages/PatientInboxPage';
-import ContactListPage from './pages/ContactListPage';
-import { AXE_CONTEXT } from './utils/constants';
-import mockMixedCernerFacilitiesUser from './fixtures/userResponse/user-cerner-mixed.json';
-import mockFacilities from './fixtures/facilityResponse/cerner-facility-mock-data.json';
-import mockEhrData from './fixtures/userResponse/vamc-ehr-cerner-mixed.json';
-import mockMixRecipients from './fixtures/multi-facilities-recipients-response.json';
+import SecureMessagingSite from '../sm_site/SecureMessagingSite';
+import PatientInboxPage from '../pages/PatientInboxPage';
+import ContactListPage from '../pages/ContactListPage';
+import { AXE_CONTEXT } from '../utils/constants';
+import mockMixedCernerFacilitiesUser from '../fixtures/userResponse/user-cerner-mixed.json';
+import mockFacilities from '../fixtures/facilityResponse/cerner-facility-mock-data.json';
+import mockEhrData from '../fixtures/userResponse/vamc-ehr-cerner-mixed.json';
+import mockMixRecipients from '../fixtures/multi-facilities-recipients-response.json';
 
 describe('SM Contact list', () => {
   it('verify base web-elements - single facility', () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-multi-facility-errors.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-multi-facility-errors.cypress.spec.js
@@ -1,11 +1,11 @@
-import SecureMessagingSite from './sm_site/SecureMessagingSite';
-import PatientInboxPage from './pages/PatientInboxPage';
-import ContactListPage from './pages/ContactListPage';
-import { AXE_CONTEXT } from './utils/constants';
-import mockEhrData from './fixtures/userResponse/vamc-ehr-cerner-mixed.json';
-import mockMixedCernerFacilitiesUser from './fixtures/userResponse/user-cerner-mixed.json';
-import mockFacilities from './fixtures/facilityResponse/cerner-facility-mock-data.json';
-import mockMixRecipients from './fixtures/multi-facilities-recipients-response.json';
+import SecureMessagingSite from '../sm_site/SecureMessagingSite';
+import PatientInboxPage from '../pages/PatientInboxPage';
+import ContactListPage from '../pages/ContactListPage';
+import { AXE_CONTEXT } from '../utils/constants';
+import mockEhrData from '../fixtures/userResponse/vamc-ehr-cerner-mixed.json';
+import mockMixedCernerFacilitiesUser from '../fixtures/userResponse/user-cerner-mixed.json';
+import mockFacilities from '../fixtures/facilityResponse/cerner-facility-mock-data.json';
+import mockMixRecipients from '../fixtures/multi-facilities-recipients-response.json';
 
 describe('SM Single Facility Contact list', () => {
   beforeEach(() => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-multi-facility-navigate-away-errors.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-multi-facility-navigate-away-errors.cypress.spec.js
@@ -1,0 +1,102 @@
+import SecureMessagingSite from '../sm_site/SecureMessagingSite';
+import PatientInboxPage from '../pages/PatientInboxPage';
+import ContactListPage from '../pages/ContactListPage';
+import { AXE_CONTEXT, Paths } from '../utils/constants';
+import mockEhrData from '../fixtures/userResponse/vamc-ehr-cerner-mixed.json';
+import mockMixedCernerFacilitiesUser from '../fixtures/userResponse/user-cerner-mixed.json';
+import mockFacilities from '../fixtures/facilityResponse/cerner-facility-mock-data.json';
+import mockMixRecipients from '../fixtures/multi-facilities-recipients-response.json';
+
+describe('SM Single Facility Contact list', () => {
+  beforeEach(() => {
+    SecureMessagingSite.login(
+      mockEhrData,
+      true,
+      mockMixedCernerFacilitiesUser,
+      mockFacilities,
+    );
+    PatientInboxPage.loadInboxMessages();
+    ContactListPage.loadContactList(mockMixRecipients);
+    ContactListPage.selectAllCheckBox();
+  });
+
+  it('navigate away using secondary navigation', () => {
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+
+    cy.window().then(win => {
+      const beforeUnloadStub = cy.stub();
+
+      win.addEventListener('beforeunload', beforeUnloadStub);
+
+      cy.visit(`${Paths.UI_MAIN}/medications/about`);
+
+      cy.then(() => {
+        expect(beforeUnloadStub).to.have.been.called;
+        expect(win.location.href).to.eq(
+          `http://localhost:3001${Paths.UI_MAIN}/medications/about`,
+        );
+      });
+    });
+  });
+
+  it(`navigate away using navbar`, () => {
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+
+    cy.window().then(win => {
+      const beforeUnloadStub = cy.stub();
+
+      win.addEventListener('beforeunload', beforeUnloadStub);
+
+      cy.visit(`${Paths.UI_MAIN}/find-locations`);
+
+      cy.then(() => {
+        expect(beforeUnloadStub).to.have.been.called;
+        expect(win.location.href).to.eq(
+          `http://localhost:3001${Paths.UI_MAIN}/find-locations`,
+        );
+      });
+    });
+  });
+
+  it(`navigate away using browser back button`, () => {
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+
+    cy.window().then(win => {
+      const beforeUnloadStub = cy.stub();
+
+      win.addEventListener('beforeunload', beforeUnloadStub);
+
+      cy.go(`back`);
+
+      cy.then(() => {
+        expect(beforeUnloadStub).to.have.been.called;
+        expect(win.location.href).to.eq(
+          `http://localhost:3001${Paths.UI_MAIN}/inbox/`,
+        );
+      });
+    });
+  });
+
+  it(`navigate away using browser reload`, () => {
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+
+    cy.window().then(win => {
+      const beforeUnloadStub = cy.stub();
+
+      win.addEventListener('beforeunload', beforeUnloadStub);
+
+      cy.reload();
+
+      cy.then(() => {
+        expect(beforeUnloadStub).to.have.been.called;
+        expect(win.location.href).to.eq(
+          `http://localhost:3001${Paths.UI_MAIN}/contact-list`,
+        );
+      });
+    });
+  });
+});

--- a/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-single-facility-errors.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-single-facility-errors.cypress.spec.js
@@ -1,7 +1,7 @@
-import SecureMessagingSite from './sm_site/SecureMessagingSite';
-import PatientInboxPage from './pages/PatientInboxPage';
-import ContactListPage from './pages/ContactListPage';
-import { AXE_CONTEXT } from './utils/constants';
+import SecureMessagingSite from '../sm_site/SecureMessagingSite';
+import PatientInboxPage from '../pages/PatientInboxPage';
+import ContactListPage from '../pages/ContactListPage';
+import { AXE_CONTEXT } from '../utils/constants';
 
 describe('SM Single Facility Contact list', () => {
   beforeEach(() => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-single-facility-navigate-away-errors.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/contact-list-tests/secure-messaging-contact-list-single-facility-navigate-away-errors.cypress.spec.js
@@ -1,0 +1,93 @@
+import SecureMessagingSite from '../sm_site/SecureMessagingSite';
+import PatientInboxPage from '../pages/PatientInboxPage';
+import ContactListPage from '../pages/ContactListPage';
+import { AXE_CONTEXT, Paths } from '../utils/constants';
+
+describe('SM Single Facility Contact list', () => {
+  beforeEach(() => {
+    SecureMessagingSite.login();
+    PatientInboxPage.loadInboxMessages();
+    ContactListPage.loadContactList();
+    ContactListPage.selectAllCheckBox();
+  });
+
+  it('navigate away using secondary navigation', () => {
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+
+    cy.window().then(win => {
+      const beforeUnloadStub = cy.stub();
+
+      win.addEventListener('beforeunload', beforeUnloadStub);
+
+      cy.visit(`${Paths.UI_MAIN}/medications/about`);
+
+      cy.then(() => {
+        expect(beforeUnloadStub).to.have.been.called;
+        expect(win.location.href).to.eq(
+          `http://localhost:3001${Paths.UI_MAIN}/medications/about`,
+        );
+      });
+    });
+  });
+
+  it(`navigate away using navbar`, () => {
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+
+    cy.window().then(win => {
+      const beforeUnloadStub = cy.stub();
+
+      win.addEventListener('beforeunload', beforeUnloadStub);
+
+      cy.visit(`${Paths.UI_MAIN}/find-locations`);
+
+      cy.then(() => {
+        expect(beforeUnloadStub).to.have.been.called;
+        expect(win.location.href).to.eq(
+          `http://localhost:3001${Paths.UI_MAIN}/find-locations`,
+        );
+      });
+    });
+  });
+
+  it(`navigate away using browser back button`, () => {
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+
+    cy.window().then(win => {
+      const beforeUnloadStub = cy.stub();
+
+      win.addEventListener('beforeunload', beforeUnloadStub);
+
+      cy.go(`back`);
+
+      cy.then(() => {
+        expect(beforeUnloadStub).to.have.been.called;
+        expect(win.location.href).to.eq(
+          `http://localhost:3001${Paths.UI_MAIN}/inbox/`,
+        );
+      });
+    });
+  });
+
+  it(`navigate away using browser reload`, () => {
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+
+    cy.window().then(win => {
+      const beforeUnloadStub = cy.stub();
+
+      win.addEventListener('beforeunload', beforeUnloadStub);
+
+      cy.reload();
+
+      cy.then(() => {
+        expect(beforeUnloadStub).to.have.been.called;
+        expect(win.location.href).to.eq(
+          `http://localhost:3001${Paths.UI_MAIN}/contact-list`,
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Adds a browser popup when a user attempts to refresh or navigate away from SM if they have unsaved changes to the contact list.
- The browser popup is triggered when clicking page refresh, browser back button, Secondary navigation (blue bar)
- A separate modal will appear if navigation is attempted using breadcrumbs or contact list buttons.
- Reverting your changes back to the originallly-loaded contact list should allow navigating away (no popup or modal)

## Related issue(s)

### [MHV-61207](https://jira.devops.va.gov/browse/MHV-61207) - Navigate away user flows for Contact list page ###

> MHV-61207Navigate away user flows for Contact list page
> 
> Need Figma file
> 
> This ticket will cover navigate away user flows within SM and outside of SM.
> 
> This will include sign out functionality.
> 
> User Story: As a Secure Messaging User, I want to so that .
> 
> Feature Flag Y/N ?
> 
> Manual Testing Y/N ? Y-Rakesh
> 
> Automated Testing Y/N ? Y-Fazil
> 
> Accessibility Testing Y/N ? Y
> 
> UCD Validation Y/N
> 
> Acceptance Criteria:
> AC1 Navigate Away user flows for Contact List page have been defined and flows are successful
> AC2
> AC3
> AC4
> 
> Links to UCD:
> Figma link: https://www.figma.com/design/uddjxccqvUyz5FSg1aD5wi/ZFeat---Triage-Group-Selection-Flows?node-id=1391-37177&t=h8XJGPcfXOpMTJIj-4
> Other Design Notes
> 
> Given: a user is on the contact list page
> And: no changes have been made
> When: they navigate away
> Then: they will navigate away without a modal
> 
> Given: a user is on the contact list page
> And: new changes have been made
> When: they navigate away
> Then: they will be served a modal asking if they want to save their changes

## Testing done

- manual testing using all navigate away buttons in the app and from the browser
- updated unit tests

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Action | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop | Make changes to the contact list, then click the browser reload button       |![Screenshot 2024-09-04 at 11 14 35 AM](https://github.com/user-attachments/assets/5234feda-5c44-4acc-8af3-7dd6b270a448)|
| Desktop | Make changes to the contact list, then click the browser back button or secondary nav links       |![Screenshot 2024-09-04 at 11 14 42 AM](https://github.com/user-attachments/assets/08330eef-e212-436a-a189-3c143fe05ffd)|

## What areas of the site does it impact?

VA.gov - Secure Messaging

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
