### PR TITLE
10-7959f-1 Toggler Fix

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/App.jsx
@@ -4,10 +4,8 @@ import {
   externalServices,
 } from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
 import PropTypes from 'prop-types';
-import { Toggler } from 'platform/utilities/feature-toggles';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
-import WIP from '../../shared/components/WIP';
 import formConfig from '../config/form';
 
 export default function App({ location, children }) {
@@ -26,30 +24,15 @@ export default function App({ location, children }) {
   const bcString = JSON.stringify(breadcrumbList);
   return (
     <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
-      <Toggler toggleName={Toggler.TOGGLE_NAMES.form107959F1}>
-        <Toggler.Enabled>
-          <va-breadcrumbs breadcrumb-list={bcString} />
-          <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-            <DowntimeNotification
-              appTitle={`CHAMPVA Form ${formConfig.formId}`}
-              dependencies={[externalServices.pega]}
-            >
-              {children}
-            </DowntimeNotification>
-          </RoutedSavableApp>
-        </Toggler.Enabled>
-        <Toggler.Disabled>
-          <br />
-          <WIP
-            content={{
-              description:
-                'We’re rolling out the Foreign Medical Program (FMP) registration (VA Form 10-7959f-1) in stages. It’s not quite ready yet. Please check back again soon.',
-              redirectLink: '/',
-              redirectText: 'Return to VA home page',
-            }}
-          />
-        </Toggler.Disabled>
-      </Toggler>
+      <va-breadcrumbs breadcrumb-list={bcString} />
+      <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+        <DowntimeNotification
+          appTitle={`CHAMPVA Form ${formConfig.formId}`}
+          dependencies={[externalServices.pega]}
+        >
+          {children}
+        </DowntimeNotification>
+      </RoutedSavableApp>
     </div>
   );
 }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR removes the toggler and WIP warning box from the form itself so that the react widget can handle the routing. 

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/93951

## Testing done
unit tests
e2e

## Screenshots

## What areas of the site does it impact?
this form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback
NA