### PR TITLE
Fix review page alert focus

### DIFF
--- a/src/platform/forms-system/src/js/review/SubmitController.jsx
+++ b/src/platform/forms-system/src/js/review/SubmitController.jsx
@@ -10,6 +10,8 @@ import {
   statementOfTruthFullName,
 } from '~/platform/forms/components/review/PreSubmitSection';
 import { autoSaveForm } from '~/platform/forms/save-in-progress/actions';
+import { $, focusElement } from '~/platform/forms-system/src/js/utilities/ui';
+
 import SubmitButtons from './SubmitButtons';
 import { isValidForm } from '../validation';
 import { createPageListByChapter, getActiveExpandedPages } from '../helpers';
@@ -80,6 +82,29 @@ class SubmitController extends Component {
       this.props.setSubmission('hasAttemptedSubmit', true);
       this.props.setSubmission('timestamp', now);
       // <PreSubmitSection/> is displaying an error for this case
+      // focus on va-privacy-agreement[show-error],
+      // va-statement-of-truth with [input-error] or [checkbox-error], or
+      // any web component with an [error] (e.g., custom statement of truth in
+      // form 20-10207)
+      setTimeout(() => {
+        const error = $(
+          [
+            'va-privacy-agreement[show-error]:not([show-error=""])',
+            'va-statement-of-truth[input-error]:not([input-error=""])',
+            'va-statement-of-truth[checkbox-error]:not([checkbox-error=""])',
+            '[error]:not([error=""])',
+          ].join(','),
+        );
+        if (
+          error?.tagName.startsWith('VA-') &&
+          formConfig?.formOptions?.focusOnAlertRole
+        ) {
+          const webComponent = $('[error]:not([error=""])', error?.shadowRoot);
+          focusElement('[role="alert"]', {}, webComponent?.shadowRoot);
+        } else {
+          focusElement(error);
+        }
+      });
       return;
     }
 

--- a/src/platform/forms/components/common/alerts/ErrorMessage.jsx
+++ b/src/platform/forms/components/common/alerts/ErrorMessage.jsx
@@ -1,6 +1,7 @@
 // libs
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
+import { waitForRenderThenFocus } from 'platform/utilities/ui/focus';
 
 /**
  * A column layout component
@@ -11,9 +12,20 @@ import PropTypes from 'prop-types';
  */
 function ErrorMessage(props) {
   const { active, children, message, testId, title } = props;
+  const alertRef = useRef(null);
+
+  useEffect(
+    () => {
+      if (active && alertRef?.current) {
+        waitForRenderThenFocus('.schemaform-failure-alert');
+      }
+    },
+    [active, alertRef],
+  );
 
   return !active ? null : (
     <va-alert
+      ref={alertRef}
       status="error"
       class="schemaform-failure-alert vads-u-margin-top--4"
       data-testid={testId}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > Focus is lost if there's an error after submitting an application from the review & submit page 
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
  > Focus on the error so screen readers read out the message
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/94687

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Privacy policy errors  | ![submit application with no focus change](https://github.com/user-attachments/assets/2ba6243e-7860-429a-a524-3a958feeb0dd) | ![submit application with focus to privacy policy web component, then submission error alert](https://github.com/user-attachments/assets/715e83aa-4490-4b16-beb6-49ce8b9d0aef) |
| Statement of truth errors | ![submit application with no focus change](https://github.com/user-attachments/assets/f333f7e8-8806-423c-9787-9da8f1fb715f) | ![submit application with focus shift to statement of trutch signature, then confirmation checkbox, then submission error alert](https://github.com/user-attachments/assets/f34a2a86-79d1-4eda-831d-3c8ab69aeba9) |

## What areas of the site does it impact?

All forms that use the review & submit page

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
