### PR TITLE
94606 Update widget content for feature toggle - form 10-10d

### DIFF
--- a/src/applications/static-pages/ivc-champva/10-10D/App.js
+++ b/src/applications/static-pages/ivc-champva/10-10D/App.js
@@ -13,20 +13,106 @@ const App = ({ formEnabled }) => {
   if (formEnabled) {
     return (
       <>
-        <p>You can submit this application online or by mail.</p>
+        <p>
+          You can apply online, by mail, or by fax. Make sure to submit the
+          required supporting documents with your application.
+        </p>
+        <va-link
+          href="/health-care/family-caregiver-benefits/champva/#supporting-documents-for-your-application"
+          text="Find out what supporting documents you need"
+        />
+        <h3>
+          <strong>Option 1: Online</strong>
+        </h3>
+        <p>You can apply online now.</p>
         <a
-          className="vads-c-action-link--blue"
-          href="/family-and-caregiver-benefits/health-and-disability/champva/apply-form-10-10d"
+          className="vads-c-action-link--green"
+          href="/family-and-caregiver-benefits/health-and-disability/champva/apply-form-10-10d/"
         >
-          Submit an application online to enroll in CHAMPVA benefits
+          Apply for CHAMPVA online
         </a>
+        <h3>Option 2: By mail</h3>
+        <p>
+          You’ll need to fill out an Application for CHAMPVA Benefits (VA Form
+          10-10d).
+        </p>
+        <va-link
+          href="/find-forms/about-form-10-10d/"
+          text="Get VA Form 10-10d to download"
+        />
+        <p>
+          Mail your completed application and supporting documents to this
+          address:
+        </p>
+        <p className="va-address-block">
+          VHA Office of Community Care
+          <br />
+          CHAMPVA Eligibility
+          <br />
+          PO Box 469028
+          <br />
+          Denver, CO 80246-9028
+          <br />
+        </p>
+        <h3>Option 3: By fax</h3>
+        <p>
+          You’ll need to fill out an Application for CHAMPVA Benefits (VA Form
+          10-10d).
+        </p>
+        <va-link
+          href="/find-forms/about-form-10-10d/"
+          text="Get VA Form 10-10d to download"
+        />
+        <p>
+          Fax your completed application and supporting documents to{' '}
+          <va-telephone contact="3033317809" />.
+        </p>
       </>
     );
   }
 
   return (
     <>
-      <p>You can submit this application by mail.</p>
+      <p>
+        You can apply by mail or by fax. You’ll need to fill out an Application
+        for CHAMPVA Benefits (VA Form 10-10d).
+      </p>
+      <a
+        className="vads-c-action-link--green"
+        href="/find-forms/about-form-10-10d/"
+      >
+        Get VA Form 10-10d to download
+      </a>
+      <p>
+        Make sure to submit the required supporting documents with your
+        application.
+      </p>
+      <va-link
+        href="/health-care/family-caregiver-benefits/champva/#supporting-documents-for-your-application"
+        text="Find out what supporting documents you need"
+      />
+      <h3>
+        <strong>Option 1: By mail</strong>
+      </h3>
+      <p>
+        Mail your completed application and supporting documents to this
+        address:
+      </p>
+      <p className="va-address-block">
+        VHA Office of Community Care
+        <br />
+        CHAMPVA Eligibility
+        <br />
+        PO Box 469028
+        <br />
+        Denver, CO 80246-9028
+        <br />
+      </p>
+      <h3>Option 2: By fax</h3>
+      <p>
+        Fax your completed application and supporting documents to{' '}
+        <va-telephone contact="3033317809" />.
+      </p>
     </>
   );
 };


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

This PR updates the static page widget for form 10-10d so that the content matches that required by CAIA.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/70698#issuecomment-2361800180
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/94606

## Testing done

- Manual

## Screenshots

|         | Static page widget | 
| ------- | ------ | 
| activated  |![Screenshot 2024-10-16 at 15 55 42](https://github.com/user-attachments/assets/f6b58ad8-8047-446b-9ac7-b861c83b3dbf)| 
| deactivated |![Screenshot 2024-10-16 at 15 53 48](https://github.com/user-attachments/assets/d62ddd15-176e-4416-85b3-1cc1c60faf8e)| 

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [X] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA