### PR TITLE
My VA - fix form Submission status mappings 

### DIFF
--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -191,14 +191,13 @@ export const getLatestCopay = statements => {
 export const normalizeSubmissionStatus = apiStatusValue => {
   const value = apiStatusValue.toLowerCase();
   switch (value) {
-    case 'pending':
-    case 'uploaded':
-      return 'inProgress';
+    case 'vbms':
+      return 'received';
     case 'error':
     case 'expired':
       return 'actionNeeded';
     default:
-      return 'received';
+      return 'inProgress';
   }
 };
 

--- a/src/applications/personalization/dashboard/mocks/benefit-applications/index.js
+++ b/src/applications/personalization/dashboard/mocks/benefit-applications/index.js
@@ -19,6 +19,19 @@ const createApplications = (updatedDaysAgo = 1) => {
           updatedAt: formatISO(daysAgo),
         },
       },
+      {
+        id: '3b03b5a0-3ad9-4207-b61e-3a13ed1c8b80',
+        type: 'submission_status',
+        attributes: {
+          id: '3b03b5a0-3ad9-4207-b61e-3a13ed1c8b80',
+          detail: '',
+          formType: '22-1990',
+          message: null,
+          status: 'vbms',
+          createdAt: '2023-12-15T20:40:47.583Z',
+          updatedAt: formatISO(daysAgo),
+        },
+      },
     ],
   };
 };

--- a/src/applications/personalization/dashboard/tests/components/apply-for-benefits/ApplicationsInProgress.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/components/apply-for-benefits/ApplicationsInProgress.unit.spec.jsx
@@ -117,6 +117,19 @@ const formsWithStatus = [
       updatedAt: STATUS_UPDATED_AT,
     },
   },
+  {
+    id: '3b03b5a0-3ad9-4207-b61e-3a13ed1c8b80',
+    type: 'submission_status',
+    attributes: {
+      id: '3b03b5a0-3ad9-4207-b61e-3a13ed1c8b80',
+      detail: '',
+      formType: '22-1990',
+      message: null,
+      status: 'vbms',
+      createdAt: STATUS_CREATED_AT,
+      updatedAt: STATUS_UPDATED_AT,
+    },
+  },
 ];
 
 describe('ApplicationsInProgress component', () => {
@@ -379,13 +392,18 @@ describe('ApplicationsInProgress component', () => {
       );
 
       const receivedApplications = view.getAllByTestId('submitted-application');
-      expect(receivedApplications.length).to.equal(1);
-      expect(receivedApplications[0]).to.contain.text('Received');
+      expect(receivedApplications.length).to.equal(2);
+      expect(receivedApplications[0]).to.contain.text('Submission in Progress');
       expect(receivedApplications[0]).to.contain.text('VA Form 21-0845');
       expect(receivedApplications[0]).to.contain.text('Submitted on: ');
       expect(receivedApplications[0]).to.contain.text('December 15, 2023');
-      expect(receivedApplications[0]).to.contain.text('Received on: ');
-      expect(receivedApplications[0]).to.contain.text(
+
+      expect(receivedApplications[1]).to.contain.text('Received');
+      expect(receivedApplications[1]).to.contain.text('VA Form 22-1990');
+      expect(receivedApplications[1]).to.contain.text('Submitted on: ');
+      expect(receivedApplications[1]).to.contain.text('December 15, 2023');
+      expect(receivedApplications[1]).to.contain.text('Received on: ');
+      expect(receivedApplications[1]).to.contain.text(
         format(new Date(STATUS_UPDATED_AT), 'MMMM d, yyyy'),
       );
     });

--- a/src/applications/personalization/dashboard/tests/e2e/in-progress-forms.cypress.spec.js
+++ b/src/applications/personalization/dashboard/tests/e2e/in-progress-forms.cypress.spec.js
@@ -190,7 +190,7 @@ describe('The My VA Dashboard', () => {
         cy.findByRole('heading', {
           name: /benefit applications and forms/i,
         }).should('exist');
-        cy.findAllByTestId('submitted-application').should('have.length', 3);
+        cy.findAllByTestId('submitted-application').should('have.length', 4);
         // make the a11y check
         cy.injectAxe();
         cy.axeCheck();

--- a/src/applications/personalization/dashboard/tests/fixtures/form-statuses.json
+++ b/src/applications/personalization/dashboard/tests/fixtures/form-statuses.json
@@ -38,6 +38,19 @@
         "createdAt": "2023-12-20T18:04:04.925Z",
         "updatedAt": "2023-12-20T18:04:09.292Z"
       }
+    },
+    {
+      "id": "3b03b5a0-3ad9-4207-b61e-3a13ed1c8b80",
+      "type": "submission_status",
+      "attributes": {
+        "id": "3b03b5a0-3ad9-4207-b61e-3a13ed1c8b80",
+        "detail": "",
+        "formType": "22-1990",
+        "message": null,
+        "status": "vbms",
+        "createdAt": "2023-12-20T18:04:04.925Z",
+        "updatedAt": "2023-12-20T18:04:09.292Z"
+      }
     }
   ],
   "errors": []

--- a/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
+++ b/src/applications/personalization/dashboard/tests/helpers.unit.spec.js
@@ -40,15 +40,17 @@ describe('profile helpers:', () => {
     });
 
     it('should normalize "received" from api submission status', () => {
-      ['received', 'processing', 'success', 'VBMS'].forEach(value => {
+      ['VBMS'].forEach(value => {
         expect(normalizeSubmissionStatus(value)).to.equal('received');
       });
     });
 
     it('should normalize "inProgress" from api submission status', () => {
-      ['pending', 'uploaded'].forEach(value => {
-        expect(normalizeSubmissionStatus(value)).to.equal('inProgress');
-      });
+      ['pending', 'uploaded', 'received', 'processing', 'success'].forEach(
+        value => {
+          expect(normalizeSubmissionStatus(value)).to.equal('inProgress');
+        },
+      );
     });
   });
 


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR fixes form submission statuses that are mapped from the Lighthouse Benefit Intake API to the frontend (My VA) and updates unit tests related to it.

- if status from LH is `pending`, `uploaded`, `success`, or `received`, then My VA status should display `Submission in Progress`
- if status from LH is `vbms`, then My VA status should display `Received`


## Related issue(s)
- Group testing ticket:  https://github.com/department-of-veterans-affairs/va.gov-team/issues/91654
- Epic: https://github.com/department-of-veterans-affairs/va.gov-team/issues/81849

## Testing done
- locally, visually 
- all existing unit and e2e 

## Screenshots

|         | Form card | Corresponding status from API |
| ------- | ------ | ----- |
|  |   ![submission-status-received-card](https://github.com/user-attachments/assets/5570d062-f7ca-458f-9466-eb19169b751e)     |   ![submission-status-received](https://github.com/user-attachments/assets/925528e7-fed2-49e1-81b1-b418ca35cf06)    |
|  |    ![submission-status-vbms-card](https://github.com/user-attachments/assets/e25c5a2e-d549-4228-85b1-66583820f67e)    |   ![submission-status-vbms](https://github.com/user-attachments/assets/37bb7dea-4d6c-4530-81ef-dd2d0b5dbb06)   |

## What areas of the site does it impact?
My VA - Benefit application and forms (behind feature flag)

## Acceptance criteria
- [ ] forms with statuses `pending`, `uploaded`, `success`, or `received` will yield `Submission in Progress` status in its card
- [ ] forms with statuses `vbms` will yield `Received` status in its card

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
