### PR TITLE
[CST] Override the display name and status of "PMR Pending" requests.

### DIFF
--- a/src/applications/claims-status/reducers/serialize.js
+++ b/src/applications/claims-status/reducers/serialize.js
@@ -1,19 +1,23 @@
-import { getTrackedItemDate } from '../utils/helpers';
+import {
+  getTrackedItemDate,
+  getTrackedItemHumanReadableName,
+} from '../utils/helpers';
 
-// NOTE: I think that in the long term it will make sense to move
-// this logic into the backend, but doing it here for now makes it
-// easier to modify this in the short term
+// NOTE: In the long term it will make sense to move some of this logic into
+//       the backend, but doing it here for now makes it easier to modify in
+//       the short-term.
 //
-// This does 2 things:
-// 1) Grabs all of the supporting documents associated with
-//    tracked items and embeds them within their respective
-//    tracked items in a new `documents` key that has been
-//    added to each tracked item
-// 2) Gets a new array of supporting documents that only
-//    includes the documents that are not associated with
-//    any tracked items. These items should already be
-//    embedded in their respective tracked items anyways,
-//    so they are no longer needed
+// This does a few things:
+// 1) Grabs all of the supporting documents associated with tracked items and
+//    embeds them within their respective tracked items in a new `documents`
+//    key that has been added to each tracked item
+// 2) Gets a new array of supporting documents that only includes the documents
+//    that are not associated with any tracked items. These items should
+//    already be embedded in their respective tracked items anyways, so they
+//    are no longer needed
+// 3) Performs any additional necessary transforms on supporting document and
+//    tracked item data, such as replacing display names and adding date
+//    attributes
 const isLighthouseClaim = claim => claim.type === 'claim';
 
 const isAssociatedWithAnyTrackedItem = doc => doc.trackedItemId !== null;
@@ -25,27 +29,49 @@ const getDocsAssociatedWithTrackedItems = docs =>
   docs.filter(isAssociatedWithAnyTrackedItem);
 
 const getDocsAssociatedWithTrackedItem = (item, docs) => {
-  const predicate = isAssociatedWithTrackedItem(item);
-  return docs.filter(predicate);
+  return docs.filter(isAssociatedWithTrackedItem(item));
 };
 
 const associateDocsWithTrackedItems = (items, docs) => {
-  return items.map(item => {
-    const newItem = { ...item };
-    const associatedDocs = getDocsAssociatedWithTrackedItem(newItem, docs);
-    newItem.documents = associatedDocs || [];
-    newItem.date = getTrackedItemDate(item);
-    return newItem;
-  });
+  return items.map(item => ({
+    ...item,
+    documents: getDocsAssociatedWithTrackedItem(item, docs),
+  }));
 };
 
 const filterAssociatedDocs = docs =>
   docs.filter(doc => !isAssociatedWithAnyTrackedItem(doc));
 
+const transformUnassociatedDocs = docs =>
+  docs.map(doc => ({
+    ...doc,
+    date: doc.uploadDate,
+  }));
+
+const transformAssociatedTrackedItems = items =>
+  items.map(item => ({
+    ...item,
+    // <tempfix>
+    // Override the first-party status of PMR (Private Medical Record) Pending
+    //   requests to third-party by replacing "NEEDED_FROM_YOU" with
+    //   "NEEDED_FROM_OTHERS".
+    // See GH issue for more details:
+    //   https://github.com/department-of-veterans-affairs/va.gov-team/issues/93456
+    // TODO: Remove this <tempfix> block once the Lighthouse API is returning
+    //       PMR Pending requests with more accurate status information.
+    status:
+      item.displayName === 'PMR Pending' ? 'NEEDED_FROM_OTHERS' : item.status,
+    // </tempfix>
+    date: getTrackedItemDate(item),
+    // This might need to be removed / moved elsewhere if future application
+    //   logic depends on the original `displayName` of the tracked item.
+    displayName: getTrackedItemHumanReadableName(item.displayName),
+  }));
+
 export const serializeClaim = claim => {
   if (!claim || !isLighthouseClaim(claim)) return claim;
 
-  const { supportingDocuments, trackedItems } = claim.attributes;
+  const { supportingDocuments = [], trackedItems = [] } = claim.attributes;
 
   const associatedDocuments = getDocsAssociatedWithTrackedItems(
     supportingDocuments,
@@ -56,19 +82,20 @@ export const serializeClaim = claim => {
     associatedDocuments,
   );
 
+  const transformedUnassociatedDocuments = transformUnassociatedDocs(
+    filterAssociatedDocs(supportingDocuments),
+  );
+
+  const transformedAssociatedTrackedItems = transformAssociatedTrackedItems(
+    associatedTrackedItems,
+  );
+
   return {
     ...claim,
     attributes: {
       ...claim.attributes,
-      supportingDocuments: filterAssociatedDocs(supportingDocuments).map(
-        doc => {
-          return {
-            ...doc,
-            date: doc.uploadDate,
-          };
-        },
-      ),
-      trackedItems: associatedTrackedItems,
+      supportingDocuments: transformedUnassociatedDocuments,
+      trackedItems: transformedAssociatedTrackedItems,
     },
   };
 };

--- a/src/applications/claims-status/tests/reducers/serialize.unit.spec.jsx
+++ b/src/applications/claims-status/tests/reducers/serialize.unit.spec.jsx
@@ -44,6 +44,22 @@ describe('Claim Serializer', () => {
     });
   });
 
