### PR TITLE
Enable new confirmation page for 10206 on dev

### DIFF
--- a/src/applications/simple-forms/20-10206/config/form.js
+++ b/src/applications/simple-forms/20-10206/config/form.js
@@ -31,15 +31,15 @@ import { getMockData } from '../helpers';
 
 const mockData = testData.data;
 
-// export isLocalhost() to facilitate unit-testing
-export function isLocalhost() {
-  return environment.isLocalhost();
+export function isLocalhostOrDev() {
+  return environment.isLocalhost() || environment.isDev();
 }
 
 /** @type {FormConfig} */
 const formConfig = {
   dev: {
-    showNavLinks: !window.Cypress,
+    showNavLinks: true,
+    collapsibleNavLinks: true,
   },
   rootUrl: manifest.rootUrl,
   urlPrefix: '/',
@@ -94,7 +94,7 @@ const formConfig = {
           title: 'Preparer type',
           // we want req'd fields prefilled for LOCAL testing/previewing
           // one single initialData prop here will suffice for entire form
-          initialData: getMockData(mockData, isLocalhost),
+          initialData: getMockData(mockData, isLocalhostOrDev),
           uiSchema: preparerTypePg.uiSchema,
           schema: preparerTypePg.schema,
           pageClass: 'preparer-type-page',

--- a/src/applications/simple-forms/20-10206/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/20-10206/containers/ConfirmationPage.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect, useSelector } from 'react-redux';
-
+import environment from 'platform/utilities/environment';
 import { ConfirmationPageView } from '../../shared/components/ConfirmationPageView';
+import { ConfirmationPageView as ConfirmationPageViewV2 } from '../../shared/components/ConfirmationPageView.v2';
 
 const content = {
   headlineText: 'You’ve submitted your personal records request',
@@ -10,11 +11,27 @@ const content = {
     'After we review your request, we’ll contact you to tell you what happens next in the request process.',
 };
 
-export const ConfirmationPage = () => {
+// TODO: remove when ready. Test on dev before enabling on prod
+const useConfirmationPageV2 = environment.isLocalhost() || environment.isDev();
+
+export const ConfirmationPage = props => {
   const form = useSelector(state => state.form || {});
   const { submission } = form;
   const submitDate = submission.timestamp;
   const confirmationNumber = submission.response?.confirmationNumber;
+
+  if (useConfirmationPageV2) {
+    return (
+      <ConfirmationPageViewV2
+        formConfig={props.route?.formConfig}
+        submitDate={submitDate}
+        confirmationNumber={confirmationNumber}
+        devOnly={{
+          showButtons: true,
+        }}
+      />
+    );
+  }
 
   return (
     <ConfirmationPageView
@@ -49,6 +66,9 @@ ConfirmationPage.propTypes = {
     }),
   }),
   name: PropTypes.string,
+  route: PropTypes.shape({
+    formConfig: PropTypes.object,
+  }),
 };
 
 function mapStateToProps(state) {

--- a/src/applications/simple-forms/20-10206/containers/IntroductionPage.jsx
+++ b/src/applications/simple-forms/20-10206/containers/IntroductionPage.jsx
@@ -132,6 +132,9 @@ export const IntroductionPage = ({ route, userIdVerified, userLoggedIn }) => {
       childContent={childContent}
       userIdVerified={userIdVerified}
       userLoggedIn={userLoggedIn}
+      devOnly={{
+        forceShowFormControls: true,
+      }}
     />
   );
 };

--- a/src/applications/simple-forms/20-10206/tests/e2e/fixtures/data/test-data.json
+++ b/src/applications/simple-forms/20-10206/tests/e2e/fixtures/data/test-data.json
@@ -33,6 +33,9 @@
     "disabilityExams": [
       {
         "disabilityExamDate": "2019-01-01"
+      },
+      {
+        "disabilityExamDate": "2021-04-15"
       }
     ],
     "otherCompAndPenDetails": "Other Comp&Pen details",

--- a/src/applications/simple-forms/20-10206/tests/unit/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/simple-forms/20-10206/tests/unit/containers/ConfirmationPage.unit.spec.jsx
@@ -52,24 +52,10 @@ describe('ConfirmationPage', () => {
       .find('ConfirmationPageView')
       .props();
 
-    expect(confirmationPageViewProps.formType).to.equal('submission');
-    expect(confirmationPageViewProps.submitterHeader).to.equal(
-      'Who submitted this form',
-    );
-    expect(confirmationPageViewProps.submitterName).to.deep.equal({
-      first: 'John',
-      middle: '',
-      last: 'Preparer',
-    });
     expect(confirmationPageViewProps.submitDate).to.equal(
       '2022-01-01T00:00:00Z',
     );
     expect(confirmationPageViewProps.confirmationNumber).to.equal('1234567890');
-    expect(confirmationPageViewProps.content).to.deep.equal({
-      headlineText: 'You’ve submitted your personal records request',
-      nextStepsText:
-        'After we review your request, we’ll contact you to tell you what happens next in the request process.',
-    });
   });
 
   it('should select form from state when state.form is defined', () => {
@@ -91,7 +77,6 @@ describe('ConfirmationPage', () => {
       </Provider>,
     );
 
-    expect(definedWrapper.text()).to.include('John Preparer');
     expect(definedWrapper.text()).to.include(
       format(submitDate, 'MMMM d, yyyy'),
     );

--- a/src/applications/simple-forms/21-10210/config/form.js
+++ b/src/applications/simple-forms/21-10210/config/form.js
@@ -127,7 +127,9 @@ const formConfig = {
           // we want req'd fields prefilled for LOCAL testing/previewing
           // one single initialData prop here will suffice for entire form
           initialData:
-            !!mockData && environment.isLocalhost() && !window.Cypress
+            !!mockData &&
+            (environment.isLocalhost() || environment.isDev()) &&
+            !environment.isTest()
               ? mockData
               : undefined,
           uiSchema: claimOwnershipPg.uiSchema,

--- a/src/applications/simple-forms/21-10210/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/21-10210/containers/ConfirmationPage.jsx
@@ -57,6 +57,7 @@ export const ConfirmationPage = props => {
       formConfig={formConfig}
       pdfUrl={submission.response?.pdfUrl}
       devOnly={{
+        showButtons: true,
         simulatedFormData: mockData,
       }}
     />

--- a/src/applications/simple-forms/mock-simple-forms-patterns/config/form.js
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/config/form.js
@@ -57,7 +57,10 @@ const initialData = {
 
 // Prefill entire form with data:
 // Helpful for testing confirmation page
-if (environment.isLocalhost() && !window.Cypress) {
+if (
+  (environment.isLocalhost() || environment.isDev()) &&
+  !environment.isTest()
+) {
   Object.assign(initialData, mockData.data);
   Object.assign(initialData, mockArrayBuilderData.data);
 }

--- a/src/applications/simple-forms/mock-simple-forms-patterns/containers/ConfirmationPage.jsx
+++ b/src/applications/simple-forms/mock-simple-forms-patterns/containers/ConfirmationPage.jsx
@@ -36,7 +36,10 @@ const ConfirmationPage = ({ route }) => {
         confirmationNumber={confirmationNumber}
         formConfig={route.formConfig}
         pdfUrl={pdfUrl}
-        devOnly={{ simulatedFormData: mockData }}
+        devOnly={{
+          showButtons: true,
+          simulatedFormData: mockData,
+        }}
       />
     );
   }

--- a/src/applications/simple-forms/shared/components/ConfirmationPageView.v2.jsx
+++ b/src/applications/simple-forms/shared/components/ConfirmationPageView.v2.jsx
@@ -41,6 +41,7 @@ const PdfDownloadLink = ({ url, trackingPrefix }) => {
  * @param {Object} props
  * @param {Object} props.formConfig
  * @param {{
+ *  showButtons: boolean
  *  simulatedFormData: Object
  * }} props.devOnly
  * @param {string} props.pdfUrl
@@ -58,7 +59,7 @@ export const ConfirmationPageView = props => {
   const [submitDate, setSubmitDate] = useState(props.submitDate || null);
 
   const DevOnlyButtons = useDevOnlyButtons({
-    formData: form.data,
+    formData: form?.data,
     mockData: devOnly?.simulatedFormData,
     setPdfUrl,
     setConfirmationNumber,
@@ -88,9 +89,9 @@ export const ConfirmationPageView = props => {
 
   return (
     <div>
-      {devOnly &&
-        !environment.isProduction() &&
-        !environment.isStaging() && <DevOnlyButtons />}
+      {devOnly?.showButtons &&
+        (environment.isLocalhost() || environment.isDev()) &&
+        !environment.isTest() && <DevOnlyButtons />}
       <div className="print-only">
         <img
           src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
@@ -212,6 +213,7 @@ export const ConfirmationPageView = props => {
 ConfirmationPageView.propTypes = {
   confirmationNumber: PropTypes.string,
   devOnly: PropTypes.shape({
+    showButtons: PropTypes.bool,
     simulatedFormData: PropTypes.object,
   }),
   formConfig: PropTypes.object,

--- a/src/platform/forms-system/src/js/containers/FormPage.jsx
+++ b/src/platform/forms-system/src/js/containers/FormPage.jsx
@@ -285,7 +285,9 @@ class FormPage extends React.Component {
       route.pageList[0].path === this.props.location.pathname;
 
     const showNavLinks =
-      environment.isLocalhost() && route.formConfig?.dev?.showNavLinks;
+      (environment.isLocalhost() || environment.isDev()) &&
+      !environment.isTest() &&
+      route.formConfig?.dev?.showNavLinks;
     const hideNavButtons =
       !environment.isProduction() &&
       (route.formConfig?.formOptions?.noBottomNav ||

--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -101,6 +101,7 @@ export function createFormPageList(formConfig) {
 }
 
 export function createPageListByChapter(formConfig) {
+  if (!formConfig?.chapters) return {};
   return Object.keys(formConfig.chapters).reduce((chapters, chapter) => {
     const pages = Object.keys(formConfig.chapters[chapter].pages).map(page => ({
       ...formConfig.chapters[chapter].pages[page],
@@ -113,6 +114,8 @@ export function createPageListByChapter(formConfig) {
 
 export function createPageList(formConfig, formPages) {
   let pageList = formPages;
+
+  if (!formConfig) return [];
 
   if (formConfig.additionalRoutes) {
     pageList = formConfig.additionalRoutes.concat(pageList);

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -331,7 +331,7 @@ class SaveInProgressIntro extends React.Component {
     const data = formData || {};
     // pathname is only provided when the first page is conditional
     if (pathname) return getNextPagePath(pageList, data, pathname);
-    return pageList[1].path;
+    return pageList[1]?.path;
   };
 
   handleClick = () => {
@@ -362,8 +362,8 @@ class SaveInProgressIntro extends React.Component {
   render() {
     const { formConfig, buttonOnly, devOnly } = this.props;
     const devOnlyForceShowFormControls =
-      environment.isLocalhost() &&
-      !window.Cypress &&
+      (environment.isLocalhost() || environment.isDev()) &&
+      !environment.isTest() &&
       devOnly?.forceShowFormControls;
     const appType = formConfig?.customText?.appType || APP_TYPE_DEFAULT;
     const { profile, login } = this.props.user;

--- a/src/platform/utilities/environment/index.js
+++ b/src/platform/utilities/environment/index.js
@@ -100,4 +100,12 @@ export default Object.freeze({
   getRawBuildtype() {
     return __BUILDTYPE__;
   },
+
+  isTest() {
+    return !!(
+      window?.Cypress ||
+      window?.Mocha ||
+      process?.env?.NODE_ENV === 'test'
+    );
+  },
 });


### PR DESCRIPTION
## Summary

- Enable confirmation v2 on 10206 (dev only at first)
- General refactors related to confirmation page v2

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team-forms#1743

## Testing done

- Browser, unit, cypress

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/79a9451c-8d78-4317-9122-5d2c71203074)

After:
![image](https://github.com/user-attachments/assets/fcd86be5-bcf3-4071-a162-1389992ad17c)

(the dev only buttons visible on localhost and dev.va.gov only)

## What areas of the site does it impact?

10206

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
