### PR TITLE
Ask-VA/ 1344 Submit form payload with attachments

### DIFF
--- a/src/applications/ask-va/actions/index.js
+++ b/src/applications/ask-va/actions/index.js
@@ -1,5 +1,6 @@
 export const SET_CATEGORY_ID = 'SET_CATEGORY_ID';
 export const SET_TOPIC_ID = 'SET_TOPIC_ID';
+export const SET_SUBTOPIC_ID = 'SET_SUBTOPIC_ID';
 export const SET_UPDATED_IN_REVIEW = 'SET_UPDATED_IN_REVIEW';
 export const OPEN_REVIEW_CHAPTER = 'OPEN_REVIEW_CHAPTER';
 export const CLOSE_REVIEW_CHAPTER = 'CLOSE_REVIEW_CHAPTER';
@@ -11,6 +12,10 @@ export function setCategoryID(id) {
 
 export function setTopicID(id) {
   return { type: SET_TOPIC_ID, payload: id };
+}
+
+export function setSubtopicID(id) {
+  return { type: SET_SUBTOPIC_ID, payload: id };
 }
 
 export function setUpdatedInReview(page) {

--- a/src/applications/ask-va/config/submit-transformer.js
+++ b/src/applications/ask-va/config/submit-transformer.js
@@ -24,7 +24,108 @@ const getFiles = files => {
   });
 };
 
