### PR TITLE
allow for formData to be accessed in array builder summary custom text

### DIFF
--- a/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
+++ b/src/platform/forms-system/src/js/patterns/array-builder/ArrayBuilderSummaryPage.jsx
@@ -264,7 +264,7 @@ export default function ArrayBuilderSummaryPage({
       // alert
       setShowUpdatedAlert(false);
 
-      setRemovedItemText(getText('alertItemDeleted', item));
+      setRemovedItemText(getText('alertItemDeleted', item, props.data));
       setRemovedItemIndex(index);
       setShowRemovedAlert(true);
       requestAnimationFrame(() => {
@@ -292,7 +292,7 @@ export default function ArrayBuilderSummaryPage({
         className="vads-u-color--gray-dark vads-u-margin-top--0"
         data-title-for-noun-singular={nounSingular}
       >
-        {getText(textType, updatedItemData)}
+        {getText(textType, updatedItemData, props.data)}
       </Heading>
     );
 
@@ -304,7 +304,7 @@ export default function ArrayBuilderSummaryPage({
               onDismiss={onDismissUpdatedAlert}
               nounSingular={nounSingular}
               index={updateItemIndex}
-              text={getText('alertItemUpdated', updatedItemData)}
+              text={getText('alertItemUpdated', updatedItemData, props.data)}
             />
           ) : null}
         </div>
@@ -352,7 +352,11 @@ export default function ArrayBuilderSummaryPage({
         <UpdatedAlert show={showUpdatedAlert} />
         <ReviewErrorAlert show={showReviewErrorAlert} />
         <ArrayBuilderCards
-          cardDescription={getText('cardDescription', updatedItemData)}
+          cardDescription={getText(
+            'cardDescription',
+            updatedItemData,
+            props.data,
+          )}
           arrayPath={arrayPath}
           nounSingular={nounSingular}
           nounPlural={nounPlural}
@@ -380,12 +384,14 @@ export default function ArrayBuilderSummaryPage({
                   className="form-review-panel-page-header vads-u-font-size--h5"
                   data-title-for-noun-singular={`${nounSingular}`}
                 >
-                  {getText('summaryTitle', updatedItemData)}
+                  {getText('summaryTitle', updatedItemData, props.data)}
                 </h4>
               </div>
               <dl className="review">
                 <div className="review-row">
-                  <dt>{getText('yesNoBlankReviewQuestion')}</dt>
+                  <dt>
+                    {getText('yesNoBlankReviewQuestion', null, props.data)}
+                  </dt>
                   <dd>
                     <span
                       className="dd-privacy-hidden"
@@ -398,9 +404,9 @@ export default function ArrayBuilderSummaryPage({
               </dl>
             </>
           )}
-          {getText('summaryDescription') && (
+          {getText('summaryDescription', null, props.data) && (
             <span className="vads-u-font-family--sans vads-u-font-weight--normal vads-u-display--block">
-              {getText('summaryDescription')}
+              {getText('summaryDescription', null, props.data)}
             </span>
           )}
           <Cards />
@@ -408,7 +414,11 @@ export default function ArrayBuilderSummaryPage({
             <div className="vads-u-margin-top--2">
               <va-button
                 data-action="add"
-                text={getText('reviewAddButtonText', updatedItemData)}
+                text={getText(
+                  'reviewAddButtonText',
+                  updatedItemData,
+                  props.data,
+                )}
                 onClick={addAnotherItemButtonClick}
                 name={`${nounPlural}AddButton`}
                 primary
@@ -424,14 +434,14 @@ export default function ArrayBuilderSummaryPage({
       uiSchema['ui:title'] = (
         <>
           <Title textType="summaryTitle" />
-          {getText('summaryDescription') && (
+          {getText('summaryDescription', null, props.data) && (
             <span className="vads-u-font-family--sans vads-u-font-weight--normal vads-u-display--block">
-              {getText('summaryDescription')}
+              {getText('summaryDescription', null, props.data)}
             </span>
           )}
           {isMaxItemsReached && (
             <MaxItemsAlert>
-              {getText('alertMaxItems', updatedItemData)}
+              {getText('alertMaxItems', updatedItemData, props.data)}
             </MaxItemsAlert>
           )}
         </>
@@ -441,7 +451,8 @@ export default function ArrayBuilderSummaryPage({
     } else {
       uiSchema['ui:title'] = <Title textType="summaryTitleWithoutItems" />;
       uiSchema['ui:description'] =
-        getText('summaryDescriptionWithoutItems') || undefined;
+        getText('summaryDescriptionWithoutItems', null, props.data) ||
+        undefined;
     }
 
     if (schema?.properties && maxItems && arrayData?.length >= maxItems) {

--- a/src/platform/forms-system/src/js/patterns/array-builder/helpers.js
+++ b/src/platform/forms-system/src/js/patterns/array-builder/helpers.js
@@ -36,9 +36,10 @@ export function initGetText({
   /**
    * @param {ArrayBuilderTextKey} key
    * @param {any} itemData
+   * @param {any} [formData]
    * @returns {string}
    */
-  return (key, itemData) => {
+  return (key, itemData, formData) => {
     const keyVal = getTextValues?.[key];
     if (key === 'getItemName' || key === 'cardDescription') {
       return typeof keyVal === 'function' ? keyVal(itemData) : keyVal;
@@ -47,6 +48,7 @@ export function initGetText({
       ? getTextValues?.[key]({
           ...getTextProps,
           itemData,
+          formData,
         })
       : keyVal;
   };


### PR DESCRIPTION
## Summary

- allow for formData to be accessed in array builder summary custom text

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#1716

## Testing done

- unit, browser, cypress

## Screenshots

n/a

## What areas of the site does it impact?

array builder

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
