### PR TITLE
Display profile not updated note to authed users

### DIFF
--- a/src/applications/representative-appoint/components/ProfileNotUpdatedNote.jsx
+++ b/src/applications/representative-appoint/components/ProfileNotUpdatedNote.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+import { isLoggedIn } from 'platform/user/selectors';
 
 export default function ProfileNotUpdatedNote({
   includePrefix = false,
@@ -10,29 +11,33 @@ export default function ProfileNotUpdatedNote({
 }) {
   return (
     <>
-      <p>
-        {includePrefix && <strong>Note: </strong>} This is the information we
-        have in your VA.gov profile. Any changes you make on this screen will
-        only affect this application.
-      </p>
-      {includePhone && (
+      {isLoggedIn && (
         <>
           <p>
-            If you need to change this information in your VA.gov profile, you
-            can call us at{' '}
-            <va-telephone contact={CONTACTS.VA_BENEFITS} extension={0} /> (
-            <va-telephone contact={CONTACTS['711']} tty />
-            ). We’re here 24/7.
+            {includePrefix && <strong>Note: </strong>} This is the information
+            we have in your VA.gov profile. Any changes you make on this screen
+            will only affect this application.
           </p>
-        </>
-      )}
-      {includeLink && (
-        <>
-          <va-link
-            href="https://va.gov"
-            text="Find out how to change you address in your VA.gov profile (opens in
+          {includePhone && (
+            <>
+              <p>
+                If you need to change this information in your VA.gov profile,
+                you can call us at{' '}
+                <va-telephone contact={CONTACTS.VA_BENEFITS} extension={0} /> (
+                <va-telephone contact={CONTACTS['711']} tty />
+                ). We’re here 24/7.
+              </p>
+            </>
+          )}
+          {includeLink && (
+            <>
+              <va-link
+                href="https://va.gov"
+                text="Find out how to change you address in your VA.gov profile (opens in
             new tab)"
-          />
+              />
+            </>
+          )}
         </>
       )}
     </>

--- a/src/applications/representative-appoint/components/ProfileNotUpdatedNote.jsx
+++ b/src/applications/representative-appoint/components/ProfileNotUpdatedNote.jsx
@@ -1,11 +1,46 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-export default function ProfileNotUpdatedNote(includePrefix = true) {
+import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
+
+export default function ProfileNotUpdatedNote({
+  includePrefix = true,
+  includePhone = true,
+  includeLink = true,
+}) {
   return (
-    <p>
-      {includePrefix && <strong>Note: </strong>} This is the information we have
-      in your VA.gov profile. Any changes you make on this screen will only
-      affect this application.
-    </p>
+    <>
+      <p>
+        {includePrefix && <strong>Note: </strong>} This is the information we
+        have in your VA.gov profile. Any changes you make on this screen will
+        only affect this application.
+      </p>
+      {includePhone && (
+        <>
+          <p>
+            If you need to change this information in your VA.gov profile, you
+            can call us at{' '}
+            <va-telephone contact={CONTACTS.VA_BENEFITS} extension={0} /> (
+            <va-telephone contact={CONTACTS['711']} tty />
+            ). We’re here 24/7.
+          </p>
+        </>
+      )}
+      {includeLink && (
+        <>
+          <va-link
+            href="https://va.gov"
+            text="Find out how to change you address in your VA.gov profile (opens in
+            new tab)"
+          />
+        </>
+      )}
+    </>
   );
 }
+
+ProfileNotUpdatedNote.propTypes = {
+  includeLink: PropTypes.bool,
+  includePhone: PropTypes.bool,
+  includePrefix: PropTypes.bool,
+};

--- a/src/applications/representative-appoint/components/ProfileNotUpdatedNote.jsx
+++ b/src/applications/representative-appoint/components/ProfileNotUpdatedNote.jsx
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
 
 export default function ProfileNotUpdatedNote({
-  includePrefix = true,
-  includePhone = true,
-  includeLink = true,
+  includePrefix = false,
+  includePhone = false,
+  includeLink = false,
 }) {
   return (
     <>

--- a/src/applications/representative-appoint/components/ProfileNotUpdatedNote.jsx
+++ b/src/applications/representative-appoint/components/ProfileNotUpdatedNote.jsx
@@ -15,9 +15,9 @@ export default function ProfileNotUpdatedNote({
       {isLoggedIn(formData) && (
         <>
           <p>
-            {includePrefix && <strong>Note: </strong>} This is the information
-            we have in your VA.gov profile. Any changes you make on this screen
-            will only affect this application.
+            {includePrefix && <strong>Note: </strong>}
+            This is the information we have in your VA.gov profile. Any changes
+            you make on this screen will only affect this application.
           </p>
           {includePhone && (
             <>

--- a/src/applications/representative-appoint/components/ProfileNotUpdatedNote.jsx
+++ b/src/applications/representative-appoint/components/ProfileNotUpdatedNote.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function ProfileNotUpdatedNote(includePrefix = true) {
+  return (
+    <p>
+      {includePrefix && <strong>Note: </strong>} This is the information we have
+      in your VA.gov profile. Any changes you make on this screen will only
+      affect this application.
+    </p>
+  );
+}

--- a/src/applications/representative-appoint/components/ProfileNotUpdatedNote.jsx
+++ b/src/applications/representative-appoint/components/ProfileNotUpdatedNote.jsx
@@ -2,16 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { CONTACTS } from '@department-of-veterans-affairs/component-library/contacts';
-import { isLoggedIn } from 'platform/user/selectors';
+import { isLoggedIn } from '../utilities/helpers';
 
 export default function ProfileNotUpdatedNote({
+  formData,
   includePrefix = false,
   includePhone = false,
   includeLink = false,
 }) {
   return (
     <>
-      {isLoggedIn && (
+      {isLoggedIn(formData) && (
         <>
           <p>
             {includePrefix && <strong>Note: </strong>} This is the information
@@ -45,6 +46,7 @@ export default function ProfileNotUpdatedNote({
 }
 
 ProfileNotUpdatedNote.propTypes = {
+  formData: PropTypes.object,
   includeLink: PropTypes.bool,
   includePhone: PropTypes.bool,
   includePrefix: PropTypes.bool,

--- a/src/applications/representative-appoint/pages/claimant/claimantContactMailing.js
+++ b/src/applications/representative-appoint/pages/claimant/claimantContactMailing.js
@@ -13,7 +13,9 @@ export const uiSchema = {
     'We’ll send any important information about your form to this address.',
   ),
   profileNotUpdatedNote: {
-    'ui:description': () => <ProfileNotUpdatedNote includePrefix includeLink />,
+    'ui:description': formData => (
+      <ProfileNotUpdatedNote formData={formData} includePrefix includeLink />
+    ),
   },
   homeAddress: addressUI({
     labels: {

--- a/src/applications/representative-appoint/pages/claimant/claimantContactMailing.js
+++ b/src/applications/representative-appoint/pages/claimant/claimantContactMailing.js
@@ -1,14 +1,20 @@
+import React from 'react';
+
 import {
   addressSchema,
   addressUI,
   titleUI,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
 
 export const uiSchema = {
   ...titleUI(
     'Your mailing address',
     'We’ll send any important information about your form to this address.',
   ),
+  profileNotUpdatedNote: {
+    'ui:description': () => <ProfileNotUpdatedNote includePrefix includeLink />,
+  },
   homeAddress: addressUI({
     labels: {
       militaryCheckbox: `This address is on a United States military base outside of the U.S.`,
@@ -19,6 +25,7 @@ export const uiSchema = {
 export const schema = {
   type: 'object',
   properties: {
+    profileNotUpdatedNote: { type: 'object', properties: {} },
     homeAddress: addressSchema({
       omit: ['street3'],
     }),

--- a/src/applications/representative-appoint/pages/claimant/claimantContactPhoneEmail.js
+++ b/src/applications/representative-appoint/pages/claimant/claimantContactPhoneEmail.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
   phoneUI,
   phoneSchema,
@@ -6,11 +8,15 @@ import {
   titleUI,
   titleSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
 
 export const blankSchema = { type: 'object', properties: {} };
 
 export const uiSchema = {
   ...titleUI('Your phone number and email address'),
+  profileNotUpdatedNote: {
+    'ui:description': () => <ProfileNotUpdatedNote includePhone />,
+  },
   applicantPhone: phoneUI({
     required: true,
   }),
@@ -22,6 +28,7 @@ export const schema = {
   required: ['applicantPhone'],
   properties: {
     titleSchema,
+    profileNotUpdatedNote: { type: 'object', properties: {} },
     applicantPhone: phoneSchema,
     applicantEmail: emailSchema,
   },

--- a/src/applications/representative-appoint/pages/claimant/claimantContactPhoneEmail.js
+++ b/src/applications/representative-appoint/pages/claimant/claimantContactPhoneEmail.js
@@ -15,7 +15,9 @@ export const blankSchema = { type: 'object', properties: {} };
 export const uiSchema = {
   ...titleUI('Your phone number and email address'),
   profileNotUpdatedNote: {
-    'ui:description': () => <ProfileNotUpdatedNote includePhone />,
+    'ui:description': formData => (
+      <ProfileNotUpdatedNote formData={formData} includePhone />
+    ),
   },
   applicantPhone: phoneUI({
     required: true,

--- a/src/applications/representative-appoint/pages/claimant/claimantContactPhoneEmail.js
+++ b/src/applications/representative-appoint/pages/claimant/claimantContactPhoneEmail.js
@@ -10,8 +10,6 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
 
-export const blankSchema = { type: 'object', properties: {} };
-
 export const uiSchema = {
   ...titleUI('Your phone number and email address'),
   profileNotUpdatedNote: {

--- a/src/applications/representative-appoint/pages/claimant/claimantPersonalInformation.js
+++ b/src/applications/representative-appoint/pages/claimant/claimantPersonalInformation.js
@@ -1,4 +1,6 @@
+import React from 'react';
 import { cloneDeep } from 'lodash';
+
 import {
   dateOfBirthUI,
   dateOfBirthSchema,
@@ -7,14 +9,18 @@ import {
   titleUI,
   titleSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
-
-export const blankSchema = { type: 'object', properties: {} };
+import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
 
 const fullNameMiddleInitialUI = cloneDeep(fullNameUI());
 fullNameMiddleInitialUI.middle['ui:title'] = 'Middle initial';
 
 export const uiSchema = {
   ...titleUI('Your personal information'),
+  profileNotUpdatedNote: {
+    'ui:description': formData => (
+      <ProfileNotUpdatedNote formData={formData} includePhone />
+    ),
+  },
   applicantName: fullNameMiddleInitialUI,
   applicantDOB: dateOfBirthUI({
     required: () => true,
@@ -26,6 +32,7 @@ export const schema = {
   required: ['applicantDOB'],
   properties: {
     titleSchema,
+    profileNotUpdatedNote: { type: 'object', properties: {} },
     applicantName: fullNameSchema,
     applicantDOB: dateOfBirthSchema,
   },

--- a/src/applications/representative-appoint/pages/veteran/veteranContactMailing.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranContactMailing.js
@@ -11,7 +11,9 @@ import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
 export const uiSchema = {
   ...titleUI('Your mailing address'),
   profileNotUpdatedNote: {
-    'ui:description': () => <ProfileNotUpdatedNote includePrefix includeLink />,
+    'ui:description': formData => (
+      <ProfileNotUpdatedNote formData={formData} includePrefix includeLink />
+    ),
   },
   veteranHomeAddress: addressUI({
     labels: {

--- a/src/applications/representative-appoint/pages/veteran/veteranContactMailing.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranContactMailing.js
@@ -1,12 +1,18 @@
+import React from 'react';
+
 import {
   addressSchema,
   addressUI,
   titleUI,
   titleSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
 
 export const uiSchema = {
   ...titleUI('Your mailing address'),
+  profileNotUpdatedNote: {
+    'ui:description': () => <ProfileNotUpdatedNote includePrefix includeLink />,
+  },
   veteranHomeAddress: addressUI({
     labels: {
       militaryCheckbox: `This address is on a United States military base outside of the U.S.`,
@@ -18,6 +24,7 @@ export const schema = {
   type: 'object',
   properties: {
     titleSchema,
+    profileNotUpdatedNote: { type: 'object', properties: {} },
     veteranHomeAddress: addressSchema({
       omit: ['street3'],
     }),

--- a/src/applications/representative-appoint/pages/veteran/veteranContactPhoneEmail.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranContactPhoneEmail.js
@@ -13,7 +13,9 @@ import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
 export const uiSchema = {
   ...titleUI(() => 'Your phone number and email address'),
   profileNotUpdatedNote: {
-    'ui:description': () => <ProfileNotUpdatedNote includePhone />,
+    'ui:description': formData => (
+      <ProfileNotUpdatedNote formData={formData} includePhone />
+    ),
   },
   'Primary phone': phoneUI({
     required: true,

--- a/src/applications/representative-appoint/pages/veteran/veteranContactPhoneEmail.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranContactPhoneEmail.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
   phoneUI,
   phoneSchema,
@@ -6,9 +8,13 @@ import {
   titleUI,
   titleSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
 
 export const uiSchema = {
   ...titleUI(() => 'Your phone number and email address'),
+  profileNotUpdatedNote: {
+    'ui:description': () => <ProfileNotUpdatedNote includePhone />,
+  },
   'Primary phone': phoneUI({
     required: true,
   }),
@@ -20,6 +26,7 @@ export const schema = {
   required: ['Primary phone'],
   properties: {
     titleSchema,
+    profileNotUpdatedNote: { type: 'object', properties: {} },
     'Primary phone': phoneSchema,
     veteranEmail: emailSchema,
   },

--- a/src/applications/representative-appoint/pages/veteran/veteranContactPhoneEmailForNonVeteran.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranContactPhoneEmailForNonVeteran.js
@@ -13,7 +13,9 @@ import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
 export const uiSchema = {
   ...titleUI(() => 'Veteran’s phone number and email address'),
   profileNotUpdatedNote: {
-    'ui:description': () => <ProfileNotUpdatedNote includePhone />,
+    'ui:description': formData => (
+      <ProfileNotUpdatedNote formData={formData} includePhone />
+    ),
   },
   'Primary phone': phoneUI({
     required: false,

--- a/src/applications/representative-appoint/pages/veteran/veteranContactPhoneEmailForNonVeteran.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranContactPhoneEmailForNonVeteran.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
   phoneUI,
   phoneSchema,
@@ -6,9 +8,13 @@ import {
   titleUI,
   titleSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
+import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
 
 export const uiSchema = {
   ...titleUI(() => 'Veteran’s phone number and email address'),
+  profileNotUpdatedNote: {
+    'ui:description': () => <ProfileNotUpdatedNote includePhone />,
+  },
   'Primary phone': phoneUI({
     required: false,
   }),
@@ -20,6 +26,8 @@ export const schema = {
   required: [],
   properties: {
     titleSchema,
+    profileNotUpdatedNote: { type: 'object', properties: {} },
+
     'Primary phone': phoneSchema,
     veteranEmail: emailSchema,
   },

--- a/src/applications/representative-appoint/pages/veteran/veteranIdentification.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranIdentification.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
   ssnUI,
   ssnSchema,
@@ -11,6 +13,7 @@ import {
   descriptionSchema,
 } from 'platform/forms-system/src/js/web-component-patterns';
 
+import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
 import { preparerIsVeteran } from '../../utilities/helpers';
 
 /** @type {PageSchema} */
@@ -28,6 +31,11 @@ export const uiSchema = {
         preparerIsVeteran({ formData }) ? 'your' : 'the Veteran’s'
       } Social Security and VA file numbers are the same. `,
   ),
+  profileNotUpdatedNote: {
+    'ui:description': () => (
+      <ProfileNotUpdatedNote includePrefix includePhone />
+    ),
+  },
   veteranSocialSecurityNumber: ssnUI('Social Security number'),
   veteranVAFileNumber: vaFileNumberUI('VA file number'),
   veteranServiceNumber: serviceNumberUI('Service Number'),
@@ -39,6 +47,7 @@ export const schema = {
   properties: {
     titleSchema,
     descriptionSchema,
+    profileNotUpdatedNote: { type: 'object', properties: {} },
     veteranSocialSecurityNumber: ssnSchema,
     veteranVAFileNumber: vaFileNumberSchema,
     veteranServiceNumber: serviceNumberSchema,

--- a/src/applications/representative-appoint/pages/veteran/veteranIdentification.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranIdentification.js
@@ -32,8 +32,8 @@ export const uiSchema = {
       } Social Security and VA file numbers are the same. `,
   ),
   profileNotUpdatedNote: {
-    'ui:description': () => (
-      <ProfileNotUpdatedNote includePrefix includePhone />
+    'ui:description': formData => (
+      <ProfileNotUpdatedNote formData={formData} includePrefix includePhone />
     ),
   },
   veteranSocialSecurityNumber: ssnUI('Social Security number'),

--- a/src/applications/representative-appoint/pages/veteran/veteranPersonalInformation.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranPersonalInformation.js
@@ -20,7 +20,9 @@ export const uiSchema = {
       } name and date of birth`,
   ),
   profileNotUpdatedNote: {
-    'ui:description': () => <ProfileNotUpdatedNote includePhone />,
+    'ui:description': formData => (
+      <ProfileNotUpdatedNote formData={formData} includePhone />
+    ),
   },
   veteranFullName: fullNameUI(),
   veteranDateOfBirth: dateOfBirthUI(),

--- a/src/applications/representative-appoint/pages/veteran/veteranPersonalInformation.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranPersonalInformation.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
   dateOfBirthUI,
   dateOfBirthSchema,
@@ -8,6 +10,7 @@ import {
 } from 'platform/forms-system/src/js/web-component-patterns';
 
 import { preparerIsVeteran } from '../../utilities/helpers';
+import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
 
 export const uiSchema = {
   ...titleUI(
@@ -16,6 +19,10 @@ export const uiSchema = {
         preparerIsVeteran({ formData }) ? 'Your' : 'Veteran’s'
       } name and date of birth`,
   ),
+  profileNotUpdatedNote: {
+    'ui:description': () => <ProfileNotUpdatedNote includePhone />,
+  },
+
   veteranFullName: fullNameUI(),
   veteranDateOfBirth: dateOfBirthUI(),
 };
@@ -24,6 +31,7 @@ export const schema = {
   type: 'object',
   properties: {
     titleSchema,
+    profileNotUpdatedNote: { type: 'object', properties: {} },
     veteranFullName: fullNameSchema,
     veteranDateOfBirth: dateOfBirthSchema,
   },

--- a/src/applications/representative-appoint/pages/veteran/veteranPersonalInformation.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranPersonalInformation.js
@@ -22,7 +22,6 @@ export const uiSchema = {
   profileNotUpdatedNote: {
     'ui:description': () => <ProfileNotUpdatedNote includePhone />,
   },
-
   veteranFullName: fullNameUI(),
   veteranDateOfBirth: dateOfBirthUI(),
 };

--- a/src/applications/representative-appoint/pages/veteran/veteranServiceInformation.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranServiceInformation.js
@@ -1,9 +1,12 @@
+import React from 'react';
+
 import {
   radioSchema,
   radioUI,
   titleUI,
   titleSchema,
 } from '~/platform/forms-system/src/js/web-component-patterns';
+import ProfileNotUpdatedNote from '../../components/ProfileNotUpdatedNote';
 import { branchOptions } from '../../constants/options';
 import { preparerIsVeteran } from '../../utilities/helpers';
 
@@ -14,6 +17,9 @@ export const uiSchema = {
         preparerIsVeteran({ formData }) ? 'Your' : 'Veteran’s'
       } service information`,
   ),
+  profileNotUpdatedNote: {
+    'ui:description': () => <ProfileNotUpdatedNote includePhone />,
+  },
   'Branch of Service': radioUI('Branch of service'),
 };
 
@@ -21,6 +27,7 @@ export const schema = {
   type: 'object',
   properties: {
     titleSchema,
+    profileNotUpdatedNote: { type: 'object', properties: {} },
     'Branch of Service': radioSchema(branchOptions),
   },
   required: ['Branch of Service'],

--- a/src/applications/representative-appoint/pages/veteran/veteranServiceInformation.js
+++ b/src/applications/representative-appoint/pages/veteran/veteranServiceInformation.js
@@ -18,7 +18,9 @@ export const uiSchema = {
       } service information`,
   ),
   profileNotUpdatedNote: {
-    'ui:description': () => <ProfileNotUpdatedNote includePhone />,
+    'ui:description': formData => (
+      <ProfileNotUpdatedNote formData={formData} includePhone />
+    ),
   },
   'Branch of Service': radioUI('Branch of service'),
 };


### PR DESCRIPTION
Resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/88991

## Summary
Add a note on the following screens that the user's profile is not updated during this form flow. The note to be added for each screen is in the designs linked below. **The content is not the same for all screens**.

[Authenticated **non-Veteran** claimant designs](https://www.figma.com/design/bzbwObT9hiItve0q3cQX9c/Find-and-Appoint-a-Representative?node-id=11012-296381&node-type=frame&t=FNLpcDuz9mWrPnV8-0)
- `/claimant-personal information` 
- `/claimant-contact-phone-email`
- `/claimant-contact-mailing` 

[Authenticated **Veteran** claimant designs](https://www.figma.com/design/bzbwObT9hiItve0q3cQX9c/Find-and-Appoint-a-Representative?node-id=9725-449126&node-type=frame&t=dViXLnRWDfiMBEdM-11)
- `/veteran-personal-information` 
- `/veteran-contact-phone-email` 
- `/veteran-contact-mailing` 
- `/veteran-identification`
- `/veteran-service`

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88991

## Testing done
- Unit tests will be added in a follow-on PR.
- 
## Screenshots
![image](https://github.com/user-attachments/assets/f92baa25-3866-47dc-ba03-35ba67ae49aa)
![image](https://github.com/user-attachments/assets/b9098a0b-b008-46ce-b88f-65dce986175a)
![image](https://github.com/user-attachments/assets/3ede2183-45ff-4d3e-bcdb-e77765f62d28)
![image](https://github.com/user-attachments/assets/50f002d4-9eb6-4671-8a41-2ff9658b1543)

## What areas of the site does it impact?
Appoint a Representative (still behind a feature flag).

## Acceptance criteria
- [x] Any authenticated user will see a note, setting expectations that updating their information in the Appoint a Rep form-fill experience will not update in the Profile.

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