+const determineInquiryDetails = data => {
+  const {
+    selectCategory,
+    selectTopic,
+    yourRole,
+    whoIsYourQuestionAbout,
+    relationshipToVeteran,
+    moreAboutYourRelationshipToVeteran,
+    aboutYourRelationshipToFamilyMember,
+    isQuestionAboutVeteranOrSomeoneElse,
+    theirRelationshipToVeteran,
+  } = data;
+
+  const isEducationBenefits =
+    selectCategory === 'Education benefits and work study' &&
+    selectTopic !== 'Veteran Readiness and Employment';
+
+  // Default return structure
+  const inquiryDetails = {
+    inquiryAbout: 'Unknown inquiry type',
+    dependentRelationship: null,
+    veteranRelationship: null,
+    levelOfAuthentication: 'Unknown',
+  };
+
+  // Determine the level of authentication
+  const levelOfAuthentication = yourRole ? 'Business' : 'Personal';
+
+  if (isEducationBenefits) {
+    inquiryDetails.inquiryAbout = "It's a general question";
+    inquiryDetails.dependentRelationship = null;
+    inquiryDetails.veteranRelationship = yourRole || null;
+    inquiryDetails.levelOfAuthentication = levelOfAuthentication;
+    return inquiryDetails;
+  }
+
+  // whoIsYourQuestionAbout === Myself, relationshipToVeteran === I'm the veteran
+  if (whoIsYourQuestionAbout === 'Myself') {
+    if (relationshipToVeteran === "I'm the Veteran") {
+      inquiryDetails.inquiryAbout = 'About Me, the Veteran';
+      inquiryDetails.levelOfAuthentication = 'Personal';
+      return inquiryDetails;
+    }
+    // whoIsYourQuestionAbout === Myself, relationshipToVeteran === I'm a family member of a Veteran, moreAboutYourRelationshipToVeteran
+    if (
+      relationshipToVeteran === "I'm a family member of a Veteran" &&
+      moreAboutYourRelationshipToVeteran
+    ) {
+      inquiryDetails.inquiryAbout = 'For the dependent of a Veteran';
+      inquiryDetails.veteranRelationship = moreAboutYourRelationshipToVeteran;
+      inquiryDetails.levelOfAuthentication = 'Personal';
+      return inquiryDetails;
+    }
+  }
+  // whoIsYourQuestionAbout === Someone else, relationshipToVeteran === I'm the veteran, aboutYourRelationshipToFamilyMember
+  if (whoIsYourQuestionAbout === 'Someone else') {
+    if (
+      relationshipToVeteran === "I'm the Veteran" &&
+      aboutYourRelationshipToFamilyMember
+    ) {
+      inquiryDetails.inquiryAbout = 'For the dependent of a Veteran';
+      inquiryDetails.dependentRelationship = aboutYourRelationshipToFamilyMember;
+      inquiryDetails.levelOfAuthentication = 'Personal';
+      return inquiryDetails;
+    }
+    // whoIsYourQuestionAbout === Someone else, relationshipToVeteran === I'm a family member of a Veteran, isQuestionaboutVeteranOrSomeoneElse === Veteran, theirRelationshipToVeteran, this is veteranRelationship to submitter
+    if (relationshipToVeteran === "I'm a family member of a Veteran") {
+      if (
+        isQuestionAboutVeteranOrSomeoneElse === 'Veteran' &&
+        theirRelationshipToVeteran
+      ) {
+        inquiryDetails.inquiryAbout = 'On Behalf of a Veteran';
+        inquiryDetails.veteranRelationship = theirRelationshipToVeteran;
+        inquiryDetails.levelOfAuthentication = 'Personal';
+        return inquiryDetails;
+      }
+      // whoIsYourQuestionAbout === Someone else, relationshipToVeteran === I'm a family member of a Veteran, isQuestionaboutVeteranOrSomeoneElse === Someone else, theirRelationshipToVeteran
+      if (
+        isQuestionAboutVeteranOrSomeoneElse === 'Someone else' &&
+        theirRelationshipToVeteran
+      ) {
+        inquiryDetails.inquiryAbout = 'For the dependent of a Veteran';
+        inquiryDetails.dependentRelationship = theirRelationshipToVeteran;
+        inquiryDetails.levelOfAuthentication = 'Personal';
+        return inquiryDetails;
+      }
+    }
+
+    if (yourRole) {
+      inquiryDetails.inquiryAbout = 'On Behalf of a Veteran';
+      inquiryDetails.veteranRelationship = yourRole;
+      inquiryDetails.levelOfAuthentication = 'Business';
+      return inquiryDetails;
+    }
+  }
+
+  return inquiryDetails;
+};
+
 export default function submitTransformer(formData, uploadFiles) {
+  const inquiryDetails = determineInquiryDetails(formData);
+
   return {
     AreYouTheDependent: null,
     AttachmentPresent: null,
@@ -42,7 +143,9 @@ export default function submitTransformer(formData, uploadFiles) {
     DependantLastName: formData.aboutTheFamilyMember.last,
     DependantMiddleName: formData.aboutTheFamilyMember.middle,
     DependantProvince: null,
-    DependantRelationship: formData.theirRelationshipToVeteran,
+    DependantRelationship: formData.aboutTheFamilyMember.first
+      ? inquiryDetails.dependentRelationship
+      : null,
     DependantSSN: null,
     DependantState: formData.familyMembersLocationOfResidence,
     DependantStreetAddress: null,
@@ -51,28 +154,29 @@ export default function submitTransformer(formData, uploadFiles) {
     EmailConfirmation: formData.emailAddress,
     FirstName: formData.aboutYourself.first,
     Gender: null,
-    InquiryAbout: formData.whoIsYourQuestionAbout,
+    InquiryAbout: inquiryDetails.inquiryAbout,
     InquiryCategory: formData.selectCategory,
     InquirySource: 'AVA',
     InquirySubtopic: formData.selectSubtopic,
     InquirySummary: formData.subject,
     InquiryTopic: formData.selectTopic,
+    InquiryType: null,
     IsVAEmployee: null,
     IsVeteran: null,
     IsVeteranAnEmployee: true,
     IsVeteranDeceased: formData.isVeteranDeceased,
-    LevelOfAuthentication: null,
+    LevelOfAuthentication: inquiryDetails.levelOfAuthentication,
     MedicalCenter: null,
     MiddleName: formData.aboutYourself.middle,
     PreferredName: formData.preferredName,
     Pronouns: formData.pronouns,
     ResponseType: formData.contactPreference,
     StreetAddress2: formData.address.street2,
-    SubmitterDependent: null,
-    SubmitterDOB: null,
-    SubmitterGender: null,
+    SubmitterDOB: formData.aboutYourself.dateOfBirth,
     SubmitterProvince: null,
     SubmitterQuestion: 'I would like to know more about my claims',
+    SubmittersDodIdEdipiNumber: null,
+    SubmitterSSN: formData.aboutYourself.ssn,
     SubmitterState: formData.address.state,
     SubmitterStateOfResidency: formData.yourLocationOfResidences,
     SubmitterStateOfSchool: formData.stateOfTheSchool,
@@ -81,11 +185,8 @@ export default function submitTransformer(formData, uploadFiles) {
     SubmitterVetCenter: null,
     SubmitterZipCodeOfResidency: formData.postalCode,
     Suffix: formData.aboutYourself.suffix,
-    SupervisorFlag: null,
-    VaEmployeeTimeStamp: null,
-    VeteranCity: null,
+    UntrustedFlag: null,
     VeteranClaimNumber: null,
-    VeteranCountry: null,
     VeteranDateOfDeath: null,
     VeteranDOB: formData.aboutTheVeteran.dateOfBirth,
     VeteranDodIdEdipiNumber: null,
@@ -100,7 +201,9 @@ export default function submitTransformer(formData, uploadFiles) {
     VeteranPreferedName: null,
     VeteranPronouns: null,
     VeteranProvince: null,
-    VeteranRelationship: formData.moreAboutYourRelationshipToVeteran,
+    VeteranRelationship: formData.aboutTheVeteran.first
+      ? inquiryDetails.veteranRelationship
+      : null,
     VeteranServiceEndDate: null,
     VeteranServiceNumber: null,
     VeteranServiceStartDate: null,
@@ -116,10 +219,68 @@ export default function submitTransformer(formData, uploadFiles) {
     School: {
       City: null,
       InstitutionName: getSchoolInfo(formData.school)?.name, // may also come from ava profile prefill
-      SchoolFacilityCode: getSchoolInfo(FormData.school)?.code, // may also come from ava profile prefill
+      SchoolFacilityCode: getSchoolInfo(formData.school)?.code, // may also come from ava profile prefill
       StateAbbreviation: formData.stateOfTheSchool || null,
       RegionalOffice: null,
     },
     ListOfAttachments: getFiles(uploadFiles),
+    SubmitterProfile: {
+      FirstName: formData.aboutYourself.first,
+      MiddleName: formData.aboutYourself.middle,
+      LastName: formData.aboutYourself.last,
+      PreferredName: formData.preferredName,
+      Suffix: formData.aboutYourself.suffix,
+      Gender: formData.gender,
+      Pronouns: formData.pronouns,
+      Country: formData.country,
+      Street: formData.address.street,
+      City: formData.address.city,
+      State: formData.address.state,
+      ZipCode: formData.postalCode,
+      Province: formData.province,
+      BusinessPhone: null,
+      PersonalPhone: formData.phoneNumber,
+      PersonalEmail: formData.emailAddress,
+      SSN: formData.aboutYourself.ssn,
+      BusinessEmail: null,
+      SchoolState: formData.stateOfTheSchool,
+      SchoolFacilityCode: getSchoolInfo(formData.school)?.code,
+      ServiceNumber: null,
+      ClaimNumber: null,
+      VeteranServiceStateDate: null,
+      VeteranServiceEndDate: null,
+      DateOfBirth: formData.aboutYourself.dateOfBirth,
+      EDIPI: null,
+      ICN: null,
+    },
+    VeteranProfile: {
+      FirstName: formData.aboutTheVeteran.first,
+      MiddleName: formData.aboutTheVeteran.middle,
+      LastName: formData.aboutTheVeteran.last,
+      PreferredName: formData.aboutTheVeteran.preferredName,
+      Suffix: formData.aboutTheVeteran.suffix,
+      Gender: formData.aboutTheVeteran.gender,
+      Pronouns: formData.aboutTheVeteran.pronouns,
+      Country: formData.aboutTheVeteran.country,
+      Street: formData.aboutTheVeteran.street,
+      City: formData.aboutTheVeteran.city,
+      State: formData.aboutTheVeteran.state,
+      ZipCode: formData.aboutTheVeteran.zipCode,
+      Province: formData.aboutTheVeteran.province,
+      BusinessPhone: formData.aboutTheVeteran.businessPhone,
+      PersonalPhone: formData.aboutTheVeteran.personalPhone,
+      PersonalEmail: formData.aboutTheVeteran.emailAddress,
+      SSN: formData.aboutTheVeteran.socialOrServiceNum.ssn,
+      BusinessEmail: formData.aboutTheVeteran.businessEmail,
+      SchoolState: formData.aboutTheVeteran.schoolState,
+      SchoolFacilityCode: formData.aboutTheVeteran.schoolFacilityCode,
+      ServiceNumber: formData.aboutTheVeteran.serviceNumber,
+      ClaimNumber: formData.aboutTheVeteran.claimNumber,
+      VeteranServiceStateDate: formData.aboutTheVeteran.serviceStartDate,
+      VeteranServiceEndDate: formData.aboutTheVeteran.serviceEndDate,
+      DateOfBirth: formData.aboutTheVeteran.dateOfBirth,
+      EDIPI: null,
+      ICN: null,
+    },
   };
 }

--- a/src/applications/ask-va/config/submit-transformer.js
+++ b/src/applications/ask-va/config/submit-transformer.js
@@ -25,6 +25,7 @@ const getFiles = files => {
 };
 
 const determineInquiryDetails = data => {
+
   const {
     selectCategory,
     selectTopic,
@@ -122,9 +123,9 @@ const determineInquiryDetails = data => {
 
   return inquiryDetails;
 };
-
-export default function submitTransformer(formData, uploadFiles) {
-  const inquiryDetails = determineInquiryDetails(formData);
+// eslint-disable-next-line sonarjs/no-extra-arguments
+export default function submitTransformer(formData, uploadFiles, askVAStore) {
+  const inquiryDetails = determineInquiryDetails(formData, askVAStore);
   return {
     AreYouTheDependent: false,
     AttachmentPresent: false,
@@ -136,17 +137,17 @@ export default function submitTransformer(formData, uploadFiles) {
     DependantMiddleName: formData.aboutTheFamilyMember.middle,
     DependantRelationship: inquiryDetails.dependentRelationship,
     InquiryAbout: inquiryDetails.inquiryAbout,
-    InquiryCategory: formData.selectCategory,
+    InquiryCategory: askVAStore.categoryID,
     InquirySource: 'AVA',
-    InquirySubtopic: formData.selectSubtopic,
+    InquirySubtopic: askVAStore.subtopicID,
     InquirySummary: formData.subject,
-    InquiryTopic: formData.selectTopic,
+    InquiryTopic: askVAStore.topicID,
     InquiryType: null,
     IsVeteranDeceased: formData.isVeteranDeceased,
     LevelOfAuthentication: inquiryDetails.levelOfAuthentication,
     MedicalCenter: null, // No corresponding field in current payload
     SchoolObj: {
-      City: formData.school.city,
+      City: formData.school?.city,
       InstitutionName: getSchoolInfo(formData.school)?.name,
       SchoolFacilityCode: getSchoolInfo(formData.school)?.code,
       StateAbbreviation: formData.stateOfTheSchool,

--- a/src/applications/ask-va/config/submit-transformer.js
+++ b/src/applications/ask-va/config/submit-transformer.js
@@ -125,35 +125,16 @@ const determineInquiryDetails = data => {
 
 export default function submitTransformer(formData, uploadFiles) {
   const inquiryDetails = determineInquiryDetails(formData);
-
   return {
-    AreYouTheDependent: null,
-    AttachmentPresent: null,
+    AreYouTheDependent: false,
+    AttachmentPresent: false,
     BranchOfService: formData.branchOfService,
-    City: formData.address.city,
     ContactMethod: formData.contactPreference,
-    Country: formData.country,
-    DaytimePhone: formData.phoneNumber,
-    DependantCity: null,
-    DependantCountry: null,
     DependantDOB: formData.aboutTheFamilyMember.dateOfBirth,
-    DependantEmail: null,
     DependantFirstName: formData.aboutTheFamilyMember.first,
-    DependantGender: null,
     DependantLastName: formData.aboutTheFamilyMember.last,
     DependantMiddleName: formData.aboutTheFamilyMember.middle,
-    DependantProvince: null,
-    DependantRelationship: formData.aboutTheFamilyMember.first
-      ? inquiryDetails.dependentRelationship
-      : null,
-    DependantSSN: null,
-    DependantState: formData.familyMembersLocationOfResidence,
-    DependantStreetAddress: null,
-    DependantZipCode: formData.postalCode,
-    EmailAddress: formData.emailAddress,
-    EmailConfirmation: formData.emailAddress,
-    FirstName: formData.aboutYourself.first,
-    Gender: null,
+    DependantRelationship: inquiryDetails.dependentRelationship,
     InquiryAbout: inquiryDetails.inquiryAbout,
     InquiryCategory: formData.selectCategory,
     InquirySource: 'AVA',
@@ -161,68 +142,24 @@ export default function submitTransformer(formData, uploadFiles) {
     InquirySummary: formData.subject,
     InquiryTopic: formData.selectTopic,
     InquiryType: null,
-    IsVAEmployee: null,
-    IsVeteran: null,
-    IsVeteranAnEmployee: true,
     IsVeteranDeceased: formData.isVeteranDeceased,
     LevelOfAuthentication: inquiryDetails.levelOfAuthentication,
-    MedicalCenter: null,
-    MiddleName: formData.aboutYourself.middle,
-    PreferredName: formData.preferredName,
-    Pronouns: formData.pronouns,
-    ResponseType: formData.contactPreference,
-    StreetAddress2: formData.address.street2,
-    SubmitterDOB: formData.aboutYourself.dateOfBirth,
-    SubmitterProvince: null,
-    SubmitterQuestion: 'I would like to know more about my claims',
-    SubmittersDodIdEdipiNumber: null,
-    SubmitterSSN: formData.aboutYourself.ssn,
-    SubmitterState: formData.address.state,
-    SubmitterStateOfResidency: formData.yourLocationOfResidences,
-    SubmitterStateOfSchool: formData.stateOfTheSchool,
-    SubmitterStateProperty: null,
-    SubmitterStreetAddress: formData.address.street,
-    SubmitterVetCenter: null,
-    SubmitterZipCodeOfResidency: formData.postalCode,
-    Suffix: formData.aboutYourself.suffix,
-    UntrustedFlag: null,
-    VeteranClaimNumber: null,
-    VeteranDateOfDeath: null,
-    VeteranDOB: formData.aboutTheVeteran.dateOfBirth,
-    VeteranDodIdEdipiNumber: null,
-    VeteranEmail: null,
-    VeteranEmailConfirmation: null,
-    VeteranEnrolled: null,
-    VeteranFirstName: formData.aboutTheVeteran.first,
-    VeteranICN: null,
-    VeteranLastName: formData.aboutTheVeteran.last,
-    VeteranMiddleName: formData.aboutTheVeteran.middle,
-    VeteranPhone: null,
-    VeteranPreferedName: null,
-    VeteranPronouns: null,
-    VeteranProvince: null,
-    VeteranRelationship: formData.aboutTheVeteran.first
-      ? inquiryDetails.veteranRelationship
-      : null,
-    VeteranServiceEndDate: null,
-    VeteranServiceNumber: null,
-    VeteranServiceStartDate: null,
-    VeteranSSN: formData.aboutTheVeteran.socialOrServiceNum.ssn,
-    VeteransState: null,
-    VeteranStreetAddress: null,
-    VeteranSuffix: formData.aboutTheVeteran.suffix,
-    VeteranSuiteAptOther: null,
-    VeteranZipCode: formData.VeteranPostalCode,
-    WhoWasTheirCounselor: null,
-    YourLastName: formData.aboutYourself.last,
-    ZipCode: formData.postalCode,
-    School: {
-      City: null,
-      InstitutionName: getSchoolInfo(formData.school)?.name, // may also come from ava profile prefill
-      SchoolFacilityCode: getSchoolInfo(formData.school)?.code, // may also come from ava profile prefill
-      StateAbbreviation: formData.stateOfTheSchool || null,
-      RegionalOffice: null,
+    MedicalCenter: null, // No corresponding field in current payload
+    SchoolObj: {
+      City: formData.school.city,
+      InstitutionName: getSchoolInfo(formData.school)?.name,
+      SchoolFacilityCode: getSchoolInfo(formData.school)?.code,
+      StateAbbreviation: formData.stateOfTheSchool,
+      RegionalOffice: null, // No corresponding field in current payload
     },
+    SubmitterQuestion: 'I would like to know more about my claims',
+    StateOfRouting: formData.stateOfTheSchool,
+    SubmitterStateOfSchool: formData.stateOfTheSchool,
+    SubmitterStateProperty: null, // No corresponding field in current payload
+    SubmitterZipCodeOfResidency: formData.postalCode,
+    UntrustedFlag: null, // No corresponding field in current payload
+    VeteranRelationship: inquiryDetails.veteranRelationship,
+    WhoWasTheirCounselor: null, // No corresponding field in current payload
     ListOfAttachments: getFiles(uploadFiles),
     SubmitterProfile: {
       FirstName: formData.aboutYourself.first,
@@ -238,20 +175,21 @@ export default function submitTransformer(formData, uploadFiles) {
       State: formData.address.state,
       ZipCode: formData.postalCode,
       Province: formData.province,
-      BusinessPhone: null,
+      BusinessPhone: null, // No corresponding field in current payload
       PersonalPhone: formData.phoneNumber,
       PersonalEmail: formData.emailAddress,
       SSN: formData.aboutYourself.ssn,
-      BusinessEmail: null,
+      BusinessEmail: null, // No corresponding field in current payload
       SchoolState: formData.stateOfTheSchool,
       SchoolFacilityCode: getSchoolInfo(formData.school)?.code,
-      ServiceNumber: null,
-      ClaimNumber: null,
-      VeteranServiceStateDate: null,
-      VeteranServiceEndDate: null,
+      SchoolId: '00000000-0000-0000-0000-000000000000', // No corresponding field in current payload
+      ServiceNumber: null, // No corresponding field in current payload
+      ClaimNumber: null, // No corresponding field in current payload
+      VeteranServiceStateDate: null, // No corresponding field in current payload
+      VeteranServiceEndDate: null, // No corresponding field in current payload
       DateOfBirth: formData.aboutYourself.dateOfBirth,
-      EDIPI: null,
-      ICN: null,
+      EDIPI: null, // No corresponding field in current payload
+      ICN: null, // No corresponding field in current payload
     },
     VeteranProfile: {
       FirstName: formData.aboutTheVeteran.first,
@@ -274,13 +212,14 @@ export default function submitTransformer(formData, uploadFiles) {
       BusinessEmail: formData.aboutTheVeteran.businessEmail,
       SchoolState: formData.aboutTheVeteran.schoolState,
       SchoolFacilityCode: formData.aboutTheVeteran.schoolFacilityCode,
+      SchoolId: '00000000-0000-0000-0000-000000000000', // No corresponding field in current payload
       ServiceNumber: formData.aboutTheVeteran.serviceNumber,
       ClaimNumber: formData.aboutTheVeteran.claimNumber,
       VeteranServiceStateDate: formData.aboutTheVeteran.serviceStartDate,
       VeteranServiceEndDate: formData.aboutTheVeteran.serviceEndDate,
       DateOfBirth: formData.aboutTheVeteran.dateOfBirth,
-      EDIPI: null,
-      ICN: null,
+      EDIPI: null, // No corresponding field in current payload
+      ICN: null, // No corresponding field in current payload
     },
   };
 }

--- a/src/applications/ask-va/config/submit-transformer.js
+++ b/src/applications/ask-va/config/submit-transformer.js
@@ -1,0 +1,125 @@
+const getSchoolInfo = school => {
+  if (!school) return null;
+  const schoolInfo = school.split('-');
+  const schoolCode = schoolInfo.splice(0, 1);
+
+  return { code: schoolCode[0].trim(), name: schoolInfo.join(' ').trim() };
+};
+
+const getFiles = files => {
+  if (!files) {
+    return [
+      {
+        FileName: null,
+        FileContent: null,
+      },
+    ];
+  }
+
+  return files.map(file => {
+    return {
+      FileName: file.fileName,
+      FileContent: file.base64,
+    };
+  });
+};
+
+export default function submitTransformer(formData, uploadFiles) {
+  return {
+    AreYouTheDependent: null,
+    AttachmentPresent: null,
+    BranchOfService: formData.branchOfService,
+    City: formData.address.city,
+    ContactMethod: formData.contactPreference,
+    Country: formData.country,
+    DaytimePhone: formData.phoneNumber,
+    DependantCity: null,
+    DependantCountry: null,
+    DependantDOB: formData.aboutTheFamilyMember.dateOfBirth,
+    DependantEmail: null,
+    DependantFirstName: formData.aboutTheFamilyMember.first,
+    DependantGender: null,
+    DependantLastName: formData.aboutTheFamilyMember.last,
+    DependantMiddleName: formData.aboutTheFamilyMember.middle,
+    DependantProvince: null,
+    DependantRelationship: formData.theirRelationshipToVeteran,
+    DependantSSN: null,
+    DependantState: formData.familyMembersLocationOfResidence,
+    DependantStreetAddress: null,
+    DependantZipCode: formData.postalCode,
+    EmailAddress: formData.emailAddress,
+    EmailConfirmation: formData.emailAddress,
+    FirstName: formData.aboutYourself.first,
+    Gender: null,
+    InquiryAbout: formData.whoIsYourQuestionAbout,
+    InquiryCategory: formData.selectCategory,
+    InquirySource: 'AVA',
+    InquirySubtopic: formData.selectSubtopic,
+    InquirySummary: formData.subject,
+    InquiryTopic: formData.selectTopic,
+    IsVAEmployee: null,
+    IsVeteran: null,
+    IsVeteranAnEmployee: true,
+    IsVeteranDeceased: formData.isVeteranDeceased,
+    LevelOfAuthentication: null,
+    MedicalCenter: null,
+    MiddleName: formData.aboutYourself.middle,
+    PreferredName: formData.preferredName,
+    Pronouns: formData.pronouns,
+    ResponseType: formData.contactPreference,
+    StreetAddress2: formData.address.street2,
+    SubmitterDependent: null,
+    SubmitterDOB: null,
+    SubmitterGender: null,
+    SubmitterProvince: null,
+    SubmitterQuestion: 'I would like to know more about my claims',
+    SubmitterState: formData.address.state,
+    SubmitterStateOfResidency: formData.yourLocationOfResidences,
+    SubmitterStateOfSchool: formData.stateOfTheSchool,
+    SubmitterStateProperty: null,
+    SubmitterStreetAddress: formData.address.street,
+    SubmitterVetCenter: null,
+    SubmitterZipCodeOfResidency: formData.postalCode,
+    Suffix: formData.aboutYourself.suffix,
+    SupervisorFlag: null,
+    VaEmployeeTimeStamp: null,
+    VeteranCity: null,
+    VeteranClaimNumber: null,
+    VeteranCountry: null,
+    VeteranDateOfDeath: null,
+    VeteranDOB: formData.aboutTheVeteran.dateOfBirth,
+    VeteranDodIdEdipiNumber: null,
+    VeteranEmail: null,
+    VeteranEmailConfirmation: null,
+    VeteranEnrolled: null,
+    VeteranFirstName: formData.aboutTheVeteran.first,
+    VeteranICN: null,
+    VeteranLastName: formData.aboutTheVeteran.last,
+    VeteranMiddleName: formData.aboutTheVeteran.middle,
+    VeteranPhone: null,
+    VeteranPreferedName: null,
+    VeteranPronouns: null,
+    VeteranProvince: null,
+    VeteranRelationship: formData.moreAboutYourRelationshipToVeteran,
+    VeteranServiceEndDate: null,
+    VeteranServiceNumber: null,
+    VeteranServiceStartDate: null,
+    VeteranSSN: formData.aboutTheVeteran.socialOrServiceNum.ssn,
+    VeteransState: null,
+    VeteranStreetAddress: null,
+    VeteranSuffix: formData.aboutTheVeteran.suffix,
+    VeteranSuiteAptOther: null,
+    VeteranZipCode: formData.VeteranPostalCode,
+    WhoWasTheirCounselor: null,
+    YourLastName: formData.aboutYourself.last,
+    ZipCode: formData.postalCode,
+    School: {
+      City: null,
+      InstitutionName: getSchoolInfo(formData.school)?.name, // may also come from ava profile prefill
+      SchoolFacilityCode: getSchoolInfo(FormData.school)?.code, // may also come from ava profile prefill
+      StateAbbreviation: formData.stateOfTheSchool || null,
+      RegionalOffice: null,
+    },
+    ListOfAttachments: getFiles(uploadFiles),
+  };
+}

--- a/src/applications/ask-va/constants.js
+++ b/src/applications/ask-va/constants.js
@@ -16,7 +16,8 @@ export const URL = {
   GET_SCHOOL: `${baseURL}/education_facilities/`,
   SEND_REPLY: `/reply/new`,
   GET_INQUIRIES: `${baseURL}/inquiries?user_mock_data=true`,
-  // GET_INQUIRIES: `${baseURL}/inquiries`,
+  INQUIRIES: `${baseURL}/inquiries`,
+  AUTH_INQUIRIES: `${baseURL}/inquiries/auth`,
 };
 
 export const CategoryEducation =

--- a/src/applications/ask-va/containers/CategorySelectPage.jsx
+++ b/src/applications/ask-va/containers/CategorySelectPage.jsx
@@ -45,7 +45,7 @@ const CategorySelectPage = props => {
       setShowModal({ show: true, selected: `${selectedValue}` });
     } else {
       dispatch(setCategoryID(selected.id));
-      onChange({ ...formData, selectCategory: selected.id });
+      onChange({ ...formData, selectCategory: selectedValue });
     }
   };
 

--- a/src/applications/ask-va/containers/CategorySelectPage.jsx
+++ b/src/applications/ask-va/containers/CategorySelectPage.jsx
@@ -45,7 +45,7 @@ const CategorySelectPage = props => {
       setShowModal({ show: true, selected: `${selectedValue}` });
     } else {
       dispatch(setCategoryID(selected.id));
-      onChange({ ...formData, selectCategory: selectedValue });
+      onChange({ ...formData, selectCategory: selected.id });
     }
   };
 

--- a/src/applications/ask-va/containers/ReviewPage.jsx
+++ b/src/applications/ask-va/containers/ReviewPage.jsx
@@ -7,18 +7,19 @@ import { getViewedPages } from '@department-of-veterans-affairs/platform-forms-s
 import React, { useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import Scroll from 'react-scroll';
-
+import { isLoggedIn } from '@department-of-veterans-affairs/platform-user/selectors';
 import {
   getActiveExpandedPages,
   getPageKeys,
 } from '@department-of-veterans-affairs/platform-forms-system/helpers';
-
 import {
   setData,
   setEditMode,
   setViewedPages,
   uploadFile,
 } from '@department-of-veterans-affairs/platform-forms-system/actions';
+import { apiRequest } from '@department-of-veterans-affairs/platform-utilities/api';
+import submitTransformer from '../config/submit-transformer';
 import {
   closeReviewChapter,
   openReviewChapter,
@@ -31,11 +32,13 @@ import {
   getChapterFormConfigAskVa,
   getPageKeysForReview,
 } from '../utils/reviewPageHelper';
+import { URL, envUrl } from '../constants';
 
 const { scroller } = Scroll;
 
 const ReviewPage = props => {
   const [showAlert, setShowAlert] = useState(true);
+  const [isDisabled, setIsDisabled] = useState(false);
   const dispatch = useDispatch();
 
   const scrollToChapter = chapterKey => {
@@ -75,8 +78,44 @@ const ReviewPage = props => {
     }
   };
 
+  const postFormData = (url, data) => {
+    setIsDisabled(true);
+    const options = {
+      method: 'POST',
+      body: JSON.stringify(data),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    };
+
+    return apiRequest(url, options)
+      .then(() => {
+        setIsDisabled(false);
+        // clear localStorage after post
+        localStorage.removeItem('askVAFiles');
+        props.goForward('/confirmation');
+      })
+      .catch(() => {
+        setIsDisabled(false);
+        localStorage.removeItem('askVAFiles');
+        // need an error page or message/alert
+        props.goForward('/confirmation');
+      });
+  };
+
   const handleSubmit = () => {
-    props.goForward('/confirmation');
+    const files = localStorage.getItem('askVAFiles');
+    const transformedData = submitTransformer(
+      props.formData,
+      JSON.parse(files),
+    );
+
+    if (props.loggedIn) {
+      // auth call
+      postFormData(`${envUrl}${URL.AUTH_INQUIRIES}`, transformedData);
+    }
+    // no auth call
+    postFormData(`${envUrl}${URL.INQUIRIES}`, transformedData);
   };
 
   return (
@@ -279,7 +318,11 @@ const ReviewPage = props => {
 
       <div className="vads-u-margin-top--4 vads-u-display--flex">
         <va-button back onClick={() => props.goBack()} />
-        <va-button text="Submit question" onClick={handleSubmit} />
+        <va-button
+          text="Submit question"
+          disabled={isDisabled}
+          onClick={handleSubmit}
+        />
       </div>
     </article>
   );
@@ -287,7 +330,7 @@ const ReviewPage = props => {
 
 function mapStateToProps(state, ownProps) {
   const { formContext } = ownProps;
-
+  const loggedIn = isLoggedIn(state);
   const { form, askVA } = state;
   const formData = form.data;
   const { openChapters } = askVA.reviewPageView;
@@ -428,6 +471,7 @@ function mapStateToProps(state, ownProps) {
     formData,
     formContext,
     viewedPages,
+    loggedIn,
     openChapterList: state.askVA.reviewPageView.openChapters,
   };
 }

--- a/src/applications/ask-va/containers/ReviewPage.jsx
+++ b/src/applications/ask-va/containers/ReviewPage.jsx
@@ -108,6 +108,7 @@ const ReviewPage = props => {
     const transformedData = submitTransformer(
       props.formData,
       JSON.parse(files),
+      props.askVA
     );
 
     if (props.loggedIn) {
@@ -473,6 +474,7 @@ function mapStateToProps(state, ownProps) {
     viewedPages,
     loggedIn,
     openChapterList: state.askVA.reviewPageView.openChapters,
+    askVA: state.askVA
   };
 }
 

--- a/src/applications/ask-va/containers/SubTopicSelectPage.jsx
+++ b/src/applications/ask-va/containers/SubTopicSelectPage.jsx
@@ -31,7 +31,10 @@ const SubTopicSelectPage = props => {
 
   const handleChange = event => {
     const selectedValue = event.detail.value;
-    onChange({ ...formData, selectSubtopic: selectedValue });
+    const selected = apiData.find(
+      subtopic => subtopic.attributes.name === selectedValue,
+    );
+    onChange({ ...formData, selectSubtopic: selected.id });
   };
 
   const getApiData = url => {

--- a/src/applications/ask-va/containers/SubTopicSelectPage.jsx
+++ b/src/applications/ask-va/containers/SubTopicSelectPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import {
   VaRadio,
   VaRadioOption,
@@ -12,9 +12,11 @@ import { focusElement } from 'platform/utilities/ui';
 import { ServerErrorAlert } from '../config/helpers';
 import { CHAPTER_1, CHAPTER_2, URL, envUrl } from '../constants';
 import CatAndTopicSummary from '../components/CatAndTopicSummary';
+import { setSubtopicID } from '../actions';
 
 const SubTopicSelectPage = props => {
   const { onChange, loggedIn, goBack, goToPath, formData, topicID } = props;
+  const dispatch = useDispatch();
 
   const [apiData, setApiData] = useState([]);
   const [loading, isLoading] = useState(false);
@@ -34,7 +36,8 @@ const SubTopicSelectPage = props => {
     const selected = apiData.find(
       subtopic => subtopic.attributes.name === selectedValue,
     );
-    onChange({ ...formData, selectSubtopic: selected.id });
+    onChange({ ...formData, selectSubtopic: selectedValue });
+    dispatch(setSubtopicID(selected.id));
   };
 
   const getApiData = url => {

--- a/src/applications/ask-va/containers/TopicSelectPage.jsx
+++ b/src/applications/ask-va/containers/TopicSelectPage.jsx
@@ -60,10 +60,13 @@ const TopicSelectPage = props => {
     const selected = apiData.find(
       topic => topic.attributes.name === selectedValue,
     );
-    dispatch(setTopicID(selected.id));
-    onChange({ ...formData, selectTopic: selected.id });
-    if (requireSignInTopics.includes(selectedValue) && !loggedIn)
+
+    if (requireSignInTopics.includes(selectedValue) && !loggedIn) {
       setShowModal({ show: true, selected: selectedValue });
+    } else {
+      dispatch(setTopicID(selected.id));
+      onChange({ ...formData, selectTopic: selectedValue });
+    }
   };
 
   const getApiData = url => {

--- a/src/applications/ask-va/containers/TopicSelectPage.jsx
+++ b/src/applications/ask-va/containers/TopicSelectPage.jsx
@@ -61,7 +61,7 @@ const TopicSelectPage = props => {
       topic => topic.attributes.name === selectedValue,
     );
     dispatch(setTopicID(selected.id));
-    onChange({ ...formData, selectTopic: selectedValue });
+    onChange({ ...formData, selectTopic: selected.id });
     if (requireSignInTopics.includes(selectedValue) && !loggedIn)
       setShowModal({ show: true, selected: selectedValue });
   };

--- a/src/applications/ask-va/reducers/index.js
+++ b/src/applications/ask-va/reducers/index.js
@@ -8,6 +8,7 @@ import {
   SET_CATEGORY_ID,
   SET_LOCATION_SEARCH,
   SET_TOPIC_ID,
+  SET_SUBTOPIC_ID,
   SET_UPDATED_IN_REVIEW,
 } from '../actions';
 
@@ -20,6 +21,7 @@ import {
 const initialState = {
   categoryID: '',
   topicID: '',
+  subtopicID: '',
   updatedInReview: '',
   searchLocationInput: '',
   getLocationInProgress: false,
@@ -45,6 +47,11 @@ export default {
         return {
           ...state,
           topicID: action.payload,
+        };
+      case SET_SUBTOPIC_ID:
+        return {
+          ...state,
+          subtopicID: action.payload,
         };
       case SET_UPDATED_IN_REVIEW:
         return {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Adding a submit data transformer and building formData payload
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- Ask VA team owns the form
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- Ticket [1344](https://app.zenhub.com/workspaces/ask-va-647a476551689d06655cc815/issues/gh/department-of-veterans-affairs/ask-va/1344)

## Testing done

- Manual testing done
- Fill out form and submit. Changes pending on the BE

## Screenshots

No UI changes

## What areas of the site does it impact?

Only impacts the Ask VA form

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [X] Did you login to a local build and verify all authenticated routes work as expected with a test user

