### PR TITLE
utilized ReactTitle to inject meta page title

### DIFF
--- a/src/applications/check-in/components/layout/Wrapper.jsx
+++ b/src/applications/check-in/components/layout/Wrapper.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
+import { ReactTitle } from 'react-meta-tags';
+import { useTranslation } from 'react-i18next';
 
 import {
   DowntimeNotification,
@@ -10,6 +12,7 @@ import { focusElement } from 'platform/utilities/ui';
 
 import { makeSelectApp } from '../../selectors';
 import { APP_NAMES } from '../../utils/appConstants';
+import { toCamelCase } from '../../utils/formatters';
 import { useDatadogRum } from '../../hooks/useDatadogRum';
 import MixedLanguageDisclaimer from '../MixedLanguageDisclaimer';
 import LanguagePicker from '../LanguagePicker';
@@ -19,6 +22,7 @@ const Wrapper = props => {
   const {
     children,
     pageTitle,
+    titleOverride,
     eyebrow,
     classNames = '',
     withBackButton = false,
@@ -29,7 +33,7 @@ const Wrapper = props => {
   }, []);
 
   useDatadogRum();
-
+  const { t } = useTranslation();
   const topPadding = withBackButton
     ? 'vads-u-padding-y--2'
     : ' vads-u-padding-y--3';
@@ -56,12 +60,18 @@ const Wrapper = props => {
       appTitle = 'appointments';
       break;
   }
+  let metaTitle = pageTitle ?? appTitle;
+
+  if (titleOverride) {
+    metaTitle = titleOverride;
+  }
   return (
     <>
       <div
         className={`vads-l-grid-container ${classNames} ${topPadding}`}
         data-testid={testID}
       >
+        <ReactTitle title={`${metaTitle} | ${t('veterans-affairs')}`} />
         <MixedLanguageDisclaimer />
         <LanguagePicker />
         {pageTitle && (
@@ -79,7 +89,8 @@ const Wrapper = props => {
           dependencies={[downtimeDependency]}
           customText={{ appType: 'tool' }}
         >
-          {children}
+          {/* Seems like the only way to unit test this ¯\_(ツ)_/¯ */}
+          <div data-testid={toCamelCase(metaTitle)}>{children}</div>
         </DowntimeNotification>
         <Footer isPreCheckIn={app === APP_NAMES.PRE_CHECK_IN} />
       </div>
@@ -93,6 +104,7 @@ Wrapper.propTypes = {
   eyebrow: PropTypes.string,
   pageTitle: PropTypes.string,
   testID: PropTypes.string,
+  titleOverride: PropTypes.string,
   withBackButton: PropTypes.bool,
 };
 

--- a/src/applications/check-in/components/layout/tests/Wrapper.unit.spec.jsx
+++ b/src/applications/check-in/components/layout/tests/Wrapper.unit.spec.jsx
@@ -8,6 +8,7 @@ import { I18nextProvider } from 'react-i18next';
 import { addDays, subDays, format } from 'date-fns';
 import { setupI18n, teardownI18n } from '../../../utils/i18n/i18n';
 import CheckInProvider from '../../../tests/unit/utils/CheckInProvider';
+import { APP_NAMES } from '../../../utils/appConstants';
 import Wrapper from '../Wrapper';
 
 describe('Wrapper component', () => {
@@ -20,7 +21,7 @@ describe('Wrapper component', () => {
   });
   it('renders the passed in page title and child', () => {
     const { getByText, getByTestId } = render(
-      <CheckInProvider store={{ app: 'PreCheckIn' }}>
+      <CheckInProvider store={{ app: APP_NAMES.PRE_CHECK_IN }}>
         <Wrapper pageTitle="Test Title" eyebrow="Check-In">
           <p>test body</p>
         </Wrapper>
@@ -34,7 +35,7 @@ describe('Wrapper component', () => {
     const mockStore = configureStore(middleware);
     const initState = {
       checkInData: {
-        app: 'PreCheckIn',
+        app: APP_NAMES.PRE_CHECK_IN,
         form: {
           pages: [],
         },
@@ -71,7 +72,7 @@ describe('Wrapper component', () => {
     const mockStore = configureStore(middleware);
     const initState = {
       checkInData: {
-        app: 'preCheckIn',
+        app: APP_NAMES.PRE_CHECK_IN,
         form: {
           pages: [],
         },
@@ -115,7 +116,7 @@ describe('Wrapper component', () => {
     const mockStore = configureStore(middleware);
     const initState = {
       checkInData: {
-        app: 'PreCheckIn',
+        app: APP_NAMES.PRE_CHECK_IN,
         form: {
           pages: [],
         },
@@ -153,5 +154,39 @@ describe('Wrapper component', () => {
     );
     expect(getByText('Test Title')).to.exist;
     expect(queryAllByText('This tool is down for maintenance')).to.be.empty;
+  });
+  it('uses the H1 as meta title', () => {
+    const { getByTestId } = render(
+      <CheckInProvider store={{ app: APP_NAMES.PRE_CHECK_IN }}>
+        <Wrapper pageTitle="Test Title" eyebrow="Check-In">
+          <p>test body</p>
+        </Wrapper>
+      </CheckInProvider>,
+    );
+    expect(getByTestId('testTitle')).to.exist;
+  });
+  it('uses the app title as meta title if no H1', () => {
+    const { getByTestId } = render(
+      <CheckInProvider store={{ app: APP_NAMES.PRE_CHECK_IN }}>
+        <Wrapper eyebrow="Check-In">
+          <p>test body</p>
+        </Wrapper>
+      </CheckInProvider>,
+    );
+    expect(getByTestId('pre-checkIn')).to.exist;
+  });
+  it('uses the overrideTitle as meta title if present', () => {
+    const { getByTestId } = render(
+      <CheckInProvider store={{ app: APP_NAMES.PRE_CHECK_IN }}>
+        <Wrapper
+          pageTitle="Test Title"
+          eyebrow="Check-In"
+          titleOverride="look at me"
+        >
+          <p>test body</p>
+        </Wrapper>
+      </CheckInProvider>,
+    );
+    expect(getByTestId('lookAtMe')).to.exist;
   });
 });

--- a/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
+++ b/src/applications/check-in/components/pages/AppointmentDetails/index.jsx
@@ -200,7 +200,11 @@ const AppointmentDetails = props => {
             prevUrl="#back"
             text={t('back-to-last-screen')}
           />
-          <Wrapper classNames="appointment-details-page" withBackButton>
+          <Wrapper
+            classNames="appointment-details-page"
+            withBackButton
+            titleOverride={appointmentTitle()}
+          >
             <div className="appointment-details--container vads-u-margin-top--2 vads-u-border--2px vads-u-border-color--gray vads-u-padding-x--2 vads-u-padding-top--4 vads-u-padding-bottom--2">
               <div className="appointment-details--icon">
                 {appointmentIcon(appointment)}

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -439,5 +439,6 @@
   "find-all-appointment-information-pre-check-in": "To find all your appointment information, finish reviewing your contact information first. Then go to appointments on VA.gov.",
   "review-your-appointments": "Review your appointments",
   "check-current-mileage-rates-new-tab": "Check current mileage rates (opens in a new tab)",
-  "bring-insurance-cards-and-list-medications-other": "Bring your insurance cards. And bring a list of your medications and other information to share with your provider."
+  "bring-insurance-cards-and-list-medications-other": "Bring your insurance cards. And bring a list of your medications and other information to share with your provider.",
+  "veterans-affairs": "Veterans Affairs"
 }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

utilized ReactTitle to inject meta page title in every page via the <Wrapper /> component. Defaults to h1, if no h1 uses the app title. Also has a `overideTitle` prop that will override the meta title logic. The override is used on the details pages which don't use the h1 from wrapper.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#91797

## Testing done

- adds unit tests
- visual tests too

## Screenshots

<img width="325" alt="Screenshot 2024-09-05 at 3 32 38 PM" src="https://github.com/user-attachments/assets/e4b7d620-5327-4e2c-a16f-847060364b62">
<hr />
<img width="1024" alt="Screenshot 2024-09-05 at 3 33 12 PM" src="https://github.com/user-attachments/assets/580062ce-1119-4b5c-b6ea-abdeb8d29832">


## What areas of the site does it impact?

all check-in apps

## Acceptance criteria
 - [ ] all pages use the `[H1] | Veterans Affairs` pattern for meta page title
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
