### PR TITLE
[10-10CG] Use CG facilities endpoint instead of hca endpoint

### DIFF
--- a/src/applications/caregivers/actions/fetchFacilities.js
+++ b/src/applications/caregivers/actions/fetchFacilities.js
@@ -18,7 +18,7 @@ const formatQueryParams = ({
   const formatFacilityIdParams = () => {
     let facilityIdParams = '';
     if (facilityIds.length > 0) {
-      facilityIdParams = facilityIds.map(id => `facilityIds[]=${id}`).join('&');
+      facilityIdParams = `facilityIds=${facilityIds.join(',')}`;
     }
 
     return facilityIdParams;

--- a/src/applications/caregivers/actions/fetchFacilities.js
+++ b/src/applications/caregivers/actions/fetchFacilities.js
@@ -67,7 +67,7 @@ export const fetchFacilities = async ({
 
   return fetchRequest
     .then(response => {
-      if (!response.data.length) {
+      if (!response?.data?.length) {
         return {
           type: 'NO_SEARCH_RESULTS',
           errorMessage: content['error--no-results-found'],

--- a/src/applications/caregivers/actions/fetchFacilities.js
+++ b/src/applications/caregivers/actions/fetchFacilities.js
@@ -91,6 +91,7 @@ export const fetchFacilities = async ({
         // Return a new facility object with the updated address
         return {
           ...attributes,
+          id: facility.id,
           address: {
             physical: newPhysicalAddress,
           },

--- a/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
+++ b/src/applications/caregivers/components/FormFields/FacilitySearch.jsx
@@ -19,13 +19,20 @@ const FacilitySearch = props => {
   const [searchInputError, setSearchInputError] = useState(null);
   const [facilitiesListError, setFacilitiesListError] = useState(null);
   const [facilities, setFacilities] = useState([]);
-  const [pages, setPages] = useState(1);
+  const [pagination, setPagination] = useState({
+    currentPage: 0,
+    totalEntries: 0,
+  });
   const dispatch = useDispatch();
   const [coordinates, setCoordinates] = useState({ lat: '', long: '' });
   const radius = 500;
 
   const hasFacilities = () => {
     return facilities?.length > 0;
+  };
+
+  const hasMoreFacilities = () => {
+    return facilities?.length < pagination.totalEntries;
   };
 
   const isReviewPage = () => {
@@ -101,7 +108,7 @@ const FacilitySearch = props => {
           return null;
         }
 
-        return parentFacilityResponse[0];
+        return parentFacilityResponse.facilities[0];
       };
 
       const setSelectedFacilities = async facilityId => {
@@ -178,10 +185,10 @@ const FacilitySearch = props => {
       return;
     }
 
-    setFacilities(facilitiesResponse);
+    setFacilities(facilitiesResponse.facilities);
+    setPagination(facilitiesResponse.meta.pagination);
     setSubmittedQuery(query);
     setLoading(false);
-    setPages(1);
     focusElement('#caregiver_facility_results');
   };
 
@@ -190,7 +197,7 @@ const FacilitySearch = props => {
     setLoadingMoreFacilities(true);
     const facilitiesResponse = await fetchFacilities({
       ...coordinates,
-      page: pages + 1,
+      page: pagination.currentPage + 1,
       radius,
       perPage: 5,
     });
@@ -201,10 +208,10 @@ const FacilitySearch = props => {
       return;
     }
 
-    setFacilities([...facilities, ...facilitiesResponse]);
+    setFacilities([...facilities, ...facilitiesResponse.facilities]);
+    setPagination(facilitiesResponse.meta.pagination);
     setSubmittedQuery(query);
     setLoadingMoreFacilities(false);
-    setPages(pages + 1);
   };
 
   const loader = () => {
@@ -226,13 +233,15 @@ const FacilitySearch = props => {
         <>
           <FacilityList {...facilityListProps} />
           {loadingMoreFacilities && loader()}
-          <button
-            type="button"
-            className="va-button-link"
-            onClick={showMoreFacilities}
-          >
-            Load more facilities
-          </button>
+          {hasMoreFacilities() && (
+            <button
+              type="button"
+              className="va-button-link"
+              onClick={showMoreFacilities}
+            >
+              Load more facilities
+            </button>
+          )}
         </>
       );
     }

--- a/src/applications/caregivers/tests/e2e/fixtures/mocks/mock-facilities.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/mocks/mock-facilities.json
@@ -1,41 +1,31 @@
-[
-  {
-      "access": null,
-      "activeStatus": null,
-      "address": {
-          "physical": {
-              "zip": "43219-2219",
-              "city": "Columbus",
-              "state": "OH",
-              "address1": "2720 Airport Drive",
-              "address3": "Suite 100"
-          }
-      },
-      "classification": "Other Outpatient Services (OOS)",
-      "detailedServices": null,
-      "distance": 7.14,
-      "facilityType": "va_health_facility",
-      "facilityTypePrefix": "vha",
-      "feedback": null,
-      "hours": {
-          "monday": "800AM-430PM",
-          "tuesday": "800AM-430PM",
-          "wednesday": "800AM-430PM",
-          "thursday": "800AM-430PM",
-          "friday": "800AM-430PM",
-          "saturday": "Closed",
-          "sunday": "Closed"
-      },
+{
+  "currentPage": 1,
+  "data": [
+    {
       "id": "vha_757QC",
-      "lat": 39.996592,
-      "long": -82.93310921,
-      "mobile": false,
-      "name": "Columbus VA Clinic",
-      "operatingStatus": {
-          "code": "NORMAL"
-      },
-      "operationalHoursSpecialInstructions": null,
-      "phone": {
+      "type": "va_facilities",
+      "attributes": {
+        "name": "Columbus VA Clinic",
+        "facilityType": "va_health_facility",
+        "classification": "Other Outpatient Services (OOS)",
+        "parent": {
+          "id": "vha_757",
+          "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757"
+        },
+        "website": "https://www.va.gov/central-ohio-health-care/locations/columbus-va-clinic/",
+        "lat": 39.996592,
+        "long": -82.93310921,
+        "timeZone": "America/New_York",
+        "address": {
+          "physical": {
+            "zip": "43219-2219",
+            "city": "Columbus",
+            "state": "OH",
+            "address1": "2720 Airport Drive",
+            "address3": "Suite 100"
+          }
+        },
+        "phone": {
           "fax": "614-388-7565",
           "main": "614-388-7650",
           "pharmacy": "614-257-5230",
@@ -43,469 +33,8 @@
           "patientAdvocate": "614-257-5449",
           "mentalHealthClinic": "614-257-5631",
           "enrollmentCoordinator": "614-257-5628"
-      },
-      "services": {
-          "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757QC/services",
-          "lastUpdated": "2024-09-03"
-      },
-      "type": "va_facilities",
-      "uniqueId": "757QC",
-      "visn": "10",
-      "website": "https://www.va.gov/central-ohio-health-care/locations/columbus-va-clinic/",
-      "parent": {
-          "id": "vha_757",
-          "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757"
-      }
-  },
-  {
-      "access": null,
-      "activeStatus": null,
-      "address": {
-          "physical": {
-              "zip": "43219-1834",
-              "city": "Columbus",
-              "state": "OH",
-              "address1": "420 North James Road"
-          }
-      },
-      "classification": "Health Care Center (HCC)",
-      "detailedServices": null,
-      "distance": 8.44,
-      "facilityType": "va_health_facility",
-      "facilityTypePrefix": "vha",
-      "feedback": {
-          "health": {
-              "primaryCareUrgent": 0.800000011920929,
-              "primaryCareRoutine": 0.8700000047683716,
-              "specialtyCareUrgent": 0.7599999904632568,
-              "specialtyCareRoutine": 0.8399999737739563
-          },
-          "effectiveDate": "2024-02-08"
-      },
-      "hours": {
-          "monday": "730AM-600PM",
-          "tuesday": "730AM-600PM",
-          "wednesday": "730AM-600PM",
-          "thursday": "730AM-600PM",
-          "friday": "730AM-600PM",
-          "saturday": "800AM-400PM",
-          "sunday": "800AM-400PM"
-      },
-      "id": "vha_757",
-      "lat": 39.98048191,
-      "long": -82.91230307,
-      "mobile": false,
-      "name": "Chalmers P. Wylie Veterans Outpatient Clinic",
-      "operatingStatus": {
-          "code": "NORMAL"
-      },
-      "operationalHoursSpecialInstructions": [
-          "Normal business hours are Monday through Friday, 8:00 a.m. to 4:30 p.m."
-      ],
-      "phone": {
-          "fax": "614-257-5460",
-          "main": "614-257-5200",
-          "pharmacy": "614-257-5230",
-          "afterHours": "614-257-5512",
-          "patientAdvocate": "614-257-5290",
-          "mentalHealthClinic": "614-257-5631",
-          "enrollmentCoordinator": "614-257-5628"
-      },
-      "services": {
-          "health": [
-              {
-                  "name": "Allergy, asthma and immunology",
-                  "serviceId": "allergy",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/allergy"
-              },
-              {
-                  "name": "Audiology and speech",
-                  "serviceId": "audiology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/audiology"
-              },
-              {
-                  "name": "Cardiology",
-                  "serviceId": "cardiology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/cardiology"
-              },
-              {
-                  "name": "CaregiverSupport",
-                  "serviceId": "caregiverSupport",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/caregiverSupport"
-              },
-              {
-                  "name": "COVID-19 vaccines",
-                  "serviceId": "covid19Vaccine",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/covid19Vaccine"
-              },
-              {
-                  "name": "Dental/oral surgery",
-                  "serviceId": "dental",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/dental"
-              },
-              {
-                  "name": "Dermatology",
-                  "serviceId": "dermatology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/dermatology"
-              },
-              {
-                  "name": "Diabetic care",
-                  "serviceId": "diabetic",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/diabetic"
-              },
-              {
-                  "name": "Endocrinology",
-                  "serviceId": "endocrinology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/endocrinology"
-              },
-              {
-                  "name": "Gastroenterology",
-                  "serviceId": "gastroenterology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/gastroenterology"
-              },
-              {
-                  "name": "Geriatrics",
-                  "serviceId": "geriatrics",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/geriatrics"
-              },
-              {
-                  "name": "Gynecology",
-                  "serviceId": "gynecology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/gynecology"
-              },
-              {
-                  "name": "Hematology/oncology",
-                  "serviceId": "hematology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/hematology"
-              },
-              {
-                  "name": "Homeless Veteran care",
-                  "serviceId": "homeless",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/homeless"
-              },
-              {
-                  "name": "Palliative and hospice care",
-                  "serviceId": "hospice",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/hospice"
-              },
-              {
-                  "name": "Laboratory and pathology",
-                  "serviceId": "laboratory",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/laboratory"
-              },
-              {
-                  "name": "LGBTQ+ Veteran care",
-                  "serviceId": "lgbtq",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/lgbtq"
-              },
-              {
-                  "name": "Minority Veteran care",
-                  "serviceId": "minorityCare",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/minorityCare"
-              },
-              {
-                  "name": "Nephrology",
-                  "serviceId": "nephrology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/nephrology"
-              },
-              {
-                  "name": "Neurology",
-                  "serviceId": "neurology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/neurology"
-              },
-              {
-                  "name": "Nutrition, food, and dietary care",
-                  "serviceId": "nutrition",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/nutrition"
-              },
-              {
-                  "name": "Ophthalmology",
-                  "serviceId": "ophthalmology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/ophthalmology"
-              },
-              {
-                  "name": "Optometry",
-                  "serviceId": "optometry",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/optometry"
-              },
-              {
-                  "name": "Orthopedics",
-                  "serviceId": "orthopedics",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/orthopedics"
-              },
-              {
-                  "name": "Otolaryngology",
-                  "serviceId": "otolaryngology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/otolaryngology"
-              },
-              {
-                  "name": "Pain management",
-                  "serviceId": "painManagement",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/painManagement"
-              },
-              {
-                  "name": "Patient advocates",
-                  "serviceId": "patientAdvocates",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/patientAdvocates"
-              },
-              {
-                  "name": "Pharmacy",
-                  "serviceId": "pharmacy",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/pharmacy"
-              },
-              {
-                  "name": "Physical medicine and rehabilitation",
-                  "serviceId": "physicalMedicine",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/physicalMedicine"
-              },
-              {
-                  "name": "Plastic and reconstructive surgery",
-                  "serviceId": "plasticSurgery",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/plasticSurgery"
-              },
-              {
-                  "name": "Podiatry",
-                  "serviceId": "podiatry",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/podiatry"
-              },
-              {
-                  "name": "Primary care",
-                  "serviceId": "primaryCare",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/primaryCare"
-              },
-              {
-                  "name": "Prosthetics and rehabilitation",
-                  "serviceId": "prosthetics",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/prosthetics"
-              },
-              {
-                  "name": "PTSD care",
-                  "serviceId": "ptsd",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/ptsd"
-              },
-              {
-                  "name": "Pulmonary medicine",
-                  "serviceId": "pulmonaryMedicine",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/pulmonaryMedicine"
-              },
-              {
-                  "name": "Radiology",
-                  "serviceId": "radiology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/radiology"
-              },
-              {
-                  "name": "Rheumatology",
-                  "serviceId": "rheumatology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/rheumatology"
-              },
-              {
-                  "name": "Smoking and tobacco cessation",
-                  "serviceId": "smoking",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/smoking"
-              },
-              {
-                  "name": "Social work",
-                  "serviceId": "socialWork",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/socialWork"
-              },
-              {
-                  "name": "Spinal cord injuries and disorders",
-                  "serviceId": "spinalInjury",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/spinalInjury"
-              },
-              {
-                  "name": "Suicide prevention",
-                  "serviceId": "suicidePrevention",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/suicidePrevention"
-              },
-              {
-                  "name": "Surgery",
-                  "serviceId": "surgery",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/surgery"
-              },
-              {
-                  "name": "Returning service member care",
-                  "serviceId": "transitionCounseling",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/transitionCounseling"
-              },
-              {
-                  "name": "Urgent care",
-                  "serviceId": "urgentCare",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/urgentCare"
-              },
-              {
-                  "name": "Urology",
-                  "serviceId": "urology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/urology"
-              },
-              {
-                  "name": "Vascular surgery",
-                  "serviceId": "vascularSurgery",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/vascularSurgery"
-              },
-              {
-                  "name": "Blind and low vision rehabilitation",
-                  "serviceId": "vision",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/vision"
-              },
-              {
-                  "name": "MOVE! weight management",
-                  "serviceId": "weightManagement",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/weightManagement"
-              },
-              {
-                  "name": "Women Veteran care",
-                  "serviceId": "womensHealth",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/womensHealth"
-              },
-              {
-                  "name": "Wound care and ostomy",
-                  "serviceId": "wound",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/wound"
-              }
-          ],
-          "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services",
-          "lastUpdated": "2024-09-03"
-      },
-      "type": "va_facilities",
-      "uniqueId": "757",
-      "visn": "10",
-      "website": "https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/",
-      "parent": {
-          "id": "vha_757",
-          "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757"
-      }
-  },
-  {
-      "access": null,
-      "activeStatus": null,
-      "address": {
-          "physical": {
-              "zip": "43219-1834",
-              "city": "Columbus",
-              "state": "OH",
-              "address1": "420 North James Road"
-          }
-      },
-      "classification": "Other Outpatient Services (OOS)",
-      "detailedServices": null,
-      "distance": 8.44,
-      "facilityType": "va_health_facility",
-      "facilityTypePrefix": "vha",
-      "feedback": null,
-      "hours": {
-          "monday": "Closed",
-          "tuesday": "900AM-300PM",
-          "wednesday": "900AM-300PM",
-          "thursday": "Closed",
-          "friday": "Closed",
-          "saturday": "Closed",
-          "sunday": "Closed"
-      },
-      "id": "vha_757QA",
-      "lat": 39.98048191,
-      "long": -82.91230307,
-      "mobile": true,
-      "name": "Columbus 1 VA Mobile Clinic",
-      "operatingStatus": {
-          "code": "NORMAL"
-      },
-      "operationalHoursSpecialInstructions": null,
-      "phone": {
-          "fax": "614-257-5460",
-          "main": "614-257-5200",
-          "pharmacy": "614-257-5230",
-          "afterHours": "614-257-5298",
-          "patientAdvocate": "614-257-5290",
-          "enrollmentCoordinator": "614-257-5628"
-      },
-      "services": null,
-      "type": "va_facilities",
-      "uniqueId": "757QA",
-      "visn": "10",
-      "website": null,
-      "parent": {
-          "id": "vha_757",
-          "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757"
-      }
-  },
-  {
-      "access": null,
-      "activeStatus": null,
-      "address": {
-          "physical": {
-              "zip": "43219-1834",
-              "city": "Columbus",
-              "state": "OH",
-              "address1": "420 North James Road"
-          }
-      },
-      "classification": "Other Outpatient Services (OOS)",
-      "detailedServices": null,
-      "distance": 8.44,
-      "facilityType": "va_health_facility",
-      "facilityTypePrefix": "vha",
-      "feedback": null,
-      "hours": {
-          "monday": "800AM-430PM",
-          "tuesday": "800AM-430PM",
-          "wednesday": "800AM-430PM",
-          "thursday": "800AM-430PM",
-          "friday": "Closed",
-          "saturday": "Closed",
-          "sunday": "Closed"
-      },
-      "id": "vha_757QB",
-      "lat": 39.98048191,
-      "long": -82.91230307,
-      "mobile": true,
-      "name": "North James Road 2 VA Mobile Clinic",
-      "operatingStatus": {
-          "code": "NORMAL"
-      },
-      "operationalHoursSpecialInstructions": null,
-      "phone": {
-          "fax": "614-257-5200",
-          "main": "614-257-5689",
-          "pharmacy": "614-257-5230",
-          "afterHours": "614-257-5298",
-          "patientAdvocate": "614-257-5290",
-          "enrollmentCoordinator": "614-257-5628"
-      },
-      "services": null,
-      "type": "va_facilities",
-      "uniqueId": "757QB",
-      "visn": "10",
-      "website": null,
-      "parent": {
-          "id": "vha_757",
-          "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757"
-      }
-  },
-  {
-      "access": null,
-      "activeStatus": null,
-      "address": {
-          "physical": {
-              "zip": "43123-4835",
-              "city": "Grove City",
-              "state": "OH",
-              "address1": "5775 North Meadows Drive"
-          }
-      },
-      "classification": "Multi-Specialty CBOC",
-      "detailedServices": null,
-      "distance": 19.04,
-      "facilityType": "va_health_facility",
-      "facilityTypePrefix": "vha",
-      "feedback": {
-          "health": {
-              "primaryCareUrgent": 0.0,
-              "primaryCareRoutine": 0.9100000262260437
-          },
-          "effectiveDate": "2024-02-08"
-      },
-      "hours": {
+        },
+        "hours": {
           "monday": "800AM-430PM",
           "tuesday": "800AM-430PM",
           "wednesday": "800AM-430PM",
@@ -513,17 +42,450 @@
           "friday": "800AM-430PM",
           "saturday": "Closed",
           "sunday": "Closed"
-      },
-      "id": "vha_757GB",
-      "lat": 39.84366105,
-      "long": -83.08458138,
-      "mobile": false,
-      "name": "Grove City VA Clinic",
-      "operatingStatus": {
+        },
+        "services": {
+          "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757QC/services",
+          "lastUpdated": "2024-09-18"
+        },
+        "mobile": false,
+        "operatingStatus": {
           "code": "NORMAL"
-      },
-      "operationalHoursSpecialInstructions": null,
-      "phone": {
+        },
+        "visn": "10"
+      }
+    },
+    {
+      "id": "vha_757",
+      "type": "va_facilities",
+      "attributes": {
+        "name": "Chalmers P. Wylie Veterans Outpatient Clinic",
+        "facilityType": "va_health_facility",
+        "classification": "Health Care Center (HCC)",
+        "parent": {
+          "id": "vha_757",
+          "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757"
+        },
+        "website": "https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/",
+        "lat": 39.98048191,
+        "long": -82.91230307,
+        "timeZone": "America/New_York",
+        "address": {
+          "physical": {
+            "zip": "43219-1834",
+            "city": "Columbus",
+            "state": "OH",
+            "address1": "420 North James Road"
+          }
+        },
+        "phone": {
+          "fax": "614-257-5460",
+          "main": "614-257-5200",
+          "pharmacy": "614-257-5230",
+          "afterHours": "614-257-5512",
+          "patientAdvocate": "614-257-5290",
+          "mentalHealthClinic": "614-257-5631",
+          "enrollmentCoordinator": "614-257-5628"
+        },
+        "hours": {
+          "monday": "730AM-600PM",
+          "tuesday": "730AM-600PM",
+          "wednesday": "730AM-600PM",
+          "thursday": "730AM-600PM",
+          "friday": "730AM-600PM",
+          "saturday": "800AM-400PM",
+          "sunday": "800AM-400PM"
+        },
+        "operationalHoursSpecialInstructions": [
+          "Normal business hours are Monday through Friday, 8:00 a.m. to 4:30 p.m."
+        ],
+        "services": {
+          "health": [
+            {
+              "name": "Allergy, asthma and immunology",
+              "serviceId": "allergy",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/allergy"
+            },
+            {
+              "name": "Audiology and speech",
+              "serviceId": "audiology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/audiology"
+            },
+            {
+              "name": "Cardiology",
+              "serviceId": "cardiology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/cardiology"
+            },
+            {
+              "name": "CaregiverSupport",
+              "serviceId": "caregiverSupport",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/caregiverSupport"
+            },
+            {
+              "name": "COVID-19 vaccines",
+              "serviceId": "covid19Vaccine",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/covid19Vaccine"
+            },
+            {
+              "name": "Dental/oral surgery",
+              "serviceId": "dental",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/dental"
+            },
+            {
+              "name": "Dermatology",
+              "serviceId": "dermatology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/dermatology"
+            },
+            {
+              "name": "Diabetic care",
+              "serviceId": "diabetic",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/diabetic"
+            },
+            {
+              "name": "Endocrinology",
+              "serviceId": "endocrinology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/endocrinology"
+            },
+            {
+              "name": "Gastroenterology",
+              "serviceId": "gastroenterology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/gastroenterology"
+            },
+            {
+              "name": "Geriatrics",
+              "serviceId": "geriatrics",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/geriatrics"
+            },
+            {
+              "name": "Gynecology",
+              "serviceId": "gynecology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/gynecology"
+            },
+            {
+              "name": "Hematology/oncology",
+              "serviceId": "hematology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/hematology"
+            },
+            {
+              "name": "Homeless Veteran care",
+              "serviceId": "homeless",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/homeless"
+            },
+            {
+              "name": "Palliative and hospice care",
+              "serviceId": "hospice",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/hospice"
+            },
+            {
+              "name": "Laboratory and pathology",
+              "serviceId": "laboratory",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/laboratory"
+            },
+            {
+              "name": "LGBTQ+ Veteran care",
+              "serviceId": "lgbtq",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/lgbtq"
+            },
+            {
+              "name": "Minority Veteran care",
+              "serviceId": "minorityCare",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/minorityCare"
+            },
+            {
+              "name": "Nephrology",
+              "serviceId": "nephrology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/nephrology"
+            },
+            {
+              "name": "Neurology",
+              "serviceId": "neurology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/neurology"
+            },
+            {
+              "name": "Nutrition, food, and dietary care",
+              "serviceId": "nutrition",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/nutrition"
+            },
+            {
+              "name": "Ophthalmology",
+              "serviceId": "ophthalmology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/ophthalmology"
+            },
+            {
+              "name": "Optometry",
+              "serviceId": "optometry",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/optometry"
+            },
+            {
+              "name": "Orthopedics",
+              "serviceId": "orthopedics",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/orthopedics"
+            },
+            {
+              "name": "Otolaryngology",
+              "serviceId": "otolaryngology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/otolaryngology"
+            },
+            {
+              "name": "Pain management",
+              "serviceId": "painManagement",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/painManagement"
+            },
+            {
+              "name": "Patient advocates",
+              "serviceId": "patientAdvocates",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/patientAdvocates"
+            },
+            {
+              "name": "Pharmacy",
+              "serviceId": "pharmacy",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/pharmacy"
+            },
+            {
+              "name": "Physical medicine and rehabilitation",
+              "serviceId": "physicalMedicine",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/physicalMedicine"
+            },
+            {
+              "name": "Plastic and reconstructive surgery",
+              "serviceId": "plasticSurgery",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/plasticSurgery"
+            },
+            {
+              "name": "Podiatry",
+              "serviceId": "podiatry",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/podiatry"
+            },
+            {
+              "name": "Primary care",
+              "serviceId": "primaryCare",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/primaryCare"
+            },
+            {
+              "name": "Prosthetics and rehabilitation",
+              "serviceId": "prosthetics",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/prosthetics"
+            },
+            {
+              "name": "PTSD care",
+              "serviceId": "ptsd",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/ptsd"
+            },
+            {
+              "name": "Pulmonary medicine",
+              "serviceId": "pulmonaryMedicine",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/pulmonaryMedicine"
+            },
+            {
+              "name": "Radiology",
+              "serviceId": "radiology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/radiology"
+            },
+            {
+              "name": "Rheumatology",
+              "serviceId": "rheumatology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/rheumatology"
+            },
+            {
+              "name": "Smoking and tobacco cessation",
+              "serviceId": "smoking",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/smoking"
+            },
+            {
+              "name": "Social work",
+              "serviceId": "socialWork",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/socialWork"
+            },
+            {
+              "name": "Spinal cord injuries and disorders",
+              "serviceId": "spinalInjury",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/spinalInjury"
+            },
+            {
+              "name": "Suicide prevention",
+              "serviceId": "suicidePrevention",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/suicidePrevention"
+            },
+            {
+              "name": "Surgery",
+              "serviceId": "surgery",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/surgery"
+            },
+            {
+              "name": "Returning service member care",
+              "serviceId": "transitionCounseling",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/transitionCounseling"
+            },
+            {
+              "name": "Urgent care",
+              "serviceId": "urgentCare",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/urgentCare"
+            },
+            {
+              "name": "Urology",
+              "serviceId": "urology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/urology"
+            },
+            {
+              "name": "Vascular surgery",
+              "serviceId": "vascularSurgery",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/vascularSurgery"
+            },
+            {
+              "name": "Blind and low vision rehabilitation",
+              "serviceId": "vision",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/vision"
+            },
+            {
+              "name": "MOVE! weight management",
+              "serviceId": "weightManagement",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/weightManagement"
+            },
+            {
+              "name": "Women Veteran care",
+              "serviceId": "womensHealth",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/womensHealth"
+            },
+            {
+              "name": "Wound care and ostomy",
+              "serviceId": "wound",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/wound"
+            }
+          ],
+          "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services",
+          "lastUpdated": "2024-09-18"
+        },
+        "satisfaction": {
+          "health": {
+            "primaryCareUrgent": 0.800000011920929,
+            "primaryCareRoutine": 0.8700000047683716,
+            "specialtyCareUrgent": 0.7599999904632568,
+            "specialtyCareRoutine": 0.8399999737739563
+          },
+          "effectiveDate": "2024-02-08"
+        },
+        "mobile": false,
+        "operatingStatus": {
+          "code": "NORMAL"
+        },
+        "visn": "10"
+      }
+    },
+    {
+      "id": "vha_757QA",
+      "type": "va_facilities",
+      "attributes": {
+        "name": "Columbus 1 VA Mobile Clinic",
+        "facilityType": "va_health_facility",
+        "classification": "Other Outpatient Services (OOS)",
+        "parent": {
+          "id": "vha_757",
+          "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757"
+        },
+        "lat": 39.98048191,
+        "long": -82.91230307,
+        "timeZone": "America/New_York",
+        "address": {
+          "physical": {
+            "zip": "43219-1834",
+            "city": "Columbus",
+            "state": "OH",
+            "address1": "420 North James Road"
+          }
+        },
+        "phone": {
+          "fax": "614-257-5460",
+          "main": "614-257-5200",
+          "pharmacy": "614-257-5230",
+          "afterHours": "614-257-5298",
+          "patientAdvocate": "614-257-5290",
+          "enrollmentCoordinator": "614-257-5628"
+        },
+        "hours": {
+          "monday": "Closed",
+          "tuesday": "900AM-300PM",
+          "wednesday": "900AM-300PM",
+          "thursday": "Closed",
+          "friday": "Closed",
+          "saturday": "Closed",
+          "sunday": "Closed"
+        },
+        "mobile": true,
+        "operatingStatus": {
+          "code": "NORMAL"
+        },
+        "visn": "10"
+      }
+    },
+    {
+      "id": "vha_757QB",
+      "type": "va_facilities",
+      "attributes": {
+        "name": "North James Road 2 VA Mobile Clinic",
+        "facilityType": "va_health_facility",
+        "classification": "Other Outpatient Services (OOS)",
+        "parent": {
+          "id": "vha_757",
+          "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757"
+        },
+        "lat": 39.98048191,
+        "long": -82.91230307,
+        "timeZone": "America/New_York",
+        "address": {
+          "physical": {
+            "zip": "43219-1834",
+            "city": "Columbus",
+            "state": "OH",
+            "address1": "420 North James Road"
+          }
+        },
+        "phone": {
+          "fax": "614-257-5200",
+          "main": "614-257-5689",
+          "pharmacy": "614-257-5230",
+          "afterHours": "614-257-5298",
+          "patientAdvocate": "614-257-5290",
+          "enrollmentCoordinator": "614-257-5628"
+        },
+        "hours": {
+          "monday": "800AM-430PM",
+          "tuesday": "800AM-430PM",
+          "wednesday": "800AM-430PM",
+          "thursday": "800AM-430PM",
+          "friday": "Closed",
+          "saturday": "Closed",
+          "sunday": "Closed"
+        },
+        "mobile": true,
+        "operatingStatus": {
+          "code": "NORMAL"
+        },
+        "visn": "10"
+      }
+    },
+    {
+      "id": "vha_757GB",
+      "type": "va_facilities",
+      "attributes": {
+        "name": "Grove City VA Clinic",
+        "facilityType": "va_health_facility",
+        "classification": "Multi-Specialty CBOC",
+        "parent": {
+          "id": "vha_757",
+          "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757"
+        },
+        "website": "https://www.va.gov/central-ohio-health-care/locations/grove-city-va-clinic/",
+        "lat": 39.84366105,
+        "long": -83.08458138,
+        "timeZone": "America/New_York",
+        "address": {
+          "physical": {
+            "zip": "43123-4835",
+            "city": "Grove City",
+            "state": "OH",
+            "address1": "5775 North Meadows Drive"
+          }
+        },
+        "phone": {
           "fax": "614-257-5801",
           "main": "614-257-5800",
           "pharmacy": "614-257-5230",
@@ -531,65 +493,119 @@
           "patientAdvocate": "614-388-7880",
           "mentalHealthClinic": "614-257-5808",
           "enrollmentCoordinator": "614-257-5628"
-      },
-      "services": {
+        },
+        "hours": {
+          "monday": "800AM-430PM",
+          "tuesday": "800AM-430PM",
+          "wednesday": "800AM-430PM",
+          "thursday": "800AM-430PM",
+          "friday": "800AM-430PM",
+          "saturday": "Closed",
+          "sunday": "Closed"
+        },
+        "services": {
           "health": [
-              {
-                  "name": "Audiology and speech",
-                  "serviceId": "audiology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/audiology"
-              },
-              {
-                  "name": "Cardiology",
-                  "serviceId": "cardiology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/cardiology"
-              },
-              {
-                  "name": "Dermatology",
-                  "serviceId": "dermatology",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/dermatology"
-              },
-              {
-                  "name": "Laboratory and pathology",
-                  "serviceId": "laboratory",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/laboratory"
-              },
-              {
-                  "name": "Nutrition, food, and dietary care",
-                  "serviceId": "nutrition",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/nutrition"
-              },
-              {
-                  "name": "Optometry",
-                  "serviceId": "optometry",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/optometry"
-              },
-              {
-                  "name": "Primary care",
-                  "serviceId": "primaryCare",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/primaryCare"
-              },
-              {
-                  "name": "Social work",
-                  "serviceId": "socialWork",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/socialWork"
-              },
-              {
-                  "name": "Suicide prevention",
-                  "serviceId": "suicidePrevention",
-                  "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/suicidePrevention"
-              }
+            {
+              "name": "Audiology and speech",
+              "serviceId": "audiology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/audiology"
+            },
+            {
+              "name": "Cardiology",
+              "serviceId": "cardiology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/cardiology"
+            },
+            {
+              "name": "Dermatology",
+              "serviceId": "dermatology",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/dermatology"
+            },
+            {
+              "name": "Laboratory and pathology",
+              "serviceId": "laboratory",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/laboratory"
+            },
+            {
+              "name": "Nutrition, food, and dietary care",
+              "serviceId": "nutrition",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/nutrition"
+            },
+            {
+              "name": "Optometry",
+              "serviceId": "optometry",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/optometry"
+            },
+            {
+              "name": "Primary care",
+              "serviceId": "primaryCare",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/primaryCare"
+            },
+            {
+              "name": "Social work",
+              "serviceId": "socialWork",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/socialWork"
+            },
+            {
+              "name": "Suicide prevention",
+              "serviceId": "suicidePrevention",
+              "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services/suicidePrevention"
+            }
           ],
           "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757GB/services",
-          "lastUpdated": "2024-09-03"
-      },
-      "type": "va_facilities",
-      "uniqueId": "757GB",
-      "visn": "10",
-      "website": "https://www.va.gov/central-ohio-health-care/locations/grove-city-va-clinic/",
-      "parent": {
-          "id": "vha_757",
-          "link": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757"
+          "lastUpdated": "2024-09-18"
+        },
+        "satisfaction": {
+          "health": {
+            "primaryCareUrgent": 0.0,
+            "primaryCareRoutine": 0.9100000262260437
+          },
+          "effectiveDate": "2024-02-08"
+        },
+        "mobile": false,
+        "operatingStatus": {
+          "code": "NORMAL"
+        },
+        "visn": "10"
       }
-  }
-]
+    }
+  ],
+  "links": {
+    "self": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities?lat=40.099155&long=-82.949986&radius=500&type=health&page=1&per_page=5",
+    "first": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities?lat=40.099155&long=-82.949986&radius=500&type=health&page=1&per_page=5",
+    "next": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities?lat=40.099155&long=-82.949986&radius=500&type=health&page=2&per_page=5",
+    "last": "https://sandbox-api.va.gov/services/va_facilities/v1/facilities?lat=40.099155&long=-82.949986&radius=500&type=health&page=108&per_page=5"
+  },
+  "meta": {
+    "pagination": {
+      "currentPage": 1,
+      "perPage": 5,
+      "totalPages": 108,
+      "totalEntries": 540
+    },
+    "distances": [
+      {
+        "id": "vha_757QC",
+        "distance": 7.14
+      },
+      {
+        "id": "vha_757",
+        "distance": 8.44
+      },
+      {
+        "id": "vha_757QA",
+        "distance": 8.44
+      },
+      {
+        "id": "vha_757QB",
+        "distance": 8.44
+      },
+      {
+        "id": "vha_757GB",
+        "distance": 19.04
+      }
+    ]
+  },
+  "perPage": 5,
+  "status": 200,
+  "totalEntries": 540
+}

--- a/src/applications/caregivers/tests/e2e/utils/helpers.js
+++ b/src/applications/caregivers/tests/e2e/utils/helpers.js
@@ -16,7 +16,7 @@ export const setupPerTest = () => {
   cy.intercept('POST', 'v0/form1010cg/attachments', mockUpload);
   cy.intercept(
     'GET',
-    '/v0/health_care_applications/facilities?*',
+    '/v0/caregivers_assistance_claims/facilities?*',
     mockFacilities,
   ).as('getFacilities');
   cy.intercept('POST', '/v0/caregivers_assistance_claims', mockSubmission);

--- a/src/applications/caregivers/tests/mocks/responses.js
+++ b/src/applications/caregivers/tests/mocks/responses.js
@@ -1,435 +1,449 @@
-export const mockFacilitiesResponse = [
-  {
-    access: null,
-    activeStatus: null,
-    address: {
-      physical: {
-        zip: '43219-2219',
-        city: 'Columbus',
-        state: 'OH',
-        address1: '2720 Airport Drive',
-        address3: 'Suite 100',
+export const mockFacilitiesResponse = {
+  data: [
+    {
+      attributes: {
+        access: null,
+        activeStatus: null,
+        address: {
+          physical: {
+            zip: '43219-2219',
+            city: 'Columbus',
+            state: 'OH',
+            address1: '2720 Airport Drive',
+            address3: 'Suite 100',
+          },
+        },
+        classification: 'Other Outpatient Services (OOS)',
+        detailedServices: null,
+        distance: 7.14,
+        facilityType: 'va_health_facility',
+        facilityTypePrefix: 'vha',
+        feedback: null,
+        hours: {
+          monday: '800AM-430PM',
+          tuesday: '800AM-430PM',
+          wednesday: '800AM-430PM',
+          thursday: '800AM-430PM',
+          friday: '800AM-430PM',
+          saturday: 'Closed',
+          sunday: 'Closed',
+        },
+        id: 'vha_757QC',
+        lat: 39.996592,
+        long: -82.93310921,
+        mobile: false,
+        name: 'Columbus VA Clinic',
+        operatingStatus: {
+          code: 'NORMAL',
+        },
+        operationalHoursSpecialInstructions: null,
+        parent: {
+          id: 'vha_757',
+        },
+        phone: {
+          fax: '614-388-7565',
+          main: '614-388-7650',
+          pharmacy: '614-257-5230',
+          afterHours: '888-838-6446',
+          patientAdvocate: '614-257-5449',
+          mentalHealthClinic: '614-257-5631',
+          enrollmentCoordinator: '614-257-5628',
+        },
+        services: {
+          link:
+            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757QC/services',
+          lastUpdated: '2024-08-18',
+        },
+        type: 'va_facilities',
+        uniqueId: '757QC',
+        visn: '10',
+        website:
+          'https://www.va.gov/central-ohio-health-care/locations/columbus-va-clinic/',
       },
     },
-    classification: 'Other Outpatient Services (OOS)',
-    detailedServices: null,
-    distance: 7.14,
-    facilityType: 'va_health_facility',
-    facilityTypePrefix: 'vha',
-    feedback: null,
-    hours: {
-      monday: '800AM-430PM',
-      tuesday: '800AM-430PM',
-      wednesday: '800AM-430PM',
-      thursday: '800AM-430PM',
-      friday: '800AM-430PM',
-      saturday: 'Closed',
-      sunday: 'Closed',
+    {
+      attributes: {
+        access: null,
+        activeStatus: null,
+        address: {
+          physical: {
+            zip: '43219-1834',
+            city: 'Columbus',
+            state: 'OH',
+            address1: '420 North James Road',
+            address3: '33',
+          },
+        },
+        classification: 'Health Care Center (HCC)',
+        detailedServices: null,
+        distance: 8.44,
+        facilityType: 'va_health_facility',
+        facilityTypePrefix: 'vha',
+        feedback: {
+          health: {
+            primaryCareUrgent: 0.800000011920929,
+            primaryCareRoutine: 0.8700000047683716,
+            specialtyCareUrgent: 0.7599999904632568,
+            specialtyCareRoutine: 0.8399999737739563,
+          },
+          effectiveDate: '2024-02-08',
+        },
+        hours: {
+          monday: '730AM-600PM',
+          tuesday: '730AM-600PM',
+          wednesday: '730AM-600PM',
+          thursday: '730AM-600PM',
+          friday: '730AM-600PM',
+          saturday: '800AM-400PM',
+          sunday: '800AM-400PM',
+        },
+        id: 'vha_757',
+        lat: 39.98048191,
+        long: -82.91230307,
+        mobile: false,
+        name: 'Chalmers P. Wylie Veterans Outpatient Clinic',
+        operatingStatus: {
+          code: 'NORMAL',
+        },
+        operationalHoursSpecialInstructions: [
+          'Normal business hours are Monday through Friday, 8:00 a.m. to 4:30 p.m.',
+        ],
+        parent: {
+          id: 'vha_757',
+        },
+        phone: {
+          fax: '614-257-5460',
+          main: '614-257-5200',
+          pharmacy: '614-257-5230',
+          afterHours: '614-257-5512',
+          patientAdvocate: '614-257-5290',
+          mentalHealthClinic: '614-257-5631',
+          enrollmentCoordinator: '614-257-5628',
+        },
+        services: {
+          health: [
+            {
+              name: 'Allergy, asthma and immunology',
+              serviceId: 'allergy',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/allergy',
+            },
+            {
+              name: 'Audiology and speech',
+              serviceId: 'audiology',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/audiology',
+            },
+            {
+              name: 'Cardiology',
+              serviceId: 'cardiology',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/cardiology',
+            },
+            {
+              name: 'CaregiverSupport',
+              serviceId: 'caregiverSupport',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/caregiverSupport',
+            },
+            {
+              name: 'COVID-19 vaccines',
+              serviceId: 'covid19Vaccine',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/covid19Vaccine',
+            },
+            {
+              name: 'Dental/oral surgery',
+              serviceId: 'dental',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/dental',
+            },
+            {
+              name: 'Dermatology',
+              serviceId: 'dermatology',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/dermatology',
+            },
+            {
+              name: 'Diabetic care',
+              serviceId: 'diabetic',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/diabetic',
+            },
+            {
+              name: 'Endocrinology',
+              serviceId: 'endocrinology',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/endocrinology',
+            },
+            {
+              name: 'Gastroenterology',
+              serviceId: 'gastroenterology',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/gastroenterology',
+            },
+            {
+              name: 'Geriatrics',
+              serviceId: 'geriatrics',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/geriatrics',
+            },
+            {
+              name: 'Gynecology',
+              serviceId: 'gynecology',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/gynecology',
+            },
+            {
+              name: 'Hematology/oncology',
+              serviceId: 'hematology',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/hematology',
+            },
+            {
+              name: 'Homeless Veteran care',
+              serviceId: 'homeless',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/homeless',
+            },
+            {
+              name: 'Palliative and hospice care',
+              serviceId: 'hospice',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/hospice',
+            },
+            {
+              name: 'Laboratory and pathology',
+              serviceId: 'laboratory',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/laboratory',
+            },
+            {
+              name: 'LGBTQ+ Veteran care',
+              serviceId: 'lgbtq',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/lgbtq',
+            },
+            {
+              name: 'Minority Veteran care',
+              serviceId: 'minorityCare',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/minorityCare',
+            },
+            {
+              name: 'Nephrology',
+              serviceId: 'nephrology',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/nephrology',
+            },
+            {
+              name: 'Neurology',
+              serviceId: 'neurology',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/neurology',
+            },
+            {
+              name: 'Nutrition, food, and dietary care',
+              serviceId: 'nutrition',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/nutrition',
+            },
+            {
+              name: 'Ophthalmology',
+              serviceId: 'ophthalmology',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/ophthalmology',
+            },
+            {
+              name: 'Optometry',
+              serviceId: 'optometry',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/optometry',
+            },
+            {
+              name: 'Orthopedics',
+              serviceId: 'orthopedics',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/orthopedics',
+            },
+            {
+              name: 'Otolaryngology',
+              serviceId: 'otolaryngology',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/otolaryngology',
+            },
+            {
+              name: 'Pain management',
+              serviceId: 'painManagement',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/painManagement',
+            },
+            {
+              name: 'Patient advocates',
+              serviceId: 'patientAdvocates',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/patientAdvocates',
+            },
+            {
+              name: 'Pharmacy',
+              serviceId: 'pharmacy',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/pharmacy',
+            },
+            {
+              name: 'Physical medicine and rehabilitation',
+              serviceId: 'physicalMedicine',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/physicalMedicine',
+            },
+            {
+              name: 'Plastic and reconstructive surgery',
+              serviceId: 'plasticSurgery',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/plasticSurgery',
+            },
+            {
+              name: 'Podiatry',
+              serviceId: 'podiatry',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/podiatry',
+            },
+            {
+              name: 'Primary care',
+              serviceId: 'primaryCare',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/primaryCare',
+            },
+            {
+              name: 'Prosthetics and rehabilitation',
+              serviceId: 'prosthetics',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/prosthetics',
+            },
+            {
+              name: 'PTSD care',
+              serviceId: 'ptsd',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/ptsd',
+            },
+            {
+              name: 'Pulmonary medicine',
+              serviceId: 'pulmonaryMedicine',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/pulmonaryMedicine',
+            },
+            {
+              name: 'Radiology',
+              serviceId: 'radiology',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/radiology',
+            },
+            {
+              name: 'Rheumatology',
+              serviceId: 'rheumatology',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/rheumatology',
+            },
+            {
+              name: 'Smoking and tobacco cessation',
+              serviceId: 'smoking',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/smoking',
+            },
+            {
+              name: 'Social work',
+              serviceId: 'socialWork',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/socialWork',
+            },
+            {
+              name: 'Spinal cord injuries and disorders',
+              serviceId: 'spinalInjury',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/spinalInjury',
+            },
+            {
+              name: 'Suicide prevention',
+              serviceId: 'suicidePrevention',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/suicidePrevention',
+            },
+            {
+              name: 'Surgery',
+              serviceId: 'surgery',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/surgery',
+            },
+            {
+              name: 'Returning service member care',
+              serviceId: 'transitionCounseling',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/transitionCounseling',
+            },
+            {
+              name: 'Urgent care',
+              serviceId: 'urgentCare',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/urgentCare',
+            },
+            {
+              name: 'Urology',
+              serviceId: 'urology',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/urology',
+            },
+            {
+              name: 'Vascular surgery',
+              serviceId: 'vascularSurgery',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/vascularSurgery',
+            },
+            {
+              name: 'Blind and low vision rehabilitation',
+              serviceId: 'vision',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/vision',
+            },
+            {
+              name: 'MOVE! weight management',
+              serviceId: 'weightManagement',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/weightManagement',
+            },
+            {
+              name: 'Women Veteran care',
+              serviceId: 'womensHealth',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/womensHealth',
+            },
+            {
+              name: 'Wound care and ostomy',
+              serviceId: 'wound',
+              link:
+                'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/wound',
+            },
+          ],
+          link:
+            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services',
+          lastUpdated: '2024-08-18',
+        },
+        type: 'va_facilities',
+        uniqueId: '757',
+        visn: '10',
+        website:
+          'https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/',
+      },
     },
-    id: 'vha_757QC',
-    lat: 39.996592,
-    long: -82.93310921,
-    mobile: false,
-    name: 'Columbus VA Clinic',
-    operatingStatus: {
-      code: 'NORMAL',
+  ],
+  meta: {
+    pagination: {
+      currentPage: 1,
+      perPage: 5,
+      totalEntries: 12,
+      totalPages: 3,
     },
-    operationalHoursSpecialInstructions: null,
-    parent: {
-      id: 'vha_757',
-    },
-    phone: {
-      fax: '614-388-7565',
-      main: '614-388-7650',
-      pharmacy: '614-257-5230',
-      afterHours: '888-838-6446',
-      patientAdvocate: '614-257-5449',
-      mentalHealthClinic: '614-257-5631',
-      enrollmentCoordinator: '614-257-5628',
-    },
-    services: {
-      link:
-        'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757QC/services',
-      lastUpdated: '2024-08-18',
-    },
-    type: 'va_facilities',
-    uniqueId: '757QC',
-    visn: '10',
-    website:
-      'https://www.va.gov/central-ohio-health-care/locations/columbus-va-clinic/',
   },
-  {
-    access: null,
-    activeStatus: null,
-    address: {
-      physical: {
-        zip: '43219-1834',
-        city: 'Columbus',
-        state: 'OH',
-        address1: '420 North James Road',
-        address3: '33',
-      },
-    },
-    classification: 'Health Care Center (HCC)',
-    detailedServices: null,
-    distance: 8.44,
-    facilityType: 'va_health_facility',
-    facilityTypePrefix: 'vha',
-    feedback: {
-      health: {
-        primaryCareUrgent: 0.800000011920929,
-        primaryCareRoutine: 0.8700000047683716,
-        specialtyCareUrgent: 0.7599999904632568,
-        specialtyCareRoutine: 0.8399999737739563,
-      },
-      effectiveDate: '2024-02-08',
-    },
-    hours: {
-      monday: '730AM-600PM',
-      tuesday: '730AM-600PM',
-      wednesday: '730AM-600PM',
-      thursday: '730AM-600PM',
-      friday: '730AM-600PM',
-      saturday: '800AM-400PM',
-      sunday: '800AM-400PM',
-    },
-    id: 'vha_757',
-    lat: 39.98048191,
-    long: -82.91230307,
-    mobile: false,
-    name: 'Chalmers P. Wylie Veterans Outpatient Clinic',
-    operatingStatus: {
-      code: 'NORMAL',
-    },
-    operationalHoursSpecialInstructions: [
-      'Normal business hours are Monday through Friday, 8:00 a.m. to 4:30 p.m.',
-    ],
-    parent: {
-      id: 'vha_757',
-    },
-    phone: {
-      fax: '614-257-5460',
-      main: '614-257-5200',
-      pharmacy: '614-257-5230',
-      afterHours: '614-257-5512',
-      patientAdvocate: '614-257-5290',
-      mentalHealthClinic: '614-257-5631',
-      enrollmentCoordinator: '614-257-5628',
-    },
-    services: {
-      health: [
-        {
-          name: 'Allergy, asthma and immunology',
-          serviceId: 'allergy',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/allergy',
-        },
-        {
-          name: 'Audiology and speech',
-          serviceId: 'audiology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/audiology',
-        },
-        {
-          name: 'Cardiology',
-          serviceId: 'cardiology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/cardiology',
-        },
-        {
-          name: 'CaregiverSupport',
-          serviceId: 'caregiverSupport',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/caregiverSupport',
-        },
-        {
-          name: 'COVID-19 vaccines',
-          serviceId: 'covid19Vaccine',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/covid19Vaccine',
-        },
-        {
-          name: 'Dental/oral surgery',
-          serviceId: 'dental',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/dental',
-        },
-        {
-          name: 'Dermatology',
-          serviceId: 'dermatology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/dermatology',
-        },
-        {
-          name: 'Diabetic care',
-          serviceId: 'diabetic',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/diabetic',
-        },
-        {
-          name: 'Endocrinology',
-          serviceId: 'endocrinology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/endocrinology',
-        },
-        {
-          name: 'Gastroenterology',
-          serviceId: 'gastroenterology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/gastroenterology',
-        },
-        {
-          name: 'Geriatrics',
-          serviceId: 'geriatrics',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/geriatrics',
-        },
-        {
-          name: 'Gynecology',
-          serviceId: 'gynecology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/gynecology',
-        },
-        {
-          name: 'Hematology/oncology',
-          serviceId: 'hematology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/hematology',
-        },
-        {
-          name: 'Homeless Veteran care',
-          serviceId: 'homeless',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/homeless',
-        },
-        {
-          name: 'Palliative and hospice care',
-          serviceId: 'hospice',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/hospice',
-        },
-        {
-          name: 'Laboratory and pathology',
-          serviceId: 'laboratory',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/laboratory',
-        },
-        {
-          name: 'LGBTQ+ Veteran care',
-          serviceId: 'lgbtq',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/lgbtq',
-        },
-        {
-          name: 'Minority Veteran care',
-          serviceId: 'minorityCare',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/minorityCare',
-        },
-        {
-          name: 'Nephrology',
-          serviceId: 'nephrology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/nephrology',
-        },
-        {
-          name: 'Neurology',
-          serviceId: 'neurology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/neurology',
-        },
-        {
-          name: 'Nutrition, food, and dietary care',
-          serviceId: 'nutrition',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/nutrition',
-        },
-        {
-          name: 'Ophthalmology',
-          serviceId: 'ophthalmology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/ophthalmology',
-        },
-        {
-          name: 'Optometry',
-          serviceId: 'optometry',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/optometry',
-        },
-        {
-          name: 'Orthopedics',
-          serviceId: 'orthopedics',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/orthopedics',
-        },
-        {
-          name: 'Otolaryngology',
-          serviceId: 'otolaryngology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/otolaryngology',
-        },
-        {
-          name: 'Pain management',
-          serviceId: 'painManagement',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/painManagement',
-        },
-        {
-          name: 'Patient advocates',
-          serviceId: 'patientAdvocates',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/patientAdvocates',
-        },
-        {
-          name: 'Pharmacy',
-          serviceId: 'pharmacy',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/pharmacy',
-        },
-        {
-          name: 'Physical medicine and rehabilitation',
-          serviceId: 'physicalMedicine',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/physicalMedicine',
-        },
-        {
-          name: 'Plastic and reconstructive surgery',
-          serviceId: 'plasticSurgery',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/plasticSurgery',
-        },
-        {
-          name: 'Podiatry',
-          serviceId: 'podiatry',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/podiatry',
-        },
-        {
-          name: 'Primary care',
-          serviceId: 'primaryCare',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/primaryCare',
-        },
-        {
-          name: 'Prosthetics and rehabilitation',
-          serviceId: 'prosthetics',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/prosthetics',
-        },
-        {
-          name: 'PTSD care',
-          serviceId: 'ptsd',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/ptsd',
-        },
-        {
-          name: 'Pulmonary medicine',
-          serviceId: 'pulmonaryMedicine',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/pulmonaryMedicine',
-        },
-        {
-          name: 'Radiology',
-          serviceId: 'radiology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/radiology',
-        },
-        {
-          name: 'Rheumatology',
-          serviceId: 'rheumatology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/rheumatology',
-        },
-        {
-          name: 'Smoking and tobacco cessation',
-          serviceId: 'smoking',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/smoking',
-        },
-        {
-          name: 'Social work',
-          serviceId: 'socialWork',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/socialWork',
-        },
-        {
-          name: 'Spinal cord injuries and disorders',
-          serviceId: 'spinalInjury',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/spinalInjury',
-        },
-        {
-          name: 'Suicide prevention',
-          serviceId: 'suicidePrevention',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/suicidePrevention',
-        },
-        {
-          name: 'Surgery',
-          serviceId: 'surgery',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/surgery',
-        },
-        {
-          name: 'Returning service member care',
-          serviceId: 'transitionCounseling',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/transitionCounseling',
-        },
-        {
-          name: 'Urgent care',
-          serviceId: 'urgentCare',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/urgentCare',
-        },
-        {
-          name: 'Urology',
-          serviceId: 'urology',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/urology',
-        },
-        {
-          name: 'Vascular surgery',
-          serviceId: 'vascularSurgery',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/vascularSurgery',
-        },
-        {
-          name: 'Blind and low vision rehabilitation',
-          serviceId: 'vision',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/vision',
-        },
-        {
-          name: 'MOVE! weight management',
-          serviceId: 'weightManagement',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/weightManagement',
-        },
-        {
-          name: 'Women Veteran care',
-          serviceId: 'womensHealth',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/womensHealth',
-        },
-        {
-          name: 'Wound care and ostomy',
-          serviceId: 'wound',
-          link:
-            'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services/wound',
-        },
-      ],
-      link:
-        'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757/services',
-      lastUpdated: '2024-08-18',
-    },
-    type: 'va_facilities',
-    uniqueId: '757',
-    visn: '10',
-    website:
-      'https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/',
-  },
-];
+};
 
 const fetchChildFacilityWithoutCaregiverSupport = {
   access: null,
@@ -490,7 +504,51 @@ const fetchChildFacilityWithoutCaregiverSupport = {
 };
 
 const fetchChildFacilityWithCaregiverSupport = {
-  ...fetchChildFacilityWithoutCaregiverSupport,
+  access: null,
+  activeStatus: null,
+  address: {
+    physical: {
+      address1: '2720 Airport Drive',
+      address2: 'Suite 100',
+      address3: 'Columbus, OH, 43219-2219',
+    },
+  },
+  classification: 'Other Outpatient Services (OOS)',
+  detailedServices: null,
+  distance: 7.14,
+  facilityType: 'va_health_facility',
+  facilityTypePrefix: 'vha',
+  feedback: null,
+  hours: {
+    monday: '800AM-430PM',
+    tuesday: '800AM-430PM',
+    wednesday: '800AM-430PM',
+    thursday: '800AM-430PM',
+    friday: '800AM-430PM',
+    saturday: 'Closed',
+    sunday: 'Closed',
+  },
+  id: 'vha_757QC',
+  lat: 39.996592,
+  long: -82.93310921,
+  mobile: false,
+  name: 'Columbus VA Clinic',
+  operatingStatus: {
+    code: 'NORMAL',
+  },
+  operationalHoursSpecialInstructions: null,
+  parent: {
+    id: 'vha_757',
+  },
+  phone: {
+    fax: '614-388-7565',
+    main: '614-388-7650',
+    pharmacy: '614-257-5230',
+    afterHours: '888-838-6446',
+    patientAdvocate: '614-257-5449',
+    mentalHealthClinic: '614-257-5631',
+    enrollmentCoordinator: '614-257-5628',
+  },
   services: {
     health: [
       {
@@ -504,6 +562,11 @@ const fetchChildFacilityWithCaregiverSupport = {
       'https://sandbox-api.va.gov/services/va_facilities/v1/facilities/vha_757QC/services',
     lastUpdated: '2024-08-18',
   },
+  type: 'va_facilities',
+  uniqueId: '757QC',
+  visn: '10',
+  website:
+    'https://www.va.gov/central-ohio-health-care/locations/columbus-va-clinic/',
 };
 
 const fetchParentFacility = {
@@ -876,15 +939,48 @@ const fetchParentFacility = {
     'https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/',
 };
 
-export const mockFetchChildFacilityResponse = [
-  fetchChildFacilityWithoutCaregiverSupport,
-];
-export const mockFetchChildFacilityWithCaregiverSupportResponse = [
-  fetchChildFacilityWithCaregiverSupport,
-];
-export const mockFetchParentFacilityResponse = [fetchParentFacility];
+export const mockFetchChildFacilityResponse = {
+  facilities: [fetchChildFacilityWithoutCaregiverSupport],
+  meta: {
+    pagination: {
+      currentPage: 1,
+      perPage: 5,
+      totalEntries: 12,
+      totalPages: 3,
+    },
+  },
+};
+export const mockFetchChildFacilityWithCaregiverSupportResponse = {
+  facilities: [fetchChildFacilityWithCaregiverSupport],
+  meta: {
+    pagination: {
+      currentPage: 1,
+      perPage: 5,
+      totalEntries: 12,
+      totalPages: 3,
+    },
+  },
+};
+export const mockFetchParentFacilityResponse = {
+  facilities: [fetchParentFacility],
+  meta: {
+    pagination: {
+      currentPage: 1,
+      perPage: 5,
+      totalEntries: 12,
+      totalPages: 3,
+    },
+  },
+};
 
-export const mockFetchFacilitiesResponse = [
-  fetchChildFacilityWithoutCaregiverSupport,
-  fetchParentFacility,
-];
+export const mockFetchFacilitiesResponse = {
+  facilities: [fetchChildFacilityWithoutCaregiverSupport, fetchParentFacility],
+  meta: {
+    pagination: {
+      currentPage: 1,
+      perPage: 5,
+      totalEntries: 12,
+      totalPages: 3,
+    },
+  },
+};

--- a/src/applications/caregivers/tests/mocks/responses.js
+++ b/src/applications/caregivers/tests/mocks/responses.js
@@ -1,3 +1,4 @@
+// Mock caregiver facilities response
 export const mockFacilitiesResponse = {
   data: [
     {
@@ -28,7 +29,6 @@ export const mockFacilitiesResponse = {
           saturday: 'Closed',
           sunday: 'Closed',
         },
-        id: 'vha_757QC',
         lat: 39.996592,
         long: -82.93310921,
         mobile: false,
@@ -60,6 +60,8 @@ export const mockFacilitiesResponse = {
         website:
           'https://www.va.gov/central-ohio-health-care/locations/columbus-va-clinic/',
       },
+      type: 'va_facilities',
+      id: 'vha_757QC',
     },
     {
       attributes: {
@@ -97,7 +99,6 @@ export const mockFacilitiesResponse = {
           saturday: '800AM-400PM',
           sunday: '800AM-400PM',
         },
-        id: 'vha_757',
         lat: 39.98048191,
         long: -82.91230307,
         mobile: false,
@@ -433,6 +434,8 @@ export const mockFacilitiesResponse = {
         website:
           'https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/',
       },
+      type: 'va_facilities',
+      id: 'vha_757',
     },
   ],
   meta: {
@@ -445,6 +448,7 @@ export const mockFacilitiesResponse = {
   },
 };
 
+// formatted fetchFacilities function responses
 const fetchChildFacilityWithoutCaregiverSupport = {
   access: null,
   activeStatus: null,

--- a/src/applications/caregivers/tests/unit/actions/fetchFacilities.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/actions/fetchFacilities.unit.spec.js
@@ -5,8 +5,8 @@ import sinon from 'sinon';
 import environment from 'platform/utilities/environment';
 import { fetchFacilities } from '../../../actions/fetchFacilities';
 import {
-  mockFacilitiesResponse,
   mockFetchFacilitiesResponse,
+  mockFacilitiesResponse,
 } from '../../mocks/responses';
 
 describe('CG fetchFacilities action', () => {
@@ -32,7 +32,7 @@ describe('CG fetchFacilities action', () => {
 
       const expectedUrl = `${
         environment.API_URL
-      }/v0/health_care_applications/facilities?type=health&lat=${lat}&long=${long}&radius=${radius}&page=${page}&per_page=${perPage}&facilityIds[]=${
+      }/v0/caregivers_assistance_claims/facilities?type=health&lat=${lat}&long=${long}&radius=${radius}&page=${page}&per_page=${perPage}&facilityIds[]=${
         facilityIds[0]
       }&facilityIds[]=${facilityIds[1]}`;
       sinon.assert.calledWith(apiRequestStub, expectedUrl);
@@ -43,7 +43,7 @@ describe('CG fetchFacilities action', () => {
 
       const expectedUrl = `${
         environment.API_URL
-      }/v0/health_care_applications/facilities?type=health`;
+      }/v0/caregivers_assistance_claims/facilities?type=health`;
       sinon.assert.calledWith(apiRequestStub, expectedUrl);
     });
 

--- a/src/applications/caregivers/tests/unit/actions/fetchFacilities.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/actions/fetchFacilities.unit.spec.js
@@ -8,6 +8,7 @@ import {
   mockFetchFacilitiesResponse,
   mockFacilitiesResponse,
 } from '../../mocks/responses';
+import content from '../../../locales/en/content.json';
 
 describe('CG fetchFacilities action', () => {
   const lat = 1;
@@ -51,6 +52,16 @@ describe('CG fetchFacilities action', () => {
       apiRequestStub.resolves(mockFacilitiesResponse);
       const response = await fetchFacilities({ long, lat, perPage, radius });
       expect(response).to.deep.eq(mockFetchFacilitiesResponse);
+    });
+
+    it('returns NO_SEARCH_RESULTS if no data array', async () => {
+      apiRequestStub.resolves({ meta: {} });
+      const response = await fetchFacilities({ long, lat, perPage, radius });
+
+      expect(response).to.deep.eq({
+        type: 'NO_SEARCH_RESULTS',
+        errorMessage: content['error--no-results-found'],
+      });
     });
   });
 

--- a/src/applications/caregivers/tests/unit/actions/fetchFacilities.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/actions/fetchFacilities.unit.spec.js
@@ -33,9 +33,9 @@ describe('CG fetchFacilities action', () => {
 
       const expectedUrl = `${
         environment.API_URL
-      }/v0/caregivers_assistance_claims/facilities?type=health&lat=${lat}&long=${long}&radius=${radius}&page=${page}&per_page=${perPage}&facilityIds[]=${
+      }/v0/caregivers_assistance_claims/facilities?type=health&lat=${lat}&long=${long}&radius=${radius}&page=${page}&per_page=${perPage}&facilityIds=${
         facilityIds[0]
-      }&facilityIds[]=${facilityIds[1]}`;
+      },${facilityIds[1]}`;
       sinon.assert.calledWith(apiRequestStub, expectedUrl);
     });
 
@@ -45,6 +45,15 @@ describe('CG fetchFacilities action', () => {
       const expectedUrl = `${
         environment.API_URL
       }/v0/caregivers_assistance_claims/facilities?type=health`;
+      sinon.assert.calledWith(apiRequestStub, expectedUrl);
+    });
+
+    it('formats facility ids correctly when only one facility id', async () => {
+      await fetchFacilities({ facilityIds: ['1'] });
+
+      const expectedUrl = `${
+        environment.API_URL
+      }/v0/caregivers_assistance_claims/facilities?type=health&facilityIds=1`;
       sinon.assert.calledWith(apiRequestStub, expectedUrl);
     });
 

--- a/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormFields/FacilitySearch.unit.spec.js
@@ -170,9 +170,9 @@ describe('CG <FacilitySearch>', () => {
     it('calls dispatch callback with facility object that offers CaregiverSupport', async () => {
       const { props, mockStore } = getData({});
       const { container, selectors } = subject({ props, mockStore });
-      const facilities = mockFetchChildFacilityWithCaregiverSupportResponse;
+      const facilitiesResponse = mockFetchChildFacilityWithCaregiverSupportResponse;
       mapboxStub.resolves(mapBoxSuccessResponse);
-      facilitiesStub.resolves(facilities);
+      facilitiesStub.resolves(facilitiesResponse);
 
       await waitFor(() => {
         inputVaSearchInput(container, 'Tampa', selectors().input);
@@ -184,7 +184,7 @@ describe('CG <FacilitySearch>', () => {
         expect(selectors().loader).to.not.exist;
       });
 
-      const [selectedFacility] = facilities;
+      const [selectedFacility] = facilitiesResponse.facilities;
 
       selectors().radioList.__events.vaValueChange({
         detail: { value: selectedFacility.id },
@@ -203,9 +203,8 @@ describe('CG <FacilitySearch>', () => {
     it('calls dispatch callback with facility object whose parent offers CaregiverSupport and is loaded', async () => {
       const { props, mockStore } = getData({});
       const { container, selectors } = subject({ props, mockStore });
-      const facilities = mockFetchFacilitiesResponse;
       mapboxStub.resolves(mapBoxSuccessResponse);
-      facilitiesStub.resolves(facilities);
+      facilitiesStub.resolves(mockFetchFacilitiesResponse);
 
       await waitFor(() => {
         inputVaSearchInput(container, 'Tampa', selectors().input);
@@ -217,7 +216,10 @@ describe('CG <FacilitySearch>', () => {
         expect(selectors().loader).to.not.exist;
       });
 
-      const [selectedFacility, parentFacility] = facilities;
+      const [
+        selectedFacility,
+        parentFacility,
+      ] = mockFetchFacilitiesResponse.facilities;
 
       selectors().radioList.__events.vaValueChange({
         detail: { value: selectedFacility.id },
@@ -237,12 +239,11 @@ describe('CG <FacilitySearch>', () => {
     it('calls dispatch callback with facility object whose parent offers CaregiverSupport and is not loaded', async () => {
       const { props, mockStore } = getData({});
       const { container, selectors } = subject({ props, mockStore });
-      const facilities = mockFetchChildFacilityResponse;
       mapboxStub.resolves(mapBoxSuccessResponse);
-      facilitiesStub.onFirstCall().resolves(facilities);
+      facilitiesStub.onFirstCall().resolves(mockFetchChildFacilityResponse);
 
-      const parentFacility = mockFetchParentFacilityResponse;
-      facilitiesStub.onSecondCall().resolves([parentFacility]);
+      const parentFacilityResponse = mockFetchParentFacilityResponse;
+      facilitiesStub.onSecondCall().resolves(parentFacilityResponse);
 
       await waitFor(() => {
         inputVaSearchInput(container, 'Tampa', selectors().input);
@@ -254,7 +255,7 @@ describe('CG <FacilitySearch>', () => {
         expect(selectors().loader).to.not.exist;
       });
 
-      const [selectedFacility] = facilities;
+      const [selectedFacility] = mockFetchChildFacilityResponse.facilities;
 
       selectors().radioList.__events.vaValueChange({
         detail: { value: selectedFacility.id },
@@ -267,7 +268,7 @@ describe('CG <FacilitySearch>', () => {
         expect(dispatch.firstCall.args[0].data).to.deep.include({
           'view:plannedClinic': {
             veteranSelected: selectedFacility,
-            caregiverSupport: parentFacility,
+            caregiverSupport: parentFacilityResponse.facilities[0],
           },
         });
       });
@@ -276,9 +277,9 @@ describe('CG <FacilitySearch>', () => {
     it('fails to retrieve parent facility', async () => {
       const { props, mockStore } = getData({});
       const { container, selectors } = subject({ props, mockStore });
-      const facilities = mockFetchChildFacilityResponse;
+      const facilitiesResponse = mockFetchChildFacilityResponse;
       mapboxStub.resolves(mapBoxSuccessResponse);
-      facilitiesStub.onFirstCall().resolves(facilities);
+      facilitiesStub.onFirstCall().resolves(facilitiesResponse);
 
       facilitiesStub.onSecondCall().resolves({
         type: 'SEARCH_FAILED',
@@ -295,7 +296,7 @@ describe('CG <FacilitySearch>', () => {
         expect(selectors().loader).to.not.exist;
       });
 
-      const [selectedFacility] = facilities;
+      const [selectedFacility] = facilitiesResponse.facilities;
 
       selectors().radioList.__events.vaValueChange({
         detail: { value: selectedFacility.id },
@@ -331,9 +332,9 @@ describe('CG <FacilitySearch>', () => {
         },
       });
       const { container, selectors } = subject({ props, mockStore });
-      const facilities = mockFetchFacilitiesResponse;
+      const facilitiesResponse = mockFetchFacilitiesResponse;
       mapboxStub.resolves(mapBoxSuccessResponse);
-      facilitiesStub.resolves(facilities);
+      facilitiesStub.resolves(facilitiesResponse);
 
       await waitFor(() => {
         inputVaSearchInput(container, 'Tampa', selectors().input);
@@ -377,8 +378,8 @@ describe('CG <FacilitySearch>', () => {
       });
     });
 
-    context('clicking more facilities', () => {
-      it('successfully loads more facilities', async () => {
+    context('more facilities buttons', () => {
+      it('successfully loads more facilities on click', async () => {
         const { props, mockStore } = getData({});
         const { selectors, getByText, container } = subject({
           props,
@@ -386,7 +387,10 @@ describe('CG <FacilitySearch>', () => {
         });
 
         mapboxStub.resolves(mapBoxSuccessResponse);
-        facilitiesStub.resolves(mockFetchFacilitiesResponse);
+        facilitiesStub
+          .onFirstCall()
+          .resolves(mockFetchChildFacilityWithCaregiverSupportResponse);
+        facilitiesStub.onSecondCall().resolves(mockFetchParentFacilityResponse);
 
         await waitFor(() => {
           inputVaSearchInput(container, 'Tampa', selectors().input);
@@ -397,7 +401,7 @@ describe('CG <FacilitySearch>', () => {
           expect(selectors().radioList).to.exist;
           expect(selectors().loader).to.not.exist;
           expect(selectors().input).to.not.have.attr('error');
-          expect(getByText(/Showing 1-2 of 2 facilities for/)).to.exist;
+          expect(getByText(/Showing 1-1 of 1 facilities for/)).to.exist;
         });
 
         await waitFor(() => {
@@ -409,7 +413,7 @@ describe('CG <FacilitySearch>', () => {
         await waitFor(() => {
           expect(selectors().radioList).to.exist;
           expect(selectors().loader).to.not.exist;
-          expect(getByText(/Showing 1-4 of 4 facilities for/)).to.exist;
+          expect(getByText(/Showing 1-2 of 2 facilities for/)).to.exist;
           expect(selectors().input).to.not.have.attr('error');
         });
 
@@ -429,7 +433,7 @@ describe('CG <FacilitySearch>', () => {
         });
       });
 
-      it('handles error loading more facilities', async () => {
+      it('handles error loading more facilities on click', async () => {
         const { props, mockStore } = getData({});
         const { selectors, getByText, container } = subject({
           props,
@@ -468,6 +472,40 @@ describe('CG <FacilitySearch>', () => {
             'ErrorSome bad error occurred.',
           );
           expect(getByText(/Showing 1-2 of 2 facilities for/)).to.exist;
+        });
+      });
+
+      it('only renders more facilities button when totalEntries is greater than facilities total', async () => {
+        const { props, mockStore } = getData({});
+        const { selectors, getByText, container } = subject({
+          props,
+          mockStore,
+        });
+
+        mapboxStub.resolves(mapBoxSuccessResponse);
+        facilitiesStub.resolves({
+          ...mockFetchFacilitiesResponse,
+          meta: {
+            pagination: {
+              currentPage: 1,
+              perPage: 5,
+              totalEntries: 2,
+              totalPages: 3,
+            },
+          },
+        });
+
+        await waitFor(() => {
+          inputVaSearchInput(container, 'Tampa', selectors().input);
+          expect(selectors().loader).to.exist;
+        });
+
+        await waitFor(() => {
+          expect(selectors().radioList).to.exist;
+          expect(selectors().loader).to.not.exist;
+          expect(selectors().input).to.not.have.attr('error');
+          expect(getByText(/Showing 1-2 of 2 facilities for/)).to.exist;
+          expect(selectors().moreFacilities).not.to.exist;
         });
       });
     });


### PR DESCRIPTION
## Summary

- Use new caregiver endpoint to query facilities. This endpoint returns pagination metadata allowing for determining if `Load more facilities` button should be loaded. The data object response is a little different format, so that is the bulk of changes in this PR. 
- 1010 Team
- Behind flipper toggle `caregiver_use_facilities_API`.
- Don't merge until corresponding [vets-api PR](https://github.com/department-of-veterans-affairs/vets-api/pull/18560) is merged. (although it's behind a toggle so it won't break for anyone)

## Related issue(s)

- [vets-api PR](https://github.com/department-of-veterans-affairs/vets-api/pull/18560) needs merged first.
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/70846

## Testing done

- Unit tests updated

## Screenshots
No visual changes other than `Load more facilities` button is not rendered if there are no more facilities to load

## What areas of the site does it impact?

10-10CG

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user