### PR TITLE
Remove ACA coverage question from the Health Care Application

### DIFF
--- a/src/applications/hca/components/FormDescriptions/index.jsx
+++ b/src/applications/hca/components/FormDescriptions/index.jsx
@@ -504,7 +504,7 @@ export const FacilityLocatorDescription = (
   <>
     <p>
       <a href={APP_URLS.facilities} rel="noopener noreferrer" target="_blank">
-        Find locations with the VA Facility Locator
+        Find locations with the VA Facility Locator (opens in new tab)
       </a>
     </p>
     <p>
@@ -515,7 +515,7 @@ export const FacilityLocatorDescription = (
         rel="noopener noreferrer"
         target="_blank"
       >
-        Learn more about the Foreign Medical Program
+        Learn more about the Foreign Medical Program (opens in new tab)
       </a>
       .
     </p>
@@ -526,7 +526,7 @@ export const FacilityLocatorDescription = (
         rel="noopener noreferrer"
         target="_blank"
       >
-        Veterans Living Abroad
+        Veterans Living Abroad (opens in new tab)
       </a>
       .
     </p>

--- a/src/applications/hca/components/FormDescriptions/index.jsx
+++ b/src/applications/hca/components/FormDescriptions/index.jsx
@@ -500,33 +500,18 @@ export const SpouseFinancialSupportDescription = (
 );
 
 /** CHAPTER 5: Insurance Information */
-export const EssentialCoverageDescription = (
-  <va-additional-info
-    trigger="Learn more about minimum essential coverage."
-    class="vads-u-margin-y--2 vads-u-margin-left--4"
-    uswds
-  >
-    To avoid the penalty for not having insurance, you must be enrolled in a
-    health plan that qualifies as minimum essential coverage. Being signed up
-    for VA health care meets the minimum essential coverage requirement under
-    the Affordable Care Act.
-  </va-additional-info>
-);
-
 export const FacilityLocatorDescription = (
   <>
     <p>
-      OR{' '}
       <a href={APP_URLS.facilities} rel="noopener noreferrer" target="_blank">
         Find locations with the VA Facility Locator
       </a>
     </p>
-
     <p>
       If you’re looking for medical care outside the continental U.S. or Guam,
       you’ll need to sign up for our Foreign Medical Program.{' '}
       <a
-        href="https://www.va.gov/COMMUNITYCARE/programs/veterans/fmp/index.asp"
+        href="/health-care/foreign-medical-program/"
         rel="noopener noreferrer"
         target="_blank"
       >

--- a/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
+++ b/src/applications/hca/components/FormFields/VaMedicalCenter.jsx
@@ -1,13 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import * as Sentry from '@sentry/browser';
-
 import { VaSelect } from '@department-of-veterans-affairs/component-library/dist/react-bindings';
 import constants from 'vets-json-schema/dist/constants.json';
-import { usePrevious } from '~/platform/utilities/react-hooks';
-import environment from '~/platform/utilities/environment';
-import { apiRequest } from '~/platform/utilities/api';
-import { focusElement } from '~/platform/utilities/ui';
+import { usePrevious } from 'platform/utilities/react-hooks';
+import environment from 'platform/utilities/environment';
+import { apiRequest } from 'platform/utilities/api';
+import { focusElement } from 'platform/utilities/ui';
 import { STATES_WITHOUT_MEDICAL } from '../../utils/constants';
 import ServerErrorAlert from '../FormAlerts/ServerErrorAlert';
 import { VaMedicalCenterReviewField } from '../FormReview/VaMedicalCenterReviewField';
@@ -150,6 +149,7 @@ const VaMedicalCenter = props => {
         isLoading(false);
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [localDataFacilityState, previousFacilityState],
   );
 
@@ -186,14 +186,7 @@ const VaMedicalCenter = props => {
   }
 
   return (
-    <fieldset className="rjsf-object-field vads-u-margin-y--2">
-      <legend
-        id="root_view:preferredFacility__title"
-        className="schemaform-block-title"
-      >
-        Select your preferred VA medical facility
-      </legend>
-
+    <>
       <VaSelect
         id={idSchema['view:facilityState'].$id}
         name={idSchema['view:facilityState'].$id}
@@ -203,7 +196,6 @@ const VaMedicalCenter = props => {
         onVaSelect={handleChange}
         onBlur={handleBlur}
         required
-        uswds
       >
         {constants.states.USA.map(s => {
           return !STATES_WITHOUT_MEDICAL.includes(s.value) ? (
@@ -223,7 +215,6 @@ const VaMedicalCenter = props => {
         onVaSelect={handleChange}
         onBlur={handleBlur}
         required
-        uswds
       >
         {facilities.map(f => (
           <option key={f.id} value={getFieldNameSuffix(f.id)}>
@@ -231,7 +222,7 @@ const VaMedicalCenter = props => {
           </option>
         ))}
       </VaSelect>
-    </fieldset>
+    </>
   );
 };
 

--- a/src/applications/hca/config/chapters/insuranceInformation/vaFacility_api.js
+++ b/src/applications/hca/config/chapters/insuranceInformation/vaFacility_api.js
@@ -1,29 +1,18 @@
 import fullSchemaHca from 'vets-json-schema/dist/10-10EZ-schema.json';
 import { titleUI } from 'platform/forms-system/src/js/web-component-patterns';
-import {
-  EssentialCoverageDescription,
-  FacilityLocatorDescription,
-} from '../../../components/FormDescriptions';
+import { FacilityLocatorDescription } from '../../../components/FormDescriptions';
 import VaMedicalCenter from '../../../components/FormFields/VaMedicalCenter';
 import { emptyObjectSchema } from '../../../definitions';
 import content from '../../../locales/en/content.json';
 
-// define default schema properties
-const {
-  isEssentialAcaCoverage,
-  wantsInitialVaContact,
-} = fullSchemaHca.properties;
+const { wantsInitialVaContact } = fullSchemaHca.properties;
 
 export default {
   uiSchema: {
-    ...titleUI(content['insurance-info--facility-title']),
-    isEssentialAcaCoverage: {
-      'ui:title':
-        'I’m enrolling to get minimum essential coverage under the Affordable Care Act.',
-    },
-    'view:isEssentialCoverageDesc': {
-      'ui:description': EssentialCoverageDescription,
-    },
+    ...titleUI(
+      content['insurance-info--facility-title'],
+      content['insurance-info--facility-description'],
+    ),
     'view:preferredFacility': {
       'ui:field': VaMedicalCenter,
     },
@@ -31,16 +20,13 @@ export default {
       'ui:description': FacilityLocatorDescription,
     },
     wantsInitialVaContact: {
-      'ui:title':
-        'Do you want VA to contact you to schedule your first appointment?',
+      'ui:title': content['insurance-info--appointment-label'],
       'ui:widget': 'yesNo',
     },
   },
   schema: {
     type: 'object',
     properties: {
-      isEssentialAcaCoverage,
-      'view:isEssentialCoverageDesc': emptyObjectSchema,
       'view:preferredFacility': {
         type: 'object',
         required: ['view:facilityState', 'vaMedicalFacility'],

--- a/src/applications/hca/locales/en/content.json
+++ b/src/applications/hca/locales/en/content.json
@@ -24,6 +24,8 @@
   "form-title": "Apply for VA health care",
   "form-subtitle": "Enrollment Application for Health Benefits (VA Form 10-10EZ)",
   "insurance-info--facility-title": "VA facility",
+  "insurance-info--facility-description": "Select your preferred VA medical facility",
+  "insurance-info--appointment-label": "Do you want VA to contact you to schedule your first appointment?",
   "insurance-info--policy-title": "Health insurance information",
   "insurance-info--array-noun-singular": "health insurance policy",
   "insurance-info--array-noun-plural": "health insurance policies",

--- a/src/applications/hca/tests/e2e/fixtures/data/foreign-address-test.json
+++ b/src/applications/hca/tests/e2e/fixtures/data/foreign-address-test.json
@@ -4,7 +4,6 @@
       "view:facilityState": "MA",
       "vaMedicalFacility": "631"
     },
-    "view:locator": {},
     "isCoveredByHealthInsurance": false,
     "isMedicaidEligible": false,
     "isEnrolledMedicarePartA": false,

--- a/src/applications/hca/tests/e2e/fixtures/data/maximal-test.json
+++ b/src/applications/hca/tests/e2e/fixtures/data/maximal-test.json
@@ -1,11 +1,9 @@
 {
   "data": {
-    "isEssentialAcaCoverage": true,
     "view:preferredFacility": {
       "view:facilityState": "MA",
       "vaMedicalFacility": "631"
     },
-    "view:locator": {},
     "wantsInitialVaContact": true,
     "isCoveredByHealthInsurance": true,
     "providers": [

--- a/src/applications/hca/tests/e2e/fixtures/data/minimal-test.json
+++ b/src/applications/hca/tests/e2e/fixtures/data/minimal-test.json
@@ -4,7 +4,6 @@
       "view:facilityState": "MA",
       "vaMedicalFacility": "631"
     },
-    "view:locator": {},
     "isCoveredByHealthInsurance": false,
     "isMedicaidEligible": false,
     "isEnrolledMedicarePartA": false,

--- a/src/applications/hca/tests/e2e/hca-keyboard-only.cypress.spec.js
+++ b/src/applications/hca/tests/e2e/hca-keyboard-only.cypress.spec.js
@@ -367,8 +367,6 @@ describe('HCA-Keyboard-Only', () => {
       cy.tabToContinueForm();
 
       // VA medical facility
-      cy.tabToElementAndPressSpace('[name="root_isEssentialAcaCoverage"]');
-
       const { vaMedicalFacility, 'view:facilityState': facilityState } = data[
         'view:preferredFacility'
       ];

--- a/src/applications/hca/tests/unit/config/insuranceInformation/vaFacility_api.unit.spec.jsx
+++ b/src/applications/hca/tests/unit/config/insuranceInformation/vaFacility_api.unit.spec.jsx
@@ -27,7 +27,7 @@ describe('hca VaFacilityLighthouse config', () => {
       />,
     );
     const formDOM = findDOMNode(form);
-    expect(formDOM.querySelectorAll('input, select').length).to.equal(3);
+    expect(formDOM.querySelectorAll('input, va-select').length).to.equal(4);
   });
 
   it('should not submit empty form', () => {


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

During review of updates to the Health Care Application provided in June 2024, the 1010 team found that the checkbox for a Veteran to indicate that they are "enrolling to get minimum essential coverage under the Affordable Care Act" was removed from the paper form and is no longer needed on the online form. This PR removes the question from the application.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#93819

## Screenshots

| Before | After |
| ------ | ----- |
| ![Screenshot 2024-10-16 at 10 24 54](https://github.com/user-attachments/assets/da813f8d-f007-4ccf-80ae-2614b5e50a7d) | ![Screenshot 2024-10-16 at 10 24 25](https://github.com/user-attachments/assets/268254b0-b349-4673-b6bd-ac16a0504a81) |

## Acceptance criteria

- The "minimum essential coverage" checkbox and accordion info has been removed from the 10-10EZ form

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution