### PR TITLE
Fix patient comments text wrapping

### DIFF
--- a/src/applications/vaos/appointment-list/components/cancel/CancelPageLayout.jsx
+++ b/src/applications/vaos/appointment-list/components/cancel/CancelPageLayout.jsx
@@ -111,7 +111,9 @@ export default function CancelPageLayout() {
         Reason: {`${reason && reason !== 'none' ? reason : 'Not available'}`}
       </span>
       <br />
-      <span>Other details: {`${otherDetails || 'Not available'}`}</span>
+      <span className="vaos-u-word-break--break-word">
+        Other details: {`${otherDetails || 'Not available'}`}
+      </span>
     </>
   );
 }

--- a/src/applications/vaos/appointment-list/components/cancel/CancelPageLayoutRequest.jsx
+++ b/src/applications/vaos/appointment-list/components/cancel/CancelPageLayoutRequest.jsx
@@ -99,7 +99,9 @@ export default function CancelPageLayoutRequest() {
         Reason: {`${reason && reason !== 'none' ? reason : 'Not available'}`}
       </span>
       <br />
-      <span>Other details: {`${otherDetails || 'Not available'}`}</span>
+      <span className="vaos-u-word-break--break-word">
+        Other details: {`${otherDetails || 'Not available'}`}
+      </span>
       <h3 className="vads-u-font-size--h5 vads-u-margin-bottom--0">
         Your contact details
       </h3>

--- a/src/applications/vaos/components/layout/CCLayout.jsx
+++ b/src/applications/vaos/components/layout/CCLayout.jsx
@@ -100,7 +100,9 @@ export default function CCLayout({ data: appointment }) {
             {`${reason && reason !== 'none' ? reason : 'Not available'}`}
           </span>
           <br />
-          <span>Other details: {`${otherDetails || 'Not available'}`}</span>
+          <span className="vaos-u-word-break--break-word">
+            Other details: {`${otherDetails || 'Not available'}`}
+          </span>
         </Section>
         {featureMedReviewInstructions &&
           !isPastAppointment &&

--- a/src/applications/vaos/components/layout/CCRequestLayout.jsx
+++ b/src/applications/vaos/components/layout/CCRequestLayout.jsx
@@ -89,7 +89,9 @@ export default function CCRequestLayout({ data: appointment }) {
             {`${reason && reason !== 'none' ? reason : 'Not available'}`}
           </span>
           <br />
-          <span>Other details: {`${otherDetails || 'Not available'}`}</span>
+          <span className="vaos-u-word-break--break-word">
+            Other details: {`${otherDetails || 'Not available'}`}
+          </span>
         </Section>
         <Section heading="Your contact details">
           <span data-dd-privacy="mask">Email: {email}</span>

--- a/src/applications/vaos/components/layout/InPersonLayout.jsx
+++ b/src/applications/vaos/components/layout/InPersonLayout.jsx
@@ -138,7 +138,9 @@ export default function InPersonLayout({ data: appointment }) {
           Reason: {`${reason && reason !== 'none' ? reason : 'Not available'}`}
         </span>
         <br />
-        <span>Other details: {`${otherDetails || 'Not available'}`}</span>
+        <span className="vaos-u-word-break--break-word">
+          Other details: {`${otherDetails || 'Not available'}`}
+        </span>
       </Section>
       {featureMedReviewInstructions &&
         !isPastAppointment &&

--- a/src/applications/vaos/components/layout/PhoneLayout.jsx
+++ b/src/applications/vaos/components/layout/PhoneLayout.jsx
@@ -107,7 +107,9 @@ export default function PhoneLayout({ data: appointment }) {
           Reason: {`${reason && reason !== 'none' ? reason : 'Not available'}`}
         </span>
         <br />
-        <span>Other details: {`${otherDetails || 'Not available'}`}</span>
+        <span className="vaos-u-word-break--break-word">
+          Other details: {`${otherDetails || 'Not available'}`}
+        </span>
       </Section>
       {featureMedReviewInstructions &&
         !isPastAppointment &&

--- a/src/applications/vaos/components/layout/VARequestLayout.jsx
+++ b/src/applications/vaos/components/layout/VARequestLayout.jsx
@@ -82,7 +82,9 @@ export default function VARequestLayout({ data: appointment }) {
             {`${reason && reason !== 'none' ? reason : 'Not available'}`}
           </span>
           <br />
-          <span>Other details: {`${otherDetails || 'Not available'}`}</span>
+          <span className="vaos-u-word-break--break-word">
+            Other details: {`${otherDetails || 'Not available'}`}
+          </span>
         </Section>
         <Section heading="Your contact details">
           <span data-dd-privacy="mask">Email: {email}</span>

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -293,6 +293,11 @@
       "patientIcn": "1013678363V916823",
       "locationId": "984",
       "clinic": "4570",
+      "reasonCode": {
+        "text": "reasonCode:QUESTIONMEDS|comments:test appointment scheduling TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "patientComments": "test appointment scheduling TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "reasonForAppointment": "Medication concern",
       "practitioners": [
           {
               "identifier": [
@@ -1048,6 +1053,11 @@
             }
         ],
         "description": "PC Established Patient",
+        "reasonCode": {
+          "text": "reasonCode:QUESTIONMEDS|comments:test appointment scheduling TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "patientComments": "test appointment scheduling TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "reasonForAppointment": "Medication concern",
         "patientIcn": "1012845331V153043",
         "locationId": "757",
         "practitioners": [
@@ -3456,6 +3466,11 @@
         "start": "2024-11-22T12:00:00Z",
         "created": "2024-11-22T20:33:54Z",
         "localStartTime": "2024-11-22T09:00:00.000-06:00",
+        "reasonCode":
+        {
+          "text": "\nNew Problem: VAOS AUTOMATED SMOKE TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "patientComments": "\nNew Problem: VAOS AUTOMATED SMOKE TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "extension": {
           "ccLocation": {
             "address": {

--- a/src/applications/vaos/services/mocks/v2/requests.json
+++ b/src/applications/vaos/services/mocks/v2/requests.json
@@ -159,7 +159,7 @@
                     }
                 ],
                 "reasonCode": {
-                    "text": "station id: 983|preferred modality: FACE TO FACE|phone number: 4173004779|email: TESTING@ABC.COM|preferred dates:07/08/2024 AM|reason code:QUESTIONMEDS|comments:DO NOT CANCEL OR PROCESS THIS REQUEST.  \n\nTHIS REQUEST IS USED TO TEST REQUEST LIMITS IN THE AUTOMATION TESTING TOOL. "
+                    "text": "station id: 983|preferred modality: FACE TO FACE|phone number: 4173004779|email: TESTING@ABC.COM|preferred dates:07/08/2024 AM|reason code:QUESTIONMEDS|comments:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                 },
                 "patientIcn": "1013012762V562525",
                 "locationId": "983",
@@ -193,7 +193,7 @@
                         }
                     ]
                 },
-                "patientComments": "DO NOT CANCEL OR PROCESS THIS REQUEST.  \n\nTHIS REQUEST IS USED TO TEST REQUEST LIMITS IN THE AUTOMATION TESTING TOOL.",
+                "patientComments": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "reasonForAppointment": "Medication concern",
                 "preferredDates": [
                     "Mon, July 8, 2024 in the morning"
@@ -333,7 +333,7 @@
                         }
                     ]
                 },
-                "additionalAppointmentDetails": "Test",
+                "patientComments": "Test",
                 "location": {
                     "id": "984GD",
                     "type": "appointments",
@@ -374,14 +374,14 @@
             }
         },
         {
-            "id": "affd60fe40dfacd5d4e6c5ef40491dcfc2f5d7e02216717c787b72ceb79fc44d",
+            "id": "9de214703fa773e7cec3011c821477e05e32c1c3d4eab44ec9b842eb71efab53",
             "type": "appointments",
             "attributes": {
-                "id": "affd60fe40dfacd5d4e6c5ef40491dcfc2f5d7e02216717c787b72ceb79fc44d",
+                "id": "9de214703fa773e7cec3011c821477e05e32c1c3d4eab44ec9b842eb71efab53",
                 "identifier": [
                     {
                         "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
-                        "value": "15802"
+                        "value": "16454"
                     }
                 ],
                 "kind": "cc",
@@ -393,15 +393,15 @@
                     }
                 ],
                 "reasonCode": {
-                    "text": "PR - Test - 03/27"
+                    "text": "\nNew Problem: VAOS AUTOMATED SMOKE TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                 },
-                "patientIcn": "1012845944V882130",
+                "patientIcn": "1012845331V153043",
                 "locationId": "983",
-                "created": "2024-03-27T22:39:00Z",
+                "created": "2024-06-25T12:49:03Z",
                 "requestedPeriods": [
                     {
-                        "start": "2024-04-02T18:00:00Z",
-                        "localStartTime": "2024-04-02T12:00:00.000-06:00"
+                        "start": "2024-06-26T08:00:00Z",
+                        "localStartTime": "2024-06-26T02:00:00.000-06:00"
                     }
                 ],
                 "contact": {
@@ -432,7 +432,13 @@
                     "ccRequestedCancellation": false,
                     "hsrmTaskId": "15802"
                 },
+                "station": null,
+                "ien": null,
                 "preferredProviderName": null,
+                "patientComments": "\nNew Problem: VAOS AUTOMATED SMOKE TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "preferredDates": [
+                    "Wed, June 26, 2024 in the morning"
+                ],
                 "location": {
                     "id": "983",
                     "type": "appointments",
@@ -489,7 +495,8 @@
                         ],
                         "operatingStatus": {
                             "code": "NORMAL"
-                        }
+                        },
+                        "ehrSystem": "VistA"
                     }
                 }
             }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- This fixes a bug where the patient adds a comment that consists of a very long word. Since word wrapping is not enabled for patient comments, it can display outside of the appointment details card.
- To reproduce, view the appointment linked in the associated issue.
- To solve this we add the `word-break: break-word` style to the fields that display user inputs (e.g. patient comments).
- Appointments (VAOS) team

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92076

## Testing done

- Tested locally, see screenshots

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| VA Request  |    <img width="846" alt="image" src="https://github.com/user-attachments/assets/e2e6dfec-d596-4396-8f14-02da49699e1c">   |  <img width="559" alt="image" src="https://github.com/user-attachments/assets/1d6454c2-d132-486e-9cd6-b13450b2042f">    |
| CC Request |    <img width="840" alt="image" src="https://github.com/user-attachments/assets/6f57db89-ac79-4a88-9cb8-5cd89c1c4694">   |    <img width="561" alt="image" src="https://github.com/user-attachments/assets/5878dae8-7ce6-4499-bd83-07354a849599">  |
| Cancel Request |    <img width="843" alt="image" src="https://github.com/user-attachments/assets/a8f5b570-3343-41ef-a897-ec60260a4a85">   |   <img width="561" alt="image" src="https://github.com/user-attachments/assets/1d32acb2-1154-4c76-8999-2a76e93d4fcf">  |
| In-person |    <img width="846" alt="image" src="https://github.com/user-attachments/assets/e9603a98-7d03-4adc-bbdf-46091cb2e034">   |   <img width="568" alt="image" src="https://github.com/user-attachments/assets/3ddb2fd5-e161-4744-b091-db256faf767c">   |
| CC |   <img width="845" alt="image" src="https://github.com/user-attachments/assets/67959891-5a7b-4895-8664-8cc40c530af9">    |   <img width="570" alt="image" src="https://github.com/user-attachments/assets/099fbea8-058e-4ded-b33d-1cf50fd69d2f">    |
| Phone |    <img width="845" alt="image" src="https://github.com/user-attachments/assets/7482962f-4050-425a-8f91-2f436025f60a">   | <img width="565" alt="image" src="https://github.com/user-attachments/assets/18cc20fc-18f3-4fee-998c-12d043af8fde"> |
| Cancel Appointment  |   <img width="843" alt="image" src="https://github.com/user-attachments/assets/94a3c833-a52f-43e2-bb17-164698c91132">    | <img width="567" alt="image" src="https://github.com/user-attachments/assets/824f2257-a13a-4084-ab83-416798e2a21b"> |

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

- [ ] The comment text should stay within the card style

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
