### PR TITLE
Reset yes/no question answer

### DIFF
--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -138,8 +138,18 @@ export default function ArrayBuilderSummaryPage({
         }
       };
 
+      const resetYesNo = () => {
+        // We shouldn't persist the 'yes' answer after an item is entered/cancelled
+        // We should ask the yes/no question again after an item is entered/cancelled
+        // Since it is required, it shouldn't be left null/undefined
+        if (props.data[hasItemsKey]) {
+          props.setData({ ...props.data, [hasItemsKey]: undefined });
+        }
+      };
+
       cleanupEmptyItems();
       redirectToIntroIfEmpty();
+      resetYesNo();
     }, []);
 
     useEffect(

--- a/src/platform/forms-system/src/js/patterns/array-builder/README.md
+++ b/src/platform/forms-system/src/js/patterns/array-builder/README.md
@@ -298,10 +298,10 @@ export const nounPluralReplaceMePages = arrayBuilderPages( options,
 ## Web Component Patterns
 | Pattern | Description |
 |---------|-------------|
-| `arrayBuilderItemFirstPageTitleUI` | Should be used instead of `titleUI` for the first item page. Includes adding "Edit" before the title if in edit mode, and showing a `va-alert` warning if an item is required when removing all. |
+| `arrayBuilderItemFirstPageTitleUI` | Should be used instead of `titleUI` for the first item page. Includes adding "Edit" before the title if in edit mode, and showing a `va-alert` warning if an item is required when removing all. The description instructions can optionally be hidden when their is only one item page via the `hasMultipleItemPages: false` function parameter. |
 | `arrayBuilderItemSubsequentPageTitleUI` | Can be used instead of `titleUI` for subsequent item pages. Includes adding "Edit" before the title if in edit mode. If you need to use a custom title instead, you can try passing `withEditTitle` into your implementation. |
-| `withEditTitle` | Used with `arrayBuilderItemFirstPageTitleUI` and `arrayBuilderItemSubsequentPageTitleUI` to show "Edit" before the title, provided as an export for custom use. |
-| `arrayBuilderYesNoUI` | Should be used instead of `yesNoUI` for the summary page. Has dynamic text for if the user has 0 items, or more 1+ items, and validation for max items. You can override all text values. |
+| `withEditTitle` | Used with `arrayBuilderItemFirstPageTitleUI` and `arrayBuilderItemSubsequentPageTitleUI` to show "Edit" before the title, provided as an export for custom use. The "Edit" title item can be optionally lowercased via the `lowerCase` function parameter. |
+| `arrayBuilderYesNoUI` | Should be used instead of `yesNoUI` for the summary page. Has dynamic text for if the user has 0 items, or more 1+ items, and validation for max items. After an item is added/cancelled the yes/no question is reset. You can override all text values. |
 
 ### Example `arrayBuilderYesNoUI` Text Overrides:
 ```js

--- a/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.js
+++ b/src/platform/forms-system/src/js/patterns/array-builder/tests/arrayBuilderSummaryPage.unit.spec.js
@@ -201,7 +201,9 @@ describe('ArrayBuilderSummaryPage', () => {
       maxItems: 5,
     });
 
-    expect(container.querySelector('va-radio')).to.exist;
+    const vaRadio = container.querySelector('va-radio');
+    expect(vaRadio).to.exist;
+    expect(vaRadio.getAttribute('value')).to.equal('false');
     expect(container.querySelector('va-card')).to.exist;
   });
 


### PR DESCRIPTION
Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes

## Description
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93219

Enhance Multiple Page List & Loop Pattern Add Another Item

When the user is asked whether they have more items to be added via the [Array Builder Pattern(Multiple responses list & loop)](https://github.com/department-of-veterans-affairs/vets-website/blob/main/src/platform/forms-system/src/js/patterns/array-builder/README.md) 'Yes' is already selected. 

The [arrayBuilderPattern](https://github.com/department-of-veterans-affairs/vets-website/blob/f35f7ab080fb6fb375c250fd6a4f9f762a38c6f6/src/platform/forms-system/src/js/types.js) follow up question should not have 'Yes' selected after an item is added or cancelled.

## Summary of Changes
When the array builder summary page is loaded, it checks if 'Yes' is selected. If 'Yes' is selected and the user has returned from entering an item or cancelled adding an item, it resets the yes/no to unanswered(undefined). Since this question is required, it must be false before continuing the form.

If 'No' is selected, then the form data is not reset.

Added new functionality to README.md.

## How to run in local environment

1. Check out this branch locally
2. Run `vets-website` and `vets-api`
3. In your local environment, set the `pension_multiple_page_response` flipper to 'enabled' at http://localhost:3000/flipper/features/pension_multiple_page_response
4. Go to `http://localhost:3001/pension/apply-for-veteran-pension-form-21p-527ez/` in your browser

## How to verify
### Add item
1. Go to a multiple page response summary page (e.g. military/other-names/summary)
2. Select 'Yes' and add an item
3. Verify that the 'Do you have another ${nounSingular} to add' question does is not answered or 'No'

### Edit an item
1. Go to a multiple page response summary page (e.g. military/other-names/summary)
2. 'Edit' an existing item
4. Verify that the 'Do you have another ${nounSingular} to add' question does is not answered or 'No'

### Cancel adding or editing an item
1. Go to a multiple page response summary page (e.g. military/other-names/summary)
2. Select 'Yes' and add an item or 'Edit' an existing item
3. Cancel adding or editing an item
4. Verify that the 'Do you have another ${nounSingular} to add' question does is not 'Yes'

### Navigation
1. Go to a multiple page response summary page (e.g. military/other-names/summary)
2. Add an item(s) and return to summary page
3. Select 'No' on ''Do you have another ${nounSingular} to add' and continue
4. Navigate back to the summary page
5. Verify that the 'Do you have another ${nounSingular} to add' question does is still 'No'


## Screenshots
### After an item is added/cancelled
| Before | After |
| ------ | ------ |
|![Screenshot 2024-10-01 at 11 22 48 AM](https://github.com/user-attachments/assets/ccfa1b82-f244-4ca8-876b-ff3d23cb97ba)|![Screenshot 2024-10-01 at 11 21 37 AM](https://github.com/user-attachments/assets/ebf259a8-f8c7-406f-b71d-6ac3232dd4e0)|

## What areas of the site does it impact?
Multi-page response pattern

### Quality Assurance & Testing
- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
