### PR TITLE
Global | Print confirmation page CSS changes

### DIFF
--- a/src/applications/appeals/10182/components/ConfirmationPageV2.jsx
+++ b/src/applications/appeals/10182/components/ConfirmationPageV2.jsx
@@ -48,6 +48,7 @@ export const ConfirmationPageV2 = () => {
           alt="VA logo"
           width="300"
         />
+        <h2 className="vads-u-margin-top--0">Request a Board Appeal</h2>
       </div>
 
       <va-alert status="success" ref={alertRef} uswds>

--- a/src/applications/appeals/996/sass/0996-higher-level-review.scss
+++ b/src/applications/appeals/996/sass/0996-higher-level-review.scss
@@ -185,29 +185,3 @@ article[data-location="review-and-submit"] {
     font-weight: normal;
   }
 }
-
-/* Confirmation page */
-article[data-location="confirmation"] {
-  h1[tabindex="-1"] {
-    outline: none;
-  }
-
-  @media print {
-    .confirmation-page-title,
-    a {
-      text-align: left;
-      padding-left: 0;
-    }
-  }
-}
-
-@media print {
-  .usa-width-two-thirds {
-    width: 100%;
-  }
-
-  .schemaform-title,
-  .schemaform-subtitle {
-    display: none;
-  }
-}

--- a/src/applications/appeals/shared/components/ConfirmationDecisionReviews.jsx
+++ b/src/applications/appeals/shared/components/ConfirmationDecisionReviews.jsx
@@ -55,7 +55,7 @@ export const ConfirmationDecisionReviews = ({
           alt="VA logo"
           width="300"
         />
-        <h2>{pageTitle}</h2>
+        <h2 className="vads-u-margin-top--0">{pageTitle}</h2>
       </div>
 
       <va-alert status="success" ref={alertRef} uswds>

--- a/src/applications/appeals/shared/sass/appeals.scss
+++ b/src/applications/appeals/shared/sass/appeals.scss
@@ -120,3 +120,11 @@ article[data-location="review-and-submit"] {
     text-align: left;
   }
 }
+
+@media print {
+  body[data-location="confirmation"] {
+    h1 {
+      display: none;
+    }
+  }
+}

--- a/src/platform/forms-system/src/js/containers/ConfirmationPage.jsx
+++ b/src/platform/forms-system/src/js/containers/ConfirmationPage.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Added this confirmation page wrapper to allow global customization of the
+ * print view.
+ */
+const ConfirmationPage = props => {
+  const { formConfig } = props.route || {};
+  const Confirmation = formConfig.confirmation || null;
+  return <Confirmation {...props} />;
+};
+
+ConfirmationPage.propTypes = {
+  route: PropTypes.shape({
+    formConfig: PropTypes.shape({
+      confirmation: PropTypes.element,
+    }),
+  }),
+};
+
+export default ConfirmationPage;

--- a/src/platform/forms-system/src/js/containers/FormApp.jsx
+++ b/src/platform/forms-system/src/js/containers/FormApp.jsx
@@ -99,7 +99,9 @@ const FormApp = props => {
     );
   }
   const wrapperClass =
-    notProd && fullWidth ? '' : 'usa-width-two-thirds medium-8 columns';
+    notProd && fullWidth
+      ? ''
+      : 'usa-width-two-thirds medium-8 columns print-full-width';
 
   return (
     <div className="form-app">

--- a/src/platform/forms-system/src/js/containers/FormApp.jsx
+++ b/src/platform/forms-system/src/js/containers/FormApp.jsx
@@ -30,6 +30,14 @@ const FormApp = props => {
     }
   }, []);
 
+  useEffect(
+    () => {
+      // Set current location in data-location for custom CSS
+      document.body.dataset.location = currentLocation.pathname.slice(1);
+    },
+    [currentLocation.pathname],
+  );
+
   const nonFormPages = additionalRoutes
     ? additionalRoutes.map(route => route.path)
     : [];

