### PR TITLE
Add codespaces config for one click public urls

### DIFF
--- a/.devcontainer/codespaces-start.sh
+++ b/.devcontainer/codespaces-start.sh
@@ -10,3 +10,50 @@ then
     printf "\n\n##### Starting vets-website #####\n"
     cd ../vets-website && yarn watch --env api=https://${CODESPACE_NAME}-3000.app.github.dev public=https://${CODESPACE_NAME}-3001.app.github.dev
 fi
+
+
+# script to start the mock API server and vets-website if MAKE_APP_PUBLIC is set to 'YES'
+
+# Set default values
+MOCK_RESPONSES=${MOCK_RESPONSES:-src/platform/testing/local-dev-mock-api/common.js}
+
+if [ "$MAKE_APP_PUBLIC" == "YES" ]; then
+    # Start mock API server
+    printf "\n\n##### Starting mock API server #####\n"
+    yarn mock-api --responses "$MOCK_RESPONSES" &
+
+    # Start vets-website
+    printf "\n\n##### Starting vets-website #####\n"
+    if [ -n "$ENTRY_APPS" ]; then
+        yarn watch --env entry="$ENTRY_APPS" api=https://${CODESPACE_NAME}-3000.app.github.dev &
+    else
+        yarn watch --env api=https://${CODESPACE_NAME}-3000.app.github.dev &
+    fi
+
+    # Wait for servers to start
+    sleep 10
+
+    # Make frontend port public
+    printf "\n\n##### Making frontend port public #####\n"
+    gh codespace ports visibility 3001:public
+
+    # Make mock API port public
+    printf "\n\n##### Making mock API port public #####\n"
+    gh codespace ports visibility 3000:public
+
+    API_URL="https://${CODESPACE_NAME}-3000.app.github.dev"
+    FRONTEND_URL="https://${CODESPACE_NAME}-3001.app.github.dev"
+
+    printf "\n\n##### Setup complete. Your servers are running and ports are public. #####\n"
+    printf "Mock API: $API_URL\n"
+    printf "Frontend: $FRONTEND_URL\n"
+    printf "Mock Responses: $MOCK_RESPONSES\n"
+    if [ -n "$ENTRY_APPS" ]; then
+        printf "Entry Apps: $ENTRY_APPS\n"
+    else
+        printf "Entry Apps: Not specified (using default)\n"
+    fi
+else
+    printf "\n\n##### MAKE_APP_PUBLIC is not set to 'YES'. Servers will not be started. #####\n"
+    printf "To make the app public and start the servers, set the MAKE_APP_PUBLIC secret to 'YES' in your Codespace settings.\n"
+fi

--- a/.devcontainer/codespaces-start.sh
+++ b/.devcontainer/codespaces-start.sh
@@ -31,28 +31,19 @@ if [ "$MAKE_APP_PUBLIC" == "YES" ]; then
     fi
 
     # Wait for servers to start
-    sleep 10
+    printf "\n\n##### Waiting 20 seconds for servers to start... #####\n"
+    sleep 20
 
     # Make frontend port public
     printf "\n\n##### Making frontend port public #####\n"
-    gh codespace ports visibility 3001:public
+    gh codespace ports visibility 3001:public -c "$CODESPACE_NAME"
 
     # Make mock API port public
     printf "\n\n##### Making mock API port public #####\n"
-    gh codespace ports visibility 3000:public
-
-    API_URL="https://${CODESPACE_NAME}-3000.app.github.dev"
-    FRONTEND_URL="https://${CODESPACE_NAME}-3001.app.github.dev"
+    gh codespace ports visibility 3000:public -c "$CODESPACE_NAME"
 
     printf "\n\n##### Setup complete. Your servers are running and ports are public. #####\n"
-    printf "Mock API: $API_URL\n"
-    printf "Frontend: $FRONTEND_URL\n"
-    printf "Mock Responses: $MOCK_RESPONSES\n"
-    if [ -n "$ENTRY_APPS" ]; then
-        printf "Entry Apps: $ENTRY_APPS\n"
-    else
-        printf "Entry Apps: Not specified (using default)\n"
-    fi
+    wait
 else
     printf "\n\n##### MAKE_APP_PUBLIC is not set to 'YES'. Servers will not be started. #####\n"
     printf "To make the app public and start the servers, set the MAKE_APP_PUBLIC secret to 'YES' in your Codespace settings.\n"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -57,9 +57,9 @@
 	"postStartCommand": "./.devcontainer/codespaces-start.sh",
 	"remoteUser": "node",
 	"hostRequirements": {
-		"cpus": 4,
-		"memory": "16gb",
-		"storage": "32gb"
+		"cpus": 16,
+		"memory": "32gb",
+		"storage": "128gb"
 	},
 	"portsAttributes": {
 		"3000": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
 		"ghcr.io/devcontainers/features/desktop-lite:1": {
 			"vncPort": "5900",
 			"webPort": "6080"
-		}
+		},
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 	"customizations": {
 		"vscode": {
@@ -56,9 +57,9 @@
 	"postStartCommand": "./.devcontainer/codespaces-start.sh",
 	"remoteUser": "node",
 	"hostRequirements": {
-		"cpus": 16,
-		"memory": "32gb",
-		"storage": "128gb"
+		"cpus": 4,
+		"memory": "16gb",
+		"storage": "32gb"
 	},
 	"portsAttributes": {
 		"3000": {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- The authenticated patterns team is using codespaces to build live protypes of forms and other ui patterns. We require the application to run in codespaces with a mock server and the frontend dev server running in watch mode.
- This PR adds a section to the codespaces-start.sh to allow the application to be started automatically.
  - The key to using this is a set of codespaces user secrets that can be set by individual users to configure how the public application is spun up.
  - `MOCK_RESPONSES` - the path to the mock server responses. The default of `src/platform/testing/local-dev-mock-api/common.js` will be used if this is not set
  - `MAKE_APP_PUBLIC` - if set to YES, then the app will be set up to be on a public port. This is basically an easy way to provide an on/off switch for the whole public app bootstrapping process.
  - `ENTRY_APPS` - this is set to allow an entry parameter to be passed to the yarn command like this `yarn watch --env entry=static-pages,auth` so in this example 'static-pages,auth' would be used as the value of `ENTRY_APPS` to build just those apps. If this is not set, then all apps will be built in watch mode and it will take longer for the codespace to build and rebuild on changes.
- Once the app is built and mock server is running, then the github cli is used programatically to set the ports for the frontend and mock server to be public
- A user can now opt into running public prototypes through codespaces and this streamlined process could be used by non-engineers to be able to spin up a codespace.


## Related issue(s)

- https://github.com/department-of-veterans-affairs/tmf-auth-exp-design-patterns/issues/110

## Testing done

- Tested on this branch, and created a public codespace to demo

## Screenshots

No ui changes

## What areas of the site does it impact?

Users using codespaces for research sessions. NO changes are actually made accross the board for all codespaces and public codespace setup is limited to opt in via users's codespace settings in github account settings.

## Acceptance criteria

- public codespaces can be created in 'one click'

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)