### PR TITLE
MHV-61878: Medication documentation PDF - do not split paragraphs between pages

### DIFF
--- a/src/applications/mhv-medications/util/pdfConfigs.js
+++ b/src/applications/mhv-medications/util/pdfConfigs.js
@@ -13,7 +13,39 @@ import {
 } from './constants';
 
 /**
+ * @typedef {object} LiItem
+ * @property {string} value
+ */
+
+/**
+ * @typedef {object} Item
+ * @property {string | undefined} title
+ * @property {string | Array<LiItem>} value
+ * @property {boolean | undefined} inline // false by default
+ * @property {boolean | undefined} isRich // false by default; must be set to true if value is an array
+ * @property {boolean | undefined} disablePageSplit // false by default
+ * @property {boolean | undefined} noIndentation // false by default
+ */
+
+/**
+ * @typedef {object} Section
+ * @property {string | undefined} header
+ * @property {Array<Item>} items
+ * @property {string | undefined} headerSize // 'H4' by default
+ */
+
+/**
+ * @typedef {Object} PdfConfigItem
+ * @property {string | undefined} header
+ * @property {boolean | undefined} sectionSeparators // false by default
+ * @property {Object | undefined} sectionSeperatorOptions
+ * @property {Array<Section>} sections
+ */
+
+/**
  * Return Non-VA prescription PDF list
+ *
+ * @returns {Array<PdfConfigItem>}
  */
 export const buildNonVAPrescriptionPDFList = prescription => {
   return [
@@ -83,6 +115,8 @@ export const buildNonVAPrescriptionPDFList = prescription => {
 
 /**
  * Return prescriptions PDF list
+ *
+ * @returns {Array<PdfConfigItem>}
  */
 export const buildPrescriptionsPDFList = prescriptions => {
   return prescriptions?.map(rx => {
@@ -182,6 +216,8 @@ export const buildPrescriptionsPDFList = prescriptions => {
 
 /**
  * Return medication information PDF
+ *
+ * @returns {PdfConfigItem}
  */
 export const buildMedicationInformationPDF = list => {
   const listOfHeaders = ['h2', 'h3'];
@@ -210,6 +246,7 @@ export const buildMedicationInformationPDF = list => {
                   },
                 ],
                 isRich: true,
+                disablePageSplit: true,
               };
             }
             return [];
@@ -219,6 +256,7 @@ export const buildMedicationInformationPDF = list => {
             {
               value: subItem.text,
               noIndentation: true,
+              disablePageSplit: true,
             },
           ];
         });
@@ -233,6 +271,8 @@ export const buildMedicationInformationPDF = list => {
 
 /**
  * Return allergies PDF list
+ *
+ * @returns {Array<PdfConfigItem>}
  */
 export const buildAllergiesPDFList = allergies => {
   return allergies.map(item => {
@@ -280,6 +320,8 @@ export const buildAllergiesPDFList = allergies => {
 
 /**
  * Return VA prescription PDF list
+ *
+ * @returns {Array<PdfConfigItem>}
  */
 export const buildVAPrescriptionPDFList = prescription => {
   const refillHistory = [...(prescription?.rxRfRecords || [])];

--- a/src/platform/pdf/templates/medications.js
+++ b/src/platform/pdf/templates/medications.js
@@ -156,13 +156,15 @@ const generateResultsMedicationListContent = async (
       }
 
       // If the next item does not fit - move to the next page
-      doc.fontSize(config.text.size);
-      let height = !resultItem.value?.type
-        ? doc.heightOfString(`${resultItem.title}: ${resultItem.value}`)
-        : resultItem.value?.options?.height;
-      height = resultItem.inline ? height : height + 24;
-      if (doc.y + height > doc.page.height - doc.page.margins.bottom)
-        await doc.addPage();
+      if (!resultItem.disablePageSplit) {
+        doc.fontSize(config.text.size);
+        let height = !resultItem.value?.type
+          ? doc.heightOfString(`${resultItem.title}: ${resultItem.value}`)
+          : resultItem.value?.options?.height;
+        height = resultItem.inline ? height : height + 24;
+        if (doc.y + height > doc.page.height - doc.page.margins.bottom)
+          await doc.addPage();
+      }
 
       for (const struct of structs) {
         results.add(struct);


### PR DESCRIPTION
## Summary

Updated Medications PDF configs JSDoc types
Removed moving to a new page if item content does not fit into current page for medication details PDF

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-61878

## Screenshots/PDF example

[medication-information-ACETIC ACID 0.25% IRRG SOLN-9-12-2024.pdf](https://github.com/user-attachments/files/16978066/medication-information-ACETIC.ACID.0.25.IRRG.SOLN-9-12-2024.pdf)

## Testing done

- Manual testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: UCD validates
AC2: paragraphs do not split between pages for the medication documentation pdf and print views. 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
