### PR TITLE
10-7959f-1 revert toggler logic

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/App.jsx
@@ -4,8 +4,10 @@ import {
   externalServices,
 } from '@department-of-veterans-affairs/platform-monitoring/DowntimeNotification';
 import PropTypes from 'prop-types';
+import { Toggler } from 'platform/utilities/feature-toggles';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import WIP from '../../shared/components/WIP';
 import formConfig from '../config/form';
 
 export default function App({ location, children }) {
@@ -24,15 +26,30 @@ export default function App({ location, children }) {
   const bcString = JSON.stringify(breadcrumbList);
   return (
     <div className="vads-l-grid-container large-screen:vads-u-padding-x--0">
-      <va-breadcrumbs breadcrumb-list={bcString} />
-      <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-        <DowntimeNotification
-          appTitle={`CHAMPVA Form ${formConfig.formId}`}
-          dependencies={[externalServices.pega]}
-        >
-          {children}
-        </DowntimeNotification>
-      </RoutedSavableApp>
+      <Toggler toggleName={Toggler.TOGGLE_NAMES.form107959F1}>
+        <Toggler.Enabled>
+          <va-breadcrumbs breadcrumb-list={bcString} />
+          <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+            <DowntimeNotification
+              appTitle={`CHAMPVA Form ${formConfig.formId}`}
+              dependencies={[externalServices.pega]}
+            >
+              {children}
+            </DowntimeNotification>
+          </RoutedSavableApp>
+        </Toggler.Enabled>
+        <Toggler.Disabled>
+          <br />
+          <WIP
+            content={{
+              description:
+                'We’re rolling out the Foreign Medical Program (FMP) registration (VA Form 10-7959f-1) in stages. It’s not quite ready yet. Please check back again soon.',
+              redirectLink: '/',
+              redirectText: 'Return to VA home page',
+            }}
+          />
+        </Toggler.Disabled>
+      </Toggler>
     </div>
   );
 }


### PR DESCRIPTION
 ## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Revert (https://github.com/department-of-veterans-affairs/vets-website/pull/32184/files) PR back to original toggler logic.  This is  done to prevent users from accidentally  accessing forms.


## Related issue(s)

https://app.zenhub.com/workspaces/ivc-forms-652da2d3f0ae4c0016bfb109/issues/gh/department-of-veterans-affairs/va.gov-team/94425

## Testing done

-  Tested on local install of vets-website/vets-api


## What areas of the site does it impact?

* 10-7959f-1 rendering of form

## Acceptance criteria
Toggler state: on, displays 10-7959f-1 form
Toggler state: off, displays WIP component ("yellow box")

