### PR TITLE
Add headline slot to review accordion

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -475,14 +475,13 @@ class ReviewCollapsibleChapter extends React.Component {
         />
         <va-accordion-item
           data-chapter={this.props.chapterKey}
-          header={chapterTitle}
-          level={3}
           subHeader={this.props.hasUnviewedPages ? subHeader : ''}
           data-unviewed-pages={this.props.hasUnviewedPages}
           open={this.props.open}
           bordered
           uswds
         >
+          <h3 slot="headline">{chapterTitle}</h3>
           {this.props.hasUnviewedPages && (
             <va-icon slot="icon" icon="error" class="vads-u-color--secondary" />
           )}

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -583,8 +583,8 @@ describe('<ReviewCollapsibleChapter>', () => {
       />,
     );
 
-    expect(wrapper.find('va-accordion-item').props().header).to.equal(
-      testChapterTitle,
+    expect(wrapper.find('va-accordion-item').html()).to.contain(
+      `<h3 slot="headline">${testChapterTitle}</h3>`,
     );
 
     const titleDiv = wrapper.find('h4.form-review-panel-page-header');
@@ -646,8 +646,8 @@ describe('<ReviewCollapsibleChapter>', () => {
       />,
     );
 
-    expect(wrapper.find('va-accordion-item').props().header).to.equal(
-      testChapterTitle,
+    expect(wrapper.find('va-accordion-item').html()).to.contain(
+      `<h3 slot="headline">${testChapterTitle}</h3>`,
     );
 
     const titleDiv = wrapper.find('.form-review-panel-page-header');
@@ -718,8 +718,8 @@ describe('<ReviewCollapsibleChapter>', () => {
       />,
     );
 
-    expect(wrapper.find('va-accordion-item').props().header).to.equal(
-      testChapterTitleFromFunction,
+    expect(wrapper.find('va-accordion-item').html()).to.contain(
+      `<h3 slot="headline">${testChapterTitleFromFunction}</h3>`,
     );
 
     wrapper.unmount();


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > On the review & submit page the H3 accordion header level is not maintained when a header with `slot="headline"` is contained anywhere on the page, even inside a `va-alert`. So to get around this issue, this PR adds an h3 with `slot="headline"` inside the accordion
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > The `va-accordion-item` web component looks for the first header with a `slot="headline"`. So since we're adding one at the top of the review accordion, it will override all subsequent slots
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

Closes https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3281

## Testing done

- _Describe what the old behavior was prior to the change_
  > Accordion header level would change to match the header inside the `va-alert` - see original ticket
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated unit tests to check for header
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|  |  |
| ------ | ----- |
| Before (issue h5)  | <img width="1020" alt="issues for review accordion with h5 title, matching the va-alert inside the page" src="https://github.com/user-attachments/assets/d79353d9-cb1d-4408-9594-20347c6949a3"> |
| After (issue h3) | <img width="1031" alt="issues for review accordion now with h3 title" src="https://github.com/user-attachments/assets/1beb849a-3830-4acb-aa00-fc49a46c0d15"> |

## What areas of the site does it impact?

All form apps using the review & submit page

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
