### PR TITLE
Revert "Migrate breakpoint names for font-size utility classes - Platform (#32102)"

### DIFF
--- a/src/applications/vaos/components/calendar/CalendarNavigation.jsx
+++ b/src/applications/vaos/components/calendar/CalendarNavigation.jsx
@@ -20,7 +20,6 @@ const CalendarNavigation = ({
           onClick={prevOnClick}
           disabled={prevDisabled}
           type="button"
-          aria-label="Previous"
         >
           <span
             className={classNames(
@@ -55,7 +54,6 @@ const CalendarNavigation = ({
           onClick={nextOnClick}
           disabled={nextDisabled}
           type="button"
-          aria-label="Next"
         >
           <span className="vads-u-display--none small-screen:vads-u-display--inline vads-u-padding-right--1">
             Next

--- a/src/platform/forms-system/src/js/web-component-patterns/titlePattern.js
+++ b/src/platform/forms-system/src/js/web-component-patterns/titlePattern.js
@@ -11,7 +11,7 @@ export const Title = ({
 }) => {
   const CustomHeader = `h${headerLevel}`;
   const style = headerStyleLevel
-    ? ` mobile-lg:vads-u-font-size--h${headerStyleLevel} vads-u-font-size--h${Number(
+    ? ` small-screen:vads-u-font-size--h${headerStyleLevel} vads-u-font-size--h${Number(
         headerStyleLevel,
       ) + 1}`
     : '';

--- a/src/platform/site-wide/sass/style.scss
+++ b/src/platform/site-wide/sass/style.scss
@@ -4,7 +4,7 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "~@department-of-veterans-affairs/formation/sass/core";
 
-@import "~@department-of-veterans-affairs/css-library/dist/stylesheets/utilities";
+@import "~@department-of-veterans-affairs/css-library/dist/stylesheets/utilities.css";
 
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/uswds-typography";
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/uswds-typography";


### PR DESCRIPTION
This reverts commit 5440cdead534bc69175538ab649789717c1a64cb.

We noticed that this change affected out UI layout:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/8376eff7-55a0-4bd6-adba-220450c4195b">

With this change reverted, we're back to the expected layout:
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/4702c4b1-9605-4186-8f4d-c6215e1373e0">



