### PR TITLE
VAGOV-91910: Updates for new spanish toggle for Family Member Hub Migration

### DIFF
--- a/src/applications/static-pages/i18Select/tests/getNonActiveLinkUrls.unit.spec.js
+++ b/src/applications/static-pages/i18Select/tests/getNonActiveLinkUrls.unit.spec.js
@@ -9,7 +9,7 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(esp|tag)/i.test(url)).to.equal(true);
     });
 
-    expect(result.length).to.equal(26);
+    expect(result.length).to.equal(27);
   });
 
   it('should not return any "-esp" suffixed links when "es" is the active language code', () => {
@@ -19,7 +19,7 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(esp)/i.test(url)).to.equal(false);
     });
 
-    expect(result.length).to.equal(26);
+    expect(result.length).to.equal(27);
   });
 
   it('should not return any "-tag" suffixed links when "tl" is the active language code', () => {
@@ -29,6 +29,6 @@ describe('getNonActiveLinkUrls util', () => {
       expect(/(tag)/i.test(url)).to.equal(false);
     });
 
-    expect(result.length).to.equal(40);
+    expect(result.length).to.equal(42);
   });
 });

--- a/src/applications/static-pages/i18Select/utilities/urls.js
+++ b/src/applications/static-pages/i18Select/utilities/urls.js
@@ -92,4 +92,10 @@ export default {
     en: '/resources/what-to-bring-to-create-your-online-sign-in-account/',
     es: '/resources/what-to-bring-to-create-your-online-sign-in-account-esp/',
   },
+  survivorDependencyIndemnity: {
+    en:
+      '/family-and-caregiver-benefits/survivor-compensation/dependency-indemnity-compensation/',
+    es:
+      '/family-and-caregiver-benefits/survivor-compensation/dependency-indemnity-compensation-esp/',
+  },
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Adds new spanish toggle for the updated URL for /family-and-caregiver-benefits/survivor-compensation/dependency-indemnity-compensation-esp/

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/91910

## Testing done

## Screenshots
Page is not live yet

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

