### PR TITLE
Appoint a Representative - replace rep screen

### DIFF
--- a/src/applications/representative-appoint/21-22-schema.json
+++ b/src/applications/representative-appoint/21-22-schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Fill out your form to appoint a VA accredited representative or VSO (21-22)",
+  "title": "Request help from a VA accredited representative or VSO",
   "type": "object",
   "additionalProperties": false,
   "definitions": {

--- a/src/applications/representative-appoint/api/fetchRepStatus.js
+++ b/src/applications/representative-appoint/api/fetchRepStatus.js
@@ -1,0 +1,44 @@
+import { fetchAndUpdateSessionExpiration as fetch } from '@department-of-veterans-affairs/platform-utilities/api';
+import environment from '@department-of-veterans-affairs/platform-utilities/environment';
+import { REPRESENTATIVE_STATUS_API } from '../constants/api';
+
+export const fetchRepStatus = async () => {
+  const requestUrl = `${
+    environment.BASE_URL === 'http://localhost:3001'
+      ? `https://staging-api.va.gov`
+      : `${environment.API_URL}`
+  }${REPRESENTATIVE_STATUS_API}`;
+  const apiSettings = {
+    'Content-Type': 'application/json',
+    mode: 'cors',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Key-Inflection': 'camel',
+    },
+  };
+  const startTime = new Date().getTime();
+
+  return new Promise((resolve, reject) => {
+    fetch(requestUrl, apiSettings)
+      .then(response => {
+        if (!response.ok && response.status !== 422) {
+          throw Error(response.statusText);
+        }
+
+        return response.json();
+      })
+      .then(res => {
+        const endTime = new Date().getTime();
+        const resultTime = endTime - startTime;
+        res.meta = {
+          ...res.meta,
+          resultTime,
+        };
+        return res;
+      })
+      .then(data => resolve(data), error => reject(error));
+  });
+};
+
+export default fetchRepStatus;

--- a/src/applications/representative-appoint/components/Address.jsx
+++ b/src/applications/representative-appoint/components/Address.jsx
@@ -4,21 +4,21 @@ import PropTypes from 'prop-types';
 export default function Address({ address }) {
   return (
     <>
-      {address.address1}
+      {address.addressLine1}
       <br />
-      {address.address2 && (
+      {address.addressLine2 && (
         <>
-          {address.address2}
+          {address.addressLine2}
           <br />
-          {address.address3 && (
+          {address.addressLine3 && (
             <>
-              {address.address3}
+              {address.addressLine3}
               <br />
             </>
           )}
         </>
       )}
-      {address.city}, {address.state} {address.zip}
+      {address.city}, {address.stateCode} {address.zipCode}
       <br />
     </>
   );

--- a/src/applications/representative-appoint/components/ClaimantTypeForm.jsx
+++ b/src/applications/representative-appoint/components/ClaimantTypeForm.jsx
@@ -11,7 +11,7 @@ const ClaimantTypeForm = props => {
   return (
     <div className="vads-u-margin-top--2p5">
       <FormTitle
-        title="Fill out your form to appoint a VA accredited representative or VSO"
+        title="Request help from a VA accredited representative or VSO"
         subTitle="VA Forms 21-22 and 21-22a"
       />
       <h3>Tell us who you are</h3>{' '}

--- a/src/applications/representative-appoint/components/ContactCard.jsx
+++ b/src/applications/representative-appoint/components/ContactCard.jsx
@@ -15,7 +15,10 @@ export default function ContactCard({
 }) {
   const { contact, extension } = parsePhoneNumber(phone);
   const addressExists =
-    address.address1 && address.city && address.state && address.zip;
+    address.addressLine1 &&
+    address.city &&
+    address.stateCode &&
+    address.zipCode;
 
   const recordContactLinkClick = () => {
     // pending analytics event

--- a/src/applications/representative-appoint/components/CurrentAccreditedRepresentative.jsx
+++ b/src/applications/representative-appoint/components/CurrentAccreditedRepresentative.jsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { parsePhoneNumber } from '../utilities/helpers';
+
+const CurrentAccreditedRepresentative = ({
+  representativeName,
+  type,
+  addressLine1,
+  addressLine2,
+  addressLine3,
+  city,
+  stateCode,
+  zipCode,
+  phone,
+  email,
+}) => {
+  const { contact, extension } = parsePhoneNumber(phone);
+
+  const addressExists = addressLine1 || city || stateCode || zipCode;
+
+  const address =
+    [
+      (addressLine1 || '').trim(),
+      (addressLine2 || '').trim(),
+      (addressLine3 || '').trim(),
+    ]
+      .filter(Boolean)
+      .join(' ') +
+    (city ? ` ${city},` : '') +
+    (stateCode ? ` ${stateCode}` : '') +
+    (zipCode ? ` ${zipCode}` : '');
+
+  const parseRepType = repType => {
+    let parsedRepType;
+    switch (repType) {
+      case 'organization':
+        parsedRepType = 'Veteran Service Organization';
+        break;
+      case 'representative':
+        parsedRepType = 'Accredited representative';
+        break;
+      case 'attorney':
+        parsedRepType = 'Accredited attorney';
+        break;
+      case 'claimsAgent':
+        parsedRepType = 'Accredited claims agent';
+        break;
+      default:
+        parsedRepType = 'Accredited representative';
+    }
+    return parsedRepType;
+  };
+
+  return (
+    <va-card class="representative-result-card vads-u-padding--4 vads-u-background-color--gray-lightest vads-u-border--0">
+      <div className="representative-result-card-content">
+        <div className="representative-info-heading">
+          {representativeName && (
+            <>
+              <h4 className="vads-u-font-family--serif vads-u-margin-top--1p5 vads-u-margin-bottom--0p5">
+                {representativeName}
+              </h4>
+              <p className="vads-u-margin-y--0">{parseRepType(type)}</p>
+              {/* {accreditedOrganizations?.length === 1 && (
+                <p style={{ marginTop: 0 }}>{accreditedOrganizations[0]}</p>
+              )} */}
+            </>
+          )}
+        </div>
+
+        <div className="representative-contact-section vads-u-margin-top--3">
+          {addressExists && (
+            <div className="address-link vads-u-display--flex">
+              <va-icon icon="location_on" size="3" />
+              <a
+                href={`https://maps.google.com?&daddr=${address}`}
+                tabIndex="0"
+                className="address-anchor vads-u-margin-left--1"
+                // onClick={() => recordContactLinkClick()}
+                target="_blank"
+                rel="noreferrer"
+                aria-label={`${address} (opens in a new tab)`}
+              >
+                {addressLine1}{' '}
+                {addressLine2 ? (
+                  <>
+                    <br /> {addressLine2}
+                  </>
+                ) : null}{' '}
+                <br />
+                {city}, {stateCode} {zipCode}
+              </a>
+            </div>
+          )}
+          {contact && (
+            <div className="vads-u-margin-top--1p5 vads-u-display--flex">
+              <va-icon icon="phone" size="3" />
+              <div className="vads-u-margin-left--1">
+                <va-telephone
+                  contact={contact}
+                  extension={extension}
+                  //   onClick={() => recordContactLinkClick()}
+                  disable-analytics
+                />
+              </div>
+            </div>
+          )}
+          {email && (
+            <div className="vads-u-margin-top--1p5 vads-u-display--flex">
+              <va-icon icon="mail" size="3" />
+              <a
+                href={`mailto:${email}`}
+                // onClick={() => recordContactLinkClick()}
+                className="vads-u-margin-left--1"
+              >
+                {email}
+              </a>
+            </div>
+          )}
+        </div>
+      </div>
+    </va-card>
+  );
+};
+
+CurrentAccreditedRepresentative.propTypes = {
+  addressLine1: PropTypes.string,
+  addressLine2: PropTypes.string,
+  addressLine3: PropTypes.string,
+  accreditedOrganizations: PropTypes.array,
+  city: PropTypes.string,
+  email: PropTypes.string,
+  representativeName: PropTypes.string,
+  phone: PropTypes.string,
+  stateCode: PropTypes.string,
+  type: PropTypes.string,
+  zipCode: PropTypes.string,
+  setFormData: PropTypes.func.isRequired,
+};
+
+export default CurrentAccreditedRepresentative;