+  it('should set supporting documents and tracked items to empty arrays when data is missing', () => {
+    const claim = {
+      id: 1,
+      type: 'claim',
+      attributes: {},
+    };
+    const serializedClaim = serializeClaim(claim);
+    expect(serializedClaim).to.eql({
+      ...claim,
+      attributes: {
+        supportingDocuments: [],
+        trackedItems: [],
+      },
+    });
+  });
+
   it('should return no supporting docs when there is only one and it is associated with a tracked item', () => {
     const claim = {
       id: 1,
@@ -135,5 +151,49 @@ describe('Claim Serializer', () => {
     const trackedItem3 = trackedItems.find(d => d.id === 3);
     expect(trackedItem3.documents.length).to.be.equal(2);
     expect(trackedItem3.documents.map(d => d.id).sort()).to.eql([3, 4]);
+  });
+
+  // <tempfix>
+  // See notes on PMR Pending in serialize.js
+  it('should manually override the status of PMR Pending requests', () => {
+    const claim = {
+      id: 1,
+      type: 'claim',
+      attributes: {
+        trackedItems: [
+          {
+            id: 1,
+            displayName: 'PMR Pending',
+            status: 'NEEDED_FROM_YOU',
+          },
+        ],
+      },
+    };
+    const serializedClaim = serializeClaim(claim);
+    const trackedItem1 = serializedClaim.attributes.trackedItems.find(
+      d => d.id === 1,
+    );
+    expect(trackedItem1.status).to.eql('NEEDED_FROM_OTHERS');
+  });
+  // </tempfix>
+
+  it('should replace the display name of some types of tracked items', () => {
+    const claim = {
+      id: 1,
+      type: 'claim',
+      attributes: {
+        trackedItems: [
+          {
+            id: 1,
+            displayName: 'PMR Pending',
+          },
+        ],
+      },
+    };
+    const serializedClaim = serializeClaim(claim);
+    const trackedItem1 = serializedClaim.attributes.trackedItems.find(
+      d => d.id === 1,
+    );
+    expect(trackedItem1.displayName).to.eql('Private Medical Record');
   });
 });

--- a/src/applications/claims-status/tests/utils/helpers.unit.spec.js
+++ b/src/applications/claims-status/tests/utils/helpers.unit.spec.js
@@ -43,6 +43,7 @@ import {
   sentenceCase,
   generateClaimTitle,
   isStandard5103Notice,
+  getTrackedItemHumanReadableName,
 } from '../../utils/helpers';
 
 import {
@@ -1540,6 +1541,16 @@ describe('Disability benefits helpers: ', () => {
           'Files for August 21, 2024 Request to Add or Remove a Dependent',
         );
       });
+    });
+  });
+  describe('getTrackedItemHumanReadableName', () => {
+    it('should return a replacment name if one is available', () => {
+      expect(getTrackedItemHumanReadableName('PMR Pending')).to.equal(
+        'Private Medical Record',
+      );
+    });
+    it("should return the provided name if a replacement doesn't exist", () => {
+      expect(getTrackedItemHumanReadableName('test')).to.equal('test');
     });
   });
 });

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -1231,3 +1231,15 @@ export const getTrackedItemDateFromStatus = item => {
       return item.requestedDate;
   }
 };
