### PR TITLE
Pension 93221 edit item description

### DIFF
--- a/src/applications/pensions/config/chapters/02-military-history/otherNamesPages.js
+++ b/src/applications/pensions/config/chapters/02-military-history/otherNamesPages.js
@@ -68,6 +68,7 @@ const otherNamePage = {
     ...arrayBuilderItemFirstPageTitleUI({
       title: 'Previous name',
       nounSingular: options.nounSingular,
+      hasMultipleItemPages: false,
     }),
     previousFullName: fullNameUI(title => `Previous ${title}`),
   },

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/currentEmploymentHistoryPages.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/currentEmploymentHistoryPages.js
@@ -56,6 +56,7 @@ const currentEmploymentHistoryPage = {
     ...arrayBuilderItemFirstPageTitleUI({
       title: 'Current employment',
       nounSingular: options.nounSingular,
+      hasMultipleItemPages: false,
     }),
     jobType: textUI('What kind of work do you currently do?'),
     jobHoursWeek: numberUI({

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/federalMedicalCentersPages.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/federalMedicalCentersPages.js
@@ -52,6 +52,7 @@ const federalMedicalCenterPage = {
     ...arrayBuilderItemFirstPageTitleUI({
       title: 'Federal medical center',
       nounSingular: options.nounSingular,
+      hasMultipleItemPages: false,
     }),
     medicalCenter: textUI('Federal medical center'),
   },

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/previousEmploymentHistoryPages.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/previousEmploymentHistoryPages.js
@@ -79,6 +79,7 @@ const previousEmploymentHistoryPage = {
     ...arrayBuilderItemFirstPageTitleUI({
       title: 'Previous employment',
       nounSingular: options.nounSingular,
+      hasMultipleItemPages: false,
     }),
     jobDate: currentOrPastDateUI('When did you last work?'),
     jobType: textUI('What kind of work did you do?'),

--- a/src/applications/pensions/config/chapters/03-health-and-employment-information/vaMedicalCentersPages.js
+++ b/src/applications/pensions/config/chapters/03-health-and-employment-information/vaMedicalCentersPages.js
@@ -51,6 +51,7 @@ const vaMedicalCenterPage = {
       title: 'VA medical center',
       nounSingular: options.nounSingular,
       lowerCase: false,
+      hasMultipleItemPages: false,
     }),
     medicalCenter: textUI('VA medical center'),
   },

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderFirstItemPage.unit.spec.js
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderFirstItemPage.unit.spec.js
@@ -82,6 +82,7 @@ describe('ArrayBuilderFirstItemPage', () => {
     arrayData = [],
     title = 'Name and address of employer',
     lowerCase = true,
+    hasMultipleItemPages = true,
     required = () => false,
   }) {
     const setFormData = sinon.spy();
@@ -104,6 +105,7 @@ describe('ArrayBuilderFirstItemPage', () => {
           title,
           nounSingular: 'employer',
           lowerCase,
+          hasMultipleItemPages,
         }),
         name: {
           'ui:title': 'Name of employer',
@@ -130,7 +132,7 @@ describe('ArrayBuilderFirstItemPage', () => {
       required,
     });
 
-    const { container, getByText } = render(
+    const { container, queryByText } = render(
       <Provider store={mockStore}>
         <CustomPage
           schema={itemPage.schema}
@@ -149,37 +151,37 @@ describe('ArrayBuilderFirstItemPage', () => {
       </Provider>,
     );
 
-    return { setFormData, goToPath, getText, container, getByText };
+    return { setFormData, goToPath, getText, container, queryByText };
   }
 
   it('should display correctly with add query parameter', () => {
-    const { getText, container, getByText } = setupArrayBuilderItemPage({
+    const { getText, container, queryByText } = setupArrayBuilderItemPage({
       title: 'Name and address of employer',
       index: 0,
       urlParams: '?add=true',
       arrayData: [{ name: 'Test' }],
     });
 
-    expect(getByText('Name and address of employer')).to.exist;
+    expect(queryByText('Name and address of employer')).to.exist;
     expect(container.querySelector('va-button[text="cancelAddButtonText"]')).to
       .exist;
   });
 
   it('should display correctly with edit query parameter', () => {
-    const { getText, container, getByText } = setupArrayBuilderItemPage({
+    const { getText, container, queryByText } = setupArrayBuilderItemPage({
       title: 'Name and address of employer',
       index: 0,
       urlParams: '?edit=true',
       arrayData: [{ name: 'Test' }],
     });
 
-    expect(getByText('Edit name and address of employer')).to.exist;
+    expect(queryByText('Edit name and address of employer')).to.exist;
     expect(container.querySelector('va-button[text="cancelEditButtonText"]')).to
       .exist;
   });
 
   it('should display correctly with edit query parameter is not lowercased', () => {
-    const { getText, container, getByText } = setupArrayBuilderItemPage({
+    const { getText, container, queryByText } = setupArrayBuilderItemPage({
       title: 'John Doe employer information',
       lowerCase: false,
       index: 0,
@@ -187,13 +189,49 @@ describe('ArrayBuilderFirstItemPage', () => {
       arrayData: [{ name: 'Test' }],
     });
 
-    expect(getByText('Edit John Doe employer information')).to.exist;
+    expect(queryByText('Edit John Doe employer information')).to.exist;
+    expect(container.querySelector('va-button[text="cancelEditButtonText"]')).to
+      .exist;
+  });
+
+  it('should display correctly when hasMultipleItemPages is true', () => {
+    const { container, queryByText } = setupArrayBuilderItemPage({
+      title: 'Multiple page employer',
+      index: 0,
+      urlParams: '?edit=true',
+      arrayData: [{ name: 'Employer One' }],
+      hasMultipleItemPages: true,
+    });
+
+    expect(
+      queryByText(
+        'We’ll take you through each of the sections of this employer for you to review and edit',
+      ),
+    ).to.exist;
+    expect(container.querySelector('va-button[text="cancelEditButtonText"]')).to
+      .exist;
+  });
+
+  it('should display correctly when hasMultipleItemPages is false', () => {
+    const { container, queryByText } = setupArrayBuilderItemPage({
+      title: 'Single page employer',
+      index: 0,
+      urlParams: '?edit=true',
+      arrayData: [{ name: 'Employer One' }],
+      hasMultipleItemPages: false,
+    });
+
+    expect(
+      queryByText(
+        'We’ll take you through each of the sections of this employer for you to review and edit',
+      ),
+    ).to.not.exist;
     expect(container.querySelector('va-button[text="cancelEditButtonText"]')).to
       .exist;
   });
 
   it('should navigate away if not edit or add', () => {
-    const { goToPath, container, getByText } = setupArrayBuilderItemPage({
+    const { goToPath, container, queryByText } = setupArrayBuilderItemPage({
       title: 'Name and address of employer',
       index: 0,
       urlParams: '',

--- a/src/platform/forms-system/src/js/web-component-patterns/arrayBuilderPatterns.jsx
+++ b/src/platform/forms-system/src/js/web-component-patterns/arrayBuilderPatterns.jsx
@@ -9,7 +9,11 @@ import {
 /**
  * Looks for URL param 'add' and 'removedAllWarn' and returns a warning alert if both are present
  */
-export function withAlertOrDescription({ description, nounSingular }) {
+export function withAlertOrDescription({
+  description,
+  nounSingular,
+  hasMultipleItemPages,
+}) {
   return () => {
     const search = getArrayUrlSearchParams();
     const isAdd = search.get('add');
@@ -28,9 +32,10 @@ export function withAlertOrDescription({ description, nounSingular }) {
         </>
       );
     }
-    return isEdit
-      ? `We’ll take you through each of the sections of this ${nounSingular} for you to review and edit`
-      : description || '';
+    if (isEdit && hasMultipleItemPages) {
+      return `We’ll take you through each of the sections of this ${nounSingular} for you to review and edit`;
+    }
+    return description || '';
   };
 }
 
@@ -87,10 +92,11 @@ export const arrayBuilderItemFirstPageTitleUI = ({
   description,
   nounSingular,
   lowerCase = true,
+  hasMultipleItemPages = true,
 }) => {
   return titleUI(
     withEditTitle(title, lowerCase),
-    withAlertOrDescription({ description, nounSingular }),
+    withAlertOrDescription({ description, nounSingular, hasMultipleItemPages }),
   );
 };
 


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary of Changes
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93221

#### Enhanced withAlertOrDescription Functionality:
- Added an optional hasMultipleItemPages parameter to the withAlertOrDescription function.
- Modified the function to display the message “We’ll take you through each of the sections of this {nounSingular} for you to review and edit” only when there are multiple item pages (hasMultipleItemPages is true) and the URL param edit is present.

#### Function Update Details:
- Previous Behavior: The function displayed the edit-specific message regardless of the number of item pages.
- New Behavior: The edit-specific message is now conditionally shown only if hasMultipleItemPages is true, ensuring it only appears when multiple item pages are included.

#### Code Changes:
- Updated the signature of withAlertOrDescription:
- Adjusted the logic to check both isEdit and hasMultipleItemPages before showing the specific message.

#### Impact
This change enhances the user experience by showing the guided message only when relevant, i.e., when navigating through multiple item pages in the form

## Related issue(s)
n/a

## Screenshots
| Before | After |
| ------ | ------ |
|![localhost_3001_pension_apply-for-veteran-pension-form-21p-527ez_form-saved (40)](https://github.com/user-attachments/assets/5cf8663e-884d-4de8-9baa-603a9af3a94b)|![localhost_3001_pension_apply-for-veteran-pension-form-21p-527ez_form-saved (39)](https://github.com/user-attachments/assets/f9ce8e5b-2f39-446e-adba-a29b43486f1d)



## What areas of the site does it impact?
Pension Benefits

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
