### PR TITLE
Update family caregiver alert position for improved accessibility

### DIFF
--- a/src/applications/caregivers/components/FormAlerts/SecondaryRequiredAlert.jsx
+++ b/src/applications/caregivers/components/FormAlerts/SecondaryRequiredAlert.jsx
@@ -7,7 +7,7 @@ const SecondaryRequiredAlert = () => {
   }, []);
 
   return (
-    <div className="caregiver-error-message">
+    <div className="caregiver-error-message vads-u-margin-bottom--4">
       <va-alert status="error">
         <h3 slot="headline">You need to add a Family Caregiver</h3>
         <p>

--- a/src/applications/caregivers/components/FormDescriptions/SecondayCaregiverIntros.jsx
+++ b/src/applications/caregivers/components/FormDescriptions/SecondayCaregiverIntros.jsx
@@ -1,23 +1,35 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import SecondaryCaregiverDescription from './SecondaryCaregiverDescription';
+import SecondaryRequiredAlert from '../FormAlerts/SecondaryRequiredAlert';
+import { hideCaregiverRequiredAlert } from '../../utils/helpers/form-config';
 
-export const SecondayCaregiverOneIntro = (
-  <>
-    <p>
-      You can use this application to apply for benefits for a Secondary Family
-      Caregiver.
-    </p>
-    <p>
-      <strong>Note:</strong> There can only be 2 Secondary Family Caregivers at
-      any one time.
-    </p>
-    {SecondaryCaregiverDescription}
-  </>
-);
+const SecondayCaregiverOneIntro = ({ formData }) => {
+  return (
+    <div aria-live="polite">
+      {!hideCaregiverRequiredAlert(formData) && <SecondaryRequiredAlert />}
+      <p>
+        You can use this application to apply for benefits for a Secondary
+        Family Caregiver.
+      </p>
+      <p>
+        <strong>Note:</strong> There can only be 2 Secondary Family Caregivers
+        at any one time.
+      </p>
+      {SecondaryCaregiverDescription}
+    </div>
+  );
+};
 
-export const SecondayCaregiverTwoIntro = (
+const SecondayCaregiverTwoIntro = (
   <>
     <p>You can have up to 2 Secondary Family Caregivers at any one time.</p>
     {SecondaryCaregiverDescription}
   </>
 );
+
+SecondayCaregiverOneIntro.propTypes = {
+  formData: PropTypes.object,
+};
+
+export { SecondayCaregiverOneIntro, SecondayCaregiverTwoIntro };

--- a/src/applications/caregivers/config/chapters/secondaryOne/hasSecondary.js
+++ b/src/applications/caregivers/config/chapters/secondaryOne/hasSecondary.js
@@ -4,15 +4,10 @@ import {
   yesNoSchema,
   descriptionUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import {
-  hasPrimaryCaregiver,
-  hideCaregiverRequiredAlert,
-} from '../../../utils/helpers/form-config';
+import { hasPrimaryCaregiver } from '../../../utils/helpers/form-config';
 import { validateCaregivers } from '../../../utils/validation';
-import { emptySchema } from '../../../definitions/sharedSchema';
 import { SecondayCaregiverOneIntro } from '../../../components/FormDescriptions/SecondayCaregiverIntros';
 import CustomYesNoReviewField from '../../../components/FormReview/CustomYesNoReviewField';
-import SecondaryRequiredAlert from '../../../components/FormAlerts/SecondaryRequiredAlert';
 import content from '../../../locales/en/content.json';
 
 const hasSecondaryCaregiverOne = {
@@ -29,18 +24,11 @@ const hasSecondaryCaregiverOne = {
         'ui:validations': [validateCaregivers],
       },
     ),
-    'view:caregiverRequiredAlert': {
-      'ui:description': SecondaryRequiredAlert,
-      'ui:options': {
-        hideIf: hideCaregiverRequiredAlert,
-      },
-    },
   },
   schema: {
     type: 'object',
     properties: {
       'view:hasSecondaryCaregiverOne': yesNoSchema,
-      'view:caregiverRequiredAlert': emptySchema,
     },
   },
 };

--- a/src/applications/caregivers/tests/unit/components/FormDescriptions/SecondaryCaregiverIntros.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormDescriptions/SecondaryCaregiverIntros.unit.spec.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import { SecondayCaregiverOneIntro } from '../../../../components/FormDescriptions/SecondayCaregiverIntros';
+
+describe('CG <SecondayCaregiverOneIntro>', () => {
+  const getData = ({ primary = false, secondary = undefined }) => ({
+    props: {
+      formData: {
+        'view:hasPrimaryCaregiver': primary,
+        'view:hasSecondaryCaregiverOne': secondary,
+      },
+    },
+  });
+  const subject = ({ props }) => {
+    const { container } = render(<SecondayCaregiverOneIntro {...props} />);
+    const selectors = () => ({
+      vaAlert: container.querySelector('va-alert'),
+    });
+    return { selectors };
+  };
+
+  it('should not render `va-alert` with prestine form input', () => {
+    const { props } = getData({});
+    const { selectors } = subject({ props });
+    expect(selectors().vaAlert).to.not.exist;
+  });
+
+  it('should not render `va-alert` when form data is valid', () => {
+    const { props } = getData({ secondary: true });
+    const { selectors } = subject({ props });
+    expect(selectors().vaAlert).to.not.exist;
+  });
+
+  it('should render `va-alert` when form data is invalid', () => {
+    const { props } = getData({ primary: false, secondary: false });
+    const { selectors } = subject({ props });
+    expect(selectors().vaAlert).to.exist;
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR updates moves the Family Caregiver Required alert on the Secondary Caregiver One page to improve accessibility for keyboard-only users. 

The previous position had the alert between the question options and the pagination buttons. This may require users with visual impairments that don't know where the alert lived on the page to have to tab through the entire page (footer, header, page content, etc.) before getting back to the question to reconsider their response.

The new position is above the page content and question, allowing the user to tab away from the alert and directly into the page content and question.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#90660

## Testing done

- Fill the form until getting to the primary caregiver declaration question--select "no" for providing primary info
- Continue to the next page (which is the secondary caregiver question--select "no" for providing secondary info
- Notice the position of the alert and test the tab order

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

| Before | After |
| ------ | ----- |
| ![Screenshot 2024-09-25 at 14 47 59](https://github.com/user-attachments/assets/bc2f7d8a-86ec-48ba-9014-c1d176e72db6) | ![Screenshot 2024-09-25 at 14 47 23](https://github.com/user-attachments/assets/7225738c-c5f9-4861-b432-f42ac7b9daf9) |

## Acceptance criteria

 - Keyboard-only users are able to efficiently navigate the page, regardless of validation state

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution