### PR TITLE
VAGOV-TEAM-90571: Render Identification Information pattern

### DIFF
--- a/src/applications/form-renderer/_config/formConfig.js
+++ b/src/applications/form-renderer/_config/formConfig.js
@@ -138,6 +138,15 @@ export const normalizedForm = {
         includeDateOfBirth: false,
       },
     },
+    {
+      id: 160592,
+      chapterTitle: 'Generated Identification Information',
+      type: 'digital_form_identification_info',
+      pageTitle: 'Identification Information',
+      additionalFields: {
+        includeServiceNumber: false,
+      },
+    },
   ],
 };
 
@@ -163,6 +172,15 @@ export const employmentQuestionnaire = {
       pageTitle: 'Name and Date of Birth',
       additionalFields: {
         includeDateOfBirth: true,
+      },
+    },
+    {
+      id: 160594,
+      chapterTitle: 'Identification information',
+      type: 'digital_form_identification_info',
+      pageTitle: 'Identification Information',
+      additionalFields: {
+        includeServiceNumber: true,
       },
     },
   ],

--- a/src/applications/form-renderer/_config/formConfig.js
+++ b/src/applications/form-renderer/_config/formConfig.js
@@ -175,7 +175,7 @@ export const employmentQuestionnaire = {
       },
     },
     {
-      id: 160594,
+      id: 20002,
       chapterTitle: 'Identification information',
       type: 'digital_form_identification_info',
       pageTitle: 'Identification Information',

--- a/src/applications/form-renderer/tests/unit/utils/formConfig.unit.spec.js
+++ b/src/applications/form-renderer/tests/unit/utils/formConfig.unit.spec.js
@@ -6,7 +6,10 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import * as IntroductionPage from 'applications/form-renderer/containers/IntroductionPage';
 import { render } from '@testing-library/react';
-import { normalizedForm } from '../../../_config/formConfig';
+import {
+  employmentQuestionnaire,
+  normalizedForm,
+} from '../../../_config/formConfig';
 import { createFormConfig } from '../../../utils/formConfig';
 import manifest from '../../../manifest.json';
 
@@ -46,7 +49,9 @@ describe('createFormConfig', () => {
     expect(formConfig.title).to.eq('Form with Two Steps');
     expect(formConfig.formId).to.eq('2121212');
     expect(formConfig.subTitle).to.eq('VA Form 2121212');
-    expect(Object.keys(formConfig.chapters).length).to.eq(2);
+    expect(Object.keys(formConfig.chapters).length).to.eq(
+      normalizedForm.chapters.length,
+    );
   });
 
   it('properly formats each chapter', () => {
@@ -100,6 +105,43 @@ describe('createFormConfig', () => {
       it('does not contain dateOfBirth', () => {
         expect(nameOnly.schema.properties.dateOfBirth).to.eq(undefined);
         expect(nameOnly.uiSchema.dateOfBirth).to.eq(undefined);
+      });
+    });
+  });
+
+  context('with Identification Information pattern', () => {
+    let serviceNumberIncluded;
+    let vetIdOnly;
+
+    beforeEach(() => {
+      serviceNumberIncluded = createFormConfig(employmentQuestionnaire)
+        .chapters[20002].pages[20002];
+
+      vetIdOnly = formConfig.chapters[160592].pages[160592];
+    });
+
+    it('contains veteranId', () => {
+      expect(serviceNumberIncluded.schema.properties.veteranId).to.not.eq(
+        undefined,
+      );
+      expect(serviceNumberIncluded.uiSchema.veteranId).to.not.eq(undefined);
+    });
+
+    context('when includeServiceNumber is true', () => {
+      it('includes serviceNumber', () => {
+        expect(serviceNumberIncluded.schema.properties.serviceNumber).to.not.eq(
+          undefined,
+        );
+        expect(serviceNumberIncluded.uiSchema.serviceNumber).to.not.eq(
+          undefined,
+        );
+      });
+    });
+
+    context('when includeServiceNumber is false', () => {
+      it('does not include serviceNumber', () => {
+        expect(vetIdOnly.schema.properties.serviceNumber).to.eq(undefined);
+        expect(vetIdOnly.uiSchema.serviceNumber).to.eq(undefined);
       });
     });
   });

--- a/src/applications/form-renderer/utils/formConfig.js
+++ b/src/applications/form-renderer/utils/formConfig.js
@@ -4,29 +4,51 @@ import {
   dateOfBirthUI,
   fullNameSchema,
   fullNameUI,
+  serviceNumberSchema,
+  serviceNumberUI,
+  ssnOrVaFileNumberSchema,
+  ssnOrVaFileNumberUI,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
 import manifest from '../manifest.json';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 
-const selectSchemas = ({ pageTitle, additionalFields }) => {
-  const schemas = {
-    schema: {
+const selectSchemas = ({ pageTitle, type, additionalFields }) => {
+  const schemas = {};
+
+  if (type === 'digital_form_name_and_date_of_bi') {
+    schemas.schema = {
       type: 'object',
       properties: {
         fullName: fullNameSchema,
       },
-    },
-    uiSchema: {
+    };
+    schemas.uiSchema = {
       ...titleUI(pageTitle),
       fullName: fullNameUI(),
-    },
-  };
+    };
 
-  if (additionalFields.includeDateOfBirth) {
-    schemas.schema.properties.dateOfBirth = dateOfBirthSchema;
-    schemas.uiSchema.dateOfBirth = dateOfBirthUI();
+    if (additionalFields.includeDateOfBirth) {
+      schemas.schema.properties.dateOfBirth = dateOfBirthSchema;
+      schemas.uiSchema.dateOfBirth = dateOfBirthUI();
+    }
+  } else if (type === 'digital_form_identification_info') {
+    schemas.schema = {
+      type: 'object',
+      properties: {
+        veteranId: ssnOrVaFileNumberSchema,
+      },
+    };
+    schemas.uiSchema = {
+      ...titleUI(pageTitle),
+      veteranId: ssnOrVaFileNumberUI(),
+    };
+
+    if (additionalFields.includeServiceNumber) {
+      schemas.schema.properties.serviceNumber = serviceNumberSchema;
+      schemas.uiSchema.serviceNumber = serviceNumberUI();
+    }
   }
 
   return schemas;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to Summary and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- Renders the [Identification Information pattern](https://design.va.gov/patterns/ask-users-for/social-security-number) from normalized data created by department-of-veterans-affairs/content-build#2274.

## Related issue(s)

- department-of-veterans-affairs/va.gov-team#90571

## Testing done

- New unit tests for the `createFormConfig` function
- Local testing using mock data

## Screenshots

The Identification Information pattern rendered from normalized data:
<img width="695" alt="Screenshot 2024-09-19 at 3 47 12 PM" src="https://github.com/user-attachments/assets/183d9b54-f067-455e-abc7-deca69a87a28">

## What areas of the site does it impact?

This PR only touches the `form-renderer` application, which is not yet live.
## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

I'm starting to think about extracting the logic to render the different schemas into its own file, since that code will only continue to grow. Not quite ready to pull the trigger on it yet though, and I'm open to feedback on code structure that will help scalability.