### PR TITLE
[91101] Add org select page to 21-22 Form

### DIFF
--- a/src/applications/representative-appoint/components/ClaimantType.jsx
+++ b/src/applications/representative-appoint/components/ClaimantType.jsx
@@ -45,6 +45,7 @@ const ClaimantType = props => {
 ClaimantType.propTypes = {
   route: PropTypes.object,
   setFormData: PropTypes.func,
+  router: PropTypes.object,
 };
 
 const mapDispatchToProps = {

--- a/src/applications/representative-appoint/components/SearchResult.jsx
+++ b/src/applications/representative-appoint/components/SearchResult.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { setData } from '~/platform/forms-system/src/js/actions';
 import { VaButton } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { getNextPagePath } from '~/platform/forms-system/src/js/routing';
 import { parsePhoneNumber } from '../utilities/helpers';
 
 const SearchResult = ({
@@ -23,10 +24,11 @@ const SearchResult = ({
   query,
   formData,
   setFormData,
-  goForward,
+  router,
+  routes,
+  location,
 }) => {
   const { contact, extension } = parsePhoneNumber(phone);
-
   const addressExists = addressLine1 || city || stateCode || zipCode;
 
   const address =
@@ -46,12 +48,21 @@ const SearchResult = ({
   };
 
   const handleSelect = selectedRepResult => {
-    setFormData({
+    const tempData = {
       ...formData,
       'view:selectedRepresentative': selectedRepResult,
+    };
+
+    setFormData({
+      ...tempData,
     });
 
-    goForward();
+    const { pageList } = routes[1];
+    const { pathname } = location;
+
+    const nextPagePath = getNextPagePath(pageList, tempData, pathname);
+
+    router.push(nextPagePath);
   };
 
   return (
@@ -175,6 +186,9 @@ SearchResult.propTypes = {
   type: PropTypes.string,
   zipCode: PropTypes.string,
   setFormData: PropTypes.func.isRequired,
+  router: PropTypes.object,
+  routes: PropTypes.array,
+  location: PropTypes.object,
 };
 
 const mapDispatchToProps = {

--- a/src/applications/representative-appoint/components/SelectAccreditedRepresentative.jsx
+++ b/src/applications/representative-appoint/components/SelectAccreditedRepresentative.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { getNextPagePath } from '~/platform/forms-system/src/js/routing';
+
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import {
@@ -40,13 +40,6 @@ const SelectAccreditedRepresentative = props => {
     }
   };
 
-  const goForward = () => {
-    const { pageList } = routes[1];
-    const { pathname } = location;
-    const nextPagePath = getNextPagePath(pageList, formData, pathname);
-    router.push(nextPagePath);
-  };
-
   const searchResults = () => {
     if (loading) {
       return <va-loading-indicator message="Loading..." set-focus />;
@@ -76,7 +69,9 @@ const SelectAccreditedRepresentative = props => {
                   representativeId={representative.id}
                   formData={formData}
                   setFormData={setFormData}
-                  goForward={goForward}
+                  router={router}
+                  routes={routes}
+                  location={location}
                 />
               </div>
             );

--- a/src/applications/representative-appoint/config/form.js
+++ b/src/applications/representative-appoint/config/form.js
@@ -26,6 +26,7 @@ import {
   veteranIdentification,
   veteranServiceInformation,
   selectAccreditedRepresentative,
+  selectedAccreditedOrganizationId,
 } from '../pages';
 
 import { prefillTransformer } from '../prefill-transformer';
@@ -112,6 +113,25 @@ const formConfig = {
           path: 'representative-select',
           uiSchema: selectAccreditedRepresentative.uiSchema,
           schema: selectAccreditedRepresentative.schema,
+        },
+        selectAccreditedOrganization: {
+          path: 'representative-organization',
+          title: 'Organization Select',
+          depends: formData =>
+            !!formData['view:selectedRepresentative'] &&
+            formData['view:selectedRepresentative'].attributes
+              ?.individualType === 'representative' &&
+            formData['view:selectedRepresentative'].attributes
+              ?.accreditedOrganizations?.data?.length > 1,
+          uiSchema: selectedAccreditedOrganizationId.uiSchema,
+          schema: {
+            type: 'object',
+            properties: {
+              selectedAccreditedOrganizationId: {
+                type: 'string',
+              },
+            },
+          },
         },
       },
     },

--- a/src/applications/representative-appoint/config/organizations/DynamicRadioWidget.jsx
+++ b/src/applications/representative-appoint/config/organizations/DynamicRadioWidget.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+import {
+  VaRadio,
+  VaRadioOption,
+} from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+
+export function DynamicRadioWidget(props) {
+  const { formData, onChange } = props;
+  let organizationList = null;
+  let upperContent = null;
+  const organizations =
+    formData['view:selectedRepresentative'].attributes.accreditedOrganizations
+      .data;
+  const [selected, setSelected] = useState(null); // app starts with no selection
+
+  upperContent = (
+    <>
+      <h3 className="vads-u-margin-y--5">Select the organization</h3>
+      <p className="vads-u-margin-bottom--0">
+        This accredited VSO representative works with more than 1 organization.
+        Ask them which organization to appoint.
+      </p>
+      <p className="vads-u-margin-y--4">
+        <strong>Note:</strong> You'll usually work with 1 accredited VSO
+        representative, but you can work with any of the accredited VSO
+        representatives from the organization you appoint.
+      </p>
+    </>
+  );
+
+  organizationList = (
+    <VaRadio
+      label="Which VSO do you want to appoint?"
+      required
+      value={selected}
+      onVaValueChange={event => {
+        onChange(event.detail.value);
+        setSelected(event.detail.value);
+      }}
+    >
+      {organizations.map((org, index) => (
+        <VaRadioOption
+          name="organization"
+          key={`${org.id}-${index}`}
+          label={`${org.attributes.name}`}
+          value={org.id}
+          checked={formData.selectedAccreditedOrganizationId === org.id}
+        />
+      ))}
+    </VaRadio>
+  );
+
+  return (
+    <>
+      {upperContent}
+      {organizationList}
+    </>
+  );
+}
+
+function mapStateToProps(state) {
+  return {
+    formData: state.form.data,
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  null,
+)(DynamicRadioWidget);

--- a/src/applications/representative-appoint/pages/index.js
+++ b/src/applications/representative-appoint/pages/index.js
@@ -18,6 +18,7 @@ import * as veteranContactMailingClaimant from './veteran/veteranContactMailingC
 import * as veteranIdentification from './veteran/veteranIdentification';
 import * as veteranServiceInformation from './veteran/veteranServiceInformation';
 import * as selectAccreditedRepresentative from './representative/selectAccreditedRepresentative';
+import * as selectedAccreditedOrganizationId from './representative/selectAccreditedOrganization';
 
 export {
   authorizeMedical,
@@ -40,4 +41,5 @@ export {
   veteranIdentification,
   veteranServiceInformation,
   selectAccreditedRepresentative,
+  selectedAccreditedOrganizationId,
 };

--- a/src/applications/representative-appoint/pages/representative/selectAccreditedOrganization.js
+++ b/src/applications/representative-appoint/pages/representative/selectAccreditedOrganization.js
@@ -1,0 +1,13 @@
+import DynamicRadioWidget from '../../config/organizations/DynamicRadioWidget';
+
+export const uiSchema = {
+  selectedAccreditedOrganizationId: {
+    'ui:title': 'Select Organization',
+    'ui:widget': DynamicRadioWidget,
+    'ui:options': {
+      hideLabelText: true,
+    },
+    'ui:required': () => true,
+  },
+};
+export const schema = {};

--- a/src/applications/representative-appoint/utilities/helpers.js
+++ b/src/applications/representative-appoint/utilities/helpers.js
@@ -151,12 +151,17 @@ export const parsePhoneNumber = phone => {
  * Setting subtitle based on rep type
  */
 export const getFormSubtitle = formData => {
-  const type = formData['view:selectedRepresentative']?.type;
+  const entity = formData['view:selectedRepresentative'];
+  const entityType = entity?.type;
 
-  if (type === 'organization') {
+  if (entityType === 'organization') {
     return 'VA Form 21-22';
   }
-  if (type === 'individual') {
+  if (entityType === 'individual') {
+    const { individualType } = entity.attributes;
+    if (individualType === 'representative') {
+      return 'VA Form 21-22';
+    }
     return 'VA Form 21-22a';
   }
   return 'VA Forms 21-22 and 21-22a';


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr adds a page to select an accredited organization on the 21-22 Form.
- the page should only appear if:
  - the selected entity on `representative-select` is a `representative`
  - the representative has more than 1 accredited organization
- the radio select should be dynamic based on the selected representative

## Related issue(s)

- [91101](https://app.zenhub.com/workspaces/accredited-representation-management-team-64d0dc51d3e8f4788ac6ef96/issues/gh/department-of-veterans-affairs/va.gov-team/91101)

## Testing done

- This page is new so the old behavior would be to go from rep select to personal or claimant information
- Unit tests to come in their own ticket later

## Screenshots

|         | After |
| ------- | ----- |
| Mobile |![image](https://github.com/user-attachments/assets/4135db8f-cb94-48a7-bb83-6f6cfcb4d9f0)|
| Desktop |![image](https://github.com/user-attachments/assets/b8d98711-b132-407f-a66a-fad6bd388532) |

## What areas of the site does it impact?

Impacts Appoint a Rep form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user