### PR TITLE
MHV-61740 SM unread column styling defect

### DIFF
--- a/src/applications/mhv-secure-messaging/sass/folder-thread-list-view.scss
+++ b/src/applications/mhv-secure-messaging/sass/folder-thread-list-view.scss
@@ -6,7 +6,6 @@
 .thread-list-draft {
   color: var(--vads-color-secondary-darkest);
   font-weight: 700;
-
 }
 
 .reply-draft-label {
@@ -20,7 +19,7 @@
   //   }
 
   .unread-column {
-    max-width: 15px;
+    max-width: 15px !important;
     padding-top: 10px;
   }
 
@@ -61,7 +60,6 @@
   flex-wrap: wrap;
 
   va-select {
-
     @media (min-width: $small-screen) {
       max-width: 225px;
     }

--- a/src/applications/mhv-secure-messaging/sass/message-list.scss
+++ b/src/applications/mhv-secure-messaging/sass/message-list.scss
@@ -25,7 +25,7 @@
   }
 
   .unread-column {
-    max-width: 15px;
+    max-width: 15px !important;
     padding-top: 10px;
   }
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- updates to formation library ( declaring `!important` on `vads-l-col` width attribute) had impact on the column containing unread icon
- temporary fix on SM, potentially further redo styling by using utilities class columns widths properties

## Related issue(s)

- https://jira.devops.va.gov/browse/MHV-61740

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |<img width=100 src="https://github.com/user-attachments/assets/0532e971-bb18-4cb9-9a0e-1f533189385b"/>|<img width=100 src="https://github.com/user-attachments/assets/7efb7d56-966a-4c2a-b846-1364b4b85b22"/>|
| Desktop |<img width=300 src="https://github.com/user-attachments/assets/61f0cadf-11f9-4e8a-8014-e317a918512a"/>|<img width=300 src="https://github.com/user-attachments/assets/751df71f-df9c-46cb-b81e-38c56d66f63b"/>|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
