### PR TITLE
MHV-61850: Updated download/print loading visualization

### DIFF
--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsList.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsList.jsx
@@ -33,7 +33,7 @@ const MedicationsList = props => {
 
   const onPageChange = page => {
     document.querySelector('.va-breadcrumbs-li')?.scrollIntoView();
-    updateLoadingStatus(true, 'Loading your list...');
+    updateLoadingStatus(true, 'Loading your medications...');
     history.push(`/?page=${page}`);
     waitForRenderThenFocus(displaynumberOfPrescriptionsSelector, document, 500);
   };

--- a/src/applications/mhv-medications/components/shared/PrintDownload.jsx
+++ b/src/applications/mhv-medications/components/shared/PrintDownload.jsx
@@ -4,7 +4,7 @@ import { DOWNLOAD_FORMAT, PRINT_FORMAT } from '../../util/constants';
 import { dataDogActionNames, pageType } from '../../util/dataDogConstants';
 
 const PrintDownload = props => {
-  const { onDownload, isSuccess, list, onPrint, onText } = props;
+  const { onDownload, isSuccess, list, onPrint, onText, isLoading } = props;
   const [isError, setIsError] = useState(false);
 
   const [menuOpen, setMenuOpen] = useState(false);
@@ -74,6 +74,13 @@ const PrintDownload = props => {
 
   return (
     <>
+      {isLoading && (
+        <va-loading-indicator
+          message="Loading..."
+          setFocus
+          data-testid="print-download-loading-indicator"
+        />
+      )}
       {isSuccess && (
         <div
           className="vads-u-margin-bottom--3"

--- a/src/applications/mhv-medications/components/shared/PrintDownload.jsx
+++ b/src/applications/mhv-medications/components/shared/PrintDownload.jsx
@@ -217,4 +217,5 @@ PrintDownload.propTypes = {
   onDownload: PropTypes.any,
   onPrint: PropTypes.func,
   onText: PropTypes.func,
+  isLoading: PropTypes.bool,
 };

--- a/src/applications/mhv-medications/containers/PrescriptionDetails.jsx
+++ b/src/applications/mhv-medications/containers/PrescriptionDetails.jsx
@@ -57,7 +57,6 @@ const PrescriptionDetails = () => {
   const [pdfTxtGenerateStatus, setPdfTxtGenerateStatus] = useState({
     status: PDF_TXT_GENERATE_STATUS.NotStarted,
     format: undefined,
-    message: undefined,
   });
   const dispatch = useDispatch();
 
@@ -202,7 +201,6 @@ const PrescriptionDetails = () => {
     setPdfTxtGenerateStatus({
       status: PDF_TXT_GENERATE_STATUS.InProgress,
       format,
-      message: 'Loading...',
     });
     await Promise.allSettled([!allergies && dispatch(getAllergiesList())]);
   };
@@ -324,11 +322,7 @@ const PrescriptionDetails = () => {
   const hasPrintError =
     prescription && !prescriptionsApiError && !allergiesError;
   const content = () => {
-    if (
-      (pdfTxtGenerateStatus.status !== PDF_TXT_GENERATE_STATUS.InProgress ||
-        allergiesError) &&
-      (prescription || prescriptionsApiError)
-    ) {
+    if (prescription || prescriptionsApiError) {
       return (
         <>
           <div className="no-print">
@@ -374,6 +368,11 @@ const PrescriptionDetails = () => {
                       pdfTxtGenerateStatus.status ===
                       PDF_TXT_GENERATE_STATUS.Success
                     }
+                    isLoading={
+                      !allergiesError &&
+                      pdfTxtGenerateStatus.status ===
+                        PDF_TXT_GENERATE_STATUS.InProgress
+                    }
                   />
                   <BeforeYouDownloadDropdown page={pageType.DETAILS} />
                 </div>
@@ -407,9 +406,7 @@ const PrescriptionDetails = () => {
     }
     return (
       <va-loading-indicator
-        message={
-          pdfTxtGenerateStatus.message || 'Loading your medication record...'
-        }
+        message="Loading your medication record..."
         setFocus
         data-testid="loading-indicator"
       />

--- a/src/applications/mhv-medications/containers/PrescriptionDetailsDocumentation.jsx
+++ b/src/applications/mhv-medications/containers/PrescriptionDetailsDocumentation.jsx
@@ -204,6 +204,7 @@ const PrescriptionDetailsDocumentation = () => {
             onText={downloadText}
             onDownload={downloadPdf}
             isSuccess={false}
+            isLoading={false}
           />
           <BeforeYouDownloadDropdown page={pageType.DOCUMENTATION} />
           <div className="no-print rx-page-total-info vads-u-border-bottom--2px vads-u-border-color--gray-lighter vads-u-margin-y--5" />

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -334,7 +334,6 @@ const Prescriptions = () => {
         pdfData(rxList, allergiesList),
       ).then(() => {
         setPdfTxtGenerateStatus({ status: PDF_TXT_GENERATE_STATUS.Success });
-        updateLoadingStatus(false, '');
       });
     },
     [userName, pdfData, setPdfTxtGenerateStatus],
@@ -349,7 +348,6 @@ const Prescriptions = () => {
         }-${dateFormat(Date.now(), 'M-D-YYYY_hmmssa').replace(/\./g, '')}`,
       );
       setPdfTxtGenerateStatus({ status: PDF_TXT_GENERATE_STATUS.Success });
-      updateLoadingStatus(false, '');
     },
     [userName, txtData, setPdfTxtGenerateStatus],
   );
@@ -447,12 +445,13 @@ const Prescriptions = () => {
     const isTxtOrPdf =
       format === DOWNLOAD_FORMAT.PDF || format === DOWNLOAD_FORMAT.TXT;
     if (
-      isTxtOrPdf ||
-      !allergies ||
-      (format === PRINT_FORMAT.PRINT_FULL_LIST && !prescriptionsFullList.length)
+      (isTxtOrPdf ||
+        !allergies ||
+        (format === PRINT_FORMAT.PRINT_FULL_LIST &&
+          !prescriptionsFullList.length)) &&
+      !prescriptionsFullList.length
     ) {
-      if (!prescriptionsFullList.length) setIsRetrievingFullList(true);
-      updateLoadingStatus(true, 'Loading...');
+      setIsRetrievingFullList(true);
     }
     setPdfTxtGenerateStatus({
       status: PDF_TXT_GENERATE_STATUS.InProgress,
@@ -587,6 +586,11 @@ const Prescriptions = () => {
                             pdfTxtGenerateStatus.status ===
                             PDF_TXT_GENERATE_STATUS.Success
                           }
+                          isLoading={
+                            !allergiesError &&
+                            pdfTxtGenerateStatus.status ===
+                              PDF_TXT_GENERATE_STATUS.InProgress
+                          }
                           list
                         />
                         <BeforeYouDownloadDropdown page={pageType.LIST} />
@@ -622,6 +626,11 @@ const Prescriptions = () => {
                           isSuccess={
                             pdfTxtGenerateStatus.status ===
                             PDF_TXT_GENERATE_STATUS.Success
+                          }
+                          isLoading={
+                            !allergiesError &&
+                            pdfTxtGenerateStatus.status ===
+                              PDF_TXT_GENERATE_STATUS.InProgress
                           }
                           list
                         />

--- a/src/applications/mhv-medications/tests/components/shared/PrintDownload.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/shared/PrintDownload.unit.spec.jsx
@@ -16,6 +16,7 @@ describe('Medicaitons Print/Download button component', () => {
     list = false,
     onText = undefined,
     onPrint = undefined,
+    isLoading = undefined,
   ) => {
     return renderWithStoreAndRouter(
       <PrintDownload
@@ -24,6 +25,7 @@ describe('Medicaitons Print/Download button component', () => {
         onPrint={onPrint}
         isSuccess={success}
         list={list}
+        isLoading={isLoading}
       />,
       {
         path: '/',
@@ -70,6 +72,19 @@ describe('Medicaitons Print/Download button component', () => {
 
     const sucessMessage = screen.getByText('Download started');
     expect(sucessMessage).to.exist;
+  });
+
+  it('displays spinner when loading ', () => {
+    const screen = setup(
+      handleFullListDownload,
+      false,
+      false,
+      undefined,
+      undefined,
+      true,
+    );
+
+    expect(screen.getByTestId('print-download-loading-indicator')).to.exist;
   });
 
   it('button displays different text for list', () => {

--- a/src/applications/mhv-medications/tests/e2e/medications-download-pdf-details-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-pdf-details-page.cypress.spec.js
@@ -16,8 +16,10 @@ describe('Medications Details Page Download', () => {
     listPage.clickGotoMedicationsLink();
     detailsPage.clickMedicationHistoryAndDetailsLink(mockPrescriptionDetails);
     listPage.clickPrintOrDownloadThisListDropDown();
+    detailsPage.verifyFocusOnPrintOrDownloadDropdownButtonOnDetailsPage();
     detailsPage.verifyDownloadMedicationsDetailsAsPDFButtonOnDetailsPage();
     detailsPage.clickDownloadMedicationDetailsAsPdfOnDetailsPage();
+    detailsPage.verifyLoadingSpinnerForDownloadOnDetailsPage();
     listPage.verifyDownloadCompleteSuccessMessageBanner();
     site.verifyDownloadedPdfFile(
       'VA-medications-list-Safari-Mhvtp',

--- a/src/applications/mhv-medications/tests/e2e/medications-download-pdf-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-pdf-list-page.cypress.spec.js
@@ -14,7 +14,9 @@ describe('Medications Download PDF on List Page', () => {
     cy.axeCheck('main');
     listPage.clickGotoMedicationsLink();
     listPage.clickPrintOrDownloadThisListDropDown();
+    listPage.verifyFocusOnPrintDownloadDropDownButton();
     listPage.clickDownloadListAsPDFButtonOnListPage();
+    listPage.verifyLoadingSpinnerForDownloadOnListPage();
     listPage.verifyDownloadCompleteSuccessMessageBanner();
     site.verifyDownloadedPdfFile(
       'VA-medications-list-Safari-Mhvtp',

--- a/src/applications/mhv-medications/tests/e2e/medications-download-txt-details-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-txt-details-page.cypress.spec.js
@@ -15,6 +15,7 @@ describe('Medications Details Page Download', () => {
     listPage.clickGotoMedicationsLink();
     detailsPage.clickMedicationHistoryAndDetailsLink(mockPrescriptionDetails);
     listPage.clickPrintOrDownloadThisListDropDown();
+    detailsPage.verifyFocusOnPrintOrDownloadDropdownButtonOnDetailsPage();
     detailsPage.clickDownloadMedicationsDetailsAsTxtOnDetailsPage();
     listPage.verifyDownloadCompleteSuccessMessageBanner();
     listPage.verifyDownloadTextFileHeadless('Safari', 'Mhvtp', 'Mhvtp, Safari');

--- a/src/applications/mhv-medications/tests/e2e/medications-download-txt-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-txt-list-page.cypress.spec.js
@@ -13,7 +13,9 @@ describe('Medications Download Txt on List Page', () => {
     cy.axeCheck('main');
     listPage.clickGotoMedicationsLink();
     listPage.clickPrintOrDownloadThisListDropDown();
+    listPage.verifyFocusOnPrintDownloadDropDownButton();
     listPage.clickDownloadListAsTxtButtonOnListPage();
+    listPage.verifyLoadingSpinnerForDownloadOnListPage();
     listPage.verifyDownloadCompleteSuccessMessageBanner();
     listPage.verifyDownloadTextFileHeadless('Safari', 'Mhvtp', 'Mhvtp, Safari');
   });

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsDetailsPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsDetailsPage.js
@@ -157,6 +157,10 @@ class MedicationsDetailsPage {
     });
   };
 
+  verifyFocusOnPrintOrDownloadDropdownButtonOnDetailsPage = () => {
+    cy.get('[data-testid="print-records-button"]').should('have.focus');
+  };
+
   clickPrintThisPageButtonOnDetailsPage = () => {
     cy.get('[data-testid="download-print-button"]').should('exist');
     cy.get('[data-testid="download-print-button"]').click({
@@ -175,6 +179,10 @@ class MedicationsDetailsPage {
     cy.get('[data-testid="download-pdf-button"]').click({
       waitForAnimations: true,
     });
+  };
+
+  verifyLoadingSpinnerForDownloadOnDetailsPage = () => {
+    cy.get('[data-testid="print-download-loading-indicator"]').should('exist');
   };
 
   verifyDownloadMedicationsDetailsAsPDFButtonOnDetailsPage = () => {

--- a/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
+++ b/src/applications/mhv-medications/tests/e2e/pages/MedicationsListPage.js
@@ -199,6 +199,10 @@ class MedicationsListPage {
     });
   };
 
+  verifyFocusOnPrintDownloadDropDownButton = () => {
+    cy.get('[data-testid="print-records-button"]').should('have.focus');
+  };
+
   verifyPrintMedicationsListEnabledOnListPage = () => {
     cy.get('[data-testid="print-records-button"] > span').should(
       'contain',
@@ -238,6 +242,10 @@ class MedicationsListPage {
     cy.get('[data-testid="download-pdf-button"]').click({
       waitForAnimations: true,
     });
+  };
+
+  verifyLoadingSpinnerForDownloadOnListPage = () => {
+    cy.get('[data-testid="print-download-loading-indicator"]').should('exist');
   };
 
   clickDownloadListAsTxtButtonOnListPage = () => {


### PR DESCRIPTION
## Summary

Whenever user downloaded PDF or text of medication(s) the entire page was refreshed. This logic has been refactored and moved to `PrintDownload` button with a spinner displayed right above the button and consequently replaced by success or error alert.

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-61850

<img width="965" alt="image" src="https://github.com/user-attachments/assets/8a1be7fe-89c3-4237-9a84-2d0f3e74d02b">

## Screenshots

<img width="595" alt="image" src="https://github.com/user-attachments/assets/ef9c8864-a624-4be7-bd56-f0db7b2cff5d">

<img width="597" alt="image" src="https://github.com/user-attachments/assets/22f08afd-7426-4456-913b-0fe5b81d0a15">

## Testing done

- Manual testing
- Unit testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Work is validated by accessibility
AC2: Focus should remain on the dropdown button in a closed state after selecting to download a page/record
AC3: Check other pages to make sure it is working properly on those. 

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