+
+// Many of the display names for tracked items provided by the API are rather
+//   esoteric, so we replace some of them to make them more user-friendly.
+const trackedItemsHumanReadableNames = new Map([
+  ['PMR Pending', 'Private Medical Record'],
+]);
+// Currently only being used by reducers/serialize, but it might need to be
+//   moved elsewhere if future application logic depends on the original
+//   `displayName` of the tracked item.
+export const getTrackedItemHumanReadableName = name => {
+  return trackedItemsHumanReadableNames.get(name) || name;
+};


### PR DESCRIPTION
## Summary

The change here for the end-user is very simple:
1. Instead of showing PMR Pending requests as first-party requests, we show them as third-party requests.
2. Instead of labeling these requests "PMR Pending", we show "Private Medical Record".

The changes under the hood are:
* Clean up and add transform logic to the `serialize` reducer.
  * Move around some of the existing code in the reducer so that all the logic in the `serializeClaim` function uses other functions. These changes should be aesthetic only and shouldn't impact the result of the function.
  * Replace display names _upon receiving them from the Lighthouse API, before they're ever passed to containers or components_.
  * Replace the status of PMR Pending requests in the same way. This logic is wrapped in a `<tempfix>` comment block to make it clear that this is not a permanent solution to the problem.  
* Create a helper function to replace the display names of tracked items. Currently it only supports replacing "PMR Pending" with "Private Medical Record", but we know there are likely some other types of requests that we'll want to make more human-readable in the future as well.
* Added tests to cover all changes.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93456

## Testing done

@jerekshoe added a PMR Pending tracked item on claim `600555011` on user `23` (Kyle Cole) in staging.

- On the Claim Details page:
  - On the Status tab:
    - There should no longer be a "warning" alert under "What you need to do"
    - The tracked item under recent activity should show an "information" alert and use the new display name.
  - On the Files tab, the "warning" alert should be replaced with an "information" alert and the new display name is used.
- On the Document Request page, the "optional" text is rendered in the description and the new display name is used.

It's possible that this tracked item appears on other pages that I'm unaware of, but the idea is that it should render properly as a third-party request with the updated display name across the app (since we're modifying it as soon as we receive data from the Lighthouse API).

A search for `PMR Pending` of the app returned no results, so it doesn't seem like there is any existing logic depending on the original display name or status (which should make this a safe change).

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Claim status - What you need to do  | <img width="669" alt="Screenshot 2024-10-03 at 1 35 38 PM" src="https://github.com/user-attachments/assets/ec3e642a-f74c-42f0-8d47-9b6c6286d09e"> |  <img width="669" alt="Screenshot 2024-10-03 at 1 36 03 PM" src="https://github.com/user-attachments/assets/050a25eb-6152-40b1-89fd-23b6705b1c80">     |
| Claim status - Recent activity  |  <img width="669" alt="Screenshot 2024-10-03 at 1 36 40 PM" src="https://github.com/user-attachments/assets/8f523e6a-3637-4358-9a81-a67ec1951380">      |  <img width="669" alt="Screenshot 2024-10-03 at 1 37 09 PM" src="https://github.com/user-attachments/assets/08a02a54-bf7a-46a8-9f76-bf8b18430adc">     |
| Claim files - Additional evidence | <img width="669" alt="Screenshot 2024-10-03 at 2 18 09 PM" src="https://github.com/user-attachments/assets/0ce7e7d1-ed9a-48d7-b082-0e349e768d7c"> | <img width="669" alt="Screenshot 2024-10-03 at 2 18 45 PM" src="https://github.com/user-attachments/assets/49b183c8-fdc4-45b8-bea7-bd8d11920acd"> |
| Document request | <img width="669" alt="Screenshot 2024-10-03 at 1 37 41 PM" src="https://github.com/user-attachments/assets/216e4609-923d-495e-9aaa-49091de68db9"> | <img width="669" alt="Screenshot 2024-10-03 at 1 38 13 PM" src="https://github.com/user-attachments/assets/b69190e2-d12b-4009-8ce0-cda7b534d754"> |

## What areas of the site does it impact?

Claim Status Tool

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [x] Documentation has been updated
  - Not necessary.
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed
  - Not necessary as only the data has changed (not any of the rendering logic).

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
  - Not necessary.
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
  - Not necessary.

### Authentication

- [x] Did you login to a local build and verify all authenticated routes work as expected with a test user
  - Not necessary.

## Requested Feedback

See self-review!