### PR TITLE
Create custom hook for populating default form data in Health Care Application

### DIFF
--- a/src/applications/hca/containers/App.jsx
+++ b/src/applications/hca/containers/App.jsx
@@ -1,18 +1,14 @@
 import React, { useEffect } from 'react';
 import { connect, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-
-import RoutedSavableApp from '~/platform/forms/save-in-progress/RoutedSavableApp';
-import recordEvent from '~/platform/monitoring/record-event';
-import { setData } from '~/platform/forms-system/src/js/actions';
-import { selectProfile } from '~/platform/user/selectors';
-
+import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import recordEvent from 'platform/monitoring/record-event';
 import { fetchEnrollmentStatus } from '../utils/actions/enrollment-status';
 import { fetchTotalDisabilityRating } from '../utils/actions/disability-rating';
 import { selectFeatureToggles } from '../utils/selectors/feature-toggles';
 import { selectAuthStatus } from '../utils/selectors/auth-status';
 import { useBrowserMonitoring } from '../hooks/useBrowserMonitoring';
-import { parseVeteranDob } from '../utils/helpers';
+import { useDefaultFormData } from '../hooks/useDefaultFormData';
 import content from '../locales/en/content.json';
 import formConfig from '../config/form';
 
@@ -20,25 +16,12 @@ const App = props => {
   const {
     children,
     location,
-    setFormData,
     getDisabilityRating,
     getEnrollmentStatus,
   } = props;
 
-  const {
-    isLoadingFeatureFlags,
-    isFacilitiesApiEnabled,
-    isInsuranceV2Enabled,
-    isRegOnlyEnabled,
-    isSigiEnabled,
-  } = useSelector(selectFeatureToggles);
-  const { dob: veteranDob } = useSelector(selectProfile);
-  const { totalRating } = useSelector(state => state.disabilityRating);
-  const { data: formData } = useSelector(state => state.form);
-  const { isUserLOA3, isLoggedIn, isLoadingProfile } = useSelector(
-    selectAuthStatus,
-  );
-  const { veteranFullName } = formData;
+  const { isLoadingFeatureFlags } = useSelector(selectFeatureToggles);
+  const { isUserLOA3, isLoadingProfile } = useSelector(selectAuthStatus);
   const isAppLoading = isLoadingFeatureFlags || isLoadingProfile;
 
   // Attempt to fetch disability rating for LOA3 users
@@ -53,52 +36,8 @@ const App = props => {
     [isUserLOA3],
   );
 
-  /**
-   * Set default view fields within the form data
-   *
-   * NOTE: we have included veteranFullName in the dependency list to reset view fields when
-   * starting a new application from save-in-progress.
-   *
-   * NOTE (2): we also included the DOB value from profile for authenticated users to fix a bug
-   * where some profiles did not contain a DOB value. In this case we need to ask the user for
-   * that data for proper submission.
-   */
-  useEffect(
-    () => {
-      const defaultViewFields = {
-        'view:isLoggedIn': isLoggedIn,
-        'view:isSigiEnabled': isSigiEnabled,
-        'view:isRegOnlyEnabled': isRegOnlyEnabled,
-        'view:isInsuranceV2Enabled': isInsuranceV2Enabled,
-        'view:isFacilitiesApiEnabled': isFacilitiesApiEnabled,
-        'view:totalDisabilityRating': parseInt(totalRating, 10) || 0,
-      };
-
-      if (isLoggedIn) {
-        setFormData({
-          ...formData,
-          ...defaultViewFields,
-          'view:userDob': parseVeteranDob(veteranDob),
-        });
-      } else {
-        setFormData({
-          ...formData,
-          ...defaultViewFields,
-        });
-      }
-    },
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      isLoggedIn,
-      veteranDob,
-      veteranFullName,
-      isSigiEnabled,
-      isRegOnlyEnabled,
-      isFacilitiesApiEnabled,
-      totalRating,
-    ],
-  );
+  // Set default view fields within the form data
+  useDefaultFormData();
 
   // Attach analytics events to all yes/no radio inputs
   useEffect(
@@ -147,11 +86,9 @@ App.propTypes = {
   getDisabilityRating: PropTypes.func,
   getEnrollmentStatus: PropTypes.func,
   location: PropTypes.object,
-  setFormData: PropTypes.func,
 };
 
 const mapDispatchToProps = {
-  setFormData: setData,
   getEnrollmentStatus: fetchEnrollmentStatus,
   getDisabilityRating: fetchTotalDisabilityRating,
 };

--- a/src/applications/hca/hooks/useDefaultFormData.jsx
+++ b/src/applications/hca/hooks/useDefaultFormData.jsx
@@ -1,0 +1,67 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { selectProfile } from 'platform/user/selectors';
+import { setData } from 'platform/forms-system/src/js/actions';
+import { selectFeatureToggles } from '../utils/selectors/feature-toggles';
+import { selectAuthStatus } from '../utils/selectors/auth-status';
+import { parseVeteranDob } from '../utils/helpers';
+
+/**
+ * NOTE: `veteranFullName` is included in the dependency list to reset view fields when
+ * starting a new application from save-in-progress.
+ *
+ * NOTE (2): `veteranDob` is included from profile for authenticated users to fix a bug
+ * where some profiles do not contain a DOB value. In this case we need to ask the user
+ * for that data for proper submission.
+ */
+export const useDefaultFormData = () => {
+  const { totalRating } = useSelector(state => state.disabilityRating);
+  const { data: formData } = useSelector(state => state.form);
+  const featureToggles = useSelector(selectFeatureToggles);
+  const { dob: veteranDob } = useSelector(selectProfile);
+  const { isLoggedIn } = useSelector(selectAuthStatus);
+  const dispatch = useDispatch();
+
+  const { veteranFullName } = formData;
+  const {
+    isFacilitiesApiEnabled,
+    isInsuranceV2Enabled,
+    isRegOnlyEnabled,
+    isSigiEnabled,
+  } = featureToggles;
+
+  const setFormData = dataToSet => dispatch(setData(dataToSet));
+
+  useEffect(
+    () => {
+      const defaultViewFields = {
+        'view:isLoggedIn': isLoggedIn,
+        'view:isSigiEnabled': isSigiEnabled,
+        'view:isRegOnlyEnabled': isRegOnlyEnabled,
+        'view:isInsuranceV2Enabled': isInsuranceV2Enabled,
+        'view:isFacilitiesApiEnabled': isFacilitiesApiEnabled,
+        'view:totalDisabilityRating': parseInt(totalRating, 10) || 0,
+      };
+      const userData = isLoggedIn
+        ? { 'view:userDob': parseVeteranDob(veteranDob) }
+        : {};
+
+      setFormData({
+        ...formData,
+        ...userData,
+        ...defaultViewFields,
+      });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      isLoggedIn,
+      veteranDob,
+      veteranFullName,
+      isSigiEnabled,
+      isRegOnlyEnabled,
+      isInsuranceV2Enabled,
+      isFacilitiesApiEnabled,
+      totalRating,
+    ],
+  );
+};

--- a/src/applications/hca/tests/unit/containers/AuthBenefitsPackagePage.unit.spec.js
+++ b/src/applications/hca/tests/unit/containers/AuthBenefitsPackagePage.unit.spec.js
@@ -67,8 +67,13 @@ describe('hca AuthBenefitsPackagePage', () => {
 
   it('should fire the routers `push` method with the correct path when the `continue` button is clicked', () => {
     const { props, mockStore } = getData();
-    const { selectors } = subject({ props, mockStore });
+    const { container, selectors } = subject({ props, mockStore });
     const { router } = props;
+    simulateInputChange(
+      container,
+      '#root_view\\3A vaBenefitsPackage_1',
+      'regOnly',
+    );
     fireEvent.click(selectors().primaryBtn);
     expect(router.push.calledWith('/next')).to.be.true;
   });

--- a/src/applications/hca/tests/unit/hooks/useDefaultFormData.unit.spec.js
+++ b/src/applications/hca/tests/unit/hooks/useDefaultFormData.unit.spec.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { useDefaultFormData } from '../../../hooks/useDefaultFormData';
+
+// create wrapper component for our hook
+const TestComponent = () => {
+  useDefaultFormData();
+  return null;
+};
+
+describe('hca `useDefaultFormData` hook', () => {
+  const getData = ({ loggedIn = false, dob = undefined }) => ({
+    mockStore: {
+      getState: () => ({
+        disabilityRating: { totalRating: 0 },
+        form: { data: { veteranFullName: {} } },
+        user: {
+          login: { currentlyLoggedIn: loggedIn },
+          profile: {
+            loa: { current: loggedIn ? 3 : null },
+            loading: false,
+            dob,
+          },
+        },
+        featureToggles: {
+          /* eslint-disable camelcase */
+          hca_sigi_enabled: false,
+          hca_reg_only_enabled: false,
+          hca_insurance_v2_enabled: false,
+          hca_use_facilities_API: true,
+          loading: false,
+        },
+      }),
+      subscribe: () => {},
+      dispatch: sinon.stub(),
+    },
+  });
+  const subject = ({ mockStore }) =>
+    render(
+      <Provider store={mockStore}>
+        <TestComponent />
+      </Provider>,
+    );
+
+  it('should fire the `setData` dispatch with the correct data when the user is logged out', () => {
+    const { mockStore } = getData({});
+    const { dispatch } = mockStore;
+    const expectedData = {
+      veteranFullName: {},
+      'view:isLoggedIn': false,
+      'view:isSigiEnabled': false,
+      'view:isRegOnlyEnabled': false,
+      'view:isInsuranceV2Enabled': false,
+      'view:isFacilitiesApiEnabled': true,
+      'view:totalDisabilityRating': 0,
+    };
+
+    subject({ mockStore });
+    expect(dispatch.firstCall.args[0].type).to.eq('SET_DATA');
+    expect(dispatch.firstCall.args[0].data).to.deep.eq(expectedData);
+  });
+
+  it('should fire the `setData` dispatch with the correct data when the user is logged in', () => {
+    const { mockStore } = getData({ loggedIn: true, dob: '12/14/1986' });
+    const { dispatch } = mockStore;
+    const expectedData = {
+      veteranFullName: {},
+      'view:isLoggedIn': true,
+      'view:isSigiEnabled': false,
+      'view:isRegOnlyEnabled': false,
+      'view:isInsuranceV2Enabled': false,
+      'view:isFacilitiesApiEnabled': true,
+      'view:totalDisabilityRating': 0,
+      'view:userDob': '12/14/1986',
+    };
+
+    subject({ mockStore });
+    expect(dispatch.firstCall.args[0].type).to.eq('SET_DATA');
+    expect(dispatch.firstCall.args[0].data).to.deep.eq(expectedData);
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

The base `App.jsx` file in the health care application has housed a useEffect method to set default form data for the application. This default data involves authentication status, feature flag values and limited user profile data that determines conditional page rendering the application. The method has grown very large and contains many redux calls to get the various data points needed to populate the default form data values.

This PR breaks that effect into a custom hook to import with the goal of cleaning up the base App file. This work is a prerequisite to the linked issue, which will add additional feature toggle values to the form data.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#87452

## Testing done

- To validate, start a new health care application
- Inspect the Redux form data to view the feature toggle values are correctly populated with the appropriate values
- Also verify the authentication status key (`view:loggedIn`) is correctly set in the form data

## Acceptance criteria

- Default form data is successfully populated using the created hook.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution