### PR TITLE
Create unit test coverage for document uploads in Health Care Application

### DIFF
--- a/src/applications/hca/config/chapters/militaryService/documentUpload.js
+++ b/src/applications/hca/config/chapters/militaryService/documentUpload.js
@@ -1,6 +1,10 @@
 import environment from 'platform/utilities/environment';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
 import DischargePapersDescription from '../../../components/FormDescriptions/DischargePapersDescription';
+import {
+  createPayload,
+  parseResponse,
+} from '../../../utils/helpers/file-attachments';
 import { attachmentsSchema } from '../../../definitions/attachments';
 
 export default {
@@ -14,16 +18,8 @@ export default {
       fileTypes: ['pdf', 'doc', 'docx', 'jpg', 'jpeg', 'rtf', 'png'],
       maxSize: 1024 * 1024 * 10,
       hideLabelText: true,
-      createPayload: file => {
-        const payload = new FormData();
-        payload.append('hca_attachment[file_data]', file);
-        return payload;
-      },
-      parseResponse: (response, file) => ({
-        name: file.name,
-        confirmationCode: response.data.attributes.guid,
-        size: file.size,
-      }),
+      createPayload,
+      parseResponse,
       attachmentSchema: {
         'ui:title': 'Document type',
       },

--- a/src/applications/hca/tests/unit/utils/helpers/file-attachments.unit.spec.js
+++ b/src/applications/hca/tests/unit/utils/helpers/file-attachments.unit.spec.js
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import {
+  createPayload,
+  parseResponse,
+} from '../../../../utils/helpers/file-attachments';
+
+describe('hca `createPayload` method', () => {
+  let mockFile;
+
+  beforeEach(() => {
+    mockFile = new File(['test'], 'test.txt', { type: 'text/plain' });
+  });
+
+  it('should create a FormData instance with file', () => {
+    const payload = createPayload(mockFile);
+    expect(payload.get('hca_attachment[file_data]')).to.equal(mockFile);
+  });
+});
+
+describe('hca `parseResponse` method', () => {
+  const response = {
+    data: {
+      attributes: {
+        guid: 'test-guid',
+      },
+      id: 'test-id',
+    },
+  };
+  let mockFile;
+  let mockResult;
+
+  beforeEach(() => {
+    mockFile = new File(['test'], 'test.txt', { type: 'text/plain' });
+    mockResult = parseResponse(response, mockFile);
+  });
+
+  it('should return an object with the name, confirmation code and file size', () => {
+    expect(mockResult).to.deep.equal({
+      name: 'test.txt',
+      confirmationCode: 'test-guid',
+      size: 4,
+    });
+  });
+});

--- a/src/applications/hca/utils/helpers/file-attachments.js
+++ b/src/applications/hca/utils/helpers/file-attachments.js
@@ -1,0 +1,11 @@
+export const createPayload = file => {
+  const payload = new FormData();
+  payload.append('hca_attachment[file_data]', file);
+  return payload;
+};
+
+export const parseResponse = (response, file) => ({
+  name: file.name,
+  confirmationCode: response.data.attributes.guid,
+  size: file.size,
+});


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR fills a void for unit test coverage for military document upload functionality in the Health Care Application.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#87452

## Screenshots

| Before | After |
| ------ | ----- |
| ![Screenshot 2024-10-16 at 11 57 14](https://github.com/user-attachments/assets/a303bb84-b6b8-405c-b053-6b871646a7bd) | ![Screenshot 2024-10-16 at 11 58 36](https://github.com/user-attachments/assets/54eb2645-a135-4524-af45-970d2593ab43) |

## Acceptance criteria

 - Unit test coverage numbers meet appropriate criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution