### PR TITLE
[91108] Form 21-22 intro page auth state fixups

### DIFF
--- a/src/applications/representative-appoint/components/SearchResult.jsx
+++ b/src/applications/representative-appoint/components/SearchResult.jsx
@@ -51,6 +51,12 @@ const SearchResult = ({
     const tempData = {
       ...formData,
       'view:selectedRepresentative': selectedRepResult,
+      // when a new representative is selected, we want to nil out the
+      //   selected organization to prevent weird states. For example,
+      //   we wouldn't want a user to select a representative, an organization,
+      //   go backwards to select an attorney, and then our state variables
+      //   say an attorney was selected with a non-null organization id
+      selectedAccreditedOrganizationId: null,
     };
 
     setFormData({

--- a/src/applications/representative-appoint/containers/IntroductionPage.jsx
+++ b/src/applications/representative-appoint/containers/IntroductionPage.jsx
@@ -4,11 +4,12 @@ import { focusElement } from 'platform/utilities/ui';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import repStatusLoader from 'applications/static-pages/representative-status';
-import { useStore } from 'react-redux';
+import { useStore, connect } from 'react-redux';
+import { isLoggedIn } from 'platform/user/selectors';
 import GetFormHelp from '../components/GetFormHelp';
 
 const IntroductionPage = props => {
-  const { route } = props;
+  const { route, loggedIn } = props;
   const { formConfig, pageList } = route;
   const store = useStore();
 
@@ -44,6 +45,21 @@ const IntroductionPage = props => {
           </div>
         </>
       </div>
+      {loggedIn && (
+        <>
+          <p />
+          <SaveInProgressIntro
+            alertTitle="Sign in with a verified account to request help from a VA accredited representative"
+            formConfig={formConfig}
+            headingLevel={2}
+            messages={formConfig.savedFormMessages}
+            prefillEnabled={formConfig.prefillEnabled}
+            pageList={pageList}
+            unauthStartText="Sign in or create an account"
+            startText="Fill out your form to request help"
+          />
+        </>
+      )}
       <h2>Follow these steps to pre-fill your form</h2>
       <div className="vads-u-padding-left--2">
         <va-process-list uswds>
@@ -118,6 +134,8 @@ const IntroductionPage = props => {
         prefillEnabled={formConfig.prefillEnabled}
         pageList={pageList}
         unauthStartText="Sign in or create an account"
+        startText="Fill out your form to request help"
+        verifiedPrefillAlert={<></>}
       />
       <p />
       <va-omb-info
@@ -140,8 +158,15 @@ IntroductionPage.propTypes = {
         appType: PropTypes.string,
       }),
     }),
+    loggedIn: PropTypes.bool,
     pageList: PropTypes.array,
   }),
 };
 
-export default IntroductionPage;
+function mapStateToProps(state) {
+  return {
+    loggedIn: isLoggedIn(state),
+  };
+}
+
+export default connect(mapStateToProps)(IntroductionPage);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This pr adds a copy change to the authenticated form in progress component, adds a second component above the process list, and hides the note on the lower component
- This pr also resets the selected organization id state when a new rep is selected on the prior page

## Related issue(s)

- [91108](https://github.com/department-of-veterans-affairs/va.gov-team/issues/91108)

## Testing done

- local testing with authed and unauthed users. There should be no changes for unauthed users.
- tested choosing new reps and org selection is resetting as expected

## Screenshots

### Authenticated User

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |![image](https://github.com/user-attachments/assets/062f149f-0b27-43b2-8864-c943f19b6bc0)|![image](https://github.com/user-attachments/assets/b1be94d6-cf65-4ed4-bbb6-21dd3d41022f)|
| Desktop |![image](https://github.com/user-attachments/assets/76988853-2f40-4a40-be9e-220ee999bb33)|![image](https://github.com/user-attachments/assets/022d625e-7af2-4754-b577-fdc6c3c9aa23)|

### Unauthenticated User

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |![image](https://github.com/user-attachments/assets/41ba152d-5b21-48f4-812d-13c5f9e4e2c7)|![image](https://github.com/user-attachments/assets/56b6233b-689c-48c8-9d43-7b2f1c6b87cd)|
| Desktop |![image](https://github.com/user-attachments/assets/2abb0fd6-0fbd-4ec9-8e25-2c4e24f65e5e)|![image](https://github.com/user-attachments/assets/29cad2d9-05f6-4431-babc-2eddca84cbc1)|

## What areas of the site does it impact?

Appoint a Rep Form 21-22

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user