### PR TITLE
Update codespace start script for more versatile public codespaces

### DIFF
--- a/.devcontainer/codespaces-start.sh
+++ b/.devcontainer/codespaces-start.sh
@@ -17,6 +17,20 @@ fi
 # Set default values
 MOCK_RESPONSES=${MOCK_RESPONSES:-src/platform/testing/local-dev-mock-api/common.js}
 
+# Get the display name of the Codespace
+DISPLAY_NAME=$(gh codespace view --json displayName -q .displayName)
+
+printf "\n\n##### Display name: $DISPLAY_NAME #####\n"
+
+# Check if the display name starts with "va-public-"
+if [[ "$DISPLAY_NAME" == va-public-* ]]; then
+    MAKE_APP_PUBLIC="YES"
+    printf "\n\n##### Codespace display name starts with 'va-public-'. Setting up public environment. #####\n"
+else
+    MAKE_APP_PUBLIC="NO"
+    printf "\n\n##### Codespace display name does not start with 'va-public-'. Setting up private environment. #####\n"
+fi
+
 if [ "$MAKE_APP_PUBLIC" == "YES" ]; then
     # Start mock API server
     printf "\n\n##### Starting mock API server #####\n"
@@ -45,6 +59,6 @@ if [ "$MAKE_APP_PUBLIC" == "YES" ]; then
     printf "\n\n##### Setup complete. Your servers are running and ports are public. #####\n"
     wait
 else
-    printf "\n\n##### MAKE_APP_PUBLIC is not set to 'YES'. Servers will not be started. #####\n"
-    printf "To make the app public and start the servers, set the MAKE_APP_PUBLIC secret to 'YES' in your Codespace settings.\n"
+    printf "\n\n##### Codespace is not set to run on a public port. #####\n"
+    printf "To make the app public and start the servers, change the Codespace 'friendly name' to start with va-public-\n"
 fi


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Instead of making codespaces public when a user's codespace secret is set, we can instead pull the display name and be able to flag a codespace as being tagged as public by changing the display name to va-public-any-name-here and the va-public- is what will determine that.

- This change allows a mix of public and private codespaces to be maintained by any user

## Related issue(s)

- https://github.com/department-of-veterans-affairs/tmf-auth-exp-design-patterns/issues/110

## Testing done

- Tested with codespaces

## Screenshots

No ui changes

## What areas of the site does it impact?

Just the codespace start script that I had previously updated

## Acceptance criteria

- codespace can be made public one by one via display name update

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
