### PR TITLE
update bredcrumbs, progress bar, and links

### DIFF
--- a/src/applications/survivor-dependent-education-benefit/22-5490/components/IntroductionLogin.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/components/IntroductionLogin.jsx
@@ -112,7 +112,11 @@ function IntroductionLogin({
             </va-alert>
             <p className="vads-u-margin-top--4">
               If you don't want to sign in, you can{' '}
-              <a href="https://www.vba.va.gov/pubs/forms/VBA-22-5490-ARE.pdf">
+              <a
+                target="_blank"
+                href="https://www.vba.va.gov/pubs/forms/VBA-22-5490-ARE.pdf"
+                rel="noreferrer"
+              >
                 apply using the paper form
               </a>
               . Please expect longer processing time for decisions when opting

--- a/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/config/form.js
@@ -130,6 +130,7 @@ const formConfig = {
   submitUrl: `${environment.API_URL}/meb_api/v0/forms_submit_claim`,
   transformForSubmit: transform5490Form,
   trackingPrefix: 'edu-22-5490-',
+  v3SegmentedProgressBar: true,
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   formId: '22-5490',
@@ -494,13 +495,20 @@ const formConfig = {
                     updates you make will change the information for your
                     education benefits only. If you want to update your personal
                     information for other VA benefits, update your information
-                    on your <a href="/profile/personal-information">profile</a>.
+                    on your{' '}
+                    <a target="_blank" href="/profile/personal-information">
+                      profile
+                    </a>
+                    .
                   </p>
                   <p>
                     <strong>Note:</strong> If you want to request that we change
                     your name or date of birth, you will need to send additional
                     information. Learn more on how to change your legal name{' '}
-                    <a href="/resources/how-to-change-your-legal-name-on-file-with-va/?_ga=2.13947071.963379013.1690376239-159354255.1663160782">
+                    <a
+                      target="_blank"
+                      href="/resources/how-to-change-your-legal-name-on-file-with-va/?_ga=2.13947071.963379013.1690376239-159354255.1663160782"
+                    >
                       on file with VA.
                     </a>
                   </p>
@@ -788,7 +796,11 @@ const formConfig = {
                     profile.
                   </p>
                   <p>
-                    <a href="https://www.va.gov/resources/managing-your-vagov-profile/">
+                    <a
+                      target="_blank"
+                      href="https://www.va.gov/resources/managing-your-vagov-profile/"
+                      rel="noreferrer"
+                    >
                       Go to your profile
                     </a>
                   </p>
@@ -878,7 +890,7 @@ const formConfig = {
                     profile.
                   </p>
                   <p>
-                    <a href="/profile/personal-information">
+                    <a target="_blank" href="/profile/personal-information">
                       Go to your profile
                     </a>
                   </p>

--- a/src/applications/survivor-dependent-education-benefit/22-5490/containers/App.jsx
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/containers/App.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
-// import { VaBreadcrumbs } from '@department-of-veterans-affairs/web-components/react-bindings';
+import { VaBreadcrumbs } from '@department-of-veterans-affairs/web-components/react-bindings';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import { setData } from 'platform/forms-system/src/js/actions';
 import { getAppData } from '../selectors';
@@ -98,9 +98,33 @@ function App({
   );
 
   return (
-    <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-      {children}
-    </RoutedSavableApp>
+    <>
+      <div className="row">
+        <div className="vads-u-margin-bottom--4">
+          <VaBreadcrumbs
+            label="Breadcrumbs"
+            wrapping
+            breadcrumbList={[
+              {
+                href: '/',
+                label: 'Home',
+              },
+              {
+                href: '/education',
+                label: 'Education and training',
+              },
+              {
+                href: '/education/survivor-dependent-education-benefit-22-5490',
+                label: 'Apply for survivor dependent benefits',
+              },
+            ]}
+          />
+        </div>
+      </div>
+      <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+        {children}
+      </RoutedSavableApp>
+    </>
   );
 }
 


### PR DESCRIPTION
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Update Breadcrumbs: [version 3.0 breadcrumbs component](https://design.va.gov/components/breadcrumbs). 
Ensure links open in new tab
confirm we are using latest progress bar: [progress bar](https://design.va.gov/components/form/progress-bar-segmented)
