### PR TITLE
SC & SC prototype: Fix review header levels

### DIFF
--- a/src/applications/appeals/995/components/EvidenceSummary.jsx
+++ b/src/applications/appeals/995/components/EvidenceSummary.jsx
@@ -235,7 +235,7 @@ const EvidenceSummary = ({
         />
         <UploadContent list={otherEvidence} {...props} />
 
-        {content.addMoreLink}
+        {content.addMoreLink()}
 
         <div className="form-nav-buttons vads-u-margin-top--4">
           {onReviewPage && (

--- a/src/applications/appeals/995/components/PrimaryPhone.jsx
+++ b/src/applications/appeals/995/components/PrimaryPhone.jsx
@@ -80,7 +80,7 @@ export const PrimaryPhone = ({
         <VaRadio
           class="vads-u-margin-y--2"
           label={content.label}
-          label-header-level="3"
+          label-header-level={onReviewPage ? 4 : 3}
           hint="We may need to contact you if we have questions about your Supplemental Claim."
           error={hasError && errorMessages.missingPrimaryPhone}
           onVaValueChange={handlers.onSelection}

--- a/src/applications/appeals/995/content/evidenceSummary.jsx
+++ b/src/applications/appeals/995/content/evidenceSummary.jsx
@@ -5,6 +5,8 @@ import recordEvent from 'platform/monitoring/record-event';
 
 import { EVIDENCE_VA_REQUEST } from '../constants';
 
+import { isOnReviewPage } from '../../shared/utils/helpers';
+
 const recordActionLinkClick = () => {
   recordEvent({
     event: 'cta-action-link-click',
@@ -30,20 +32,23 @@ export const content = {
 
   otherTitle: 'You uploaded these documents:',
 
-  addMoreLink: (
-    <>
-      <h4 className="sr-only">Are you missing evidence?</h4>
-      <p>
-        <Link
-          to={`/${EVIDENCE_VA_REQUEST}`}
-          className="vads-c-action-link--green"
-          onClick={recordActionLinkClick}
-        >
-          Add more evidence
-        </Link>
-      </p>
-    </>
-  ),
+  addMoreLink: () => {
+    const Header = isOnReviewPage() ? 'h5' : 'h4';
+    return (
+      <>
+        <Header className="sr-only">Are you missing evidence?</Header>
+        <p>
+          <Link
+            to={`/${EVIDENCE_VA_REQUEST}`}
+            className="vads-c-action-link--green"
+            onClick={recordActionLinkClick}
+          >
+            Add more evidence
+          </Link>
+        </p>
+      </>
+    );
+  },
 
   // remove messages
   removeEvidence: {

--- a/src/applications/appeals/995/tests/content/evidenceSummary.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/content/evidenceSummary.unit.spec.jsx
@@ -8,7 +8,9 @@ describe('evidenceSummary', () => {
   describe('addMoreLink', () => {
     it('should render', () => {
       global.window.dataLayer = [];
-      const { getByText, getByRole } = render(<div>{content.addMoreLink}</div>);
+      const { getByText, getByRole } = render(
+        <div>{content.addMoreLink()}</div>,
+      );
 
       fireEvent.click(getByText('Add more evidence'));
 

--- a/src/applications/appeals/shared/utils/helpers.js
+++ b/src/applications/appeals/shared/utils/helpers.js
@@ -32,3 +32,6 @@ export const isOutsideForm = pathname => {
   const currentPath = (pathname || '').replace(trailingSlashRegex, '');
   return outsidePaths.some(path => currentPath.endsWith(path));
 };
+
+export const isOnReviewPage = () =>
+  window.location.pathname.endsWith('/review-and-submit');

--- a/src/applications/appeals/testing/sc/components/EvidenceSummary.jsx
+++ b/src/applications/appeals/testing/sc/components/EvidenceSummary.jsx
@@ -235,7 +235,7 @@ const EvidenceSummary = ({
         />
         <UploadContent list={otherEvidence} {...props} />
 
-        {content.addMoreLink}
+        {content.addMoreLink()}
 
         <div className="form-nav-buttons vads-u-margin-top--4">
           {onReviewPage && (

--- a/src/applications/appeals/testing/sc/components/PrimaryPhone.jsx
+++ b/src/applications/appeals/testing/sc/components/PrimaryPhone.jsx
@@ -80,7 +80,7 @@ export const PrimaryPhone = ({
         <VaRadio
           class="vads-u-margin-y--2"
           label={content.label}
-          label-header-level="3"
+          label-header-level={onReviewPage ? 4 : 3}
           hint="We may need to contact you if we have questions about your Supplemental Claim."
           error={hasError && errorMessages.missingPrimaryPhone}
           onVaValueChange={handlers.onSelection}

--- a/src/applications/appeals/testing/sc/content/evidenceSummary.jsx
+++ b/src/applications/appeals/testing/sc/content/evidenceSummary.jsx
@@ -5,6 +5,8 @@ import recordEvent from 'platform/monitoring/record-event';
 
 import { EVIDENCE_VA_REQUEST } from '../constants';
 
+import { isOnReviewPage } from '../../../shared/utils/helpers';
+
 const recordActionLinkClick = () => {
   recordEvent({
     event: 'cta-action-link-click',
@@ -31,20 +33,23 @@ export const content = {
 
   otherTitle: 'You uploaded these documents:',
 
-  addMoreLink: (
-    <>
-      <h4 className="sr-only">Are you missing evidence?</h4>
-      <p>
-        <Link
-          to={`/${EVIDENCE_VA_REQUEST}`}
-          className="vads-c-action-link--green"
-          onClick={recordActionLinkClick}
-        >
-          Add more evidence
-        </Link>
-      </p>
-    </>
-  ),
+  addMoreLink: () => {
+    const Header = isOnReviewPage() ? 'h5' : 'h4';
+    return (
+      <>
+        <Header className="sr-only">Are you missing evidence?</Header>
+        <p>
+          <Link
+            to={`/${EVIDENCE_VA_REQUEST}`}
+            className="vads-c-action-link--green"
+            onClick={recordActionLinkClick}
+          >
+            Add more evidence
+          </Link>
+        </p>
+      </>
+    );
+  },
 
   // remove messages
   removeEvidence: {

--- a/src/applications/appeals/testing/sc/content/livingSituation.jsx
+++ b/src/applications/appeals/testing/sc/content/livingSituation.jsx
@@ -91,7 +91,7 @@ export const domesticViolenceInfo = (
 /**
  * Other housing risks page
  */
-export const OtherHousingRisksTitle = (
+export const OtherHousingRisksTitle = () => (
   <>
     <h3>Other housing risks</h3>
     <p>

--- a/src/applications/appeals/testing/sc/pages/housingRisk.js
+++ b/src/applications/appeals/testing/sc/pages/housingRisk.js
@@ -19,7 +19,7 @@ export default {
       },
       updateUiSchema: () => ({
         'ui:options': {
-          labelHeaderLevel: isOnReviewPage ? 4 : 3,
+          labelHeaderLevel: isOnReviewPage() ? 4 : 3,
         },
       }),
     }),

--- a/src/applications/appeals/testing/sc/pages/housingRisk.js
+++ b/src/applications/appeals/testing/sc/pages/housingRisk.js
@@ -5,6 +5,8 @@ import {
 
 import { housingRiskTitle } from '../content/livingSituation';
 
+import { isOnReviewPage } from '../../../shared/utils/helpers';
+
 export default {
   uiSchema: {
     housingRisk: yesNoUI({
@@ -15,6 +17,11 @@ export default {
         Y: 'Yes',
         N: 'No',
       },
+      updateUiSchema: () => ({
+        'ui:options': {
+          labelHeaderLevel: isOnReviewPage ? 4 : 3,
+        },
+      }),
     }),
   },
   schema: {

--- a/src/applications/appeals/testing/sc/pages/livingSituation.js
+++ b/src/applications/appeals/testing/sc/pages/livingSituation.js
@@ -27,7 +27,7 @@ export default {
         labels: livingSituationChoices,
         updateUiSchema: () => ({
           'ui:options': {
-            labelHeaderLevel: isOnReviewPage ? 4 : 3,
+            labelHeaderLevel: isOnReviewPage() ? 4 : 3,
           },
         }),
       }),

--- a/src/applications/appeals/testing/sc/pages/livingSituation.js
+++ b/src/applications/appeals/testing/sc/pages/livingSituation.js
@@ -12,6 +12,8 @@ import {
 } from '../content/livingSituation';
 import { livingSituationNone } from '../validations/livingSituation';
 
+import { isOnReviewPage } from '../../../shared/utils/helpers';
+
 const labels = Object.keys(livingSituationChoices);
 
 export default {
@@ -23,6 +25,11 @@ export default {
         required: false,
         labelHeaderLevel: '3',
         labels: livingSituationChoices,
+        updateUiSchema: () => ({
+          'ui:options': {
+            labelHeaderLevel: isOnReviewPage ? 4 : 3,
+          },
+        }),
       }),
       'ui:validations': [livingSituationNone],
       'ui:errorMessages': {

--- a/src/applications/appeals/testing/sc/pages/optionForMst.js
+++ b/src/applications/appeals/testing/sc/pages/optionForMst.js
@@ -6,6 +6,8 @@ import {
 import { optionForMstTitle, supportInfo } from '../content/optionForMst';
 import { MST_OPTION } from '../constants';
 
+import { isOnReviewPage } from '../../../shared/utils/helpers';
+
 export default {
   uiSchema: {
     [MST_OPTION]: yesNoUI({
@@ -17,6 +19,11 @@ export default {
         N: 'No',
       },
       required: false,
+      updateUiSchema: () => ({
+        'ui:options': {
+          labelHeaderLevel: isOnReviewPage ? 4 : 3,
+        },
+      }),
     }),
 
     'view:supportInfo': {

--- a/src/applications/appeals/testing/sc/pages/optionForMst.js
+++ b/src/applications/appeals/testing/sc/pages/optionForMst.js
@@ -21,7 +21,7 @@ export default {
       required: false,
       updateUiSchema: () => ({
         'ui:options': {
-          labelHeaderLevel: isOnReviewPage ? 4 : 3,
+          labelHeaderLevel: isOnReviewPage() ? 4 : 3,
         },
       }),
     }),

--- a/src/applications/appeals/testing/sc/pages/optionIndicator.js
+++ b/src/applications/appeals/testing/sc/pages/optionIndicator.js
@@ -10,6 +10,8 @@ import {
   optionIndicatorChoices,
 } from '../content/optionIndicator';
 
+import { isOnReviewPage } from '../../../shared/utils/helpers';
+
 export default {
   uiSchema: {
     'view:vhaContent': {
@@ -22,6 +24,11 @@ export default {
       labelHeaderLevel: '3',
       labels: optionIndicatorChoices,
       required: false,
+      updateUiSchema: () => ({
+        'ui:options': {
+          labelHeaderLevel: isOnReviewPage ? 4 : 3,
+        },
+      }),
     }),
   },
   schema: {

--- a/src/applications/appeals/testing/sc/pages/optionIndicator.js
+++ b/src/applications/appeals/testing/sc/pages/optionIndicator.js
@@ -26,7 +26,7 @@ export default {
       required: false,
       updateUiSchema: () => ({
         'ui:options': {
-          labelHeaderLevel: isOnReviewPage ? 4 : 3,
+          labelHeaderLevel: isOnReviewPage() ? 4 : 3,
         },
       }),
     }),

--- a/src/applications/appeals/testing/sc/pages/otherHousingRisk.js
+++ b/src/applications/appeals/testing/sc/pages/otherHousingRisk.js
@@ -10,8 +10,12 @@ import { OTHER_HOUSING_RISK_MAX } from '../constants';
 
 export default {
   uiSchema: {
-    'view:otherHousingRisk': {
-      'ui:description': OtherHousingRisksTitle,
+    otherHousingRiskTitle: {
+      'ui:title': OtherHousingRisksTitle,
+      'ui:options': {
+        forceDivWrapper: true,
+        showFieldLabel: false,
+      },
     },
     otherHousingRisks: textareaUI({
       title: otherHousingRisksLabel,
@@ -28,7 +32,7 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      'view:otherHousingRisk': {
+      otherHousingRiskTitle: {
         type: 'object',
         properties: {},
       },


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > When editing pages on the review & submit page, the page headers need to increase their level by one to match the expected header level pattern. This PR focused on fixing pages that didn't change the header levels in the Supplemental Claim and Supplemental Claim prototype.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/90568

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         |  |
| ------- | ----- |
| Primary phone | (view) <img width="803" alt="primary-phone-view" src="https://github.com/user-attachments/assets/db60ec3e-60da-4283-a9af-75e4f8e9a565"> (edit before) <img width="790" alt="primary-phone-edit-before" src="https://github.com/user-attachments/assets/4a75b4be-7d47-4b76-94af-0baffd54df1f"> (edit after) <img width="795" alt="primary-phone-edit-after" src="https://github.com/user-attachments/assets/4161a828-f2f7-43ec-aa18-725de63801eb"> |
| Housing risk | (view) <img width="757" alt="housing-risk-view" src="https://github.com/user-attachments/assets/f11a7d09-e201-4ce3-9875-4298d25cd985"> (edit before) <img width="776" alt="housing-risk-edit-before" src="https://github.com/user-attachments/assets/9bc340f8-12e8-4294-9c80-4d3213a5dcd1"> (edit after) <img width="764" alt="housing-risk-edit-after" src="https://github.com/user-attachments/assets/8c6e3f41-6860-497a-a55e-8209f28ced45"> |
| Living situation | (view) <img width="779" alt="living-situation-view" src="https://github.com/user-attachments/assets/5dff4ec8-d202-4e18-90d1-bf4f547cde63"> (edit before) <img width="789" alt="living-situation-edit-before" src="https://github.com/user-attachments/assets/940bd30b-151a-4f27-8f6c-64e5aba5b5ae"> (edit after) <img width="789" alt="living-situation-edit-after" src="https://github.com/user-attachments/assets/221b3cd8-7fd7-4724-bbb0-3ce521ab9a25"> |
| Option for MST | (view) <img width="756" alt="option-for-mst-view" src="https://github.com/user-attachments/assets/50677522-a0c1-472d-80b5-2613fc24b3ad"> (edit before) <img width="787" alt="option-for-mst-edit-before" src="https://github.com/user-attachments/assets/dbf046d5-7740-4250-8b32-f3693d8a9723"> (edit after) <img width="755" alt="option-for-mst-edit-after" src="https://github.com/user-attachments/assets/daf9ef15-a5fd-4f35-9e3e-240b4b8594f3"> |
| Option indicator | (view) <img width="746" alt="option-indicator-view" src="https://github.com/user-attachments/assets/64c22c3d-f702-4e73-b6e8-d098b6b8b4c3"> (edit before) <img width="790" alt="option-indicator-edit-before" src="https://github.com/user-attachments/assets/5e2a9a05-75ad-4be9-b6ba-bdc1e6d390c1"> (edit after) <img width="759" alt="option-indicator-edit-after" src="https://github.com/user-attachments/assets/f3ceba2d-5886-4b25-99b0-992a52475f1d"> |
| Evidence summary (hidden header) | (view - no header) <img width="746" alt="evidence-summary-view" src="https://github.com/user-attachments/assets/6235a079-2b79-407e-b8b2-8aa89ea9f876"> (edit before) <img width="649" alt="evidence-summary-edit-before" src="https://github.com/user-attachments/assets/17ce8577-1648-45eb-840e-4a07a64cc634"> (edit after) <img width="645" alt="evidence-summary-edit-after" src="https://github.com/user-attachments/assets/fb6ef2c3-6028-483d-87e5-de97a165d5dc"> |

## What areas of the site does it impact?

Supplemental Claim & Supplemental Claim prototype

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
