### PR TITLE
Create custom hook for yes/no radio input events in Health Care Application

### DIFF
--- a/src/applications/hca/containers/App.jsx
+++ b/src/applications/hca/containers/App.jsx
@@ -2,12 +2,12 @@ import React, { useEffect } from 'react';
 import { connect, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
-import recordEvent from 'platform/monitoring/record-event';
 import { fetchEnrollmentStatus } from '../utils/actions/enrollment-status';
 import { fetchTotalDisabilityRating } from '../utils/actions/disability-rating';
 import { selectFeatureToggles } from '../utils/selectors/feature-toggles';
 import { selectAuthStatus } from '../utils/selectors/auth-status';
 import { useBrowserMonitoring } from '../hooks/useBrowserMonitoring';
+import { useYesNoInputEvents } from '../hooks/useYesNoInputEvents';
 import { useDefaultFormData } from '../hooks/useDefaultFormData';
 import content from '../locales/en/content.json';
 import formConfig from '../config/form';
@@ -40,27 +40,7 @@ const App = props => {
   useDefaultFormData();
 
   // Attach analytics events to all yes/no radio inputs
-  useEffect(
-    () => {
-      if (!isAppLoading) {
-        const radios = document.querySelectorAll(
-          'input[id$=Yes], input[id$=No]',
-        );
-        for (const radio of radios) {
-          radio.onclick = e => {
-            const label = e.target.nextElementSibling.innerText;
-            recordEvent({
-              event: 'hca-yesno-option-click',
-              'hca-radio-label': label,
-              'hca-radio-clicked': e.target,
-              'hca-radio-value-selected': e.target.value,
-            });
-          };
-        }
-      }
-    },
-    [isAppLoading, location],
-  );
+  useYesNoInputEvents(isAppLoading, location);
 
   // Add Datadog UX monitoring to the application
   useBrowserMonitoring();

--- a/src/applications/hca/hooks/useYesNoInputEvents.jsx
+++ b/src/applications/hca/hooks/useYesNoInputEvents.jsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import recordEvent from 'platform/monitoring/record-event';
+
+export const useYesNoInputEvents = (loading, location) => {
+  const handleClick = ({ target: element }) => {
+    const label = element.nextElementSibling.innerText;
+    recordEvent({
+      event: 'hca-yesno-option-click',
+      'hca-radio-label': label,
+      'hca-radio-clicked': element,
+      'hca-radio-value-selected': element.value,
+    });
+  };
+
+  useEffect(
+    () => {
+      if (loading) return false;
+
+      const radios = document.querySelectorAll('input[id$=Yes], input[id$=No]');
+      const modifyEventListeners = action => {
+        for (const radio of radios) {
+          radio[action]('click', handleClick);
+        }
+      };
+
+      modifyEventListeners('addEventListener');
+      return () => modifyEventListeners('removeEventListener');
+    },
+    [loading, location],
+  );
+};

--- a/src/applications/hca/tests/unit/hooks/useYesNoInputEvents.unit.spec.js
+++ b/src/applications/hca/tests/unit/hooks/useYesNoInputEvents.unit.spec.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import YesNoWidget from 'platform/forms-system/src/js/widgets/YesNoWidget';
+import * as recordEventModule from 'platform/monitoring/record-event';
+import { useYesNoInputEvents } from '../../../hooks/useYesNoInputEvents';
+
+// create wrapper component for our hook
+// eslint-disable-next-line react/prop-types
+const TestComponent = ({ loading }) => {
+  useYesNoInputEvents(loading, {});
+  return !loading ? (
+    <YesNoWidget id="root_response" onChange={() => {}} value={null} />
+  ) : null;
+};
+
+describe('hca `useYesNoInputEvents` hook', () => {
+  const subject = ({ loading = false }) => {
+    const { container } = render(<TestComponent loading={loading} />);
+    const selectors = () => ({
+      input: container.querySelector('input[id$=Yes]'),
+    });
+    return { selectors };
+  };
+
+  it('should not render any inputs that get event attachment when the app is loading', () => {
+    const { selectors } = subject({ loading: true });
+    expect(selectors().input).to.not.exist;
+  });
+
+  it('should fire the `recordEvent` method to log the interaction to analytics', async () => {
+    const recordEventStub = sinon.stub(recordEventModule, 'default');
+    const { selectors } = subject({});
+    await waitFor(() => {
+      userEvent.click(selectors().input);
+      expect(recordEventStub.called).to.be.true;
+      recordEventStub.restore();
+    });
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

The base `App.jsx` file in the health care application has housed a useEffect method to attach click events to all the Yes/No queestions in the application. The method is large enough to be housed in its own custom hook. This PR breaks that effect into a custom hook to import with the goal of cleaning up the base App file. The custom hook also includes a clean-up method to remove any listeners on dismount. This work is a prerequisite to the linked issue.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#87452

## Testing done

- To validate, start a new health care application
- Navigate to a question that is a simple Yes/No question
- Click either response with a network tab open and notice the GA event call that is made

## Acceptance criteria

- Click events are successfully added and removed/cleaned up using the created hook.

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution