### PR TITLE
Update SASS imports & vars in the Caregiver app to meet DST standards

### DIFF
--- a/src/applications/caregivers/sass/_facilitiesSearch.scss
+++ b/src/applications/caregivers/sass/_facilitiesSearch.scss
@@ -1,5 +1,3 @@
-@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
-
 .caregiver-facilities-search-input-error {
   border-left: 0.25rem solid var(--vads-color-error-dark);
   padding-left: 1rem;

--- a/src/applications/caregivers/sass/_submitLoader.scss
+++ b/src/applications/caregivers/sass/_submitLoader.scss
@@ -13,7 +13,7 @@
     line-height: 40px;
   }
 
-  @include media($medium-screen) {
+  @include media(var(--medium-screen)) {
     max-width: 75%;
   }
 }

--- a/src/applications/caregivers/sass/caregivers.scss
+++ b/src/applications/caregivers/sass/caregivers.scss
@@ -1,4 +1,4 @@
-@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+@import "~@department-of-veterans-affairs/css-library/dist/stylesheets/mixins";
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/modules/m-process-list";
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/modules/m-form-process";
 @import "~@department-of-veterans-affairs/css-library/dist/stylesheets/modules/m-modal";


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

Per a [DSVA post](https://dsva.slack.com/archives/C5HP4GN3F/p1727731554166469) on 9/30, the Design System Team is starting on some of the final steps to move off of Formation. One of those steps is removing the shared-variables import from everywhere it is currently used. This PR removes this import from the Caregiver application and updates the method variables are referenced in the stylesheet(s).

## Acceptance criteria

 - The Caregiver application does not include any redundant imports

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution