### PR TITLE
remove auto scroll when an element is focused

### DIFF
--- a/src/applications/mhv-secure-messaging/components/MessageThreadHeader.jsx
+++ b/src/applications/mhv-secure-messaging/components/MessageThreadHeader.jsx
@@ -15,7 +15,10 @@ import {
   RecipientStatus,
   BlockedTriageAlertStyles,
 } from '../util/constants';
-import { updateTriageGroupRecipientStatus } from '../util/helpers';
+import {
+  scrollIfFocusedAndNotInView,
+  updateTriageGroupRecipientStatus,
+} from '../util/helpers';
 import { closeAlert } from '../actions/alerts';
 import CannotReplyAlert from './shared/CannotReplyAlert';
 import BlockedTriageGroupAlert from './shared/BlockedTriageGroupAlert';
@@ -113,6 +116,12 @@ const MessageThreadHeader = props => {
     },
     [categoryLabel, message, subject],
   );
+
+  useEffect(() => {
+    setTimeout(() => {
+      scrollIfFocusedAndNotInView(50);
+    }, 100);
+  }, []);
 
   return (
     <div className="message-detail-block">

--- a/src/applications/mhv-secure-messaging/components/shared/ScrollToTop.jsx
+++ b/src/applications/mhv-secure-messaging/components/shared/ScrollToTop.jsx
@@ -6,7 +6,7 @@ const ScrollToTop = props => {
   const location = useLocation();
   useEffect(
     () => {
-      if (!location.hash) {
+      if (!location.hash && !document.hasFocus()) {
         window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
       }
     },

--- a/src/applications/mhv-secure-messaging/containers/LandingPageAuth.jsx
+++ b/src/applications/mhv-secure-messaging/containers/LandingPageAuth.jsx
@@ -34,6 +34,7 @@ import WelcomeMessage from '../components/Dashboard/WelcomeMessage';
 import FrequentlyAskedQuestions from '../components/FrequentlyAskedQuestions';
 import AlertBackgroundBox from '../components/shared/AlertBackgroundBox';
 import CernerTransitioningFacilityAlert from '../components/Alerts/CernerTransitioningFacilityAlert';
+import { scrollIfFocusedAndNotInView } from '../util/helpers';
 
 const LandingPageAuth = () => {
   const dispatch = useDispatch();
@@ -58,6 +59,12 @@ const LandingPageAuth = () => {
   useEffect(() => {
     focusElement(document.querySelector('h1'));
     updatePageTitle(PageTitles.DEFAULT_PAGE_TITLE_TAG);
+  }, []);
+
+  useEffect(() => {
+    setTimeout(() => {
+      scrollIfFocusedAndNotInView(50);
+    }, 100);
   }, []);
 
   return (

--- a/src/applications/mhv-secure-messaging/util/helpers.js
+++ b/src/applications/mhv-secure-messaging/util/helpers.js
@@ -389,3 +389,30 @@ export const scrollTo = (element, behavior = 'smooth') => {
 export const scrollToTop = () => {
   window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
 };
+
+export const scrollIfFocusedAndNotInView = (offset = 0) => {
+  const element = document.activeElement; // Get the currently focused element
+
+  if (element) {
+    const rect = element.getBoundingClientRect();
+
+    // Check if the element is out of the viewport
+    const inViewport =
+      rect.top >= 0 &&
+      rect.left >= 0 &&
+      rect.bottom <=
+        (window.innerHeight || document.documentElement.clientHeight) &&
+      rect.right <= (window.innerWidth || document.documentElement.clientWidth);
+
+    if (!inViewport) {
+      // Calculate the position to scroll to, with an offset from the top
+      const scrollY = window.scrollY + rect.top - offset;
+
+      // Scroll to the element with the offset
+      window.scrollTo({
+        top: scrollY,
+        behavior: 'smooth', // Optional smooth scroll
+      });
+    }
+  }
+};


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- When a user is on mobile, or zoomed in to 300%, navigating through the app causes the scroll position to not be consistent and occasionally the focused H1 title was off the screen.
- This stops scroll behavior when navigating between folders and adds a delayed scroll to the header after choosing a thread to view/edit

## Related issue(s)

### [MHV-59102](https://jira.devops.va.gov/browse/MHV-59102) - Focus issue-H1 not showing on screen for mobile users with zoom 300x ###

> Focus issue-H1 not showing on screen for mobile users with zoom 300x.
> 
> Rakesh found that while zoomed to 300x in mobile view the focus is misfiring incorrectly.  
> 
> Notes from 6/21 meeting:  Remedy to scroll the element to the top of the window and start with checking with platform to see if anything needs to be changed across the board.  Back to top button and skip to main content.
> 
> Focus is going to the H1, but the H1 is not on the screen.  
> 
> Interim fix would be to remove the focus from the H1, but this would introduce other issues for screen readers.  we will need to research and find a better solution that is acceptable to all types of users.
> 
> https://dsva.slack.com/files/U060B43FACX/F0783HY0161/screenshare_-_2024-06-11_8_40_14_am__1_.mp4
> 
> Feature Flag Y/N ?
> 
> DataDog Analytics  Y/N ?
> 
> Manual Testing Y/N ? Y-Rakesh
> 
> Automated Testing Y/N ? N
> 
> Accessibility Testing Y/N ? Y-Bobby

## Testing done

- manual testing.  no new tests added

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

Va.gov - Secure Messaging

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
