### PR TITLE
Adding unit tests to increase code coverage for staging review

### DIFF
--- a/src/applications/benefit-eligibility-questionnaire/tests/unit/config/form.unit.spec.js
+++ b/src/applications/benefit-eligibility-questionnaire/tests/unit/config/form.unit.spec.js
@@ -51,10 +51,34 @@ describe('Questionnaire Form - Title Function', () => {
       expect(title).to.equal('Review your entries');
     });
 
-    it('should return "Complete the benefit eligibility questionnaire" by default', () => {
+    it('should return "Benefit and resource recommendation tool" by default', () => {
       const currentLocation = { pathname: '/some-other-page' };
       const title = formConfig.title({ currentLocation });
-      expect(title).to.equal('Complete the benefit eligibility questionnaire');
+      expect(title).to.equal('Benefit and resource recommendation tool');
+    });
+  });
+});
+
+describe('Questionnaire Form - SubTitle Function', () => {
+  describe('title function', () => {
+    it('should return blank when on the confirmation page', () => {
+      const currentLocation = { pathname: '/confirmation' };
+      const title = formConfig.subTitle({ currentLocation });
+      expect(title).to.equal('');
+    });
+
+    it('should return blank when on the review page', () => {
+      const currentLocation = { pathname: '/review-and-submit' };
+      const title = formConfig.subTitle({ currentLocation });
+      expect(title).to.equal('');
+    });
+
+    it('should return "Please answer the questions to help us recommend helpful resources and benefits." by default', () => {
+      const currentLocation = { pathname: '/some-other-page' };
+      const title = formConfig.subTitle({ currentLocation });
+      expect(title).to.equal(
+        'Please answer the questions to help us recommend helpful resources and benefits.',
+      );
     });
   });
 });

--- a/src/applications/benefit-eligibility-questionnaire/tests/unit/container/ConfirmationPage.unit.spec.js
+++ b/src/applications/benefit-eligibility-questionnaire/tests/unit/container/ConfirmationPage.unit.spec.js
@@ -11,7 +11,7 @@ import { BENEFITS_LIST } from '../../../constants/benefits';
 
 describe('<ConfirmationPage>', () => {
   sinon.stub(Date, 'getTime');
-  const getData = () => ({
+  const getData = resultsData => ({
     props: {
       formConfig,
       route: {
@@ -51,7 +51,7 @@ describe('<ConfirmationPage>', () => {
           },
         },
         results: {
-          data: [BENEFITS_LIST[0]],
+          data: resultsData,
           error: null,
           isError: false,
           isLoading: false,
@@ -69,7 +69,17 @@ describe('<ConfirmationPage>', () => {
     );
 
   it('should render results page', () => {
-    const { mockStore, props } = getData();
+    const { mockStore, props } = getData([BENEFITS_LIST[0]]);
+    const { container } = subject({ mockStore, props });
+
+    const ulQualified = container.querySelectorAll('ul.benefit-list');
+    expect(container.querySelector('#results-container')).to.exist;
+    expect(ulQualified[1].querySelectorAll('li')).to.have.lengthOf(1);
+  });
+
+  it('should render results page when query string is provided', () => {
+    const { mockStore, props } = getData([]);
+    props.location.query.benefits = 'SVC,FHV';
     const { container } = subject({ mockStore, props });
 
     expect(container.querySelector('#results-container')).to.exist;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Unit test coverage for Benefit Eligibility Questionnaire.

## Related issue(s)

[https://jira.devops.va.gov/browse/PTEMSVT-120](https://jira.devops.va.gov/browse/PTEMSVT-120)

## Testing done

Unit tests.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |![image](https://github.com/user-attachments/assets/ff51b9f1-5c64-4644-98ef-45f5818c70fa)|

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
