### PR TITLE
rolling back utils to previous version

### DIFF
--- a/script/utils.js
+++ b/script/utils.js
@@ -8,26 +8,17 @@ process.on('SIGINT', () => {
 });
 
 const runCommand = cmd => {
-  return new Promise((resolve, reject) => {
-    const child = spawn(cmd, [], { shell: true, stdio: 'inherit' });
+  const child = spawn(cmd, [], { shell: true, stdio: 'inherit' });
 
-    // When the child process exits, resolve or reject the promise
-    child.on('exit', code => {
-      if (code === 0) {
-        resolve(); // Successfully completed
-      } else {
-        reject(new Error(`Process exited with code ${code}`)); // Error occurred
-      }
-    });
-
-    // When we ^C out of the parent Node script, also interrupt the child
-    childProcesses.push(child);
-
-    // Handle process errors like spawning failure
-    child.on('error', err => {
-      reject(err);
-    });
+  // If the child process exits abnormally, exit parent with the same code
+  child.on('exit', code => {
+    if (code) {
+      process.exit(code);
+    }
   });
+
+  // When we ^C out of the parent Node script, also interrupt the child
+  childProcesses.push(child);
 };
 
 const runCommandSync = cmd => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [ ] No
- [x] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Given that failing unit tests are not currently causing the `vets-website` CI workflow to fail, this pull request will roll the utils.js script with the fail logic back to its previous version.

Previous version [link](https://github.com/department-of-veterans-affairs/vets-website/blob/3551496e2be8ec44bbe0078de7dfb6a48552f71a/script/utils.js).


## Related issue(s)
https://dsva.slack.com/archives/CBU0KDSB1/p1727794960412109

## Testing done
GitHub actions are hard to test. Going by the results of the unit test checks for this branch. The behavior appears to be appropriately failing.

## Screenshots
N/A

## What areas of the site does it impact?

This impacts the unit test execution in the CI workflow.

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
