### PR TITLE
NEW Confirmation Page: remove expand all link and padding from lists

### DIFF
--- a/src/applications/simple-forms/shared/components/ConfirmationPageView.v2.jsx
+++ b/src/applications/simple-forms/shared/components/ConfirmationPageView.v2.jsx
@@ -98,7 +98,7 @@ export const ConfirmationPageView = props => {
       <div className="screen-only">
         <h2>Save a copy of your form</h2>
         <p>If you’d like a copy of your completed form, you can download it.</p>
-        <VaAccordion bordered uswds>
+        <VaAccordion bordered open-single uswds>
           <VaAccordionItem
             header="Information you submitted on this form"
             id="info"

--- a/src/applications/simple-forms/shared/components/confirmationPageViewHelpers.jsx
+++ b/src/applications/simple-forms/shared/components/confirmationPageViewHelpers.jsx
@@ -188,7 +188,9 @@ export const ChapterSectionCollection = ({
       fields.length > 0 && (
         <div key={`chapter_${chapter.name}`}>
           <h3>{chapterTitle}</h3>
-          <ul style={{ listStyle: 'none' }}>{fields}</ul>
+          <ul className="vads-u-padding--0" style={{ listStyle: 'none' }}>
+            {fields}
+          </ul>
         </div>
       )
     );


### PR DESCRIPTION
## Summary
This pull request removes the expand all link from the accordion on the new confirmation page. It also removes the padding from the lists inside the accordion.

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#1657

## Screenshots
![image](https://github.com/user-attachments/assets/1dc2046a-ca81-46fb-8f94-5eb86c562538)
