### PR TITLE
[DBX-89576] injest new 0781 flipper from BE

### DIFF
--- a/src/applications/disability-benefits/all-claims/prefill-transformer.js
+++ b/src/applications/disability-benefits/all-claims/prefill-transformer.js
@@ -143,12 +143,24 @@ export default function prefillTransformer(pages, formData, metadata) {
     return newData;
   };
 
+  const prefillSyncModern0781Flow = data => {
+    const newData = _.omit(['syncModern0781Flow™'], data);
+    const { syncModern0781Flow } = data;
+
+    if (syncModern0781Flow) {
+      newData.syncModern0781Flow = syncModern0781Flow;
+    }
+
+    return newData;
+  };
+
   const transformations = [
     prefillRatedDisabilities,
     prefillContactInformation,
     prefillServiceInformation,
     prefillBankInformation,
     prefillStartedFormVersion,
+    prefillSyncModern0781Flow,
   ];
 
   const applyTransformations = (data = {}, transformer) => transformer(data);

--- a/src/applications/disability-benefits/all-claims/tests/prefill-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/prefill-transformer.unit.spec.js
@@ -383,6 +383,21 @@ describe('526v2 prefill transformer', () => {
       );
     });
   });
+
+  describe('prefillSyncModern0781Flow', () => {
+    it('should surface PTSD form flow decision when present', () => {
+      const { pages, metadata } = noTransformData;
+      const formData = {
+        syncModern0781Flow: true,
+      };
+
+      const transformedData = prefillTransformer(pages, formData, metadata)
+        .formData;
+      expect(transformedData.syncModern0781Flow).to.equal(
+        formData.syncModern0781Flow,
+      );
+    });
+  });
 });
 
 describe('addNoneDisabilityActionType', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- [surface a value provided by the backend flipper in this PR](https://github.com/department-of-veterans-affairs/vets-api/pull/18720) in the Form 526 Submission flow.
- This will not be used right now. It will be leveraged during our 0781 paper form sync

## Related issue(s)

- [Ticket 1](https://github.com/department-of-veterans-affairs/va.gov-team/issues/92013)
- [Ticket 2](https://github.com/department-of-veterans-affairs/va.gov-team/issues/92199)

**NOTE: this change accomplishes both goals**

## Testing done

-  click through testing in a local dev env leveraging the flipper configuration in the backend app
- Confirmed the following:
  - no errors
  - flipper logic is correctly ingested
  - value is successfully saved by the Save In Progress Form logic

## Screenshots

N/a

## What areas of the site does it impact?

This *will* be used to roll out our 0781 paper form sync. There is no currently active usecase

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated (see tickets)
- [x] Screenshot of the developed feature is added (n/a - no visible changes)
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed (n/a, no user facing changes)

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution (n/a)
- [ ] Feature/bug has a monitor built into Datadog or Grafana (n/a)

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
