### PR TITLE
93403 Update toxic exposure date validations and review page error messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -334,7 +334,7 @@
     "url-search-params-polyfill": "^8.1.1",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#a2088d24571c7d4b83f3fe50a28a2d75e2904fe5"
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#be610f6623ef1fac432e5616372d4a5eadb93773"
   },
   "resolutions": {
     "**/lodash": "4.17.21",

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -402,13 +402,10 @@ export const ADDITIONAL_EXPOSURES = Object.freeze({
   notsure: 'I’m not sure if I have been exposed to these hazards',
 });
 
-/* Toxic exposure date must be in the format of YYYY-MM-DD with the following
-      year: must be 4 digits and start with 19 or 20, e.g. 1990 or 2000
-      month: must be 2 digits, ranging from 01 - 12
-      day: must be 2 digits, ranging from 01 - 31
-   Note: X's are being removed to avoid submission failures   
+/* todo: remove this and use vets-json-schema
 */
 export const toxicExposureDate = {
-  pattern: '^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$',
+  pattern:
+    '^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$',
   type: 'string',
 };

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -401,8 +401,3 @@ export const ADDITIONAL_EXPOSURES = Object.freeze({
   none: 'None of these',
   notsure: 'I’m not sure if I have been exposed to these hazards',
 });
-
-export const toxicExposureDateSchema = {
-  pattern: fullSchema.definitions.nullableMinimumYearDate.pattern,
-  type: 'string',
-};

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -402,10 +402,7 @@ export const ADDITIONAL_EXPOSURES = Object.freeze({
   notsure: 'I’m not sure if I have been exposed to these hazards',
 });
 
-/* todo: remove this and use vets-json-schema
-*/
-export const toxicExposureDate = {
-  pattern:
-    '^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2]|XX)-(0[1-9]|[1-2][0-9]|3[0-1]|XX)$',
+export const toxicExposureDateSchema = {
+  pattern: fullSchema.definitions.nullableMinimumYearDate.pattern,
   type: 'string',
 };

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -406,6 +406,7 @@ export const ADDITIONAL_EXPOSURES = Object.freeze({
       year: must be 4 digits and start with 19 or 20, e.g. 1990 or 2000
       month: must be 2 digits, ranging from 01 - 12
       day: must be 2 digits, ranging from 01 - 31
+   Note: X's are being removed to avoid submission failures   
 */
 export const toxicExposureDate = {
   pattern: '^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$',

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -401,3 +401,13 @@ export const ADDITIONAL_EXPOSURES = Object.freeze({
   none: 'None of these',
   notsure: 'I’m not sure if I have been exposed to these hazards',
 });
+
+/* Toxic exposure date must be in the format of YYYY-MM-DD with the following
+      year: must be 4 digits and start with 19 or 20, e.g. 1990 or 2000
+      month: must be 2 digits, ranging from 01 - 12
+      day: must be 2 digits, ranging from 01 - 31
+*/
+export const toxicExposureDate = {
+  pattern: '^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$',
+  type: 'string',
+};

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposuresDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposuresDetails.js
@@ -15,7 +15,7 @@ import {
 import {
   ADDITIONAL_EXPOSURES,
   TE_URL_PREFIX,
-  toxicExposureDate,
+  toxicExposureDateSchema,
 } from '../../constants';
 
 /**
@@ -79,8 +79,8 @@ function makeSchema(itemId) {
               [itemId]: {
                 type: 'object',
                 properties: {
-                  startDate: toxicExposureDate,
-                  endDate: toxicExposureDate,
+                  startDate: toxicExposureDateSchema,
+                  endDate: toxicExposureDateSchema,
                   'view:notSure': {
                     type: 'boolean',
                   },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposuresDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposuresDetails.js
@@ -1,7 +1,4 @@
-import {
-  currentOrPastDateUI,
-  currentOrPastDateSchema,
-} from 'platform/forms-system/src/js/web-component-patterns';
+import { currentOrPastDateUI } from 'platform/forms-system/src/js/web-component-patterns';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
   additionalExposuresPageTitle,
@@ -15,7 +12,11 @@ import {
   showCheckboxLoopDetailsPage,
   teSubtitle,
 } from '../../content/toxicExposure';
-import { ADDITIONAL_EXPOSURES, TE_URL_PREFIX } from '../../constants';
+import {
+  ADDITIONAL_EXPOSURES,
+  TE_URL_PREFIX,
+  toxicExposureDate,
+} from '../../constants';
 
 /**
  * Make the uiSchema for each additional exposures details page
@@ -78,8 +79,8 @@ function makeSchema(itemId) {
               [itemId]: {
                 type: 'object',
                 properties: {
-                  startDate: currentOrPastDateSchema,
-                  endDate: currentOrPastDateSchema,
+                  startDate: toxicExposureDate,
+                  endDate: toxicExposureDate,
                   'view:notSure': {
                     type: 'boolean',
                   },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposuresDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/additionalExposuresDetails.js
@@ -1,3 +1,4 @@
+import full526EZSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { currentOrPastDateUI } from 'platform/forms-system/src/js/web-component-patterns';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
@@ -12,11 +13,7 @@ import {
   showCheckboxLoopDetailsPage,
   teSubtitle,
 } from '../../content/toxicExposure';
-import {
-  ADDITIONAL_EXPOSURES,
-  TE_URL_PREFIX,
-  toxicExposureDateSchema,
-} from '../../constants';
+import { ADDITIONAL_EXPOSURES, TE_URL_PREFIX } from '../../constants';
 
 /**
  * Make the uiSchema for each additional exposures details page
@@ -79,8 +76,8 @@ function makeSchema(itemId) {
               [itemId]: {
                 type: 'object',
                 properties: {
-                  startDate: toxicExposureDateSchema,
-                  endDate: toxicExposureDateSchema,
+                  startDate: full526EZSchema.definitions.minimumYearDate,
+                  endDate: full526EZSchema.definitions.minimumYearDate,
                   'view:notSure': {
                     type: 'boolean',
                   },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
@@ -1,7 +1,4 @@
-import {
-  currentOrPastDateUI,
-  currentOrPastDateSchema,
-} from 'platform/forms-system/src/js/web-component-patterns';
+import { currentOrPastDateUI } from 'platform/forms-system/src/js/web-component-patterns';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
   endDateApproximate,
@@ -16,6 +13,16 @@ import {
   detailsPageBegin,
 } from '../../content/toxicExposure';
 import { GULF_WAR_1990_LOCATIONS, TE_URL_PREFIX } from '../../constants';
+
+/* Date must be in the format of YYYY-MM-DD with the following
+      year: must be 4 digits and start with 19 or 20, e.g. 1990 or 2000
+      month: must be 2 digits, ranging from 01 - 12
+      day: must be 2 digits, ranging from 01 - 31
+*/
+const dateSchema = {
+  type: 'string',
+  pattern: '^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$',
+};
 
 /**
  * Make the uiSchema for each gulf war 1990 details page
@@ -76,8 +83,8 @@ function makeSchema(locationId) {
               [locationId]: {
                 type: 'object',
                 properties: {
-                  startDate: currentOrPastDateSchema,
-                  endDate: currentOrPastDateSchema,
+                  startDate: dateSchema,
+                  endDate: dateSchema,
                   'view:notSure': {
                     type: 'boolean',
                   },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
@@ -1,28 +1,22 @@
 import { currentOrPastDateUI } from 'platform/forms-system/src/js/web-component-patterns';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
+  dateRangeAdditionalInfo,
+  detailsPageBegin,
   endDateApproximate,
   getKeyIndex,
   getSelectedCount,
-  dateRangeAdditionalInfo,
   gulfWar1990PageTitle,
+  notSureDatesDetails,
   showCheckboxLoopDetailsPage,
   startDateApproximate,
   teSubtitle,
-  notSureDatesDetails,
-  detailsPageBegin,
 } from '../../content/toxicExposure';
-import { GULF_WAR_1990_LOCATIONS, TE_URL_PREFIX } from '../../constants';
-
-/* Date must be in the format of YYYY-MM-DD with the following
-      year: must be 4 digits and start with 19 or 20, e.g. 1990 or 2000
-      month: must be 2 digits, ranging from 01 - 12
-      day: must be 2 digits, ranging from 01 - 31
-*/
-const dateSchema = {
-  pattern: '^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$',
-  type: 'string',
-};
+import {
+  GULF_WAR_1990_LOCATIONS,
+  TE_URL_PREFIX,
+  toxicExposureDate,
+} from '../../constants';
 
 /**
  * Make the uiSchema for each gulf war 1990 details page
@@ -83,8 +77,8 @@ function makeSchema(locationId) {
               [locationId]: {
                 type: 'object',
                 properties: {
-                  startDate: dateSchema,
-                  endDate: dateSchema,
+                  startDate: toxicExposureDate,
+                  endDate: toxicExposureDate,
                   'view:notSure': {
                     type: 'boolean',
                   },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
@@ -20,8 +20,8 @@ import { GULF_WAR_1990_LOCATIONS, TE_URL_PREFIX } from '../../constants';
       day: must be 2 digits, ranging from 01 - 31
 */
 const dateSchema = {
-  type: 'string',
   pattern: '^(?:19|20)[0-9][0-9]-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$',
+  type: 'string',
 };
 
 /**

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
@@ -1,3 +1,4 @@
+import full526EZSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { currentOrPastDateUI } from 'platform/forms-system/src/js/web-component-patterns';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
@@ -12,11 +13,7 @@ import {
   startDateApproximate,
   teSubtitle,
 } from '../../content/toxicExposure';
-import {
-  GULF_WAR_1990_LOCATIONS,
-  TE_URL_PREFIX,
-  toxicExposureDateSchema,
-} from '../../constants';
+import { GULF_WAR_1990_LOCATIONS, TE_URL_PREFIX } from '../../constants';
 
 /**
  * Make the uiSchema for each gulf war 1990 details page
@@ -77,8 +74,8 @@ function makeSchema(locationId) {
               [locationId]: {
                 type: 'object',
                 properties: {
-                  startDate: toxicExposureDateSchema,
-                  endDate: toxicExposureDateSchema,
+                  startDate: full526EZSchema.definitions.minimumYearDate,
+                  endDate: full526EZSchema.definitions.minimumYearDate,
                   'view:notSure': {
                     type: 'boolean',
                   },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar1990Details.js
@@ -15,7 +15,7 @@ import {
 import {
   GULF_WAR_1990_LOCATIONS,
   TE_URL_PREFIX,
-  toxicExposureDate,
+  toxicExposureDateSchema,
 } from '../../constants';
 
 /**
@@ -77,8 +77,8 @@ function makeSchema(locationId) {
               [locationId]: {
                 type: 'object',
                 properties: {
-                  startDate: toxicExposureDate,
-                  endDate: toxicExposureDate,
+                  startDate: toxicExposureDateSchema,
+                  endDate: toxicExposureDateSchema,
                   'view:notSure': {
                     type: 'boolean',
                   },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
@@ -15,7 +15,7 @@ import {
 import {
   GULF_WAR_2001_LOCATIONS,
   TE_URL_PREFIX,
-  toxicExposureDate,
+  toxicExposureDateSchema,
 } from '../../constants';
 
 /**
@@ -77,8 +77,8 @@ function makeSchema(locationId) {
               [locationId]: {
                 type: 'object',
                 properties: {
-                  startDate: toxicExposureDate,
-                  endDate: toxicExposureDate,
+                  startDate: toxicExposureDateSchema,
+                  endDate: toxicExposureDateSchema,
                   'view:notSure': {
                     type: 'boolean',
                   },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
@@ -1,3 +1,4 @@
+import full526EZSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { currentOrPastDateUI } from 'platform/forms-system/src/js/web-component-patterns';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
@@ -12,11 +13,7 @@ import {
   startDateApproximate,
   teSubtitle,
 } from '../../content/toxicExposure';
-import {
-  GULF_WAR_2001_LOCATIONS,
-  TE_URL_PREFIX,
-  toxicExposureDateSchema,
-} from '../../constants';
+import { GULF_WAR_2001_LOCATIONS, TE_URL_PREFIX } from '../../constants';
 
 /**
  * Make the uiSchema for each gulf war 2001 details page
@@ -77,8 +74,8 @@ function makeSchema(locationId) {
               [locationId]: {
                 type: 'object',
                 properties: {
-                  startDate: toxicExposureDateSchema,
-                  endDate: toxicExposureDateSchema,
+                  startDate: full526EZSchema.definitions.minimumYearDate,
+                  endDate: full526EZSchema.definitions.minimumYearDate,
                   'view:notSure': {
                     type: 'boolean',
                   },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/gulfWar2001Details.js
@@ -1,21 +1,22 @@
-import {
-  currentOrPastDateUI,
-  currentOrPastDateSchema,
-} from 'platform/forms-system/src/js/web-component-patterns';
+import { currentOrPastDateUI } from 'platform/forms-system/src/js/web-component-patterns';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
+  dateRangeAdditionalInfo,
+  detailsPageBegin,
   endDateApproximate,
   getKeyIndex,
   getSelectedCount,
-  dateRangeAdditionalInfo,
-  startDateApproximate,
   gulfWar2001PageTitle,
-  showCheckboxLoopDetailsPage,
-  teSubtitle,
   notSureDatesDetails,
-  detailsPageBegin,
+  showCheckboxLoopDetailsPage,
+  startDateApproximate,
+  teSubtitle,
 } from '../../content/toxicExposure';
-import { GULF_WAR_2001_LOCATIONS, TE_URL_PREFIX } from '../../constants';
+import {
+  GULF_WAR_2001_LOCATIONS,
+  TE_URL_PREFIX,
+  toxicExposureDate,
+} from '../../constants';
 
 /**
  * Make the uiSchema for each gulf war 2001 details page
@@ -76,8 +77,8 @@ function makeSchema(locationId) {
               [locationId]: {
                 type: 'object',
                 properties: {
-                  startDate: currentOrPastDateSchema,
-                  endDate: currentOrPastDateSchema,
+                  startDate: toxicExposureDate,
+                  endDate: toxicExposureDate,
                   'view:notSure': {
                     type: 'boolean',
                   },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
@@ -1,7 +1,4 @@
-import {
-  currentOrPastDateUI,
-  currentOrPastDateSchema,
-} from 'platform/forms-system/src/js/web-component-patterns';
+import { currentOrPastDateUI } from 'platform/forms-system/src/js/web-component-patterns';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
   dateRangeAdditionalInfo,
@@ -15,7 +12,11 @@ import {
   startDateApproximate,
   teSubtitle,
 } from '../../content/toxicExposure';
-import { HERBICIDE_LOCATIONS, TE_URL_PREFIX } from '../../constants';
+import {
+  HERBICIDE_LOCATIONS,
+  TE_URL_PREFIX,
+  toxicExposureDate,
+} from '../../constants';
 
 /**
  * Make the uiSchema for each herbicide details page
@@ -76,8 +77,8 @@ function makeSchema(locationId) {
               [locationId]: {
                 type: 'object',
                 properties: {
-                  startDate: currentOrPastDateSchema,
-                  endDate: currentOrPastDateSchema,
+                  startDate: toxicExposureDate,
+                  endDate: toxicExposureDate,
                   'view:notSure': {
                     type: 'boolean',
                   },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
@@ -1,3 +1,4 @@
+import full526EZSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { currentOrPastDateUI } from 'platform/forms-system/src/js/web-component-patterns';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
@@ -12,11 +13,7 @@ import {
   startDateApproximate,
   teSubtitle,
 } from '../../content/toxicExposure';
-import {
-  HERBICIDE_LOCATIONS,
-  TE_URL_PREFIX,
-  toxicExposureDateSchema,
-} from '../../constants';
+import { HERBICIDE_LOCATIONS, TE_URL_PREFIX } from '../../constants';
 
 /**
  * Make the uiSchema for each herbicide details page
@@ -77,8 +74,8 @@ function makeSchema(locationId) {
               [locationId]: {
                 type: 'object',
                 properties: {
-                  startDate: toxicExposureDateSchema,
-                  endDate: toxicExposureDateSchema,
+                  startDate: full526EZSchema.definitions.minimumYearDate,
+                  endDate: full526EZSchema.definitions.minimumYearDate,
                   'view:notSure': {
                     type: 'boolean',
                   },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideDetails.js
@@ -15,7 +15,7 @@ import {
 import {
   HERBICIDE_LOCATIONS,
   TE_URL_PREFIX,
-  toxicExposureDate,
+  toxicExposureDateSchema,
 } from '../../constants';
 
 /**
@@ -77,8 +77,8 @@ function makeSchema(locationId) {
               [locationId]: {
                 type: 'object',
                 properties: {
-                  startDate: toxicExposureDate,
-                  endDate: toxicExposureDate,
+                  startDate: toxicExposureDateSchema,
+                  endDate: toxicExposureDateSchema,
                   'view:notSure': {
                     type: 'boolean',
                   },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
@@ -11,7 +11,7 @@ import {
   startDateApproximate,
   teSubtitle,
 } from '../../content/toxicExposure';
-import { toxicExposureDate } from '../../constants';
+import { toxicExposureDateSchema } from '../../constants';
 
 export const uiSchema = {
   'ui:title': ({ formData }) => {
@@ -60,8 +60,8 @@ export const schema = {
         otherHerbicideLocations: {
           type: 'object',
           properties: {
-            startDate: toxicExposureDate,
-            endDate: toxicExposureDate,
+            startDate: toxicExposureDateSchema,
+            endDate: toxicExposureDateSchema,
             'view:notSure': {
               type: 'boolean',
             },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
@@ -1,3 +1,4 @@
+import full526EZSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { currentOrPastDateUI } from 'platform/forms-system/src/js/web-component-patterns';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
@@ -11,7 +12,6 @@ import {
   startDateApproximate,
   teSubtitle,
 } from '../../content/toxicExposure';
-import { toxicExposureDateSchema } from '../../constants';
 
 export const uiSchema = {
   'ui:title': ({ formData }) => {
@@ -60,8 +60,8 @@ export const schema = {
         otherHerbicideLocations: {
           type: 'object',
           properties: {
-            startDate: toxicExposureDateSchema,
-            endDate: toxicExposureDateSchema,
+            startDate: full526EZSchema.definitions.minimumYearDate,
+            endDate: full526EZSchema.definitions.minimumYearDate,
             'view:notSure': {
               type: 'boolean',
             },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/herbicideOtherLocations.js
@@ -1,7 +1,4 @@
-import {
-  currentOrPastDateUI,
-  currentOrPastDateSchema,
-} from 'platform/forms-system/src/js/web-component-patterns';
+import { currentOrPastDateUI } from 'platform/forms-system/src/js/web-component-patterns';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
   dateRangeAdditionalInfo,
@@ -14,6 +11,7 @@ import {
   startDateApproximate,
   teSubtitle,
 } from '../../content/toxicExposure';
+import { toxicExposureDate } from '../../constants';
 
 export const uiSchema = {
   'ui:title': ({ formData }) => {
@@ -62,8 +60,8 @@ export const schema = {
         otherHerbicideLocations: {
           type: 'object',
           properties: {
-            startDate: currentOrPastDateSchema,
-            endDate: currentOrPastDateSchema,
+            startDate: toxicExposureDate,
+            endDate: toxicExposureDate,
             'view:notSure': {
               type: 'boolean',
             },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/specifyOtherExposures.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/specifyOtherExposures.js
@@ -1,3 +1,4 @@
+import full526EZSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { currentOrPastDateUI } from 'platform/forms-system/src/js/web-component-patterns';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
@@ -11,7 +12,6 @@ import {
   notSureHazardDetails,
   teSubtitle,
 } from '../../content/toxicExposure';
-import { toxicExposureDateSchema } from '../../constants';
 
 export const uiSchema = {
   'ui:title': ({ formData }) => {
@@ -63,8 +63,8 @@ export const schema = {
         specifyOtherExposures: {
           type: 'object',
           properties: {
-            startDate: toxicExposureDateSchema,
-            endDate: toxicExposureDateSchema,
+            startDate: full526EZSchema.definitions.minimumYearDate,
+            endDate: full526EZSchema.definitions.minimumYearDate,
             'view:notSure': {
               type: 'boolean',
             },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/specifyOtherExposures.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/specifyOtherExposures.js
@@ -11,7 +11,7 @@ import {
   notSureHazardDetails,
   teSubtitle,
 } from '../../content/toxicExposure';
-import { toxicExposureDate } from '../../constants';
+import { toxicExposureDateSchema } from '../../constants';
 
 export const uiSchema = {
   'ui:title': ({ formData }) => {
@@ -63,8 +63,8 @@ export const schema = {
         specifyOtherExposures: {
           type: 'object',
           properties: {
-            startDate: toxicExposureDate,
-            endDate: toxicExposureDate,
+            startDate: toxicExposureDateSchema,
+            endDate: toxicExposureDateSchema,
             'view:notSure': {
               type: 'boolean',
             },

--- a/src/applications/disability-benefits/all-claims/pages/toxicExposure/specifyOtherExposures.js
+++ b/src/applications/disability-benefits/all-claims/pages/toxicExposure/specifyOtherExposures.js
@@ -1,7 +1,4 @@
-import {
-  currentOrPastDateUI,
-  currentOrPastDateSchema,
-} from 'platform/forms-system/src/js/web-component-patterns';
+import { currentOrPastDateUI } from 'platform/forms-system/src/js/web-component-patterns';
 import VaCheckboxField from 'platform/forms-system/src/js/web-component-fields/VaCheckboxField';
 import {
   additionalExposuresPageTitle,
@@ -14,6 +11,7 @@ import {
   notSureHazardDetails,
   teSubtitle,
 } from '../../content/toxicExposure';
+import { toxicExposureDate } from '../../constants';
 
 export const uiSchema = {
   'ui:title': ({ formData }) => {
@@ -65,8 +63,8 @@ export const schema = {
         specifyOtherExposures: {
           type: 'object',
           properties: {
-            startDate: currentOrPastDateSchema,
-            endDate: currentOrPastDateSchema,
+            startDate: toxicExposureDate,
+            endDate: toxicExposureDate,
             'view:notSure': {
               type: 'boolean',
             },

--- a/src/applications/disability-benefits/all-claims/reviewErrors.js
+++ b/src/applications/disability-benefits/all-claims/reviewErrors.js
@@ -184,48 +184,50 @@ export default {
   'toxicExposure.specifyOtherExposures.endDate':
     'Exposure end date for other toxic exposures',
   _override: error => {
-    if (error?.endsWith('startDate') || error?.endsWith('endDate')) {
-      const errorParts = error.split('.');
-      if (error.startsWith('toxicExposure.gulfWar1990Details')) {
-        return {
-          chapterKey: 'disabilities',
-          pageKey: `gulf-war-1990-location-${errorParts[2]}`,
-        };
-      }
-      if (error.startsWith('toxicExposure.gulfWar2001Details')) {
-        return {
-          chapterKey: 'disabilities',
-          pageKey: `gulf-war-2001-location-${errorParts[2]}`,
-        };
-      }
-      if (error.startsWith('toxicExposure.herbicideDetails')) {
-        return {
-          chapterKey: 'disabilities',
-          pageKey: `herbicide-location-${errorParts[2]}`,
-        };
-      }
-      if (error.startsWith('toxicExposure.otherExposureDetails')) {
-        return {
-          chapterKey: 'disabilities',
-          pageKey: `additional-exposure-${errorParts[2]}`,
-        };
-      }
-      if (error.startsWith('toxicExposure.otherHerbicideLocations')) {
-        return {
-          chapterKey: 'disabilities',
-          pageKey: `herbicide-location-other}`,
-        };
-      }
-      if (error.startsWith('toxicExposure.specifyOtherExposures')) {
-        return {
-          chapterKey: 'disabilities',
-          pageKey: `additional-exposure-other`,
-        };
+    if (typeof error === 'string') {
+      if (error?.endsWith('startDate') || error?.endsWith('endDate')) {
+        const errorParts = error.split('.');
+        if (error.startsWith('toxicExposure.gulfWar1990Details')) {
+          return {
+            chapterKey: 'disabilities',
+            pageKey: `gulf-war-1990-location-${errorParts[2]}`,
+          };
+        }
+        if (error.startsWith('toxicExposure.gulfWar2001Details')) {
+          return {
+            chapterKey: 'disabilities',
+            pageKey: `gulf-war-2001-location-${errorParts[2]}`,
+          };
+        }
+        if (error.startsWith('toxicExposure.herbicideDetails')) {
+          return {
+            chapterKey: 'disabilities',
+            pageKey: `herbicide-location-${errorParts[2]}`,
+          };
+        }
+        if (error.startsWith('toxicExposure.otherExposureDetails')) {
+          return {
+            chapterKey: 'disabilities',
+            pageKey: `additional-exposure-${errorParts[2]}`,
+          };
+        }
+        if (error.startsWith('toxicExposure.otherHerbicideLocations')) {
+          return {
+            chapterKey: 'disabilities',
+            pageKey: `herbicide-location-other`,
+          };
+        }
+        if (error.startsWith('toxicExposure.specifyOtherExposures')) {
+          return {
+            chapterKey: 'disabilities',
+            pageKey: `additional-exposure-other`,
+          };
+        }
       }
       if (error === 'toxicExposure.otherHerbicideLocations.description') {
         return {
           chapterKey: 'disabilities',
-          pageKey: `herbidideLocations`,
+          pageKey: `herbicideLocations`,
         };
       }
       if (error === 'toxicExposure.specifyOtherExposures.description') {

--- a/src/applications/disability-benefits/all-claims/reviewErrors.js
+++ b/src/applications/disability-benefits/all-claims/reviewErrors.js
@@ -1,151 +1,5 @@
 import numberToWords from 'platform/forms-system/src/js/utilities/data/numberToWords';
 
-// mapping of toxic exposure error key to page
-const teErrorToPage = {
-  'toxicExposure.gulfWar1990Details.afghanistan.startDate':
-    'gulf-war-1990-location-afghanistan',
-  'toxicExposure.gulfWar1990Details.afghanistan.endDate':
-    'gulf-war-1990-location-afghanistan',
-  'toxicExposure.gulfWar1990Details.bahrain.startDate':
-    'gulf-war-1990-location-bahrain',
-  'toxicExposure.gulfWar1990Details.bahrain.endDate':
-    'gulf-war-1990-location-bahrain',
-  'toxicExposure.gulfWar1990Details.egypt.startDate':
-    'gulf-war-1990-location-egypt',
-  'toxicExposure.gulfWar1990Details.egypt.endDate':
-    'gulf-war-1990-location-egypt',
-  'toxicExposure.gulfWar1990Details.iraq.startDate':
-    'gulf-war-1990-location-iraq',
-  'toxicExposure.gulfWar1990Details.iraq.endDate':
-    'gulf-war-1990-location-iraq',
-  'toxicExposure.gulfWar1990Details.israel.startDate':
-    'gulf-war-1990-location-israel',
-  'toxicExposure.gulfWar1990Details.israel.endDate':
-    'gulf-war-1990-location-israel',
-  'toxicExposure.gulfWar1990Details.jordan.startDate':
-    'gulf-war-1990-location-jordan',
-  'toxicExposure.gulfWar1990Details.jordan.endDate':
-    'gulf-war-1990-location-jordan',
-  'toxicExposure.gulfWar1990Details.kuwait.startDate':
-    'gulf-war-1990-location-kuwait',
-  'toxicExposure.gulfWar1990Details.kuwait.endDate':
-    'gulf-war-1990-location-kuwait',
-  'toxicExposure.gulfWar1990Details.neutralzone.startDate':
-    'gulf-war-1990-location-neutralzone',
-  'toxicExposure.gulfWar1990Details.neutralzone.endDate':
-    'gulf-war-1990-location-neutralzone',
-  'toxicExposure.gulfWar1990Details.oman.startDate':
-    'gulf-war-1990-location-oman',
-  'toxicExposure.gulfWar1990Details.oman.endDate':
-    'gulf-war-1990-location-oman',
-  'toxicExposure.gulfWar1990Details.qatar.startDate':
-    'gulf-war-1990-location-qatar',
-  'toxicExposure.gulfWar1990Details.qatar.endDate':
-    'gulf-war-1990-location-qatar',
-  'toxicExposure.gulfWar1990Details.saudiarabia.startDate':
-    'gulf-war-1990-location-saudiarabia',
-  'toxicExposure.gulfWar1990Details.saudiarabia.endDate':
-    'gulf-war-1990-location-saudiarabia',
-  'toxicExposure.gulfWar1990Details.somalia.startDate':
-    'gulf-war-1990-location-somalia',
-  'toxicExposure.gulfWar1990Details.somalia.endDate':
-    'gulf-war-1990-location-somalia',
-  'toxicExposure.gulfWar1990Details.syria.startDate':
-    'gulf-war-1990-location-syria',
-  'toxicExposure.gulfWar1990Details.syria.endDate':
-    'gulf-war-1990-location-syria',
-  'toxicExposure.gulfWar1990Details.uae.startDate':
-    'gulf-war-1990-location-uae',
-  'toxicExposure.gulfWar1990Details.uae.endDate': 'gulf-war-1990-location-uae',
-  'toxicExposure.gulfWar1990Details.turkey.startDate':
-    'gulf-war-1990-location-turkey',
-  'toxicExposure.gulfWar1990Details.turkey.endDate':
-    'gulf-war-1990-location-turkey',
-  'toxicExposure.gulfWar1990Details.waters.startDate':
-    'gulf-war-1990-location-waters',
-  'toxicExposure.gulfWar1990Details.waters.endDate':
-    'gulf-war-1990-location-waters',
-  'toxicExposure.gulfWar1990Details.airspace.startDate':
-    'gulf-war-1990-location-airspace',
-  'toxicExposure.gulfWar1990Details.airspace.endDate':
-    'gulf-war-1990-location-airspace',
-  'toxicExposure.gulfWar2001Details.djibouti.startDate':
-    'gulf-war-2001-location-djibouti',
-  'toxicExposure.gulfWar2001Details.djibouti.endDate':
-    'gulf-war-2001-location-djibouti',
-  'toxicExposure.gulfWar2001Details.lebanon.startDate':
-    'gulf-war-2001-location-lebanon',
-  'toxicExposure.gulfWar2001Details.lebanon.endDate':
-    'gulf-war-2001-location-lebanon',
-  'toxicExposure.gulfWar2001Details.uzbekistan.startDate':
-    'gulf-war-2001-location-uzbekistan',
-  'toxicExposure.gulfWar2001Details.uzbekistan.endDate':
-    'gulf-war-2001-location-uzbekistan',
-  'toxicExposure.gulfWar2001Details.yemen.startDate':
-    'gulf-war-2001-location-yemen',
-  'toxicExposure.gulfWar2001Details.yemen.endDate':
-    'gulf-war-2001-location-yemen',
-  'toxicExposure.gulfWar2001Details.airspace.startDate':
-    'gulf-war-2001-location-airspace',
-  'toxicExposure.gulfWar2001Details.airspace.endDate':
-    'gulf-war-2001-location-airspace',
-  'toxicExposure.herbicideDetails.cambodia.startDate':
-    'herbicide-location-cambodia',
-  'toxicExposure.herbicideDetails.cambodia.endDate':
-    'herbicide-location-cambodia',
-  'toxicExposure.herbicideDetails.guam.startDate': 'herbicide-location-guam',
-  'toxicExposure.herbicideDetails.guam.endDate': 'herbicide-location-guam',
-  'toxicExposure.herbicideDetails.koreandemilitarizedzone.startDate':
-    'herbicide-location-koreandemilitarizedzone',
-  'toxicExposure.herbicideDetails.koreandemilitarizedzone.endDate':
-    'herbicide-location-koreandemilitarizedzone',
-  'toxicExposure.herbicideDetails.johnston.startDate':
-    'herbicide-location-johnston',
-  'toxicExposure.herbicideDetails.johnston.endDate':
-    'herbicide-location-johnston',
-  'toxicExposure.herbicideDetails.laos.startDate': 'herbicide-location-laos',
-  'toxicExposure.herbicideDetails.laos.endDate': 'herbicide-location-laos',
-  'toxicExposure.herbicideDetails.c123.startDate': 'herbicide-location-c123',
-  'toxicExposure.herbicideDetails.c123.endDate': 'herbicide-location-c123',
-  'toxicExposure.herbicideDetails.thailand.startDate':
-    'herbicide-location-thailand',
-  'toxicExposure.herbicideDetails.thailand.endDate':
-    'herbicide-location-thailand',
-  'toxicExposure.herbicideDetails.vietnam.startDate':
-    'herbicide-location-vietnam',
-  'toxicExposure.herbicideDetails.vietnam.endDate':
-    'herbicide-location-vietnam',
-  'toxicExposure.otherExposuresDetails.asbestos.startDate':
-    'additional-exposure-asbestos',
-  'toxicExposure.otherExposuresDetails.asbestos.endDate':
-    'additional-exposure-asbestos',
-  'toxicExposure.otherExposuresDetails.chemical.startDate':
-    'additional-exposure-chemical',
-  'toxicExposure.otherExposuresDetails.chemical.endDate':
-    'additional-exposure-chemical',
-  'toxicExposure.otherExposuresDetails.water.startDate':
-    'additional-exposure-water',
-  'toxicExposure.otherExposuresDetails.water.endDate':
-    'additional-exposure-water',
-  'toxicExposure.otherExposuresDetails.mos.startDate':
-    'additional-exposure-mos',
-  'toxicExposure.otherExposuresDetails.mos.endDate': 'additional-exposure-mos',
-  'toxicExposure.otherExposuresDetails.mustardgas.startDate':
-    'additional-exposure-mustardgas',
-  'toxicExposure.otherExposuresDetails.mustardgas.endDate':
-    'additional-exposure-mustardgas',
-  'toxicExposure.otherExposuresDetails.radiation.startDate':
-    'additional-exposure-radiation',
-  'toxicExposure.otherExposuresDetails.radiation.endDate':
-    'additional-exposure-radiation',
-  'toxicExposure.otherHerbicideLocations.description': 'herbicideLocations',
-  'toxicExposure.otherHerbicideLocations.startDate': 'herbicide-location-other',
-  'toxicExposure.otherHerbicideLocations.endDate': 'herbicide-location-other',
-  'toxicExposure.specifyOtherExposures.description': 'additional-exposures',
-  'toxicExposure.specifyOtherExposures.startDate': 'additional-exposure-other',
-  'toxicExposure.specifyOtherExposures.endDate': 'additional-exposure-other',
-};
-
 // Link text for review & submit page errors
 // key = "name" from `form.formErrors.errors`
 // see src/platform/forms-system/docs/reviewErrors.md
@@ -330,11 +184,56 @@ export default {
   'toxicExposure.specifyOtherExposures.endDate':
     'Exposure end date for other toxic exposures',
   _override: error => {
-    if (Object.keys(teErrorToPage).includes(error)) {
-      return {
-        chapterKey: 'disabilities',
-        pageKey: teErrorToPage[error],
-      };
+    if (error?.endsWith('startDate') || error?.endsWith('endDate')) {
+      const errorParts = error.split('.');
+      if (error.startsWith('toxicExposure.gulfWar1990Details')) {
+        return {
+          chapterKey: 'disabilities',
+          pageKey: `gulf-war-1990-location-${errorParts[2]}`,
+        };
+      }
+      if (error.startsWith('toxicExposure.gulfWar2001Details')) {
+        return {
+          chapterKey: 'disabilities',
+          pageKey: `gulf-war-2001-location-${errorParts[2]}`,
+        };
+      }
+      if (error.startsWith('toxicExposure.herbicideDetails')) {
+        return {
+          chapterKey: 'disabilities',
+          pageKey: `herbicide-location-${errorParts[2]}`,
+        };
+      }
+      if (error.startsWith('toxicExposure.otherExposureDetails')) {
+        return {
+          chapterKey: 'disabilities',
+          pageKey: `additional-exposure-${errorParts[2]}`,
+        };
+      }
+      if (error.startsWith('toxicExposure.otherHerbicideLocations')) {
+        return {
+          chapterKey: 'disabilities',
+          pageKey: `herbicide-location-other}`,
+        };
+      }
+      if (error.startsWith('toxicExposure.specifyOtherExposures')) {
+        return {
+          chapterKey: 'disabilities',
+          pageKey: `additional-exposure-other`,
+        };
+      }
+      if (error === 'toxicExposure.otherHerbicideLocations.description') {
+        return {
+          chapterKey: 'disabilities',
+          pageKey: `herbidideLocations`,
+        };
+      }
+      if (error === 'toxicExposure.specifyOtherExposures.description') {
+        return {
+          chapterKey: 'disabilities',
+          pageKey: `additional-exposures`,
+        };
+      }
     }
 
     // always return null for non-matches

--- a/src/applications/disability-benefits/all-claims/reviewErrors.js
+++ b/src/applications/disability-benefits/all-claims/reviewErrors.js
@@ -99,7 +99,7 @@ export default {
   'toxicExposure.gulfWar1990Details.airspace.startDate':
     'Service start date for the airspace above Gulf War locations on or after August 2, 1990',
   'toxicExposure.gulfWar1990Details.airspace.endDate':
-    'Service end date for Gulf War locations on or after August 2, 1990',
+    'Service end date for the airspace above Gulf War locations on or after August 2, 1990',
   'toxicExposure.gulfWar2001Details.djibouti.startDate':
     'Service start date for Djibouti',
   'toxicExposure.gulfWar2001Details.djibouti.endDate':
@@ -140,9 +140,9 @@ export default {
     'Service start date for Laos',
   'toxicExposure.herbicideDetails.laos.endDate': 'Service end date for Laos',
   'toxicExposure.herbicideDetails.c123.startDate':
-    'Service start date for Somewhere you had contact with C-123 airplanes while serving in the Air Force or the Air Force Reserves',
+    'Service start date for somewhere you had contact with C-123 airplanes while serving in the Air Force or the Air Force Reserves',
   'toxicExposure.herbicideDetails.c123.endDate':
-    'Service end date for Somewhere you had contact with C-123 airplanes while serving in the Air Force or the Air Force Reserves',
+    'Service end date for somewhere you had contact with C-123 airplanes while serving in the Air Force or the Air Force Reserves',
   'toxicExposure.herbicideDetails.thailand.startDate':
     'Service start date for a U.S. or Royal Thai military base in Thailand',
   'toxicExposure.herbicideDetails.thailand.endDate':
@@ -151,6 +151,10 @@ export default {
     'Service start date for Vietnam or the waters in or off of Vietnam',
   'toxicExposure.herbicideDetails.vietnam.endDate':
     'Service end date for Vietnam or the waters in or off of Vietnam',
+  'toxicExposure.otherHerbicideLocations.startDate':
+    'Exposure start date for other Agent Orange locations',
+  'toxicExposure.otherHerbicideLocations.endDate':
+    'Exposure end date for other Agent Orange locations ',
   'toxicExposure.otherHerbicideLocations.description':
     'Agent Orange other locations',
   'toxicExposure.otherExposuresDetails.asbestos.startDate':
@@ -205,7 +209,7 @@ export default {
             pageKey: `herbicide-location-${errorParts[2]}`,
           };
         }
-        if (error.startsWith('toxicExposure.otherExposureDetails')) {
+        if (error.startsWith('toxicExposure.otherExposuresDetails')) {
           return {
             chapterKey: 'disabilities',
             pageKey: `additional-exposure-${errorParts[2]}`,

--- a/src/applications/disability-benefits/all-claims/reviewErrors.js
+++ b/src/applications/disability-benefits/all-claims/reviewErrors.js
@@ -1,5 +1,151 @@
 import numberToWords from 'platform/forms-system/src/js/utilities/data/numberToWords';
 
+// mapping of toxic exposure error key to page
+const teErrorToPage = {
+  'toxicExposure.gulfWar1990Details.afghanistan.startDate':
+    'gulf-war-1990-location-afghanistan',
+  'toxicExposure.gulfWar1990Details.afghanistan.endDate':
+    'gulf-war-1990-location-afghanistan',
+  'toxicExposure.gulfWar1990Details.bahrain.startDate':
+    'gulf-war-1990-location-bahrain',
+  'toxicExposure.gulfWar1990Details.bahrain.endDate':
+    'gulf-war-1990-location-bahrain',
+  'toxicExposure.gulfWar1990Details.egypt.startDate':
+    'gulf-war-1990-location-egypt',
+  'toxicExposure.gulfWar1990Details.egypt.endDate':
+    'gulf-war-1990-location-egypt',
+  'toxicExposure.gulfWar1990Details.iraq.startDate':
+    'gulf-war-1990-location-iraq',
+  'toxicExposure.gulfWar1990Details.iraq.endDate':
+    'gulf-war-1990-location-iraq',
+  'toxicExposure.gulfWar1990Details.israel.startDate':
+    'gulf-war-1990-location-israel',
+  'toxicExposure.gulfWar1990Details.israel.endDate':
+    'gulf-war-1990-location-israel',
+  'toxicExposure.gulfWar1990Details.jordan.startDate':
+    'gulf-war-1990-location-jordan',
+  'toxicExposure.gulfWar1990Details.jordan.endDate':
+    'gulf-war-1990-location-jordan',
+  'toxicExposure.gulfWar1990Details.kuwait.startDate':
+    'gulf-war-1990-location-kuwait',
+  'toxicExposure.gulfWar1990Details.kuwait.endDate':
+    'gulf-war-1990-location-kuwait',
+  'toxicExposure.gulfWar1990Details.neutralzone.startDate':
+    'gulf-war-1990-location-neutralzone',
+  'toxicExposure.gulfWar1990Details.neutralzone.endDate':
+    'gulf-war-1990-location-neutralzone',
+  'toxicExposure.gulfWar1990Details.oman.startDate':
+    'gulf-war-1990-location-oman',
+  'toxicExposure.gulfWar1990Details.oman.endDate':
+    'gulf-war-1990-location-oman',
+  'toxicExposure.gulfWar1990Details.qatar.startDate':
+    'gulf-war-1990-location-qatar',
+  'toxicExposure.gulfWar1990Details.qatar.endDate':
+    'gulf-war-1990-location-qatar',
+  'toxicExposure.gulfWar1990Details.saudiarabia.startDate':
+    'gulf-war-1990-location-saudiarabia',
+  'toxicExposure.gulfWar1990Details.saudiarabia.endDate':
+    'gulf-war-1990-location-saudiarabia',
+  'toxicExposure.gulfWar1990Details.somalia.startDate':
+    'gulf-war-1990-location-somalia',
+  'toxicExposure.gulfWar1990Details.somalia.endDate':
+    'gulf-war-1990-location-somalia',
+  'toxicExposure.gulfWar1990Details.syria.startDate':
+    'gulf-war-1990-location-syria',
+  'toxicExposure.gulfWar1990Details.syria.endDate':
+    'gulf-war-1990-location-syria',
+  'toxicExposure.gulfWar1990Details.uae.startDate':
+    'gulf-war-1990-location-uae',
+  'toxicExposure.gulfWar1990Details.uae.endDate': 'gulf-war-1990-location-uae',
+  'toxicExposure.gulfWar1990Details.turkey.startDate':
+    'gulf-war-1990-location-turkey',
+  'toxicExposure.gulfWar1990Details.turkey.endDate':
+    'gulf-war-1990-location-turkey',
+  'toxicExposure.gulfWar1990Details.waters.startDate':
+    'gulf-war-1990-location-waters',
+  'toxicExposure.gulfWar1990Details.waters.endDate':
+    'gulf-war-1990-location-waters',
+  'toxicExposure.gulfWar1990Details.airspace.startDate':
+    'gulf-war-1990-location-airspace',
+  'toxicExposure.gulfWar1990Details.airspace.endDate':
+    'gulf-war-1990-location-airspace',
+  'toxicExposure.gulfWar2001Details.djibouti.startDate':
+    'gulf-war-2001-location-djibouti',
+  'toxicExposure.gulfWar2001Details.djibouti.endDate':
+    'gulf-war-2001-location-djibouti',
+  'toxicExposure.gulfWar2001Details.lebanon.startDate':
+    'gulf-war-2001-location-lebanon',
+  'toxicExposure.gulfWar2001Details.lebanon.endDate':
+    'gulf-war-2001-location-lebanon',
+  'toxicExposure.gulfWar2001Details.uzbekistan.startDate':
+    'gulf-war-2001-location-uzbekistan',
+  'toxicExposure.gulfWar2001Details.uzbekistan.endDate':
+    'gulf-war-2001-location-uzbekistan',
+  'toxicExposure.gulfWar2001Details.yemen.startDate':
+    'gulf-war-2001-location-yemen',
+  'toxicExposure.gulfWar2001Details.yemen.endDate':
+    'gulf-war-2001-location-yemen',
+  'toxicExposure.gulfWar2001Details.airspace.startDate':
+    'gulf-war-2001-location-airspace',
+  'toxicExposure.gulfWar2001Details.airspace.endDate':
+    'gulf-war-2001-location-airspace',
+  'toxicExposure.herbicideDetails.cambodia.startDate':
+    'herbicide-location-cambodia',
+  'toxicExposure.herbicideDetails.cambodia.endDate':
+    'herbicide-location-cambodia',
+  'toxicExposure.herbicideDetails.guam.startDate': 'herbicide-location-guam',
+  'toxicExposure.herbicideDetails.guam.endDate': 'herbicide-location-guam',
+  'toxicExposure.herbicideDetails.koreandemilitarizedzone.startDate':
+    'herbicide-location-koreandemilitarizedzone',
+  'toxicExposure.herbicideDetails.koreandemilitarizedzone.endDate':
+    'herbicide-location-koreandemilitarizedzone',
+  'toxicExposure.herbicideDetails.johnston.startDate':
+    'herbicide-location-johnston',
+  'toxicExposure.herbicideDetails.johnston.endDate':
+    'herbicide-location-johnston',
+  'toxicExposure.herbicideDetails.laos.startDate': 'herbicide-location-laos',
+  'toxicExposure.herbicideDetails.laos.endDate': 'herbicide-location-laos',
+  'toxicExposure.herbicideDetails.c123.startDate': 'herbicide-location-c123',
+  'toxicExposure.herbicideDetails.c123.endDate': 'herbicide-location-c123',
+  'toxicExposure.herbicideDetails.thailand.startDate':
+    'herbicide-location-thailand',
+  'toxicExposure.herbicideDetails.thailand.endDate':
+    'herbicide-location-thailand',
+  'toxicExposure.herbicideDetails.vietnam.startDate':
+    'herbicide-location-vietnam',
+  'toxicExposure.herbicideDetails.vietnam.endDate':
+    'herbicide-location-vietnam',
+  'toxicExposure.otherExposuresDetails.asbestos.startDate':
+    'additional-exposure-asbestos',
+  'toxicExposure.otherExposuresDetails.asbestos.endDate':
+    'additional-exposure-asbestos',
+  'toxicExposure.otherExposuresDetails.chemical.startDate':
+    'additional-exposure-chemical',
+  'toxicExposure.otherExposuresDetails.chemical.endDate':
+    'additional-exposure-chemical',
+  'toxicExposure.otherExposuresDetails.water.startDate':
+    'additional-exposure-water',
+  'toxicExposure.otherExposuresDetails.water.endDate':
+    'additional-exposure-water',
+  'toxicExposure.otherExposuresDetails.mos.startDate':
+    'additional-exposure-mos',
+  'toxicExposure.otherExposuresDetails.mos.endDate': 'additional-exposure-mos',
+  'toxicExposure.otherExposuresDetails.mustardgas.startDate':
+    'additional-exposure-mustardgas',
+  'toxicExposure.otherExposuresDetails.mustardgas.endDate':
+    'additional-exposure-mustardgas',
+  'toxicExposure.otherExposuresDetails.radiation.startDate':
+    'additional-exposure-radiation',
+  'toxicExposure.otherExposuresDetails.radiation.endDate':
+    'additional-exposure-radiation',
+  'toxicExposure.otherHerbicideLocations.description': 'herbicideLocations',
+  'toxicExposure.otherHerbicideLocations.startDate': 'herbicide-location-other',
+  'toxicExposure.otherHerbicideLocations.endDate': 'herbicide-location-other',
+  'toxicExposure.specifyOtherExposures.description': 'additional-exposures',
+  'toxicExposure.specifyOtherExposures.startDate': 'additional-exposure-other',
+  'toxicExposure.specifyOtherExposures.endDate': 'additional-exposure-other',
+};
+
 // Link text for review & submit page errors
 // key = "name" from `form.formErrors.errors`
 // see src/platform/forms-system/docs/reviewErrors.md
@@ -34,4 +180,164 @@ export default {
   homelessOrAtRisk:
     'Are you homeless or at risk of becoming homeless? (select one of the answers)',
   isVaEmployee: 'Are you a VA employee? (select yes or no)',
+  'toxicExposure.gulfWar1990Details.afghanistan.startDate':
+    'Service start date for Afghanistan',
+  'toxicExposure.gulfWar1990Details.afghanistan.endDate':
+    'Service end date for Afghanistan',
+  'toxicExposure.gulfWar1990Details.bahrain.startDate':
+    'Service start date for Bahrain',
+  'toxicExposure.gulfWar1990Details.bahrain.endDate':
+    'Service end date for Bahrain',
+  'toxicExposure.gulfWar1990Details.egypt.startDate':
+    'Service start date for Egypt',
+  'toxicExposure.gulfWar1990Details.egypt.endDate':
+    'Service end date for Egypt',
+  'toxicExposure.gulfWar1990Details.iraq.startDate':
+    'Service start date for Iraq',
+  'toxicExposure.gulfWar1990Details.iraq.endDate': 'Service end date for Iraq',
+  'toxicExposure.gulfWar1990Details.israel.startDate':
+    'Service start date for Israel',
+  'toxicExposure.gulfWar1990Details.israel.endDate':
+    'Service end date for Israel',
+  'toxicExposure.gulfWar1990Details.jordan.startDate':
+    'Service start date for Jordan',
+  'toxicExposure.gulfWar1990Details.jordan.endDate':
+    'Service end date for Jordan',
+  'toxicExposure.gulfWar1990Details.kuwait.startDate':
+    'Service start date for Kuwait',
+  'toxicExposure.gulfWar1990Details.kuwait.endDate':
+    'Service end date for Kuwait',
+  'toxicExposure.gulfWar1990Details.neutralzone.startDate':
+    'Service start date for the neutral zone between Iraq and Saudi Arabia',
+  'toxicExposure.gulfWar1990Details.neutralzone.endDate':
+    'Service end date for the neutral zone between Iraq and Saudi Arabia',
+  'toxicExposure.gulfWar1990Details.oman.startDate':
+    'Service start date for Oman',
+  'toxicExposure.gulfWar1990Details.oman.endDate': 'Service end date for Oman',
+  'toxicExposure.gulfWar1990Details.qatar.startDate':
+    'Service start date for Qatar',
+  'toxicExposure.gulfWar1990Details.qatar.endDate':
+    'Service end date for Qatar',
+  'toxicExposure.gulfWar1990Details.saudiarabia.startDate':
+    'Service start date for Saudi Arabia',
+  'toxicExposure.gulfWar1990Details.saudiarabia.endDate':
+    'Service end date for Saudi Arabia',
+  'toxicExposure.gulfWar1990Details.somalia.startDate':
+    'Service start date for Somalia',
+  'toxicExposure.gulfWar1990Details.somalia.endDate':
+    'Service end date for Somalia',
+  'toxicExposure.gulfWar1990Details.syria.startDate':
+    'Service start date for Syria',
+  'toxicExposure.gulfWar1990Details.syria.endDate':
+    'Service end date for Syria',
+  'toxicExposure.gulfWar1990Details.uae.startDate':
+    'Service start date for The United Arab Emirates (UAE)',
+  'toxicExposure.gulfWar1990Details.uae.endDate':
+    'Service end date for The United Arab Emirates (UAE)',
+  'toxicExposure.gulfWar1990Details.turkey.startDate':
+    'Service start date for Turkey',
+  'toxicExposure.gulfWar1990Details.turkey.endDate':
+    'Service end date for Turkey',
+  'toxicExposure.gulfWar1990Details.waters.startDate':
+    'Service start date for Oman',
+  'toxicExposure.gulfWar1990Details.waters.endDate':
+    'Service end date for Oman',
+  'toxicExposure.gulfWar1990Details.airspace.startDate':
+    'Service start date for the airspace above Gulf War locations on or after August 2, 1990',
+  'toxicExposure.gulfWar1990Details.airspace.endDate':
+    'Service end date for Gulf War locations on or after August 2, 1990',
+  'toxicExposure.gulfWar2001Details.djibouti.startDate':
+    'Service start date for Djibouti',
+  'toxicExposure.gulfWar2001Details.djibouti.endDate':
+    'Service end date for Djibouti',
+  'toxicExposure.gulfWar2001Details.lebanon.startDate':
+    'Service start date for Lebanon',
+  'toxicExposure.gulfWar2001Details.lebanon.endDate':
+    'Service end date for Lebanon',
+  'toxicExposure.gulfWar2001Details.uzbekistan.startDate':
+    'Service start date for Uzbekistan',
+  'toxicExposure.gulfWar2001Details.uzbekistan.endDate':
+    'Service end date for Uzbekistan',
+  'toxicExposure.gulfWar2001Details.yemen.startDate':
+    'Service start date for Yemen',
+  'toxicExposure.gulfWar2001Details.yemen.endDate':
+    'Service end date for Yemen',
+  'toxicExposure.gulfWar2001Details.airspace.startDate':
+    'Service start date for the airspace above Service post-9/11 locations',
+  'toxicExposure.gulfWar2001Details.airspace.endDate':
+    'Service end date for the airspace above Service post-9/11 locations',
+  'toxicExposure.herbicideDetails.cambodia.startDate':
+    'Service start date for Cambodia at Mimot or Krek, Kampong Cham Province',
+  'toxicExposure.herbicideDetails.cambodia.endDate':
+    'Service end date for Cambodia at Mimot or Krek, Kampong Cham Province',
+  'toxicExposure.herbicideDetails.guam.startDate':
+    'Service start date for Guam, American Samoa, or their territorial waters',
+  'toxicExposure.herbicideDetails.guam.endDate':
+    'Service end date for Guam, American Samoa, or their territorial waters',
+  'toxicExposure.herbicideDetails.koreandemilitarizedzone.startDate':
+    'Service start date for In or near the Korean demilitarized zone',
+  'toxicExposure.herbicideDetails.koreandemilitarizedzone.endDate':
+    'Service end date for In or near the Korean demilitarized zone',
+  'toxicExposure.herbicideDetails.johnston.startDate':
+    'Service start date for Johnston Atoll or on a ship that called at Johnston Atoll',
+  'toxicExposure.herbicideDetails.johnston.endDate':
+    'Service end date for Johnston Atoll or on a ship that called at Johnston Atoll',
+  'toxicExposure.herbicideDetails.laos.startDate':
+    'Service start date for Laos',
+  'toxicExposure.herbicideDetails.laos.endDate': 'Service end date for Laos',
+  'toxicExposure.herbicideDetails.c123.startDate':
+    'Service start date for Somewhere you had contact with C-123 airplanes while serving in the Air Force or the Air Force Reserves',
+  'toxicExposure.herbicideDetails.c123.endDate':
+    'Service end date for Somewhere you had contact with C-123 airplanes while serving in the Air Force or the Air Force Reserves',
+  'toxicExposure.herbicideDetails.thailand.startDate':
+    'Service start date for a U.S. or Royal Thai military base in Thailand',
+  'toxicExposure.herbicideDetails.thailand.endDate':
+    'Service end date for a U.S. or Royal Thai military base in Thailand',
+  'toxicExposure.herbicideDetails.vietnam.startDate':
+    'Service start date for Vietnam or the waters in or off of Vietnam',
+  'toxicExposure.herbicideDetails.vietnam.endDate':
+    'Service end date for Vietnam or the waters in or off of Vietnam',
+  'toxicExposure.otherHerbicideLocations.description':
+    'Agent Orange other locations',
+  'toxicExposure.otherExposuresDetails.asbestos.startDate':
+    'Exposure start date for Asbestos',
+  'toxicExposure.otherExposuresDetails.asbestos.endDate':
+    'Exposure end date for Asbestos',
+  'toxicExposure.otherExposuresDetails.chemical.startDate':
+    'Exposure start date for chemical and biological warfare testing through Project 112 or Project Shipboard Hazard and Defense (SHAD)',
+  'toxicExposure.otherExposuresDetails.chemical.endDate':
+    'Exposure end date for chemical and biological warfare testing through Project 112 or Project Shipboard Hazard and Defense (SHAD)',
+  'toxicExposure.otherExposuresDetails.water.startDate':
+    'Exposure start date for contaminated water at Camp Lejeune or MCAS New River, North Carolina',
+  'toxicExposure.otherExposuresDetails.water.endDate':
+    'Exposure end date for contaminated water at Camp Lejeune or MCAS New River, North Carolina',
+  'toxicExposure.otherExposuresDetails.mos.startDate':
+    'Exposure start date for Military Occupational Specialty (MOS)-related toxin',
+  'toxicExposure.otherExposuresDetails.mos.endDate':
+    'Exposure end date for Military Occupational Specialty (MOS)-related toxin',
+  'toxicExposure.otherExposuresDetails.mustardgas.startDate':
+    'Exposure start date for Mustard Gas',
+  'toxicExposure.otherExposuresDetails.mustardgas.endDate':
+    'Exposure end date for Mustard Gas',
+  'toxicExposure.otherExposuresDetails.radiation.startDate':
+    'Exposure start date for Radiation',
+  'toxicExposure.otherExposuresDetails.radiation.endDate':
+    'Exposure end date for Radiation',
+  'toxicExposure.specifyOtherExposures.description':
+    'Other toxic exposures not listed',
+  'toxicExposure.specifyOtherExposures.startDate':
+    'Exposure start date for other toxic exposures',
+  'toxicExposure.specifyOtherExposures.endDate':
+    'Exposure end date for other toxic exposures',
+  _override: error => {
+    if (Object.keys(teErrorToPage).includes(error)) {
+      return {
+        chapterKey: 'disabilities',
+        pageKey: teErrorToPage[error],
+      };
+    }
+
+    // always return null for non-matches
+    return null;
+  },
 };

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/additionalExposuresDetails.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/additionalExposuresDetails.unit.spec.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import sinon from 'sinon';
 import { expect } from 'chai';
 import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
 import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
@@ -14,6 +12,7 @@ import {
   exposureStartDateApproximate,
   notSureHazardDetails,
 } from '../../../content/toxicExposure';
+import { pageSubmitTest } from '../../unit.helpers.spec';
 
 /**
  * Unit tests for the additional exposures details pages. Verifies each page can render and submit with
@@ -93,18 +92,22 @@ describe('additional exposures details', () => {
       });
 
       it(`should submit without dates for ${itemId}`, () => {
-        const onSubmit = sinon.spy();
-        const { getByText } = render(
-          <DefinitionTester
-            schema={pageSchema.schema}
-            uiSchema={pageSchema.uiSchema}
-            data={formData}
-            onSubmit={onSubmit}
-          />,
+        pageSubmitTest(
+          schemas[`additional-exposure-${itemId}`],
+          formData,
+          true,
         );
+      });
 
-        userEvent.click(getByText('Submit'));
-        expect(onSubmit.calledOnce).to.be.true;
+      it(`should submit with both dates for ${itemId}`, () => {
+        const data = JSON.parse(JSON.stringify(formData));
+        data.toxicExposure.otherExposuresDetails = {};
+        data.toxicExposure.otherExposuresDetails[itemId] = {
+          startDate: '2020-05-19',
+          endDate: '2021-11-30',
+        };
+
+        pageSubmitTest(schemas[`additional-exposure-${itemId}`], data, true);
       });
     });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/gulfWar1990Details.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/gulfWar1990Details.unit.spec.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import sinon from 'sinon';
 import { expect } from 'chai';
 import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
 import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
@@ -14,6 +12,9 @@ import {
   startDateApproximate,
 } from '../../../content/toxicExposure';
 import { GULF_WAR_1990_LOCATIONS } from '../../../constants';
+import { pageSubmitTest } from '../../unit.helpers.spec';
+
+const schemas = { ...makePages() };
 
 /**
  * Unit tests for the gulf war 1990 details pages. Verifies each page can render and submit with
@@ -21,7 +22,6 @@ import { GULF_WAR_1990_LOCATIONS } from '../../../constants';
  * the location was selected.
  */
 describe('gulfWar1990Details', () => {
-  const schemas = { ...makePages() };
   const formData = {
     toxicExposure: {
       gulfWar1990: {
@@ -87,18 +87,139 @@ describe('gulfWar1990Details', () => {
       });
 
       it(`should submit without dates for ${locationId}`, () => {
-        const onSubmit = sinon.spy();
-        const { getByText } = render(
-          <DefinitionTester
-            schema={schemas[`gulf-war-1990-location-${locationId}`]?.schema}
-            uiSchema={schemas[`gulf-war-1990-location-${locationId}`]?.uiSchema}
-            data={formData}
-            onSubmit={onSubmit}
-          />,
+        pageSubmitTest(
+          schemas[`gulf-war-1990-location-${locationId}`],
+          formData,
+          true,
         );
+      });
 
-        userEvent.click(getByText('Submit'));
-        expect(onSubmit.calledOnce).to.be.true;
+      it(`should submit with both dates for ${locationId}`, () => {
+        const data = JSON.parse(JSON.stringify(formData));
+        data.toxicExposure.gulfWar1990Details = {};
+        data.toxicExposure.gulfWar1990Details[locationId] = {
+          startDate: '1990-01-01',
+          endDate: '1995-02-28',
+        };
+
+        pageSubmitTest(
+          schemas[`gulf-war-1990-location-${locationId}`],
+          data,
+          true,
+        );
       });
     });
+
+  // more things to test but would be heavy to test for every TE details page and location/hazard
+  it(`should submit with start date only`, () => {
+    const data = JSON.parse(JSON.stringify(formData));
+    data.toxicExposure.gulfWar1990Details = {
+      bahrain: {
+        startDate: '1990-01-01',
+      },
+    };
+
+    pageSubmitTest(schemas['gulf-war-1990-location-bahrain'], data, true);
+  });
+
+  it(`should submit with end date only`, () => {
+    const data = JSON.parse(JSON.stringify(formData));
+    data.toxicExposure.gulfWar1990Details = {
+      egypt: {
+        endDate: '1970-04-02',
+      },
+    };
+
+    pageSubmitTest(schemas['gulf-war-1990-location-egypt'], data, true);
+  });
+
+  it(`should submit with both dates and not sure`, () => {
+    const data = JSON.parse(JSON.stringify(formData));
+    data.toxicExposure.gulfWar1990Details = {
+      saudiarabia: {
+        startDate: '1991-06-03',
+        endDate: '1992-07-04',
+        'view:notSure': true,
+      },
+    };
+
+    pageSubmitTest(schemas['gulf-war-1990-location-saudiarabia'], data, true);
+  });
+
+  it(`should not submit when empty month`, () => {
+    const data = JSON.parse(JSON.stringify(formData));
+    data.toxicExposure.gulfWar1990Details = {
+      jordan: {
+        startDate: '1990-XX-05',
+      },
+    };
+
+    pageSubmitTest(schemas['gulf-war-1990-location-jordan'], data, false);
+  });
+
+  it(`should not submit when empty day`, () => {
+    const data = JSON.parse(JSON.stringify(formData));
+    data.toxicExposure.gulfWar1990Details = {
+      kuwait: {
+        startDate: '1990-01-XX',
+      },
+    };
+
+    pageSubmitTest(schemas['gulf-war-1990-location-kuwait'], data, false);
+  });
+
+  it(`should not submit when empty year`, () => {
+    const data = JSON.parse(JSON.stringify(formData));
+    data.toxicExposure.gulfWar1990Details = {
+      neutralzone: {
+        startDate: 'XXXX-01-01',
+      },
+    };
+
+    pageSubmitTest(schemas['gulf-war-1990-location-neutralzone'], data, false);
+  });
+
+  it(`should not submit when non numeric chars`, () => {
+    const data = JSON.parse(JSON.stringify(formData));
+    data.toxicExposure.gulfWar1990Details = {
+      oman: {
+        startDate: 'abcd-xy-yz',
+      },
+    };
+
+    pageSubmitTest(schemas['gulf-war-1990-location-oman'], data, false);
+  });
+
+  it(`should not submit when two digit year`, () => {
+    const data = JSON.parse(JSON.stringify(formData));
+    data.toxicExposure.gulfWar1990Details = {
+      qatar: {
+        startDate: '77-05-20',
+      },
+    };
+
+    pageSubmitTest(schemas['gulf-war-1990-location-qatar'], data, false);
+  });
+
+  it(`should not submit when future date`, () => {
+    const data = JSON.parse(JSON.stringify(formData));
+    data.toxicExposure.gulfWar1990Details = {
+      uae: {
+        startDate: '2030-08-22',
+      },
+    };
+
+    pageSubmitTest(schemas['gulf-war-1990-location-uae'], data, false);
+  });
+
+  it(`should not submit when very old date`, () => {
+    const data = JSON.parse(JSON.stringify(formData));
+    data.toxicExposure.gulfWar1990Details = {
+      turkey: {
+        startDate: '1800-09-25',
+      },
+    };
+
+    pageSubmitTest(schemas['gulf-war-1990-location-turkey'], data, false);
+  });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/gulfWar1990Details.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/gulfWar1990Details.unit.spec.jsx
@@ -110,7 +110,10 @@ describe('gulfWar1990Details', () => {
       });
     });
 
-  // more things to test but would be heavy to test for every TE details page and location/hazard
+  /* more things to test but would be heavy to test for every TE details page and 
+  location/hazard. since all the TE pages are similarly setup, we'll test edge 
+  cases here. all pages should test for submission with no dates and with both dates.
+  */
   it(`should submit with start date only`, () => {
     const data = JSON.parse(JSON.stringify(formData));
     data.toxicExposure.gulfWar1990Details = {

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/gulfWar2001Details.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/gulfWar2001Details.unit.spec.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import sinon from 'sinon';
 import { expect } from 'chai';
 import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
 import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
@@ -14,6 +12,7 @@ import {
   startDateApproximate,
 } from '../../../content/toxicExposure';
 import { GULF_WAR_2001_LOCATIONS } from '../../../constants';
+import { pageSubmitTest } from '../../unit.helpers.spec';
 
 /**
  * Unit tests for the gulf war 2001 details pages. Verifies each page can render and submit with
@@ -87,18 +86,26 @@ describe('gulfWar2001Details', () => {
       });
 
       it(`should submit without dates for ${locationId}`, () => {
-        const onSubmit = sinon.spy();
-        const { getByText } = render(
-          <DefinitionTester
-            schema={pageSchema.schema}
-            uiSchema={pageSchema.uiSchema}
-            data={formData}
-            onSubmit={onSubmit}
-          />,
+        pageSubmitTest(
+          schemas[`gulf-war-2001-location-${locationId}`],
+          formData,
+          true,
         );
+      });
 
-        userEvent.click(getByText('Submit'));
-        expect(onSubmit.calledOnce).to.be.true;
+      it(`should submit with both dates for ${locationId}`, () => {
+        const data = JSON.parse(JSON.stringify(formData));
+        data.toxicExposure.gulfWar2001Details = {};
+        data.toxicExposure.gulfWar2001Details[locationId] = {
+          startDate: '2002-10-15',
+          endDate: '2004-03-31',
+        };
+
+        pageSubmitTest(
+          schemas[`gulf-war-2001-location-${locationId}`],
+          data,
+          true,
+        );
       });
     });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideDetails.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideDetails.unit.spec.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import sinon from 'sinon';
 import { expect } from 'chai';
 import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
 import { $ } from '@department-of-veterans-affairs/platform-forms-system/ui';
@@ -14,6 +12,7 @@ import {
   notSureDatesDetails,
   startDateApproximate,
 } from '../../../content/toxicExposure';
+import { pageSubmitTest } from '../../unit.helpers.spec';
 
 /**
  * Unit tests for the herbicide details pages. Verifies each page can render and submit with
@@ -87,18 +86,22 @@ describe('herbicideDetails', () => {
       });
 
       it(`should submit without dates for ${locationId}`, () => {
-        const onSubmit = sinon.spy();
-        const { getByText } = render(
-          <DefinitionTester
-            schema={pageSchema.schema}
-            uiSchema={pageSchema.uiSchema}
-            data={formData}
-            onSubmit={onSubmit}
-          />,
+        pageSubmitTest(
+          schemas[`herbicide-location-${locationId}`],
+          formData,
+          true,
         );
+      });
 
-        userEvent.click(getByText('Submit'));
-        expect(onSubmit.calledOnce).to.be.true;
+      it(`should submit with both dates for ${locationId}`, () => {
+        const data = JSON.parse(JSON.stringify(formData));
+        data.toxicExposure.herbicideDetails = {};
+        data.toxicExposure.herbicideDetails[locationId] = {
+          startDate: '1975-04-02',
+          endDate: '1978-08-05',
+        };
+
+        pageSubmitTest(schemas[`herbicide-location-${locationId}`], data, true);
       });
     });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideOtherLocations.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/herbicideOtherLocations.unit.spec.jsx
@@ -11,6 +11,20 @@ import {
   notSureDatesDetails,
   startDateApproximate,
 } from '../../../content/toxicExposure';
+import { pageSubmitTest } from '../../unit.helpers.spec';
+
+const formData = {
+  toxicExposure: {
+    herbicide: {
+      cambodia: true,
+      koreandemilitarizedzone: false,
+      laos: true,
+    },
+    otherHerbicideLocations: {
+      description: 'Test Location 1',
+    },
+  },
+};
 
 describe('Herbicide Other Locations', () => {
   const {
@@ -19,19 +33,6 @@ describe('Herbicide Other Locations', () => {
   } = formConfig.chapters.disabilities.pages.herbicideOtherLocations;
 
   it('should render', () => {
-    const formData = {
-      toxicExposure: {
-        herbicide: {
-          cambodia: true,
-          koreandemilitarizedzone: false,
-          laos: true,
-        },
-        otherHerbicideLocations: {
-          description: 'Test Location 1',
-        },
-      },
-    };
-
     const { container, getByText } = render(
       <DefinitionTester schema={schema} uiSchema={uiSchema} data={formData} />,
     );
@@ -59,6 +60,26 @@ describe('Herbicide Other Locations', () => {
     expect(addlInfo).to.have.attribute(
       'trigger',
       'What if I have more than one date range?',
+    );
+  });
+
+  it('should submit without dates', () => {
+    pageSubmitTest(
+      formConfig.chapters.disabilities.pages.herbicideOtherLocations,
+      formData,
+      true,
+    );
+  });
+
+  it('should submit with both dates', () => {
+    const data = JSON.parse(JSON.stringify(formData));
+    data.toxicExposure.otherHerbicideLocations.startDate = '2021-12-22';
+    data.toxicExposure.otherHerbicideLocations.endDate = '2023-01-09';
+
+    pageSubmitTest(
+      formConfig.chapters.disabilities.pages.herbicideOtherLocations,
+      data,
+      true,
     );
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/specifyOtherExposures.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/toxicExposure/specifyOtherExposures.unit.spec.jsx
@@ -11,6 +11,33 @@ import {
   exposureStartDateApproximate,
   notSureHazardDetails,
 } from '../../../content/toxicExposure';
+import { pageSubmitTest } from '../../unit.helpers.spec';
+
+const formData = {
+  toxicExposure: {
+    otherExposures: {
+      asbestos: true,
+      mos: true,
+      notsure: true,
+    },
+    otherExposuresDetails: {
+      asbestos: {
+        startDate: '1995-02-01',
+        endDate: '1997-03-05',
+      },
+      chemical: {},
+      water: {},
+      mos: {},
+      mustardgas: {},
+      radiation: {},
+    },
+    specifyOtherExposures: {
+      description: 'Test Substance',
+      startDate: '2000-05-20',
+      endDate: '2001-03-01',
+    },
+  },
+};
 
 describe('Specify Other Exposures', () => {
   const {
@@ -19,32 +46,6 @@ describe('Specify Other Exposures', () => {
   } = formConfig.chapters.disabilities.pages.specifyOtherExposures;
 
   it('should render', () => {
-    const formData = {
-      toxicExposure: {
-        otherExposures: {
-          asbestos: true,
-          mos: true,
-          notsure: true,
-        },
-        otherExposuresDetails: {
-          asbestos: {
-            startDate: '1995-02-01',
-            endDate: '1997-03-05',
-          },
-          chemical: {},
-          water: {},
-          mos: {},
-          mustardgas: {},
-          radiation: {},
-        },
-        specifyOtherExposures: {
-          description: 'Test Substance',
-          startDate: '2000-05-20',
-          endDate: '2001-03-01',
-        },
-      },
-    };
-
     const { container, getByText } = render(
       <DefinitionTester schema={schema} uiSchema={uiSchema} data={formData} />,
     );
@@ -77,6 +78,26 @@ describe('Specify Other Exposures', () => {
     expect(addlInfo).to.have.attribute(
       'trigger',
       'What if I have more than one date range?',
+    );
+  });
+
+  it('should submit without dates', () => {
+    const dataNoDates = JSON.parse(JSON.stringify(formData));
+    dataNoDates.toxicExposure.specifyOtherExposures.startDate = undefined;
+    dataNoDates.toxicExposure.specifyOtherExposures.endDate = undefined;
+
+    pageSubmitTest(
+      formConfig.chapters.disabilities.pages.specifyOtherExposures,
+      dataNoDates,
+      true,
+    );
+  });
+
+  it('should submit with both dates', () => {
+    pageSubmitTest(
+      formConfig.chapters.disabilities.pages.specifyOtherExposures,
+      formData,
+      true,
     );
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/reviewErrors.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/reviewErrors.unit.spec.js
@@ -16,4 +16,92 @@ describe('reviewErrors', () => {
       expect(reviewErrors.newDisabilities()).to.equal(null);
     });
   });
+
+  describe('toxicExposure', () => {
+    it('builds error for gulf war 1990 details page', () => {
+      const res = reviewErrors._override(
+        'toxicExposure.gulfWar1990Details.afghanistan.startDate',
+      );
+
+      expect(typeof res).to.equal('object');
+      expect(res.chapterKey).to.equal('disabilities');
+      expect(res.pageKey).to.equal('gulf-war-1990-location-afghanistan');
+    });
+
+    it('builds error for gulf war 2001 details page', () => {
+      const res = reviewErrors._override(
+        'toxicExposure.gulfWar2001Details.lebanon.endDate',
+      );
+
+      expect(typeof res).to.equal('object');
+      expect(res.chapterKey).to.equal('disabilities');
+      expect(res.pageKey).to.equal('gulf-war-2001-location-lebanon');
+    });
+
+    it('builds error for herbicide details page', () => {
+      const res = reviewErrors._override(
+        'toxicExposure.herbicideDetails.cambodia.startDate',
+      );
+
+      expect(typeof res).to.equal('object');
+      expect(res.chapterKey).to.equal('disabilities');
+      expect(res.pageKey).to.equal('herbicide-location-cambodia');
+    });
+
+    it('builds error for other exposure details', () => {
+      const res = reviewErrors._override(
+        'toxicExposure.otherExposureDetails.mos.startDate',
+      );
+
+      expect(typeof res).to.equal('object');
+      expect(res.chapterKey).to.equal('disabilities');
+      expect(res.pageKey).to.equal('additional-exposure-mos');
+    });
+
+    it('builds error for other herbicide locations', () => {
+      const res = reviewErrors._override(
+        'toxicExposure.otherHerbicideLocations.startDate',
+      );
+
+      expect(typeof res).to.equal('object');
+      expect(res.chapterKey).to.equal('disabilities');
+      expect(res.pageKey).to.equal('herbicide-location-other');
+    });
+
+    it('builds error for other exposures details page', () => {
+      const res = reviewErrors._override(
+        'toxicExposure.specifyOtherExposures.endDate',
+      );
+
+      expect(typeof res).to.equal('object');
+      expect(res.chapterKey).to.equal('disabilities');
+      expect(res.pageKey).to.equal('additional-exposure-other');
+    });
+
+    it('builds error for herbicide locations page', () => {
+      const res = reviewErrors._override(
+        'toxicExposure.otherHerbicideLocations.description',
+      );
+
+      expect(typeof res).to.equal('object');
+      expect(res.chapterKey).to.equal('disabilities');
+      expect(res.pageKey).to.equal('herbicideLocations');
+    });
+
+    it('builds error for additional exposures page', () => {
+      const res = reviewErrors._override(
+        'toxicExposure.specifyOtherExposures.description',
+      );
+
+      expect(typeof res).to.equal('object');
+      expect(res.chapterKey).to.equal('disabilities');
+      expect(res.pageKey).to.equal('additional-exposures');
+    });
+  });
+
+  describe('default', () => {
+    it('handles key not found', () => {
+      expect(reviewErrors._override('foo.bar.foo')).to.equal(null);
+    });
+  });
 });

--- a/src/applications/disability-benefits/all-claims/tests/reviewErrors.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/reviewErrors.unit.spec.js
@@ -50,7 +50,7 @@ describe('reviewErrors', () => {
 
     it('builds error for other exposure details', () => {
       const res = reviewErrors._override(
-        'toxicExposure.otherExposureDetails.mos.startDate',
+        'toxicExposure.otherExposuresDetails.mos.startDate',
       );
 
       expect(typeof res).to.equal('object');

--- a/src/applications/disability-benefits/all-claims/tests/unit.helpers.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/unit.helpers.spec.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import sinon from 'sinon';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+import { DefinitionTester } from '@department-of-veterans-affairs/platform-testing/schemaform-utils';
+
+/**
+ * Helper to verify a page submits or does not submit successfully based on given form data
+ *
+ * @param {object} schemaDefinition - page schema
+ * @param {object} formData - form data for the page
+ * @param {boolean} isSuccessfulSubmit - true if the submit should be successful, false otherwise
+ */
+export function pageSubmitTest(schemaDefinition, formData, isSuccessfulSubmit) {
+  const onSubmit = sinon.spy();
+  const { getByText } = render(
+    <DefinitionTester
+      schema={schemaDefinition?.schema}
+      uiSchema={schemaDefinition?.uiSchema}
+      data={formData}
+      onSubmit={onSubmit}
+    />,
+  );
+
+  userEvent.click(getByText('Submit'));
+
+  if (isSuccessfulSubmit) {
+    expect(onSubmit.calledOnce).to.be.true;
+  } else {
+    expect(onSubmit.calledOnce).to.be.false;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -21251,9 +21251,9 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#a2088d24571c7d4b83f3fe50a28a2d75e2904fe5":
-  version "24.3.3"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#a2088d24571c7d4b83f3fe50a28a2d75e2904fe5"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#be610f6623ef1fac432e5616372d4a5eadb93773":
+  version "24.4.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#be610f6623ef1fac432e5616372d4a5eadb93773"
   dependencies:
     minimist "^1.2.3"
 


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

###  TeamSites 
Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- Update FE schema used for toxic exposure dates to no longer allow X's in years which were causing submission failures
- Error message improvements on the review page
- More unit tests to check for valid and invalid date submission
- Dependent on vets-json-schema change
https://github.com/department-of-veterans-affairs/vets-json-schema/pull/939

team: @department-of-veterans-affairs/dbex-trex 

## Related issue(s)
- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#93403

## Testing done
- Unit tests updated and lots of manual testing

**Manual test setup**
1. Enable toggle `disability_526_toxic_exposure`
2. Start a new claim with new conditions
3. On the toxic-exposure/conditions page, select at least one new condition
4. For each of the TE locations or hazards questions, select at least one hazard or question
5. **regression:** enter full dates (month, day, year) on a TE details page. **verify**: date(s) are saved and claim can be submitted
6. **new:** enter month + day + partial year on a TE details page.  **verify** error message displays on the page "Please enter a valid current or past date" or "Please enter a year between 1900 and 2124", depending on what was entered.
7. **new:** for step 6, if somehow you are able to get the date saved and move forward (known issue with the component), continue all the way to the review page and try to submit. **verify** new error message displays on the review page (as shown in screenshot)

## Screenshots
Both screenshots were built with the same formData. Invalid or empty dates were used for the years and invalid chars (e.g. `(` or `?`) were used for the other locations and hazards fields. Note how we are doing more validations here for the year, so more error messages display on the review page. We also added friendly error messages for parsing issues on the pages with other herbicide locations and other exposures fields.

Each of the links goes to the tops of the Conditions section and the page itself should be expanded within it in edit mode. 
[93403 review errors pr.pdf](https://github.com/user-attachments/files/17234482/93403.review.errors.pr.pdf)

## What areas of the site does it impact?
526ez

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [n/a] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [n/a] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
none
