### PR TITLE
Temporarily skipping time zone-dependent tests

### DIFF
--- a/src/applications/mhv-medical-records/tests/containers/App.unit.spec.jsx
+++ b/src/applications/mhv-medical-records/tests/containers/App.unit.spec.jsx
@@ -176,7 +176,7 @@ describe('App', () => {
       expect(screen.getByRole('navigation', { name: 'My HealtheVet' }));
     });
 
-    it('renders the global downtime notification', () => {
+    it.skip('renders the global downtime notification', () => {
       const screen = renderWithStoreAndRouter(<App />, {
         initialState: {
           ...initialState,

--- a/src/applications/mhv-medical-records/tests/reducers/careSummariesAndNotes.unit.spec.js
+++ b/src/applications/mhv-medical-records/tests/reducers/careSummariesAndNotes.unit.spec.js
@@ -283,7 +283,8 @@ describe('getNote', () => {
 });
 
 describe('getDateSigned', () => {
-  it('returns formatted date when extension array has an item with valueDateTime', () => {
+  // This test is time-zone dependent and will fail in certain circumstances. Skipping for now.
+  it.skip('returns formatted date when extension array has an item with valueDateTime', () => {
     const mockRecord = {
       authenticator: {
         extension: [

--- a/src/applications/mhv-medical-records/tests/reducers/careSummariesAndNotes.unit.spec.js
+++ b/src/applications/mhv-medical-records/tests/reducers/careSummariesAndNotes.unit.spec.js
@@ -298,7 +298,8 @@ describe('getDateSigned', () => {
     expect(result).to.equal('February 7, 2024');
   });
 
-  it('returns null when the date is invalid', () => {
+  // This test is time-zone dependent and will fail in certain circumstances. Skipping for now.
+  it.skip('returns null when the date is invalid', () => {
     const mockRecord = {
       authenticator: { extension: [{ valueDateTime: 'bad date' }] },
     };

--- a/src/applications/mhv-medical-records/tests/util/helpers.unit.spec.js
+++ b/src/applications/mhv-medical-records/tests/util/helpers.unit.spec.js
@@ -449,7 +449,8 @@ describe('getStatusExtractPhase', () => {
 });
 
 describe('getLastUpdatedText', () => {
-  it('should return the last updated string when the refreshStateStatus contains the extractType and lastSuccessfulCompleted', () => {
+  // This test is time-zone dependent and will fail in certain circumstances. Skipping for now.
+  it.skip('should return the last updated string when the refreshStateStatus contains the extractType and lastSuccessfulCompleted', () => {
     const refreshStateStatus = [
       { extract: 'type1', lastSuccessfulCompleted: '2024-09-15T10:00:00Z' },
     ];


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Skip tests that fail in some time zones until they can be re-written.

I created a ticket to go back and fix these tests later: [MHV-62731](https://jira.devops.va.gov/browse/MHV-62731)

## Related issue(s)

https://dsva.slack.com/archives/C5HP4GN3F/p1727875566193829?thread_ts=1727802245.653169&cid=C5HP4GN3F

## Testing done

N/A

## Screenshots

N/A

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
