### PR TITLE
Simplified solution to validation bug on evidence types page

### DIFF
--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -83,14 +83,12 @@ export const SERVICE_CONNECTION_TYPES = {
 };
 
 export const DATA_PATHS = {
-  hasVAEvidence:
-    'view:hasEvidenceFollowUp.view:selectableEvidenceTypes.view:hasVaMedicalRecords',
+  hasVAEvidence: 'view:selectableEvidenceTypes.view:hasVaMedicalRecords',
   hasPrivateEvidence:
-    'view:hasEvidenceFollowUp.view:selectableEvidenceTypes.view:hasPrivateMedicalRecords',
+    'view:selectableEvidenceTypes.view:hasPrivateMedicalRecords',
   hasPrivateRecordsToUpload:
     'view:uploadPrivateRecordsQualifier.view:hasPrivateRecordsToUpload',
-  hasAdditionalDocuments:
-    'view:hasEvidenceFollowUp.view:selectableEvidenceTypes.view:hasOtherEvidence',
+  hasAdditionalDocuments: 'view:selectableEvidenceTypes.view:hasOtherEvidence',
 };
 
 export const DISABILITY_526_V2_ROOT_URL =

--- a/src/applications/disability-benefits/all-claims/content/evidenceTypesBDD.jsx
+++ b/src/applications/disability-benefits/all-claims/content/evidenceTypesBDD.jsx
@@ -6,20 +6,12 @@ export const evidenceTypeTitle = (
   </h3>
 );
 
-export const privateMedicalRecords = 'Private medical records';
-
-export const bddShaOtherEvidence =
-  'Required Separation Health Assessment - Part A Self-Assessment or other documents like your DD Form 214, supporting (lay) statements, or other evidence';
-
 export const defaultOtherEvidence = (
   <>
     Additional VA forms, medical records, separation documents (DD Form 214),
     supporting (lay) statements, or other evidence
   </>
 );
