### PR TITLE
Fix failing unit tests in Caregivers application

### DIFF
--- a/src/applications/caregivers/tests/unit/components/FormFields/FacilityList.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormFields/FacilityList.unit.spec.js
@@ -14,7 +14,7 @@ describe('CG <FacilityList>', () => {
     error = undefined,
   }) => ({
     props: {
-      facilities: mockFetchFacilitiesResponse,
+      facilities: mockFetchFacilitiesResponse.facilities,
       formContext: { reviewMode, submitted },
       onChange: sinon.spy(),
       query: 'Tampa',

--- a/src/applications/caregivers/tests/unit/components/FormPages/FacilityConfirmation.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormPages/FacilityConfirmation.unit.spec.js
@@ -7,7 +7,7 @@ import { mockFetchFacilitiesResponse } from '../../../mocks/responses';
 import FacilityConfirmation from '../../../../components/FormPages/FacilityConfirmation';
 
 describe('CG <FacilityConfirmation>', () => {
-  const facilities = mockFetchFacilitiesResponse;
+  const { facilities } = mockFetchFacilitiesResponse;
   const selectedFacility = facilities[0];
   const caregiverFacility = facilities[1];
 

--- a/src/applications/caregivers/tests/unit/components/FormReview/FacilityReview.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/components/FormReview/FacilityReview.unit.spec.js
@@ -7,7 +7,7 @@ import { mockFetchFacilitiesResponse } from '../../../mocks/responses';
 import FacilityReview from '../../../../components/FormReview/FacilityReview';
 
 describe('CG <FacilityReview>', () => {
-  const facilities = mockFetchFacilitiesResponse;
+  const { facilities } = mockFetchFacilitiesResponse;
   const selectedFacility = facilities[0];
   const caregiverFacility = facilities[1];
   const goToPath = sinon.spy();

--- a/src/applications/caregivers/tests/unit/config/submit-transformer.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/config/submit-transformer.unit.spec.js
@@ -267,7 +267,8 @@ describe('CG `submitTransformer` method', () => {
 
   context('view:useFacilitiesAPI is turned on', () => {
     it('sets plannedClinic from view:plannedClinic', () => {
-      const veteranSelectedPlannedClinic = mockFetchFacilitiesResponse[0];
+      const { facilities } = mockFetchFacilitiesResponse;
+      const veteranSelectedPlannedClinic = facilities[0];
       const plannedClinicId = veteranSelectedPlannedClinic.id.split('_').pop();
 
       const requiredOnlyFormData = {

--- a/src/applications/caregivers/tests/unit/utils/helpers/form-config.unit.spec.js
+++ b/src/applications/caregivers/tests/unit/utils/helpers/form-config.unit.spec.js
@@ -46,17 +46,17 @@ describe('CG `hideUploadWarningAlert` method', () => {
     expect(hideUploadWarningAlert(formData)).to.be.true;
   });
 
+  it('should return `true` if upload array is empty', () => {
+    const formData = { signAsRepresentativeDocumentUpload: [] };
+    expect(hideUploadWarningAlert(formData)).to.be.true;
+  });
+
   it('should return `false` when valid file data exists', () => {
     const formData = {
       signAsRepresentativeDocumentUpload: [
         { name: 'test-name', guid: 'test-guid' },
       ],
     };
-    expect(hideUploadWarningAlert(formData)).to.be.false;
-  });
-
-  it('should return `false` if upload array is empty', () => {
-    const formData = { signAsRepresentativeDocumentUpload: [] };
     expect(hideUploadWarningAlert(formData)).to.be.false;
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR fixes failing unit tests in the Caregivers app as identified in this [DSVA slack post](https://dsva.slack.com/archives/C5HP4GN3F/p1727802245653169).

## Acceptance criteria

 - Caregivers test suite successfully passes CI

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution