### PR TITLE
[10-10CG] Update fetchFacilities params

### DIFF
--- a/src/applications/caregivers/actions/fetchFacilities.js
+++ b/src/applications/caregivers/actions/fetchFacilities.js
@@ -26,14 +26,17 @@ export const fetchFacilities = async ({
     facilityIdParams || null,
   ];
 
-  const filteredParams = queryParams.filter(Boolean);
+  let filteredParams = queryParams.filter(Boolean);
+  if (filteredParams.length > 0) {
+    filteredParams = `&${filteredParams.join('&')}`;
+  }
 
   const baseUrl = `${
     environment.API_URL
   }/v0/health_care_applications/facilities?type=health`;
 
-  const requestUrl = `${baseUrl}&${filteredParams.join('&')}`;
-  const fetchRequest = apiRequest(requestUrl, {});
+  const requestUrl = `${baseUrl}${filteredParams}`;
+  const fetchRequest = apiRequest(requestUrl);
 
   // Helper function to join address parts, filtering out null or undefined values
   const joinAddressParts = (...parts) => {

--- a/src/applications/caregivers/actions/fetchFacilities.js
+++ b/src/applications/caregivers/actions/fetchFacilities.js
@@ -15,11 +15,15 @@ const formatQueryParams = ({
   perPage,
   facilityIds,
 }) => {
-  let facilityIdParams = '';
-  if (facilityIds.length > 0) {
-    facilityIdParams = facilityIds.map(id => `facilityIds[]=${id}`);
-    facilityIdParams = `${facilityIdParams.join('&')}`;
-  }
+  const formatFacilityIdParams = () => {
+    let facilityIdParams = '';
+    if (facilityIds.length > 0) {
+      facilityIdParams = facilityIds.map(id => `facilityIds[]=${id}`);
+      facilityIdParams = `${facilityIdParams.join('&')}`;
+    }
+
+    return facilityIdParams;
+  };
 
   const params = [
     lat ? `lat=${lat}` : null,
@@ -27,7 +31,7 @@ const formatQueryParams = ({
     radius ? `radius=${radius}` : null,
     page ? `page=${page}` : null,
     perPage ? `per_page=${perPage}` : null,
-    facilityIdParams || null,
+    formatFacilityIdParams() || null,
   ];
 
   let filteredParams = params.filter(Boolean);

--- a/src/applications/caregivers/actions/fetchFacilities.js
+++ b/src/applications/caregivers/actions/fetchFacilities.js
@@ -3,13 +3,17 @@ import environment from 'platform/utilities/environment';
 import { apiRequest } from 'platform/utilities/api';
 import content from '../locales/en/content.json';
 
-export const fetchFacilities = async ({
-  lat = null,
-  long = null,
-  radius = null,
-  page = null,
-  perPage = null,
-  facilityIds = [],
+const joinAddressParts = (...parts) => {
+  return parts.filter(part => part != null).join(', ');
+};
+
+const formatQueryParams = ({
+  lat,
+  long,
+  radius,
+  page,
+  perPage,
+  facilityIds,
 }) => {
   let facilityIdParams = '';
   if (facilityIds.length > 0) {
@@ -17,7 +21,7 @@ export const fetchFacilities = async ({
     facilityIdParams = `${facilityIdParams.join('&')}`;
   }
 
-  const queryParams = [
+  const params = [
     lat ? `lat=${lat}` : null,
     long ? `long=${long}` : null,
     radius ? `radius=${radius}` : null,
@@ -26,22 +30,37 @@ export const fetchFacilities = async ({
     facilityIdParams || null,
   ];
 
-  let filteredParams = queryParams.filter(Boolean);
+  let filteredParams = params.filter(Boolean);
   if (filteredParams.length > 0) {
     filteredParams = `&${filteredParams.join('&')}`;
   }
 
+  return filteredParams;
+};
+
+export const fetchFacilities = async ({
+  lat = null,
+  long = null,
+  radius = null,
+  page = null,
+  perPage = null,
+  facilityIds = [],
+}) => {
   const baseUrl = `${
     environment.API_URL
   }/v0/health_care_applications/facilities?type=health`;
 
-  const requestUrl = `${baseUrl}${filteredParams}`;
-  const fetchRequest = apiRequest(requestUrl);
+  const queryParams = formatQueryParams({
+    lat,
+    long,
+    radius,
+    page,
+    perPage,
+    facilityIds,
+  });
 
-  // Helper function to join address parts, filtering out null or undefined values
-  const joinAddressParts = (...parts) => {
-    return parts.filter(part => part != null).join(', ');
-  };
+  const requestUrl = `${baseUrl}${queryParams}`;
+  const fetchRequest = apiRequest(requestUrl);
 
   return fetchRequest
     .then(response => {

--- a/src/applications/caregivers/actions/fetchFacilities.js
+++ b/src/applications/caregivers/actions/fetchFacilities.js
@@ -18,8 +18,7 @@ const formatQueryParams = ({
   const formatFacilityIdParams = () => {
     let facilityIdParams = '';
     if (facilityIds.length > 0) {
-      facilityIdParams = facilityIds.map(id => `facilityIds[]=${id}`);
-      facilityIdParams = `${facilityIdParams.join('&')}`;
+      facilityIdParams = facilityIds.map(id => `facilityIds[]=${id}`).join('&');
     }
 
     return facilityIdParams;

--- a/src/applications/caregivers/actions/fetchFacilities.js
+++ b/src/applications/caregivers/actions/fetchFacilities.js
@@ -4,17 +4,36 @@ import { apiRequest } from 'platform/utilities/api';
 import content from '../locales/en/content.json';
 
 export const fetchFacilities = async ({
-  lat,
-  long,
-  radius = 500,
-  page = 1,
-  perPage = 5,
+  lat = null,
+  long = null,
+  radius = null,
+  page = null,
+  perPage = null,
+  facilityIds = [],
 }) => {
-  const lightHouseRequestUrl = `${
-    environment.API_URL
-  }/v0/health_care_applications/facilities?type=health&lat=${lat}&long=${long}&radius=${radius}&page=${page}&per_page=${perPage}`;
+  let facilityIdParams = '';
+  if (facilityIds.length > 0) {
+    facilityIdParams = facilityIds.map(id => `facilityIds[]=${id}`);
+    facilityIdParams = `${facilityIdParams.join('&')}`;
+  }
 
-  const fetchRequest = apiRequest(`${lightHouseRequestUrl}`, {});
+  const queryParams = [
+    lat ? `lat=${lat}` : null,
+    long ? `long=${long}` : null,
+    radius ? `radius=${radius}` : null,
+    page ? `page=${page}` : null,
+    perPage ? `per_page=${perPage}` : null,
+    facilityIdParams || null,
+  ];
+
+  const filteredParams = queryParams.filter(Boolean);
+
+  const baseUrl = `${
+    environment.API_URL
+  }/v0/health_care_applications/facilities?type=health`;
+
+  const requestUrl = `${baseUrl}&${filteredParams.join('&')}`;
+  const fetchRequest = apiRequest(requestUrl, {});
 
   // Helper function to join address parts, filtering out null or undefined values
   const joinAddressParts = (...parts) => {

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -60,7 +60,7 @@ const FacilitySearch = props => {
         }
 
         const parentFacilityResponse = await fetchFacilities({
-          id: facility.parent.id,
+          facilityIds: [facility.parent.id],
         });
 
         if (parentFacilityResponse.errorMessage) {
@@ -68,7 +68,7 @@ const FacilitySearch = props => {
           return null;
         }
 
-        return parentFacilityResponse;
+        return parentFacilityResponse[0];
       };
 
       const setSelectedFacilities = async facilityId => {
@@ -134,6 +134,9 @@ const FacilitySearch = props => {
     const facilitiesResponse = await fetchFacilities({
       long: longitude,
       lat: latitude,
+      radius: 500,
+      perPage: 5,
+      page: 1,
     });
 
     if (facilitiesResponse.errorMessage) {
@@ -155,6 +158,7 @@ const FacilitySearch = props => {
     const facilitiesResponse = await fetchFacilities({
       ...coordinates,
       page: pages + 1,
+      radius: 500,
       perPage: 5,
     });
 
@@ -189,11 +193,7 @@ const FacilitySearch = props => {
         <>
           <FacilityList {...facilityListProps} />
           {loadingMoreFacilities && loader()}
-          <button
-            type="button"
-            className="va-button-link"
-            onClick={showMoreFacilities}
-          >
+          <button className="va-button-link" onClick={showMoreFacilities}>
             Load more facilities
           </button>
         </>

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -22,6 +22,7 @@ const FacilitySearch = props => {
   const [pages, setPages] = useState(1);
   const dispatch = useDispatch();
   const [coordinates, setCoordinates] = useState({ lat: '', long: '' });
+  const radius = 500;
 
   const hasFacilities = () => {
     return facilities?.length > 0;
@@ -134,7 +135,7 @@ const FacilitySearch = props => {
     const facilitiesResponse = await fetchFacilities({
       long: longitude,
       lat: latitude,
-      radius: 500,
+      radius,
       perPage: 5,
       page: 1,
     });
@@ -158,7 +159,7 @@ const FacilitySearch = props => {
     const facilitiesResponse = await fetchFacilities({
       ...coordinates,
       page: pages + 1,
-      radius: 500,
+      radius,
       perPage: 5,
     });
 

--- a/src/applications/caregivers/tests/unit/actions/fetchFacilities.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/actions/fetchFacilities.unit.spec.js
@@ -1,10 +1,8 @@
 import { expect } from 'chai';
-import {
-  mockApiRequest,
-  setFetchJSONFailure,
-} from 'platform/testing/unit/helpers';
+import * as api from 'platform/utilities/api';
 import * as Sentry from '@sentry/browser';
 import sinon from 'sinon';
+import environment from 'platform/utilities/environment';
 import { fetchFacilities } from '../../../actions/fetchFacilities';
 import {
   mockFacilitiesResponse,
@@ -12,15 +10,51 @@ import {
 } from '../../mocks/responses';
 
 describe('CG fetchFacilities action', () => {
+  const lat = 1;
+  const long = 2;
+  const perPage = 5;
+  const page = 1;
+  const radius = 500;
+  const facilityIds = ['12', '34'];
+  let apiRequestStub;
+
+  beforeEach(() => {
+    apiRequestStub = sinon.stub(api, 'apiRequest').resolves([]);
+  });
+
+  afterEach(() => {
+    apiRequestStub.restore();
+  });
+
   context('success', () => {
-    it('returns valid response when lat and long are passed', async () => {
-      mockApiRequest(mockFacilitiesResponse);
-      const response = await fetchFacilities({ lat: 1, long: 2 });
+    it('calls correct url when all params are passed', async () => {
+      await fetchFacilities({ long, lat, perPage, radius, page, facilityIds });
+
+      const expectedUrl = `${
+        environment.API_URL
+      }/v0/health_care_applications/facilities?type=health&lat=${lat}&long=${long}&radius=${radius}&page=${page}&per_page=${perPage}&facilityIds[]=${
+        facilityIds[0]
+      }&facilityIds[]=${facilityIds[1]}`;
+      sinon.assert.calledWith(apiRequestStub, expectedUrl);
+    });
+
+    it('calls url without params when no params are passed', async () => {
+      await fetchFacilities({});
+
+      const expectedUrl = `${
+        environment.API_URL
+      }/v0/health_care_applications/facilities?type=health`;
+      sinon.assert.calledWith(apiRequestStub, expectedUrl);
+    });
+
+    it('formats facility addresses', async () => {
+      apiRequestStub.resolves(mockFacilitiesResponse);
+      const response = await fetchFacilities({ long, lat, perPage, radius });
       expect(response).to.deep.eq(mockFetchFacilitiesResponse);
     });
   });
 
-  context('when the request fails', () => {
+  context('failure', () => {
     let sentrySpy;
 
     beforeEach(() => {
@@ -31,12 +65,11 @@ describe('CG fetchFacilities action', () => {
       sentrySpy.restore();
     });
 
-    it('should return an error object', async () => {
+    it('should log to sentry and return an error object', async () => {
       const errorResponse = { bad: 'some error' };
-      mockApiRequest(errorResponse, false);
-      setFetchJSONFailure(global.fetch.onCall(0), errorResponse);
+      apiRequestStub.rejects(errorResponse);
 
-      const response = await fetchFacilities({ lat: 1, long: 2 });
+      const response = await fetchFacilities({ long, lat });
       expect(response).to.eql({
         type: 'SEARCH_FAILED',
         errorMessage: 'There was an error fetching the health care facilities.',

--- a/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch.unit.spec.js
@@ -100,7 +100,11 @@ describe('CG <FacilitySearch>', () => {
   });
 
   context('when search is attempted with valid data', () => {
-    const mapBoxSuccessResponse = { center: [1, 2] };
+    const lat = 1;
+    const long = 2;
+    const perPage = 5;
+    const radius = 500;
+    const mapBoxSuccessResponse = { center: [long, lat] };
     let mapboxStub;
     let facilitiesStub;
 
@@ -129,6 +133,14 @@ describe('CG <FacilitySearch>', () => {
         expect(selectors().radioList).to.exist;
         expect(selectors().loader).to.not.exist;
         expect(selectors().input).to.not.have.attr('error');
+        sinon.assert.calledWith(mapboxStub, 'Tampa');
+        sinon.assert.calledWith(facilitiesStub, {
+          lat,
+          long,
+          perPage,
+          radius,
+          page: 1,
+        });
       });
     });
 
@@ -227,7 +239,7 @@ describe('CG <FacilitySearch>', () => {
       facilitiesStub.onFirstCall().resolves(facilities);
 
       const parentFacility = mockFetchParentFacilityResponse;
-      facilitiesStub.onSecondCall().resolves(parentFacility);
+      facilitiesStub.onSecondCall().resolves([parentFacility]);
 
       await waitFor(() => {
         inputVaSearchInput(container, 'Tampa', selectors().input);
@@ -246,6 +258,8 @@ describe('CG <FacilitySearch>', () => {
       });
 
       await waitFor(() => {
+        sinon.assert.calledWith(mapboxStub, 'Tampa');
+        sinon.assert.calledWith(facilitiesStub, { facilityIds: ['vha_757'] });
         expect(dispatch.firstCall.args[0].type).to.eq('SET_DATA');
         expect(dispatch.firstCall.args[0].data).to.deep.include({
           'view:plannedClinic': {
@@ -397,6 +411,14 @@ describe('CG <FacilitySearch>', () => {
         });
 
         await waitFor(() => {
+          sinon.assert.calledWith(mapboxStub, 'Tampa');
+          sinon.assert.calledWith(facilitiesStub, {
+            lat,
+            long,
+            perPage,
+            radius,
+            page: 2,
+          });
           expect(mapboxStub.callCount).to.equal(1);
           // This is 3 because there is an existing bug that using submit with the va-search-input component triggers two requests
           // https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3117


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updated the fetchFacilites implementation to allow for passing `facilityIds` params. When we moved from calling the lighthouse api to the vets-api (which calls lighthouse api), the endpoint is a little bit different. We needed to update how we were calling it. This also included updated the fetchFacilities spec to better test the behavior. 
- This work is still behind a flipper toggle (`caregiver_use_facilities_API`)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90381

## Testing done

Updated unit tests for this

## What areas of the site does it impact?

10-10CG

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
