### PR TITLE
MHV-53461 Add alert for virus attachments

### DIFF
--- a/src/applications/mhv-secure-messaging/actions/messages.js
+++ b/src/applications/mhv-secure-messaging/actions/messages.js
@@ -169,6 +169,17 @@ export const sendMessage = (message, attachments) => async dispatch => {
           Constants.Alerts.Message.BLOCKED_MESSAGE_ERROR,
         ),
       );
+    } else if (
+      e.errors &&
+      e.errors[0].code === Constants.Errors.Code.ATTACHMENT_SCAN_FAIL
+    ) {
+      dispatch(
+        addAlert(
+          Constants.ALERT_TYPE_ERROR,
+          '',
+          Constants.Alerts.Message.ATTACHMENT_SCAN_FAIL,
+        ),
+      );
     } else
       dispatch(
         addAlert(

--- a/src/applications/mhv-secure-messaging/actions/messages.js
+++ b/src/applications/mhv-secure-messaging/actions/messages.js
@@ -229,6 +229,17 @@ export const sendReply = (
       e.errors[0].code === Constants.Errors.Code.TG_NOT_ASSOCIATED
     ) {
       dispatch(addAlert(Constants.ALERT_TYPE_ERROR, '', e.errors[0].detail));
+    } else if (
+      e.errors &&
+      e.errors[0].code === Constants.Errors.Code.ATTACHMENT_SCAN_FAIL
+    ) {
+      dispatch(
+        addAlert(
+          Constants.ALERT_TYPE_ERROR,
+          '',
+          Constants.Alerts.Message.ATTACHMENT_SCAN_FAIL,
+        ),
+      );
     } else {
       dispatch(
         addAlert(

--- a/src/applications/mhv-secure-messaging/components/AttachmentsList.jsx
+++ b/src/applications/mhv-secure-messaging/components/AttachmentsList.jsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
 import { focusElement } from '@department-of-veterans-affairs/platform-utilities/ui';
 import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { closeAlert } from '../actions/alerts';
 import RemoveAttachmentModal from './Modals/RemoveAttachmentModal';
 import HowToAttachFiles from './HowToAttachFiles';
+import * as Constants from '../util/constants';
 
 const AttachmentsList = props => {
   const {
@@ -18,7 +21,9 @@ const AttachmentsList = props => {
     attachFileSuccess,
     setAttachFileSuccess,
     forPrint,
+    attachmentVirusError,
   } = props;
+  const dispatch = useDispatch();
   const attachmentReference = useRef(null);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [isAttachmentRemoved, setIsAttachmentRemoved] = useState(false);
@@ -50,7 +55,7 @@ const AttachmentsList = props => {
 
   useEffect(
     () => {
-      if (attachFileSuccess && attachFileAlertRef.current.shadowRoot) {
+      if (attachFileSuccess && attachFileAlertRef?.current?.shadowRoot) {
         setTimeout(() => {
           setFocusedElement(
             document.querySelector('#close-success-alert-button'),
@@ -122,7 +127,8 @@ const AttachmentsList = props => {
       {editingEnabled && <HowToAttachFiles />}
 
       {attachFileSuccess &&
-        attachments.length > 0 && (
+        attachments.length > 0 &&
+        !attachmentVirusError && (
           <VaAlert
             aria-live="polite"
             aria-label="file successfully attached"
@@ -158,6 +164,22 @@ const AttachmentsList = props => {
             </button>
           </VaAlert>
         )}
+
+      {attachmentVirusError && (
+        <VaAlert
+          data-testid="attachment-virus-alert"
+          aria-live="polite"
+          aria-label={Constants.Alerts.Message.ATTACHMENT_SCAN_FAIL}
+          background-only
+          className="file-attached-success vads-u-margin-top--2"
+          disable-analytics
+          full-width="false"
+          show-icon
+          status="error"
+        >
+          {Constants.Alerts.Message.ATTACHMENT_SCAN_FAIL}
+        </VaAlert>
+      )}
 
       <ul className="attachments-list">
         {!!attachments.length &&
@@ -261,6 +283,7 @@ const AttachmentsList = props => {
             setIsAttachmentRemoved(false);
           }}
           onDelete={() => {
+            dispatch(closeAlert());
             setNavigationError();
             setIsModalVisible(false);
             removeAttachment(fileToRemove);

--- a/src/applications/mhv-secure-messaging/components/AttachmentsList.jsx
+++ b/src/applications/mhv-secure-messaging/components/AttachmentsList.jsx
@@ -7,7 +7,7 @@ import { VaAlert } from '@department-of-veterans-affairs/component-library/dist/
 import { closeAlert } from '../actions/alerts';
 import RemoveAttachmentModal from './Modals/RemoveAttachmentModal';
 import HowToAttachFiles from './HowToAttachFiles';
-import * as Constants from '../util/constants';
+import { Alerts } from '../util/constants';
 
 const AttachmentsList = props => {
   const {
@@ -21,7 +21,7 @@ const AttachmentsList = props => {
     attachFileSuccess,
     setAttachFileSuccess,
     forPrint,
-    attachmentVirusError,
+    attachmentScanError,
   } = props;
   const dispatch = useDispatch();
   const attachmentReference = useRef(null);
@@ -32,6 +32,19 @@ const AttachmentsList = props => {
   const [recentlyRemovedFile, setRecentlyRemovedFile] = useState(false);
   const attachFileAlertRef = useRef();
   const [focusedElement, setFocusedElement] = useState(null);
+
+  useEffect(
+    () => {
+      if (attachmentScanError) {
+        setFocusedElement(
+          attachments.length > 1
+            ? document.querySelector('#remove-all-attachments-button')
+            : document.querySelector('remove-attachment-button'),
+        );
+      }
+    },
+    [attachmentScanError],
+  );
 
   const getSize = num => {
     if (num > 999999) {
@@ -139,7 +152,7 @@ const AttachmentsList = props => {
 
       {attachFileSuccess &&
         attachments.length > 0 &&
-        !attachmentVirusError && (
+        !attachmentScanError && (
           <VaAlert
             aria-live="polite"
             aria-label="file successfully attached"
@@ -176,12 +189,12 @@ const AttachmentsList = props => {
           </VaAlert>
         )}
 
-      {attachmentVirusError &&
+      {attachmentScanError &&
         (attachments.length > 1 ? (
           <VaAlert
             data-testid="attachment-virus-alert"
-            aria-live="polite"
-            aria-label={Constants.Alerts.Message.ATTACHMENT_SCAN_FAIL}
+            aria-live="assertive"
+            aria-label={Alerts.Message.ATTACHMENT_SCAN_FAIL}
             background-only
             className="file-attached-success vads-u-margin-top--2"
             disable-analytics
@@ -195,6 +208,7 @@ const AttachmentsList = props => {
             </p>
             <button
               className="usa-button-secondary vads-u-margin-bottom--0 vads-u-margin-right--0"
+              data-testid="remove-all-attachments-button"
               onClick={() => {
                 handleRemoveAllAttachments();
               }}
@@ -205,8 +219,8 @@ const AttachmentsList = props => {
         ) : (
           <VaAlert
             data-testid="attachment-virus-alert"
-            aria-live="polite"
-            aria-label={Constants.Alerts.Message.ATTACHMENT_SCAN_FAIL}
+            aria-live="assertive"
+            aria-label={Alerts.Message.ATTACHMENT_SCAN_FAIL}
             background-only
             className="file-attached-success vads-u-margin-top--2"
             disable-analytics
@@ -214,7 +228,7 @@ const AttachmentsList = props => {
             show-icon
             status="error"
           >
-            {Constants.Alerts.Message.ATTACHMENT_SCAN_FAIL}
+            {Alerts.Message.ATTACHMENT_SCAN_FAIL}
           </VaAlert>
         ))}
 
@@ -364,6 +378,7 @@ AttachmentsList.propTypes = {
   setAttachments: PropTypes.func,
   setIsModalVisible: PropTypes.func,
   setNavigationError: PropTypes.func,
+  attachmentScanError: PropTypes.bool,
 };
 
 export default AttachmentsList;

--- a/src/applications/mhv-secure-messaging/components/AttachmentsList.jsx
+++ b/src/applications/mhv-secure-messaging/components/AttachmentsList.jsx
@@ -98,6 +98,17 @@ const AttachmentsList = props => {
     }
   };
 
+  const handleRemoveAllAttachments = () => {
+    setAttachments([]);
+    dispatch(closeAlert()).then(() =>
+      setFocusedElement(
+        document
+          .querySelector('.attach-file-button')
+          .shadowRoot.querySelector('button'),
+      ),
+    );
+  };
+
   const handleSuccessAlertClose = () => {
     setAttachFileSuccess(false);
     if (attachments.length > 0) {
@@ -165,21 +176,47 @@ const AttachmentsList = props => {
           </VaAlert>
         )}
 
-      {attachmentVirusError && (
-        <VaAlert
-          data-testid="attachment-virus-alert"
-          aria-live="polite"
-          aria-label={Constants.Alerts.Message.ATTACHMENT_SCAN_FAIL}
-          background-only
-          className="file-attached-success vads-u-margin-top--2"
-          disable-analytics
-          full-width="false"
-          show-icon
-          status="error"
-        >
-          {Constants.Alerts.Message.ATTACHMENT_SCAN_FAIL}
-        </VaAlert>
-      )}
+      {attachmentVirusError &&
+        (attachments.length > 1 ? (
+          <VaAlert
+            data-testid="attachment-virus-alert"
+            aria-live="polite"
+            aria-label={Constants.Alerts.Message.ATTACHMENT_SCAN_FAIL}
+            background-only
+            className="file-attached-success vads-u-margin-top--2"
+            disable-analytics
+            full-width="false"
+            show-icon
+            status="error"
+          >
+            <p className="vads-u-margin--0">
+              One or more of the files you attached has a virus. You’ll need to
+              remove it to send your message.
+            </p>
+            <button
+              className="usa-button-secondary vads-u-margin-bottom--0 vads-u-margin-right--0"
+              onClick={() => {
+                handleRemoveAllAttachments();
+              }}
+            >
+              Remove all attachments
+            </button>
+          </VaAlert>
+        ) : (
+          <VaAlert
+            data-testid="attachment-virus-alert"
+            aria-live="polite"
+            aria-label={Constants.Alerts.Message.ATTACHMENT_SCAN_FAIL}
+            background-only
+            className="file-attached-success vads-u-margin-top--2"
+            disable-analytics
+            full-width="false"
+            show-icon
+            status="error"
+          >
+            {Constants.Alerts.Message.ATTACHMENT_SCAN_FAIL}
+          </VaAlert>
+        ))}
 
       <ul className="attachments-list">
         {!!attachments.length &&
@@ -283,7 +320,9 @@ const AttachmentsList = props => {
             setIsAttachmentRemoved(false);
           }}
           onDelete={() => {
-            dispatch(closeAlert());
+            if (attachments.length === 1) {
+              dispatch(closeAlert());
+            }
             setNavigationError();
             setIsModalVisible(false);
             removeAttachment(fileToRemove);

--- a/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -114,7 +114,7 @@ const ComposeForm = props => {
   );
   const alertsList = useSelector(state => state.sm.alerts.alertList);
 
-  const attachmentVirusError = useMemo(
+  const attachmentScanError = useMemo(
     () =>
       alertsList.filter(
         alert =>
@@ -895,14 +895,14 @@ const ComposeForm = props => {
                     setAttachFileSuccess={setAttachFileSuccess}
                     setNavigationError={setNavigationError}
                     editingEnabled
-                    attachmentVirusError={attachmentVirusError}
+                    attachmentScanError={attachmentScanError}
                   />
 
                   <FileInput
                     attachments={attachments}
                     setAttachments={setAttachments}
                     setAttachFileSuccess={setAttachFileSuccess}
-                    attachmentVirusError={attachmentVirusError}
+                    attachmentScanError={attachmentScanError}
                   />
                 </section>
               ))}

--- a/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -32,6 +32,7 @@ import {
   RecipientStatus,
   BlockedTriageAlertStyles,
   FormLabels,
+  Alerts,
 } from '../../util/constants';
 import EmergencyNote from '../EmergencyNote';
 import ComposeFormActionButtons from './ComposeFormActionButtons';
@@ -110,6 +111,17 @@ const ComposeForm = props => {
   const debouncedRecipient = useDebounce(
     selectedRecipient,
     draftAutoSaveTimeout,
+  );
+  const alertsList = useSelector(state => state.sm.alerts.alertList);
+
+  const attachmentVirusError = useMemo(
+    () =>
+      alertsList.filter(
+        alert =>
+          alert.content === Alerts.Message.ATTACHMENT_SCAN_FAIL &&
+          alert.isActive,
+      ).length > 0,
+    [alertsList],
   );
 
   const localStorageValues = useMemo(() => {
@@ -883,12 +895,14 @@ const ComposeForm = props => {
                     setAttachFileSuccess={setAttachFileSuccess}
                     setNavigationError={setNavigationError}
                     editingEnabled
+                    attachmentVirusError={attachmentVirusError}
                   />
 
                   <FileInput
                     attachments={attachments}
                     setAttachments={setAttachments}
                     setAttachFileSuccess={setAttachFileSuccess}
+                    attachmentVirusError={attachmentVirusError}
                   />
                 </section>
               ))}

--- a/src/applications/mhv-secure-messaging/components/ComposeForm/FileInput.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/FileInput.jsx
@@ -12,6 +12,7 @@ const FileInput = props => {
     setAttachments,
     setAttachFileSuccess,
     draftSequence,
+    attachmentVirusError,
   } = props;
 
   const [error, setError] = useState();
@@ -142,42 +143,45 @@ const FileInput = props => {
         </label>
       )}
 
-      {attachments?.length < Attachments.MAX_FILE_COUNT && (
-        <>
-          {/* Wave plugin addressed this as an issue, label required */}
-          <label
-            htmlFor={`attachments${draftSequence ? `-${draftSequence}` : ''}`}
-            hidden
-          >
-            Attachments input
-          </label>
-          <input
-            ref={fileInputRef}
-            type="file"
-            id={`attachments${draftSequence ? `-${draftSequence}` : ''}`}
-            name={`attachments${draftSequence ? `-${draftSequence}` : ''}`}
-            data-testid={`attach-file-input${
-              draftSequence ? `-${draftSequence}` : ''
-            }`}
-            onChange={handleFiles}
-            hidden
-          />
+      {attachments?.length < Attachments.MAX_FILE_COUNT &&
+        !attachmentVirusError && (
+          <>
+            {/* Wave plugin addressed this as an issue, label required */}
+            <label
+              htmlFor={`attachments${draftSequence ? `-${draftSequence}` : ''}`}
+              hidden
+            >
+              Attachments input
+            </label>
+            <input
+              ref={fileInputRef}
+              type="file"
+              id={`attachments${draftSequence ? `-${draftSequence}` : ''}`}
+              name={`attachments${draftSequence ? `-${draftSequence}` : ''}`}
+              data-testid={`attach-file-input${
+                draftSequence ? `-${draftSequence}` : ''
+              }`}
+              onChange={handleFiles}
+              hidden
+            />
 
-          <va-button
-            onClick={useFileInput}
-            secondary
-            text={`${attachText}${draftText}`}
-            class="attach-file-button"
-            data-testid={`attach-file-button${
-              draftSequence ? `-${draftSequence}` : ''
-            }`}
-            id={`attach-file-button${draftSequence ? `-${draftSequence}` : ''}`}
-            data-dd-action-name={`Attach File Button${
-              draftSequence ? `-${draftSequence}` : ''
-            }`}
-          />
-        </>
-      )}
+            <va-button
+              onClick={useFileInput}
+              secondary
+              text={`${attachText}${draftText}`}
+              class="attach-file-button"
+              data-testid={`attach-file-button${
+                draftSequence ? `-${draftSequence}` : ''
+              }`}
+              id={`attach-file-button${
+                draftSequence ? `-${draftSequence}` : ''
+              }`}
+              data-dd-action-name={`Attach File Button${
+                draftSequence ? `-${draftSequence}` : ''
+              }`}
+            />
+          </>
+        )}
     </div>
   );
 };

--- a/src/applications/mhv-secure-messaging/components/ComposeForm/FileInput.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/FileInput.jsx
@@ -12,7 +12,7 @@ const FileInput = props => {
     setAttachments,
     setAttachFileSuccess,
     draftSequence,
-    attachmentVirusError,
+    attachmentScanError,
   } = props;
 
   const [error, setError] = useState();
@@ -144,7 +144,7 @@ const FileInput = props => {
       )}
 
       {attachments?.length < Attachments.MAX_FILE_COUNT &&
-        !attachmentVirusError && (
+        !attachmentScanError && (
           <>
             {/* Wave plugin addressed this as an issue, label required */}
             <label

--- a/src/applications/mhv-secure-messaging/components/ComposeForm/ReplyDraftItem.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/ReplyDraftItem.jsx
@@ -80,7 +80,7 @@ const ReplyDraftItem = props => {
   const [draftId, setDraftId] = useState(null);
 
   const alertsList = useSelector(state => state.sm.alerts.alertList);
-  const attachmentVirusError = useMemo(
+  const attachmentScanError = useMemo(
     () =>
       alertsList?.filter(
         alert =>
@@ -538,7 +538,7 @@ const ReplyDraftItem = props => {
                 attachFileSuccess={attachFileSuccess}
                 setAttachFileSuccess={setAttachFileSuccess}
                 draftSequence={draftSequence}
-                attachmentVirusError={attachmentVirusError}
+                attachmentScanError={attachmentScanError}
               />
 
               <FileInput
@@ -546,7 +546,7 @@ const ReplyDraftItem = props => {
                 setAttachments={setAttachments}
                 setAttachFileSuccess={setAttachFileSuccess}
                 draftSequence={draftSequence}
-                attachmentVirusError={attachmentVirusError}
+                attachmentScanError={attachmentScanError}
               />
             </section>
           )}

--- a/src/applications/mhv-secure-messaging/components/ComposeForm/ReplyDraftItem.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/ReplyDraftItem.jsx
@@ -22,7 +22,11 @@ import FileInput from './FileInput';
 import DraftSavedInfo from './DraftSavedInfo';
 import ComposeFormActionButtons from './ComposeFormActionButtons';
 import MessageThreadBody from '../MessageThread/MessageThreadBody';
-import { ErrorMessages, draftAutoSaveTimeout } from '../../util/constants';
+import {
+  ErrorMessages,
+  draftAutoSaveTimeout,
+  Alerts,
+} from '../../util/constants';
 import useDebounce from '../../hooks/use-debounce';
 import { saveReplyDraft } from '../../actions/draftDetails';
 import RouteLeavingGuard from '../shared/RouteLeavingGuard';
@@ -74,6 +78,17 @@ const ReplyDraftItem = props => {
   const [saveError, setSaveError] = useState(null);
   const [focusToTextarea, setFocusToTextarea] = useState(false);
   const [draftId, setDraftId] = useState(null);
+
+  const alertsList = useSelector(state => state.sm.alerts.alertList);
+  const attachmentVirusError = useMemo(
+    () =>
+      alertsList?.filter(
+        alert =>
+          alert.content === Alerts.Message.ATTACHMENT_SCAN_FAIL &&
+          alert.isActive,
+      ).length > 0,
+    [alertsList],
+  );
 
   const localStorageValues = useMemo(() => {
     return {
@@ -523,6 +538,7 @@ const ReplyDraftItem = props => {
                 attachFileSuccess={attachFileSuccess}
                 setAttachFileSuccess={setAttachFileSuccess}
                 draftSequence={draftSequence}
+                attachmentVirusError={attachmentVirusError}
               />
 
               <FileInput
@@ -530,6 +546,7 @@ const ReplyDraftItem = props => {
                 setAttachments={setAttachments}
                 setAttachFileSuccess={setAttachFileSuccess}
                 draftSequence={draftSequence}
+                attachmentVirusError={attachmentVirusError}
               />
             </section>
           )}

--- a/src/applications/mhv-secure-messaging/components/MessageThread/MessageThreadAttachments.jsx
+++ b/src/applications/mhv-secure-messaging/components/MessageThread/MessageThreadAttachments.jsx
@@ -11,6 +11,7 @@ const MessageThreadAttachments = props => {
         <AttachmentsList
           attachments={props.attachments}
           forPrint={props.forPrint}
+          attachmentVirusError={false}
         />
       </div>
     )

--- a/src/applications/mhv-secure-messaging/components/MessageThread/MessageThreadAttachments.jsx
+++ b/src/applications/mhv-secure-messaging/components/MessageThread/MessageThreadAttachments.jsx
@@ -11,7 +11,7 @@ const MessageThreadAttachments = props => {
         <AttachmentsList
           attachments={props.attachments}
           forPrint={props.forPrint}
-          attachmentVirusError={false}
+          attachmentScanError={false}
         />
       </div>
     )

--- a/src/applications/mhv-secure-messaging/components/shared/AlertBackgroundBox.jsx
+++ b/src/applications/mhv-secure-messaging/components/shared/AlertBackgroundBox.jsx
@@ -16,7 +16,13 @@
  * since in this case there are no other content on screen.
  */
 
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, {
+  useEffect,
+  useState,
+  useRef,
+  useCallback,
+  useMemo,
+} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import PropTypes from 'prop-types';
@@ -35,6 +41,16 @@ const AlertBackgroundBox = props => {
   const [alertContent, setAlertContent] = useState('');
   const alertRef = useRef();
   const [activeAlert, setActiveAlert] = useState(null);
+
+  const hideAlert = useMemo(
+    () =>
+      alertList.filter(
+        alert =>
+          alert.content === Alerts.Message.ATTACHMENT_SCAN_FAIL &&
+          alert.isActive,
+      ).length > 0,
+    [alertList],
+  );
 
   const {
     Message: { SERVER_ERROR_503 },
@@ -141,37 +157,38 @@ const AlertBackgroundBox = props => {
 
   return (
     <>
-      {activeAlert && (
-        <VaAlert
-          uswds
-          ref={alertRef}
-          background-only
-          closeable={props.closeable}
-          className="vads-u-margin-bottom--1 va-alert"
-          close-btn-aria-label={`${alertContent}. ${alertAriaLabel} Close notification.`}
-          disable-analytics="false"
-          full-width="false"
-          show-icon={handleShowIcon()}
-          status={activeAlert.alertType}
-          onCloseEvent={
-            closeAlertBox // success, error, warning, info, continue
-          }
-          onVa-component-did-load={handleAlertFocus}
-        >
-          <div>
-            <p className="vads-u-margin-y--0" data-testid="alert-text">
-              {alertContent}
-              <SrOnlyTag
-                className="sr-only"
-                aria-live="polite"
-                aria-atomic="true"
-              >
-                {alertAriaLabel}
-              </SrOnlyTag>
-            </p>
-          </div>
-        </VaAlert>
-      )}
+      {activeAlert &&
+        !hideAlert && (
+          <VaAlert
+            uswds
+            ref={alertRef}
+            background-only
+            closeable={props.closeable}
+            className="vads-u-margin-bottom--1 va-alert"
+            close-btn-aria-label={`${alertContent}. ${alertAriaLabel} Close notification.`}
+            disable-analytics="false"
+            full-width="false"
+            show-icon={handleShowIcon()}
+            status={activeAlert.alertType}
+            onCloseEvent={
+              closeAlertBox // success, error, warning, info, continue
+            }
+            onVa-component-did-load={handleAlertFocus}
+          >
+            <div>
+              <p className="vads-u-margin-y--0" data-testid="alert-text">
+                {alertContent}
+                <SrOnlyTag
+                  className="sr-only"
+                  aria-live="polite"
+                  aria-atomic="true"
+                >
+                  {alertAriaLabel}
+                </SrOnlyTag>
+              </p>
+            </div>
+          </VaAlert>
+        )}
     </>
   );
 };

--- a/src/applications/mhv-secure-messaging/tests/components/Compose/AttachmentsList.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/Compose/AttachmentsList.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderWithStoreAndRouter } from '@department-of-veterans-affairs/platform-testing/react-testing-library-helpers';
 import { expect } from 'chai';
-import { render, cleanup, fireEvent, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, waitFor } from '@testing-library/react';
 import triageTeams from '../../fixtures/recipients.json';
 import categories from '../../fixtures/categories-response.json';
 import reducer from '../../../reducers';
@@ -65,8 +65,17 @@ describe('Attachments List component', () => {
             'http://127.0.0.1:3000/my_health/v1/messaging/messages/2664846/attachments/2664842',
         },
       ],
+      attachmentVirusError: false,
+      editingEnabled: false,
     };
-    const screen = render(<AttachmentsList {...customProps} />);
+    const screen = renderWithStoreAndRouter(
+      <AttachmentsList {...customProps} />,
+      {
+        initialState,
+        reducers: reducer,
+        path: Paths.MESSAGE_THREAD,
+      },
+    );
     expect(document.querySelector('.message-body-attachments-label')).to.exist;
     expect(screen.getByTestId('attachments-count').textContent).to.equal(
       ' (1)',
@@ -181,5 +190,24 @@ describe('Attachments List component', () => {
     waitFor(() => {
       expect(screen.queryByTestId('file-attached-success-alert')).to.not.exist;
     });
+  });
+
+  it('renders error message when attachment contains a virus', async () => {
+    const customProps = {
+      attachments: [
+        {
+          id: 2664842,
+          messageId: 2664846,
+          name: 'BIRD 1.gif',
+          attachmentSize: 31127,
+          download:
+            'http://127.0.0.1:3000/my_health/v1/messaging/messages/2664846/attachments/2664842',
+        },
+      ],
+      attachmentVirusError: false,
+    };
+    const screen = setup(initialState, Paths.COMPOSE, customProps);
+
+    expect(screen.findByTestId('attachment-virus-alert')).to.exist;
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/components/Compose/AttachmentsList.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/Compose/AttachmentsList.unit.spec.jsx
@@ -65,7 +65,7 @@ describe('Attachments List component', () => {
             'http://127.0.0.1:3000/my_health/v1/messaging/messages/2664846/attachments/2664842',
         },
       ],
-      attachmentVirusError: false,
+      attachmentScanError: false,
       editingEnabled: false,
     };
     const screen = renderWithStoreAndRouter(
@@ -204,7 +204,7 @@ describe('Attachments List component', () => {
             'http://127.0.0.1:3000/my_health/v1/messaging/messages/2664846/attachments/2664842',
         },
       ],
-      attachmentVirusError: false,
+      attachmentScanError: false,
     };
     const screen = setup(initialState, Paths.COMPOSE, customProps);
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-attachment-virus-alert.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-attachment-virus-alert.cypress.spec.js
@@ -32,6 +32,7 @@ describe('Verify attachment with virus alert', () => {
       .and(`have.text`, Alerts.VIRUS_ATTCH);
 
     cy.get(Locators.ATTACH_FILE_INPUT).should(`not.exist`);
+    // cy.get(Locators.BUTTONS.REMOVE_ATTACHMENT).should('be.focused');
 
     cy.injectAxe();
     cy.axeCheck(AXE_CONTEXT);

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-attachment-virus-alert.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-attachment-virus-alert.cypress.spec.js
@@ -1,0 +1,56 @@
+import SecureMessagingSite from './sm_site/SecureMessagingSite';
+import PatientInboxPage from './pages/PatientInboxPage';
+import PatientComposePage from './pages/PatientComposePage';
+import { AXE_CONTEXT, Data, Locators, Paths, Alerts } from './utils/constants';
+
+describe('Verify attachment with virus alert', () => {
+  beforeEach(() => {
+    SecureMessagingSite.login();
+    PatientInboxPage.loadInboxMessages();
+    PatientInboxPage.navigateToComposePage();
+
+    PatientComposePage.selectRecipient();
+    PatientComposePage.selectCategory();
+    PatientComposePage.getMessageSubjectField().type(Data.TEST_SUBJECT);
+    PatientComposePage.getMessageBodyField().type(Data.TEST_MESSAGE_BODY, {
+      force: true,
+      waitforanimations: true,
+    });
+    PatientComposePage.attachMessageFromFile(Data.SAMPLE_IMG);
+    cy.intercept('POST', Paths.SM_API_EXTENDED, {
+      statusCode: 400,
+      body: { errors: [{ code: 'SM172' }] },
+    }).as('failed');
+    cy.get(Locators.BUTTONS.SEND)
+      .contains('Send')
+      .click({ force: true });
+  });
+
+  it('verify alert exist and attach button disappears', () => {
+    cy.get(`[data-testid="attachment-virus-alert"]`)
+      .should(`be.visible`)
+      .and(`have.text`, Alerts.VIRUS_ATTCH);
+
+    cy.get(Locators.ATTACH_FILE_INPUT).should(`not.exist`);
+
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+
+  it(`verify attach button back`, () => {
+    cy.get(Locators.BUTTONS.REMOVE_ATTACHMENT).click({ force: true });
+    cy.get(Locators.BUTTONS.CONFIRM_REMOVE_ATTACHMENT)
+      .should(`be.visible`)
+      .then(btn => {
+        return new Cypress.Promise(resolve => {
+          setTimeout(resolve, 2000);
+          cy.wrap(btn).click();
+        });
+      });
+
+    cy.get(Locators.ATTACH_FILE_INPUT).should(`exist`);
+
+    cy.injectAxe();
+    cy.axeCheck(AXE_CONTEXT);
+  });
+});

--- a/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-attachment-virus-alert.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/secure-messaging-attachment-virus-alert.cypress.spec.js
@@ -27,7 +27,7 @@ describe('Verify attachment with virus alert', () => {
   });
 
   it('verify alert exist and attach button disappears', () => {
-    cy.get(`[data-testid="attachment-virus-alert"]`)
+    cy.get(Locators.ALERTS.ATTCH_VIRUS)
       .should(`be.visible`)
       .and(`have.text`, Alerts.VIRUS_ATTCH);
 

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -128,6 +128,7 @@ export const Locators = {
     SORT: '[data-testid="sort-button"]',
     ATTACH_FILE: '[data-testid="attach-file-button"]',
     REMOVE_ATTACHMENT: '[data-testid="remove-attachment-button"]',
+    REMOVE_ALL_ATTCH: `[data-testid="attachment-virus-alert"]>button`,
     CONFIRM_REMOVE_ATTACHMENT:
       '[data-testid="confirm-remove-attachment-button"]',
     CONTINUE_EDITING: 'va-button[text="Continue editing"]',
@@ -272,6 +273,7 @@ export const Alerts = {
   SAVE_SIGN: `We can't save your signature in a draft message`,
   SAVE_SIGN_ATTCH: `We can't save your signature or attachments in a draft message`,
   VIRUS_ATTCH: `The file you attached has a virus. Remove the file to send your message.`,
+  VIRUS_MULTI_ATTCH: `One or more of the files you attached has a virus. You’ll need to remove it to send your message.`,
 };
 
 export const Data = {

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -202,6 +202,7 @@ export const Locators = {
     CL_SAVE: `[data-testid="sm-route-navigation-guard-confirm-button"]`,
     CL_DELETE_AND_EXIT: `[data-testid="sm-route-navigation-guard-cancel-button"]`,
     ALERT_TEXT: `[data-testid="alert-text"]`,
+    ATTCH_VIRUS: `[data-testid="attachment-virus-alert"]`,
   },
   FIELDS: {
     RECIPIENT: '#select',

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -270,6 +270,7 @@ export const Alerts = {
   EL_SIGN_CHECK: `You must certify by checking the box.`,
   SAVE_SIGN: `We can't save your signature in a draft message`,
   SAVE_SIGN_ATTCH: `We can't save your signature or attachments in a draft message`,
+  VIRUS_ATTCH: `The file you attached has a virus. Remove the file to send your message.`,
 };
 
 export const Data = {

--- a/src/applications/mhv-secure-messaging/util/constants.js
+++ b/src/applications/mhv-secure-messaging/util/constants.js
@@ -161,6 +161,8 @@ export const Alerts = {
     SERVER_ERROR_503:
       'We’re sorry. We couldn’t load this page. Try again later.',
     SAVE_CONTACT_LIST_SUCCESS: 'Contact list changes saved',
+    ATTACHMENT_SCAN_FAIL:
+      'The file you attached has a virus. Remove the file to send your message.',
   },
 
   Folder: {
@@ -205,6 +207,7 @@ export const Errors = {
     BLOCKED_USER2: 'SM151',
     TG_NOT_ASSOCIATED: 'SM129',
     SERVICE_OUTAGE: '503',
+    ATTACHMENT_SCAN_FAIL: 'SM172',
   },
 };
 

--- a/src/platform/mhv/api/mocks/index.js
+++ b/src/platform/mhv/api/mocks/index.js
@@ -76,11 +76,7 @@ const responses = {
 
   'GET /my_health/v1/messaging/messages/categories':
     categories.defaultCategories,
-  // 'POST /my_health/v1/messaging/messages': drafts.sendDraft,
-  'POST /my_health/v1/messaging/messages': {
-    status: 400,
-    message: { code: 172, detail: 'Attachment scan failed', source: '' },
-  },
+  'POST /my_health/v1/messaging/messages': drafts.sendDraft,
   'POST /my_health/v1/messaging/message_drafts': drafts.newDraft,
   'PUT /my_health/v1/messaging/message_drafts/:id': drafts.updateDraft,
   'DELETE /my_health/v1/messaging/messages/:id': drafts.deleteDraft,

--- a/src/platform/mhv/api/mocks/index.js
+++ b/src/platform/mhv/api/mocks/index.js
@@ -76,7 +76,11 @@ const responses = {
 
   'GET /my_health/v1/messaging/messages/categories':
     categories.defaultCategories,
-  'POST /my_health/v1/messaging/messages': drafts.sendDraft,
+  // 'POST /my_health/v1/messaging/messages': drafts.sendDraft,
+  'POST /my_health/v1/messaging/messages': {
+    status: 400,
+    message: { code: 172, detail: 'Attachment scan failed', source: '' },
+  },
   'POST /my_health/v1/messaging/message_drafts': drafts.newDraft,
   'PUT /my_health/v1/messaging/message_drafts/:id': drafts.updateDraft,
   'DELETE /my_health/v1/messaging/messages/:id': drafts.deleteDraft,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [ ] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Adds logic and alert for attachments that fail virus scanning.

## Related issue(s)
https://jira.devops.va.gov/browse/MHV-53461
> Add error message for attachments that failed virus scan by the API (Start a new message page)
> 
> Note:  This does not apply to a multiple draft scenario. (0.1% of session on va.gov run into multiple drafts)
> 
> Attachments will be scanned for viruses by the backend.  The front end will need to let the user know that the attachment did not pass the scanning process and will not be attached to the message.

## Testing done
To test, download txt test file from https://www.eicar.org/download-anti-malware-testfile/#top. This appears to the api as a virus, but is NOT an actual virus. Attach it to a message and send it. The api should throw an error and the alert should appear. This may not work with the other test file types (such as pdf), but should work with the txt file.

Unit tests fixed, 1 added

## Screenshots
![Screen Shot 2024-09-23 at 11 08 17 AM](https://github.com/user-attachments/assets/4c7f0d2d-61da-4a5e-ad8a-8d54a5a53ccd)

## What areas of the site does it impact?
mhv secure messaging

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
