### PR TITLE
Remove reg only option from Review Page in the Health Care Application

### DIFF
--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -293,6 +293,7 @@ const formConfig = {
           path: 'va-benefits/benefits-package',
           title: 'VA benefits package',
           depends: includeRegOnlyGuestQuestions,
+          CustomPageReview: () => null,
           uiSchema: benefitsPackage.uiSchema,
           schema: benefitsPackage.schema,
         },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

Since the registration only pathway question is only designed to affect the flow of the Health Care Application, we don't want to give the user the option to change that on the review page. This PR removes the option to modify that response on the review page.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#91898

## Testing done

- Navigate through the application as a guest user
- When the question of VA compensation is presented, select "Yes, for up to 40%..."
- Select the full medical package response to the service-connected care question
- Continue to the review page
- Expand the "VA benefits" collapsable and not the response is not present

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
| ![Screenshot 2024-09-17 at 14 56 33](https://github.com/user-attachments/assets/60f218a1-1245-4572-95d0-bb483857dbba) | ![Screenshot 2024-09-17 at 14 55 10](https://github.com/user-attachments/assets/5eea0b97-d385-44fc-80e6-c00b40161f1f) |

## Acceptance criteria

 - Flow-related questions are not able to be modified on the review page

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution