### PR TITLE
Add support for radio patterns to the new confirmation page

### DIFF
--- a/src/applications/simple-forms/shared/components/confirmationPageViewHelpers.jsx
+++ b/src/applications/simple-forms/shared/components/confirmationPageViewHelpers.jsx
@@ -56,6 +56,15 @@ const fieldEntries = (key, uiSchema, data, schema, schemaFromState) => {
   const label = uiSchema['ui:title'] || schemaFromState?.properties[key].title;
 
   let refinedData = typeof data === 'object' ? data[key] : data;
+
+  // long term, make this a switch statement
+  if (
+    uiSchema['ui:widget'] === 'radio' &&
+    uiSchema['ui:options']?.labels?.[refinedData]
+  ) {
+    refinedData = uiSchema['ui:options'].labels[refinedData];
+  }
+
   const dataType = schema.properties[key].type;
 
   if (ConfirmationField) {


### PR DESCRIPTION
## Summary
This adds support to the new confirmation page for radio web component patterns and old radio definitions. I wanted to use a switch statement since this solution will scale to other unique patterns, like checkbox group, but apparently you can't commit a switch statement with less than 3 cases.

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#1658

## Screenshots
![image](https://github.com/user-attachments/assets/c881ea9a-a564-416d-9f90-0c2aad96665a)
