### PR TITLE
Upcoming appointment time validation against CC referral slot selection

### DIFF
--- a/src/applications/vaos/referral-appointments/ChooseDateAndTime.jsx
+++ b/src/applications/vaos/referral-appointments/ChooseDateAndTime.jsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { startOfMonth, format } from 'date-fns';
+import { startOfMonth, format, addMinutes, isWithinInterval } from 'date-fns';
+import { zonedTimeToUtc } from 'date-fns-tz';
 import { useHistory } from 'react-router-dom';
 import CalendarWidget from '../components/calendar/CalendarWidget';
 import FormLayout from '../new-appointment/components/FormLayout';
@@ -8,14 +9,18 @@ import { onCalendarChange } from '../new-appointment/redux/actions';
 import FormButtons from '../components/FormButtons';
 import { referral } from './temp-data/referral';
 import { getSelectedDate } from '../new-appointment/redux/selectors';
+import { selectUpcomingAppointments } from '../appointment-list/redux/selectors';
 
 export const ChooseDateAndTime = () => {
   const history = useHistory();
-  const selectedDates = useSelector(state => getSelectedDate(state));
+  const selectedDate = useSelector(state => getSelectedDate(state));
+  const upcomingAppointments = useSelector(state =>
+    selectUpcomingAppointments(state),
+  );
   const dispatch = useDispatch();
   const startMonth = format(startOfMonth(referral.preferredDate), 'yyyy-MM');
-  const [submitted, setSubmitted] = useState(false);
-  const pageTitle = 'Choose a date and time';
+  const [error, setError] = useState('');
+  const pageTitle = 'Schedule an appointment with your provider';
   const latestAvailableSlot = new Date(
     Math.max.apply(
       null,
@@ -39,14 +44,18 @@ export const ChooseDateAndTime = () => {
   };
   const onChange = useCallback(
     value => {
+      setError('');
       dispatch(onCalendarChange(value));
     },
     [dispatch],
   );
   const onSubmit = () => {
-    setSubmitted(true);
-    if (selectedDates) {
+    if (selectedDate && !error) {
       history.push('/confirm-approved');
+    } else if (!selectedDate) {
+      setError(
+        'Please choose your preferred date and time for your appointment',
+      );
     }
   };
   const getTzName = name => {
@@ -59,12 +68,63 @@ export const ChooseDateAndTime = () => {
   };
   const tzLong = getTzName('longGeneric');
   const tzShort = getTzName('shortGeneric');
+  useEffect(
+    () => {
+      if (selectedDate && upcomingAppointments) {
+        const selectedMonth = format(new Date(selectedDate), 'yyyy-MM');
+        if (selectedMonth in upcomingAppointments) {
+          const selectedDay = format(new Date(selectedDate), 'dd');
+          const monthOfApts = upcomingAppointments[selectedMonth];
+          const daysWithApts = monthOfApts.map(apt => {
+            return format(new Date(apt.start), 'dd');
+          });
+          if (daysWithApts.includes(selectedDay)) {
+            const unavailableTimes = monthOfApts.map(upcomingAppointment => {
+              return {
+                start: zonedTimeToUtc(
+                  new Date(upcomingAppointment.start),
+                  upcomingAppointment.timezone,
+                ),
+                end: zonedTimeToUtc(
+                  addMinutes(
+                    new Date(upcomingAppointment.start),
+                    upcomingAppointment.minutesDuration,
+                  ),
+                  upcomingAppointment.timezone,
+                ),
+              };
+            });
+            unavailableTimes.forEach(range => {
+              if (
+                isWithinInterval(
+                  zonedTimeToUtc(new Date(selectedDate), referral.timezone),
+                  {
+                    start: range.start,
+                    end: range.end,
+                  },
+                )
+              ) {
+                setError(
+                  'You already have an appointment at this time. Please select another day or time.',
+                );
+              }
+            });
+          }
+        }
+      }
+    },
+    [selectedDate, upcomingAppointments],
+  );
   return (
     <FormLayout pageTitle={pageTitle}>
       <>
         <div>
           <h1>{pageTitle}</h1>
-          <p className="vads-u-font-weight--bold vads-u-font-size--lg vads-u-margin--0">
+          <p>
+            You or your referring VA facility selected to schedule an
+            appointment online with this provider:
+          </p>
+          <p className="vads-u-font-weight--bold vads-u-margin--0">
             {referral.providerName}
           </p>
           <p className="vads-u-margin-top--0">{referral.typeOfCare}</p>
@@ -115,8 +175,9 @@ export const ChooseDateAndTime = () => {
           <p>
             {referral.driveTime} ({referral.driveDistance})
           </p>
+          <h2>Choose a date and time</h2>
           <p>
-            Please select an available date and time from the calendar below.
+            Select an available date and time from the calendar below.
             Appointment times are displayed in {`${tzLong} (${tzShort})`}.
           </p>
         </div>
@@ -124,7 +185,7 @@ export const ChooseDateAndTime = () => {
           <CalendarWidget
             maxSelections={1}
             availableSlots={referral.slots}
-            value={[selectedDates]}
+            value={[selectedDate]}
             id="dateTime"
             timezone={referral.timezone}
             additionalOptions={{
@@ -144,9 +205,9 @@ export const ChooseDateAndTime = () => {
             minDate={format(new Date(), 'yyyy-MM-dd')}
             maxDate={format(latestAvailableSlot, 'yyyy-MM-dd')}
             required
-            requiredMessage="Please choose your preferred date and time for your appointment"
+            requiredMessage={error}
             startMonth={startMonth}
-            showValidation={submitted && !selectedDates?.length}
+            showValidation={error.length > 0}
             showWeekends
             overrideMaxDays
           />

--- a/src/applications/vaos/referral-appointments/temp-data/referral.js
+++ b/src/applications/vaos/referral-appointments/temp-data/referral.js
@@ -35,5 +35,9 @@ const referral = {
   preferredDate: new Date(),
   timezone: 'America/Denver',
 };
-
+referral.slots.push({
+  end: '2024-11-22T16:30:00.000Z',
+  id: 35145,
+  start: '2024-11-22T16:00:00.000Z',
+});
 module.exports = { getAvailableSlots, referral };

--- a/src/applications/vaos/tests/referral-appointments/ChooseDateAndTime.unit.spec.js
+++ b/src/applications/vaos/tests/referral-appointments/ChooseDateAndTime.unit.spec.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { expect } from 'chai';
+// import sinon from 'sinon';
+import userEvent from '@testing-library/user-event';
+import { createTestStore, renderWithStoreAndRouter } from '../mocks/setup';
+import ChooseDateAndTime from '../../referral-appointments/ChooseDateAndTime';
+
+// Tests skipped for now since there are issues with displaying TZ and redux/data in flux.
+describe('VAOS referral-appointments', () => {
+  const store = createTestStore();
+  // it.skip('should store the selected date', async () => {
+  //   const screen = renderWithStoreAndRouter(<ChooseDateAndTime />, {
+  //     store,
+  //   });
+  // });
+  it.skip('should validate on submit', async () => {
+    const screen = renderWithStoreAndRouter(<ChooseDateAndTime />, {
+      store,
+    });
+    const button = await screen.findByText(/^Continue/);
+
+    userEvent.click(button);
+    expect(
+      screen.findByText(
+        'Please choose your preferred date and time for your appointment',
+      ),
+    ).to.be.ok;
+  });
+  // it('should display the timezone in the correct format', async () => {
+
+  // });
+});


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Adds validation against existing upcoming appointments for community care referral slot selection. Also includes the most recent content changes for this page.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#91914

## Testing done

Visual tests, unit tests are TBD while things in flux. But some were stubbed out.

## Screenshots

![localhost_3001_my-health_appointments_](https://github.com/user-attachments/assets/33c50c32-07e4-438e-95b4-f40a3b3ed8b3)


## What areas of the site does it impact?

Community care referrals within VAOS

## Acceptance criteria
 - [ ] Validation error shows when conflicting referral slot is chosen
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)
