### PR TITLE
fix direct deposit data structure

### DIFF
--- a/src/applications/survivor-dependent-education-benefit/22-5490/components/IntroductionLogin.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/components/IntroductionLogin.jsx
@@ -112,7 +112,7 @@ function IntroductionLogin({
             </va-alert>
             <p className="vads-u-margin-top--4">
               If you don't want to sign in, you can{' '}
-              <a href="https://www.va.gov/find-forms/about-form-22-1990e/">
+              <a href="https://www.vba.va.gov/pubs/forms/VBA-22-5490-ARE.pdf">
                 apply using the paper form
               </a>
               . Please expect longer processing time for decisions when opting

--- a/src/applications/survivor-dependent-education-benefit/22-5490/pages/directDeposit.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/pages/directDeposit.js
@@ -18,7 +18,7 @@ const checkImageSrc = (() => {
 
 const directDeposit = {
   uiSchema: {
-    'view:directDeposit': {
+    directDeposit: {
       'ui:title': (
         <h4 className="vads-u-font-size--h5 vads-u-margin-top--0">
           Direct deposit information

--- a/src/applications/survivor-dependent-education-benefit/22-5490/tests/unit/config/form.unit.spec.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/tests/unit/config/form.unit.spec.js
@@ -305,7 +305,6 @@ describe('Complex Form 22-5490 Detailed Interaction Tests', () => {
         formData={{}}
       />,
     );
-
     fillData(
       form,
       'input[name="root_view:directDeposit_bankAccount_accountNumber"]',
@@ -316,11 +315,7 @@ describe('Complex Form 22-5490 Detailed Interaction Tests', () => {
       'input[name="root_view:directDeposit_bankAccount_routingNumber"]',
       '031101279',
     );
-    selectRadio(
-      form,
-      'root_view:directDeposit_bankAccount_accountType',
-      'checking',
-    );
+
     expect(
       form
         .find('input[name="root_view:directDeposit_bankAccount_accountNumber"]')
@@ -331,13 +326,6 @@ describe('Complex Form 22-5490 Detailed Interaction Tests', () => {
         .find('input[name="root_view:directDeposit_bankAccount_routingNumber"]')
         .prop('value'),
     ).to.equal('031101279');
-    expect(
-      form
-        .find(
-          'input[name="root_view:directDeposit_bankAccount_accountType"][value="checking"]',
-        )
-        .props().checked,
-    ).to.be.true;
     form.unmount();
   });
 });

--- a/src/applications/survivor-dependent-education-benefit/22-5490/utils/form-submit-transform.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/utils/form-submit-transform.js
@@ -417,9 +417,12 @@ export function transform5490Form(_formConfig, form) {
       highSchoolDiplomaOrCertificateDate: form?.data?.graduationDate,
     },
     directDeposit: {
-      directDepositAccountType: form?.data?.bankAccount?.accountType,
-      directDepositAccountNumber: form?.data?.bankAccount?.accountNumber,
-      directDepositRoutingNumber: form?.data?.bankAccount?.routingNumber,
+      directDepositAccountType:
+        form?.data?.directDeposit?.bankAccount?.accountType,
+      directDepositAccountNumber:
+        form?.data?.directDeposit?.bankAccount?.accountNumber,
+      directDepositRoutingNumber:
+        form?.data?.directDeposit?.bankAccount?.routingNumber,
     },
     additionalConsiderations: {
       outstandingFelony: form?.data?.felonyOrWarrant,


### PR DESCRIPTION
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Update link to paper form
- update direct deposit data structure

