### PR TITLE
crossDomainRedirects for benefits sites

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -1387,5 +1387,45 @@
     "domain": "www.benefits.va.gov",
     "src": "/vso/",
     "dest": "/resources/va-accredited-representative-faqs/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/portland/",
+    "dest": "/portland-va-regional-benefit-office/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/ROPORTLAND",
+    "dest": "/portland-va-regional-benefit-office/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/albuquerque/",
+    "dest": "/albuquerque-va-regional-benefit-office/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/ROALBUQUERQUE",
+    "dest": "/albuquerque-va-regional-benefit-office/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/roanoke/",
+    "dest": "/roanoke-va-regional-benefit-office"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/ROROANOKE",
+    "dest": "/roanoke-va-regional-benefit-office"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/togus/",
+    "dest": "/togus-va-regional-benefit-office-at-togus-va-medical-center"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/ROTOGUS/",
+    "dest": "/togus-va-regional-benefit-office-at-togus-va-medical-center"
   }
 ]


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Added redirects for benefits.va.gov sites now on va.gov Portland, Albuquerque, Roanoke, and Togus
- Sitewide team (we own redirects)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90957

## Testing done

- Must wait until in production to see redirects

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._
N/A

## What areas of the site does it impact?

redirects

## Acceptance criteria

- [x] Redirects added for Portland, Albuquerque, Roanoke, and Togus

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
Should all go to `va.gov/togus-va-regional-benefit-office-at-togus-va-medical-center`
[www.benefits.va.gov/ROTOGUS/](http://www.benefits.va.gov/ROTOGUS/)*
[www.benefits.va.gov/Togus/](http://www.benefits.va.gov/Togus/)*
[www.benefits.va.gov/togus/](http://www.benefits.va.gov/togus/)*
Same for 
`/ROROANOKE/*`
`/roanoake/*`
etc.