--- a/src/applications/representative-appoint/components/GoogleMapLink.jsx
+++ b/src/applications/representative-appoint/components/GoogleMapLink.jsx
@@ -5,12 +5,12 @@ import Address from './Address';
 
 export default function GoogleMapLink({ address, recordClick }) {
   const addressString =
-    [address.address1, address.address2, address.address3]
+    [address.addressLine1, address.addressLine2, address.addressLine3]
       .filter(Boolean)
       .join(' ') +
     (address.city ? ` ${address.city},` : '') +
-    (address.state ? ` ${address.state}` : '') +
-    (address.zip ? ` ${address.zip}` : '');
+    (address.stateCode ? ` ${address.stateCode}` : '') +
+    (address.zipCode ? ` ${address.zipCode}` : '');
 
   return (
     <>

--- a/src/applications/representative-appoint/components/ReplaceAccreditedRepresentative.jsx
+++ b/src/applications/representative-appoint/components/ReplaceAccreditedRepresentative.jsx
@@ -8,8 +8,7 @@ const ReplaceAccreditedRepresentative = props => {
   const { formData } = props;
 
   const currentRepresentative = formData?.['view:representativeStatus'] || {};
-  const selectedRepresentative =
-    formData?.['view:selectedRepresentative'] || {};
+  const selectedRepresentative = formData?.['view:selectedAccreditedRep'] || {};
 
   const address = {
     addressLine1: (selectedRepresentative.addressLine1 || '').trim(),

--- a/src/applications/representative-appoint/components/ReplaceAccreditedRepresentative.jsx
+++ b/src/applications/representative-appoint/components/ReplaceAccreditedRepresentative.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router';
+import CurrentAccreditedRepresentative from './CurrentAccreditedRepresentative';
+
+const ReplaceAccreditedRepresentative = props => {
+  const { formData } = props;
+
+  const currentRepresentative = formData['view:representativeStatus'] || null;
+
+  // Grab attorney/claimsAgent/representative for individuals, otherwise 'organization'
+  const type =
+    currentRepresentative.attributes?.individualType || 'organization';
+
+  return (
+    <div>
+      <h3 className="vads-u-margin-y--5 ">
+        Replace your current accredited representative
+      </h3>
+      <p>
+        You’ll replace your current accredited representative with the new one
+        you’ve selected.
+      </p>
+      <h4 className="vads-u-margin-y--5">
+        You’ll replace this current accredited representative:
+      </h4>
+      <CurrentAccreditedRepresentative
+        representativeName={
+          currentRepresentative.name || currentRepresentative.fullName
+        }
+        type={type}
+        addressLine1={currentRepresentative.addressLine1}
+        addressLine2={currentRepresentative.addressLine2}
+        addressLine3={currentRepresentative.addressLine3}
+        city={currentRepresentative.city}
+        stateCode={currentRepresentative.stateCode}
+        zipCode={currentRepresentative.zipCode}
+        phone={currentRepresentative.phone}
+        email={currentRepresentative.email}
+      />
+
+      <h4 className="vads-u-margin-y--5">
+        You’ve selected this new accredited representative:
+      </h4>
+    </div>
+  );
+};
+
+ReplaceAccreditedRepresentative.propTypes = {
+  fetchRepresentatives: PropTypes.func,
+};
+
+export default withRouter(ReplaceAccreditedRepresentative);

--- a/src/applications/representative-appoint/components/ReplaceAccreditedRepresentative.jsx
+++ b/src/applications/representative-appoint/components/ReplaceAccreditedRepresentative.jsx
@@ -2,11 +2,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
 import CurrentAccreditedRepresentative from './CurrentAccreditedRepresentative';
+import ContactCard from './ContactCard';
 
 const ReplaceAccreditedRepresentative = props => {
   const { formData } = props;
 
-  const currentRepresentative = formData['view:representativeStatus'] || null;
+  const currentRepresentative = formData?.['view:representativeStatus'] || {};
+  const selectedRepresentative =
+    formData?.['view:selectedRepresentative'] || {};
+
+  const address = {
+    addressLine1: (selectedRepresentative.addressLine1 || '').trim(),
+    addressLine2: (selectedRepresentative.addressLine2 || '').trim(),
+    addressLine3: (selectedRepresentative.addressLine3 || '').trim(),
+    city: (selectedRepresentative.city || '').trim(),
+    stateCode: (selectedRepresentative.stateCode || '').trim(),
+    zipCode: (selectedRepresentative.zipCode || '').trim(),
+  };
 
   // Grab attorney/claimsAgent/representative for individuals, otherwise 'organization'
   const type =
@@ -38,10 +50,16 @@ const ReplaceAccreditedRepresentative = props => {
         phone={currentRepresentative.phone}
         email={currentRepresentative.email}
       />
-
       <h4 className="vads-u-margin-y--5">
         You’ve selected this new accredited representative:
       </h4>
+      <ContactCard
+        repName={selectedRepresentative.fullName}
+        orgName={selectedRepresentative.name}
+        address={address}
+        phone={selectedRepresentative.phone}
+        email={selectedRepresentative.email}
+      />
     </div>
   );
 };

--- a/src/applications/representative-appoint/components/SearchResult.jsx
+++ b/src/applications/representative-appoint/components/SearchResult.jsx
@@ -204,11 +204,15 @@ SearchResult.propTypes = {
   location: PropTypes.object,
 };
 
+const mapStateToProps = state => ({
+  formData: state.form?.data || {},
+});
+
 const mapDispatchToProps = {
   setFormData: setData,
 };
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps,
 )(SearchResult);

--- a/src/applications/representative-appoint/config/form.js
+++ b/src/applications/representative-appoint/config/form.js
@@ -25,7 +25,7 @@ import {
   veteranIdentification,
   veteranServiceInformation,
   selectAccreditedRepresentative,
-  selectedAccreditedOrganizationId,
+  replaceAccreditedRepresentative,
 } from '../pages';
 
 import { prefillTransformer } from '../prefill-transformer';
@@ -102,28 +102,15 @@ const formConfig = {
           uiSchema: selectAccreditedRepresentative.uiSchema,
           schema: selectAccreditedRepresentative.schema,
         },
-        selectAccreditedOrganization: {
-          path: 'representative-organization',
-          title: 'Organization Select',
-          depends: formData =>
-            !!formData['view:selectedRepresentative'] &&
-            formData['view:selectedRepresentative'].attributes
-              ?.individualType === 'representative' &&
-            formData['view:selectedRepresentative'].attributes
-              ?.accreditedOrganizations?.data?.length > 1,
-          uiSchema: selectedAccreditedOrganizationId.uiSchema,
-          schema: {
-            type: 'object',
-            properties: {
-              selectedAccreditedOrganizationId: {
-                type: 'string',
-              },
-            },
-          },
+        replaceAccreditedRepresentative: {
+          title: 'Representative Replace',
+          path: 'representative-replace',
+          uiSchema: replaceAccreditedRepresentative.uiSchema,
+          schema: replaceAccreditedRepresentative.schema,
         },
       },
     },
-    claimant: {
+    claimantInfo: {
       title: 'Your information',
       pages: {
         claimantRelationship: {
@@ -185,12 +172,6 @@ const formConfig = {
           schema: claimantContactMailing.schema,
           editModeOnReviewPage: true,
         },
-      },
-    },
-    veteranInfoForVeterans: {
-      title: 'Your Information',
-      depends: formData => preparerIsVeteran({ formData }),
-      pages: {
         veteranPersonalInformation: {
           title: `Your name and date of birth`,
           path: 'veteran-personal-information',
@@ -233,7 +214,7 @@ const formConfig = {
         },
       },
     },
-    veteranInfoForNonVeterans: {
+    veteranInfo: {
       title: 'Veteran information',
       depends: formData => !preparerIsVeteran({ formData }),
       pages: {

--- a/src/applications/representative-appoint/config/form.js
+++ b/src/applications/representative-appoint/config/form.js
@@ -84,7 +84,7 @@ const formConfig = {
     noAuth:
       'Please sign in again to continue your application for VA accredited representative appointment.',
   },
-  title: 'Fill out your form to appoint a VA accredited representative or VSO',
+  title: 'Request help from a VA accredited representative or VSO',
   subTitle: formConfigFromService.subTitle || 'VA Forms 21-22 and 21-22a',
   defaultDefinitions: {
     fullName,

--- a/src/applications/representative-appoint/config/form.js
+++ b/src/applications/representative-appoint/config/form.js
@@ -26,6 +26,7 @@ import {
   veteranServiceInformation,
   selectAccreditedRepresentative,
   replaceAccreditedRepresentative,
+  selectedAccreditedOrganizationId,
 } from '../pages';
 
 import { prefillTransformer } from '../prefill-transformer';
@@ -102,9 +103,31 @@ const formConfig = {
           uiSchema: selectAccreditedRepresentative.uiSchema,
           schema: selectAccreditedRepresentative.schema,
         },
+        selectAccreditedOrganization: {
+          path: 'representative-organization',
+          title: 'Organization Select',
+          depends: formData =>
+            !!formData['view:selectedRepresentative'] &&
+            formData['view:selectedRepresentative'].attributes
+              ?.individualType === 'representative' &&
+            formData['view:selectedRepresentative'].attributes
+              ?.accreditedOrganizations?.data?.length > 1,
+          uiSchema: selectedAccreditedOrganizationId.uiSchema,
+          schema: {
+            type: 'object',
+            properties: {
+              selectedAccreditedOrganizationId: {
+                type: 'string',
+              },
+            },
+          },
+        },
         replaceAccreditedRepresentative: {
           title: 'Representative Replace',
           path: 'representative-replace',
+          depends: formData =>
+            !!formData['view:representativeStatus']?.id &&
+            !!formData['view:selectedRepresentative'],
           uiSchema: replaceAccreditedRepresentative.uiSchema,
           schema: replaceAccreditedRepresentative.schema,
         },

--- a/src/applications/representative-appoint/constants/api.js
+++ b/src/applications/representative-appoint/constants/api.js
@@ -1,2 +1,5 @@
 export const REPRESENTATIVES_API =
   '/representation_management/v0/accredited_entities_for_appoint';
+
+export const REPRESENTATIVE_STATUS_API =
+  '/representation_management/v0/power_of_attorney';

--- a/src/applications/representative-appoint/containers/App.jsx
+++ b/src/applications/representative-appoint/containers/App.jsx
@@ -10,6 +10,8 @@ import configService from '../utilities/configService';
 
 import { getFormSubtitle } from '../utilities/helpers';
 
+import fetchRepStatus from '../api/fetchRepStatus';
+
 function App({ loggedIn, location, children, formData, setFormData }) {
   const subTitle = getFormSubtitle(formData);
 
@@ -24,6 +26,18 @@ function App({ loggedIn, location, children, formData, setFormData }) {
     [subTitle],
   );
 
+  useEffect(() => {
+    const fetchAndSetRepStatus = async () => {
+      const repStatus = await fetchRepStatus();
+      setFormData(prevData => ({
+        ...prevData,
+        'view:representativeStatus': repStatus,
+      }));
+    };
+
+    fetchAndSetRepStatus();
+  }, []);
+
   useEffect(
     () => {
       const defaultViewFields = {
@@ -37,12 +51,7 @@ function App({ loggedIn, location, children, formData, setFormData }) {
     [loggedIn],
   );
 
-  // Exclude the 'next-steps' route from being wrapped in RoutedSavableApp
-  const isNextStepsRoute = pathname === '/next-steps';
-
-  const content = isNextStepsRoute ? (
-    <>{children}</> // Directly render children for 'next-steps'
-  ) : (
+  const content = (
     <RoutedSavableApp formConfig={updatedFormConfig} currentLocation={location}>
       {children}
     </RoutedSavableApp>

--- a/src/applications/representative-appoint/containers/IntroductionPage.jsx
+++ b/src/applications/representative-appoint/containers/IntroductionPage.jsx
@@ -56,7 +56,7 @@ const IntroductionPage = props => {
             prefillEnabled={formConfig.prefillEnabled}
             pageList={pageList}
             unauthStartText="Sign in or create an account"
-            startText="Fill out your form to request help"
+            startText="Request help from a VA accredited representative or VSO"
           />
         </>
       )}
@@ -134,7 +134,7 @@ const IntroductionPage = props => {
         prefillEnabled={formConfig.prefillEnabled}
         pageList={pageList}
         unauthStartText="Sign in or create an account"
-        startText="Fill out your form to request help"
+        startText="Request help from a VA accredited representative or VSO"
         verifiedPrefillAlert={<></>}
       />
       <p />

--- a/src/applications/representative-appoint/containers/NextStepsPage.jsx
+++ b/src/applications/representative-appoint/containers/NextStepsPage.jsx
@@ -75,7 +75,7 @@ export default function NextStepsPage() {
     <div className="row">
       <div className="usa-width-two-thirds medium-8 columns">
         <FormTitle
-          title="Fill out your form to appoint a VA accredited representative or VSO"
+          title="Request help from a VA accredited representative or VSO"
           subTitle={getFormSubtitle(formData)}
         />
         <h2 className="vads-u-font-size--h3">Your next steps</h2>

--- a/src/applications/representative-appoint/containers/NextStepsPage.jsx
+++ b/src/applications/representative-appoint/containers/NextStepsPage.jsx
@@ -12,18 +12,20 @@ export default function NextStepsPage() {
   const repType =
     formData['view:selectedRepresentative'].attributes?.individualType;
   const address = {
-    address1: (
+    addressLine1: (
       formData['view:selectedRepresentative']?.addressLine1 || ''
     ).trim(),
-    address2: (
+    addressLine2: (
       formData['view:selectedRepresentative']?.addressLine2 || ''
     ).trim(),
-    address3: (
+    addressLine3: (
       formData['view:selectedRepresentative']?.addressLine3 || ''
     ).trim(),
     city: (formData['view:selectedRepresentative']?.city || '').trim(),
-    state: (formData['view:selectedRepresentative']?.stateCode || '').trim(),
-    zip: (formData['view:selectedRepresentative']?.zipCode || '').trim(),
+    stateCode: (
+      formData['view:selectedRepresentative']?.stateCode || ''
+    ).trim(),
+    zipCode: (formData['view:selectedRepresentative']?.zipCode || '').trim(),
   };
   const isOrg =
     formData['view:selectedRepresentative']?.type === 'organization';

--- a/src/applications/representative-appoint/pages/index.js
+++ b/src/applications/representative-appoint/pages/index.js
@@ -17,7 +17,7 @@ import * as veteranContactMailingClaimant from './veteran/veteranContactMailingC
 import * as veteranIdentification from './veteran/veteranIdentification';
 import * as veteranServiceInformation from './veteran/veteranServiceInformation';
 import * as selectAccreditedRepresentative from './representative/selectAccreditedRepresentative';
-import * as selectedAccreditedOrganizationId from './representative/selectAccreditedOrganization';
+import * as replaceAccreditedRepresentative from './representative/replaceAccreditedRepresentative';
 
 export {
   authorizeMedical,
@@ -39,5 +39,5 @@ export {
   veteranIdentification,
   veteranServiceInformation,
   selectAccreditedRepresentative,
-  selectedAccreditedOrganizationId,
+  replaceAccreditedRepresentative,
 };

--- a/src/applications/representative-appoint/pages/index.js
+++ b/src/applications/representative-appoint/pages/index.js
@@ -18,6 +18,7 @@ import * as veteranIdentification from './veteran/veteranIdentification';
 import * as veteranServiceInformation from './veteran/veteranServiceInformation';
 import * as selectAccreditedRepresentative from './representative/selectAccreditedRepresentative';
 import * as replaceAccreditedRepresentative from './representative/replaceAccreditedRepresentative';
+import * as selectedAccreditedOrganizationId from './representative/selectAccreditedOrganization';
 
 export {
   authorizeMedical,
@@ -40,4 +41,5 @@ export {
   veteranServiceInformation,
   selectAccreditedRepresentative,
   replaceAccreditedRepresentative,
+  selectedAccreditedOrganizationId,
 };

--- a/src/applications/representative-appoint/pages/representative/replaceAccreditedRepresentative.js
+++ b/src/applications/representative-appoint/pages/representative/replaceAccreditedRepresentative.js
@@ -1,0 +1,20 @@
+import ReplaceAccreditedRepresentative from '../../components/ReplaceAccreditedRepresentative';
+
+export const uiSchema = {
+  replaceAccreditedRepresentative: {
+    'ui:title': 'Replace your current accredited representative',
+    'ui:widget': ReplaceAccreditedRepresentative,
+    'ui:options': {
+      hideLabelText: true,
+    },
+  },
+};
+
+export const schema = {
+  type: 'object',
+  properties: {
+    replaceAccreditedRepresentative: {
+      type: 'string',
+    },
+  },
+};

--- a/src/applications/representative-appoint/tests/components/AddressBlock.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/components/AddressBlock.unit.spec.jsx
@@ -6,12 +6,12 @@ import AddressBlock from '../../components/AddressBlock';
 
 describe('AddressBlock Component', () => {
   const address = {
-    address1: '123 Main Street',
-    address2: 'Suite 4B',
-    address3: '',
+    addressLine1: '123 Main Street',
+    addressLine2: 'Suite 4B',
+    addressLine3: '',
     city: 'Anytown',
-    state: 'AA',
-    zip: '11111',
+    stateCode: 'AA',
+    zipCode: '11111',
   };
   const repName = 'Steven McBob';
   const orgName = 'Best VSO';

--- a/src/applications/representative-appoint/tests/components/ContactCard.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/components/ContactCard.unit.spec.jsx
@@ -7,11 +7,11 @@ import ContactCard from '../../components/ContactCard';
 
 describe('ContactCard Component', () => {
   const address = {
-    address1: '400 South 18th Street',
-    address2: 'Room 119',
+    addressLine1: '400 South 18th Street',
+    addressLine2: 'Room 119',
     city: 'Newark',
-    state: 'NJ',
-    zip: '07102',
+    stateCode: 'NJ',
+    zipCode: '07102',
   };
   const repName = 'Brian Daniel';
   const orgName = 'Disabled American Veterans';

--- a/src/applications/representative-appoint/tests/components/GoogleMapLink.unit.spec.jsx
+++ b/src/applications/representative-appoint/tests/components/GoogleMapLink.unit.spec.jsx
@@ -7,12 +7,12 @@ import GoogleMapLink from '../../components/GoogleMapLink';
 
 describe('GoogleMapLink Component', () => {
   const address = {
-    address1: '400 South 18th Street',
-    address2: 'Room 119',
-    address3: '',
+    addressLine1: '400 South 18th Street',
+    addressLine2: 'Room 119',
+    addressLine3: '',
     city: 'Newark',
-    state: 'NJ',
-    zip: '07102',
+    stateCode: 'NJ',
+    zipCode: '07102',
   };
   const mockRecordClick = () => {};
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No

## Summary

- Added method for fetching rep status and setting within formData on app load
- Added ReplaceAccreditedRepresentative component
- Renamed object props
- Copy updates

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/91104
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/87860

## Screenshots

<img width="581" alt="image" src="https://github.com/user-attachments/assets/ba58a89a-14fc-4e8b-ae9b-c4cd51ebbe89">


## What areas of the site does it impact?

Non-prod form app Appoint a Representative