### PR TITLE
10-10CG - Always display required label on facilities search input

### DIFF
--- a/src/applications/caregivers/components/FormFields/FacilityList.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilityList.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import {
   VaRadio,
@@ -11,11 +11,8 @@ const FacilityList = props => {
   const reviewMode = props?.formContext?.reviewMode || false;
   const submitted = props?.formContext?.submitted || false;
 
-  const [dirty, setDirty] = useState(false);
-
   const handleChange = e => {
     onChange(e.detail.value);
-    setDirty(true);
   };
 
   const showError = () => {
@@ -23,8 +20,8 @@ const FacilityList = props => {
       return error;
     }
 
-    return (submitted || dirty) && !value
-      ? content['validation-facialities--default-required']
+    return submitted && !value
+      ? content['validation-facilities--default-required']
       : null;
   };
 

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -238,11 +238,7 @@ const FacilitySearch = props => {
               className="vads-u-margin-top--0 vads-u-margin-bottom--1"
             >
               {content['form-facilities-search-label']}
-              {searchInputError && (
-                <span className="vads-u-color--secondary-dark">
-                  (*Required)
-                </span>
-              )}
+              <span className="vads-u-color--secondary-dark">(*Required)</span>
             </label>
             {searchInputError && searchError()}
             <VaSearchInput

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -33,9 +33,11 @@ const FacilitySearch = props => {
       formData?.['view:plannedClinic']?.caregiverSupport?.id;
     if (!caregiverSupportFacilityId) {
       if (hasFacilities()) {
-        setFacilitiesListError('Select a medical center or clinic');
+        setFacilitiesListError(
+          content['validation-facilities--default-required'],
+        );
       } else {
-        setSearchInputError('Select a medical center or clinic');
+        setSearchInputError(content['validation-facilities--default-required']);
       }
     } else {
       goForward(formData);
@@ -194,7 +196,11 @@ const FacilitySearch = props => {
         <>
           <FacilityList {...facilityListProps} />
           {loadingMoreFacilities && loader()}
-          <button className="va-button-link" onClick={showMoreFacilities}>
+          <button
+            type="button"
+            className="va-button-link"
+            onClick={showMoreFacilities}
+          >
             Load more facilities
           </button>
         </>

--- a/src/applications/caregivers/locales/en/content.json
+++ b/src/applications/caregivers/locales/en/content.json
@@ -134,7 +134,7 @@
   "validation-address--county-required": "Enter a county",
   "validation-default-required": "Please provide a response",
   "validation-facilities--search-required": "Enter a city, state or postal code",
-  "validation-facialities--default-required": "Select a medical center or clinic",
+  "validation-facilities--default-required": "Select a medical center or clinic",
   "validation-signature-required": "Must certify by checking box",
   "validation-sign-as-rep": "You must sign as representative.",
   "validation-sign-as-rep--vet-name": "Your signature must match previously entered name: %s",

--- a/src/applications/caregivers/tests/unit/components/FormFields/FacilityList.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormFields/FacilityList.unit.spec.js
@@ -74,7 +74,7 @@ describe('CG <FacilityList>', () => {
       const { selectors } = subject({ props });
       expect(selectors().vaRadio).to.have.attr(
         'error',
-        content['validation-facialities--default-required'],
+        content['validation-facilities--default-required'],
       );
     });
 

--- a/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch.unit.spec.js
@@ -95,7 +95,7 @@ describe('CG <FacilitySearch>', () => {
       expect(selectors().radioList).not.to.exist;
       expect(selectors().moreFacilities).not.to.exist;
       expect(queryByText(content['form-facilities-search-label'])).to.exist;
-      expect(queryByText('(*Required)')).not.to.exist;
+      expect(queryByText('(*Required)')).to.exist;
     });
   });
 

--- a/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch.unit.spec.js
@@ -369,7 +369,7 @@ describe('CG <FacilitySearch>', () => {
         expect(goForward.calledOnce).to.be.false;
         expect(selectors().radioList).to.have.attr(
           'error',
-          'Select a medical center or clinic',
+          content['validation-facilities--default-required'],
         );
       });
     });
@@ -575,7 +575,7 @@ describe('CG <FacilitySearch>', () => {
         userEvent.click(selectors().formNavButtons.forward);
         expect(goForward.calledOnce).to.be.false;
         expect(selectors().searchInputError.textContent).to.eq(
-          'ErrorSelect a medical center or clinic',
+          `Error${content['validation-facilities--default-required']}`,
         );
         expect(selectors().searchInputError.parentElement).to.have.class(
           'caregiver-facilities-search-input-error',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Always display facilities search as `required`
- Fixed a typo in the content key and updated some hard coded messages to use the content value. 
- Removed the `dirty` state from the facility list component. This was causing the error message to flash when setting the value since we were using `dirty` as another reason to render the error message.
- This is new functionality that is still behind a flipper toggle. (`caregiver_use_facilities_API`)

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/90381

## Testing done

- Field is still required, it just now shows a required label all of the time instead of when no value was passed.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |![Screenshot 2024-09-16 at 12 14 15 PM](https://github.com/user-attachments/assets/fe339f18-b933-4ea5-8e61-d20658bf2421)|![Screenshot 2024-09-16 at 12 11 04 PM](https://github.com/user-attachments/assets/48406406-4bd6-4ee5-b1c2-c7d109a65a82)|
| Desktop | ![Screenshot 2024-09-16 at 12 14 05 PM](https://github.com/user-attachments/assets/bf117ca1-2dea-4c9f-ab4e-322933c26b3e)| ![Screenshot 2024-09-16 at 12 10 25 PM](https://github.com/user-attachments/assets/7e1bb149-502f-40c4-9697-83523b545732)|

## What areas of the site does it impact?

10-10 CG Facilities page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
