### PR TITLE
[10-10CG] Update Cypress specs to validate pdf download

### DIFF
--- a/src/applications/caregivers/tests/e2e/fixtures/mocks/mock-pdf-download.json
+++ b/src/applications/caregivers/tests/e2e/fixtures/mocks/mock-pdf-download.json
@@ -1,0 +1,8 @@
+{
+  "statusCode": 200,
+  "headers": {
+    "Content-Type": "application/pdf",
+    "Content-Disposition": "attachment; filename=\"10-10CG_Mickey_Mouse.pdf\""
+  },
+  "body": "Fake 10-10CG Form for Micky Mouse"
+}

--- a/src/applications/caregivers/tests/e2e/utils/helpers.js
+++ b/src/applications/caregivers/tests/e2e/utils/helpers.js
@@ -10,6 +10,7 @@ import featureToggles from '../fixtures/mocks/feature-toggles.json';
 import mockUpload from '../fixtures/mocks/mock-upload.json';
 import mockFacilities from '../fixtures/mocks/mock-facilities.json';
 import mockSubmission from '../fixtures/mocks/mock-submission.json';
+import mockPdfDownload from '../fixtures/mocks/mock-pdf-download.json';
 
 export const setupPerTest = () => {
   cy.intercept('GET', '/v0/feature_toggles?*', featureToggles);
@@ -20,6 +21,11 @@ export const setupPerTest = () => {
     mockFacilities,
   ).as('getFacilities');
   cy.intercept('POST', '/v0/caregivers_assistance_claims', mockSubmission);
+  cy.intercept(
+    'POST',
+    '/v0/caregivers_assistance_claims/download_pdf',
+    mockPdfDownload,
+  ).as('downloadPdf');
 };
 
 export const pageHooks = {
@@ -174,6 +180,17 @@ export const pageHooks = {
           );
           break;
       }
+    });
+  },
+  confirmation: ({ afterHook }) => {
+    afterHook(() => {
+      cy.get('va-link')
+        .contains('Download your completed application (PDF)')
+        .click();
+
+      cy.wait('@downloadPdf').then(() => {
+        cy.get('va-link').contains('Download your completed application (PDF)');
+      });
     });
   },
 };

--- a/src/applications/caregivers/tests/e2e/utils/helpers.js
+++ b/src/applications/caregivers/tests/e2e/utils/helpers.js
@@ -185,11 +185,11 @@ export const pageHooks = {
   confirmation: ({ afterHook }) => {
     afterHook(() => {
       cy.get('va-link')
-        .contains('Download your completed application (PDF)')
+        .contains(content['button-download'])
         .click();
 
       cy.wait('@downloadPdf').then(() => {
-        cy.get('va-link').contains('Download your completed application (PDF)');
+        cy.get('va-link').contains(content['button-download']);
       });
     });
   },


### PR DESCRIPTION

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Updated existing cypress specs to validate the pdf download functionality on a successful form submission
- 10-10 Health Apps

## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/94916


## Testing done

- We were not testing this previously, and now we are.

## Screenshots

- This is only a test change

## What areas of the site does it impact?

10-10CG tests

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

