### PR TITLE
92708 Cancel screen shows up twice before canceling

### DIFF
--- a/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
+++ b/src/applications/vaos/appointment-list/components/ConfirmedAppointmentDetailsPage/DetailsVA.jsx
@@ -15,6 +15,7 @@ import CancelConfirmationPage from '../cancel/CancelConfirmationPage';
 import FacilityAddress from '../../../components/FacilityAddress';
 import ClaimExamLayout from '../../../components/layout/ClaimExamLayout';
 import PhoneLayout from '../../../components/layout/PhoneLayout';
+import FullWidthLayout from '../../../components/FullWidthLayout';
 
 export default function DetailsVA({ appointment, facilityData }) {
   const { id } = useParams();
@@ -43,11 +44,18 @@ export default function DetailsVA({ appointment, facilityData }) {
     return <InPersonLayout data={appointment} />;
   }
 
-  if (
-    cancelInfo.cancelAppointmentStatus === FETCH_STATUS.notStarted ||
-    cancelInfo.cancelAppointmentStatus === FETCH_STATUS.loading
-  ) {
+  if (cancelInfo.cancelAppointmentStatus === FETCH_STATUS.notStarted) {
     return <CancelWarningPage {...data} />;
+  }
+  if (cancelInfo.cancelAppointmentStatus === FETCH_STATUS.loading) {
+    return (
+      <FullWidthLayout>
+        <va-loading-indicator
+          set-focus
+          message="Canceling your appointment..."
+        />
+      </FullWidthLayout>
+    );
   }
   if (cancelInfo.cancelAppointmentStatus === FETCH_STATUS.succeeded) {
     return (

--- a/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
+++ b/src/applications/vaos/appointment-list/components/RequestedAppointmentDetailsPage.jsx
@@ -117,10 +117,18 @@ export default function RequestedAppointmentDetailsPage() {
   if (isCC === false && cancelInfo.showCancelModal === false) {
     return <VARequestLayout data={appointment} />;
   }
-  if (
-    cancelInfo.cancelAppointmentStatus === FETCH_STATUS.notStarted ||
-    cancelInfo.cancelAppointmentStatus === FETCH_STATUS.loading
-  ) {
+
+  if (cancelInfo.cancelAppointmentStatus === FETCH_STATUS.loading) {
+    return (
+      <FullWidthLayout>
+        <va-loading-indicator
+          set-focus
+          message="Canceling your appointment..."
+        />
+      </FullWidthLayout>
+    );
+  }
+  if (cancelInfo.cancelAppointmentStatus === FETCH_STATUS.notStarted) {
     return (
       <PageLayout showNeedHelp isDetailPage>
         <CancelWarningPage

--- a/src/applications/vaos/components/layout/DetailPageLayout.jsx
+++ b/src/applications/vaos/components/layout/DetailPageLayout.jsx
@@ -110,6 +110,7 @@ function CancelButton({ appointment }) {
   const dispatch = useDispatch();
   const { status, vaos } = appointment;
   const { isCancellable, isPastAppointment } = vaos;
+  const isCancelled = APPOINTMENT_STATUS.cancelled === status;
 
   let event = `${GA_PREFIX}-cancel-booked-clicked`;
   if (APPOINTMENT_STATUS.proposed === status)
@@ -130,6 +131,8 @@ function CancelButton({ appointment }) {
       data-testid="cancel-button"
     />
   );
+
+  if (isCancelled) return null;
 
   if (!!isCancellable && !isPastAppointment) return button;
 

--- a/src/applications/vaos/components/layout/DetailPageLayout.jsx
+++ b/src/applications/vaos/components/layout/DetailPageLayout.jsx
@@ -110,7 +110,6 @@ function CancelButton({ appointment }) {
   const dispatch = useDispatch();
   const { status, vaos } = appointment;
   const { isCancellable, isPastAppointment } = vaos;
-  const isCancelled = APPOINTMENT_STATUS.cancelled === status;
 
   let event = `${GA_PREFIX}-cancel-booked-clicked`;
   if (APPOINTMENT_STATUS.proposed === status)
@@ -131,8 +130,6 @@ function CancelButton({ appointment }) {
       data-testid="cancel-button"
     />
   );
-
-  if (isCancelled) return null;
 
   if (!!isCancellable && !isPastAppointment) return button;
 

--- a/src/applications/vaos/services/mocks/index.js
+++ b/src/applications/vaos/services/mocks/index.js
@@ -300,6 +300,7 @@ const responses = {
     if (req.body.status === 'cancelled') {
       appt.attributes.status = 'cancelled';
       appt.attributes.cancelationReason = { coding: [{ code: 'pat' }] };
+      appt.attributes.cancellable = false;
     }
 
     return res.json({

--- a/src/applications/vaos/tests/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/BackendAppointmentServiceAlert.unit.spec.js
@@ -208,6 +208,7 @@ describe('VAOS Backend Service Alert', () => {
       requests: [appointment],
       statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
       backendServiceFailures: true,
+      avs: true,
     });
 
     const screen = renderWithStoreAndRouter(<PastAppointmentsList />, {
@@ -267,6 +268,7 @@ describe('VAOS Backend Service Alert', () => {
       requests: [appointment],
       statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
       backendServiceFailures: false,
+      avs: true,
     });
 
     const screen = renderWithStoreAndRouter(<PastAppointmentsList />, {

--- a/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/ConfirmedAppointmentDetailsPage/index.unit.spec.js
@@ -128,9 +128,10 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
     // Arrange
     const response = new MockAppointmentResponse();
 
-    mockAppointmentApi({ response });
+    mockAppointmentApi({ response, avs: true });
     mockGetUpcomingAppointmentsApi({
       response: [response],
+      avs: true,
     });
     mockGetPendingAppointmentsApi({
       response: [response],
@@ -158,7 +159,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
       const responses = MockAppointmentResponse.createAtlasResponses({
         localStartTime: today,
       });
-      mockAppointmentApi({ response: responses[0] });
+      mockAppointmentApi({ response: responses[0], avs: true });
 
       // Act
       renderWithStoreAndRouter(<AppointmentList />, {
@@ -182,7 +183,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
       const responses = MockAppointmentResponse.createAtlasResponses({
         localStartTime: yesterday,
       });
-      mockAppointmentApi({ response: responses[0] });
+      mockAppointmentApi({ response: responses[0], avs: true });
 
       // Act
       renderWithStoreAndRouter(<AppointmentList />, {
@@ -207,7 +208,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
         localStartTime: today,
       });
       responses[0].setStatus(APPOINTMENT_STATUS.cancelled);
-      mockAppointmentApi({ response: responses[0] });
+      mockAppointmentApi({ response: responses[0], avs: true });
 
       // Act
       renderWithStoreAndRouter(<AppointmentList />, {
@@ -231,7 +232,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
       const responses = MockAppointmentResponse.createGfeResponses({
         localStartTime: today,
       });
-      mockAppointmentApi({ response: responses[0] });
+      mockAppointmentApi({ response: responses[0], avs: true });
 
       // Act
       renderWithStoreAndRouter(<AppointmentList />, {
@@ -255,7 +256,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
       const responses = MockAppointmentResponse.createGfeResponses({
         localStartTime: yesterday,
       });
-      mockAppointmentApi({ response: responses[0] });
+      mockAppointmentApi({ response: responses[0], avs: true });
 
       // Act
       renderWithStoreAndRouter(<AppointmentList />, {
@@ -280,7 +281,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
         localStartTime: today,
       });
       responses[0].setStatus(APPOINTMENT_STATUS.cancelled);
-      mockAppointmentApi({ response: responses[0] });
+      mockAppointmentApi({ response: responses[0], avs: true });
 
       // Act
       renderWithStoreAndRouter(<AppointmentList />, {
@@ -304,7 +305,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
       const responses = MockAppointmentResponse.createClinicResponses({
         localStartTime: today,
       });
-      mockAppointmentApi({ response: responses[0] });
+      mockAppointmentApi({ response: responses[0], avs: true });
 
       // Act
       renderWithStoreAndRouter(<AppointmentList />, {
@@ -328,7 +329,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
       const responses = MockAppointmentResponse.createClinicResponses({
         localStartTime: yesterday,
       });
-      mockAppointmentApi({ response: responses[0] });
+      mockAppointmentApi({ response: responses[0], avs: true });
 
       // Act
       renderWithStoreAndRouter(<AppointmentList />, {
@@ -353,7 +354,7 @@ describe('VAOS Page: ConfirmedAppointmentDetailsPage with VAOS service', () => {
         localStartTime: today,
       });
       responses[0].setStatus(APPOINTMENT_STATUS.cancelled);
-      mockAppointmentApi({ response: responses[0] });
+      mockAppointmentApi({ response: responses[0], avs: true });
 
       // Act
       renderWithStoreAndRouter(<AppointmentList />, {

--- a/src/applications/vaos/tests/appointment-list/components/PastAppointmentsListV2.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/PastAppointmentsListV2.unit.spec.js
@@ -76,6 +76,7 @@ describe('VAOS Page: PastAppointmentsList V2 api', () => {
       end: testDates().end.format('YYYY-MM-DD'),
       requests: [],
       statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      avs: true,
     });
     mockVAOSAppointmentsFetch({
       start: testDates()
@@ -88,6 +89,7 @@ describe('VAOS Page: PastAppointmentsList V2 api', () => {
         .format('YYYY-MM-DD'),
       requests: [response],
       statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      avs: true,
     });
 
     // Act
@@ -128,6 +130,7 @@ describe('VAOS Page: PastAppointmentsList V2 api', () => {
       end: testDates().end.format('YYYY-MM-DD'),
       requests: [appointment],
       statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      avs: true,
     });
 
     const screen = renderWithStoreAndRouter(<PastAppointmentsList />, {
@@ -212,6 +215,7 @@ describe('VAOS Page: PastAppointmentsList V2 api', () => {
       end: testDates().end.format('YYYY-MM-DD'),
       requests: [appointment],
       statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      avs: true,
     });
 
     const screen = renderWithStoreAndRouter(<PastAppointmentsList />, {
@@ -257,6 +261,7 @@ describe('VAOS Page: PastAppointmentsList V2 api', () => {
       end: testDates().end.format('YYYY-MM-DD'),
       requests: [appointment],
       statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      avs: true,
     });
 
     const screen = renderWithStoreAndRouter(<PastAppointmentsList />, {
@@ -297,6 +302,7 @@ describe('VAOS Page: PastAppointmentsList V2 api', () => {
       end: testDates().end.format('YYYY-MM-DD'),
       requests: [appointment],
       statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      avs: true,
     });
 
     const screen = renderWithStoreAndRouter(<PastAppointmentsList />, {
@@ -364,6 +370,7 @@ describe('VAOS Page: PastAppointmentsList V2 api', () => {
       end: testDates().end.format('YYYY-MM-DD'),
       requests: [appointment],
       statuses: ['booked', 'arrived', 'fulfilled', 'cancelled'],
+      avs: true,
     });
 
     const myInitialState = {

--- a/src/applications/vaos/tests/mocks/helpers.js
+++ b/src/applications/vaos/tests/mocks/helpers.js
@@ -55,6 +55,7 @@ export function mockSingleVAOSAppointmentFetch({ appointment, error = null }) {
  * @param {Array<VAOSRequest>} params.request Request to be returned from the mock
  * @param {boolean} [params.error=null] Whether or not to return a fetch error from the mock
  * @param {boolean} [params.backendServiceFailures=null] Whether or not to return a backend service error with the mock
+ * @param {boolean} [params.avs=false] Flag to include after visit summary information or not.
  */
 export function mockVAOSAppointmentsFetch({
   start,
@@ -63,10 +64,13 @@ export function mockVAOSAppointmentsFetch({
   requests,
   error = null,
   backendServiceFailures = null,
+  avs = false,
 }) {
   const baseUrl = `${
     environment.API_URL
-  }/vaos/v2/appointments?_include=facilities,clinics&start=${start}&end=${end}&${statuses
+  }/vaos/v2/appointments?_include=facilities,clinics${
+    avs ? ',avs' : ''
+  }&start=${start}&end=${end}&${statuses
     .map(status => `statuses[]=${status}`)
     .join('&')}`;
 
@@ -297,11 +301,16 @@ export function mockAppointmentUpdateApi({
  * @param {Object} arguments - Function arguments.
  * @param {Object} [arguments.response] - The response to return from the mock api call.
  * @param {number} [arguments.responseCode=200] - The response code to return from the mock api call.
+ * @param {boolean} [arguments.avs=false] Flag to include after visit summary information or not.
  */
-export function mockAppointmentApi({ response: data, responseCode = 200 }) {
+export function mockAppointmentApi({
+  response: data,
+  responseCode = 200,
+  avs = false,
+}) {
   const baseUrl = `${environment.API_URL}/vaos/v2/appointments/${
     data.id
-  }?_include=facilities,clinics`;
+  }?_include=facilities,clinics${avs ? ',avs' : ''}`;
 
   if (responseCode === 200) {
     setFetchJSONResponse(global.fetch.withArgs(baseUrl), { data });


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
Cancel screen shows up twice before canceling and appointment
- _(If bug, how to reproduce)_
See [issue](department-of-veterans-affairs/va.gov-team#92708)
- _(What is the solution, why is this the solution)_
Display the loading widget to indicate to the use that the cancelation request is being processed.
- _(Which team do you work for, does your team own the maintenance of this component?)_
VAOS
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
N/A

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#92708

## Testing done
Unit and e2e testing.


## Screenshots
N/A

## What areas of the site does it impact?
VAOS

## Acceptance criteria
- [ ] Once the user cancels the appointment/request, there will be a spinning loading indicator to let the user know it is in process to cancel.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