--- a/src/platform/forms-system/src/js/containers/FormApp.jsx
+++ b/src/platform/forms-system/src/js/containers/FormApp.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 import PropTypes from 'prop-types';
@@ -16,113 +16,110 @@ const { Element } = Scroll;
 /*
  * Primary component for a schema generated form app.
  */
-class FormApp extends React.Component {
-  /* eslint-disable-next-line camelcase */
-  UNSAFE_componentWillMount() {
-    const { additionalRoutes } = this.props.formConfig;
-    this.nonFormPages = [];
-    if (additionalRoutes) {
-      this.nonFormPages = additionalRoutes.map(route => route.path);
-    }
+const FormApp = props => {
+  const { currentLocation, formConfig, children, formData } = props;
+  const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
+  const lastPathComponent = currentLocation.pathname.split('/').pop();
+  const { additionalRoutes, CustomTopContent } = formConfig;
 
+  useEffect(() => {
     setGlobalScroll();
 
     if (window.History) {
       window.History.scrollRestoration = 'manual';
     }
+  }, []);
+
+  const nonFormPages = additionalRoutes
+    ? additionalRoutes.map(route => route.path)
+    : [];
+
+  const isIntroductionPage = trimmedPathname.endsWith('introduction');
+  const isNonFormPage = nonFormPages.includes(lastPathComponent);
+  const Footer = formConfig.footerContent;
+  const title =
+    typeof formConfig.title === 'function'
+      ? formConfig.title(props)
+      : formConfig.title;
+  const subTitle =
+    typeof formConfig.subTitle === 'function'
+      ? formConfig.subTitle(props)
+      : formConfig.subTitle;
+  const { noTitle, noTopNav, fullWidth } = formConfig?.formOptions || {};
+  const notProd = !environment.isProduction();
+  const hasHiddenFormTitle = hideFormTitle(formConfig, trimmedPathname);
+  let useTopBackLink = false;
+
+  let formTitle;
+  let formNav;
+  let renderedChildren = children;
+  // Show title only if:
+  // 1. we're not on the intro page *or* one of the additionalRoutes
+  //    specified in the form config
+  // 2. there is a title specified in the form config
+  if (!isIntroductionPage && !isNonFormPage && !hasHiddenFormTitle && title) {
+    formTitle = <FormTitle title={title} subTitle={subTitle} />;
   }
 
-  render() {
-    const { currentLocation, formConfig, children, formData } = this.props;
-    const trimmedPathname = currentLocation.pathname.replace(/\/$/, '');
-    const lastPathComponent = currentLocation.pathname.split('/').pop();
-    const isIntroductionPage = trimmedPathname.endsWith('introduction');
-    const isNonFormPage = this.nonFormPages.includes(lastPathComponent);
-    const Footer = formConfig.footerContent;
-    const title =
-      typeof formConfig.title === 'function'
-        ? formConfig.title(this.props)
-        : formConfig.title;
-    const subTitle =
-      typeof formConfig.subTitle === 'function'
-        ? formConfig.subTitle(this.props)
-        : formConfig.subTitle;
-    const { noTitle, noTopNav, fullWidth } = formConfig?.formOptions || {};
-    const notProd = !environment.isProduction();
-    const hasHiddenFormTitle = hideFormTitle(formConfig, trimmedPathname);
-    let useTopBackLink = false;
-    const { CustomTopContent } = formConfig;
+  if (!isNonFormPage) {
+    useTopBackLink = formConfig.useTopBackLink;
+  }
 
-    let formTitle;
-    let formNav;
-    let renderedChildren = children;
-    // Show title only if:
-    // 1. we're not on the intro page *or* one of the additionalRoutes
-    //    specified in the form config
-    // 2. there is a title specified in the form config
-    if (!isIntroductionPage && !isNonFormPage && !hasHiddenFormTitle && title) {
-      formTitle = <FormTitle title={title} subTitle={subTitle} />;
-    }
+  // Show nav only if we're not on the intro, form-saved, error, confirmation
+  // page or one of the additionalRoutes specified in the form config
+  // Also add form classes only if on an actual form page
+  if (!isNonFormPage && isInProgress(trimmedPathname)) {
+    formNav = (
+      <FormNav
+        formData={formData}
+        formConfig={formConfig}
+        currentPath={trimmedPathname}
+        isLoggedIn={props.isLoggedIn}
+        inProgressFormId={props.inProgressFormId}
+      />
+    );
 
-    if (!isNonFormPage) {
-      useTopBackLink = formConfig.useTopBackLink;
-    }
-
-    // Show nav only if we're not on the intro, form-saved, error, confirmation
-    // page or one of the additionalRoutes specified in the form config
-    // Also add form classes only if on an actual form page
-    if (!isNonFormPage && isInProgress(trimmedPathname)) {
-      formNav = (
-        <FormNav
-          formData={formData}
-          formConfig={formConfig}
-          currentPath={trimmedPathname}
-          isLoggedIn={this.props.isLoggedIn}
-          inProgressFormId={this.props.inProgressFormId}
-        />
-      );
-
-      renderedChildren = (
-        <div className="progress-box progress-box-schemaform">{children}</div>
-      );
-    }
-
-    let footer;
-    if (Footer && !isNonFormPage) {
-      footer = (
-        <Footer formConfig={formConfig} currentLocation={currentLocation} />
-      );
-    }
-    const wrapperClass =
-      notProd && fullWidth ? '' : 'usa-width-two-thirds medium-8 columns';
-
-    return (
-      <div>
-        <div className={notProd && fullWidth ? '' : 'row'}>
-          <div className={wrapperClass}>
-            <Element name="topScrollElement" />
-            {CustomTopContent && (
-              <CustomTopContent currentLocation={currentLocation} />
-            )}
-            {useTopBackLink && <BackLink />}
-            {notProd && noTitle ? null : formTitle}
-            {notProd && noTopNav ? null : formNav}
-            <Element name="topContentElement" />
-            {renderedChildren}
-          </div>
-        </div>
-        {footer}
-        <span
-          className="js-test-location hidden"
-          data-location={trimmedPathname}
-          hidden
-        />
-      </div>
+    renderedChildren = (
+      <div className="progress-box progress-box-schemaform">{children}</div>
     );
   }
-}
+
+  let footer;
+  if (Footer && !isNonFormPage) {
+    footer = (
+      <Footer formConfig={formConfig} currentLocation={currentLocation} />
+    );
+  }
+  const wrapperClass =
+    notProd && fullWidth ? '' : 'usa-width-two-thirds medium-8 columns';
+
+  return (
+    <div className="form-app">
+      <div className={notProd && fullWidth ? '' : 'row'}>
+        <div className={wrapperClass}>
+          <Element name="topScrollElement" />
+          {CustomTopContent && (
+            <CustomTopContent currentLocation={currentLocation} />
+          )}
+          {useTopBackLink && <BackLink />}
+          {notProd && noTitle ? null : formTitle}
+          {notProd && noTopNav ? null : formNav}
+          <Element name="topContentElement" />
+          {renderedChildren}
+        </div>
+      </div>
+      {footer}
+      <span
+        className="js-test-location hidden"
+        data-location={trimmedPathname}
+        hidden
+      />
+    </div>
+  );
+};
 
 FormApp.propTypes = {
+  additionalRoutes: PropTypes.array,
   children: PropTypes.any,
   currentLocation: PropTypes.shape({
     pathname: PropTypes.string,
@@ -133,6 +130,7 @@ FormApp.propTypes = {
     formOptions: PropTypes.shape({}),
     subTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     title: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    useTopBackLink: PropTypes.bool,
     CustomTopContent: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
   }),
   formData: PropTypes.shape({}),

--- a/src/platform/forms-system/src/js/routing.js
+++ b/src/platform/forms-system/src/js/routing.js
@@ -8,6 +8,7 @@ import validateConfig from './validate-config';
 
 import FormPage from './containers/FormPage';
 import ReviewPage from './review/ReviewPage';
+import ConfirmationPage from './containers/ConfirmationPage';
 /*
  * Returns the page list without conditional pages that have not satisfied
  * their dependencies and therefore should be skipped.
@@ -100,7 +101,7 @@ export function createRoutes(formConfig) {
     {
       path: 'confirmation',
       formConfig,
-      component: formConfig.confirmation,
+      component: ConfirmationPage,
       pageList,
     },
     {

--- a/src/platform/forms/sass/_m-form-confirmation.scss
+++ b/src/platform/forms/sass/_m-form-confirmation.scss
@@ -1,3 +1,14 @@
+@media print {
+  body[data-location="confirmation"] {
+    va-breadcrumbs {
+      display: none;
+    }
+    .usa-width-two-thirds {
+      width: 100%;
+    }
+  }
+}
+
 .confirmation-page-title {
   &:focus {
     outline: none;
@@ -8,6 +19,7 @@
   margin-top: 0;
 }
 
+/* This class should be replaced by the va-summary-box web component */
 .inset {
   margin: 1.25rem 0rem;
   padding: 1.25rem 1.875rem;
@@ -32,7 +44,7 @@
   font-weight: normal;
 }
 
-ul.claim-list{
+ul.claim-list {
   list-style: none;
   padding-left: 0;
   li {

--- a/src/platform/forms/sass/_m-form-confirmation.scss
+++ b/src/platform/forms/sass/_m-form-confirmation.scss
@@ -3,7 +3,7 @@
     va-breadcrumbs {
       display: none;
     }
-    .usa-width-two-thirds {
+    .print-full-width {
       width: 100%;
     }
   }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > On the confirmation page, when printed, we will now be hiding the breadcrumbs and make the content full width
  >
  > To accomplish this using CSS specific to the confirmation page, the `FormApp` now adds the current path to a `data-location` attribute. This was needed because in our appeals forms, the H1 and the breadcrumbs (usually) are rendered outside of the confirmation page content.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Multiple solutions were attempted, but only this solution is backwards compatible with current implementations
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/3299
- [Slack discussion](https://dsva.slack.com/archives/C01DBGX4P45/p1727360438288899)

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Updated unit tests as needed
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| HLR  | <img width="517" alt="HLR print confirmation with breadcrumbs and already full width" src="https://github.com/user-attachments/assets/39eed070-108f-42ce-84a0-46dc0bcd01da"> | <img width="515" alt="HLR print confirmation not showing breadcrumbs and still at full width" src="https://github.com/user-attachments/assets/b7009009-2d08-4a38-a314-22459df24a80"> |
| NOD | <img width="515" alt="NOD print confirmation with breadcrumbs and filling two-thirds page width" src="https://github.com/user-attachments/assets/bdc19f6b-57fb-453f-b798-6d353aeadc2d"> | <img width="515" alt="NOD confirmation without breadcrumbs and at full page width" src="https://github.com/user-attachments/assets/32384e50-3aec-44e3-adda-f74869fffd0e"> |
| SC | <img width="518" alt="SC print confirmation with breadcrumbs and filling two-thirds page width" src="https://github.com/user-attachments/assets/deec16e4-6774-4558-8909-4f78fb084b98"> | <img width="514" alt="SC confirmation without breadcrumbs and at full page width" src="https://github.com/user-attachments/assets/df5bb33a-9372-4f38-bd9d-feacefb60125"> |

## What areas of the site does it impact?

All form confirmation pages - NOTE that only the appeals screenshots above include a black and white VA logo, not all forms are including that in the print styling

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
