### PR TITLE
Ensure link icons are clickable and remove srtext

### DIFF
--- a/src/applications/vaos/components/FacilityDirectionsLink.jsx
+++ b/src/applications/vaos/components/FacilityDirectionsLink.jsx
@@ -30,7 +30,7 @@ function buildAddressArray(location) {
   return [];
 }
 
-export default function FacilityDirectionsLink({ location }) {
+export default function FacilityDirectionsLink({ location, icon }) {
   if (!location) {
     return null;
   }
@@ -52,6 +52,7 @@ export default function FacilityDirectionsLink({ location }) {
         aria-label={`Directions to ${location.name ||
           location.providerPractice}`}
       >
+        {icon && <va-icon icon="directions" size="3" />}
         Directions
       </NewTabAnchor>
     </span>
@@ -59,5 +60,6 @@ export default function FacilityDirectionsLink({ location }) {
 }
 
 FacilityDirectionsLink.propTypes = {
+  icon: PropTypes.bool,
   location: PropTypes.object,
 };

--- a/src/applications/vaos/components/FacilityPhone.jsx
+++ b/src/applications/vaos/components/FacilityPhone.jsx
@@ -31,11 +31,6 @@ export default function FacilityPhone({
       {typeof icon === 'undefined' &&
         typeof level === 'undefined' &&
         `${heading} `}
-      {!!icon === true && (
-        <span>
-          <va-icon icon="phone" size="3" srtext="Phone icon" />{' '}
-        </span>
-      )}
       <VaTelephone
         contact={contact}
         extension={extension}

--- a/src/applications/vaos/components/layout/CCLayout.jsx
+++ b/src/applications/vaos/components/layout/CCLayout.jsx
@@ -81,8 +81,7 @@ export default function CCLayout({ data: appointment }) {
             <>
               <Address address={address} />
               <div className="vads-u-margin-top--1 vads-u-color--link-default">
-                <va-icon icon="directions" size="3" srtext="Directions icon" />{' '}
-                <FacilityDirectionsLink location={{ address }} />
+                <FacilityDirectionsLink location={{ address }} icon />
               </div>
             </>
           )}

--- a/src/applications/vaos/components/layout/ClaimExamLayout.jsx
+++ b/src/applications/vaos/components/layout/ClaimExamLayout.jsx
@@ -118,8 +118,7 @@ export default function ClaimExamLayout({ data: appointment }) {
             <br />
             <Address address={facility?.address} />
             <div className="vads-u-margin-top--1 vads-u-color--link-default">
-              <va-icon icon="directions" size="3" srtext="Directions icon" />
-              <FacilityDirectionsLink location={facility} />
+              <FacilityDirectionsLink location={facility} icon />
             </div>
             <br />
             <span>Clinic: {clinicName || 'Not available'}</span> <br />

--- a/src/applications/vaos/components/layout/InPersonLayout.jsx
+++ b/src/applications/vaos/components/layout/InPersonLayout.jsx
@@ -118,8 +118,7 @@ export default function InPersonLayout({ data: appointment }) {
             <br />
             <Address address={facility?.address} />
             <div className="vads-u-margin-top--1 vads-u-color--link-default">
-              <va-icon icon="directions" size="3" srtext="Directions icon" />
-              <FacilityDirectionsLink location={facility} />
+              <FacilityDirectionsLink location={facility} icon />
             </div>
             <br />
             <span>Clinic: {clinicName || 'Not available'}</span> <br />

--- a/src/applications/vaos/components/layout/VARequestLayout.jsx
+++ b/src/applications/vaos/components/layout/VARequestLayout.jsx
@@ -64,8 +64,7 @@ export default function VARequestLayout({ data: appointment }) {
           )}
           <Address address={facility?.address} />
           <div className="vads-u-margin-top--1 vads-u-color--link-default">
-            <va-icon icon="directions" size="3" srtext="Directions icon" />{' '}
-            <FacilityDirectionsLink location={facility} />
+            <FacilityDirectionsLink location={facility} icon />
           </div>
         </Section>
         <Section heading="Phone">

--- a/src/applications/vaos/components/layout/VideoLayoutAtlas.jsx
+++ b/src/applications/vaos/components/layout/VideoLayoutAtlas.jsx
@@ -97,8 +97,7 @@ export default function VideoLayoutAtlas({ data: appointment }) {
         >
           <Address address={videoProviderAddress} />
           <div className="vads-u-margin-top--1 vads-u-color--link-default">
-            <va-icon icon="directions" size="3" srtext="Directions icon" />{' '}
-            <FacilityDirectionsLink location={facility} />
+            <FacilityDirectionsLink location={facility} icon />
           </div>
         </Where>
       )}

--- a/src/applications/vaos/components/layout/VideoLayoutVA.jsx
+++ b/src/applications/vaos/components/layout/VideoLayoutVA.jsx
@@ -115,8 +115,7 @@ export default function VideoLayoutVA({ data: appointment }) {
             <br />
             <Address address={facility?.address} />
             <div className="vads-u-margin-top--1 vads-u-color--link-default">
-              <va-icon icon="directions" size="3" srtext="Directions icon" />{' '}
-              <FacilityDirectionsLink location={facility} />
+              <FacilityDirectionsLink location={facility} icon />
             </div>
             <br />
             <span>Clinic: {clinicName || 'Not available'}</span> <br />

--- a/src/applications/vaos/referral-appointments/ChooseCommunityCare.jsx
+++ b/src/applications/vaos/referral-appointments/ChooseCommunityCare.jsx
@@ -92,11 +92,12 @@ export default function ChooseCommunityCare() {
         <div className="vads-l-grid-container vads-u-padding--0 vads-u-margin-top--2">
           <div className="vads-l-row">
             <div className="vads-l-col vads-u-font-weight--bold">
-              <va-icon icon="filter_list" size={4} srtext="Filter icon" />{' '}
               <va-link
                 aria-label="Filter"
                 text="Filter"
                 data-testid="filter-link"
+                icon-name="filter_list"
+                icon-size={4}
                 onClick={goToFilterPage}
               />
             </div>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- This PR addresses removes `srtext` from link icons and ensures the links are clickable.
- Based on discussions in the linked issue, we also decided to remove the phone icon from facility phone number links
- Appointments (VAOS) Team
- This fix is not behind a Flipper toggle.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/91739

## Testing done

- Tested UI locally, see screenshots

## Screenshots

|     Icon    | Before | After |
| ------- | ------ | ----- |
| Facility phone & Directions (VA Request)  |   <img width="613" alt="image" src="https://github.com/user-attachments/assets/4e992a8c-5300-4a8a-a04e-ef91768fb144">   |  <img width="610" alt="image" src="https://github.com/user-attachments/assets/a01023c2-f4f1-4a47-87c4-1a3c6449db4b">    |
| Facility phone (Cancel Request)  |  <img width="622" alt="image" src="https://github.com/user-attachments/assets/13e1ed51-e115-4947-b6d8-74e28a935c06">  |   <img width="609" alt="image" src="https://github.com/user-attachments/assets/e962acc7-0b65-4226-8eaa-5fdffb1f0a3e">   |
| Directions (CC) |   <img width="610" alt="image" src="https://github.com/user-attachments/assets/51ee3034-39f2-4646-85e3-3ab36973bcb6">   |  <img width="609" alt="image" src="https://github.com/user-attachments/assets/13d73819-24f5-43ce-a7de-a026bb6e0456">   |
| Directions (Claim Exam) |   <img width="611" alt="image" src="https://github.com/user-attachments/assets/d5df8ff4-37d6-4832-ab56-4815f3808302">   |  <img width="610" alt="image" src="https://github.com/user-attachments/assets/ac3747c3-a310-4787-a620-6e70a7c51760">    |
| Directions (In-person) |   <img width="609" alt="image" src="https://github.com/user-attachments/assets/016e907e-2a37-409e-80de-b890d699bbfa">   |   <img width="611" alt="image" src="https://github.com/user-attachments/assets/ee1c1704-350e-420f-96ac-cf030a2653ac">   |
| Directions (Video ATLAS) |   <img width="612" alt="image" src="https://github.com/user-attachments/assets/c5ade442-41b6-44aa-913e-fd1074cdcc26">   |  <img width="612" alt="image" src="https://github.com/user-attachments/assets/c7cd8c8c-e475-4fb5-80b4-2e9f6679a614">  |
| Directions (Video VA) |  <img width="613" alt="image" src="https://github.com/user-attachments/assets/c4b6527c-58c7-488b-bded-028cff24c9be"> |   <img width="611" alt="image" src="https://github.com/user-attachments/assets/f65f54cf-6dd2-49fc-9533-0223b5b5ed15">  |
| Filter List (Referral - Choose CC, not yet released) |  <img width="616" alt="image" src="https://github.com/user-attachments/assets/781b9403-9f6f-42e3-9c1a-cd3cd29d76b1">   |   <img width="638" alt="image" src="https://github.com/user-attachments/assets/4f20316e-5ee5-460f-9067-0194524908b4">  |

## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

For all applicable appointment types
- [ ] The directions icon is a clickable part of the link
- [ ] Remove `srtext` attribute from directions icon
- [ ] Remove the phone icon from facility phone number link

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

