### PR TITLE
Global | Add `focusOnAlertRole` to `formOptions`

### DIFF
--- a/src/platform/forms-system/src/js/components/SchemaForm.jsx
+++ b/src/platform/forms-system/src/js/components/SchemaForm.jsx
@@ -98,7 +98,7 @@ class SchemaForm extends React.Component {
       this.state.formContext,
     );
     this.setState({ formContext });
-    scrollToFirstError();
+    scrollToFirstError(this.props.formOptions);
   }
 
   onBlur(id) {
@@ -227,18 +227,24 @@ class SchemaForm extends React.Component {
 }
 
 SchemaForm.propTypes = {
+  idSchema: PropTypes.object.isRequired,
   name: PropTypes.string.isRequired,
-  title: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
   schema: PropTypes.object.isRequired,
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
   uiSchema: PropTypes.object.isRequired,
-  data: PropTypes.any,
-  appStateData: PropTypes.object,
-  reviewMode: PropTypes.bool,
-  editModeOnReviewPage: PropTypes.bool,
-  onSubmit: PropTypes.func,
-  onChange: PropTypes.func,
-  hideTitle: PropTypes.bool,
   addNameAttribute: PropTypes.bool,
+  appStateData: PropTypes.object,
+  children: PropTypes.any,
+  data: PropTypes.any,
+  editModeOnReviewPage: PropTypes.bool,
+  formContext: PropTypes.shape({}),
+  formOptions: PropTypes.shape({}),
+  hideTitle: PropTypes.bool,
+  pagePerItemIndex: PropTypes.number,
+  reviewMode: PropTypes.bool,
+  safeRenderCompletion: PropTypes.bool,
+  onChange: PropTypes.func,
+  onSubmit: PropTypes.func,
 };
 
 SchemaForm.defaultProps = {

--- a/src/platform/forms-system/src/js/containers/FormPage.jsx
+++ b/src/platform/forms-system/src/js/containers/FormPage.jsx
@@ -378,6 +378,7 @@ class FormPage extends React.Component {
           uploadFile={this.props.uploadFile}
           onChange={this.onChange}
           onSubmit={this.onSubmit}
+          formOptions={route.formConfig?.formOptions || {}}
         >
           {pageContentBeforeButtons}
           {hideNavButtons ? (

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -2,6 +2,7 @@ import Scroll from 'react-scroll';
 import {
   focusElement,
   focusByOrder,
+  scrollToFirstError,
   getScrollOptions,
 } from '../../../../../utilities/ui';
 import { webComponentList } from '../../web-component-fields/webComponentList';
@@ -22,7 +23,7 @@ export const $$ = (selector, root) => [
 
 /**
  * fixSelector
- * When a page name includes a color, e.g. "view:exampleFoo", the name ends up
+ * When a page name includes a colon, e.g. "view:exampleFoo", the name ends up
  * in a scroll element with name="view:exampleFooScrollElement". Using
  * querySelector without escaping the colon will fail to find the target
  * Note: We shouldn't be passing in something like `:not([name="test"])`
@@ -30,7 +31,13 @@ export const $$ = (selector, root) => [
 const REGEXP_COLON = /:/g;
 export const fixSelector = selector => selector.replace(REGEXP_COLON, '\\:');
 
-export { focusElement, focusByOrder };
+export {
+  focusElement,
+  focusByOrder,
+  scrollToFirstError,
+  getScrollOptions,
+  ERROR_ELEMENTS,
+};
 
 /**
  * Find all the focusable elements within a block
@@ -120,41 +127,4 @@ export function setGlobalScroll() {
       smooth: true,
     },
   };
-}
-
-// Duplicate of function in platform/utilities/ui/scroll
-export function scrollToFirstError() {
-  // [error] will focus any web-components with an error message
-  const errorEl = document.querySelector(ERROR_ELEMENTS.join(','));
-  if (errorEl) {
-    // document.body.scrollTop doesn’t work with all browsers, so we’ll cover them all like so:
-    const currentPosition =
-      window.pageYOffset ||
-      document.documentElement.scrollTop ||
-      document.body.scrollTop ||
-      0;
-    const position = errorEl.getBoundingClientRect().top + currentPosition;
-    // Don't animate the scrolling if there is an open modal on the page. This
-    // prevents the page behind the modal from scrolling if there is an error in
-    // modal's form.
-
-    // We have to search the shadow root of web components that have a slotted va-modal
-    const isShadowRootModalOpen = Array.from(
-      document.querySelectorAll('va-omb-info'),
-    ).some(ombInfo =>
-      ombInfo.shadowRoot?.querySelector(
-        'va-modal[visible]:not([visible="false"])',
-      ),
-    );
-
-    const isModalOpen =
-      document.body.classList.contains('modal-open') ||
-      document.querySelector('va-modal[visible]:not([visible="false"])') ||
-      isShadowRootModalOpen;
-
-    if (!isModalOpen) {
-      Scroll.animateScroll.scrollTo(position - 10, getScrollOptions());
-    }
-    focusElement(errorEl);
-  }
 }

--- a/src/platform/utilities/constants.js
+++ b/src/platform/utilities/constants.js
@@ -11,7 +11,7 @@ export const SCROLL_ELEMENT_SUFFIX = 'ScrollElement';
 // Focus on error message/component selectors
 export const ERROR_ELEMENTS = [
   '.usa-input-error',
-  'input-error-date',
+  '.input-error-date',
   '[error]',
 ];
 

--- a/src/platform/utilities/tests/ui/scroll.unit.spec.jsx
+++ b/src/platform/utilities/tests/ui/scroll.unit.spec.jsx
@@ -1,0 +1,190 @@
+import React from 'react';
+import Scroll from 'react-scroll';
+import { expect } from 'chai';
+import { render, waitFor } from '@testing-library/react';
+import sinon from 'sinon';
+
+import { $ } from '../../../forms-system/src/js/utilities/ui';
+import * as focusUtils from '../../ui/focus';
+
+import { scrollToFirstError, scrollAndFocus } from '../../ui';
+
+describe('scrollToFirstError', () => {
+  let scrollSpy;
+  let focusSpy;
+
+  beforeEach(() => {
+    scrollSpy = sinon.stub(Scroll.animateScroll, 'scrollTo');
+    focusSpy = sinon.stub(focusUtils, 'focusElement');
+  });
+  afterEach(() => {
+    scrollSpy.restore();
+    focusSpy.restore();
+  });
+
+  it('should scroll to & focus first usa-input-error class', () => {
+    render(
+      <form>
+        <p />
+        <div id="first" className="usa-input">
+          not an error
+        </div>
+        <div id="second" className="usa-input-error">
+          error 1
+        </div>
+        <div id="third" className="usa-input-error input-error-date">
+          error 2
+        </div>
+      </form>,
+    );
+    scrollToFirstError();
+    waitFor(() => {
+      expect(scrollSpy.args[0]).to.deep.equal([
+        -10, // offsets, scrollTop & top all return zero (-10 hard-coded offset)
+        { duration: 0, delay: 0, smooth: false },
+      ]);
+      expect(focusSpy.args[0][0].id).to.eq('second');
+    });
+  });
+
+  it('should scroll to & focus first input-error-date class', () => {
+    render(
+      <form>
+        <p />
+        <div id="first" className="usa-input">
+          not an error
+        </div>
+        <div id="second" className="input-error-date">
+          error 1
+        </div>
+        <div id="third" className="usa-input-error input-error-date">
+          error 2
+        </div>
+      </form>,
+    );
+    scrollToFirstError();
+    waitFor(() => {
+      expect(scrollSpy.args[0]).to.deep.equal([
+        -10, // offsets, scrollTop & top all return zero (-10 hard-coded offset)
+        { duration: 0, delay: 0, smooth: false },
+      ]);
+      expect(focusSpy.args[0][0].id).to.eq('second');
+    });
+  });
+
+  it('should scroll to & focus first error attribute (web component)', () => {
+    render(
+      <form>
+        <p />
+        <div id="first" className="usa-input">
+          not an error
+        </div>
+        <div id="second" error="some error">
+          error 1
+        </div>
+        <div id="third" className="usa-input-error input-error-date">
+          error 2
+        </div>
+      </form>,
+    );
+    scrollToFirstError();
+    waitFor(() => {
+      expect(scrollSpy.args[0]).to.deep.equal([
+        -10, // offsets, scrollTop & top all return zero (-10 hard-coded offset)
+        { duration: 0, delay: 0, smooth: false },
+      ]);
+      expect(focusSpy.args[0][0].id).to.eq('second');
+    });
+  });
+
+  it('should scroll to first error attribute (web component) & focus internal role="alert"', () => {
+    render(
+      <form>
+        <p />
+        <div id="first" className="usa-input">
+          not an error
+        </div>
+        <va-text-input id="second" label="test" error="some error" />
+        <div id="third" className="usa-input-error input-error-date">
+          error 2
+        </div>
+      </form>,
+    );
+    scrollToFirstError({ focusOnAlertRole: true });
+    waitFor(() => {
+      expect(scrollSpy.args[0]).to.deep.equal([
+        -10, // offsets, scrollTop & top all return zero (-10 hard-coded offset)
+        { duration: 0, delay: 0, smooth: false },
+      ]);
+      expect(focusSpy.args[0][0]).to.eq('[role="alert"]');
+    });
+  });
+
+  it('should not scroll or focus if a modal is open', () => {
+    render(
+      <form>
+        <p />
+        <div id="first" className="usa-input">
+          not an error
+        </div>
+        <div id="second" error="some error">
+          error 1
+        </div>
+        <div id="third" className="usa-input-error input-error-date">
+          error 2
+        </div>
+        <va-modal visible="true" />
+      </form>,
+    );
+    scrollToFirstError();
+    waitFor(() => {
+      expect(scrollSpy.notCalled).to.be.true;
+      expect(focusSpy.notCalled).to.be.true;
+    });
+  });
+});
+
+describe('scrollAndFocus', () => {
+  let scrollSpy;
+  let focusSpy;
+
+  beforeEach(() => {
+    scrollSpy = sinon.stub(Scroll.scroller, 'scrollTo');
+    focusSpy = sinon.stub(focusUtils, 'focusElement');
+  });
+  afterEach(() => {
+    scrollSpy.restore();
+    focusSpy.restore();
+  });
+
+  it('should scroll to & focus element', () => {
+    const { container } = render(
+      <div>
+        <div id="first" />
+        <div id="second" />
+      </div>,
+    );
+    scrollAndFocus($('#second', container));
+    waitFor(() => {
+      expect(scrollSpy.args[0]).to.deep.equal([
+        -10, // offsets, scrollTop & top all return zero (-10 hard-coded offset)
+        { duration: 0, delay: 0, smooth: false },
+      ]);
+      expect(focusSpy.args[0][0].id).to.eq('second');
+    });
+  });
+
+  it('should not scroll or focus when element is missing', () => {
+    const { container } = render(
+      <div>
+        <div id="first" />
+        <div id="second" />
+      </div>,
+    );
+    scrollAndFocus($('#third', container));
+    waitFor(() => {
+      expect(scrollSpy.notCalled).to.be.true;
+      expect(focusSpy.notCalled).to.be.true;
+    });
+  });
+});

--- a/src/platform/utilities/ui/scroll.js
+++ b/src/platform/utilities/ui/scroll.js
@@ -26,41 +26,63 @@ export function scrollToTop(position = 0, options = getScrollOptions()) {
   scroller.scrollTo(position, options);
 }
 
-// Duplicate of function in platform/forms-system/src/js/utilities/ui/index
-export function scrollToFirstError() {
-  // [error] will focus any web-components with an error message
-  const errorEl = document.querySelector(ERROR_ELEMENTS.join(','));
-  if (errorEl) {
-    // document.body.scrollTop doesn’t work with all browsers, so we’ll cover them all like so:
-    const currentPosition =
-      window.pageYOffset ||
-      document.documentElement.scrollTop ||
-      document.body.scrollTop ||
-      0;
-    const position = errorEl.getBoundingClientRect().top + currentPosition;
-    // Don't animate the scrolling if there is an open modal on the page. This
-    // prevents the page behind the modal from scrolling if there is an error in
-    // modal's form.
+/**
+ * scrollToFirstError options
+ * @typedef scrollToFirstErrorOptions
+ * @type {Object}
+ * @property {Boolean} focusOnAlertRole=false - When a web component is targetted, find
+ *  and focus on the element with role=alert to ensure screen readers are
+ *  reading out the correct content; it's set default to false while we perform
+ *  further accessibility evaluation
+ */
+/**
+ * Find first error and scroll it to the top of the page, then focus on it
+ * @param {scrollToFirstErrorOptions} options
+ */
+export function scrollToFirstError({ focusOnAlertRole = false } = {}) {
+  setTimeout(() => {
+    // [error] will focus any web-components with an error message
+    const errorEl = document.querySelector(ERROR_ELEMENTS.join(','));
+    if (errorEl) {
+      // document.body.scrollTop doesn’t work with all browsers, so we’ll cover them all like so:
+      const currentPosition =
+        window.pageYOffset ||
+        document.documentElement.scrollTop ||
+        document.body.scrollTop ||
+        0;
+      const position = errorEl.getBoundingClientRect().top + currentPosition;
+      // Don't animate the scrolling if there is an open modal on the page. This
+      // prevents the page behind the modal from scrolling if there is an error in
+      // modal's form.
 
-    // We have to search the shadow root of web components that have a slotted va-modal
-    const isShadowRootModalOpen = Array.from(
-      document.querySelectorAll('va-omb-info'),
-    ).some(ombInfo =>
-      ombInfo.shadowRoot?.querySelector(
-        'va-modal[visible]:not([visible="false"])',
-      ),
-    );
+      // We have to search the shadow root of web components that have a slotted va-modal
+      const isShadowRootModalOpen = Array.from(
+        document.querySelectorAll('va-omb-info'),
+      ).some(ombInfo =>
+        ombInfo.shadowRoot?.querySelector(
+          'va-modal[visible]:not([visible="false"])',
+        ),
+      );
 
-    const isModalOpen =
-      document.body.classList.contains('modal-open') ||
-      document.querySelector('va-modal[visible]:not([visible="false"])') ||
-      isShadowRootModalOpen;
+      const isModalOpen =
+        document.body.classList.contains('modal-open') ||
+        document.querySelector('va-modal[visible]:not([visible="false"])') ||
+        isShadowRootModalOpen;
 
-    if (!isModalOpen) {
-      Scroll.animateScroll.scrollTo(position - 10, getScrollOptions());
+      if (!isModalOpen) {
+        Scroll.animateScroll.scrollTo(position - 10, getScrollOptions());
+
+        if (focusOnAlertRole && errorEl.tagName.startsWith('VA-')) {
+          focusElement('[role="alert"]', {}, errorEl.shadowRoot);
+        } else {
+          focusElement(errorEl);
+        }
+      }
+    } else {
+      // eslint-disable-next-line no-console
+      console.error('scrollToFirstError: No error found');
     }
-    focusElement(errorEl);
-  }
+  });
 }
 
 export function scrollAndFocus(errorEl) {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > When a form error becomes visible, a screen reader will detect a `role="alert"` and sound a ding and read out the content of the `role="alert"`; but if focus is shifted to an element or web component, the screen reader will read out the content but skip the more important error message inside the `role="alert"`.
  > 
  > This PR adds a `focusOnAlertRole` setting within the `formOptions` in the form config within the platform code. We're adding this functionality to perform accessibility testing. If this method improves accessibility in forms, then we'll remove the `focusOnAlertRole` setting and implement the change. If it isn't a good solution, we'll remove the setting and associated code.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Focus on the alert role will ensure that screen readers will read out the message
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93251
- https://github.com/department-of-veterans-affairs/vets-website/pull/32316

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
  > Add & updated unit tests
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before (focus entire web component) | After (focus on error inside web component) |
| ------- | ------ | ----- |
| Radio error focus | ![focus & scroll on entire web component](https://github.com/user-attachments/assets/aaa8f2dc-3f39-444c-b918-30909b4aae57) | ![focus on error message & scroll to web component](https://github.com/user-attachments/assets/06cf10e1-b2e4-47c0-89df-a4a68f4acc56) |

## What areas of the site does it impact?

Any form that adds a `focusOnAlertRole` within the form config `formOptions`

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
