### PR TITLE
added opens in new tab text

### DIFF
--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -41,7 +41,6 @@
   "care-you-receive": "Care you receive from other providers",
   "certify-statements": "<0>I have incurred a cost in relation to the travel claim.</0><0>I have neither obtained transportation at Government expense nor through the use of Government request, tickets, or tokens, and have not used any Government-owned convenience or incurred any expenses which may be presented as charges against the Department of Veterans Affairs for transportation, meals, or lodgings in connection with my authorized travel that is not herein claimed.</0><0>I have not received other transportation resources at no-cost to me.</0><0>I am the only person claiming for the travel listed.</0><0>I have not previously received payment for the transportation claimed.</0>",
   "changes-in-medications": "Changes in the medications you’re taking or how you’re taking them",
-  "check-current-mileage-rates": "Check current mileage rates",
   "check-if-your-info-is-up-to-date": "Check if your information is up to date",
   "check-in": "Check-In",
   "check-in-at-va": "Check in at VA",
@@ -440,5 +439,6 @@
   "some-appointment-information-not-available": "Some of your appointment information is not available right now.",
   "find-all-appointment-information-check-in": "To find all your appointment information, finish checking in for your appointment first. Then go to appointments on VA.gov.",
   "find-all-appointment-information-pre-check-in": "To find all your appointment information, finish reviewing your contact information first. Then go to appointments on VA.gov.",
-  "review-your-appointments": "Review your appointments"
+  "review-your-appointments": "Review your appointments",
+  "check-current-mileage-rates-new-tab": "Check current mileage rates (opens in a new tab)"
 }

--- a/src/applications/check-in/locales/es/translation.json
+++ b/src/applications/check-in/locales/es/translation.json
@@ -41,7 +41,6 @@
   "care-you-receive": "Cuidados que recibe de otros proveedores",
   "certify-statements": "<0>He incurrido en un gasto en relación con la reclamación de viaje.</0><0>No he obtenido transporte a expensas del gobierno ni mediante el uso de solicitudes, boletos o vales del gobierno, y no he utilizado ninguna instalación propiedad del gobierno ni he incurrido en ningún gasto que pueda presentarse como cargo contra el Departamento de Asuntos de los Veteranos por concepto de transporte, comidas o alojamiento en relación con mi viaje autorizado que no se reclame en el presente documento.</0><0>No he recibido otros recursos de transporte sin costo alguno para mí.</0><0>Soy la única persona que reclama el viaje indicado.</0> <0>No he recibido previamente el pago por el transporte reclamado.</0>",
   "changes-in-medications": "Cambios en los medicamentos que toma o en la forma de tomarlos",
-  "check-current-mileage-rates": "Compruebe las tarifas de millaje actuales",
   "check-if-your-info-is-up-to-date": "Compruebe si su información está actualizada",
   "check-in": "Registrarse",
   "check-in-at-va": "Regístrese en VA",

--- a/src/applications/check-in/travel-claim/pages/travel-mileage/index.jsx
+++ b/src/applications/check-in/travel-claim/pages/travel-mileage/index.jsx
@@ -102,7 +102,7 @@ const TravelMileage = props => {
               rel="noreferrer"
               className="vads-u-padding-top--3 vads-u-display--block"
             >
-              {t('check-current-mileage-rates')}
+              {t('check-current-mileage-rates-new-tab')}
             </ExternalLink>
           </va-alert-expandable>
           {multipleAppointments ? (


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

adds `opens in new tab` text

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#91796

## Testing done

visual

## Screenshots

![localhost_3001_my-health_appointment-travel-claim_travel-mileage (6)](https://github.com/user-attachments/assets/c2ec9f1f-19cd-4104-b1b6-72fa1a85c507)

## What areas of the site does it impact?

O.H. stand alone travel

## Acceptance criteria
 - [ ] link has `(opens in a new tab)` appended
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
