### PR TITLE
91342 Use va-checkbox component

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
+++ b/src/applications/disability-benefits/all-claims/content/toxicExposure.jsx
@@ -88,16 +88,10 @@ export const goBackLink = 'Edit locations and dates';
 export const goBackLinkExposures = 'Edit exposures and dates';
 export const noDatesEntered = 'No dates entered';
 export const notSureDatesSummary = 'I’m not sure of the dates';
-export const notSureDatesDetails = (
-  <p className="vads-spacing-1">
-    I’m not sure of the dates I served in this location
-  </p>
-);
-export const notSureHazardDetails = (
-  <p className="vads-spacing-1">
-    I’m not sure of the dates I was exposed to this hazard
-  </p>
-);
+export const notSureDatesDetails =
+  'I’m not sure of the dates I served in this location';
+export const notSureHazardDetails =
+  'I’m not sure of the dates I was exposed to this hazard';
 
 /**
  * Generate the Toxic Exposure subtitle, which is used on Review and Submit and on the pages

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposuresDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposuresDetails.js
@@ -2,6 +2,7 @@ import {
   currentOrPastDateUI,
   currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
   additionalExposuresPageTitle,
   dateRangeAdditionalInfo,
@@ -45,6 +46,10 @@ function makeUiSchema(itemId) {
           }),
           'view:notSure': {
             'ui:title': notSureHazardDetails,
+            'ui:webComponentField': VaCheckboxField,
+            'ui:options': {
+              classNames: 'vads-u-margin-y--3',
+            },
           },
         },
       },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
@@ -2,6 +2,7 @@ import {
   currentOrPastDateUI,
   currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
   endDateApproximate,
   getKeyIndex,
@@ -43,6 +44,10 @@ function makeUiSchema(locationId) {
           }),
           'view:notSure': {
             'ui:title': notSureDatesDetails,
+            'ui:webComponentField': VaCheckboxField,
+            'ui:options': {
+              classNames: 'vads-u-margin-y--3',
+            },
           },
         },
       },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
@@ -2,6 +2,7 @@ import {
   currentOrPastDateUI,
   currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
   endDateApproximate,
   getKeyIndex,
@@ -43,6 +44,10 @@ function makeUiSchema(locationId) {
           }),
           'view:notSure': {
             'ui:title': notSureDatesDetails,
+            'ui:webComponentField': VaCheckboxField,
+            'ui:options': {
+              classNames: 'vads-u-margin-y--3',
+            },
           },
         },
       },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
@@ -2,6 +2,7 @@ import {
   currentOrPastDateUI,
   currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
   dateRangeAdditionalInfo,
   detailsPageBegin,
@@ -43,6 +44,10 @@ function makeUiSchema(locationId) {
           }),
           'view:notSure': {
             'ui:title': notSureDatesDetails,
+            'ui:webComponentField': VaCheckboxField,
+            'ui:options': {
+              classNames: 'vads-u-margin-y--3',
+            },
           },
         },
       },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
@@ -2,6 +2,7 @@ import {
   currentOrPastDateUI,
   currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
   dateRangeAdditionalInfo,
   detailsPageBegin,
@@ -40,6 +41,10 @@ export const uiSchema = {
       }),
       'view:notSure': {
         'ui:title': notSureDatesDetails,
+        'ui:webComponentField': VaCheckboxField,
+        'ui:options': {
+          classNames: 'vads-u-margin-y--3',
+        },
       },
     },
     'view:herbicideAdditionalInfo': {

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/specifyOtherExposures.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/specifyOtherExposures.js
@@ -2,6 +2,7 @@ import {
   currentOrPastDateUI,
   currentOrPastDateSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
   additionalExposuresPageTitle,
   dateRangeAdditionalInfo,
@@ -10,7 +11,7 @@ import {
   exposureStartDateApproximate,
   getOtherFieldDescription,
   getSelectedCount,
-  notSureDatesDetails,
+  notSureHazardDetails,
   teSubtitle,
 } from '../../content/toxicExposure';
 
@@ -42,7 +43,11 @@ export const uiSchema = {
         title: exposureEndDateApproximate,
       }),
       'view:notSure': {
-        'ui:title': notSureDatesDetails,
+        'ui:title': notSureHazardDetails,
+        'ui:webComponentField': VaCheckboxField,
+        'ui:options': {
+          classNames: 'vads-u-margin-y--3',
+        },
       },
     },
     'view:additionalExposuresAdditionalInfo': {

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/additionalExposuresDetails.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/additionalExposuresDetails.unit.spec.jsx
@@ -12,6 +12,7 @@ import {
   dateRangeDescriptionWithHazard,
   exposureEndDateApproximate,
   exposureStartDateApproximate,
+  notSureHazardDetails,
 } from '../../../content/toxicExposure';
 
 /**
@@ -59,7 +60,8 @@ describe('additional exposures details', () => {
           ),
         ).to.exist;
 
-        getByText('I’m not sure of the dates I was exposed to this hazard');
+        expect($(`va-checkbox[label="${notSureHazardDetails}"]`, container)).to
+          .exist;
 
         const addlInfo = container.querySelector('va-additional-info');
         expect(addlInfo).to.have.attribute(

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/gulfWar1990Details.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/gulfWar1990Details.unit.spec.jsx
@@ -10,6 +10,7 @@ import {
   dateRangeDescriptionWithLocation,
   endDateApproximate,
   gulfWar1990PageTitle,
+  notSureDatesDetails,
   startDateApproximate,
 } from '../../../content/toxicExposure';
 import { GULF_WAR_1990_LOCATIONS } from '../../../constants';
@@ -53,7 +54,8 @@ describe('gulfWar1990Details', () => {
         expect($(`va-memorable-date[label="${endDateApproximate}"]`, container))
           .to.exist;
 
-        getByText('I’m not sure of the dates I served in this location');
+        expect($(`va-checkbox[label="${notSureDatesDetails}"]`, container)).to
+          .exist;
 
         const addlInfo = container.querySelector('va-additional-info');
         expect(addlInfo).to.have.attribute(

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/gulfWar2001Details.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/gulfWar2001Details.unit.spec.jsx
@@ -10,6 +10,7 @@ import {
   dateRangeDescriptionWithLocation,
   endDateApproximate,
   gulfWar2001PageTitle,
+  notSureDatesDetails,
   startDateApproximate,
 } from '../../../content/toxicExposure';
 import { GULF_WAR_2001_LOCATIONS } from '../../../constants';
@@ -53,7 +54,8 @@ describe('gulfWar2001Details', () => {
         expect($(`va-memorable-date[label="${endDateApproximate}"]`, container))
           .to.exist;
 
-        getByText('I’m not sure of the dates I served in this location');
+        expect($(`va-checkbox[label="${notSureDatesDetails}"]`, container)).to
+          .exist;
 
         const addlInfo = container.querySelector('va-additional-info');
         expect(addlInfo).to.have.attribute(

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideDetails.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideDetails.unit.spec.jsx
@@ -11,6 +11,7 @@ import {
   dateRangeDescriptionWithLocation,
   endDateApproximate,
   herbicidePageTitle,
+  notSureDatesDetails,
   startDateApproximate,
 } from '../../../content/toxicExposure';
 
@@ -53,7 +54,8 @@ describe('herbicideDetails', () => {
         expect($(`va-memorable-date[label="${endDateApproximate}"]`, container))
           .to.exist;
 
-        getByText('I’m not sure of the dates I served in this location');
+        expect($(`va-checkbox[label="${notSureDatesDetails}"]`, container)).to
+          .exist;
 
         const addlInfo = container.querySelector('va-additional-info');
         expect(addlInfo).to.have.attribute(

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideOtherLocations.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideOtherLocations.unit.spec.jsx
@@ -8,6 +8,7 @@ import {
   dateRangeDescriptionWithLocation,
   endDateApproximate,
   herbicidePageTitle,
+  notSureDatesDetails,
   startDateApproximate,
 } from '../../../content/toxicExposure';
 
@@ -51,7 +52,8 @@ describe('Herbicide Other Locations', () => {
     expect($(`va-memorable-date[label="${endDateApproximate}"]`, container)).to
       .exist;
 
-    getByText('I’m not sure of the dates I served in this location');
+    expect($(`va-checkbox[label="${notSureDatesDetails}"]`, container)).to
+      .exist;
 
     const addlInfo = container.querySelector('va-additional-info');
     expect(addlInfo).to.have.attribute(

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/specifyOtherExposures.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/specifyOtherExposures.unit.spec.jsx
@@ -9,6 +9,7 @@ import {
   dateRangeDescriptionWithHazard,
   exposureEndDateApproximate,
   exposureStartDateApproximate,
+  notSureHazardDetails,
 } from '../../../content/toxicExposure';
 
 describe('Specify Other Exposures', () => {
@@ -68,6 +69,9 @@ describe('Specify Other Exposures', () => {
     expect(
       $(`va-memorable-date[label="${exposureEndDateApproximate}"]`, container),
     ).to.exist;
+
+    expect($(`va-checkbox[label="${notSureHazardDetails}"]`, container)).to
+      .exist;
 
     const addlInfo = container.querySelector('va-additional-info');
     expect(addlInfo).to.have.attribute(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- On each of the Toxic exposure details pages, there is an "I'm not sure..." checkbox that was previously using html and is now switched to a web component 

team: @department-of-veterans-affairs/dbex-trex 
toggle cleanup: department-of-veterans-affairs/va.gov-team#65089

## Related issue(s)
department-of-veterans-affairs/va.gov-team#91342

## Testing done
- Unit tests updated, e2e tests passing

**Manual test setup**
1. Enable toggle `disability_526_toxic_exposure`
2. Start a new claim with new conditions
3. On the toxic-exposure/conditions page, select at least one new condition
4. For each of the TE locations or hazards pages, select one or more checkboxes so that you can view each of the details pages
5. **Verify** details pages are now using web components for the "I'm not sure" checkbox.

## Screenshots
<img width="1461" alt="image" src="https://github.com/user-attachments/assets/c8be859a-0249-4e63-8602-77ceffe76181">

## What areas of the site does it impact?
526ez

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
