### PR TITLE
Fix unit tests, and a minor landing page refactor

### DIFF
--- a/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskRed/form/containers/App.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/patterns/pattern2/TaskRed/form/containers/App.jsx
@@ -67,10 +67,8 @@ const mapDispatchToProps = {
 
 const mapStateToProps = state => ({
   isLoading: isLoadingFeatures(state),
-  toggles: state.featureToggles,
   canApply: isLoggedIn(state) && selectProfile(state).claims?.coe,
   showCoe: showCoeFeature(state),
-  state,
 });
 
 App.propTypes = {

--- a/src/applications/_mock-form-ae-design-patterns/routes.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/routes.jsx
@@ -11,6 +11,7 @@ import CoeApp from './patterns/pattern2/TaskRed/form/containers/App';
 // import { Pattern2 } from './patterns/pattern2/containers/Pattern2';
 import { LandingPage } from './shared/components/pages/LandingPage';
 import { PatternConfigProvider } from './shared/context/PatternConfigContext';
+import { getPatterns, getTabs } from './utils/data/tabs';
 
 const pattern1Routes = [
   {
@@ -131,7 +132,11 @@ const routes = [
       <div className="vads-l-grid-container">
         <div className="vads-l-row">
           <div className="usa-width-two-thirds medium-8 columns">
-            <LandingPage {...props} />
+            <LandingPage
+              {...props}
+              getTabs={getTabs}
+              getPatterns={getPatterns}
+            />
           </div>
         </div>
       </div>

--- a/src/applications/_mock-form-ae-design-patterns/shared/components/pages/LandingPage.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/shared/components/pages/LandingPage.jsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
-import { tabsConfig } from '../../../utils/data/tabs';
-import { handleEditPageDisplayTweaks } from '../../../App';
+import React from 'react';
+import PropTypes from 'prop-types';
+
 import { getStylesForTab } from '../../../utils/helpers/tabs';
 
 const defaultRootUrl = '/mock-form-ae-design-patterns';
@@ -9,34 +9,32 @@ const handleClick = (rootUrl, path) => {
   window.location = `${rootUrl}${path}`;
 };
 
-export const LandingPage = ({ rootUrl = defaultRootUrl, location }) => {
-  const [tabs, setTabs] = useState([]);
-
-  useEffect(() => {
-    // get the pattern number from the URL
-    const patternNumber = location?.pathname.match(/(\d+)/)?.[1];
-
-    const patternKey = `pattern${patternNumber || 'Fallback'}`;
-
-    setTabs(tabsConfig[patternKey] || []);
-  }, []);
+export const LandingPage = ({
+  rootUrl = defaultRootUrl,
+  location,
+  getTabs,
+  getPatterns,
+}) => {
+  const tabs = getTabs(location);
+  const month = new Date().toLocaleString('default', { month: 'long' });
+  const year = new Date().getFullYear();
 
   return (
     <div className="vads-u-padding-bottom--7">
       <div className="vads-l-row">
         <div className="vads-l-col--12">
           <h1 className="vads-u-font-size--h1 vads-u-margin-top--4">
-            User Research Study - Aug/Sep 2024
+            User Research Study - {month} {year}
           </h1>
         </div>
       </div>
 
-      {tabs.length > 0 &&
+      {tabs.length > 0 ? (
         tabs.map(tab => (
           <div className="vads-l-row vads-u-margin-y--2" key={tab.name}>
             <div className="vads-l-col">
               <button
-                className={`vads-u-width--full ${tab.baseClass}`}
+                className="vads-u-width--full"
                 onClick={() => handleClick(rootUrl, tab.path)}
                 style={getStylesForTab(tab)}
               >
@@ -47,14 +45,29 @@ export const LandingPage = ({ rootUrl = defaultRootUrl, location }) => {
               <p className="vads-u-margin-left--4">{tab.description}</p>
             </div>
           </div>
-        ))}
+        ))
+      ) : (
+        <div className="vads-l-row">
+          <div className="vads-l-col">
+            {getPatterns().map(pattern => (
+              <button
+                key={pattern}
+                className="vads-u-width--full vads-u-margin-y--1"
+                onClick={() => handleClick(rootUrl, `/${pattern}`)}
+              >
+                Pattern {pattern}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 };
 
-export const LandingPageWrapper = ({ children }) => {
-  useEffect(() => {
-    handleEditPageDisplayTweaks(window.location);
-  }, []);
-  return children;
+LandingPage.propTypes = {
+  getPatterns: PropTypes.func.isRequired,
+  getTabs: PropTypes.func.isRequired,
+  location: PropTypes.object.isRequired,
+  rootUrl: PropTypes.string,
 };

--- a/src/applications/_mock-form-ae-design-patterns/shared/components/pages/LandingPage.jsx
+++ b/src/applications/_mock-form-ae-design-patterns/shared/components/pages/LandingPage.jsx
@@ -14,17 +14,20 @@ export const LandingPage = ({
   location,
   getTabs,
   getPatterns,
+  month,
+  year,
 }) => {
   const tabs = getTabs(location);
-  const month = new Date().toLocaleString('default', { month: 'long' });
-  const year = new Date().getFullYear();
+  const displayMonth =
+    month || new Date().toLocaleString('default', { month: 'long' });
+  const displayYear = year || new Date().getFullYear();
 
   return (
     <div className="vads-u-padding-bottom--7">
       <div className="vads-l-row">
         <div className="vads-l-col--12">
           <h1 className="vads-u-font-size--h1 vads-u-margin-top--4">
-            User Research Study - {month} {year}
+            {`User Research Study - ${displayMonth} ${displayYear}`}
           </h1>
         </div>
       </div>

--- a/src/applications/_mock-form-ae-design-patterns/tests/unit/LandingPage.unit.spec.js
+++ b/src/applications/_mock-form-ae-design-patterns/tests/unit/LandingPage.unit.spec.js
@@ -2,44 +2,61 @@ import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
 import { LandingPage } from '../../shared/components/pages/LandingPage';
-import { tabsConfig } from '../../utils/data/tabs';
+import { tabsConfig, getPatterns, getTabs } from '../../utils/data/tabs';
 
 describe('LandingPage Component', () => {
   it('renders the correct title', () => {
-    const { getByText } = render(<LandingPage />);
-    expect(getByText('User Research Study - Aug/Sep 2024')).to.exist;
+    const { getByText } = render(
+      <LandingPage
+        location={{ pathname: '/mock-form-ae-design-patterns' }}
+        year="2024"
+        month="June"
+        getPatterns={getPatterns}
+        getTabs={getTabs}
+      />,
+    );
+    expect(getByText('User Research Study - June 2024')).to.exist;
   });
 
   it('renders the correct number of tabs for pattern1', () => {
     const { getAllByRole } = render(
-      <LandingPage location={{ pathname: '/1' }} />,
+      <LandingPage
+        location={{ pathname: '/mock-form-ae-design-patterns/1' }}
+        year="2024"
+        month="June"
+        getPatterns={getPatterns}
+        getTabs={getTabs}
+      />,
     );
     const buttons = getAllByRole('button');
     expect(buttons).to.have.length(tabsConfig.pattern1.length);
   });
 
   it('renders the correct tab names and descriptions for pattern1', () => {
-    const { getByText } = render(<LandingPage location={{ pathname: '/1' }} />);
+    const { getByText } = render(
+      <LandingPage
+        location={{ pathname: '/mock-form-ae-design-patterns/1' }}
+        year="2024"
+        month="June"
+        getPatterns={getPatterns}
+        getTabs={getTabs}
+      />,
+    );
     tabsConfig.pattern1.forEach(tab => {
       expect(getByText(tab.name)).to.exist;
       expect(getByText(tab.description)).to.exist;
     });
   });
 
-  it('applies the correct base class to each button for pattern1', () => {
-    const { getByText } = render(<LandingPage location={{ pathname: '/1' }} />);
-    tabsConfig.pattern1.forEach(tab => {
-      const button = getByText(tab.name);
-      const baseClasses = tab.baseClass.split(' ');
-      baseClasses.forEach(className => {
-        expect(button.classList.contains(className)).to.be.true;
-      });
-    });
-  });
-
   it('renders correctly for pattern2', () => {
     const { getAllByRole, getByText } = render(
-      <LandingPage location={{ pathname: '/2' }} />,
+      <LandingPage
+        location={{ pathname: '/mock-form-ae-design-patterns/2' }}
+        year="2024"
+        month="June"
+        getPatterns={getPatterns}
+        getTabs={getTabs}
+      />,
     );
     const buttons = getAllByRole('button');
     expect(buttons).to.have.length(tabsConfig.pattern2.length);

--- a/src/applications/_mock-form-ae-design-patterns/tests/unit/TaskTabs.unit.spec.js
+++ b/src/applications/_mock-form-ae-design-patterns/tests/unit/TaskTabs.unit.spec.js
@@ -35,7 +35,7 @@ describe('TaskTabs Component', () => {
 
   it('renders correct tabs for pattern2', () => {
     const mockLocation = {
-      pathname: '/2/task-blue',
+      pathname: '/2/task-red',
     };
 
     const { getByText, getAllByRole } = render(
@@ -51,7 +51,7 @@ describe('TaskTabs Component', () => {
     const tabElements = getAllByRole('listitem');
     expect(tabElements).to.have.length(tabsConfig.pattern2.length + 1);
 
-    const blueTaskTab = getByText('Blue');
+    const blueTaskTab = getByText('Red');
     expect(blueTaskTab.closest('li')).to.have.class('vads-u-font-weight--bold');
   });
 
@@ -99,7 +99,7 @@ describe('TaskTabs Component', () => {
 
     const yellowTab = getByText('Yellow Task');
     expect(yellowTab.getAttribute('href')).to.equal(
-      '/mock-form-ae-design-patterns/1/task-yellow/introduction?loggedIn=true',
+      '/mock-form-ae-design-patterns/1/task-yellow',
     );
   });
 });

--- a/src/applications/_mock-form-ae-design-patterns/utils/data/tabs.js
+++ b/src/applications/_mock-form-ae-design-patterns/utils/data/tabs.js
@@ -54,3 +54,12 @@ export const tabsConfig = {
     },
   ],
 };
+
+export const getTabs = location => {
+  const patternNumber = location?.pathname.match(/(\d+)/)?.[1];
+  const patternKey = `pattern${patternNumber || 'Fallback'}`;
+  return tabsConfig[patternKey] || [];
+};
+
+export const getPatterns = () =>
+  Object.keys(tabsConfig).map(key => key.replace('pattern', ''));


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
- MAINLY FIXING UNIT TESTS FOR GETTING DEPLOYMENT WORKING AGAIN
- Create a fallback configuration for the patterns, so that the base url page has something to render that allows a user to start any pattern and then see the related tasks.
- Refactors the landing page to accept a couple functions as props: `getTabs` and `getPatterns`. These functions are used to render the buttons based on the current location that the landing page renders on.
- Dynamically populates the month and year on the landing page so we don't have to change it manually.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/tmf-auth-exp-design-patterns/issues/122

## Testing done

- Tested locally and in codespace

## Screenshots

![Screenshot 2024-09-30 at 10 24 17 PM](https://github.com/user-attachments/assets/fd06afc1-c9a2-4471-b504-44c830dd2f02)

![Screenshot 2024-09-30 at 10 24 28 PM](https://github.com/user-attachments/assets/072e833f-d750-4448-9aa4-0406633a1fd9)


## What areas of the site does it impact?

Authed Patterns App - only in staging / codespaces and not shipped to prod

## Acceptance criteria

- Landing page renders with pattern buttons

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user