### PR TITLE
Fixed MHV sign in widget not displaying custom content

### DIFF
--- a/src/applications/static-pages/mhv-signin-cta/README.md
+++ b/src/applications/static-pages/mhv-signin-cta/README.md
@@ -1,0 +1,41 @@
+This MHV verify sign-in call-to-action widget shows an alert if the user is unauthenticated or unverified, or otherwise will show any provided content.
+
+## Widget Features
+- Displays an alert instead of content if the user is not signed in
+- Displays an alert instead of content if the user is not verified
+- Displays optional custom content if no alert is displayed
+  - Custom content is defined under a child element with the `static-widget-content` class (see sample in Template section below). This allows the static content maintainers to update or change the content as needed. 
+  - If there is no content specified then simply nothing is displayed. This allows this widget to be used with or without content. 
+  - For security, custom content HTML is sanitized before being displayed.
+
+## Template for Static Pages
+The template follows the already stablished [template defined in vets-website](https://github.com/department-of-veterans-affairs/vets-website/blob/cb8e27a144d78ab2b6f7d378468b6d14da4fcb5e/src/platform/landing-pages/dev-template.ejs#L195) and already used in other static pages like the [secure messaging static page](https://staging.va.gov/health-care/secure-messaging/). Here is a specific template example to use this new widget:
+```html
+<div data-template="paragraphs/react_widget" data-entity-id="13348" data-widget-type="mhv-signin-cta"
+  data-widget-timeout="20" data-service-description="order medical supplies">
+  <div class="loading-indicator-container">
+    <div aria-label="Loading..." aria-valuetext="Loading your application..." class="loading-indicator" role="progressbar">
+    </div>
+    <span class="loading-indicator-message loading-indicator-message--normal">      
+    </span>
+    <span class="loading-indicator-message loading-indicator-message--slow vads-u-display--none" aria-hidden="true">
+          Sorry, this is taking longer than expected.
+    </span>
+  </div>
+  <span class="static-widget-content vads-u-display--none" aria-hidden="true">
+    <p>
+      <a class="vads-c-action-link--green" href="https://staging.va.gov/health-care/order-hearing-aid-or-CPAP-supplies-form" hreflang="en">
+        Order hearing aid and CPAP supplies online</a>
+    </p>
+  </span>
+  <div class="usa-alert usa-alert-error sip-application-error vads-u-display--none" aria-hidden="true">
+    <div class="usa-alert-body">
+      <strong>We&#x2019;re sorry. Something went wrong on our end.</strong><br>Please try refreshing your browser.
+    </div>
+  </div>
+</div>
+```
+
+- Note the use of `data-widget-type="mhv-signin-cta"` on the first line. All the HTML content under the first div is replaced by the React component which is the widget.
+- `data-service-description` is an optional service description string to be added to the headline of the alerts, so they read more specific to the intended call to action
+- Also note the content under the span with the class `static-widget-content`. This is the optional content to be displayed if no alert is shown. This content can be zero or more HTML elements.

--- a/src/applications/static-pages/mhv-signin-cta/index.js
+++ b/src/applications/static-pages/mhv-signin-cta/index.js
@@ -47,7 +47,9 @@ export const MhvSigninCallToAction = ({
   return (
     <div
       // eslint-disable-next-line react/no-danger
-      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(noAlertContent) }}
+      dangerouslySetInnerHTML={{
+        __html: DOMPurify.sanitize(noAlertContent.innerHTML),
+      }}
     />
   );
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Fixed MHV sign in widget not displaying custom content. The content is displayed if there are no alerts. The code takes the specified HTML content as part of a span with the class names `static-widget-content vads-u-display--none` and renders it. The problem was that the span will not be displayed due to the `vads-u-display--none` class. This change just grabs the `innerHtml` from that span instead of the span itself.

Also added a README explaining the usage of this widget.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/89275

## Testing done
- Existing unit tests
- Manual testing of the widget replacement
  1. Run a watch on content-build. Make sure to use the cached-assets to build the repo. This process can take hours.
  2. Edit the file build/localhost/health-care/order-medical-supplies/index.html in your local content-build repo. Replace the `Order hearing aid and CPAP supplies online` link with the template in the README file. Save the file. DO NOT RESTART the content-build watch.
  4. Build this branch in vets-website with yarn build --env --entry=static-pages.
  5. Open http://localhost:3002/health-care/order-medical-supplies/ and verify the widget is shown.

## Screenshots
N/A

## What areas of the site does it impact?
N/A

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

