### PR TITLE
MHV-61787 Fix accessibility issue: Screen readers are detecting and reading content that is intended for print only

### DIFF
--- a/src/applications/mhv-medical-records/components/RecordList/AllergyListItem.jsx
+++ b/src/applications/mhv-medical-records/components/RecordList/AllergyListItem.jsx
@@ -20,12 +20,13 @@ const AllergyListItem = props => {
       </Link>
 
       {/* print view header */}
-      <h3
+      <span
         className="vads-u-font-size--h4 vads-u-line-height--4 print-only"
+        aria-hidden="true"
         data-dd-privacy="mask"
       >
         {record.name}
-      </h3>
+      </span>
 
       {/* web view fields */}
       <div className="no-print">

--- a/src/applications/mhv-medical-records/components/RecordList/CareSummariesAndNotesListItem.jsx
+++ b/src/applications/mhv-medical-records/components/RecordList/CareSummariesAndNotesListItem.jsx
@@ -53,12 +53,13 @@ const CareSummariesAndNotesListItem = props => {
       </Link>
 
       {/* print view header */}
-      <h3
+      <p
         className="vads-u-font-size--h5 vads-u-line-height--4 print-only"
+        aria-hidden="true"
         data-dd-privacy="mask"
       >
         {record.name}
-      </h3>
+      </p>
 
       {/* fields */}
       <div data-testid="note-item-date">

--- a/src/applications/mhv-medical-records/components/RecordList/ConditionListItem.jsx
+++ b/src/applications/mhv-medical-records/components/RecordList/ConditionListItem.jsx
@@ -20,12 +20,13 @@ const ConditionListItem = props => {
           {record.name} <span className="sr-only">on {record.date}</span>
         </span>
       </Link>
-      <h3
+      <span
         className="vads-u-font-size--h4 vads-u-line-height--4 print-only"
+        aria-hidden="true"
         data-dd-privacy="mask"
       >
         {record.name}
-      </h3>
+      </span>
 
       <p className="vads-u-margin--0">Date entered: {record?.date}</p>
     </va-card>

--- a/src/applications/mhv-medical-records/components/RecordList/VaccinesListItem.jsx
+++ b/src/applications/mhv-medical-records/components/RecordList/VaccinesListItem.jsx
@@ -20,12 +20,13 @@ const VaccinesListItem = props => {
       </Link>
 
       {/* print view header */}
-      <h3
+      <span
         className="vads-u-font-size--h4 vads-u-line-height--4 print-only"
+        aria-hidden="true"
         data-dd-privacy="mask"
       >
         {record.name}
-      </h3>
+      </span>
 
       {/* fields */}
       <div>


### PR DESCRIPTION
## Summary

- Fixed accessibility issue where the screen reader read text that should have only been for print.
- This is not a bug.
- Updated the JSX by turning h3's into span's and adding aria-hidden="true". 
- MHV Medical Records.

## Related issue(s)

### [MHV-61787](https://jira.devops.va.gov/browse/MHV-61787) Screen readers are detecting and reading content that is intended for print only ###

![Screenshot 2024-09-11 at 3 32 19 PM](https://github.com/user-attachments/assets/f35b4e07-8c99-4818-8fe1-da7c9d74a974)

## Screenshot


## Testing done

-  All tests were passing.

## What areas of the site does it impact?
MHV Medical Records