-
-export const evidenceTypeError =
-  'Please select at least one type of supporting evidence';
 
 export const evidenceTypeHelp = (
   <va-additional-info trigger="Which evidence type should I choose?">

--- a/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
@@ -19,21 +19,21 @@ export const uiSchema = {
       expandUnder: 'view:hasEvidence',
     },
     'ui:required': formData => get('view:hasEvidence', formData, false),
+    'ui:validations': [
+      {
+        validator: validateIfHasEvidence,
+        options: { wrappedValidator: validateBooleanGroup },
+      },
+    ],
+    'ui:errorMessages': {
+      atLeastOne: 'Please select at least one type of supporting evidence',
+    },
     'view:selectableEvidenceTypes': {
       'ui:title':
         'What type of evidence do you want us to review as part of your claim?',
       'ui:webComponentField': VaCheckboxGroupField,
       'ui:options': { showFieldLabel: true },
-      'ui:validations': [
-        {
-          validator: validateIfHasEvidence,
-          options: { wrappedValidator: validateBooleanGroup },
-        },
-      ],
-      'ui:errorMessages': {
-        atLeastOne: 'Please select at least one type of supporting evidence',
-      },
-      'ui:required': formData => get('view:hasEvidence', formData, false),
+      // 'ui:required': formData => get('view:hasEvidence', formData, false),
       'view:hasVaMedicalRecords': { 'ui:title': 'VA medical records' },
       'view:hasPrivateMedicalRecords': {
         'ui:title': 'Private medical records',

--- a/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
@@ -42,7 +42,6 @@ export const uiSchema = {
   },
   'view:evidenceTypeHelp': {
     'ui:options': {
-      showFieldLabel: true,
       expandUnder: 'view:hasEvidence',
     },
     'ui:title': ' ',

--- a/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
@@ -41,6 +41,10 @@ export const uiSchema = {
     },
   },
   'view:evidenceTypeHelp': {
+    'ui:options': {
+      showFieldLabel: true,
+      expandUnder: 'view:hasEvidence',
+    },
     'ui:title': ' ',
     'ui:description': evidenceTypeHelp,
   },

--- a/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
@@ -14,8 +14,12 @@ export const uiSchema = {
     title:
       'Is there any evidence you’d like us to review as part of your claim?',
   }),
-  'view:hasEvidenceFollowUp': {
+  'view:selectableEvidenceTypes': {
+    'ui:title':
+      'What type of evidence do you want us to review as part of your claim?',
+    'ui:webComponentField': VaCheckboxGroupField,
     'ui:options': {
+      showFieldLabel: true,
       expandUnder: 'view:hasEvidence',
     },
     'ui:required': formData => get('view:hasEvidence', formData, false),
@@ -28,24 +32,17 @@ export const uiSchema = {
     'ui:errorMessages': {
       atLeastOne: 'Please select at least one type of supporting evidence',
     },
-    'view:selectableEvidenceTypes': {
-      'ui:title':
-        'What type of evidence do you want us to review as part of your claim?',
-      'ui:webComponentField': VaCheckboxGroupField,
-      'ui:options': { showFieldLabel: true },
-      // 'ui:required': formData => get('view:hasEvidence', formData, false),
-      'view:hasVaMedicalRecords': { 'ui:title': 'VA medical records' },
-      'view:hasPrivateMedicalRecords': {
-        'ui:title': 'Private medical records',
-      },
-      'view:hasOtherEvidence': {
-        'ui:title': 'Supporting (lay) statements or other evidence',
-      },
+    'view:hasVaMedicalRecords': { 'ui:title': 'VA medical records' },
+    'view:hasPrivateMedicalRecords': {
+      'ui:title': 'Private medical records',
     },
-    'view:evidenceTypeHelp': {
-      'ui:title': ' ',
-      'ui:description': evidenceTypeHelp,
+    'view:hasOtherEvidence': {
+      'ui:title': 'Supporting (lay) statements or other evidence',
     },
+  },
+  'view:evidenceTypeHelp': {
+    'ui:title': ' ',
+    'ui:description': evidenceTypeHelp,
   },
 };
 
@@ -54,22 +51,17 @@ export const schema = {
   required: ['view:hasEvidence'],
   properties: {
     'view:hasEvidence': yesNoSchema,
-    'view:hasEvidenceFollowUp': {
+    'view:selectableEvidenceTypes': {
       type: 'object',
       properties: {
-        'view:selectableEvidenceTypes': {
-          type: 'object',
-          properties: {
-            'view:hasVaMedicalRecords': { type: 'boolean' },
-            'view:hasPrivateMedicalRecords': { type: 'boolean' },
-            'view:hasOtherEvidence': { type: 'boolean' },
-          },
-        },
-        'view:evidenceTypeHelp': {
-          type: 'object',
-          properties: {},
-        },
+        'view:hasVaMedicalRecords': { type: 'boolean' },
+        'view:hasPrivateMedicalRecords': { type: 'boolean' },
+        'view:hasOtherEvidence': { type: 'boolean' },
       },
+    },
+    'view:evidenceTypeHelp': {
+      type: 'object',
+      properties: {},
     },
   },
 };

--- a/src/applications/disability-benefits/all-claims/pages/evidenceTypesBDD.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceTypesBDD.js
@@ -50,12 +50,13 @@ export const uiSchema = {
       'ui:webComponentField': VaCheckboxField,
       'ui:title': bddShaOtherEvidence,
     },
-    'view:evidenceTypeHelp': {
-      'ui:title': ' ',
-      'ui:description': evidenceTypeHelp,
-      'ui:options': {
-        forceDivWrapper: true,
-      },
+  },
+  'view:evidenceTypeHelp': {
+    'ui:title': ' ',
+    'ui:description': evidenceTypeHelp,
+    'ui:options': {
+      expandUnder: 'view:hasEvidence',
+      forceDivWrapper: true,
     },
   },
   'view:evidenceSubmitLater': {
@@ -77,11 +78,11 @@ export const schema = {
       properties: {
         'view:hasPrivateMedicalRecords': { type: 'boolean' },
         'view:hasOtherEvidence': { type: 'boolean' },
-        'view:evidenceTypeHelp': {
-          type: 'object',
-          properties: {},
-        },
       },
+    },
+    'view:evidenceTypeHelp': {
+      type: 'object',
+      properties: {},
     },
     'view:evidenceSubmitLater': {
       type: 'object',

--- a/src/applications/disability-benefits/all-claims/pages/evidenceTypesBDD.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceTypesBDD.js
@@ -27,31 +27,28 @@ export const uiSchema = {
       N: 'No, I will submit more information later',
     },
   }),
-  'view:hasEvidenceFollowUp': {
+  'view:selectableEvidenceTypes': {
     'ui:options': {
       expandUnder: 'view:hasEvidence',
     },
     'ui:required': formData => get('view:hasEvidence', formData, false),
-    'view:selectableEvidenceTypes': {
-      'ui:title': evidenceTypeTitle,
-      'ui:validations': [
-        {
-          validator: validateIfHasEvidence,
-          options: { wrappedValidator: validateBooleanGroup },
-        },
-      ],
-      'ui:errorMessages': {
-        atLeastOne: evidenceTypeError,
+    'ui:title': evidenceTypeTitle,
+    'ui:validations': [
+      {
+        validator: validateIfHasEvidence,
+        options: { wrappedValidator: validateBooleanGroup },
       },
-      'ui:required': formData => get('view:hasEvidence', formData, false),
-      'view:hasPrivateMedicalRecords': {
-        'ui:webComponentField': VaCheckboxField,
-        'ui:title': privateMedicalRecords,
-      },
-      'view:hasOtherEvidence': {
-        'ui:webComponentField': VaCheckboxField,
-        'ui:title': bddShaOtherEvidence,
-      },
+    ],
+    'ui:errorMessages': {
+      atLeastOne: evidenceTypeError,
+    },
+    'view:hasPrivateMedicalRecords': {
+      'ui:webComponentField': VaCheckboxField,
+      'ui:title': privateMedicalRecords,
+    },
+    'view:hasOtherEvidence': {
+      'ui:webComponentField': VaCheckboxField,
+      'ui:title': bddShaOtherEvidence,
     },
     'view:evidenceTypeHelp': {
       'ui:title': ' ',
@@ -75,16 +72,11 @@ export const schema = {
   required: ['view:hasEvidence'],
   properties: {
     'view:hasEvidence': yesNoSchema,
-    'view:hasEvidenceFollowUp': {
+    'view:selectableEvidenceTypes': {
       type: 'object',
       properties: {
-        'view:selectableEvidenceTypes': {
-          type: 'object',
-          properties: {
-            'view:hasPrivateMedicalRecords': { type: 'boolean' },
-            'view:hasOtherEvidence': { type: 'boolean' },
-          },
-        },
+        'view:hasPrivateMedicalRecords': { type: 'boolean' },
+        'view:hasOtherEvidence': { type: 'boolean' },
         'view:evidenceTypeHelp': {
           type: 'object',
           properties: {},

--- a/src/applications/disability-benefits/all-claims/pages/evidenceTypesBDD.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceTypesBDD.js
@@ -1,5 +1,5 @@
+import VaCheckboxGroupField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxGroupField';
 import { validateBooleanGroup } from '@department-of-veterans-affairs/platform-forms-system/validation';
-import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import _ from 'platform/utilities/data';
 import {
   yesNoUI,
@@ -8,13 +8,7 @@ import {
 import get from '@department-of-veterans-affairs/platform-forms-system/get';
 import { validateIfHasEvidence } from '../validations';
 
-import {
-  evidenceTypeTitle,
-  privateMedicalRecords,
-  evidenceTypeError,
-  evidenceTypeHelp,
-  bddShaOtherEvidence,
-} from '../content/evidenceTypesBDD';
+import { evidenceTypeHelp } from '../content/evidenceTypesBDD';
 
 import { BddEvidenceSubmitLater } from '../content/bddEvidenceSubmitLater';
 
@@ -28,11 +22,17 @@ export const uiSchema = {
     },
   }),
   'view:selectableEvidenceTypes': {
+    // Displaying atLeastOne validation errors requires using a VaCheckboxGroupField,
+    // which for some reason won't render if export title text from evidenceTypesBDD.jsx.
+    // Thus, titles are written out here.
+    'ui:title':
+      'What type of evidence do you want to submit as part of your claim',
+    'ui:webComponentField': VaCheckboxGroupField,
     'ui:options': {
+      showFieldLabel: true,
       expandUnder: 'view:hasEvidence',
     },
     'ui:required': formData => get('view:hasEvidence', formData, false),
-    'ui:title': evidenceTypeTitle,
     'ui:validations': [
       {
         validator: validateIfHasEvidence,
@@ -40,15 +40,14 @@ export const uiSchema = {
       },
     ],
     'ui:errorMessages': {
-      atLeastOne: evidenceTypeError,
+      atLeastOne: 'Please select at least one type of supporting evidence',
     },
     'view:hasPrivateMedicalRecords': {
-      'ui:webComponentField': VaCheckboxField,
-      'ui:title': privateMedicalRecords,
+      'ui:title': 'Private medical records',
     },
     'view:hasOtherEvidence': {
-      'ui:webComponentField': VaCheckboxField,
-      'ui:title': bddShaOtherEvidence,
+      'ui:title':
+        'Required Separation Health Assessment - Part A Self-Assessment or other documents like your DD Form 214, supporting (lay) statements, or other evidence',
     },
   },
   'view:evidenceTypeHelp': {
@@ -56,7 +55,6 @@ export const uiSchema = {
     'ui:description': evidenceTypeHelp,
     'ui:options': {
       expandUnder: 'view:hasEvidence',
-      forceDivWrapper: true,
     },
   },
   'view:evidenceSubmitLater': {

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-bdd-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-bdd-test.json
@@ -84,13 +84,11 @@
     ],
     "view:vaMedicalRecordsIntro": {},
     "view:hasEvidence": true,
-    "view:hasEvidenceFollowUp": {
-      "view:selectableEvidenceTypes": {
-        "view:hasPrivateMedicalRecords": true,
-        "view:hasOtherEvidence": true
-      },
-      "view:evidenceTypeHelp": {}
+    "view:selectableEvidenceTypes": {
+      "view:hasPrivateMedicalRecords": true,
+      "view:hasOtherEvidence": true
     },
+    "view:evidenceTypeHelp": {},
     "view:uploadServiceTreatmentRecordsQualifier": {
       "view:hasServiceTreatmentRecordsToUpload": true
     },

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-test.json
@@ -122,14 +122,12 @@
       }
     ],
     "view:hasEvidence": true,
-    "view:hasEvidenceFollowUp": {
-      "view:selectableEvidenceTypes": {
-        "view:hasVaMedicalRecords": true,
-        "view:hasPrivateMedicalRecords": true,
-        "view:hasOtherEvidence": true
-      },
-      "view:evidenceTypeHelp": {}
+    "view:selectableEvidenceTypes": {
+      "view:hasVaMedicalRecords": true,
+      "view:hasPrivateMedicalRecords": true,
+      "view:hasOtherEvidence": true
     },
+    "view:evidenceTypeHelp": {},
     "view:unemployable": false,
     "view:aidAndAttendance": true,
     "view:modifyingHome": true,

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-toxic-exposure-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-toxic-exposure-test.json
@@ -121,14 +121,12 @@
       }
     ],
     "view:hasEvidence": true,
-    "view:hasEvidenceFollowUp": {
-      "view:selectableEvidenceTypes": {
-        "view:hasVaMedicalRecords": true,
-        "view:hasPrivateMedicalRecords": true,
-        "view:hasOtherEvidence": true
-      },
-      "view:evidenceTypeHelp": {}
+    "view:selectableEvidenceTypes": {
+      "view:hasVaMedicalRecords": true,
+      "view:hasPrivateMedicalRecords": true,
+      "view:hasOtherEvidence": true
     },
+    "view:evidenceTypeHelp": {},
     "view:unemployable": false,
     "view:aidAndAttendance": true,
     "view:modifyingHome": true,

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/secondary-new-test.json
@@ -100,14 +100,12 @@
       }
     ],
     "view:hasEvidence": true,
-    "view:hasEvidenceFollowUp": {
-      "view:selectableEvidenceTypes": {
-        "view:hasVaMedicalRecords": true,
-        "view:hasPrivateMedicalRecords": true,
-        "view:hasOtherEvidence": true
-      },
-      "view:evidenceTypeHelp": {}
+    "view:selectableEvidenceTypes": {
+      "view:hasVaMedicalRecords": true,
+      "view:hasPrivateMedicalRecords": true,
+      "view:hasOtherEvidence": true
     },
+    "view:evidenceTypeHelp": {},
     "view:unemployable": false,
     "view:aidAndAttendance": true,
     "view:modifyingHome": true,

--- a/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypesBDD.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypesBDD.unit.spec.jsx
@@ -84,10 +84,8 @@ describe('evidenceTypes', () => {
         uiSchema={uiSchema}
         data={{
           'view:hasEvidence': true,
-          'view:hasEvidenceFollowUp': {
-            'view:selectableEvidenceTypes': {
-              'view:hasPrivateMedicalRecords': true,
-            },
+          'view:selectableEvidenceTypes': {
+            'view:hasPrivateMedicalRecords': true,
           },
         }}
         formData={{}}

--- a/src/applications/disability-benefits/all-claims/tests/pages/summaryOfEvidence.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/summaryOfEvidence.unit.spec.jsx
@@ -118,9 +118,7 @@ describe('Summary of Evidence', () => {
           // to select at least one type if hasEvidence is true, but it lets us
           // test that unselected evidence types aren't displayed
           'view:hasEvidence': true,
-          'view:hasEvidenceFollowUp': {
-            'view:selectableEvidenceTypes': {},
-          },
+          'view:selectableEvidenceTypes': {},
           vaTreatmentFacilities,
           privateMedicalRecordAttachments,
           additionalDocuments,
@@ -141,10 +139,8 @@ describe('Summary of Evidence', () => {
         uiSchema={uiSchema}
         data={{
           'view:hasEvidence': true,
-          'view:hasEvidenceFollowUp': {
-            'view:selectableEvidenceTypes': {
-              'view:hasVaMedicalRecords': true,
-            },
+          'view:selectableEvidenceTypes': {
+            'view:hasVaMedicalRecords': true,
           },
           vaTreatmentFacilities,
         }}
@@ -163,10 +159,8 @@ describe('Summary of Evidence', () => {
         uiSchema={uiSchema}
         data={{
           'view:hasEvidence': true,
-          'view:hasEvidenceFollowUp': {
-            'view:selectableEvidenceTypes': {
-              'view:hasPrivateMedicalRecords': true,
-            },
+          'view:selectableEvidenceTypes': {
+            'view:hasPrivateMedicalRecords': true,
           },
           'view:uploadPrivateRecordsQualifier': {
             'view:hasPrivateRecordsToUpload': false,
@@ -190,10 +184,8 @@ describe('Summary of Evidence', () => {
         uiSchema={uiSchema}
         data={{
           'view:hasEvidence': true,
-          'view:hasEvidenceFollowUp': {
-            'view:selectableEvidenceTypes': {
-              'view:hasPrivateMedicalRecords': true,
-            },
+          'view:selectableEvidenceTypes': {
+            'view:hasPrivateMedicalRecords': true,
           },
           'view:uploadPrivateRecordsQualifier': {
             'view:hasPrivateRecordsToUpload': true,
@@ -228,10 +220,8 @@ describe('Summary of Evidence', () => {
         uiSchema={uiSchema}
         data={{
           'view:hasEvidence': true,
-          'view:hasEvidenceFollowUp': {
-            'view:selectableEvidenceTypes': {
-              'view:hasPrivateMedicalRecords': true,
-            },
+          'view:selectableEvidenceTypes': {
+            'view:hasPrivateMedicalRecords': true,
           },
           'view:uploadPrivateRecordsQualifier': {
             'view:hasPrivateRecordsToUpload': true,
@@ -253,10 +243,8 @@ describe('Summary of Evidence', () => {
         uiSchema={uiSchema}
         data={{
           'view:hasEvidence': true,
-          'view:hasEvidenceFollowUp': {
-            'view:selectableEvidenceTypes': {
-              'view:hasPrivateMedicalRecords': true,
-            },
+          'view:selectableEvidenceTypes': {
+            'view:hasPrivateMedicalRecords': true,
           },
           'view:uploadPrivateRecordsQualifier': {
             'view:hasPrivateRecordsToUpload': false,
@@ -278,10 +266,8 @@ describe('Summary of Evidence', () => {
         uiSchema={uiSchema}
         data={{
           'view:hasEvidence': true,
-          'view:hasEvidenceFollowUp': {
-            'view:selectableEvidenceTypes': {
-              'view:hasOtherEvidence': true,
-            },
+          'view:selectableEvidenceTypes': {
+            'view:hasOtherEvidence': true,
           },
           additionalDocuments,
         }}

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
@@ -49,10 +49,8 @@ describe('VA Medical Records', () => {
         data={{
           ...claimType,
           ratedDisabilities,
-          'view:hasEvidenceFollowUp': {
-            'view:selectableEvidenceTypes': {
-              'view:hasVaMedicalRecords': true,
-            },
+          'view:selectableEvidenceTypes': {
+            'view:hasVaMedicalRecords': true,
           },
         }}
       />,
@@ -77,10 +75,8 @@ describe('VA Medical Records', () => {
           },
           newDisabilities,
           ratedDisabilities,
-          'view:hasEvidenceFollowUp': {
-            'view:selectableEvidenceTypes': {
-              'view:hasVaMedicalRecords': true,
-            },
+          'view:selectableEvidenceTypes': {
+            'view:hasVaMedicalRecords': true,
           },
         }}
       />,
@@ -104,10 +100,8 @@ describe('VA Medical Records', () => {
         data={{
           ...claimType,
           ratedDisabilities,
-          'view:hasEvidenceFollowUp': {
-            'view:selectableEvidenceTypes': {
-              'view:hasVaMedicalRecords': false,
-            },
+          'view:selectableEvidenceTypes': {
+            'view:hasVaMedicalRecords': false,
           },
           vaTreatmentFacilities: [],
         }}
@@ -132,10 +126,8 @@ describe('VA Medical Records', () => {
         data={{
           ...claimType,
           ratedDisabilities,
-          'view:hasEvidenceFollowUp': {
-            'view:selectableEvidenceTypes': {
-              'view:hasVaMedicalRecords': true,
-            },
+          'view:selectableEvidenceTypes': {
+            'view:hasVaMedicalRecords': true,
           },
           vaTreatmentFacilities: [],
         }}

--- a/src/applications/disability-benefits/all-claims/tests/property-names.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/property-names.unit.spec.js
@@ -56,7 +56,6 @@ describe('Root property names', () => {
     const duplicatedProperties = {};
     const duplicatedPropertiesToIgnore = [
       'view:hasEvidence',
-      'view:hasEvidenceFollowUp',
       'view:newDisabilityErrors',
     ];
 

--- a/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils/utils.unit.spec.jsx
@@ -184,10 +184,8 @@ describe('526 helpers', () => {
   describe('hasotherEvidence', () => {
     it('should return false if additional evidence type is not selected', () => {
       const formData = {
-        'view:hasEvidenceFollowUp': {
-          'view:selectableEvidenceTypes': {
-            // 'view:hasOtherEvidence': no data
-          },
+        'view:selectableEvidenceTypes': {
+          // 'view:hasOtherEvidence': no data
         },
       };
       expect(hasOtherEvidence(formData)).to.equal(false);
@@ -195,10 +193,8 @@ describe('526 helpers', () => {
 
     it('should return true if additional evidence type is selected', () => {
       const formData = {
-        'view:hasEvidenceFollowUp': {
-          'view:selectableEvidenceTypes': {
-            'view:hasOtherEvidence': true,
-          },
+        'view:selectableEvidenceTypes': {
+          'view:hasOtherEvidence': true,
         },
       };
       expect(hasOtherEvidence(formData)).to.equal(true);


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
Fixed an issue where a validation error would be shown when attempting to check one of the evidence types on the supporting evidence screen.

- _(If bug, how to reproduce)_
  - Navigate to /disability/file-disability-claim-form-21-526ez/start
  - Sign in with any user
  - Fill in info and click 'continue' through the form screens until you reach Step 3 of 5, Supporting Evidence (/supporting-evidence/orientation)
  - Click 'continue' until you see the question "Is there any evidence you'd like us to review as part of your claim?"
  - Select "Yes"
  - Confirm that a second question asking "What type of evidence do you want us to review as part of your claim?" expands under the original question
  - Attempt to check one of the checkboxes
  - Confirm that a validation error is thrown and the box clicked is not checked
  - This bug can also be reproduced in the BDD flow


- _(What is the solution, why is this the solution)_
  - There is a parent component blocking the checkboxes and consuming the click. This parent component is unnecessary and so the checkbox component has been lifted out. This nesting was done previous to allow a "help" section to expand with the checkbox components, however this behavior can be implemented by also giving the "help" section an expandUnder event

- _(Which team do you work for, does your team own the maintenance of this component?)_
  DBEx, yes
 
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_
N/A

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#90449


## Testing done

Click testing, keyboard only run, unit test update

## Screenshots

<img width="600" alt="Screenshot 2024-09-26 at 5 27 37 PM" src="https://github.com/user-attachments/assets/2f84818b-8279-4709-a2d3-540133938ff7">
<img width="627" alt="Screenshot 2024-09-26 at 5 27 47 PM" src="https://github.com/user-attachments/assets/37cab38d-8b4b-4aeb-ad70-8087859334d7">
<img width="662" alt="Screenshot 2024-09-26 at 5 27 54 PM" src="https://github.com/user-attachments/assets/6a33820f-fb13-48ee-bcb8-a1e75584e201">
<img width="645" alt="Screenshot 2024-09-26 at 5 28 01 PM" src="https://github.com/user-attachments/assets/88740b98-5f44-40dd-b163-0bbc908d67a2">
<img width="701" alt="Screenshot 2024-09-26 at 5 28 07 PM" src="https://github.com/user-attachments/assets/1811b503-e5f5-4654-a13e-494b30e90638">


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
