### PR TITLE
Bugfix user date of birth data population in the Health Care Application

### DIFF
--- a/src/applications/hca/hooks/useDefaultFormData.jsx
+++ b/src/applications/hca/hooks/useDefaultFormData.jsx
@@ -43,7 +43,11 @@ export const useDefaultFormData = () => {
         'view:totalDisabilityRating': parseInt(totalRating, 10) || 0,
       };
       const userData = isLoggedIn
-        ? { 'view:userDob': parseVeteranDob(veteranDob) }
+        ? {
+            'view:veteranInformation': {
+              veteranDateOfBirth: parseVeteranDob(veteranDob),
+            },
+          }
         : {};
 
       setFormData({

--- a/src/applications/hca/tests/unit/hooks/useDefaultFormData.unit.spec.js
+++ b/src/applications/hca/tests/unit/hooks/useDefaultFormData.unit.spec.js
@@ -74,7 +74,9 @@ describe('hca `useDefaultFormData` hook', () => {
       'view:isInsuranceV2Enabled': false,
       'view:isTeraBranchingEnabled': true,
       'view:totalDisabilityRating': 0,
-      'view:userDob': '12/14/1986',
+      'view:veteranInformation': {
+        veteranDateOfBirth: '12/14/1986',
+      },
     };
 
     subject({ mockStore });

--- a/src/applications/hca/tests/unit/utils/helpers/form-config.unit.spec.js
+++ b/src/applications/hca/tests/unit/utils/helpers/form-config.unit.spec.js
@@ -177,6 +177,13 @@ describe('hca form config helpers', () => {
   });
 
   context('when `isMissingVeteranDob` executes', () => {
+    it('should return `true` when veteran information is not populated', () => {
+      const formData = {
+        'view:isLoggedIn': true,
+      };
+      expect(isMissingVeteranDob(formData)).to.be.true;
+    });
+
     it('should return `true` when date of birth value is `null`', () => {
       const formData = {
         'view:isLoggedIn': true,

--- a/src/applications/hca/tests/unit/utils/helpers/form-config.unit.spec.js
+++ b/src/applications/hca/tests/unit/utils/helpers/form-config.unit.spec.js
@@ -177,15 +177,20 @@ describe('hca form config helpers', () => {
   });
 
   context('when `isMissingVeteranDob` executes', () => {
-    it('should return `true` when viewfield is `null`', () => {
-      const formData = { 'view:isLoggedIn': true, 'view:userDob': null };
+    it('should return `true` when date of birth value is `null`', () => {
+      const formData = {
+        'view:isLoggedIn': true,
+        'view:veteranInformation': { veteranDateOfBirth: null },
+      };
       expect(isMissingVeteranDob(formData)).to.be.true;
     });
 
-    it('should return `false` when viewfield is populated', () => {
+    it('should return `false` when date of birth value is populated', () => {
       const formData = {
         'view:isLoggedIn': true,
-        'view:userDob': '1990-01-01',
+        'view:veteranInformation': {
+          veteranDateOfBirth: '1990-01-01',
+        },
       };
       expect(isMissingVeteranDob(formData)).to.be.false;
     });

--- a/src/applications/hca/utils/helpers/form-config.js
+++ b/src/applications/hca/utils/helpers/form-config.js
@@ -86,8 +86,9 @@ export function dischargePapersRequired(formData) {
  * @returns {Boolean} - true if the user is logged in and viewfield is empty
  */
 export function isMissingVeteranDob(formData) {
-  const { 'view:userDob': userDob } = formData;
-  return !isLoggedOut(formData) && !userDob;
+  const { 'view:veteranInformation': veteranInfo } = formData;
+  const { veteranDateOfBirth } = veteranInfo;
+  return !isLoggedOut(formData) && !veteranDateOfBirth;
 }
 
 /**

--- a/src/applications/hca/utils/helpers/form-config.js
+++ b/src/applications/hca/utils/helpers/form-config.js
@@ -86,7 +86,7 @@ export function dischargePapersRequired(formData) {
  * @returns {Boolean} - true if the user is logged in and viewfield is empty
  */
 export function isMissingVeteranDob(formData) {
-  const { 'view:veteranInformation': veteranInfo } = formData;
+  const { 'view:veteranInformation': veteranInfo = {} } = formData;
   const { veteranDateOfBirth } = veteranInfo;
   return !isLoggedOut(formData) && !veteranDateOfBirth;
 }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR updates the format for storing user date of birth data from the VA.gov profile to the form data in the Health Care Application. This format matches the same pattern we currently use for guest users in their form data.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#94779

## Testing done

- [x] Updated unit tests with new structure
- [x] Cypress tests are in place to validate the behavior 

## Acceptance criteria

 - User data is stored consistently for both auth and guest users

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution