### PR TITLE
Update Registration Only pathway options in the Health Care Application

### DIFF
--- a/src/applications/hca/components/FormDescriptions/RegistrationOnlyDescription.jsx
+++ b/src/applications/hca/components/FormDescriptions/RegistrationOnlyDescription.jsx
@@ -1,11 +1,22 @@
 import React from 'react';
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 const RegistrationOnlyDescription = (
   <>
-    <p>Select the type of health care you want to apply for.</p>
     <p>
       You have the option to register for health care for your service-connected
       conditions only without enrolling in our full medical benefits package.
+    </p>
+    <p>
+      <strong>Note:</strong> If you’re not sure which option to select, we
+      recommend calling our Health Eligibility Center at{' '}
+      <va-telephone contact={CONTACTS['222_VETS']} /> (
+      <va-telephone contact={CONTACTS['711']} tty />
+      ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m.{' '}
+      <dfn>
+        <abbr title="Eastern Time">ET</abbr>
+      </dfn>
+      .
     </p>
   </>
 );

--- a/src/applications/hca/config/chapters/vaBenefits/benefitsPackage.js
+++ b/src/applications/hca/config/chapters/vaBenefits/benefitsPackage.js
@@ -20,7 +20,6 @@ export default {
         labels: {
           fullPackage: content['benefits--reg-only-full-package-label'],
           regOnly: content['benefits--reg-only-service-connected-label'],
-          notSure: content['benefits--reg-only-not-sure-label'],
         },
       },
     },
@@ -33,7 +32,7 @@ export default {
     properties: {
       'view:vaBenefitsPackage': {
         type: 'string',
-        enum: ['fullPackage', 'regOnly', 'notSure'],
+        enum: ['fullPackage', 'regOnly'],
       },
       'view:healthEnrollmentDescription': emptyObjectSchema,
     },

--- a/src/applications/hca/locales/en/content.json
+++ b/src/applications/hca/locales/en/content.json
@@ -1,9 +1,8 @@
 {
   "benefits--reg-only-title": "Health care for your service-connected conditions",
   "benefits--reg-only-label" : "What type of health care do you want to apply for?",
-  "benefits--reg-only-full-package-label": "I want to enroll in the full medical benefits package",
+  "benefits--reg-only-full-package-label": "I want to apply to enroll in the full medical benefits package",
   "benefits--reg-only-service-connected-label": "I want to register for care for my service-connected conditions only",
-  "benefits--reg-only-not-sure-label": "I\u2019m not sure",
   "button-back": "Back",
   "household-dependent-info-basic-title": "%s\u2019s basic information",
   "household-dependent-info-addtl-title": "%s\u2019s additional information",

--- a/src/applications/hca/tests/e2e/hca-registration-only.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-registration-only.cypress.spec.js
@@ -96,13 +96,6 @@ describe('HCA-Registration-Only-Authenticated-User', () => {
       cy.axeCheck();
     });
 
-    it('should allow user to advance to the application if `not sure` is selected on the form page', () => {
-      cy.get('[name="root_view:vaBenefitsPackage"]').check('notSure');
-      goToNextPage('/veteran-information/birth-information');
-      cy.injectAxe();
-      cy.axeCheck();
-    });
-
     it('should block user from advancing to the application if `reg only` is selected on the form page', () => {
       cy.get('[name="root_view:vaBenefitsPackage"]').check('regOnly');
       goToNextPage('/care-for-service-connected-conditions');
@@ -202,13 +195,6 @@ describe('HCA-Registration-Only-Guest-User', () => {
 
     it('should allow user to continue through the application if `full medical benefits` is selected on the form page', () => {
       cy.get('[name="root_view:vaBenefitsPackage"]').check('fullPackage');
-      goToNextPage('/military-service/service-information');
-      cy.injectAxe();
-      cy.axeCheck();
-    });
-
-    it('should allow user to continue through the application if `not sure` is selected on the form page', () => {
-      cy.get('[name="root_view:vaBenefitsPackage"]').check('notSure');
       goToNextPage('/military-service/service-information');
       cy.injectAxe();
       cy.axeCheck();

--- a/src/applications/hca/tests/unit/config/vaBenefits/benefitsPackage.unit.spec.js
+++ b/src/applications/hca/tests/unit/config/vaBenefits/benefitsPackage.unit.spec.js
@@ -32,7 +32,7 @@ describe('hca VaBenefitsPackage config', () => {
 
   it('should render correct number of inputs', () => {
     const { selectors } = subject();
-    expect(selectors().inputs.length).to.equal(3);
+    expect(selectors().inputs.length).to.equal(2);
   });
 
   it('should submit empty form', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

During CAIA Review, it was recommended that we add an "I'm not sure" option to the Registration Only Experiment page. However, during an August 2024 monthly demo, our PO and Design Lead were not keen on the "I'm not sure" option, along with the radio options to "Register for connected service care" or "Enroll in the full benefits package". Especially since the option would direct users through the application and submit, duplicating the Enroll option actions as well as conflicting with design system direction for radio buttons having individual functions/actions.

The team came together to discuss the "I'm not sure" option, and how best to present it to Veterans, and the decision was made to remove the option, and provide a sentence to help guide Veterans if they are not sure. This PR updates the registration only pathway options to remove the "Not Sure" and add in the appropriate content.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#91896

## Screenshot(s)

| Before | After |
| ------ | ----- |
| ![Screenshot 2024-09-11 at 14 57 47](https://github.com/user-attachments/assets/7b5413ec-7e52-4196-980b-4659e1a79a70) | ![Screenshot 2024-09-11 at 14 56 16](https://github.com/user-attachments/assets/a133e900-377c-451d-b58b-05e219acf29b) |

## Acceptance criteria

 - Available options for registration only provide unique paths through the application
 - Veterans are appropriately directed to the call center if they have any questions regarding the presented options

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot has been added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution