### PR TITLE
updated heading on travel review page

### DIFF
--- a/src/applications/check-in/day-of/pages/TravelReview.jsx
+++ b/src/applications/check-in/day-of/pages/TravelReview.jsx
@@ -80,7 +80,9 @@ const TravelQuestion = props => {
         className="vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-bottom--4 vads-u-font-family--sans"
         style={{ overflow: 'hidden' }}
       >
-        <h3>{t('beneficiary-travel-agreement')}</h3>
+        <h2 className="vads-u-font-size--h3">
+          {t('beneficiary-travel-agreement')}
+        </h2>
         <p>
           <Trans
             i18nKey="penalty-statement"

--- a/src/applications/check-in/travel-claim/pages/travel-review/index.jsx
+++ b/src/applications/check-in/travel-claim/pages/travel-review/index.jsx
@@ -93,7 +93,9 @@ const TravelReview = props => {
         className="vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-bottom--4 vads-u-font-family--sans"
         style={{ overflow: 'hidden' }}
       >
-        <h3>{t('beneficiary-travel-agreement')}</h3>
+        <h2 className="vads-u-font-size--h3">
+          {t('beneficiary-travel-agreement')}
+        </h2>
         <p>
           <Trans
             i18nKey="penalty-statement"


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Updates heading for travel agreement on review page to be h2 styled like an h3

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#91795

## Testing done

visual

## Screenshots

**travel app:**
<img width="1131" alt="Screenshot 2024-09-04 at 3 29 14 PM" src="https://github.com/user-attachments/assets/59c31bd2-0a02-400d-a1a2-93845c788348">

**day-of check-in**
<img width="1033" alt="Screenshot 2024-09-04 at 3 30 01 PM" src="https://github.com/user-attachments/assets/53dfccac-5fda-40c3-8138-672ea515e4bf">

## What areas of the site does it impact?

stand alone travel app for O.H. appointments and day-of check-in

## Acceptance criteria
 - [ ] the `Beneficiary travel agreement` heading is an h2
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
