### PR TITLE
removed re-order shenanigans

### DIFF
--- a/src/applications/check-in/travel-claim/pages/travel-mileage/index.jsx
+++ b/src/applications/check-in/travel-claim/pages/travel-mileage/index.jsx
@@ -133,21 +133,21 @@ const TravelMileage = props => {
             <va-button
               uswds
               big
+              secondary
+              onClick={goToPreviousPage}
+              data-testid="back-button"
+              class="vads-u-margin-top--2"
+              value="back"
+              back
+            />
+            <va-button
+              uswds
+              big
               onClick={continueClick}
               continue
               data-testid="continue-button"
               class="vads-u-margin-top--2"
               value="continue"
-            />
-            <va-button
-              uswds
-              big
-              secondary
-              onClick={goToPreviousPage}
-              data-testid="back-button"
-              class="vads-u-margin-top--2 small-screen:vads-u-order--first"
-              value="back"
-              back
             />
           </div>
         </div>


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Removes the re-ordering of buttons based on screen size on the travel mileage page in the travel app. I decided to go this route so that we can seamlessly convert these to the [va-button-pair](https://design.va.gov/storybook/?path=/docs/uswds-va-button-pair--docs) component in a future ticket now that it allows custom text.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#91801

## Testing done

Visual

## Screenshots

### Small (stacked)
<img width="345" alt="Screenshot 2024-09-06 at 11 16 21 AM" src="https://github.com/user-attachments/assets/91af5d07-6f0e-4c91-baf9-b228a787fe72">

### Big (inline)
<img width="611" alt="Screenshot 2024-09-06 at 11 16 30 AM" src="https://github.com/user-attachments/assets/10dcaf15-b003-4a6e-8c4d-7ff866bd98e6">

## What areas of the site does it impact?

Stand alone travel pay app for O.H. appointments

## Acceptance criteria
 - [ ] Tab order follows the visual order of elements on the travel-mileage page.
 
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

