### PR TITLE
Bugfix document success alert render in Caregivers form

### DIFF
--- a/src/applications/caregivers/config/chapters/signAsRepresentative/documentUpload.js
+++ b/src/applications/caregivers/config/chapters/signAsRepresentative/documentUpload.js
@@ -13,12 +13,12 @@ import {
   parseResponse,
 } from '../../../utils/helpers/file-attachments';
 import { hideUploadWarningAlert } from '../../../utils/helpers/form-config';
-import CheckUploadWarning from '../../../components/FormAlerts/CheckUploadWarning';
 import SupportingDocumentDescription from '../../../components/FormDescriptions/SupportingDocumentDescription';
+import CheckUploadWarning from '../../../components/FormAlerts/CheckUploadWarning';
 import { emptySchema } from '../../../definitions/sharedSchema';
 import content from '../../../locales/en/content.json';
 
-const uploadPoaDocument = {
+const documentUpload = {
   uiSchema: {
     ...titleUI(
       content['sign-as-rep-title--upload'],
@@ -26,7 +26,7 @@ const uploadPoaDocument = {
     ),
     ...descriptionUI(SupportingDocumentDescription),
     'view:uploadSuccessAlert': {
-      'ui:description': CheckUploadWarning,
+      ...descriptionUI(CheckUploadWarning),
       'ui:options': {
         hideIf: hideUploadWarningAlert,
       },
@@ -73,4 +73,4 @@ const uploadPoaDocument = {
   },
 };
 
-export default uploadPoaDocument;
+export default documentUpload;

--- a/src/applications/caregivers/config/form.js
+++ b/src/applications/caregivers/config/form.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-cycle */
 import { VA_FORM_IDS } from 'platform/forms/constants';
 import environment from 'platform/utilities/environment';
 import FormFooter from 'platform/forms/components/FormFooter';

--- a/src/applications/caregivers/config/form.js
+++ b/src/applications/caregivers/config/form.js
@@ -55,7 +55,7 @@ import FacilityConfirmation from '../components/FormPages/FacilityConfirmation';
 
 // sign as representative
 import signAsRepresentativeYesNo from './chapters/signAsRepresentative/signAsRepresentativeYesNo';
-import uploadPOADocument from './chapters/signAsRepresentative/uploadPOADocument';
+import documentUpload from './chapters/signAsRepresentative/documentUpload';
 
 const {
   address,
@@ -314,8 +314,8 @@ const formConfig = {
           title: content['sign-as-rep-title--upload'],
           depends: formData => formData.signAsRepresentativeYesNo === 'yes',
           editModeOnReviewPage: false,
-          uiSchema: uploadPOADocument.uiSchema,
-          schema: uploadPOADocument.schema,
+          uiSchema: documentUpload.uiSchema,
+          schema: documentUpload.schema,
         },
       },
     },

--- a/src/applications/caregivers/tests/unit/config/signAsRepresentative/documentUpload.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/config/signAsRepresentative/documentUpload.unit.spec.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { expect } from 'chai';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
+import formConfig from '../../../../config/form';
+
+const {
+  chapters: {
+    signAsRepresentative: {
+      pages: { documentUpload },
+    },
+  },
+} = formConfig;
+const { title: pageTitle, schema, uiSchema } = documentUpload;
+const { defaultDefinitions } = formConfig;
+
+// run test to ensure the document upload alert does not render by default
+describe(`${pageTitle} page`, () => {
+  const getData = () => ({
+    mockStore: {
+      getState: () => ({
+        featureToggles: {},
+      }),
+      subscribe: () => {},
+      dispatch: () => {},
+    },
+  });
+  const subject = () => {
+    const { mockStore } = getData();
+    const { container } = render(
+      <Provider store={mockStore}>
+        <DefinitionTester
+          definitions={defaultDefinitions}
+          uiSchema={uiSchema}
+          schema={schema}
+          formData={{}}
+          data={{}}
+        />
+      </Provider>,
+    );
+    const selectors = () => ({
+      submitBtn: container.querySelector('button[type="submit"]'),
+      errors: container.querySelectorAll('[role="alert"]'),
+      inputs: container.querySelectorAll('input, select, textarea'),
+      vaAlert: container.querySelector('.caregivers-upload-warning'),
+    });
+    return { selectors };
+  };
+
+  it('should render the correct number of fields', async () => {
+    const { selectors } = subject();
+    const expectedNumberOfFields = 1;
+    await waitFor(() => {
+      expect(selectors().inputs).to.have.lengthOf(expectedNumberOfFields);
+    });
+  });
+
+  it('should not render document upload warning by default', async () => {
+    const { selectors } = subject();
+    await waitFor(() => {
+      expect(selectors().vaAlert).to.not.exist;
+    });
+  });
+
+  it('should render the correct number of errors on submit', async () => {
+    const { selectors } = subject();
+    const expectedNumberOfErrors = 1;
+    await waitFor(() => {
+      const { submitBtn, errors } = selectors();
+      fireEvent.click(submitBtn);
+      expect(errors).to.have.lengthOf(expectedNumberOfErrors);
+    });
+  });
+});

--- a/src/applications/caregivers/utils/helpers/form-config.js
+++ b/src/applications/caregivers/utils/helpers/form-config.js
@@ -18,9 +18,9 @@ export const hideCaregiverRequiredAlert = formData => {
 
 export const hideUploadWarningAlert = formData => {
   const { signAsRepresentativeDocumentUpload: upload } = formData;
-  const hasDocument = upload?.length;
+  const hasDocument = !!upload?.length;
 
-  if (!hasDocument) return false;
+  if (!hasDocument) return true;
 
   const { guid, name, errorMessage } = upload[0];
   return !(guid && name && !errorMessage);


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR bugfixes the render conditions for the document upload success alert in the Caregivers form.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#90633

## Testing done

- Previous the upload alert was rendering regardless of the display conditions
- In order for the alert to render, the user should successfully upload a valid document
- To test alert render, navigate through the application--filling out both the Veteran information and information for one caregiver. After filling out caregiver information, select that you will be signing as a representative for the Veteran. The next page to render will be the document upload page. The alert should not render until a valid document is successfully uploaded.

## Acceptance criteria

 - Alert success renders based on the correct conditions

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution