### PR TITLE
Add support for the yesNo pattern to the new confirmation page

### DIFF
--- a/src/applications/simple-forms/shared/components/confirmationPageViewHelpers.jsx
+++ b/src/applications/simple-forms/shared/components/confirmationPageViewHelpers.jsx
@@ -65,6 +65,13 @@ const fieldEntries = (key, uiSchema, data, schema, schemaFromState) => {
     refinedData = uiSchema['ui:options'].labels[refinedData];
   }
 
+  if (
+    uiSchema['ui:widget'] === 'yesNo' &&
+    uiSchema['ui:options']?.labels?.[refinedData ? 'Y' : 'N']
+  ) {
+    refinedData = uiSchema['ui:options'].labels[refinedData ? 'Y' : 'N'];
+  }
+
   const dataType = schema.properties[key].type;
 
   if (ConfirmationField) {

--- a/src/applications/simple-forms/shared/tests/components/confirmationPageViewHelpers.unit.spec.js
+++ b/src/applications/simple-forms/shared/tests/components/confirmationPageViewHelpers.unit.spec.js
@@ -365,18 +365,18 @@ describe('confirmation page view helpers', () => {
     expect(title).to.equal('Review function title');
   });
 
-  // it('should show radio fields correctly', () => {
-  //   const chapter = new MockChapter(mockChapterRadio, mockChapterRadioData);
-  //   const fields = chapter.buildConfirmationFields();
-  //   const { getByText } = render(fields);
-  //   expect(getByText('Widget radio')).to.exist;
-  //   expect(getByText('Widget radio option 1')).to.exist;
-  //   expect(getByText('Web component radio')).to.exist;
-  //   expect(getByText('Web component radio option 1')).to.exist;
+  it('should show radio fields correctly', () => {
+    const chapter = new MockChapter(mockChapterRadio, mockChapterRadioData);
+    const fields = chapter.buildConfirmationFields();
+    const { getByText } = render(fields);
+    expect(getByText('Widget radio')).to.exist;
+    expect(getByText('Widget radio option 1')).to.exist;
+    expect(getByText('Web component radio')).to.exist;
+    expect(getByText('Web component radio option 1')).to.exist;
 
-  //   expect(getByText('Web component yes/no')).to.exist;
-  //   expect(getByText('Yes')).to.exist;
-  // });
+    expect(getByText('Web component yes/no')).to.exist;
+    expect(getByText('Yes')).to.exist;
+  });
 
   it('should show text fields correctly', () => {
     const chapter = new MockChapter(mockChapterText, mockChapterTextData);


### PR DESCRIPTION
## Summary
This pull request enables support for the yesNo pattern on the new confirmation page. Previously, support for generic radio patterns was added, but yesNo is unique in that it uses a boolean value for the formData but has strings for the key/value pair of the displayed labels. This change also supports custom labels for the yesNo pattern,

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#1670

## Testing done
Uncommented unit tests for radio patterns, such as yesNo

## Screenshots
Custom Yes label
![image](https://github.com/user-attachments/assets/d1ed0215-9722-453f-b653-b21ffdb08122)

Standard No label
![image](https://github.com/user-attachments/assets/0b0c2fed-1f0c-4522-870e-2afd522c06b5)
