### PR TITLE
Update content for supply re-order sign-in alert widget

### DIFF
--- a/src/applications/static-pages/mhv-signin-cta/README.md
+++ b/src/applications/static-pages/mhv-signin-cta/README.md
@@ -1,5 +1,7 @@
 This MHV verify sign-in call-to-action widget shows an alert if the user is unauthenticated or unverified, or otherwise will show any provided content.
 
+The default alert content matches the global versions of sign-in alerts that will eventually be included as part of VADS.
+
 ## Widget Features
 - Displays an alert instead of content if the user is not signed in
 - Displays an alert instead of content if the user is not verified

--- a/src/applications/static-pages/mhv-signin-cta/components/messages/UnauthenticatedAlert.jsx
+++ b/src/applications/static-pages/mhv-signin-cta/components/messages/UnauthenticatedAlert.jsx
@@ -31,23 +31,25 @@ const UnauthenticatedAlert = ({ recordEvent, serviceDescription }) => {
       >
         <div>
           <p>
-            You’ll need to sign in with a verified account through one of our
-            account providers. Identity verification helps us protect your
-            information and prevent fraud and identity theft.
+            You’ll need to sign in with an identity-verified account through one
+            of our account providers. Identity verification helps us protect all
+            Veterans’ information and prevent scammers from stealing your
+            benefits.
           </p>
           <p>
             <strong>Don’t yet have a verified account?</strong> Create a{' '}
-            <strong>Login.gov</strong> or <strong>ID.me</strong> account now.
-            Then come back here and sign in. We’ll help you verify.
+            <strong>Login.gov</strong> or <strong>ID.me</strong> account. We’ll
+            help you verify your identity for your account now.
           </p>
           <p>
             <strong>Not sure if your account is verified?</strong> Sign in here.
-            We’ll tell you if you need to verify.
+            If you still need to verify your identity, we’ll help you do that
+            now.
           </p>
           <p>
             <va-button
               onClick={handleSignIn}
-              text="Sign in or create account"
+              text="Sign in or create an account"
             />
           </p>
           <p>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Update the content for supply re-order sign-in alert widget to match the global sign-in version that was recently finalized for VA.gov site.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/94862


## Testing done

- Manual testing of the widget replacement
  - Run a watch on `content-build`. Make sure to use the `cached-assets` to build the repo. `yarn watch` - this process can take a while to complete.
  - Build this branch in `vets-website` with `yarn build --env --entry=static-pages`.
  - Open http://localhost:3002/health-care/order-medical-supplies/ and verify the widget is shown.

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |   <img width="482" alt="Screenshot 2024-10-16 at 4 58 21 PM" src="https://github.com/user-attachments/assets/34d754bd-da5f-4024-bdec-9b576fe70e4c">     |   <img width="482" alt="Screenshot 2024-10-16 at 4 55 47 PM" src="https://github.com/user-attachments/assets/43d5be63-239a-49d1-b618-e26f8d67145e">    |
| Desktop |   <img width="675" alt="Screenshot 2024-10-16 at 1 59 55 PM" src="https://github.com/user-attachments/assets/aa866fb8-6f5e-4c79-b17c-4c1b938d4945">     |    <img width="675" alt="Screenshot 2024-10-16 at 4 13 40 PM" src="https://github.com/user-attachments/assets/cde84f67-0977-4e6f-aa53-1ad75afed4c0">   |

## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria
- MHV Sign-in CTA README shows the updated sample service description..
- MHV Sign-in CTA Sign-in alert body content is now a match w/ the global version.
- Except for the heading, which is still custom to specify the purpose of ordering supplies
- QA review

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
