### PR TITLE
MHV Secondary Nav (A11y) - Announce current selection

### DIFF
--- a/src/platform/mhv/secondary-nav/components/MhvSecondaryNavItem.jsx
+++ b/src/platform/mhv/secondary-nav/components/MhvSecondaryNavItem.jsx
@@ -52,6 +52,7 @@ const MhvSecondaryNavItem = ({
         data-dd-action-name={actionName}
         className="vads-u-text-decoration--none"
         aria-label={abbreviation && ariaLabel}
+        aria-current={isActive ? 'page' : false}
         onClick={() => {
           recordEvent({
             event: 'nav-mhv-secondary',


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Add 'aria-current="page"' to the selected Nav bar to enable screen reader to correctly announce the current page location.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/93727

## Testing done
- Visually check that aria-current="page" is an attribute of the active/selected 'a' tag.
- Test with VoiceOver and Chrome browser (my Safari browser is not yet setup locally to run the app) to verify voiceOver is announcing the current page

## Screenshots
No visual UI change.

## What areas of the site does it impact?
MHV Secondary Navigation

## Acceptance criteria
- When a user focuses on the secondary nav item/section that is visually highlighted to indicate the page's location, screen reader indicates this as well
- QA review
- A11y review

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
