### PR TITLE
Update conditions for document upload page in the Health Care Application

### DIFF
--- a/src/applications/hca/tests/unit/utils/helpers/form-config.unit.spec.js
+++ b/src/applications/hca/tests/unit/utils/helpers/form-config.unit.spec.js
@@ -144,8 +144,14 @@ describe('hca form config helpers', () => {
   });
 
   context('when `dischargePapersRequired` executes', () => {
-    const getData = ({ inMvi = true, disabilityRating = 0 }) => ({
-      'view:totalDisabilityRating': disabilityRating,
+    const getData = ({
+      inMvi = true,
+      loggedIn = false,
+      compensation = 'none',
+    }) => ({
+      vaCompensationType: compensation,
+      'view:totalDisabilityRating': 0,
+      'view:isLoggedIn': loggedIn,
       'view:isUserInMvi': inMvi,
     });
 
@@ -160,7 +166,12 @@ describe('hca form config helpers', () => {
     });
 
     it('should return `false` when user is short form eligible', () => {
-      const formData = getData({ disabilityRating: 80 });
+      const formData = getData({ compensation: 'highDisability' });
+      expect(dischargePapersRequired(formData)).to.be.false;
+    });
+
+    it('should return `false` when user is authenticated', () => {
+      const formData = getData({ loggedIn: true });
       expect(dischargePapersRequired(formData)).to.be.false;
     });
   });

--- a/src/applications/hca/utils/helpers/form-config.js
+++ b/src/applications/hca/utils/helpers/form-config.js
@@ -68,11 +68,14 @@ export function notShortFormEligible(formData) {
  * Helper that determines if the form data contains values that require users
  * to upload their military discharge papers
  * @param {Object} formData - the current data object passed from the form
- * @returns {Boolean} - true if the user was not found in the MPI database
+ * @returns {Boolean} - true if the user is unauthenticated and was not found
+ * in the MPI database
  */
 export function dischargePapersRequired(formData) {
   const { 'view:isUserInMvi': isUserInMvi } = formData;
-  return notShortFormEligible(formData) && !isUserInMvi;
+  return (
+    isLoggedOut(formData) && notShortFormEligible(formData) && !isUserInMvi
+  );
 }
 
 /**


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR updates the conditions for the document upload page of the Health Care Application. Previously, there was no auth check and it was discovered Veterans were seeing this page unnecessarily when logged in. Authenticated users do not need to provide supporting documents related to their discharge.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#92917

## Testing done

- Log in and complete the application until you get to the military service section
- Complete the military service section--you should not be prompted to upload discharge documents

## Acceptance criteria

 - The file upload screen is displayed to the appropriate audience, as expected

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution