### PR TITLE
Edm 91/part 2

### DIFF
--- a/src/applications/gi/components/profile/YellowRibbonTableRows.jsx
+++ b/src/applications/gi/components/profile/YellowRibbonTableRows.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const deriveDegreeLevel = degreeLevel => {
+  // Show unknown if there's no degreeLevel.
+  if (!degreeLevel) {
+    return 'Not provided';
+  }
+
+  // Show the degreeLevel.
+  return degreeLevel;
+};
+
+export const deriveMaxAmount = contributionAmount => {
+  // Show unknown if there's no contributionAmount.
+  if (!contributionAmount) {
+    return 'Not provided';
+  }
+
+  // Derive the contribution amount number.
+  const contributionAmountNum = parseFloat(contributionAmount);
+
+  // Show unlimited contribution amount state.
+  if (contributionAmountNum >= 99999) {
+    return "Pays remaining tuition that Post-9/11 GI Bill doesn't cover";
+  }
+
+  // Show formatted contributionAmount.
+  return contributionAmountNum.toLocaleString('en-US', {
+    currency: 'USD',
+    maximumFractionDigits: 0,
+    minimumFractionDigits: 0,
+    style: 'currency',
+  });
+};
+
+export const deriveEligibleStudents = numberOfStudents => {
+  // Show unknown if there's no numberOfStudents.
+  if (!numberOfStudents) {
+    return 'Not provided';
+  }
+
+  // Escape early if the data indicates all eligible students.
+  if (numberOfStudents >= 99999) {
+    return 'All eligible students';
+  }
+
+  // Show numberOfStudents.
+  return `${numberOfStudents} students`;
+};
+
+export const formatDegree = degreeLevel => {
+  let degreeLevels;
+
+  if (degreeLevel.includes(',')) {
+    degreeLevels = degreeLevel.split(',');
+    return `${degreeLevels[0]}/${degreeLevels[1].trim()}`;
+  }
+
+  return degreeLevel;
+};
+
+function YellowRibbonTableRows({ programs }) {
+  return (
+    <>
+      {programs.map((program, index) => {
+        const {
+          degreeLevel,
+          divisionProfessionalSchool,
+          numberOfStudents,
+          contributionAmount,
+        } = program;
+
+        return (
+          <va-table-row key={`row-default-${index}`}>
+            <span>{formatDegree(deriveDegreeLevel(degreeLevel))}</span>
+            <span>{divisionProfessionalSchool}</span>
+            <span>{deriveEligibleStudents(numberOfStudents)}</span>
+            <span>{deriveMaxAmount(contributionAmount)}</span>
+          </va-table-row>
+        );
+      })}
+    </>
+  );
+}
+
+YellowRibbonTableRows.propTypes = { program: PropTypes.object };
+export default YellowRibbonTableRows;

--- a/src/applications/gi/components/profile/YellowRibbonTableRows.jsx
+++ b/src/applications/gi/components/profile/YellowRibbonTableRows.jsx
@@ -84,5 +84,5 @@ function YellowRibbonTableRows({ programs }) {
   );
 }
 
-YellowRibbonTableRows.propTypes = { program: PropTypes.object };
+YellowRibbonTableRows.propTypes = { programs: PropTypes.object };
 export default YellowRibbonTableRows;

--- a/src/applications/gi/tests/components/profile/YellowRibbonTableRows.unit.spec.jsx
+++ b/src/applications/gi/tests/components/profile/YellowRibbonTableRows.unit.spec.jsx
@@ -1,0 +1,63 @@
+import { expect } from 'chai';
+import {
+  deriveDegreeLevel,
+  deriveMaxAmount,
+  deriveEligibleStudents,
+  formatDegree,
+} from '../../../components/profile/YellowRibbonTableRows';
+
+describe('Test deriveDegreeLevel function', () => {
+  it('should return "Not provided" if degreeLevel is undefined or null', () => {
+    expect(deriveDegreeLevel(undefined)).to.equal('Not provided');
+    expect(deriveDegreeLevel(null)).to.equal('Not provided');
+  });
+
+  it('should return the provided degree level when degreeLevel is defined', () => {
+    expect(deriveDegreeLevel('Bachelor')).to.equal('Bachelor');
+    expect(deriveDegreeLevel('Master')).to.equal('Master');
+  });
+});
+
+describe('Test deriveMaxAmount function', () => {
+  it('should return "Not provided" if contributionAmount is undefined or null', () => {
+    expect(deriveMaxAmount(undefined)).to.equal('Not provided');
+    expect(deriveMaxAmount(null)).to.equal('Not provided');
+  });
+
+  it('should return correct formatted contribution amount for a valid number', () => {
+    expect(deriveMaxAmount('5000')).to.equal('$5,000');
+    expect(deriveMaxAmount('10000')).to.equal('$10,000');
+  });
+
+  it('should return "Pays remaining tuition that Post-9/11 GI Bill doesn\'t cover" if contributionAmount is 99999 or greater', () => {
+    expect(deriveMaxAmount('99999')).to.equal(
+      "Pays remaining tuition that Post-9/11 GI Bill doesn't cover",
+    );
+    expect(deriveMaxAmount('100000')).to.equal(
+      "Pays remaining tuition that Post-9/11 GI Bill doesn't cover",
+    );
+  });
+});
+
+describe('Test deriveEligibleStudents function', () => {
+  it('should return "Not provided" if numberOfStudents is null or undefined', () => {
+    expect(deriveEligibleStudents(undefined)).to.equal('Not provided');
+    expect(deriveEligibleStudents(null)).to.equal('Not provided');
+  });
+
+  it('should return the number of students with "students" suffix', () => {
+    expect(deriveEligibleStudents(50)).to.equal('50 students');
+    expect(deriveEligibleStudents(100)).to.equal('100 students');
+  });
+
+  it('should return "All eligible students" if numberOfStudents is 99999 or greater', () => {
+    expect(deriveEligibleStudents(99999)).to.equal('All eligible students');
+    expect(deriveEligibleStudents(100000)).to.equal('All eligible students');
+  });
+});
+
+describe('Test formatDegree function', () => {
+  it('should format degreeLevel with a comma separator into first/second format', () => {
+    expect(formatDegree('Bachelor, Master')).to.equal('Bachelor/Master');
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Related issue(s)

- EDM-91: Begin creating frontend on mockups in Staging
- Subtasks
  - EDM-145: Fix YR table columns
  - EDM-146: Establish consistent formatting for degree level, contributions amount, eligible number of students.

## Testing done

- Added unit tests for each of the functions responsible for formatting incoming Yellow Ribbon data
- In the case of null or undefined values, "Not provided" is returned
- In the case of values over 99999, for eligible students and contribution amount, "All eligible students" and "Pays remaining tuition that Post-9/11 GI Bill doesn't cover" are returned, respectively.


## Screenshots

| Mobile  | 
<img width="443" alt="yr_rows_mobile" src="https://github.com/user-attachments/assets/82a47045-2b50-415e-bda7-eed15ca1c903">
|
| Desktop |     
<img width="1010" alt="yr_rows_desktop" src="https://github.com/user-attachments/assets/d519c007-3391-4529-a6a1-0c4181199a67">
   |

## What areas of the site does it impact?

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

No authentication required
