### PR TITLE
MBMS-55218 Supporting Documents acceptable file types and text changes

### DIFF
--- a/src/applications/pre-need-integration/components/SupportingFilesDescription.jsx
+++ b/src/applications/pre-need-integration/components/SupportingFilesDescription.jsx
@@ -22,8 +22,8 @@ export default function SupportingFilesDescription() {
       Guidelines for uploading a file:
       <ul>
         <li>File types you can upload: .pdf, .jpg, .jpeg, .png</li>
-        <li>Maximum non-PDF file size: 50MB.</li>
-        <li>Maximum PDF file size: 100MB.</li>
+        <li>Maximum non-PDF file size: 50MB</li>
+        <li>Maximum PDF file size: 100MB</li>
       </ul>
     </div>
   );

--- a/src/applications/pre-need-integration/components/SupportingFilesDescription.jsx
+++ b/src/applications/pre-need-integration/components/SupportingFilesDescription.jsx
@@ -21,8 +21,9 @@ export default function SupportingFilesDescription() {
       </div>
       Guidelines for uploading a file:
       <ul>
-        <li>You can only upload .pdf files.</li>
-        <li>Your file should be no larger than 15MB.</li>
+        <li>File types you can upload: .pdf, .jpg, .jpeg, .png</li>
+        <li>Maximum non-PDF file size: 50MB.</li>
+        <li>Maximum PDF file size: 100MB.</li>
       </ul>
     </div>
   );

--- a/src/applications/pre-need-integration/utils/upload.js
+++ b/src/applications/pre-need-integration/utils/upload.js
@@ -13,7 +13,7 @@ export function fileUploadUi(content) {
       fileUploadUrl: `${
         environment.API_URL
       }/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
-      fileTypes: ['pdf', '.jpg', '.jpeg', '.png'],
+      fileTypes: ['pdf', 'jpg', 'jpeg', 'png'],
       maxSize: 1024 * 1024 * 100, // 100 MB max size,
       minSize: 1024,
       createPayload,

--- a/src/applications/pre-need-integration/utils/upload.js
+++ b/src/applications/pre-need-integration/utils/upload.js
@@ -13,8 +13,8 @@ export function fileUploadUi(content) {
       fileUploadUrl: `${
         environment.API_URL
       }/simple_forms_api/v1/simple_forms/submit_supporting_documents`,
-      fileTypes: ['pdf'],
-      maxSize: 15728640,
+      fileTypes: ['pdf', '.jpg', '.jpeg', '.png'],
+      maxSize: 1024 * 1024 * 100, // 100 MB max size,
       minSize: 1024,
       createPayload,
       parseResponse,


### PR DESCRIPTION
## Summary

- Increased the acceptable file types from `.pdf` to `.pdf, .jpg, .jpeg, .png`
- Changed sizing informational text
- Changed max file size to 100MB (waiting for benefits intake api file validation changes for more specific file validation)

## Related issue(s)

- https://jira.devops.va.gov/browse/MBMS-55218

## Testing done

- [x] POR/UI/UX Review
- [x] Internal Review
- [x] Unit Tests Passing
- [x] QA
- [ ] External Review

## Screenshots
https://github.com/user-attachments/assets/d0830f03-4c82-4bd8-b03f-255295d8ba75

https://github.com/user-attachments/assets/66700a34-bc53-459b-94ab-f37008430a6e

## What areas of the site does it impact?

- pre-need-integration supporting documents

## Acceptance criteria
![image](https://github.com/user-attachments/assets/d2f41b19-6ffd-4ab5-9ab8-52da9a274903)
