### PR TITLE
Ask-VA/1353-Caregiver Requirement

### DIFF
--- a/src/applications/ask-va/components/RequireSignInModal.jsx
+++ b/src/applications/ask-va/components/RequireSignInModal.jsx
@@ -6,7 +6,7 @@ import {
 } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import { focusElement } from 'platform/utilities/ui';
 
-const RequireSignInModal = ({ onClose, show, restrictedItem }) => {
+const RequireSignInModal = ({ onClose, show, restrictedItem, message }) => {
   useEffect(
     () => {
       focusElement('p.ask-va-modal-content');
@@ -22,10 +22,14 @@ const RequireSignInModal = ({ onClose, show, restrictedItem }) => {
       onCloseEvent={onClose}
       visible={show}
     >
-      <p className="ask-va-modal-content">
-        To continue with {restrictedItem} selected you must Sign In or make
-        another selection.
-      </p>
+      {message ? (
+        <p className="ask-va-modal-content">{message}</p>
+      ) : (
+        <p className="ask-va-modal-content">
+          To continue with {restrictedItem} selected you must Sign In or make
+          another selection.
+        </p>
+      )}
       <Link aria-label="Go sign in" to="/contact-us/ask-va-too/introduction">
         <VaButton onClick={() => {}} primary text="Sign in and Start Over" />
       </Link>

--- a/src/applications/ask-va/components/SignInMyBeRequired.jsx
+++ b/src/applications/ask-va/components/SignInMyBeRequired.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-const SignInMyBeRequired = ({ loggedIn }) => {
+const SignInMayBeRequired = ({ loggedIn }) => {
   // Render for users that are Unauthenticated
   return !loggedIn ? (
     <div className="vads-u-margin-bottom--3">
@@ -25,7 +25,7 @@ const SignInMyBeRequired = ({ loggedIn }) => {
   ) : null;
 };
 
-SignInMyBeRequired.propTypes = {
+SignInMayBeRequired.propTypes = {
   loggedIn: PropTypes.bool,
 };
 
@@ -35,4 +35,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(SignInMyBeRequired);
+export default connect(mapStateToProps)(SignInMayBeRequired);

--- a/src/applications/ask-va/config/chapters/personalInformation/schoolInYourProfile.js
+++ b/src/applications/ask-va/config/chapters/personalInformation/schoolInYourProfile.js
@@ -2,7 +2,6 @@ import {
   radioSchema,
   radioUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
-import React from 'react';
 import FormElementTitle from '../../../components/FormElementTitle';
 import YourSchool from '../../../components/FormFields/YourSchool';
 import PageFieldSummary from '../../../components/PageFieldSummary';
@@ -14,7 +13,7 @@ const schoolInYourProfilePage = {
     'ui:description': YourSchool,
     'ui:objectViewField': PageFieldSummary,
     useSchoolInProfile: radioUI({
-      title: <strong>{CHAPTER_3.USE_THIS_SCHOOL.QUESTION_1}</strong>,
+      title: 'Do you want to use the school in your profile?',
       labels: schoolInYourProfileOptions,
     }),
   },

--- a/src/applications/ask-va/config/chapters/yourQuestion/whoIsYourQuestionAbout.js
+++ b/src/applications/ask-va/config/chapters/yourQuestion/whoIsYourQuestionAbout.js
@@ -1,39 +1,20 @@
-import {
-  radioSchema,
-  radioUI,
-} from 'platform/forms-system/src/js/web-component-patterns';
 import PageFieldSummary from '../../../components/PageFieldSummary';
-import SignInMayBeRequired from '../../../components/SignInMyBeRequired';
-import {
-  CHAPTER_2,
-  whoIsYourQuestionAboutDescriptions,
-  whoIsYourQuestionAboutLabels,
-} from '../../../constants';
+import { CHAPTER_2 } from '../../../constants';
 
 const whoIsYourQuestionAboutPage = {
   uiSchema: {
-    'ui:description': SignInMayBeRequired,
     'ui:objectViewField': PageFieldSummary,
     whoIsYourQuestionAbout: {
-      ...radioUI({
-        title: CHAPTER_2.PAGE_1.TITLE,
-        labelHeaderLevel: '3',
-        labels: whoIsYourQuestionAboutLabels,
-        descriptions: whoIsYourQuestionAboutDescriptions,
-        required: () => true,
-        errorMessages: {
-          required: 'Please select who your question is about',
-        },
-      }),
+      'ui:title': CHAPTER_2.PAGE_1.TITLE,
     },
   },
   schema: {
     type: 'object',
     required: ['whoIsYourQuestionAbout'],
     properties: {
-      whoIsYourQuestionAbout: radioSchema(
-        Object.values(whoIsYourQuestionAboutLabels),
-      ),
+      whoIsYourQuestionAbout: {
+        type: 'string',
+      },
     },
   },
 };

--- a/src/applications/ask-va/config/form.js
+++ b/src/applications/ask-va/config/form.js
@@ -34,7 +34,6 @@ import {
   aboutSomeoneElseRelationshipFamilyMemberPages,
   aboutSomeoneElseRelationshipVeteranOrFamilyMemberEducationPages,
   aboutSomeoneElseRelationshipVeteranPages,
-  flowPaths,
   generalQuestionPages,
 } from './schema-helpers/formFlowHelper';
 
@@ -47,6 +46,7 @@ import CategorySelectPage from '../containers/CategorySelectPage';
 import ReviewPage from '../containers/ReviewPage';
 import SubTopicSelectPage from '../containers/SubTopicSelectPage';
 import TopicSelectPage from '../containers/TopicSelectPage';
+import WhoIsYourQuestionAboutCustomPage from '../containers/WhoIsYourQuestionAboutCustomPage';
 
 import CustomPageReviewField from '../components/CustomPageReviewField';
 import prefillTransformer from './prefill-transformer';
@@ -136,20 +136,12 @@ const formConfig = {
           editModeOnReviewPage: false,
           path: CHAPTER_2.PAGE_1.PATH,
           title: CHAPTER_2.PAGE_1.TITLE,
+          CustomPage: WhoIsYourQuestionAboutCustomPage,
           CustomPageReview: CustomPageReviewField,
           uiSchema: whoIsYourQuestionAboutPage.uiSchema,
           schema: whoIsYourQuestionAboutPage.schema,
           // Hidden - EDU Question are always 'General Question'
           depends: form => form.selectCategory !== CategoryEducation,
-          onNavForward: ({ formData, goPath }) => {
-            if (
-              formData.selectCategory !== CategoryEducation &&
-              formData.whoIsYourQuestionAbout !==
-                whoIsYourQuestionAboutLabels.GENERAL
-            ) {
-              goPath(CHAPTER_3.RELATIONSHIP_TO_VET.PATH);
-            } else goPath(`/${flowPaths.general}-1`);
-          },
         },
         relationshipToVeteran: {
           editModeOnReviewPage: false,
@@ -264,11 +256,6 @@ const formConfig = {
     generalQuestion: {
       title: CHAPTER_3.CHAPTER_TITLE,
       hideFormNavProgress: true,
-      depends: formData =>
-        formData.whoIsYourQuestionAbout ===
-          whoIsYourQuestionAboutLabels.GENERAL &&
-        formData.selectTopic === 'VEAP (Ch 32)',
-      // we will need the VR&E option added to topics,
       pages: { ...generalQuestionPages },
     },
     yourQuestionPart2: {

--- a/src/applications/ask-va/config/schema-helpers/formFlowHelper.js
+++ b/src/applications/ask-va/config/schema-helpers/formFlowHelper.js
@@ -6,6 +6,7 @@ import {
   healthcareCategoryLabels,
   schoolInYourProfileOptions,
   yourRoleOptions,
+  whoIsYourQuestionAboutLabels,
 } from '../../constants';
 
 // Personal Information
@@ -207,8 +208,9 @@ const ch3Pages = {
     uiSchema: schoolInYourProfilePage.uiSchema,
     schema: schoolInYourProfilePage.schema,
     depends: form =>
-      form.yourRole === yourRoleOptions.SCO ||
-      form.yourRole === yourRoleOptions.TRAINING_OR_APPRENTICESHIP_SUP,
+      yourRoleOptions[form.yourRoleEducation] === yourRoleOptions.SCO ||
+      yourRoleOptions[form.yourRoleEducation] ===
+        yourRoleOptions.TRAINING_OR_APPRENTICESHIP_SUP,
   },
   yourContactInformation: {
     title: CHAPTER_3.CONTACT_INFORMATION.TITLE,
@@ -379,18 +381,20 @@ const aboutSomeoneElseRelationshipConnectedThroughWorkEducationCondition = formD
 
 const aboutSomeoneElseRelationshipVeteranOrFamilyMemberEducationCondition = formData => {
   return (
-    formData.whoIsYourQuestionAbout === 'Someone else' &&
+    whoIsYourQuestionAboutLabels[formData.whoIsYourQuestionAbout] ===
+      'Someone else' &&
     formData.relationshipToVeteran !==
       "I'm connected to the Veteran through my work (for example, as a School Certifying Official or fiduciary)" &&
-    formData.selectCategory === CategoryEducation
+    formData.selectCategory === 'Education benefits and work study'
   );
 };
 
 const generalQuestionCondition = formData => {
   return (
-    formData.whoIsYourQuestionAbout === "It's a general question" ||
-    (formData.selectCategory === CategoryEducation &&
-      formData.selectTopic === 'VEAP (Ch 32)')
+    whoIsYourQuestionAboutLabels[formData.whoIsYourQuestionAbout] ===
+      "It's a general question" ||
+    (formData.selectCategory === 'Education benefits and work study' &&
+      formData.selectTopic === 'Veteran Readiness and Employment (Chapter 31)')
   );
 };
 

--- a/src/applications/ask-va/constants.js
+++ b/src/applications/ask-va/constants.js
@@ -24,6 +24,7 @@ export const CategoryEducation =
 
 export const requireSignInCategories = [
   CategoryEducation,
+  'Education benefits and work study',
   'Disability compensation',
   'Debt for benefit overpayments and health care copay bills',
   'Benefits issues outside the U.S.',

--- a/src/applications/ask-va/containers/WhoIsYourQuestionAboutCustomPage.jsx
+++ b/src/applications/ask-va/containers/WhoIsYourQuestionAboutCustomPage.jsx
@@ -1,0 +1,130 @@
+import { VaRadio } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
+import { isLoggedIn } from '@department-of-veterans-affairs/platform-user/selectors';
+import { focusElement } from 'platform/utilities/ui';
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import { connect } from 'react-redux';
+import FormNavButtons from '~/platform/forms-system/src/js/components/FormNavButtons';
+import RequireSignInModal from '../components/RequireSignInModal';
+import SignInMayBeRequired from '../components/SignInMyBeRequired';
+import {
+  CategoryEducation,
+  whoIsYourQuestionAboutLabels,
+  CHAPTER_3,
+  CHAPTER_2,
+} from '../constants';
+import { flowPaths } from '../config/schema-helpers/formFlowHelper';
+
+const WhoIsYourQuestionAboutCustomPage = props => {
+  const { onChange, loggedIn, goBack, goToPath, formData } = props;
+  const [validationError, setValidationError] = useState(null);
+  const [showModal, setShowModal] = useState({ show: false, message: '' });
+
+  const caregiverSelected = {
+    category: 'Health care',
+    topic: 'Caregiver support program',
+    subtopic: 'Program of General Caregiver Support Services (PGCSS)',
+  };
+
+  const radioOptions = () => {
+    const labels = Object.values(whoIsYourQuestionAboutLabels);
+    const values = Object.keys(whoIsYourQuestionAboutLabels);
+    return labels.map((option, index) => {
+      return { label: option, value: values[index] };
+    });
+  };
+
+  const onModalNo = () => {
+    onChange({ ...formData, whoIsYourQuestionAbout: undefined });
+    setShowModal({ show: false, message: '' });
+  };
+
+  const showError = data => {
+    if (data.whoIsYourQuestionAbout) {
+      if (
+        data.selectCategory !== CategoryEducation &&
+        data.whoIsYourQuestionAbout !== radioOptions()[2].value
+      ) {
+        return goToPath(`/${CHAPTER_3.RELATIONSHIP_TO_VET.PATH}`);
+      }
+      return goToPath(`/${flowPaths.general}-1`);
+    }
+    focusElement('va-radio');
+    return setValidationError('Please select who your question is about');
+  };
+
+  const handleChange = event => {
+    const selectedValue = event.detail.value;
+    onChange({ ...formData, whoIsYourQuestionAbout: selectedValue });
+    if (
+      formData.selectCategory === caregiverSelected.category &&
+      formData.selectTopic === caregiverSelected.topic &&
+      formData.selectSubtopic === caregiverSelected.subtopic &&
+      !loggedIn &&
+      (selectedValue === radioOptions()[0].value ||
+        selectedValue === radioOptions()[1].value)
+    ) {
+      setShowModal({
+        show: true,
+        message: `If your question is about yourself or someone else you need to sign in.`,
+      });
+    } else {
+      onChange({ ...formData, whoIsYourQuestionAbout: selectedValue });
+    }
+  };
+
+  return (
+    <>
+      <SignInMayBeRequired />
+      <form className="rjsf">
+        <VaRadio
+          class="rjsf-web-component-field"
+          label={CHAPTER_2.PAGE_1.TITLE}
+          label-header-level="3"
+          name="root_whoIsYourQuestionAbout"
+          required="true"
+          onVaValueChange={handleChange}
+          error={validationError}
+        >
+          {radioOptions().map(option => (
+            <va-radio-option
+              key={option.value}
+              name="who-is-your-question-about"
+              label={option.label}
+              value={option.value}
+              checked={formData.whoIsYourQuestionAbout === option.value}
+              aria-describedby={
+                formData.whoIsYourQuestionAbout === option.value
+                  ? option.value
+                  : null
+              }
+            />
+          ))}
+        </VaRadio>
+        <FormNavButtons goBack={goBack} goForward={() => showError(formData)} />
+      </form>
+
+      <RequireSignInModal
+        onClose={onModalNo}
+        show={showModal.show}
+        message={showModal.message}
+      />
+    </>
+  );
+};
+
+WhoIsYourQuestionAboutCustomPage.propTypes = {
+  id: PropTypes.string,
+  loggedIn: PropTypes.bool,
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+};
+
+function mapStateToProps(state) {
+  return {
+    loggedIn: isLoggedIn(state),
+    formData: state.form.data,
+  };
+}
+
+export default connect(mapStateToProps)(WhoIsYourQuestionAboutCustomPage);

--- a/src/applications/ask-va/tests/config/chapters/yourQuestion/whoIsYourQuestionAbout.unit.spec.js
+++ b/src/applications/ask-va/tests/config/chapters/yourQuestion/whoIsYourQuestionAbout.unit.spec.js
@@ -15,7 +15,7 @@ const {
 
 describe('whoIsYourQuestionAboutPage', () => {
   it('should render', () => {
-    const { container } = render(
+    const { container, getByLabelText } = render(
       <Provider store={{ ...getData().mockStore }}>
         <DefinitionTester
           definitions={{}}
@@ -35,10 +35,7 @@ describe('whoIsYourQuestionAboutPage', () => {
       "It's a general question",
     ];
 
-    const vaRadio = container.querySelector('va-radio');
-    expect(vaRadio.getAttribute('label')).to.equal(
-      'Who is your question about?',
-    );
+    expect(getByLabelText(/Who is your question about/)).to.exist;
 
     radioLabels.forEach(
       radio => expect(radioLabelList.includes(radio.textContent)).to.be.true,

--- a/src/applications/ask-va/tests/containers/WhoIsYourQuestionAboutCustomPage.unit.spec.js
+++ b/src/applications/ask-va/tests/containers/WhoIsYourQuestionAboutCustomPage.unit.spec.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { expect } from 'chai';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import WhoIsYourQuestionAboutCustomPage from '../../containers/WhoIsYourQuestionAboutCustomPage';
+
+const mockStore = configureStore([]);
+
+describe('WhoIsYourQuestionAboutCustomPage', () => {
+  let store;
+  let defaultProps;
+
+  beforeEach(() => {
+    store = mockStore({
+      form: {
+        data: {
+          whoIsYourQuestionAbout: '',
+          selectCategory: '',
+          selectTopic: '',
+          selectSubtopic: '',
+        },
+      },
+      user: {
+        login: {
+          currentlyLoggedIn: false,
+        },
+      },
+    });
+
+    defaultProps = {
+      goBack: () => {},
+      goToPath: () => {},
+      onChange: () => {},
+    };
+  });
+
+  it('should render the component and radio options', () => {
+    const { container } = render(
+      <Provider store={store}>
+        <WhoIsYourQuestionAboutCustomPage {...defaultProps} />
+      </Provider>,
+    );
+    const options = container.querySelectorAll('va-radio-option');
+
+    expect(options[0].getAttribute('label')).to.eq('Myself');
+    expect(options[1].getAttribute('label')).to.eq('Someone else');
+    expect(options[2].getAttribute('label')).to.eq("It's a general question");
+  });
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Require sign-in for Caregiver program on Who is your question about page
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- Ask VA team owns the page/form.
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- Ticekt: [1353](https://app.zenhub.com/workspaces/ask-va-647a476551689d06655cc815/issues/gh/department-of-veterans-affairs/ask-va/1353)

## Testing done

- Did not require sign-in for caregiver program
- Creating request: Health care, Caregiver support program, Program of General Caregiver Support Services (PGCSS), Who is your question about? - Select "Myself" or "Someone else"
- Manual tests and Unit tests done.
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing


## Screenshots
UI did not change

## What areas of the site does it impact?

Only impacts the Ask VA form

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

