### PR TITLE
DR | Edit review page focuses on headers

### DIFF
--- a/src/applications/appeals/10182/config/form.js
+++ b/src/applications/appeals/10182/config/form.js
@@ -105,6 +105,7 @@ const formConfig = {
   // scrollAndFocusTarget (selector string or function to scroll & focus)
   useCustomScrollAndFocus: true,
   scrollAndFocusTarget: focusH3, // scroll and focus fallback
+  reviewEditFocusOnHeaders: true,
   // Fix double headers (only show v3)
   v3SegmentedProgressBar: true,
 

--- a/src/applications/appeals/995/components/PrimaryPhone.jsx
+++ b/src/applications/appeals/995/components/PrimaryPhone.jsx
@@ -62,7 +62,11 @@ export const PrimaryPhone = ({
   };
 
   const navButtons = onReviewPage ? (
-    <va-button text={content.update} onClick={updatePage} uswds />
+    <va-button
+      text={content.update}
+      onClick={updatePage}
+      label="update primary phone number"
+    />
   ) : (
     <>
       {contentBeforeButtons}

--- a/src/applications/appeals/995/config/form.js
+++ b/src/applications/appeals/995/config/form.js
@@ -124,6 +124,7 @@ const formConfig = {
   // scrollAndFocusTarget (selector string or function to scroll & focus)
   useCustomScrollAndFocus: true,
   scrollAndFocusTarget: focusH3, // scroll and focus fallback
+  reviewEditFocusOnHeaders: true,
   // Fix double headers (only show v3)
   v3SegmentedProgressBar: true,
 

--- a/src/applications/appeals/995/content/notice5103.jsx
+++ b/src/applications/appeals/995/content/notice5103.jsx
@@ -22,7 +22,7 @@ export const Notice5103Description = ({ onReviewPage }) => {
   const hideAlert = () => {
     setVisibleAlert(false);
     recordEvent({ ...analyticsEvent, event: 'int-alert-box-close' });
-    setTimeout(focusH3AfterAlert);
+    setTimeout(() => focusH3AfterAlert({ name: 'notice5103', onReviewPage }));
   };
   if (visibleAlert) {
     recordEvent({ ...analyticsEvent, event: 'visible-alert-box' });

--- a/src/applications/appeals/995/tests/utils/focus.unit.spec.js
+++ b/src/applications/appeals/995/tests/utils/focus.unit.spec.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
+import * as focusUtils from 'platform/utilities/ui/focus';
 
 import { focusEvidence, focusH3AfterAlert } from '../../utils/focus';
 
@@ -35,20 +38,66 @@ describe('focusEvidence', () => {
 });
 
 describe('focusH3AfterAlert', () => {
-  it('should focus on header', async () => {
-    const { container } = await render(
+  let focusElementSpy;
+  beforeEach(() => {
+    focusElementSpy = sinon.stub(focusUtils, 'focusElement');
+  });
+  afterEach(() => {
+    focusElementSpy.restore();
+  });
+  // set offsets source:
+  // https://github.com/testing-library/react-testing-library/issues/353#issuecomment-510046921
+  const getOffset = name =>
+    Object.getOwnPropertyDescriptor(HTMLElement.prototype, name);
+  const setOffset = (name, value) =>
+    Object.defineProperty(HTMLElement.prototype, name, value);
+
+  const offsets = {
+    height: getOffset('offsetHeight'),
+    width: getOffset('offsetWidth'),
+  };
+  const testOffsets = { configurable: true, value: 10 };
+
+  beforeEach(() => {
+    setOffset('offsetHeight', testOffsets);
+    setOffset('offsetWidth', testOffsets);
+  });
+  afterEach(() => {
+    setOffset('offsetHeight', offsets.height);
+    setOffset('offsetWidth', offsets.width);
+  });
+
+  const setup = () =>
+    render(
       <div id="main">
-        <va-alert>
-          <h3>Inside alert</h3>
-        </va-alert>
-        <h3 id="header">Outside alert</h3>
+        <div name="topContentElement" />
+        <div name="testScrollElement" />
+        <div>
+          <va-alert status="info" visible="false">
+            <h3 id="alert" slot="headline">
+              Alert header
+            </h3>
+          </va-alert>
+          <h3 id="header">Page header</h3>
+        </div>
       </div>,
     );
 
-    await focusH3AfterAlert(null, container);
+  it('should focus on h3 outside of va-alert on review page', async () => {
+    setup();
+
+    await focusH3AfterAlert();
     await waitFor(() => {
-      const target = $('#header', container);
-      expect(document.activeElement).to.eq(target);
+      expect(focusElementSpy.args[0][0]).to.eq('h3#header');
+    });
+  });
+
+  it('should focus on header on review page', async () => {
+    setup();
+
+    await focusH3AfterAlert({ name: 'test', onReviewPage: true });
+    await waitFor(() => {
+      expect(focusElementSpy.args[0][0].id).to.eq('alert');
     });
   });
 });

--- a/src/applications/appeals/995/utils/focus.js
+++ b/src/applications/appeals/995/utils/focus.js
@@ -3,6 +3,7 @@ import {
   scrollTo,
   scrollToFirstError,
 } from 'platform/utilities/ui';
+import { focusReview } from 'platform/forms-system/src/js/utilities/ui/focus-review';
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
 
 export const focusEvidence = (_index, root) => {
@@ -18,7 +19,15 @@ export const focusEvidence = (_index, root) => {
   });
 };
 
-export const focusH3AfterAlert = () => {
-  scrollTo('topContentElement');
-  focusElement('h3#header');
+export const focusH3AfterAlert = ({ name, onReviewPage } = {}) => {
+  if (name && onReviewPage) {
+    focusReview(
+      name, // name of scroll element
+      true, // review accordion in edit mode
+      true, // reviewEditFocusOnHeaders setting from form/config.js
+    );
+  } else {
+    scrollTo('topContentElement');
+    focusElement('h3#header');
+  }
 };

--- a/src/applications/appeals/996/config/form.js
+++ b/src/applications/appeals/996/config/form.js
@@ -125,6 +125,7 @@ const formConfig = {
   // scrollAndFocusTarget (selector string or function to scroll & focus)
   useCustomScrollAndFocus: true,
   scrollAndFocusTarget: focusH3, // scroll and focus fallback
+  reviewEditFocusOnHeaders: true,
   // Fix double headers (only show v3)
   v3SegmentedProgressBar: true,
 

--- a/src/applications/appeals/testing/sc/components/PrimaryPhone.jsx
+++ b/src/applications/appeals/testing/sc/components/PrimaryPhone.jsx
@@ -62,7 +62,11 @@ export const PrimaryPhone = ({
   };
 
   const navButtons = onReviewPage ? (
-    <va-button text={content.update} onClick={updatePage} uswds />
+    <va-button
+      text={content.update}
+      onClick={updatePage}
+      label="update primary phone number page"
+    />
   ) : (
     <>
       {contentBeforeButtons}

--- a/src/applications/appeals/testing/sc/config/form.js
+++ b/src/applications/appeals/testing/sc/config/form.js
@@ -141,6 +141,7 @@ const formConfig = {
   // scrollAndFocusTarget (selector string or function to scroll & focus)
   useCustomScrollAndFocus: true,
   scrollAndFocusTarget: focusH3,
+  reviewEditFocusOnHeaders: true,
 
   // Fix double headers (only show v3)
   v3SegmentedProgressBar: true,
@@ -213,6 +214,9 @@ const formConfig = {
           uiSchema: otherHousingRisk.uiSchema,
           schema: otherHousingRisk.schema,
           depends: hasOtherHousingRisk,
+          initialData: {
+            'view:otherHousingRisk': {},
+          },
         },
         contact: {
           title: 'Your point of contact',

--- a/src/applications/appeals/testing/sc/content/notice5103.jsx
+++ b/src/applications/appeals/testing/sc/content/notice5103.jsx
@@ -22,7 +22,7 @@ export const Notice5103Description = ({ onReviewPage }) => {
   const hideAlert = () => {
     setVisibleAlert(false);
     recordEvent({ ...analyticsEvent, event: 'int-alert-box-close' });
-    setTimeout(focusH3AfterAlert);
+    setTimeout(() => focusH3AfterAlert({ name: 'notice5103', onReviewPage }));
   };
   if (visibleAlert) {
     recordEvent({ ...analyticsEvent, event: 'visible-alert-box' });

--- a/src/applications/appeals/testing/sc/pages/otherHousingRisk.js
+++ b/src/applications/appeals/testing/sc/pages/otherHousingRisk.js
@@ -10,7 +10,7 @@ import { OTHER_HOUSING_RISK_MAX } from '../constants';
 
 export default {
   uiSchema: {
-    otherHousingRiskTitle: {
+    'view:otherHousingRisk': {
       'ui:title': OtherHousingRisksTitle,
       'ui:options': {
         forceDivWrapper: true,
@@ -32,7 +32,7 @@ export default {
   schema: {
     type: 'object',
     properties: {
-      otherHousingRiskTitle: {
+      'view:otherHousingRisk': {
         type: 'object',
         properties: {},
       },

--- a/src/applications/appeals/testing/sc/utils/focus.js
+++ b/src/applications/appeals/testing/sc/utils/focus.js
@@ -3,6 +3,7 @@ import {
   scrollTo,
   scrollToFirstError,
 } from 'platform/utilities/ui';
+import { focusReview } from 'platform/forms-system/src/js/utilities/ui/focus-review';
 import { $ } from 'platform/forms-system/src/js/utilities/ui';
 
 export const focusEvidence = (_index, root) => {
@@ -18,7 +19,14 @@ export const focusEvidence = (_index, root) => {
   });
 };
 
-export const focusH3AfterAlert = () => {
-  scrollTo('topContentElement');
-  focusElement('h3#header');
+export const focusH3AfterAlert = ({ name, onReviewPage } = {}) => {
+  if (name && onReviewPage) {
+    // name, editing (alert only visible in edit mode), reviewEditFocusOnHeaders
+    const editing = true; // alert only visible in edit mode
+    const reviewEditFocusOnHeaders = true; // from form/config.js setting
+    focusReview(name, editing, reviewEditFocusOnHeaders);
+  } else {
+    scrollTo('topContentElement');
+    focusElement('h3#header');
+  }
 };

--- a/src/applications/appeals/testing/sc/utils/focus.js
+++ b/src/applications/appeals/testing/sc/utils/focus.js
@@ -21,10 +21,11 @@ export const focusEvidence = (_index, root) => {
 
 export const focusH3AfterAlert = ({ name, onReviewPage } = {}) => {
   if (name && onReviewPage) {
-    // name, editing (alert only visible in edit mode), reviewEditFocusOnHeaders
-    const editing = true; // alert only visible in edit mode
-    const reviewEditFocusOnHeaders = true; // from form/config.js setting
-    focusReview(name, editing, reviewEditFocusOnHeaders);
+    focusReview(
+      name, // name of scroll element
+      true, // review accordion in edit mode
+      true, // reviewEditFocusOnHeaders setting from form/config.js
+    );
   } else {
     scrollTo('topContentElement');
     focusElement('h3#header');

--- a/src/platform/forms-system/src/js/review/ReviewChapters.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewChapters.jsx
@@ -88,6 +88,7 @@ class ReviewChapters extends React.Component {
             open={chapter.open}
             pageKeys={chapter.pageKeys}
             pageList={pageList}
+            reviewEditFocusOnHeaders={formConfig?.reviewEditFocusOnHeaders}
             setData={(...args) => this.handleSetData(...args)}
             hasUnviewedPages={chapter.hasUnviewedPages}
             uploadFile={this.props.uploadFile}

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -8,25 +8,21 @@ import get from '../../../../utilities/data/get';
 import set from '../../../../utilities/data/set';
 import {
   ERROR_ELEMENTS,
-  FOCUSABLE_ELEMENTS,
   SCROLL_ELEMENT_SUFFIX,
 } from '../../../../utilities/constants';
+import { focusReview } from '../utilities/ui/focus-review';
 
 import ProgressButton from '../components/ProgressButton';
-import {
-  focusOnChange,
-  getFocusableElements,
-  fixSelector,
-} from '../utilities/ui';
+import { focusOnChange, fixSelector } from '../utilities/ui';
 import SchemaForm from '../components/SchemaForm';
 import { getArrayFields, getNonArraySchema, showReviewField } from '../helpers';
 import ArrayField from './ArrayField';
 import { getPreviousPagePath, checkValidPagePath } from '../routing';
 
-import { focusableWebComponentList } from '../web-component-fields/webComponentList';
 import { isValidForm } from '../validation';
 import { reduceErrors } from '../utilities/data/reduceErrors';
 import { setFormErrors } from '../actions';
+
 /*
  * Displays all the pages in a chapter on the review page
  */
@@ -39,43 +35,11 @@ class ReviewCollapsibleChapter extends React.Component {
   handleEdit(key, editing, index = null) {
     if (editing || !this.hasValidationError(key, index)) {
       this.props.onEdit(key, editing, index);
-      const name = fixSelector(key);
-
-      // Wait for edit view to render
-      setTimeout(() => {
-        const scrollElement = document.querySelector(
-          `[name="${name}${SCROLL_ELEMENT_SUFFIX}"]`,
-        );
-
-        if (scrollElement && scrollElement?.nextElementSibling) {
-          const [target] = getFocusableElements(
-            scrollElement.nextElementSibling,
-            {
-              returnWebComponent: true,
-              focusableWebComponents: focusableWebComponentList,
-            },
-          );
-
-          if (target) {
-            let selector = target.tagName;
-            // File upload pages may only show a delete va-button (form 10182)
-            const shadowSelector = selector.startsWith('VA-')
-              ? [...FOCUSABLE_ELEMENTS, ...focusableWebComponentList].join(',')
-              : null;
-
-            // Sets focus on the first focusable error or element
-            if (target.id) {
-              // id may include a colon, e.g. #root_view:foo
-              selector = `#${target.id}`;
-            } else if (target.className) {
-              selector = `${target.tagName}.${target.className
-                .split(' ')
-                .join('.')}`;
-            }
-            focusOnChange(name, fixSelector(selector), shadowSelector);
-          }
-        }
-      }, 100);
+      focusReview(
+        fixSelector(`${key}${index ?? ''}`),
+        editing,
+        this.props.reviewEditFocusOnHeaders || false,
+      );
     }
   }
 
@@ -512,6 +476,7 @@ ReviewCollapsibleChapter.propTypes = {
     pathname: PropTypes.string,
   }),
   open: PropTypes.bool,
+  reviewEditFocusOnHeaders: PropTypes.bool,
   reviewErrors: PropTypes.shape({}),
   router: PropTypes.shape({
     push: PropTypes.func,

--- a/src/platform/forms-system/src/js/types.js
+++ b/src/platform/forms-system/src/js/types.js
@@ -44,6 +44,7 @@
  * @property {boolean} [prefillEnabled]
  * @property {Function} [prefillTransformer]
  * @property {PreSubmitInfo} [preSubmitInfo]
+ * @property {boolean} [reviewEditFocusOnHeaders]
  * @property {Object} [reviewErrors]
  * @property {string} [rootUrl]
  * @property {SavedFormMessages} [savedFormMessages]

--- a/src/platform/forms-system/src/js/utilities/ui/focus-review.js
+++ b/src/platform/forms-system/src/js/utilities/ui/focus-review.js
@@ -1,0 +1,87 @@
+import {
+  FOCUSABLE_ELEMENTS,
+  SCROLL_ELEMENT_SUFFIX,
+} from '../../../../../utilities/constants';
+
+import {
+  focusOnChange,
+  focusElement,
+  getFocusableElements,
+  fixSelector,
+  scrollToElement,
+} from '.';
+
+import {
+  focusableWebComponentList,
+  webComponentsWithHeaders,
+} from '../../web-component-fields/webComponentList';
+
+export const focusReview = (name, editing, reviewEditFocusOnHeaders) => {
+  setTimeout(() => {
+    const scrollName = `${name}${SCROLL_ELEMENT_SUFFIX}`;
+    const scrollElement = document.querySelector(`[name="${scrollName}"]`);
+
+    if (scrollElement && scrollElement?.nextElementSibling) {
+      scrollToElement(scrollName);
+      const pageWrap = scrollElement.nextElementSibling;
+
+      const focusOnFirstFocusableElement = () => {
+        const [target] = getFocusableElements(pageWrap, {
+          returnWebComponent: true,
+          focusableWebComponents: focusableWebComponentList,
+        });
+
+        if (target) {
+          let selector = target.tagName;
+          // File upload pages may only show a delete va-button (form 10182)
+          const shadowSelector = selector.startsWith('VA-')
+            ? [...FOCUSABLE_ELEMENTS, ...focusableWebComponentList].join(',')
+            : null;
+
+          // Sets focus on the first focusable error or element
+          if (target.id) {
+            // id may include a colon, e.g. #root_view:foo
+            selector = `#${target.id}`;
+          } else if (target.className) {
+            selector = `${target.tagName}.${target.className
+              .split(' ')
+              .join('.')}`;
+          }
+          focusOnChange(name, fixSelector(selector), shadowSelector);
+        }
+      };
+
+      if (editing && reviewEditFocusOnHeaders) {
+        // Headers inside accordion; should be an h4, but the page h3 may not
+        // be properly updated to an h4 on the review & submit page
+        const headers = 'h3,h4,h5,h6';
+        const [target] = getFocusableElements(pageWrap, {
+          returnWebComponent: true,
+          // look for headers _above_ web components first
+          focusableElements: headers.split(','),
+          focusableWebComponents: webComponentsWithHeaders,
+        });
+
+        let root = pageWrap;
+        const tag = target?.tagName || '';
+        if (tag.startsWith('H')) {
+          focusElement(target);
+        } else if (tag.startsWith('VA-')) {
+          const wcName = target?.getAttribute('name');
+          // Target WC using name attribute and as a selector; it works
+          // better within the focusElement WC checks to be a string
+          root = `${tag}${wcName ? `[name="${wcName}"]` : ''}`;
+          focusElement(headers, {}, root);
+        }
+        // check if nothing is focused, i.e. root doesn't contain any headers
+        setTimeout(() => {
+          if (document.activeElement.tagName === 'BODY') {
+            focusOnFirstFocusableElement();
+          }
+        }, 250);
+      } else {
+        focusOnFirstFocusableElement();
+      }
+    }
+  }, 100);
+};

--- a/src/platform/forms-system/src/js/web-component-fields/webComponentList.js
+++ b/src/platform/forms-system/src/js/web-component-fields/webComponentList.js
@@ -22,7 +22,7 @@ export const webComponentList = [
 export const focusableWebComponentList = [
   'va-accordion-item',
   // 'va-accordion',
-  'va-alert',
+  'va-alert:not([visible="false"])',
   // 'va-breadcrumbs',
   // 'va-button-pair',
   'va-button',
@@ -37,4 +37,12 @@ export const focusableWebComponentList = [
   'va-select',
   'va-text-input',
   'va-textarea',
+];
+
+// Web components with a `label-header-level` property
+export const webComponentsWithHeaders = [
+  'va-checkbox-group',
+  'va-radio',
+  'va-textarea',
+  'va-alert:not([visible="false"])',
 ];

--- a/src/platform/forms-system/test/js/utilities/focusReview.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/focusReview.unit.spec.js
@@ -1,0 +1,145 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { focusableWebComponentList } from '../../../src/js/web-component-fields/webComponentList';
+import { FOCUSABLE_ELEMENTS } from '../../../../utilities/constants';
+
+import * as focusUtils from '../../../src/js/utilities/ui';
+import * as moreFocusUtils from '../../../../utilities/ui/focus';
+import { focusReview } from '../../../src/js/utilities/ui/focus-review';
+
+describe('focusReview', () => {
+  let focusElementSpy;
+  let focusOnChangeSpy;
+
+  // set offsets source:
+  // https://github.com/testing-library/react-testing-library/issues/353#issuecomment-510046921
+  const getOffset = name =>
+    Object.getOwnPropertyDescriptor(HTMLElement.prototype, name);
+  const setOffset = (name, value) =>
+    Object.defineProperty(HTMLElement.prototype, name, value);
+
+  const offsets = {
+    height: getOffset('offsetHeight'),
+    width: getOffset('offsetWidth'),
+  };
+  const testOffsets = { configurable: true, value: 10 };
+
+  beforeEach(() => {
+    // focusElementSpy = sinon.stub(focusUtils, 'focusElement');
+    focusElementSpy = sinon.stub(moreFocusUtils, 'focusElement');
+    focusOnChangeSpy = sinon.stub(focusUtils, 'focusOnChange');
+    setOffset('offsetHeight', testOffsets);
+    setOffset('offsetWidth', testOffsets);
+  });
+  afterEach(() => {
+    focusElementSpy.restore();
+    focusOnChangeSpy.restore();
+    setOffset('offsetHeight', offsets.height);
+    setOffset('offsetWidth', offsets.width);
+  });
+
+  const setupEdit = () =>
+    render(
+      <div id="main">
+        <div name="testScrollElement" />
+        <div>
+          <h3 id="header">Test header</h3>
+          <va-text-input id="test" label="text" name="test" />
+        </div>
+      </div>,
+    );
+
+  it('should focus on the page edit button', async () => {
+    render(
+      <div className="form-review-panel-page">
+        <div name="testScrollElement" />
+        <form className="rjsf">
+          <div className="form-review-panel-page-header-row">
+            <h4 className="form-review-panel-page-header">Test</h4>
+            <div className="vads-u-justify-content--flex-end">
+              <va-button secondary label="Edit Test" text="Edit" />
+            </div>
+          </div>
+          <dl className="review">
+            <div className="review-row">
+              <dt>Is this a test?</dt>
+              <dd>
+                <span>Yes</span>
+              </dd>
+            </div>
+          </dl>
+          <div />
+        </form>
+      </div>,
+    );
+
+    focusReview(
+      'test', // name results in "testScrollElement"
+      false, // editing (review page edit mode)
+      false, // reviewEditFocusOnHeaders
+    );
+
+    await waitFor(() => {
+      expect(focusOnChangeSpy.args[0][0]).to.eq('test');
+      expect(focusOnChangeSpy.args[0][1]).to.eq('VA-BUTTON');
+    });
+  });
+
+  it('should focus on va-text-input when reviewEditFocusOnHeaders is not set', async () => {
+    setupEdit();
+
+    focusReview(
+      'test', // name results in "testScrollElement"
+      true, // editing (review page edit mode)
+      false, // reviewEditFocusOnHeaders
+    );
+
+    await waitFor(() => {
+      expect(focusOnChangeSpy.args[0]).to.deep.equal([
+        'test',
+        '#test',
+        [...FOCUSABLE_ELEMENTS, ...focusableWebComponentList].join(','),
+      ]);
+    });
+  });
+
+  it('should focus on header in edit mode when reviewEditFocusOnHeaders is set', async () => {
+    setupEdit();
+
+    focusReview(
+      'test', // name results in "testScrollElement"
+      true, // editing (review page edit mode)
+      true, // reviewEditFocusOnHeaders
+    );
+
+    await waitFor(() => {
+      expect(focusElementSpy.args[0][0].innerHTML).to.eq('Test header');
+    });
+  });
+
+  it('should focus va-text-input when no header exists', async () => {
+    render(
+      <div id="main">
+        <div name="testScrollElement" />
+        <div>
+          <va-text-input id="test" label="text" name="test" />
+          <va-button text="update page" />
+        </div>
+      </div>,
+    );
+
+    focusReview(
+      'test', // name results in "testScrollElement"
+      true, // editing (review page edit mode)
+      true, // reviewEditFocusOnHeaders
+    );
+
+    await waitFor(() => {
+      expect(focusOnChangeSpy.args[0][0]).to.eq('test');
+      expect(focusOnChangeSpy.args[0][1]).to.eq('#test');
+    });
+  });
+});

--- a/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
@@ -36,7 +36,7 @@ describe('focusElement', () => {
         <h2>test</h2>
       </div>,
     );
-    const h2 = screen.getByRole('heading', { levh2: 2 });
+    const h2 = screen.getByRole('heading', { level: 2 });
 
     expect(h2.tabIndex).to.eq(-1);
     expect(h2.getAttribute('tabindex')).to.be.null;
@@ -60,7 +60,7 @@ describe('focusElement', () => {
         <h2>test</h2>
       </div>,
     );
-    const h2 = screen.getByRole('heading', { levh2: 2 });
+    const h2 = screen.getByRole('heading', { level: 2 });
 
     expect(h2.tabIndex).to.eq(-1);
     expect(h2.getAttribute('tabindex')).to.be.null;

--- a/src/platform/forms/tests/forms.unit.spec.js
+++ b/src/platform/forms/tests/forms.unit.spec.js
@@ -83,6 +83,7 @@ const formConfigKeys = [
   'prefillEnabled',
   'prefillTransformer',
   'preSubmitInfo',
+  'reviewEditFocusOnHeaders',
   'reviewErrors',
   'rootUrl',
   'savedFormMessages',

--- a/src/platform/utilities/ui/focus.js
+++ b/src/platform/utilities/ui/focus.js
@@ -15,7 +15,7 @@ export const defaultFocusSelector =
  * @param {Element} root - root element for querySelector; would allow focusing
  *  on elements inside of shadow dom
  */
-export function focusElement(selectorOrElement, options, root) {
+export function focusElement(selectorOrElement, options = {}, root) {
   function applyFocus(el) {
     if (el) {
       // Use getAttribute to grab the "tabindex" attribute (returns string), not


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > - Adding `reviewEditFocusOnHeaders` option to `config/form` to change review page edit focus behavior. Currently, when a page is editing on the review & submit page, the first focusable element is focused.
  > - Also updated SC 5103 behavior to re-focus on the second header after the alert is closed
  > - Fixed area of disagreement focus on header
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/92801

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated and added unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         |  After |
| ------ | ----- |
| NOD | ![focus-nod](https://github.com/user-attachments/assets/62402fa6-c685-4657-8656-2109b7308ca7) |
| HLR | ![focus-hlr](https://github.com/user-attachments/assets/0b073b94-c172-45c3-b8f3-0a5e61d1a7f6) |
| SC | ![focus-sc](https://github.com/user-attachments/assets/431dfbe3-5cd4-4b28-8712-8b5b0a0bc489) |
| SC prototype | ![focus-sc-proto](https://github.com/user-attachments/assets/92e42a99-b794-42b2-8924-2859a4df1bc7) |

## What areas of the site does it impact?

- All DR forms
- All forms that set `reviewEditFocusOnHeaders` in the `config/form` to `true`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
