### PR TITLE
Add pdf download and events to confirmation v2

### DIFF
--- a/src/applications/simple-forms/21-10210/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-10210/containers/ConfirmationPage.jsx
@@ -48,6 +48,7 @@ export const ConfirmationPage = props => {
       submitDate={submitDate}
       confirmationNumber={confirmationNumber}
       formConfig={formConfig}
+      pdfUrl={submission.response?.pdfUrl}
     />
   ) : (
     <OldConfirmationPageView

--- a/src/applications/simple-forms/21-10210/tests/e2e/fixtures/mocks/form-submit.json
+++ b/src/applications/simple-forms/21-10210/tests/e2e/fixtures/mocks/form-submit.json
@@ -1,9 +1,4 @@
 {
-  "data": {
-    "id": "123456789",
-    "type": "mockData",
-    "attributes": {
-      "status": "processed"
-    }
-  }
+  "confirmationNumber":"047e841c-28b5-45f5-b2c7-f4ee865c9bb4",
+  "pdfUrl": "https://www.va.gov/"
 }

--- a/src/applications/simple-forms/shared/components/ConfirmationPageView.v2.jsx
+++ b/src/applications/simple-forms/shared/components/ConfirmationPageView.v2.jsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef } from 'react';
+/* eslint-disable no-unused-vars */
+import React, { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { format, isValid } from 'date-fns';
 import scrollTo from 'platform/utilities/ui/scrollTo';
@@ -20,6 +21,50 @@ import {
 import { PropTypes } from 'prop-types';
 import GetFormHelp from './GetFormHelp';
 import { ChapterSectionCollection } from './confirmationPageViewHelpers';
+
+const PdfDownload = () => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(true);
+
+  // placeholder for now
+  const pdfDownloadUrl = '/';
+
+  // mock loading time until we have a real PDF to download
+  useEffect(() => {
+    setTimeout(() => {
+      setLoading(false);
+    }, 3000);
+  }, []);
+
+  if (loading) {
+    return (
+      <div>
+        <va-loading-indicator
+          label="Loading"
+          message="Generating your PDF. This may take a minute."
+        />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <va-alert slim status="error" visible>
+        Sorry, we’re unable to generate a PDF at this time. You can still review
+        and print the information you submitted in your form.
+      </va-alert>
+    );
+  }
+
+  return (
+    <va-link
+      download
+      filetype="PDF"
+      href={pdfDownloadUrl}
+      text="Download a copy of your VA Form"
+    />
+  );
+};
 
 export const ConfirmationPageView = props => {
   const alertRef = useRef(null);
@@ -98,6 +143,7 @@ export const ConfirmationPageView = props => {
       <div className="screen-only">
         <h2>Save a copy of your form</h2>
         <p>If you’d like a copy of your completed form, you can download it.</p>
+        <PdfDownload />
         <VaAccordion bordered uswds>
           <VaAccordionItem
             header="Information you submitted on this form"

--- a/src/applications/simple-forms/shared/components/ConfirmationPageView.v2.jsx
+++ b/src/applications/simple-forms/shared/components/ConfirmationPageView.v2.jsx
@@ -19,12 +19,13 @@ import {
   getActiveExpandedPages,
 } from '~/platform/forms-system/exportsFile';
 import { PropTypes } from 'prop-types';
+import recordEvent from 'platform/monitoring/record-event';
 import GetFormHelp from './GetFormHelp';
 import { ChapterSectionCollection } from './confirmationPageViewHelpers';
 
-const PdfDownload = () => {
+const PdfDownload = ({ trackingPrefix }) => {
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(true);
+  const [error, setError] = useState(false);
 
   // placeholder for now
   const pdfDownloadUrl = '/';
@@ -35,6 +36,12 @@ const PdfDownload = () => {
       setLoading(false);
     }, 3000);
   }, []);
+
+  const onClick = () => {
+    recordEvent({
+      event: `${trackingPrefix}confirmation-pdf-download`,
+    });
+  };
 
   if (loading) {
     return (
@@ -61,6 +68,7 @@ const PdfDownload = () => {
       download
       filetype="PDF"
       href={pdfDownloadUrl}
+      onClick={onClick}
       text="Download a copy of your VA Form"
     />
   );
@@ -143,7 +151,7 @@ export const ConfirmationPageView = props => {
       <div className="screen-only">
         <h2>Save a copy of your form</h2>
         <p>If you’d like a copy of your completed form, you can download it.</p>
-        <PdfDownload />
+        <PdfDownload trackingPrefix={formConfig.trackingPrefix} />
         <VaAccordion bordered uswds>
           <VaAccordionItem
             header="Information you submitted on this form"


### PR DESCRIPTION
## Summary

- Add pdf download placeholder to confirmation v2
- Add events for pdf click and going to my-va

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#1541
department-of-veterans-affairs/va.gov-team-forms#1600
department-of-veterans-affairs/va.gov-team-forms#1601


## Testing done

- Browser. No integration testing with backend since not ready yet.

## Screenshots

![image](https://github.com/user-attachments/assets/f124df7c-5a2a-41fb-94a3-c3993c23f562)
![image](https://github.com/user-attachments/assets/3991c918-bcdd-4b78-a3fc-4b2e8adffee7)
![image](https://github.com/user-attachments/assets/d1de3972-95e0-403f-8619-3dff0a98fa87)


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
