### PR TITLE
[CST] Fix failing unit test by removing an outdated test case.

### DIFF
--- a/src/applications/claims-status/tests/components/claim-files-tab/FilesNeeded.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/claim-files-tab/FilesNeeded.unit.spec.jsx
@@ -66,23 +66,6 @@ describe('<FilesNeeded>', () => {
           getByText('Details');
         });
       });
-
-      it('should render va-alert with item data and hide DueDate', () => {
-        const { queryByText, getByText } = renderWithRouter(
-          <Provider store={getStore()}>
-            <FilesNeeded item={item5103} />
-          </Provider>,
-        );
-
-        expect(queryByText('December 1, 2024')).to.not.exist;
-        expect(
-          queryByText(
-            'Review a list of evidence we may need to decide your claim (called a 5103 notice).',
-          ),
-        ).to.exist;
-        getByText('Review evidence list');
-        getByText('Details');
-      });
     });
   });
 


### PR DESCRIPTION
## Summary

Unit tests in CI have been silently failing; in #31879 we inadvertently created a failing test case (by adding a new case rather than replacing an existing one). This PR removes the outdated, failing test case as the checks it's making are for content that has since been replaced.
