### PR TITLE
MHV-61850: Focus & Offline handling

### DIFF
--- a/src/applications/mhv-medications/components/PrescriptionDetails/NonVaPrescription.jsx
+++ b/src/applications/mhv-medications/components/PrescriptionDetails/NonVaPrescription.jsx
@@ -16,7 +16,7 @@ const NonVaPrescription = prescription => {
           <h3 className="vads-u-font-size--base vads-u-font-family--sans">
             Status
           </h3>
-          <div data-testid="rx-status">{validateField(status)}</div>
+          <p data-testid="rx-status">{validateField(status)}</p>
           <div className="no-print">
             <va-additional-info
               trigger="What does this status mean?"

--- a/src/applications/mhv-medications/components/shared/PrintDownload.jsx
+++ b/src/applications/mhv-medications/components/shared/PrintDownload.jsx
@@ -9,7 +9,8 @@ const PrintDownload = props => {
 
   const [menuOpen, setMenuOpen] = useState(false);
   const [printIndex, setPrintIndex] = useState(0);
-  const menu = useRef(null);
+  const containerEl = useRef(null);
+  const toggleButton = useRef(null);
   let toggleMenuButtonClasses =
     'toggle-menu-button vads-u-justify-content--space-between';
   let menuOptionsClasses = 'menu-options';
@@ -20,8 +21,14 @@ const PrintDownload = props => {
   }
 
   const handleDownload = async format => {
+    setMenuOpen(!menuOpen);
+    toggleButton.current.focus();
+    if (!navigator.onLine) {
+      setIsError(true);
+      return;
+    }
+
     try {
-      setMenuOpen(!menuOpen);
       setIsError(false);
       if (format === DOWNLOAD_FORMAT.TXT && onText) {
         onText();
@@ -43,7 +50,11 @@ const PrintDownload = props => {
   };
 
   const closeMenu = e => {
-    if (menu.current && menuOpen && !menu.current.contains(e.target)) {
+    if (
+      containerEl.current &&
+      menuOpen &&
+      !containerEl.current.contains(e.target)
+    ) {
       setMenuOpen(false);
     }
   };
@@ -77,23 +88,27 @@ const PrintDownload = props => {
       {isLoading && (
         <va-loading-indicator
           message="Loading..."
-          setFocus
           data-testid="print-download-loading-indicator"
         />
       )}
-      {isSuccess && (
-        <div
-          className="vads-u-margin-bottom--3"
-          data-testid="download-success-banner"
-        >
-          <va-alert role="alert" status="success" background-only uswds>
-            <h2 slot="headline">Download started</h2>
-            <p className="vads-u-margin--0">
-              Check your device’s downloads location for your file.
-            </p>
-          </va-alert>
-        </div>
-      )}
+      {isSuccess &&
+        !isError && (
+          <div
+            className="vads-u-margin-bottom--3"
+            data-testid="download-success-banner"
+          >
+            <va-alert role="alert" status="success" background-only uswds>
+              <h2 slot="headline">Download started</h2>
+              <p className="vads-u-margin--0">
+                Check your device’s downloads location for your file.
+              </p>
+            </va-alert>
+          </div>
+        )}
+      {/* hack to generate va-alert and va-telephone web components in case there is no network at the time of download */}
+      <va-alert visible="false" uswds>
+        <va-telephone />
+      </va-alert>
       {isError && (
         <div className="vads-u-margin-bottom--3">
           <va-alert role="alert" status="error" uswds>
@@ -119,7 +134,7 @@ const PrintDownload = props => {
         className="print-download vads-u-margin-y--2 no-print"
         role="none"
         onKeyDown={handleUserKeyPress}
-        ref={menu}
+        ref={containerEl}
         onFocus={handleFocus}
       >
         <button
@@ -131,6 +146,7 @@ const PrintDownload = props => {
           onClick={() => setMenuOpen(!menuOpen)}
           data-testid="print-records-button"
           aria-expanded={menuOpen}
+          ref={toggleButton}
         >
           <span>Print or download</span>
           <va-icon

--- a/src/applications/mhv-medications/containers/Prescriptions.jsx
+++ b/src/applications/mhv-medications/containers/Prescriptions.jsx
@@ -620,7 +620,6 @@ const Prescriptions = () => {
                     )}
                     {showFilterContent && (
                       <>
-                        <BeforeYouDownloadDropdown page={pageType.LIST} />
                         <PrintDownload
                           onDownload={handleFullListDownload}
                           isSuccess={
@@ -634,6 +633,7 @@ const Prescriptions = () => {
                           }
                           list
                         />
+                        <BeforeYouDownloadDropdown page={pageType.LIST} />
                       </>
                     )}
                   </div>

--- a/src/applications/mhv-medications/tests/components/shared/PrintDownload.unit.spec.jsx
+++ b/src/applications/mhv-medications/tests/components/shared/PrintDownload.unit.spec.jsx
@@ -95,6 +95,9 @@ describe('Medicaitons Print/Download button component', () => {
   });
 
   it('should start downloading PDF on PDF button click', () => {
+    global.navigator = {
+      onLine: true,
+    };
     const screen = setup(handleFullListDownload, false, true);
     const downloadButton = screen.getByText('Download a PDF of this list');
     fireEvent.click(downloadButton);
@@ -104,6 +107,9 @@ describe('Medicaitons Print/Download button component', () => {
   });
 
   it('should start downloading TXT on TXT button click', () => {
+    global.navigator = {
+      onLine: true,
+    };
     const screen = setup(handleFullListDownload, false, true);
     const downloadButton = screen.getByText(
       'Download a text file (.txt) of this list',
@@ -122,6 +128,9 @@ describe('Medicaitons Print/Download button component', () => {
   });
 
   it('should start txt download using custom fn on txt button click', () => {
+    global.navigator = {
+      onLine: true,
+    };
     const screen = setup(
       undefined,
       false,

--- a/src/applications/mhv-medications/tests/e2e/medications-download-pdf-details-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-pdf-details-page.cypress.spec.js
@@ -21,6 +21,7 @@ describe('Medications Details Page Download', () => {
     detailsPage.clickDownloadMedicationDetailsAsPdfOnDetailsPage();
     detailsPage.verifyLoadingSpinnerForDownloadOnDetailsPage();
     listPage.verifyDownloadCompleteSuccessMessageBanner();
+    detailsPage.verifyFocusOnPrintOrDownloadDropdownButtonOnDetailsPage();
     site.verifyDownloadedPdfFile(
       'VA-medications-list-Safari-Mhvtp',
       moment(),

--- a/src/applications/mhv-medications/tests/e2e/medications-download-pdf-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-pdf-list-page.cypress.spec.js
@@ -18,6 +18,7 @@ describe('Medications Download PDF on List Page', () => {
     listPage.clickDownloadListAsPDFButtonOnListPage();
     listPage.verifyLoadingSpinnerForDownloadOnListPage();
     listPage.verifyDownloadCompleteSuccessMessageBanner();
+    listPage.verifyFocusOnPrintDownloadDropDownButton();
     site.verifyDownloadedPdfFile(
       'VA-medications-list-Safari-Mhvtp',
       moment(),

--- a/src/applications/mhv-medications/tests/e2e/medications-download-txt-details-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-txt-details-page.cypress.spec.js
@@ -18,6 +18,7 @@ describe('Medications Details Page Download', () => {
     detailsPage.verifyFocusOnPrintOrDownloadDropdownButtonOnDetailsPage();
     detailsPage.clickDownloadMedicationsDetailsAsTxtOnDetailsPage();
     listPage.verifyDownloadCompleteSuccessMessageBanner();
+    detailsPage.verifyFocusOnPrintOrDownloadDropdownButtonOnDetailsPage();
     listPage.verifyDownloadTextFileHeadless('Safari', 'Mhvtp', 'Mhvtp, Safari');
     cy.injectAxe();
     cy.axeCheck('main');

--- a/src/applications/mhv-medications/tests/e2e/medications-download-txt-list-page.cypress.spec.js
+++ b/src/applications/mhv-medications/tests/e2e/medications-download-txt-list-page.cypress.spec.js
@@ -17,6 +17,7 @@ describe('Medications Download Txt on List Page', () => {
     listPage.clickDownloadListAsTxtButtonOnListPage();
     listPage.verifyLoadingSpinnerForDownloadOnListPage();
     listPage.verifyDownloadCompleteSuccessMessageBanner();
+    listPage.verifyFocusOnPrintDownloadDropDownButton();
     listPage.verifyDownloadTextFileHeadless('Safari', 'Mhvtp', 'Mhvtp, Safari');
   });
 });


### PR DESCRIPTION
## Summary

This is a follow up of #32100 

Removed auto focus from the spinner and made sure the focus stays on the `PrintDownloadButton` after the download attempt (both error and successful).

Added special error treatment to `PrintDownloadButton` in case there is no network.

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-61850

<img width="965" alt="image" src="https://github.com/user-attachments/assets/8a1be7fe-89c3-4237-9a84-2d0f3e74d02b">

## Testing done

- Manual testing

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1: Work is validated by accessibility
AC2: Focus should remain on the dropdown button in a closed state after selecting to download a page/record
AC3: Check other pages to make sure it is working properly on those. 

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
