### PR TITLE
Vebt 443 update Prevent API call with empty filters

### DIFF
--- a/src/applications/gi/components/ClearFiltersBtn.jsx
+++ b/src/applications/gi/components/ClearFiltersBtn.jsx
@@ -30,7 +30,7 @@ function ClearFiltersBtn({
       accredited: false,
       studentVeteran: false,
       yellowRibbonScholarship: false,
-      employers: false,
+      employers: true,
       vettec: false,
       preferredProvider: false,
       country: 'ALL',

--- a/src/applications/gi/components/search/KeywordSearch.jsx
+++ b/src/applications/gi/components/search/KeywordSearch.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { WAIT_INTERVAL, KEY_CODES } from '../../constants';
 import {
   handleScrollOnInputFocus,
-  validateSearchTerm,
+  validateSearchTermSubmit,
 } from '../../utils/helpers';
 import { setError } from '../../actions';
 
@@ -94,8 +94,8 @@ export function KeywordSearch({
       if (value !== '') {
         debouncedFetchSuggestion(value);
       }
-      if (validateSearchTerm) {
-        validateSearchTerm(value, dispatchError, error, filters, type);
+      if (validateSearchTermSubmit) {
+        validateSearchTermSubmit(value, dispatchError, error, filters, type);
       }
     }
   };
@@ -230,7 +230,7 @@ KeywordSearch.propTypes = {
   required: PropTypes.any,
   suggestions: PropTypes.array,
   type: PropTypes.string,
-  validateSearchTerm: PropTypes.func,
+  validateSearchTermSubmit: PropTypes.func,
   version: PropTypes.string,
   onFetchAutocompleteSuggestions: PropTypes.func,
   onPressEnter: PropTypes.func,

--- a/src/applications/gi/components/search/KeywordSearch.jsx
+++ b/src/applications/gi/components/search/KeywordSearch.jsx
@@ -24,7 +24,6 @@ export function KeywordSearch({
   required,
   suggestions,
   version,
-  // filters,
   dispatchError,
   errorReducer,
   type,
@@ -94,7 +93,6 @@ export function KeywordSearch({
       if (value !== '') {
         debouncedFetchSuggestion(value);
       }
-      // validateSearchTerm(value, dispatchError, error, filters, type);
       validateSearchTerm(value, dispatchError, error, type);
     }
   };

--- a/src/applications/gi/components/search/KeywordSearch.jsx
+++ b/src/applications/gi/components/search/KeywordSearch.jsx
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { WAIT_INTERVAL, KEY_CODES } from '../../constants';
 import {
   handleScrollOnInputFocus,
-  validateSearchTermSubmit,
+  validateSearchTerm,
 } from '../../utils/helpers';
 import { setError } from '../../actions';
 
@@ -24,7 +24,7 @@ export function KeywordSearch({
   required,
   suggestions,
   version,
-  filters,
+  // filters,
   dispatchError,
   errorReducer,
   type,
@@ -94,9 +94,8 @@ export function KeywordSearch({
       if (value !== '') {
         debouncedFetchSuggestion(value);
       }
-      if (validateSearchTermSubmit) {
-        validateSearchTermSubmit(value, dispatchError, error, filters, type);
-      }
+      // validateSearchTerm(value, dispatchError, error, filters, type);
+      validateSearchTerm(value, dispatchError, error, type);
     }
   };
 
@@ -230,7 +229,7 @@ KeywordSearch.propTypes = {
   required: PropTypes.any,
   suggestions: PropTypes.array,
   type: PropTypes.string,
-  validateSearchTermSubmit: PropTypes.func,
+  validateSearchTerm: PropTypes.func,
   version: PropTypes.string,
   onFetchAutocompleteSuggestions: PropTypes.func,
   onPressEnter: PropTypes.func,

--- a/src/applications/gi/constants.js
+++ b/src/applications/gi/constants.js
@@ -425,3 +425,11 @@ export const yellowRibbonColumns = {
     key: 'contributionAmount',
   },
 };
+
+export const ERROR_MESSAGES = {
+  searchByNameInputEmpty:
+    'Please fill in a school, employer, or training provider.',
+  searchbyLocationInputEmpty: 'Please fill in a city, state, or postal code.',
+  invalidZipCode: 'Please enter a valid postal code.',
+  checkBoxFilterEmpty: 'Please select at least one filter.',
+};

--- a/src/applications/gi/containers/FilterYourResults.jsx
+++ b/src/applications/gi/containers/FilterYourResults.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { connect } from 'react-redux';
 import _ from 'lodash';
@@ -16,12 +16,14 @@ import {
   createId,
   validateSearchTermSubmit,
   isShowVetTec,
+  isEmptyCheckboxFilters,
 } from '../utils/helpers';
 import { showModal, filterChange, setError, focusSearch } from '../actions';
 import {
   TABS,
   INSTITUTION_TYPES,
   INSTITUTION_TYPES_DICTIONARY,
+  ERROR_MESSAGES,
 } from '../constants';
 import CheckboxGroup from '../components/CheckboxGroup';
 import { updateUrlParams } from '../selectors/search';
@@ -82,6 +84,7 @@ export function FilterYourResults({
   const { version } = preview;
   const { error } = errorReducer;
   const {
+    schools,
     expanded,
     excludedSchoolTypes,
     excludeCautionFlags,
@@ -104,6 +107,33 @@ export function FilterYourResults({
     specialMissionPBI,
     specialMissionTRIBAL,
   } = filters;
+
+  useEffect(
+    () => {
+      const isEmpty = isEmptyCheckboxFilters(filters);
+
+      if (error === ERROR_MESSAGES.checkBoxFilterEmpty && !isEmpty)
+        dispatchError(null);
+    },
+    [
+      schools,
+      excludeCautionFlags,
+      accredited,
+      studentVeteran,
+      yellowRibbonScholarship,
+      employers,
+      specialMissionHbcu,
+      specialMissionMenonly,
+      specialMissionWomenonly,
+      specialMissionRelaffil,
+      specialMissionHSI,
+      specialMissionNANTI,
+      specialMissionANNHI,
+      specialMissionAANAPII,
+      specialMissionPBI,
+      specialMissionTRIBAL,
+    ],
+  );
 
   const facets =
     search.tab === TABS.name ? search.name.facets : search.location.facets;

--- a/src/applications/gi/containers/FilterYourResults.jsx
+++ b/src/applications/gi/containers/FilterYourResults.jsx
@@ -14,7 +14,7 @@ import {
   sortOptionsByStateName,
   addAllOption,
   createId,
-  validateSearchTerm,
+  validateSearchTermSubmit,
   isShowVetTec,
 } from '../utils/helpers';
 import { showModal, filterChange, setError, focusSearch } from '../actions';
@@ -208,7 +208,13 @@ export function FilterYourResults({
 
   const updateResults = () => {
     if (
-      validateSearchTerm(nameValue, dispatchError, error, filters, searchType)
+      validateSearchTermSubmit(
+        nameValue,
+        dispatchError,
+        error,
+        filters,
+        searchType,
+      )
     ) {
       updateInstitutionFilters('search', true);
       updateUrlParams(history, search.tab, search.query, filters, version);

--- a/src/applications/gi/containers/search/FilterBeforeResults.jsx
+++ b/src/applications/gi/containers/search/FilterBeforeResults.jsx
@@ -19,7 +19,7 @@ import {
   createId,
   specializedMissionDefinitions,
   sortedSpecializedMissionDefinitions,
-  validateSearchTerm,
+  validateSearchTermSubmit,
   isShowVetTec,
   isShowCommunityFocusVACheckbox,
 } from '../../utils/helpers';
@@ -571,7 +571,13 @@ export function FilterBeforeResults({
 
   const closeAndUpdate = () => {
     if (
-      validateSearchTerm(nameVal, dispatchError, error, filters, searchType)
+      validateSearchTermSubmit(
+        nameVal,
+        dispatchError,
+        error,
+        filters,
+        searchType,
+      )
     ) {
       recordEvent({
         event: 'gibct-form-change',

--- a/src/applications/gi/containers/search/FilterBeforeResults.jsx
+++ b/src/applications/gi/containers/search/FilterBeforeResults.jsx
@@ -22,12 +22,14 @@ import {
   validateSearchTermSubmit,
   isShowVetTec,
   isShowCommunityFocusVACheckbox,
+  isEmptyCheckboxFilters,
 } from '../../utils/helpers';
 import { showModal, filterChange, setError } from '../../actions';
 import {
   TABS,
   INSTITUTION_TYPES,
   INSTITUTION_TYPES_DICTIONARY,
+  ERROR_MESSAGES,
 } from '../../constants';
 import CheckboxGroup from '../../components/CheckboxGroup';
 import { updateUrlParams } from '../../selectors/search';
@@ -343,6 +345,33 @@ export function FilterBeforeResults({
     specialMissionPBI,
     specialMissionTRIBAL,
   } = filters;
+
+  useEffect(
+    () => {
+      const isEmpty = isEmptyCheckboxFilters(filters);
+
+      if (error === ERROR_MESSAGES.checkBoxFilterEmpty && !isEmpty)
+        dispatchError(null);
+    },
+    [
+      schools,
+      excludeCautionFlags,
+      accredited,
+      studentVeteran,
+      yellowRibbonScholarship,
+      employers,
+      specialMissionHbcu,
+      specialMissionMenonly,
+      specialMissionWomenonly,
+      specialMissionRelaffil,
+      specialMissionHSI,
+      specialMissionNANTI,
+      specialMissionANNHI,
+      specialMissionAANAPII,
+      specialMissionPBI,
+      specialMissionTRIBAL,
+    ],
+  );
 
   const facets =
     search.tab === TABS.name ? search.name.facets : search.location.facets;

--- a/src/applications/gi/containers/search/FilterBeforeResults.jsx
+++ b/src/applications/gi/containers/search/FilterBeforeResults.jsx
@@ -565,7 +565,7 @@ export function FilterBeforeResults({
       accredited: false,
       studentVeteran: false,
       yellowRibbonScholarship: false,
-      employers: false,
+      employers: true,
       vettec: false,
       preferredProvider: false,
       country: 'ALL',

--- a/src/applications/gi/containers/search/LocationSearchForm.jsx
+++ b/src/applications/gi/containers/search/LocationSearchForm.jsx
@@ -84,18 +84,6 @@ export function LocationSearchForm({
     [search.loadFromUrl],
   );
 
-  // const validateSearchTermSubmit = searchTerm => {
-  //   const invalidZipCodePattern = /^\d{6,}$/;
-
-  //   if (searchTerm.trim() === '') {
-  //     setError('Please fill in a city, state, or postal code.');
-  //   } else if (invalidZipCodePattern.test(searchTerm)) {
-  //     setError('Please enter a valid postal code.');
-  //   } else if (error !== null) {
-  //     setError(null);
-  //   }
-  // };
-
   const onResetSearchClick = () => {
     inputRef.current.focus();
   };
@@ -286,7 +274,6 @@ export function LocationSearchForm({
               onSelection={selected => setAutocompleteSelection(selected)}
               onUpdateAutocompleteSearchTerm={onUpdateAutocompleteSearchTerm}
               suggestions={[...autocomplete.locationSuggestions]}
-              // validateSearchTermSubmit={validateSearchTermSubmit}
               version={version}
             />
           </div>

--- a/src/applications/gi/containers/search/LocationSearchForm.jsx
+++ b/src/applications/gi/containers/search/LocationSearchForm.jsx
@@ -27,7 +27,7 @@ import { TABS } from '../../constants';
 import { INITIAL_STATE } from '../../reducers/search';
 import {
   isProductionOrTestProdEnv,
-  validateSearchTerm,
+  validateSearchTermSubmit,
 } from '../../utils/helpers';
 
 export function LocationSearchForm({
@@ -84,7 +84,7 @@ export function LocationSearchForm({
     [search.loadFromUrl],
   );
 
-  // const validateSearchTerm = searchTerm => {
+  // const validateSearchTermSubmit = searchTerm => {
   //   const invalidZipCodePattern = /^\d{6,}$/;
 
   //   if (searchTerm.trim() === '') {
@@ -103,7 +103,13 @@ export function LocationSearchForm({
     if (event) {
       event.preventDefault();
       if (
-        validateSearchTerm(location, dispatchError, error, filters, 'location')
+        validateSearchTermSubmit(
+          location,
+          dispatchError,
+          error,
+          filters,
+          'location',
+        )
       ) {
         let paramLocation = location;
         dispatchMapChanged({ changed: false, distance: null });
@@ -280,7 +286,7 @@ export function LocationSearchForm({
               onSelection={selected => setAutocompleteSelection(selected)}
               onUpdateAutocompleteSearchTerm={onUpdateAutocompleteSearchTerm}
               suggestions={[...autocomplete.locationSuggestions]}
-              // validateSearchTerm={validateSearchTerm}
+              // validateSearchTermSubmit={validateSearchTermSubmit}
               version={version}
             />
           </div>

--- a/src/applications/gi/containers/search/NameSearchForm.jsx
+++ b/src/applications/gi/containers/search/NameSearchForm.jsx
@@ -17,7 +17,7 @@ import { FILTERS_SCHOOL_TYPE_EXCLUDE_FLIP } from '../../selectors/filters';
 import FilterBeforeResults from './FilterBeforeResults';
 import {
   isProductionOrTestProdEnv,
-  validateSearchTerm,
+  validateSearchTermSubmit,
 } from '../../utils/helpers';
 
 export function NameSearchForm({
@@ -121,7 +121,7 @@ export function NameSearchForm({
 
   const handleSubmit = event => {
     event.preventDefault();
-    if (validateSearchTerm(name, dispatchError, error, filters, 'name')) {
+    if (validateSearchTermSubmit(name, dispatchError, error, filters, 'name')) {
       recordEvent({
         event: 'gibct-form-change',
         'gibct-form-field': 'nameSearch',

--- a/src/applications/gi/tests/containers/search/NameSearchForm.unit.spec.jsx
+++ b/src/applications/gi/tests/containers/search/NameSearchForm.unit.spec.jsx
@@ -89,7 +89,7 @@ describe('<NameSearchForm>', () => {
     });
   });
   it('validates empty search term correctly', async () => {
-    const validateSearchTermSpy = sinon.spy();
+    const validateSearchTermSubmitSpy = sinon.spy();
     const props = {
       autocomplete: { nameSuggestions: [] },
       filters: {
@@ -99,7 +99,10 @@ describe('<NameSearchForm>', () => {
       search: { query: { name: 'some name' }, tab: null, loadFromUrl: false },
     };
     const screen = renderWithStoreAndRouter(
-      <NameSearchForm validateSearchTerm={validateSearchTermSpy} {...props} />,
+      <NameSearchForm
+        validateSearchTermSubmit={validateSearchTermSubmitSpy}
+        {...props}
+      />,
       {
         initialState: {
           constants: mockConstants(),
@@ -111,7 +114,7 @@ describe('<NameSearchForm>', () => {
     const submitButton = screen.getByRole('button', { name: 'Search' });
     userEvent.click(submitButton);
     await waitFor(() => {
-      expect(validateSearchTermSpy.calledWith('')).to.be.false;
+      expect(validateSearchTermSubmitSpy.calledWith('')).to.be.false;
       expect(
         screen.getByText(
           'Please fill in a school, employer, or training provider.',
@@ -120,11 +123,11 @@ describe('<NameSearchForm>', () => {
     });
   });
   it('validates with no filters selected', async () => {
-    const validateSearchTermSpy = sinon.spy();
+    const validateSearchTermSubmitSpy = sinon.spy();
     const doSearchSpy = sinon.spy();
     const screen = renderWithStoreAndRouter(
       <NameSearchForm
-        validateSearchTerm={validateSearchTermSpy}
+        validateSearchTermSubmit={validateSearchTermSubmitSpy}
         doSearch={doSearchSpy}
         filters={{
           ...noFilters,
@@ -154,12 +157,12 @@ describe('<NameSearchForm>', () => {
       userEvent.click(submitButton);
     });
     await waitFor(() => {
-      expect(validateSearchTermSpy.calledWith('')).to.be.false;
+      expect(validateSearchTermSubmitSpy.calledWith('')).to.be.false;
       expect(screen.queryByText('Please select at least one filter.')).to.exist;
     });
   });
   it('should call doSearch with search?.query?.name', () => {
-    const validateSearchTermSpy = sinon.spy();
+    const validateSearchTermSubmitSpy = sinon.spy();
     const doSearchSpy = sinon.spy();
     const props = {
       autocomplete: { nameSuggestions: [] },
@@ -172,7 +175,7 @@ describe('<NameSearchForm>', () => {
     };
     renderWithStoreAndRouter(
       <NameSearchForm
-        validateSearchTerm={validateSearchTermSpy}
+        validateSearchTermSubmit={validateSearchTermSubmitSpy}
         doSearch={doSearchSpy}
         {...props}
       />,
@@ -186,7 +189,7 @@ describe('<NameSearchForm>', () => {
     expect(doSearchSpy.calledWith('some name')).to.be.false;
   });
   it('should not call doSearch with search?.query?.name is null', () => {
-    const validateSearchTermSpy = sinon.spy();
+    const validateSearchTermSubmitSpy = sinon.spy();
     const doSearchSpy = sinon.spy();
     const props = {
       autocomplete: { nameSuggestions: [] },
@@ -199,7 +202,7 @@ describe('<NameSearchForm>', () => {
     };
     renderWithStoreAndRouter(
       <NameSearchForm
-        validateSearchTerm={validateSearchTermSpy}
+        validateSearchTermSubmit={validateSearchTermSubmitSpy}
         doSearch={doSearchSpy}
         {...props}
       />,

--- a/src/applications/gi/tests/utils/helpers.unit.spec.js
+++ b/src/applications/gi/tests/utils/helpers.unit.spec.js
@@ -22,7 +22,7 @@ import {
   locationInfo,
   scrollToFocusedElement,
   handleInputFocusWithPotentialOverLap,
-  validateSearchTerm,
+  validateSearchTermSubmit,
   searchCriteriaFromCoords,
 } from '../../utils/helpers';
 
@@ -356,7 +356,7 @@ describe('GIBCT helpers:', () => {
       expect(result.position).to.deep.equal({ longitude, latitude });
     });
   });
-  describe('validateSearchTerm', () => {
+  describe('validateSearchTermSubmit', () => {
     let dispatchError;
     let error;
     let filters;
@@ -368,7 +368,7 @@ describe('GIBCT helpers:', () => {
     });
 
     it('should validate name search term', () => {
-      const valid = validateSearchTerm(
+      const valid = validateSearchTermSubmit(
         'Test',
         dispatchError,
         error,
@@ -378,7 +378,7 @@ describe('GIBCT helpers:', () => {
       expect(valid).to.be.true;
       expect(dispatchError.called).to.be.false;
 
-      const invalid = validateSearchTerm(
+      const invalid = validateSearchTermSubmit(
         ' ',
         dispatchError,
         error,
@@ -394,7 +394,7 @@ describe('GIBCT helpers:', () => {
     });
 
     it('should validate location search term', () => {
-      const valid = validateSearchTerm(
+      const valid = validateSearchTermSubmit(
         '12345',
         dispatchError,
         error,
@@ -404,7 +404,7 @@ describe('GIBCT helpers:', () => {
       expect(valid).to.be.true;
       expect(dispatchError.called).to.be.false;
 
-      const invalid = validateSearchTerm(
+      const invalid = validateSearchTermSubmit(
         '123456',
         dispatchError,
         error,
@@ -416,7 +416,7 @@ describe('GIBCT helpers:', () => {
         .be.true;
     });
     it('should not dispatchError when error is not null for name', () => {
-      const invalid = validateSearchTerm(
+      const invalid = validateSearchTermSubmit(
         'new york',
         dispatchError,
         (error = 'error'),
@@ -431,7 +431,7 @@ describe('GIBCT helpers:', () => {
       ).to.be.false;
     });
     it('should not dispatchError when error is not null for location', () => {
-      const invalid = validateSearchTerm(
+      const invalid = validateSearchTermSubmit(
         '94121',
         dispatchError,
         (error = 'error'),
@@ -443,7 +443,7 @@ describe('GIBCT helpers:', () => {
         .be.false;
     });
     it('should dispatchError search input is empty', () => {
-      validateSearchTerm('', dispatchError, error, filters, 'location');
+      validateSearchTermSubmit('', dispatchError, error, filters, 'location');
 
       expect(
         dispatchError.calledWith(

--- a/src/applications/gi/utils/helpers.js
+++ b/src/applications/gi/utils/helpers.js
@@ -15,6 +15,7 @@ import {
   SMALL_SCREEN_WIDTH,
   PREVIOUS_URL_PUSHED_TO_HISTORY,
   filterKeys,
+  ERROR_MESSAGES,
 } from '../constants';
 
 /**
@@ -392,6 +393,38 @@ export const sortedSpecializedMissionDefinitions = () => {
   );
 };
 
+export const validateSearchTerm = (searchTerm, dispatchError, error, type) => {
+  const empty = searchTerm.trim() === '';
+  const invalidZipCodePattern = /^\d{6,}$/;
+
+  // if (type === 'name') {
+  // if (empty) {
+  //   dispatchError('Please fill in a school, employer, or training provider.');
+  // } else
+  if (
+    type === 'name' &&
+    error === ERROR_MESSAGES.searchByNameInputEmpty &&
+    !empty
+  ) {
+    dispatchError(null);
+  }
+  // }
+  else if (type === 'location') {
+    // if (empty) {
+    //   dispatchError('Please fill in a city, state, or postal code.');
+    // } else if (invalidZipCodePattern.test(searchTerm)) {
+    //   dispatchError('Please enter a valid postal code.');
+    // } else
+    if (error === ERROR_MESSAGES.searchbyLocationInputEmpty && !empty) {
+      dispatchError(null);
+    } else if (
+      error === ERROR_MESSAGES.invalidZipCode &&
+      !invalidZipCodePattern.test(searchTerm)
+    )
+      dispatchError(null);
+  }
+};
+
 export const validateSearchTermSubmit = (
   searchTerm,
   dispatchError,
@@ -404,9 +437,9 @@ export const validateSearchTermSubmit = (
 
   if (type === 'name') {
     if (empty) {
-      dispatchError('Please fill in a school, employer, or training provider.');
+      dispatchError(ERROR_MESSAGES.searchByNameInputEmpty);
     } else if (filterKeys.every(key => filters[key] === false)) {
-      dispatchError('Please select at least one filter.');
+      dispatchError(ERROR_MESSAGES.checkBoxFilterEmpty);
     } else if (error !== null) {
       dispatchError(null);
     }
@@ -415,11 +448,11 @@ export const validateSearchTermSubmit = (
 
   if (type === 'location') {
     if (empty) {
-      dispatchError('Please fill in a city, state, or postal code.');
-    } else if (filterKeys.every(key => filters[key] === false)) {
-      dispatchError('Please select at least one filter.');
+      dispatchError(ERROR_MESSAGES.searchbyLocationInputEmpty);
     } else if (invalidZipCodePattern.test(searchTerm)) {
-      dispatchError('Please enter a valid postal code.');
+      dispatchError(ERROR_MESSAGES.invalidZipCode);
+    } else if (filterKeys.every(key => filters[key] === false)) {
+      dispatchError(ERROR_MESSAGES.checkBoxFilterEmpty);
     } else if (error !== null) {
       dispatchError(null);
     }
@@ -431,6 +464,14 @@ export const validateSearchTermSubmit = (
   }
 
   return !empty;
+};
+
+export const isEmptyCheckboxFilters = filters => {
+  let isEmpty = true;
+
+  if (!filterKeys.every(key => filters[key] === false)) isEmpty = false;
+
+  return isEmpty;
 };
 
 export const currentTab = () => {

--- a/src/applications/gi/utils/helpers.js
+++ b/src/applications/gi/utils/helpers.js
@@ -397,24 +397,13 @@ export const validateSearchTerm = (searchTerm, dispatchError, error, type) => {
   const empty = searchTerm.trim() === '';
   const invalidZipCodePattern = /^\d{6,}$/;
 
-  // if (type === 'name') {
-  // if (empty) {
-  //   dispatchError('Please fill in a school, employer, or training provider.');
-  // } else
   if (
     type === 'name' &&
     error === ERROR_MESSAGES.searchByNameInputEmpty &&
     !empty
   ) {
     dispatchError(null);
-  }
-  // }
-  else if (type === 'location') {
-    // if (empty) {
-    //   dispatchError('Please fill in a city, state, or postal code.');
-    // } else if (invalidZipCodePattern.test(searchTerm)) {
-    //   dispatchError('Please enter a valid postal code.');
-    // } else
+  } else if (type === 'location') {
     if (error === ERROR_MESSAGES.searchbyLocationInputEmpty && !empty) {
       dispatchError(null);
     } else if (

--- a/src/applications/gi/utils/helpers.js
+++ b/src/applications/gi/utils/helpers.js
@@ -392,7 +392,7 @@ export const sortedSpecializedMissionDefinitions = () => {
   );
 };
 
-export const validateSearchTerm = (
+export const validateSearchTermSubmit = (
   searchTerm,
   dispatchError,
   error,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

### - _(Summarize the changes that have been made to the platform)_
- Updated comparison tool search input errors to only show when using the search button
### - _(If bug, how to reproduce)_ 
- Errors would update and show with the onChange of the input field
### - _(What is the solution, why is this the solution)_
- Removed dispatching error from the input field and added it to the onSubmit
### - _(Which team do you work for, does your team own the maintenance of this component?)_ 
- GovCIO, we are the code owners
### - _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_ N/A

## Related issue(s)

Jira -> https://jira.devops.va.gov/browse/VEBT-443

When a user doesn't select a filter item and clicks search, the API is called and "results" are displayed but no search should be executed. This makes unnecessary API calls without searching anything the user inputs as no filters were selected in the first place. This problem applies to search by name, search by location, and post search by name after initial search.

Solution: When the user types something and hits search without any filters, an error is thrown stating at least one filter should be selected. This error needs to be thrown only when hitting the Search button. (Currently it gets thrown when you remove all filters and start typing). 

## Testing done

### - _Describe what the old behavior was prior to the change_
- Comparison tool search input errors shown when typing in the field
### - _Describe the steps required to verify your changes are working as expected_
- Comparison tool search input errors show now when using the search button
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

![image](https://github.com/user-attachments/assets/3efdd114-3b65-49f9-abd8-457c47ba223b)


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
