### PR TITLE
Overhaul appointments reason and comments fields

### DIFF
--- a/src/applications/vaos/appointment-list/components/cancel/CancelPageLayout.jsx
+++ b/src/applications/vaos/appointment-list/components/cancel/CancelPageLayout.jsx
@@ -43,7 +43,6 @@ export default function CancelPageLayout() {
   const { id } = useParams();
   const {
     appointment,
-    bookingNotes,
     clinicName,
     clinicPhone,
     clinicPhoneExtension,
@@ -61,7 +60,7 @@ export default function CancelPageLayout() {
   );
 
   const heading = getHeading(appointment);
-  const [reason, otherDetails] = bookingNotes.split(':');
+  const { reasonForAppointment, patientComments } = appointment || {};
   const facilityId = locationId;
 
   return (
@@ -176,7 +175,11 @@ export default function CancelPageLayout() {
           />
         </Where>
       )}
-      <Details reason={reason} otherDetails={otherDetails} level={3} />
+      <Details
+        reason={reasonForAppointment}
+        otherDetails={patientComments}
+        level={3}
+      />
     </>
   );
 }

--- a/src/applications/vaos/appointment-list/components/cancel/CancelPageLayoutRequest.jsx
+++ b/src/applications/vaos/appointment-list/components/cancel/CancelPageLayoutRequest.jsx
@@ -7,7 +7,11 @@ import Address from '../../../components/Address';
 import FacilityPhone from '../../../components/FacilityPhone';
 import { selectRequestedAppointmentDetails } from '../../redux/selectors';
 import ListBestTimeToCall from '../ListBestTimeToCall';
-import { Details, Section } from '../../../components/layout/DetailPageLayout';
+import {
+  CCDetails,
+  Details,
+  Section,
+} from '../../../components/layout/DetailPageLayout';
 import { APPOINTMENT_STATUS } from '../../../utils/constants';
 import { getRealFacilityId } from '../../../utils/appointment';
 import NewTabAnchor from '../../../components/NewTabAnchor';
@@ -76,6 +80,7 @@ export default function CancelPageLayoutRequest() {
           <Section heading="Language you’d prefer the provider speak" level={3}>
             {preferredLanguage}
           </Section>
+          <CCDetails otherDetails={patientComments} request level={3} />
         </>
       )}
       {!isCC && (
@@ -126,14 +131,14 @@ export default function CancelPageLayoutRequest() {
             )}
             {!facilityPhone && <>Not available</>}
           </Section>
+          <Details
+            reason={reasonForAppointment}
+            otherDetails={patientComments}
+            request
+            level={3}
+          />
         </>
       )}
-      <Details
-        reason={reasonForAppointment}
-        otherDetails={patientComments}
-        request
-        level={3}
-      />
       <Section heading="Your contact details" level={3}>
         <span data-dd-privacy="mask">Email: {email}</span>
         <br />

--- a/src/applications/vaos/appointment-list/components/cancel/CancelPageLayoutRequest.jsx
+++ b/src/applications/vaos/appointment-list/components/cancel/CancelPageLayoutRequest.jsx
@@ -15,7 +15,7 @@ import NewTabAnchor from '../../../components/NewTabAnchor';
 export default function CancelPageLayoutRequest() {
   const { id } = useParams();
   const {
-    bookingNotes,
+    appointment,
     email,
     facility,
     facilityId,
@@ -34,11 +34,8 @@ export default function CancelPageLayoutRequest() {
     state => selectRequestedAppointmentDetails(state, id),
     shallowEqual,
   );
-  let [reason, otherDetails] = bookingNotes.split(':');
-  if (isCC) {
-    reason = null;
-    otherDetails = bookingNotes;
-  }
+
+  const { reasonForAppointment, patientComments } = appointment || {};
   const { providerName } = preferredProvider || {};
 
   return (
@@ -131,7 +128,12 @@ export default function CancelPageLayoutRequest() {
           </Section>
         </>
       )}
-      <Details reason={reason} otherDetails={otherDetails} request level={3} />
+      <Details
+        reason={reasonForAppointment}
+        otherDetails={patientComments}
+        request
+        level={3}
+      />
       <Section heading="Your contact details" level={3}>
         <span data-dd-privacy="mask">Email: {email}</span>
         <br />

--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -201,44 +201,9 @@ export function selectCanUseVaccineFlow(state) {
   );
 }
 
-export function selectAppointmentDetails(appointment) {
-  if (!appointment) return '';
-
-  if (appointment.version === 2) {
-    return appointment.comment ? appointment.comment : 'none';
-  }
-
-  const { comment } = appointment;
-  if (appointment.vaos.isCommunityCare) {
-    return comment || 'none';
-  }
-  return appointment.reasonForAppointment && comment
-    ? `${appointment.reasonForAppointment}: ${comment}`
-    : comment ||
-        (appointment.reasonForAppointment
-          ? appointment.reasonForAppointment
-          : null);
-}
-
 export function selectProviderAddress(appointment) {
   const practitioners = appointment?.practitioners || [];
   return practitioners.length > 0 ? practitioners[0].address : null;
-}
-
-export function selectComment(appointment) {
-  if (!appointment) return '';
-
-  if (appointment.version === 2) {
-    return appointment.comment ? appointment.comment : 'none';
-  }
-
-  const { comment } = appointment;
-  if (appointment.vaos.isCommunityCare) {
-    return comment || 'none';
-  }
-  return appointment.reason && comment
-    ? `${appointment.reason}: ${comment}`
-    : comment || (appointment.reason ? appointment.reason : null);
 }
 
 export function getRequestedAppointmentListInfo(state) {
@@ -643,7 +608,6 @@ export function selectAtlasConfirmationCode(appointment) {
 }
 
 export function selectConfirmedAppointmentData(state, appointment) {
-  const comment = selectComment(appointment);
   const isCommunityCare = appointment?.vaos?.isCommunityCare;
   const appointmentTypePrefix = isCommunityCare ? 'cc' : 'va';
 
@@ -670,7 +634,6 @@ export function selectConfirmedAppointmentData(state, appointment) {
     facility?.telecom?.find(tele => tele.system === 'phone')?.value;
 
   const duration = appointment?.minutesDuration;
-  const bookingNotes = selectAppointmentDetails(appointment);
   const isPhone = selectIsPhone(appointment);
   const timeZoneAbbr = selectTimeZoneAbbr(appointment);
   const providerAddress = selectProviderAddress(appointment);
@@ -688,14 +651,12 @@ export function selectConfirmedAppointmentData(state, appointment) {
     appointmentDetailsStatus,
     appointmentTypePrefix,
     atlasConfirmationCode,
-    bookingNotes,
     cancelInfo: getCancelInfo(state),
     ccProvider,
     clinicName,
     clinicPhone,
     clinicPhoneExtension,
     clinicPhysicalLocation,
-    comment,
     duration,
     facility,
     facilityData,
@@ -737,10 +698,8 @@ export function selectRequestedAppointmentData(state, appointment) {
   );
   const { facilityData } = state?.appointments || [];
 
-  const bookingNotes = selectAppointmentDetails(appointment);
   const cancelInfo = getCancelInfo(state);
   const canceled = appointment?.status === APPOINTMENT_STATUS.cancelled;
-  const comment = selectComment(appointment);
   const email = getPatientTelecom(appointment, 'email');
   const facilityId = getVAAppointmentLocationId(appointment);
   const facility = facilityData?.[facilityId];
@@ -769,10 +728,8 @@ export function selectRequestedAppointmentData(state, appointment) {
 
   return {
     appointment,
-    bookingNotes,
     cancelInfo,
     canceled,
-    comment,
     email,
     facility,
     facilityData,
@@ -805,10 +762,8 @@ export function selectRequestedAppointmentDetails(state, id) {
     APPOINTMENT_TYPES.ccRequest,
   ]);
 
-  const bookingNotes = selectAppointmentDetails(appointment);
   const cancelInfo = getCancelInfo(state);
   const canceled = appointment?.status === APPOINTMENT_STATUS.cancelled;
-  const comment = selectComment(appointment);
   const email = getPatientTelecom(appointment, 'email');
   const facilityId = getVAAppointmentLocationId(appointment);
   const facility = facilityData?.[facilityId];
@@ -838,10 +793,8 @@ export function selectRequestedAppointmentDetails(state, id) {
   return {
     appointment,
     appointmentDetailsStatus,
-    bookingNotes,
     cancelInfo,
     canceled,
-    comment,
     email,
     facility,
     facilityData,

--- a/src/applications/vaos/components/layout/CCLayout.jsx
+++ b/src/applications/vaos/components/layout/CCLayout.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { shallowEqual } from 'recompose';
 import { useSelector } from 'react-redux';
 import DetailPageLayout, {
-  Details,
+  CCDetails,
   Section,
   What,
   When,
@@ -36,7 +36,7 @@ export default function CCLayout({ data: appointment }) {
   if (!appointment) return null;
 
   const { address, providerName, treatmentSpecialty } = ccProvider;
-  const { reasonForAppointment, patientComments } = appointment || {};
+  const { patientComments } = appointment || {};
 
   let heading = 'Community care appointment';
   if (isPastAppointment) heading = 'Past community care appointment';
@@ -88,7 +88,7 @@ export default function CCLayout({ data: appointment }) {
             </>
           )}
         </Section>
-        <Details reason={reasonForAppointment} otherDetails={patientComments} />
+        <CCDetails otherDetails={patientComments} />
         {!isPastAppointment &&
           (APPOINTMENT_STATUS.booked === status ||
             APPOINTMENT_STATUS.cancelled === status) && (

--- a/src/applications/vaos/components/layout/CCLayout.jsx
+++ b/src/applications/vaos/components/layout/CCLayout.jsx
@@ -22,7 +22,6 @@ import Address from '../Address';
 
 export default function CCLayout({ data: appointment }) {
   const {
-    comment,
     facility,
     isPastAppointment,
     ccProvider,
@@ -37,7 +36,7 @@ export default function CCLayout({ data: appointment }) {
   if (!appointment) return null;
 
   const { address, providerName, treatmentSpecialty } = ccProvider;
-  const [reason, otherDetails] = comment ? comment?.split(':') : [];
+  const { reasonForAppointment, patientComments } = appointment || {};
 
   let heading = 'Community care appointment';
   if (isPastAppointment) heading = 'Past community care appointment';
@@ -89,7 +88,7 @@ export default function CCLayout({ data: appointment }) {
             </>
           )}
         </Section>
-        <Details reason={reason} otherDetails={otherDetails} />
+        <Details reason={reasonForAppointment} otherDetails={patientComments} />
         {!isPastAppointment &&
           (APPOINTMENT_STATUS.booked === status ||
             APPOINTMENT_STATUS.cancelled === status) && (

--- a/src/applications/vaos/components/layout/CCRequestLayout.jsx
+++ b/src/applications/vaos/components/layout/CCRequestLayout.jsx
@@ -5,7 +5,7 @@ import { VaTelephone } from '@department-of-veterans-affairs/component-library/d
 import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { selectRequestedAppointmentData } from '../../appointment-list/redux/selectors';
-import DetailPageLayout, { Details, Section } from './DetailPageLayout';
+import DetailPageLayout, { CCDetails, Section } from './DetailPageLayout';
 import ListBestTimeToCall from '../../appointment-list/components/ListBestTimeToCall';
 import PageLayout from '../../appointment-list/components/PageLayout';
 import { APPOINTMENT_STATUS } from '../../utils/constants';
@@ -79,7 +79,7 @@ export default function CCRequestLayout({ data: appointment }) {
         <Section heading="Language you’d prefer the provider speak">
           {preferredLanguage}
         </Section>
-        <Details otherDetails={patientComments} request />
+        <CCDetails otherDetails={patientComments} request />
         <Section heading="Your contact details">
           <span data-dd-privacy="mask">Email: {email}</span>
           <br />

--- a/src/applications/vaos/components/layout/CCRequestLayout.jsx
+++ b/src/applications/vaos/components/layout/CCRequestLayout.jsx
@@ -13,7 +13,6 @@ import { APPOINTMENT_STATUS } from '../../utils/constants';
 export default function CCRequestLayout({ data: appointment }) {
   const { search } = useLocation();
   const {
-    comment,
     email,
     facility,
     isPendingAppointment,
@@ -34,10 +33,7 @@ export default function CCRequestLayout({ data: appointment }) {
   const queryParams = new URLSearchParams(search);
   const showConfirmMsg = queryParams.get('confirmMsg');
 
-  // There is no reason for appointment for CC appointment request.
-  // const [reason, otherDetails] = comment?.split(':') || [];
-  const reason = null;
-  const otherDetails = comment;
+  const { patientComments } = appointment;
 
   let heading = 'We have received your request';
   if (isPendingAppointment && !showConfirmMsg)
@@ -83,7 +79,7 @@ export default function CCRequestLayout({ data: appointment }) {
         <Section heading="Language you’d prefer the provider speak">
           {preferredLanguage}
         </Section>
-        <Details reason={reason} otherDetails={otherDetails} request />
+        <Details otherDetails={patientComments} request />
         <Section heading="Your contact details">
           <span data-dd-privacy="mask">Email: {email}</span>
           <br />

--- a/src/applications/vaos/components/layout/DetailPageLayout.jsx
+++ b/src/applications/vaos/components/layout/DetailPageLayout.jsx
@@ -99,6 +99,24 @@ Prepare.propTypes = {
   children: PropTypes.node,
 };
 
+export function CCDetails({ otherDetails, request, level = 2 }) {
+  const heading = request
+    ? 'Details you’d like to share with your provider'
+    : 'Details you shared with your provider';
+  return (
+    <Section heading={heading} level={level}>
+      <span className="vaos-u-word-break--break-word">
+        Other details: {`${otherDetails || 'Not available'}`}
+      </span>
+    </Section>
+  );
+}
+CCDetails.propTypes = {
+  level: PropTypes.number,
+  otherDetails: PropTypes.string,
+  request: PropTypes.bool,
+};
+
 export function Details({ reason, otherDetails, request, level = 2 }) {
   const heading = request
     ? 'Details you’d like to share with your provider'

--- a/src/applications/vaos/components/layout/InPersonLayout.jsx
+++ b/src/applications/vaos/components/layout/InPersonLayout.jsx
@@ -29,7 +29,6 @@ export default function InPersonLayout({ data: appointment }) {
     clinicPhysicalLocation,
     clinicPhone,
     clinicPhoneExtension,
-    comment,
     facility,
     facilityPhone,
     locationId,
@@ -45,7 +44,7 @@ export default function InPersonLayout({ data: appointment }) {
 
   if (!appointment) return null;
 
-  const [reason, otherDetails] = comment ? comment?.split(':') : [];
+  const { reasonForAppointment, patientComments } = appointment || {};
   const facilityId = locationId;
 
   let heading = 'In-person appointment';
@@ -127,7 +126,7 @@ export default function InPersonLayout({ data: appointment }) {
           facilityPhone={facilityPhone}
         />
       </Where>
-      <Details reason={reason} otherDetails={otherDetails} />
+      <Details reason={reasonForAppointment} otherDetails={patientComments} />
       {!isPastAppointment &&
         (APPOINTMENT_STATUS.booked === status ||
           APPOINTMENT_STATUS.cancelled === status) && (

--- a/src/applications/vaos/components/layout/PhoneLayout.jsx
+++ b/src/applications/vaos/components/layout/PhoneLayout.jsx
@@ -26,7 +26,6 @@ export default function PhoneLayout({ data: appointment }) {
     clinicName,
     clinicPhone,
     clinicPhoneExtension,
-    comment,
     facility,
     facilityPhone,
     isPastAppointment,
@@ -39,7 +38,7 @@ export default function PhoneLayout({ data: appointment }) {
     shallowEqual,
   );
 
-  const [reason, otherDetails] = comment ? comment?.split(':') : [];
+  const { reasonForAppointment, patientComments } = appointment || {};
 
   let heading = 'Phone appointment';
   if (isPastAppointment) heading = 'Past phone appointment';
@@ -98,7 +97,7 @@ export default function PhoneLayout({ data: appointment }) {
           facilityPhone={facilityPhone}
         />
       </Section>
-      <Details reason={reason} otherDetails={otherDetails} />
+      <Details reason={reasonForAppointment} otherDetails={patientComments} />
       {!isPastAppointment &&
         (APPOINTMENT_STATUS.booked === status ||
           APPOINTMENT_STATUS.cancelled === status) && (

--- a/src/applications/vaos/components/layout/VARequestLayout.jsx
+++ b/src/applications/vaos/components/layout/VARequestLayout.jsx
@@ -17,7 +17,6 @@ import NewTabAnchor from '../NewTabAnchor';
 export default function VARequestLayout({ data: appointment }) {
   const { search } = useLocation();
   const {
-    bookingNotes,
     email,
     facility,
     facilityId,
@@ -34,7 +33,7 @@ export default function VARequestLayout({ data: appointment }) {
   const queryParams = new URLSearchParams(search);
   const showConfirmMsg = queryParams.get('confirmMsg');
   const preferredModality = appointment?.preferredModality;
-  const [reason, otherDetails] = bookingNotes?.split(':') || [];
+  const { reasonForAppointment, patientComments } = appointment || {};
 
   let heading = 'We have received your request';
   if (isPendingAppointment && !showConfirmMsg)
@@ -104,7 +103,11 @@ export default function VARequestLayout({ data: appointment }) {
           )}
           {!facilityPhone && <>Not available</>}
         </Section>
-        <Details reason={reason} otherDetails={otherDetails} request />
+        <Details
+          reason={reasonForAppointment}
+          otherDetails={patientComments}
+          request
+        />
         <Section heading="Your contact details">
           <span data-dd-privacy="mask">Email: {email}</span>
           <br />

--- a/src/applications/vaos/components/tests/CCLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/CCLayout.unit.spec.js
@@ -60,14 +60,6 @@ describe('VAOS Component: CCLayout', () => {
         screen.getByText((content, element) => {
           return (
             element.tagName.toLowerCase() === 'span' &&
-            content === 'Reason: Not available'
-          );
-        }),
-      );
-      expect(
-        screen.getByText((content, element) => {
-          return (
-            element.tagName.toLowerCase() === 'span' &&
             content === 'Other details: Not available'
           );
         }),
@@ -157,7 +149,6 @@ describe('VAOS Component: CCLayout', () => {
           name: /Details you shared with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason: Not available/i));
       expect(
         screen.getByText(
           /Other details: This is a test:Additional information/i,
@@ -289,7 +280,6 @@ describe('VAOS Component: CCLayout', () => {
           name: /Details you shared with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason: Not available/i));
       expect(
         screen.getByText(
           /Other details: This is a test:Additional information/i,
@@ -409,7 +399,6 @@ describe('VAOS Component: CCLayout', () => {
           name: /Details you shared with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason: Not available/i));
       expect(
         screen.getByText(
           /Other details: This is a test:Additional information/i,

--- a/src/applications/vaos/components/tests/CCLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/CCLayout.unit.spec.js
@@ -80,7 +80,7 @@ describe('VAOS Component: CCLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
+        patientComments: 'This is a test:Additional information',
         communityCareProvider: {
           address: {
             line: ['line 1'],
@@ -157,10 +157,12 @@ describe('VAOS Component: CCLayout', () => {
           name: /Details you shared with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason:/i));
-      expect(screen.getByText(/This is a test/i));
-      expect(screen.getByText(/Other details:/i));
-      expect(screen.getByText(/Additional information/i));
+      expect(screen.getByText(/Reason: Not available/i));
+      expect(
+        screen.getByText(
+          /Other details: This is a test:Additional information/i,
+        ),
+      );
 
       expect(
         screen.getByRole('heading', {
@@ -199,7 +201,7 @@ describe('VAOS Component: CCLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
+        patientComments: 'This is a test:Additional information',
         communityCareProvider: {
           address: {
             line: ['line 1'],
@@ -287,10 +289,12 @@ describe('VAOS Component: CCLayout', () => {
           name: /Details you shared with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason:/i));
-      expect(screen.getByText(/This is a test/i));
-      expect(screen.getByText(/Other details:/i));
-      expect(screen.getByText(/Additional information/i));
+      expect(screen.getByText(/Reason: Not available/i));
+      expect(
+        screen.getByText(
+          /Other details: This is a test:Additional information/i,
+        ),
+      );
 
       expect(
         screen.queryByRole('heading', {
@@ -311,7 +315,7 @@ describe('VAOS Component: CCLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
+        patientComments: 'This is a test:Additional information',
         communityCareProvider: {
           address: {
             line: ['line 1'],
@@ -405,10 +409,12 @@ describe('VAOS Component: CCLayout', () => {
           name: /Details you shared with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason:/i));
-      expect(screen.getByText(/This is a test/i));
-      expect(screen.getByText(/Other details:/i));
-      expect(screen.getByText(/Additional information/i));
+      expect(screen.getByText(/Reason: Not available/i));
+      expect(
+        screen.getByText(
+          /Other details: This is a test:Additional information/i,
+        ),
+      );
 
       expect(
         screen.getByRole('heading', {

--- a/src/applications/vaos/components/tests/CCRequestLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/CCRequestLayout.unit.spec.js
@@ -137,7 +137,6 @@ describe('VAOS Component: VARequestLayout', () => {
           name: /Details you.d like to share with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason: Not available/i));
       expect(
         screen.getByText(
           /Other details: This is a test:Additional information/i,
@@ -276,7 +275,6 @@ describe('VAOS Component: VARequestLayout', () => {
           name: /Details you.d like to share with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason: Not available/i));
       expect(
         screen.getByText(
           /Other details: This is a test:Additional information/i,

--- a/src/applications/vaos/components/tests/CCRequestLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/CCRequestLayout.unit.spec.js
@@ -37,7 +37,7 @@ describe('VAOS Component: VARequestLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
+        patientComments: 'This is a test:Additional information',
         contact: {
           telecom: [
             {
@@ -137,10 +137,12 @@ describe('VAOS Component: VARequestLayout', () => {
           name: /Details you.d like to share with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason:/i));
-      expect(screen.getByText(/This is a test/i));
-      expect(screen.getByText(/Other details:/i));
-      expect(screen.getByText(/Additional information/i));
+      expect(screen.getByText(/Reason: Not available/i));
+      expect(
+        screen.getByText(
+          /Other details: This is a test:Additional information/i,
+        ),
+      );
 
       expect(
         screen.getByRole('heading', {
@@ -173,7 +175,7 @@ describe('VAOS Component: VARequestLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
+        patientComments: 'This is a test:Additional information',
         contact: {
           telecom: [
             {
@@ -274,10 +276,12 @@ describe('VAOS Component: VARequestLayout', () => {
           name: /Details you.d like to share with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason:/i));
-      expect(screen.getByText(/This is a test/i));
-      expect(screen.getByText(/Other details:/i));
-      expect(screen.getByText(/Additional information/i));
+      expect(screen.getByText(/Reason: Not available/i));
+      expect(
+        screen.getByText(
+          /Other details: This is a test:Additional information/i,
+        ),
+      );
 
       expect(
         screen.getByRole('heading', {

--- a/src/applications/vaos/components/tests/ClaimExamLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/ClaimExamLayout.unit.spec.js
@@ -383,7 +383,6 @@ describe('VAOS Component: ClaimExamLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -483,7 +482,6 @@ describe('VAOS Component: ClaimExamLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',

--- a/src/applications/vaos/components/tests/InPersonLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/InPersonLayout.unit.spec.js
@@ -258,7 +258,8 @@ describe('VAOS Component: InPersonLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
+        reasonForAppointment: 'This is a test',
+        patientComments: 'Additional information:colon',
         practitioners: [
           {
             name: {
@@ -364,10 +365,8 @@ describe('VAOS Component: InPersonLayout', () => {
           name: /Details you shared with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason:/i));
-      expect(screen.getByText(/This is a test/i));
-      expect(screen.getByText(/Other details:/i));
-      expect(screen.getByText(/Additional information/i));
+      expect(screen.getByText(/Reason: This is a test/i));
+      expect(screen.getByText(/Other details: Additional information:colon/i));
 
       expect(screen.container.querySelector('va-button[text="Print"]'));
       expect(
@@ -379,7 +378,8 @@ describe('VAOS Component: InPersonLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
+        reasonForAppointment: 'This is a test',
+        patientComments: 'Additional information:colon',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -470,10 +470,8 @@ describe('VAOS Component: InPersonLayout', () => {
           name: /Details you shared with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason:/i));
-      expect(screen.getByText(/This is a test/i));
-      expect(screen.getByText(/Other details:/i));
-      expect(screen.getByText(/Additional information/i));
+      expect(screen.getByText(/Reason: This is a test/i));
+      expect(screen.getByText(/Other details: Additional information:colon/i));
 
       expect(screen.container.querySelector('va-button[text="Print"]'));
       expect(
@@ -487,7 +485,8 @@ describe('VAOS Component: InPersonLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
+        reasonForAppointment: 'This is a test',
+        patientComments: 'Additional information:colon',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -563,10 +562,8 @@ describe('VAOS Component: InPersonLayout', () => {
           name: /Details you shared with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason:/i));
-      expect(screen.getByText(/This is a test/i));
-      expect(screen.getByText(/Other details:/i));
-      expect(screen.getByText(/Additional information/i));
+      expect(screen.getByText(/Reason: This is a test/i));
+      expect(screen.getByText(/Other details: Additional information:colon/i));
 
       expect(screen.container.querySelector('va-button[text="Print"]')).to.be
         .ok;
@@ -581,7 +578,8 @@ describe('VAOS Component: InPersonLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
+        reasonForAppointment: 'This is a test',
+        patientComments: 'Additional information:colon',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -678,10 +676,8 @@ describe('VAOS Component: InPersonLayout', () => {
           name: /Details you shared with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason:/i));
-      expect(screen.getByText(/This is a test/i));
-      expect(screen.getByText(/Other details:/i));
-      expect(screen.getByText(/Additional information/i));
+      expect(screen.getByText(/Reason: This is a test/i));
+      expect(screen.getByText(/Other details: Additional information:colon/i));
 
       expect(screen.container.querySelector('va-button[text="Print"]')).to.be
         .ok;

--- a/src/applications/vaos/components/tests/PhoneLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/PhoneLayout.unit.spec.js
@@ -176,7 +176,8 @@ describe('VAOS Component: PhoneLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
+        reasonForAppointment: 'This is a test',
+        patientComments: 'Additional information:colon',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -261,10 +262,8 @@ describe('VAOS Component: PhoneLayout', () => {
           name: /Details you shared with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason:/i));
-      expect(screen.getByText(/This is a test/i));
-      expect(screen.getByText(/Other details:/i));
-      expect(screen.getByText(/Additional information/i));
+      expect(screen.getByText(/Reason: This is a test/i));
+      expect(screen.getByText(/Other details: Additional information:colon/i));
 
       expect(
         screen.getByRole('heading', {
@@ -297,7 +296,8 @@ describe('VAOS Component: PhoneLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
+        reasonForAppointment: 'This is a test',
+        patientComments: 'Additional information:colon',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -367,10 +367,8 @@ describe('VAOS Component: PhoneLayout', () => {
           name: /Details you shared with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason:/i));
-      expect(screen.getByText(/This is a test/i));
-      expect(screen.getByText(/Other details:/i));
-      expect(screen.getByText(/Additional information/i));
+      expect(screen.getByText(/Reason: This is a test/i));
+      expect(screen.getByText(/Other details: Additional information:colon/i));
 
       expect(
         screen.getByRole('heading', {
@@ -406,7 +404,8 @@ describe('VAOS Component: PhoneLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
+        reasonForAppointment: 'This is a test',
+        patientComments: 'Additional information:colon',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -478,10 +477,8 @@ describe('VAOS Component: PhoneLayout', () => {
           name: /Details you shared with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason:/i));
-      expect(screen.getByText(/This is a test/i));
-      expect(screen.getByText(/Other details:/i));
-      expect(screen.getByText(/Additional information/i));
+      expect(screen.getByText(/Reason: This is a test/i));
+      expect(screen.getByText(/Other details: Additional information:colon/i));
 
       expect(
         screen.queryByRole('heading', {
@@ -502,7 +499,8 @@ describe('VAOS Component: PhoneLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
+        reasonForAppointment: 'This is a test',
+        patientComments: 'Additional information:colon',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -579,10 +577,8 @@ describe('VAOS Component: PhoneLayout', () => {
           name: /Details you shared with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason:/i));
-      expect(screen.getByText(/This is a test/i));
-      expect(screen.getByText(/Other details:/i));
-      expect(screen.getByText(/Additional information/i));
+      expect(screen.getByText(/Reason: This is a test/i));
+      expect(screen.getByText(/Other details: Additional information:colon/i));
 
       expect(
         screen.getByRole('heading', {

--- a/src/applications/vaos/components/tests/VARequestLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/VARequestLayout.unit.spec.js
@@ -37,7 +37,8 @@ describe('VAOS Component: VARequestLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
+        reasonForAppointment: 'This is a test',
+        patientComments: 'Additional information:colon',
         contact: {
           telecom: [
             {
@@ -130,10 +131,8 @@ describe('VAOS Component: VARequestLayout', () => {
           name: /Details you.d like to share with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason:/i));
-      expect(screen.getByText(/This is a test/i));
-      expect(screen.getByText(/Other details:/i));
-      expect(screen.getByText(/Additional information/i));
+      expect(screen.getByText(/Reason: This is a test/i));
+      expect(screen.getByText(/Other details: Additional information:colon/i));
 
       expect(
         screen.getByRole('heading', {
@@ -172,7 +171,8 @@ describe('VAOS Component: VARequestLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
+        reasonForAppointment: 'This is a test',
+        patientComments: 'Additional information:colon',
         contact: {
           telecom: [
             {
@@ -256,10 +256,8 @@ describe('VAOS Component: VARequestLayout', () => {
           name: /Details you.d like to share with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason:/i));
-      expect(screen.getByText(/This is a test/i));
-      expect(screen.getByText(/Other details:/i));
-      expect(screen.getByText(/Additional information/i));
+      expect(screen.getByText(/Reason: This is a test/i));
+      expect(screen.getByText(/Other details: Additional information:colon/i));
 
       expect(
         screen.getByRole('heading', {
@@ -292,7 +290,8 @@ describe('VAOS Component: VARequestLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
+        reasonForAppointment: 'This is a test',
+        patientComments: 'Additional information:colon',
         contact: {
           telecom: [
             {
@@ -387,10 +386,8 @@ describe('VAOS Component: VARequestLayout', () => {
           name: /Details you.d like to share with your provider/i,
         }),
       );
-      expect(screen.getByText(/Reason:/i));
-      expect(screen.getByText(/This is a test/i));
-      expect(screen.getByText(/Other details:/i));
-      expect(screen.getByText(/Additional information/i));
+      expect(screen.getByText(/Reason: This is a test/i));
+      expect(screen.getByText(/Other details: Additional information:colon/i));
 
       expect(
         screen.getByRole('heading', {

--- a/src/applications/vaos/components/tests/VideoLayout.unit.spec.js
+++ b/src/applications/vaos/components/tests/VideoLayout.unit.spec.js
@@ -39,7 +39,6 @@ describe('VAOS Component: VideoLayout', () => {
       // Arrange
       const store = createTestStore(nullInitialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
         location: {},
         videoData: {
           isVideo: true,
@@ -102,7 +101,6 @@ describe('VAOS Component: VideoLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
         location: {
           stationId: '983',
         },
@@ -144,7 +142,6 @@ describe('VAOS Component: VideoLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
         location: {},
         videoData: {
           isVideo: true,
@@ -186,7 +183,6 @@ describe('VAOS Component: VideoLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -330,7 +326,6 @@ describe('VAOS Component: VideoLayout', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -460,7 +455,6 @@ describe('VAOS Component: VideoLayout', () => {
         // Arrange
         const store = createTestStore(initialState);
         const appointment = {
-          comment: 'This is a test:Additional information',
           location: {
             stationId: '983',
             clinicName: 'Clinic 1',
@@ -623,7 +617,6 @@ describe('VAOS Component: VideoLayout', () => {
         // Arrange
         const store = createTestStore(initialState);
         const appointment = {
-          comment: 'This is a test:Additional information',
           location: {
             stationId: '983',
             clinicName: 'Clinic 1',

--- a/src/applications/vaos/components/tests/VideoLayoutAtlas.unit.spec.js
+++ b/src/applications/vaos/components/tests/VideoLayoutAtlas.unit.spec.js
@@ -42,7 +42,6 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
 
       const store = createTestStore(state);
       const appointment = {
-        comment: 'This is a test:Additional information',
         location: {
           stationId: '983',
         },
@@ -234,7 +233,6 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -409,7 +407,6 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -551,7 +548,6 @@ describe('VAOS Component: VideoLayoutAtlas', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',

--- a/src/applications/vaos/components/tests/VideoLayoutVA.unit.spec.js
+++ b/src/applications/vaos/components/tests/VideoLayoutVA.unit.spec.js
@@ -147,7 +147,6 @@ describe('VAOS Component: VideoLayoutVA', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -287,7 +286,6 @@ describe('VAOS Component: VideoLayoutVA', () => {
         // Arrange
         const store = createTestStore(initialState);
         const appointment = {
-          comment: 'This is a test:Additional information',
           location: {
             stationId: '983',
             clinicName: 'Clinic 1',
@@ -432,7 +430,6 @@ describe('VAOS Component: VideoLayoutVA', () => {
         // Arrange
         const store = createTestStore(initialState);
         const appointment = {
-          comment: 'This is a test:Additional information',
           location: {
             stationId: '983',
             clinicName: 'Clinic 1',
@@ -576,7 +573,6 @@ describe('VAOS Component: VideoLayoutVA', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',
@@ -707,7 +703,6 @@ describe('VAOS Component: VideoLayoutVA', () => {
       // Arrange
       const store = createTestStore(initialState);
       const appointment = {
-        comment: 'This is a test:Additional information',
         location: {
           stationId: '983',
           clinicName: 'Clinic 1',

--- a/src/applications/vaos/services/mocks/v2/confirmed.json
+++ b/src/applications/vaos/services/mocks/v2/confirmed.json
@@ -1,2136 +1,692 @@
 {
   "data": [
-{
-    "id": "d25610df3e30a8d6701e6ed42ee661890bbc198c33b4e996be6bb96ddb4363e7",
-    "type": "appointments",
-    "attributes": {
-        "id": "d25610df3e30a8d6701e6ed42ee661890bbc198c33b4e996be6bb96ddb4363e7",
-        "identifier": [
+    {
+      "id": "00C891va",
+      "type": "Appointment",
+      "attributes": {
+        "clinic": "437",
+        "comment": "Follow-up/Routine: I have a headache",
+        "contact": {
+          "telecom": [
             {
-                "system": "Appointment/",
-                "value": "4139383435363538"
-            },
-            {
-                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
-                "value": "984:5658"
+              "type": "email",
+              "value": null
             }
+          ]
+        },
+        "description": "Upcoming COVID-19 appointment",
+        "end": "2024-10-13T16:00:00Z",
+        "id": "00C891va",
+        "kind": "clinic",
+        "locationId": "983",
+        "minutesDuration": 30,
+        "patientIcn": null,
+        "practitioners": [],
+        "preferredTimesForPhoneCall": [],
+        "priority": 0,
+        "reasonCode": {
+          "text": "Follow-up/Routine: Covid shot"
+        },
+        "requestedPeriods": null,
+        "serviceType": "covid",
+        "start": "2023-10-13T15:00:00Z",
+        "status": "booked",
+        "created": "2024-11-01T00:00:00Z",
+        "cancellable": false,
+        "localStartTime": "2023-10-13T09:00:00.000-06:00",
+        "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988663350853",
+        "telehealth": null
+      }
+    },
+    {
+      "id": "1923055",
+      "type": "appointments",
+      "attributes": {
+        "id": "192308",
+        "identifier": [
+          {
+            "system": "Appointment/",
+            "value": "413938333131363637"
+          },
+          {
+            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+            "value": "983:11667"
+          }
         ],
-        "kind": "telehealth",
+        "kind": "clinic",
         "status": "booked",
         "serviceType": "outpatientMentalHealth",
-        "serviceTypes": [
-            {
-                "coding": [
-                    {
-                        "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
-                        "code": "outpatientMentalHealth"
-                    }
-                ]
-            }
-        ],
         "serviceCategory": [
-            {
-                "coding": [
-                    {
-                        "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
-                        "code": "REGULAR",
-                        "display": "REGULAR"
-                    }
-                ],
-                "text": "REGULAR"
-            }
-        ],
-        "patientIcn": "1012845331V153043",
-        "locationId": "984GA",
-        "clinic": "4284",
-        "practitioners": [
-            {
-                "identifier": [
-                    {
-                        "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
-                        "value": "0000546167"
-                    }
-                ],
-                "name": {
-                    "family": "ZZZPPP",
-                    "given": [
-                        "LLL"
-                    ]
-                }
-            }
-        ],
-        "start": "2024-08-16T15:30:00Z",
-        "end": "2024-08-16T16:00:00Z",
-        "minutesDuration": 30,
-        "slot": {
-            "id": "3230323430383134313533303A323032343038313431363030",
-            "start": "2024-08-16T15:30:00Z",
-            "end": "2024-08-16T16:00:00Z"
-        },
-        "created": "2023-07-25T00:00:00Z",
-        "cancellable": false,
-        "extension": {
-            "ccLocation": {
-                "address": {}
-            },
-            "vistaStatus": [
-                "NO ACTION TAKEN"
-            ],
-            "preCheckinAllowed": false,
-            "eCheckinAllowed": false,
-            "clinic": {
-                "physicalLocation": "",
-                "phoneNumber": "",
-                "phoneNumberExtension": ""
-            }
-        },
-        "localStartTime": "2024-08-16T14:00:00.000-04:00",
-        "station": "984",
-        "ien": "5658",
-        "avsPath": null,
-        "serviceName": "MID-V10 CRH MH PSY MD PT",
-        "friendlyName": "MID-V10 CRH MH PSY MD PT",
-        "location": {
-            "id": "984GA",
-            "type": "appointments",
-            "attributes": {
-                "id": "984GA",
-                "vistaSite": "984",
-                "vastParent": "984",
-                "type": "va_health_facility",
-                "name": "Middletown VA Clinic",
-                "classification": "Multi-Specialty CBOC",
-                "timezone": {
-                    "timeZoneId": "America/New_York"
-                },
-                "lat": 39.50603,
-                "long": -84.316475,
-                "website": "https://www.dayton.va.gov/locations/midtwn_cboc.asp",
-                "phone": {
-                    "main": "513-423-8387"
-                },
-                "physicalAddress": {
-                    "type": "physical",
-                    "line": [
-                        "4337 North Union Road"
-                    ],
-                    "city": "Middletown",
-                    "state": "OH",
-                    "postalCode": "45005-5211"
-                },
-                "healthService": [
-                    "Audiology",
-                    "MentalHealthCare",
-                    "Optometry",
-                    "Podiatry",
-                    "PrimaryCare",
-                    "SpecialtyCare"
-                ]
-            }
-        }
-    }
-},
-{
-    "id": "7e5cab9523b99cbe1ca941399ef419f942837cda5dda71bbf95f6e5a375d2710",
-    "type": "appointments",
-    "attributes": {
-        "id": "7e5cab9523b99cbe1ca941399ef419f942837cda5dda71bbf95f6e5a375d2710",
-        "identifier": [
-            {
-                "system": "Appointment/",
-                "value": "413938333133333234"
-            },
-            {
-                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
-                "value": "983:13324"
-            }
-        ],
-        "kind": "clinic",
-        "status": "booked",
-        "serviceType": "optometry",
-        "serviceTypes": [
-            {
-                "coding": [
-                    {
-                        "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
-                        "code": "optometry"
-                    }
-                ]
-            }
-        ],
-        "serviceCategory": [
-            {
-                "coding": [
-                    {
-                        "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
-                        "code": "REGULAR",
-                        "display": "REGULAR"
-                    }
-                ],
-                "text": "REGULAR"
-            }
-        ],
-        "reasonCode": {
-            "text": "reasonCode:ROUTINEVISIT|comments:test  vaos-7661"
-        },
-        "patientIcn": "1013678363V916823",
-        "locationId": "983",
-        "clinic": "437",
-        "start": "2025-02-25T16:25:00Z",
-        "end": "2025-02-25T16:40:00Z",
-        "minutesDuration": 15,
-        "slot": {
-            "id": "3230323431303235313632353A323032343130323531363430",
-            "start": "2025-02-25T16:25:00Z",
-            "end": "2025-02-25T16:40:00Z"
-        },
-        "created": "2024-11-16T00:00:00Z",
-        "cancellable": true,
-        "extension": {
-            "ccLocation": {
-                "address": {}
-            },
-            "vistaStatus": [
-                "FUTURE"
-            ],
-            "preCheckinAllowed": false,
-            "eCheckinAllowed": false,
-            "clinic": {}
-        },
-        "localStartTime": "2025-02-25T10:25:00.000-06:00",
-        "serviceName": "VISUAL FIELD",
-        "friendlyName": "VISUAL FIELD",
-        "location": {
-            "id": "983",
-            "type": "appointments",
-            "attributes": {
-                "id": "983",
-                "vistaSite": "983",
-                "vastParent": "983",
-                "type": "va_facilities",
-                "name": "Cheyenne VA Medical Center",
-                "classification": "VA Medical Center (VAMC)",
-                "timezone": {
-                    "timeZoneId": "America/Denver"
-                },
-                "lat": 39.744507,
-                "long": -104.830956,
-                "website": "https://www.denver.va.gov/locations/directions.asp",
-                "phone": {
-                    "main": "307-778-7550",
-                    "fax": "307-778-7381",
-                    "pharmacy": "866-420-6337",
-                    "afterHours": "307-778-7550",
-                    "patientAdvocate": "307-778-7550 x7517",
-                    "mentalHealthClinic": "307-778-7349",
-                    "enrollmentCoordinator": "307-778-7550 x7579"
-                },
-                "physicalAddress": {
-                    "type": "physical",
-                    "line": [
-                        "2360 East Pershing Boulevard"
-                    ],
-                    "city": "Cheyenne",
-                    "state": "WY",
-                    "postalCode": "82001-5356"
-                },
-                "mobile": false,
-                "healthService": [
-                    "Audiology",
-                    "Cardiology",
-                    "DentalServices",
-                    "EmergencyCare",
-                    "Gastroenterology",
-                    "Gynecology",
-                    "MentalHealthCare",
-                    "Nutrition",
-                    "Ophthalmology",
-                    "Optometry",
-                    "Orthopedics",
-                    "Podiatry",
-                    "PrimaryCare",
-                    "SpecialtyCare",
-                    "UrgentCare",
-                    "Urology",
-                    "WomensHealth"
-                ],
-                "operatingStatus": {
-                    "code": "NORMAL"
-                }
-            }
-        }
-    }
-},
-{
-  "id": "e01555000d5c7ce9b754ea7ad8fa1d481298fec531ff43919734d31eb34ceb46",
-  "type": "appointments",
-  "attributes": {
-      "id": "e01555000d5c7ce9b754ea7ad8fa1d481298fec531ff43919734d31eb34ceb46",
-      "identifier": [
           {
-              "system": "Appointment/",
-              "value": "4139383436333437"
-          },
-          {
-              "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
-              "value": "984:6347"
-          }
-      ],
-      "kind": "phone",
-      "status": "booked",
-      "serviceCategory": [
-          {
-              "coding": [
-                  {
-                      "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
-                      "code": "REGULAR",
-                      "display": "REGULAR"
-                  }
-              ],
-              "text": "REGULAR"
-          }
-      ],
-      "patientIcn": "1013678363V916823",
-      "locationId": "984",
-      "clinic": "4570",
-      "reasonCode": {
-        "text": "reasonCode:QUESTIONMEDS|comments:test appointment scheduling TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-      },
-      "patientComments": "test appointment scheduling TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      "reasonForAppointment": "Medication concern",
-      "practitioners": [
-          {
-              "identifier": [
-                  {
-                      "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
-                      "value": null
-                  }
-              ],
-              "name": {
-                  "family": "ISS",
-                  "given": [
-                      "PROVIDERONE"
-                  ]
+            "coding": [
+              {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                "code": "SERVICE CONNECTED",
+                "display": "SERVICE CONNECTED"
               }
-          }
-      ],
-      "start": "2024-12-05T18:00:00Z",
-      "end": "2024-12-05T18:15:00Z",
-      "minutesDuration": 15,
-      "slot": {
-          "id": "3230323331323035313830303A323032333132303531383135",
-          "start": "2024-12-05T18:00:00Z",
-          "end": "2024-12-05T18:15:00Z"
-      },
-      "created": "2024-11-28T00:00:00Z",
-      "cancellable": true,
-      "extension": {
-          "ccLocation": {
-              "address": {}
-          },
-          "vistaStatus": [
-              "NO ACTION TAKEN"
-          ],
-          "preCheckinAllowed": false,
-          "eCheckinAllowed": false,
-          "clinic": {
-              "physicalLocation": "DAYTSHR PHONE Provider",
-              "phoneNumber": "555-555-6551",
-              "phoneNumberExtension": "6001"
-          }
-      },
-      "localStartTime": "2024-12-05T13:00:00.000-05:00",
-      "serviceName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
-      "friendlyName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
-      "physicalLocation": "DAYTSHR PHONE Provider",
-      "location": {
-          "id": "984",
-          "type": "appointments",
-          "attributes": {
-              "id": "984",
-              "vistaSite": "984",
-              "vastParent": "984",
-              "type": "va_health_facility",
-              "name": "Dayton VA Medical Center",
-              "classification": "VA Medical Center (VAMC)",
-              "timezone": {
-                  "timeZoneId": "America/New_York"
-              },
-              "lat": 39.74935,
-              "long": -84.2532,
-              "website": "https://www.dayton.va.gov/locations/directions.asp",
-              "phone": {
-                  "main": "937-268-6511"
-              },
-              "physicalAddress": {
-                  "type": "physical",
-                  "line": [
-                      "4100 West Third Street"
-                  ],
-                  "city": "Dayton",
-                  "state": "OH",
-                  "postalCode": "45428-9000"
-              },
-              "healthService": [
-                  "Audiology",
-                  "Cardiology",
-                  "DentalServices",
-                  "Dermatology",
-                  "Gastroenterology",
-                  "Gynecology",
-                  "MentalHealthCare",
-                  "Nutrition",
-                  "Ophthalmology",
-                  "Optometry",
-                  "Orthopedics",
-                  "Podiatry",
-                  "PrimaryCare",
-                  "SpecialtyCare",
-                  "Urology",
-                  "WomensHealth"
-              ]
-          }
-      }
-  }
-},
-{
-    "id": "e01555000d5c7ce9b754ea7ad8fa1d481298fec531ff43919734d31eb34ceb47",
-    "type": "appointments",
-    "attributes": {
-        "id": "e01555000d5c7ce9b754ea7ad8fa1d481298fec531ff43919734d31eb34ceb47",
-        "identifier": [
-            {
-                "system": "Appointment/",
-                "value": "4139383436333438"
-            },
-            {
-                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
-                "value": "984:6347"
-            }
-        ],
-        "kind": "phone",
-        "status": "cancelled",
-        "serviceCategory": [
-            {
-                "coding": [
-                    {
-                        "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
-                        "code": "REGULAR",
-                        "display": "REGULAR"
-                    }
-                ],
-                "text": "REGULAR"
-            }
-        ],
-        "patientIcn": "1013678363V916823",
-        "locationId": "984",
-        "clinic": "4570",
-        "practitioners": [
-            {
-                "identifier": [
-                    {
-                        "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
-                        "value": null
-                    }
-                ],
-                "name": {
-                    "family": "ISS",
-                    "given": [
-                        "PROVIDERONE"
-                    ]
-                }
-            }
-        ],
-        "start": "2024-12-05T19:00:00Z",
-        "end": "2024-12-05T19:15:00Z",
-        "minutesDuration": 15,
-        "slot": {
-            "id": "3230323331323035313830303A323032333132303531383135",
-            "start": "2024-12-05T19:00:00Z",
-            "end": "2024-12-05T19:15:00Z"
-        },
-        "created": "2024-11-28T00:00:00Z",
-        "cancellable": false,
-        "extension": {
-            "ccLocation": {
-                "address": {}
-            },
-            "vistaStatus": [
-                "NO ACTION TAKEN"
             ],
-            "preCheckinAllowed": false,
-            "eCheckinAllowed": false,
-            "clinic": {
-                "physicalLocation": "DAYTSHR PHONE Provider",
-                "phoneNumber": "555-555-6551",
-                "phoneNumberExtension": "6001"
-            }
-        },
-        "localStartTime": "2024-12-05T14:00:00.000-05:00",
-        "serviceName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
-        "friendlyName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
-        "physicalLocation": "DAYTSHR PHONE Provider",
-        "location": {
-            "id": "984",
-            "type": "appointments",
-            "attributes": {
-                "id": "984",
-                "vistaSite": "984",
-                "vastParent": "984",
-                "type": "va_health_facility",
-                "name": "Dayton VA Medical Center",
-                "classification": "VA Medical Center (VAMC)",
-                "timezone": {
-                    "timeZoneId": "America/New_York"
-                },
-                "lat": 39.74935,
-                "long": -84.2532,
-                "website": "https://www.dayton.va.gov/locations/directions.asp",
-                "phone": {
-                    "main": "937-268-6511"
-                },
-                "physicalAddress": {
-                    "type": "physical",
-                    "line": [
-                        "4100 West Third Street"
-                    ],
-                    "city": "Dayton",
-                    "state": "OH",
-                    "postalCode": "45428-9000"
-                },
-                "healthService": [
-                    "Audiology",
-                    "Cardiology",
-                    "DentalServices",
-                    "Dermatology",
-                    "Gastroenterology",
-                    "Gynecology",
-                    "MentalHealthCare",
-                    "Nutrition",
-                    "Ophthalmology",
-                    "Optometry",
-                    "Orthopedics",
-                    "Podiatry",
-                    "PrimaryCare",
-                    "SpecialtyCare",
-                    "Urology",
-                    "WomensHealth"
-                ]
-            }
-        }
-    }
-},
-{
-    "id": "9c6a43ce99d9d8406d3cd3b463f4d383d4f6f08d91b56d7ed8282928f9a58957",
-    "type": "appointments",
-    "attributes": {
-        "id": "9c6a43ce99d9d8406d3cd3b463f4d383d4f6f08d91b56d7ed8282928f9a58957",
-        "identifier": [
-            {
-                "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
-                "value": "524670||158||1"
-            },
-            {
-                "system": "http://hl7.org/fhir/sid/us-npi",
-                "value": "1346206547"
-            }
+            "text": "SERVICE CONNECTED"
+          }
         ],
-        "kind": "cc",
-        "status": "booked",
-        "serviceTypes": [
-            {
-                "text": "Cardiology Cath - PCI_REV_PRCT SEOC 1.1.14"
-            }
-        ],
-        "description": "Cardiology Cath - PCI_REV_PRCT SEOC 1.1.14",
         "patientIcn": "1012845331V153043",
-        "locationId": "552",
-        "practitioners": [
-            {
-                "name": {
-                    "family": "HEALTH CARE PROFS",
-                    "given": [
-                        "A & D"
-                    ]
-                }
-            }
-        ],
-        "start": "2025-02-02T13:00:00Z",
-        "created": "2025-02-02T20:29:46Z",
-        "cancellable": false,
-        "extension": {
-            "ccLocation": {
-                "address": {
-                    "line": [
-                        "1601 NEEDMORE RD ; STE 1 &amp; 2"
-                    ],
-                    "city": "DAYTON",
-                    "state": "OH",
-                    "postalCode": "45414",
-                    "text": "1601 NEEDMORE RD ; STE 1 &amp; 2\nDAYTON OH 45414"
-                },
-                "telecom": [
-                    {
-                        "system": "phone",
-                        "value": "937-236-6750"
-                    }
-                ]
-            },
-            "hsrmTaskId": "",
-            "hsrmConsultId": "984_646372",
-            "ccTreatingSpecialty": "Home Health"
-        },
-        "localStartTime": "2025-02-02T09:00:00.000-04:00",
-        "avsPath": null,
-        "location": {
-            "id": "552",
-            "type": "appointments",
-            "attributes": {
-                "id": "552",
-                "facilitiesApiId": "vha_552",
-                "vistaSite": "552",
-                "vastParent": "552",
-                "type": "va_health_facility",
-                "name": "Dayton VA Medical Center",
-                "classification": "VA Medical Center (VAMC)",
-                "timezone": {
-                    "timeZoneId": "America/New_York"
-                },
-                "lat": 39.74935,
-                "long": -84.2532,
-                "website": "https://www.va.gov/dayton-health-care/locations/dayton-va-medical-center/",
-                "phone": {
-                    "main": "937-268-6511",
-                    "fax": "937-262-2179",
-                    "pharmacy": "800-368-8262 x1",
-                    "afterHours": "888-838-6446",
-                    "patientAdvocate": "800-368-8262 x2164",
-                    "mentalHealthClinic": "937-262-2186",
-                    "enrollmentCoordinator": "800-368-8262 x5336"
-                },
-                "hoursOfOperation": [
-                    {
-                        "daysOfWeek": "sun",
-                        "openingTime": "24/7",
-                        "closingTime": "24/7"
-                    },
-                    {
-                        "daysOfWeek": "mon",
-                        "openingTime": "24/7",
-                        "closingTime": "24/7"
-                    },
-                    {
-                        "daysOfWeek": "tue",
-                        "openingTime": "24/7",
-                        "closingTime": "24/7"
-                    },
-                    {
-                        "daysOfWeek": "wed",
-                        "openingTime": "24/7",
-                        "closingTime": "24/7"
-                    },
-                    {
-                        "daysOfWeek": "thu",
-                        "openingTime": "24/7",
-                        "closingTime": "24/7"
-                    },
-                    {
-                        "daysOfWeek": "fri",
-                        "openingTime": "24/7",
-                        "closingTime": "24/7"
-                    },
-                    {
-                        "daysOfWeek": "sat",
-                        "openingTime": "24/7",
-                        "closingTime": "24/7"
-                    }
-                ],
-                "physicalAddress": {
-                    "type": "physical",
-                    "line": [
-                        "4100 West Third Street",
-                        null,
-                        null
-                    ],
-                    "city": "Dayton",
-                    "state": "OH",
-                    "postalCode": "45428-9000"
-                },
-                "mobile": false,
-                "healthService": [
-                    "Addiction",
-                    "Anesthesia",
-                    "Audiology",
-                    "Cardiology",
-                    "CaregiverSupport",
-                    "Chiropractic",
-                    "CriticalCare",
-                    "Dental",
-                    "Dermatology",
-                    "EmergencyCare",
-                    "EmploymentPrograms",
-                    "Endocrinology",
-                    "Gastroenterology",
-                    "Gynecology",
-                    "Hematology",
-                    "Homeless",
-                    "Hospice",
-                    "InfectiousDisease",
-                    "Laboratory",
-                    "Lgbtq",
-                    "MentalHealth",
-                    "MilitarySexualTrauma",
-                    "MinorityCare",
-                    "MyHealtheVetCoordinator",
-                    "Nephrology",
-                    "Neurology",
-                    "Nutrition",
-                    "Ophthalmology",
-                    "Optometry",
-                    "Orthopedics",
-                    "Otolaryngology",
-                    "PainManagement",
-                    "PatientAdvocates",
-                    "Pharmacy",
-                    "PhysicalMedicine",
-                    "PhysicalTherapy",
-                    "Podiatry",
-                    "Polytrauma",
-                    "PrimaryCare",
-                    "Prosthetics",
-                    "Psychiatry",
-                    "Psychology",
-                    "Ptsd",
-                    "PulmonaryMedicine",
-                    "RadiationOncology",
-                    "Radiology",
-                    "RecreationTherapy",
-                    "RegistryExams",
-                    "Rehabilitation",
-                    "Rheumatology",
-                    "SleepMedicine",
-                    "Smoking",
-                    "SocialWork",
-                    "SpinalInjury",
-                    "SuicidePrevention",
-                    "Surgery",
-                    "Telehealth",
-                    "ThoracicSurgery",
-                    "TransitionCounseling",
-                    "TransplantSurgery",
-                    "TravelReimbursement",
-                    "UrgentCare",
-                    "Urology",
-                    "VascularSurgery",
-                    "Vision",
-                    "WeightManagement",
-                    "WomensHealth",
-                    "Wound"
-                ],
-                "operatingStatus": {
-                    "code": "NORMAL"
-                },
-                "visn": "10"
-            }
-        }
-    }
-},
-{
-    "id": "aa6bb54b5f8ba22a82720a30abdfa3efe0805cc0dc1b6b248815e942ad61847e",
-    "type": "appointments",
-    "attributes": {
-        "id": "aa6bb54b5f8ba22a82720a30abdfa3efe0805cc0dc1b6b248815e942ad61847e",
-        "identifier": [
-            {
-                "system": "Appointment/",
-                "value": "413938333133353533"
-            },
-            {
-                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
-                "value": "983:13553"
-            }
-        ],
-        "kind": "clinic",
-        "status": "booked",
-        "serviceType": "covid",
-        "serviceTypes": [
-            {
-                "coding": [
-                    {
-                        "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
-                        "code": "covid"
-                    }
-                ]
-            }
-        ],
-        "serviceCategory": [
-            {
-                "coding": [
-                    {
-                        "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
-                        "code": "REGULAR",
-                        "display": "REGULAR"
-                    }
-                ],
-                "text": "REGULAR"
-            }
-        ],
-        "patientIcn": "1012846043V576341",
         "locationId": "983",
-        "clinic": "1038",
-        "practitioners": [
-            {
-                "identifier": [
-                    {
-                        "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
-                        "value": null
-                    }
-                ],
-                "name": {
-                    "family": "BERNARDO",
-                    "given": [
-                        "KENNETH J"
-                    ]
-                }
-            }
-        ],
-        "start": "2024-12-01T14:00:00Z",
-        "end": "2024-08-01T14:15:00Z",
-        "minutesDuration": 15,
-        "slot": {
-            "id": "3230323430383031313430303A323032343038303131343135",
-            "start": "2024-12-01T14:00:00Z",
-            "end": "2024-12-01T14:15:00Z"
-        },
-        "created": "2024-12-09T00:00:00Z",
-        "cancellable": false,
-        "extension": {
-            "ccLocation": {
-                "address": {}
-            },
-            "vistaStatus": [
-                "FUTURE"
-            ],
-            "preCheckinAllowed": true,
-            "eCheckinAllowed": true,
-            "clinic": {
-                "physicalLocation": "MHC"
-            }
-        },
-        "localStartTime": "2024-12-01T08:00:00.000-06:00",
-        "serviceName": "COVID VACCINE CLIN1",
-        "friendlyName": "COVID VACCINE CLIN1",
-        "physicalLocation": "MHC",
-        "location": {
-            "id": "983",
-            "type": "appointments",
-            "attributes": {
-                "id": "983",
-                "vistaSite": "983",
-                "vastParent": "983",
-                "type": "va_facilities",
-                "name": "Cheyenne VA Medical Center",
-                "classification": "VA Medical Center (VAMC)",
-                "timezone": {
-                    "timeZoneId": "America/Denver"
-                },
-                "lat": 39.744507,
-                "long": -104.830956,
-                "website": "https://www.denver.va.gov/locations/directions.asp",
-                "phone": {
-                    "main": "307-778-7550",
-                    "fax": "307-778-7381",
-                    "pharmacy": "866-420-6337",
-                    "afterHours": "307-778-7550",
-                    "patientAdvocate": "307-778-7550 x7517",
-                    "mentalHealthClinic": "307-778-7349",
-                    "enrollmentCoordinator": "307-778-7550 x7579"
-                },
-                "physicalAddress": {
-                    "type": "physical",
-                    "line": [
-                        "2360 East Pershing Boulevard"
-                    ],
-                    "city": "Cheyenne",
-                    "state": "WY",
-                    "postalCode": "82001-5356"
-                },
-                "mobile": false,
-                "healthService": [
-                    "Audiology",
-                    "Cardiology",
-                    "DentalServices",
-                    "EmergencyCare",
-                    "Gastroenterology",
-                    "Gynecology",
-                    "MentalHealthCare",
-                    "Nutrition",
-                    "Ophthalmology",
-                    "Optometry",
-                    "Orthopedics",
-                    "Podiatry",
-                    "PrimaryCare",
-                    "SpecialtyCare",
-                    "UrgentCare",
-                    "Urology",
-                    "WomensHealth"
-                ],
-                "operatingStatus": {
-                    "code": "NORMAL"
-                }
-            }
-        }
-    }
-},
-{
-    "id": "aa6bb54b5f8ba22a82720a30abdfa3efe0805cc0dc1b6b248815e942ad61847f",
-    "type": "appointments",
-    "attributes": {
-        "id": "aa6bb54b5f8ba22a82720a30abdfa3efe0805cc0dc1b6b248815e942ad61847f",
-        "identifier": [
-            {
-                "system": "Appointment/",
-                "value": "413938333133353534"
-            },
-            {
-                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
-                "value": "983:13553"
-            }
-        ],
-        "kind": "clinic",
-        "status": "cancelled",
-        "serviceType": "covid",
-        "serviceTypes": [
-            {
-                "coding": [
-                    {
-                        "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
-                        "code": "covid"
-                    }
-                ]
-            }
-        ],
-        "serviceCategory": [
-            {
-                "coding": [
-                    {
-                        "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
-                        "code": "REGULAR",
-                        "display": "REGULAR"
-                    }
-                ],
-                "text": "REGULAR"
-            }
-        ],
-        "patientIcn": "1012846043V576341",
-        "locationId": "983",
-        "clinic": "1038",
-        "practitioners": [
-            {
-                "identifier": [
-                    {
-                        "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
-                        "value": null
-                    }
-                ],
-                "name": {
-                    "family": "BERNARDO",
-                    "given": [
-                        "KENNETH J"
-                    ]
-                }
-            }
-        ],
-        "start": "2024-12-01T15:00:00Z",
-        "end": "2024-08-01T15:15:00Z",
-        "minutesDuration": 15,
-        "slot": {
-            "id": "3230323430383031313430303A323032343038303131343135",
-            "start": "2024-12-01T15:00:00Z",
-            "end": "2024-12-01T15:15:00Z"
-        },
-        "created": "2024-12-09T00:00:00Z",
-        "cancellable": false,
-        "extension": {
-            "ccLocation": {
-                "address": {}
-            },
-            "vistaStatus": [
-                "FUTURE"
-            ],
-            "preCheckinAllowed": true,
-            "eCheckinAllowed": true,
-            "clinic": {
-                "physicalLocation": "MHC"
-            }
-        },
-        "localStartTime": "2024-12-01T09:00:00.000-06:00",
-        "serviceName": "COVID VACCINE CLIN1",
-        "friendlyName": "COVID VACCINE CLIN1",
-        "physicalLocation": "MHC",
-        "location": {
-            "id": "983",
-            "type": "appointments",
-            "attributes": {
-                "id": "983",
-                "vistaSite": "983",
-                "vastParent": "983",
-                "type": "va_facilities",
-                "name": "Cheyenne VA Medical Center",
-                "classification": "VA Medical Center (VAMC)",
-                "timezone": {
-                    "timeZoneId": "America/Denver"
-                },
-                "lat": 39.744507,
-                "long": -104.830956,
-                "website": "https://www.denver.va.gov/locations/directions.asp",
-                "phone": {
-                    "main": "307-778-7550",
-                    "fax": "307-778-7381",
-                    "pharmacy": "866-420-6337",
-                    "afterHours": "307-778-7550",
-                    "patientAdvocate": "307-778-7550 x7517",
-                    "mentalHealthClinic": "307-778-7349",
-                    "enrollmentCoordinator": "307-778-7550 x7579"
-                },
-                "physicalAddress": {
-                    "type": "physical",
-                    "line": [
-                        "2360 East Pershing Boulevard"
-                    ],
-                    "city": "Cheyenne",
-                    "state": "WY",
-                    "postalCode": "82001-5356"
-                },
-                "mobile": false,
-                "healthService": [
-                    "Audiology",
-                    "Cardiology",
-                    "DentalServices",
-                    "EmergencyCare",
-                    "Gastroenterology",
-                    "Gynecology",
-                    "MentalHealthCare",
-                    "Nutrition",
-                    "Ophthalmology",
-                    "Optometry",
-                    "Orthopedics",
-                    "Podiatry",
-                    "PrimaryCare",
-                    "SpecialtyCare",
-                    "UrgentCare",
-                    "Urology",
-                    "WomensHealth"
-                ],
-                "operatingStatus": {
-                    "code": "NORMAL"
-                }
-            }
-        }
-    }
-},
-{
-    "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44ce",
-    "type": "appointments",
-    "attributes": {
-        "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44ce",
-        "identifier": [
-            {
-                "system": "urn:va.gov:masv2:cerner:appointment",
-                "value": "Appointment/52499027"
-            }
-        ],
-        "kind": "clinic",
-        "status": "booked",
-        "serviceTypes": [
-            {
-                "coding": [
-                    {
-                        "system": "https://fhir.cerner.com/d45741b3-8335-463d-ab16-8c5f0bcf78ed/codeSet/14249",
-                        "code": "381456583"
-                    }
-                ]
-            }
-        ],
-        "description": "PC Established Patient",
-        "reasonCode": {
-          "text": "reasonCode:QUESTIONMEDS|comments:test appointment scheduling TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        "patientComments": "test appointment scheduling TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "reasonForAppointment": "Medication concern",
-        "patientIcn": "1012845331V153043",
-        "locationId": "757",
-        "practitioners": [
-            {
-                "name": {
-                    "family": "Everett",
-                    "given": [
-                        "CERNER",
-                        "DO"
-                    ]
-                }
-            }
-        ],
-        "start": "2024-12-23T13:30:00Z",
-        "end": "2024-12-23T14:00:00Z",
-        "minutesDuration": 30,
-        "comment": "\nContact preference: Secure message",
-        "cancellable": false,
-        "patientInstruction": "Preparations:\n- If you have any new non-VA medical records since your last visit, please bring them.\r\nIf you need to cancel or reschedule your appointment, please call our Contact Center at 614-257-5200 or visit the patient portal.",
-        "extension": {
-            "ccLocation": {
-                "address": {}
-            }
-        },
-        "requestedPeriods": null,
-        "localStartTime": "2024-12-23T09:30:00.000-04:00",
-        "location": {
-            "id": "757",
-            "type": "appointments",
-            "attributes": {
-                "id": "757",
-                "facilitiesApiId": "vha_757",
-                "vistaSite": "757",
-                "vastParent": "757",
-                "type": "va_health_facility",
-                "name": "Chalmers P. Wylie Veterans CERNER Clinic",
-                "classification": "Health Care Center (HCC)",
-                "timezone": {
-                    "timeZoneId": "America/New_York"
-                },
-                "lat": 39.98048,
-                "long": -82.9123,
-                "website": "https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/",
-                "phone": {
-                    "main": "614-257-5200",
-                    "fax": "614-257-5460",
-                    "pharmacy": "614-257-5230",
-                    "afterHours": "614-257-5512",
-                    "patientAdvocate": "614-257-5290",
-                    "mentalHealthClinic": "614-257-5631",
-                    "enrollmentCoordinator": "614-257-5628"
-                },
-                "hoursOfOperation": [
-                    {
-                        "daysOfWeek": "sun",
-                        "openingTime": "800AM",
-                        "closingTime": "400PM"
-                    },
-                    {
-                        "daysOfWeek": "mon",
-                        "openingTime": "730AM",
-                        "closingTime": "600PM"
-                    },
-                    {
-                        "daysOfWeek": "tue",
-                        "openingTime": "730AM",
-                        "closingTime": "600PM"
-                    },
-                    {
-                        "daysOfWeek": "wed",
-                        "openingTime": "730AM",
-                        "closingTime": "600PM"
-                    },
-                    {
-                        "daysOfWeek": "thu",
-                        "openingTime": "730AM",
-                        "closingTime": "600PM"
-                    },
-                    {
-                        "daysOfWeek": "fri",
-                        "openingTime": "730AM",
-                        "closingTime": "600PM"
-                    },
-                    {
-                        "daysOfWeek": "sat",
-                        "openingTime": "800AM",
-                        "closingTime": "400PM"
-                    }
-                ],
-                "physicalAddress": {
-                    "type": "physical",
-                    "line": [
-                        "420 North James Road",
-                        null,
-                        null
-                    ],
-                    "city": "Columbus",
-                    "state": "OH",
-                    "postalCode": "43219-1834"
-                },
-                "mobile": false,
-                "healthService": [
-                    "Allergy",
-                    "Audiology",
-                    "Cardiology",
-                    "CaregiverSupport",
-                    "Covid19Vaccine",
-                    "Dental",
-                    "Dermatology",
-                    "Diabetic",
-                    "Endocrinology",
-                    "Gastroenterology",
-                    "Geriatrics",
-                    "Gynecology",
-                    "Hematology",
-                    "Homeless",
-                    "Hospice",
-                    "Laboratory",
-                    "Lgbtq",
-                    "MinorityCare",
-                    "Nephrology",
-                    "Neurology",
-                    "Nutrition",
-                    "Ophthalmology",
-                    "Optometry",
-                    "Orthopedics",
-                    "Otolaryngology",
-                    "PainManagement",
-                    "PatientAdvocates",
-                    "Pharmacy",
-                    "PhysicalMedicine",
-                    "PlasticSurgery",
-                    "Podiatry",
-                    "PrimaryCare",
-                    "Prosthetics",
-                    "Ptsd",
-                    "PulmonaryMedicine",
-                    "Radiology",
-                    "Rheumatology",
-                    "Smoking",
-                    "SocialWork",
-                    "SpinalInjury",
-                    "SuicidePrevention",
-                    "Surgery",
-                    "TransitionCounseling",
-                    "UrgentCare",
-                    "Urology",
-                    "VascularSurgery",
-                    "Vision",
-                    "WeightManagement",
-                    "WomensHealth",
-                    "Wound"
-                ],
-                "operatingStatus": {
-                    "code": "NORMAL"
-                },
-                "visn": "10"
-            }
-        }
-    }
-},
-{
-    "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44cf",
-    "type": "appointments",
-    "attributes": {
-        "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44cf",
-        "identifier": [
-            {
-                "system": "urn:va.gov:masv2:cerner:appointment",
-                "value": "Appointment/52499028"
-            }
-        ],
-        "kind": "clinic",
-        "status": "cancelled",
-        "serviceTypes": [
-            {
-                "coding": [
-                    {
-                        "system": "https://fhir.cerner.com/d45741b3-8335-463d-ab16-8c5f0bcf78ed/codeSet/14249",
-                        "code": "381456583"
-                    }
-                ]
-            }
-        ],
-        "description": "PC Established Patient",
-        "patientIcn": "1012845331V153043",
-        "locationId": "757",
-        "practitioners": [
-            {
-                "name": {
-                    "family": "Everett",
-                    "given": [
-                        "CERNER",
-                        "DO"
-                    ]
-                }
-            }
-        ],
-        "start": "2024-12-23T14:30:00Z",
-        "end": "2024-12-23T15:00:00Z",
-        "minutesDuration": 30,
-        "comment": "\nContact preference: Secure message",
-        "cancellable": false,
-        "patientInstruction": "Preparations:\n- If you have any new non-VA medical records since your last visit, please bring them.\r\nIf you need to cancel or reschedule your appointment, please call our Contact Center at 614-257-5200 or visit the patient portal.",
-        "extension": {
-            "ccLocation": {
-                "address": {}
-            }
-        },
-        "requestedPeriods": null,
-        "localStartTime": "2024-12-23T10:30:00.000-04:00",
-        "location": {
-            "id": "757",
-            "type": "appointments",
-            "attributes": {
-                "id": "757",
-                "facilitiesApiId": "vha_757",
-                "vistaSite": "757",
-                "vastParent": "757",
-                "type": "va_health_facility",
-                "name": "Chalmers P. Wylie Veterans CERNER Clinic",
-                "classification": "Health Care Center (HCC)",
-                "timezone": {
-                    "timeZoneId": "America/New_York"
-                },
-                "lat": 39.98048,
-                "long": -82.9123,
-                "website": "https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/",
-                "phone": {
-                    "main": "614-257-5200",
-                    "fax": "614-257-5460",
-                    "pharmacy": "614-257-5230",
-                    "afterHours": "614-257-5512",
-                    "patientAdvocate": "614-257-5290",
-                    "mentalHealthClinic": "614-257-5631",
-                    "enrollmentCoordinator": "614-257-5628"
-                },
-                "hoursOfOperation": [
-                    {
-                        "daysOfWeek": "sun",
-                        "openingTime": "800AM",
-                        "closingTime": "400PM"
-                    },
-                    {
-                        "daysOfWeek": "mon",
-                        "openingTime": "730AM",
-                        "closingTime": "600PM"
-                    },
-                    {
-                        "daysOfWeek": "tue",
-                        "openingTime": "730AM",
-                        "closingTime": "600PM"
-                    },
-                    {
-                        "daysOfWeek": "wed",
-                        "openingTime": "730AM",
-                        "closingTime": "600PM"
-                    },
-                    {
-                        "daysOfWeek": "thu",
-                        "openingTime": "730AM",
-                        "closingTime": "600PM"
-                    },
-                    {
-                        "daysOfWeek": "fri",
-                        "openingTime": "730AM",
-                        "closingTime": "600PM"
-                    },
-                    {
-                        "daysOfWeek": "sat",
-                        "openingTime": "800AM",
-                        "closingTime": "400PM"
-                    }
-                ],
-                "physicalAddress": {
-                    "type": "physical",
-                    "line": [
-                        "420 North James Road",
-                        null,
-                        null
-                    ],
-                    "city": "Columbus",
-                    "state": "OH",
-                    "postalCode": "43219-1834"
-                },
-                "mobile": false,
-                "healthService": [
-                    "Allergy",
-                    "Audiology",
-                    "Cardiology",
-                    "CaregiverSupport",
-                    "Covid19Vaccine",
-                    "Dental",
-                    "Dermatology",
-                    "Diabetic",
-                    "Endocrinology",
-                    "Gastroenterology",
-                    "Geriatrics",
-                    "Gynecology",
-                    "Hematology",
-                    "Homeless",
-                    "Hospice",
-                    "Laboratory",
-                    "Lgbtq",
-                    "MinorityCare",
-                    "Nephrology",
-                    "Neurology",
-                    "Nutrition",
-                    "Ophthalmology",
-                    "Optometry",
-                    "Orthopedics",
-                    "Otolaryngology",
-                    "PainManagement",
-                    "PatientAdvocates",
-                    "Pharmacy",
-                    "PhysicalMedicine",
-                    "PlasticSurgery",
-                    "Podiatry",
-                    "PrimaryCare",
-                    "Prosthetics",
-                    "Ptsd",
-                    "PulmonaryMedicine",
-                    "Radiology",
-                    "Rheumatology",
-                    "Smoking",
-                    "SocialWork",
-                    "SpinalInjury",
-                    "SuicidePrevention",
-                    "Surgery",
-                    "TransitionCounseling",
-                    "UrgentCare",
-                    "Urology",
-                    "VascularSurgery",
-                    "Vision",
-                    "WeightManagement",
-                    "WomensHealth",
-                    "Wound"
-                ],
-                "operatingStatus": {
-                    "code": "NORMAL"
-                },
-                "visn": "10"
-            }
-        }
-    }
-},
-{
-    "id": "9726bd1ca2a1cf349d6d56071140e02c3883fc275bde03dd3c44e855b19b3a67",
-    "type": "appointments",
-    "attributes": {
-        "id": "9726bd1ca2a1cf349d6d56071140e02c3883fc275bde03dd3c44e855b19b3a67",
-        "identifier": [
-            {
-                "system": "Appointment/",
-                "value": "413938333132333035"
-            },
-            {
-                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
-                "value": "983:12305"
-            }
-        ],
-        "kind": "clinic",
-        "status": "booked",
-        "serviceType": "audiology",
-        "serviceTypes": [
-            {
-                "coding": [
-                    {
-                        "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
-                        "code": "audiology"
-                    }
-                ]
-            }
-        ],
-        "serviceCategory": [
-            {
-                "coding": [
-                    {
-                        "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
-                        "code": "COMPENSATION & PENSION",
-                        "display": "COMPENSATION & PENSION"
-                    }
-                ],
-                "text": "COMPENSATION & PENSION"
-            }
-        ],
-        "patientIcn": "1013678363V916823",
-        "locationId": "983GC",
-        "clinic": "945",
-        "start": "2024-12-19T15:40:00Z",
-        "end": "2024-12-19T16:40:00Z",
+        "clinic": "1049",
+        "start": "2023-10-13T15:00:00Z",
+        "end": "2023-10-13T16:00:00Z",
         "minutesDuration": 60,
         "slot": {
-            "id": "3230323431323139313534303A323032343132313931363430",
-            "start": "2024-12-19T15:40:00Z",
-            "end": "2024-12-19T16:40:00Z"
+          "id": "3230323331303133313530303A323032333130313331363030",
+          "start": "2023-10-13T15:00:00Z",
+          "end": "2023-10-13T16:00:00Z"
         },
-        "created": "2024-01-08T00:00:00Z",
-        "cancellable": false,
+        "created": "2023-10-01T00:00:00Z",
+        "cancellable": true,
         "extension": {
-            "ccLocation": {
-                "address": {}
-            },
-            "vistaStatus": [
-                "FUTURE"
-            ],
-            "preCheckinAllowed": false,
-            "eCheckinAllowed": false,
-            "clinic": {
-                "physicalLocation": "FORT COLLINS AUDIO"
-            }
-        },
-        "localStartTime": "2024-12-19T08:40:00.000-07:00",
-        "serviceName": "C&P BEV AUDIO FTC",
-        "friendlyName": "C&P BEV AUDIO FTC",
-        "physicalLocation": "FORT COLLINS AUDIO",
-        "location": {
-            "id": "983GC",
-            "type": "appointments",
-            "attributes": {
-                "id": "983GC",
-                "vistaSite": "983",
-                "vastParent": "983",
-                "type": "va_facilities",
-                "name": "Fort Collins VA Clinic",
-                "classification": "Multi-Specialty CBOC",
-                "timezone": {
-                    "timeZoneId": "America/Denver"
-                },
-                "lat": 40.553875,
-                "long": -105.08795,
-                "website": "https://www.cheyenne.va.gov/locations/Fort_Collins_VA_CBOC.asp",
-                "phone": {
-                    "main": "970-224-1550"
-                },
-                "physicalAddress": {
-                    "line": [
-                        "2509 Research Boulevard"
-                    ],
-                    "city": "Fort Collins",
-                    "state": "CO",
-                    "postalCode": "80526-8108"
-                },
-                "healthService": [
-                    "Audiology",
-                    "EmergencyCare",
-                    "MentalHealthCare",
-                    "PrimaryCare",
-                    "SpecialtyCare"
-                ]
-            }
-        }
-    }
-},
-{
-    "id": "d9faffb0d9cf0c641e53faf221fb0a08b2f6c661cc470a94817556dc0ce3589a",
-    "type": "appointments",
-    "attributes": {
-        "id": "d9faffb0d9cf0c641e53faf221fb0a08b2f6c661cc470a94817556dc0ce3589a",
-        "identifier": [
-            {
-                "system": "http://med.va.gov/fhir/urn/vaos/vvs/id",
-                "value": "381ba035-c30a-4f21-ad0e-1204a6ef3fc8"
-            }
-        ],
-        "kind": "telehealth",
-        "status": "booked",
-        "patientIcn": "1012846043V576341",
-        "locationId": "983",
-        "practitioners": [
-            {
-                "identifier": [
-                    {
-                        "system": "dfn-983",
-                        "value": "520648070"
-                    }
-                ],
-                "name": {
-                    "family": "Chapman",
-                    "given": [
-                        "Jeremy"
-                    ]
-                },
-                "practiceName": "Cheyenne VA Medical Center"
-            }
-        ],
-        "start": "2024-12-12T19:55:00Z",
-        "end": "2024-12-12T20:15:00Z",
-        "minutesDuration": 20,
-        "created": "2024-12-12T19:57:42.025Z",
-        "cancellable": false,
-        "patientInstruction": "",
-        "telehealth": {
-            "url": "https://pexip.mapsandbox.net/vvc-app/?join=1&media=1&escalate=1&userType=guest&conference=VAC000005810@pexip.mapsandbox.net&pin=356403&aid=381ba035-c30a-4f21-ad0e-1204a6ef3fc8#",
-            "group": false,
-            "vvsKind": "ADHOC"
-        },
-        "extension": {
-            "ccLocation": {
-                "address": {}
-            },
-            "vistaStatus": [],
-            "patientHasMobileGfe": true
-        },
-        "localStartTime": "2024-12-12T13:55:00.000-06:00",
-        "location": {
-            "id": "983",
-            "type": "appointments",
-            "attributes": {
-                "id": "983",
-                "vistaSite": "983",
-                "vastParent": "983",
-                "type": "va_facilities",
-                "name": "Cheyenne VA Medical Center",
-                "classification": "VA Medical Center (VAMC)",
-                "timezone": {
-                    "timeZoneId": "America/Denver"
-                },
-                "lat": 39.744507,
-                "long": -104.830956,
-                "website": "https://www.denver.va.gov/locations/directions.asp",
-                "phone": {
-                    "main": "307-778-7550",
-                    "fax": "307-778-7381",
-                    "pharmacy": "866-420-6337",
-                    "afterHours": "307-778-7550",
-                    "patientAdvocate": "307-778-7550 x7517",
-                    "mentalHealthClinic": "307-778-7349",
-                    "enrollmentCoordinator": "307-778-7550 x7579"
-                },
-                "physicalAddress": {
-                    "type": "physical",
-                    "line": [
-                        "2360 East Pershing Boulevard"
-                    ],
-                    "city": "Cheyenne",
-                    "state": "WY",
-                    "postalCode": "82001-5356"
-                },
-                "mobile": false,
-                "healthService": [
-                    "Audiology",
-                    "Cardiology",
-                    "DentalServices",
-                    "EmergencyCare",
-                    "Gastroenterology",
-                    "Gynecology",
-                    "MentalHealthCare",
-                    "Nutrition",
-                    "Ophthalmology",
-                    "Optometry",
-                    "Orthopedics",
-                    "Podiatry",
-                    "PrimaryCare",
-                    "SpecialtyCare",
-                    "UrgentCare",
-                    "Urology",
-                    "WomensHealth"
-                ],
-                "operatingStatus": {
-                    "code": "NORMAL"
-                }
-            }
-        }
-    }
-},
-{
-    "id": "cbc61b77eab168d7bb886649c0d42f6f2951b912e358cab744ca65b2296468a2",
-    "type": "appointments",
-    "attributes": {
-        "id": "cbc61b77eab168d7bb886649c0d42f6f2951b912e358cab744ca65b2296468a2",
-        "identifier": [
-            {
-                "system": "http://med.va.gov/fhir/urn/vaos/vvs/id",
-                "value": "38fc7910-fa4a-4973-8a50-c9533fb0e3c0"
-            }
-        ],
-        "kind": "telehealth",
-        "status": "booked",
-        "patientIcn": "1013124304V115761",
-        "locationId": "983",
-        "practitioners": [
-            {
-                "identifier": [
-                    {
-                        "system": "dfn-983",
-                        "value": "520647363"
-                    }
-                ],
-                "name": {
-                    "family": "NADEAU",
-                    "given": [
-                        "MARCY"
-                    ]
-                },
-                "practiceName": "Cheyenne VA Medical Center"
-            }
-        ],
-        "start": "2025-02-25T19:00:00Z",
-        "end": "2025-02-25T19:20:00Z",
-        "minutesDuration": 20,
-        "created": "2024-02-29T18:22:31.642Z",
-        "cancellable": false,
-        "patientInstruction": "Medication Review\n\nAs part of your video visit, your provider will review all the medications, vitamins, herbs, and supplements you are taking\n(even items you get from a local store, another provider, or another VA clinic). Please have information about everything you\ntake available during the visit. Informing your provider about all these will help you get the best and safest care possible.\nRemember, it is your medications, your life. Play it safe by reviewing all your medications with your health care team.\n",
-        "telehealth": {
-            "url": "https://pexip.mapsandbox.net/vvc-app/?join=1&media=1&escalate=1&userType=guest&conference=VAC000003848@pexip.mapsandbox.net&pin=111200&aid=38fc7910-fa4a-4973-8a50-c9533fb0e3c0#",
-            "group": false,
-            "vvsKind": "ADHOC"
-        },
-        "extension": {
-            "ccLocation": {
-                "address": {}
-            },
-            "vistaStatus": [],
-            "patientHasMobileGfe": false
-        },
-        "localStartTime": "2025-02-25T12:00:00.000-07:00",
-        "location": {
-            "id": "983",
-            "type": "appointments",
-            "attributes": {
-                "id": "983",
-                "vistaSite": "983",
-                "vastParent": "983",
-                "type": "va_facilities",
-                "name": "Cheyenne VA Medical Center",
-                "classification": "VA Medical Center (VAMC)",
-                "timezone": {
-                    "timeZoneId": "America/Denver"
-                },
-                "lat": 39.744507,
-                "long": -104.830956,
-                "website": "https://www.denver.va.gov/locations/directions.asp",
-                "phone": {
-                    "main": "307-778-7550",
-                    "fax": "307-778-7381",
-                    "pharmacy": "866-420-6337",
-                    "afterHours": "307-778-7550",
-                    "patientAdvocate": "307-778-7550 x7517",
-                    "mentalHealthClinic": "307-778-7349",
-                    "enrollmentCoordinator": "307-778-7550 x7579"
-                },
-                "physicalAddress": {
-                    "type": "physical",
-                    "line": [
-                        "2360 East Pershing Boulevard"
-                    ],
-                    "city": "Cheyenne",
-                    "state": "WY",
-                    "postalCode": "82001-5356"
-                },
-                "mobile": false,
-                "healthService": [
-                    "Audiology",
-                    "Cardiology",
-                    "DentalServices",
-                    "EmergencyCare",
-                    "Gastroenterology",
-                    "Gynecology",
-                    "MentalHealthCare",
-                    "Nutrition",
-                    "Ophthalmology",
-                    "Optometry",
-                    "Orthopedics",
-                    "Podiatry",
-                    "PrimaryCare",
-                    "SpecialtyCare",
-                    "UrgentCare",
-                    "Urology",
-                    "WomensHealth"
-                ],
-                "operatingStatus": {
-                    "code": "NORMAL"
-                }
-            }
-        }
-    }
-},
-{
-    "id": "805eb1710aefb85bcc07813ae36a744f1467fd4306c0a950ba16e023fb514ce9",
-    "type": "appointments",
-    "attributes": {
-        "id": "805eb1710aefb85bcc07813ae36a744f1467fd4306c0a950ba16e023fb514ce9",
-        "identifier": [
-            {
-                "system": "Appointment/",
-                "value": "4139383436323830"
-            },
-            {
-                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
-                "value": "984:6280"
-            },
-            {
-                "system": "http://med.va.gov/fhir/urn/vaos/vvs/id",
-                "value": "6641d9ca-bcf0-4040-947a-ed9ed822e495"
-            }
-        ],
-        "kind": "telehealth",
-        "status": "booked",
-        "serviceType": "outpatientMentalHealth",
-        "serviceTypes": [
-            {
-                "coding": [
-                    {
-                        "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
-                        "code": "outpatientMentalHealth"
-                    }
-                ]
-            }
-        ],
-        "serviceCategory": [
-            {
-                "coding": [
-                    {
-                        "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
-                        "code": "REGULAR",
-                        "display": "REGULAR"
-                    }
-                ],
-                "text": "REGULAR"
-            }
-        ],
-        "patientIcn": "1012845331V153043",
-        "locationId": "984GA",
-        "clinic": "4284",
-        "practitioners": [
-            {
-                "identifier": [
-                    {
-                        "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
-                        "value": "1034242903"
-                    }
-                ],
-                "name": {
-                    "family": "ALSAHHAR",
-                    "given": [
-                        "SAMI"
-                    ]
-                }
-            }
-        ],
-        "start": "2025-01-14T13:00:00Z",
-        "end": "2025-01-14T13:30:00Z",
-        "minutesDuration": 30,
-        "slot": {
-            "id": "3230323331313134313330303A323032333131313431333330",
-            "start": "2025-01-14T13:00:00Z",
-            "end": "2025-01-14T13:30:00Z"
-        },
-        "created": "2025-01-07T00:00:00Z",
-        "cancellable": false,
-        "telehealth": {
-            "url": "https://dev.care.va.gov/vvc-app/?join=1&media=1&escalate=1&userType=guest&conference=VAC000001440@dev.care.va.gov&pin=590094&aid=6641d9ca-bcf0-4040-947a-ed9ed822e495#",
-            "group": false,
-            "vvsKind": "CLINIC_BASED"
-        },
-        "extension": {
-            "ccLocation": {
-                "address": {}
-            },
-            "vistaStatus": [
-                "NO ACTION TAKEN"
-            ],
-            "patientHasMobileGfe": true,
-            "preCheckinAllowed": false,
-            "eCheckinAllowed": false,
-            "clinic": {}
-        },
-        "localStartTime": "2025-01-14T08:00:00.000-05:00",
-        "avsPath": null,
-        "serviceName": "MID-V10 CRH MH PSY MD PT",
-        "friendlyName": "MID-V10 CRH MH PSY MD PT",
-        "location": {
-            "id": "984GA",
-            "type": "appointments",
-            "attributes": {
-                "id": "984GA",
-                "vistaSite": "984",
-                "vastParent": "984",
-                "type": "va_health_facility",
-                "name": "Middletown VA Clinic",
-                "classification": "Multi-Specialty CBOC",
-                "timezone": {
-                    "timeZoneId": "America/New_York"
-                },
-                "lat": 39.50603,
-                "long": -84.316475,
-                "website": "https://www.dayton.va.gov/locations/midtwn_cboc.asp",
-                "phone": {
-                    "main": "513-423-8387"
-                },
-                "physicalAddress": {
-                    "type": "physical",
-                    "line": [
-                        "4337 North Union Road"
-                    ],
-                    "city": "Middletown",
-                    "state": "OH",
-                    "postalCode": "45005-5211"
-                },
-                "healthService": [
-                    "Audiology",
-                    "MentalHealthCare",
-                    "Optometry",
-                    "Podiatry",
-                    "PrimaryCare",
-                    "SpecialtyCare"
-                ]
-            }
-        }
-    }
-},
-{
-  "id": "805eb1710aefb85bcc07813ae36a744f1467fd4306c0a950ba16e023fb514cea",
-  "type": "appointments",
-  "attributes": {
-      "id": "805eb1710aefb85bcc07813ae36a744f1467fd4306c0a950ba16e023fb514cea",
-      "identifier": [
-          {
-              "system": "Appointment/",
-              "value": "4139383436323830"
-          },
-          {
-              "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
-              "value": "984:6280"
-          },
-          {
-              "system": "http://med.va.gov/fhir/urn/vaos/vvs/id",
-              "value": "6641d9ca-bcf0-4040-947a-ed9ed822e495"
-          }
-      ],
-      "kind": "telehealth",
-      "status": "cancelled",
-      "serviceType": "outpatientMentalHealth",
-      "serviceTypes": [
-          {
-              "coding": [
-                  {
-                      "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
-                      "code": "outpatientMentalHealth"
-                  }
-              ]
-          }
-      ],
-      "serviceCategory": [
-          {
-              "coding": [
-                  {
-                      "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
-                      "code": "REGULAR",
-                      "display": "REGULAR"
-                  }
-              ],
-              "text": "REGULAR"
-          }
-      ],
-      "patientIcn": "1012845331V153043",
-      "locationId": "984GA",
-      "clinic": "4284",
-      "practitioners": [
-          {
-              "identifier": [
-                  {
-                      "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
-                      "value": "1034242903"
-                  }
-              ],
-              "name": {
-                  "family": "ALSAHHAR",
-                  "given": [
-                      "SAMI"
-                  ]
-              }
-          }
-      ],
-      "start": "2025-01-14T14:00:00Z",
-      "end": "2025-01-14T14:30:00Z",
-      "minutesDuration": 30,
-      "slot": {
-          "id": "3230323331313134313330303A323032333131313431333330",
-          "start": "2025-01-14T14:00:00Z",
-          "end": "2025-01-14T14:30:00Z"
-      },
-      "created": "2025-01-07T00:00:00Z",
-      "cancellable": false,
-      "telehealth": {
-          "url": "https://dev.care.va.gov/vvc-app/?join=1&media=1&escalate=1&userType=guest&conference=VAC000001440@dev.care.va.gov&pin=590094&aid=6641d9ca-bcf0-4040-947a-ed9ed822e495#",
-          "group": false,
-          "vvsKind": "CLINIC_BASED"
-      },
-      "extension": {
           "ccLocation": {
-              "address": {}
+            "address": {}
           },
           "vistaStatus": [
-              "NO ACTION TAKEN"
+            "CHECKED OUT"
           ],
-          "patientHasMobileGfe": true,
+          "preCheckinAllowed": false,
+          "eCheckinAllowed": true
+        },
+        "localStartTime": "2023-10-13T09:00:00.000-06:00",
+        "avsPath": "Error retrieving AVS link",
+        "serviceName": "CHY MENTAL HEALTH ONE",
+        "friendlyName": "CHY MENTAL HEALTH ONE",
+        "location": {
+          "id": "983",
+          "type": "appointments",
+          "attributes": {
+            "id": "983",
+            "vistaSite": "983",
+            "vastParent": "983",
+            "type": "va_facilities",
+            "name": "Cheyenne VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/Denver"
+            },
+            "lat": 39.744507,
+            "long": -104.830956,
+            "website": "https://www.denver.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "307-778-7550",
+              "fax": "307-778-7381",
+              "pharmacy": "866-420-6337",
+              "afterHours": "307-778-7550",
+              "patientAdvocate": "307-778-7550 x7517",
+              "mentalHealthClinic": "307-778-7349",
+              "enrollmentCoordinator": "307-778-7550 x7579"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
+              "city": "Cheyenne",
+              "state": "WY",
+              "postalCode": "82001-5356"
+            },
+            "mobile": false,
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "EmergencyCare",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "UrgentCare",
+              "Urology",
+              "WomensHealth"
+            ],
+            "operatingStatus": {
+              "code": "NORMAL"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "176889",
+      "type": "appointments",
+      "attributes": {
+        "id": "176889",
+        "identifier": [
+          {
+            "system": "Appointment/",
+            "value": "413938333131363637"
+          },
+          {
+            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+            "value": "983:11667"
+          }
+        ],
+        "kind": "clinic",
+        "status": "booked",
+        "serviceCategory": [
+          {
+            "coding": [
+              {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                "code": "SERVICE CONNECTED",
+                "display": "SERVICE CONNECTED"
+              }
+            ],
+            "text": "SERVICE CONNECTED"
+          }
+        ],
+        "patientIcn": "1012845331V153043",
+        "locationId": "983",
+        "clinic": "1049",
+        "start": "2023-10-13T15:00:00Z",
+        "end": "2023-10-13T16:00:00Z",
+        "minutesDuration": 60,
+        "slot": {
+          "id": "3230323331303133313530303A323032333130313331363030",
+          "start": "2023-10-13T15:00:00Z",
+          "end": "2023-10-13T16:00:00Z"
+        },
+        "created": "2023-11-01T00:00:00Z",
+        "cancellable": true,
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [
+            "CHECKED OUT"
+          ],
+          "preCheckinAllowed": false,
+          "eCheckinAllowed": true
+        },
+        "localStartTime": "2023-10-13T09:00:00.000-06:00",
+        "avsPath": null,
+        "serviceName": "CHY MENTAL HEALTH ONE",
+        "friendlyName": "CHY MENTAL HEALTH ONE",
+        "location": {
+          "id": "983",
+          "type": "appointments",
+          "attributes": {
+            "id": "983",
+            "vistaSite": "983",
+            "vastParent": "983",
+            "type": "va_facilities",
+            "name": "Cheyenne VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/Denver"
+            },
+            "lat": 39.744507,
+            "long": -104.830956,
+            "website": "https://www.denver.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "307-778-7550",
+              "fax": "307-778-7381",
+              "pharmacy": "866-420-6337",
+              "afterHours": "307-778-7550",
+              "patientAdvocate": "307-778-7550 x7517",
+              "mentalHealthClinic": "307-778-7349",
+              "enrollmentCoordinator": "307-778-7550 x7579"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
+              "city": "Cheyenne",
+              "state": "WY",
+              "postalCode": "82001-5356"
+            },
+            "mobile": false,
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "EmergencyCare",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "UrgentCare",
+              "Urology",
+              "WomensHealth"
+            ],
+            "operatingStatus": {
+              "code": "NORMAL"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "567678",
+      "type": "appointments",
+      "attributes": {
+        "id": "567678",
+        "identifier": [
+          {
+            "system": "Appointment/",
+            "value": "413938333131363637"
+          },
+          {
+            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+            "value": "983:11667"
+          }
+        ],
+        "kind": "clinic",
+        "status": "booked",
+        "serviceCategory": [
+          {
+            "coding": [
+              {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                "code": "SERVICE CONNECTED",
+                "display": "SERVICE CONNECTED"
+              }
+            ],
+            "text": "SERVICE CONNECTED"
+          }
+        ],
+        "patientIcn": "1012845331V153043",
+        "locationId": "983",
+        "clinic": "1049",
+        "start": "2023-10-13T15:00:00Z",
+        "end": "2023-10-13T16:00:00Z",
+        "minutesDuration": 60,
+        "slot": {
+          "id": "3230323331303133313530303A323032333130313331363030",
+          "start": "2023-10-13T15:00:00Z",
+          "end": "2023-10-13T16:00:00Z"
+        },
+        "created": "2023-11-01T00:00:00Z",
+        "cancellable": true,
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [
+            "CHECKED OUT"
+          ],
+          "preCheckinAllowed": false,
+          "eCheckinAllowed": true
+        },
+        "localStartTime": "2023-10-13T09:00:00.000-06:00",
+        "serviceName": "CHY MENTAL HEALTH ONE",
+        "friendlyName": "CHY MENTAL HEALTH ONE",
+        "location": {
+          "id": "983",
+          "type": "appointments",
+          "attributes": {
+            "id": "983",
+            "vistaSite": "983",
+            "vastParent": "983",
+            "type": "va_facilities",
+            "name": "Cheyenne VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/Denver"
+            },
+            "lat": 39.744507,
+            "long": -104.830956,
+            "website": "https://www.denver.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "307-778-7550",
+              "fax": "307-778-7381",
+              "pharmacy": "866-420-6337",
+              "afterHours": "307-778-7550",
+              "patientAdvocate": "307-778-7550 x7517",
+              "mentalHealthClinic": "307-778-7349",
+              "enrollmentCoordinator": "307-778-7550 x7579"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
+              "city": "Cheyenne",
+              "state": "WY",
+              "postalCode": "82001-5356"
+            },
+            "mobile": false,
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "EmergencyCare",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "UrgentCare",
+              "Urology",
+              "WomensHealth"
+            ],
+            "operatingStatus": {
+              "code": "NORMAL"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "193059",
+      "type": "appointments",
+      "attributes": {
+        "id": "193059",
+        "identifier": [
+          {
+            "system": "Appointment/",
+            "value": "413938333131363633"
+          },
+          {
+            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+            "value": "983:11663"
+          }
+        ],
+        "kind": "phone",
+        "status": "booked",
+        "serviceType": "primaryCare",
+        "serviceTypes": [
+          {
+            "coding": [
+              {
+                "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                "code": "primaryCare"
+              }
+            ]
+          }
+        ],
+        "serviceCategory": [
+          {
+            "coding": [
+              {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                "code": "REGULAR",
+                "display": "REGULAR"
+              }
+            ],
+            "text": "REGULAR"
+          }
+        ],
+        "patientIcn": "1012845331V153043",
+        "locationId": "983",
+        "clinic": "455",
+        "start": "2023-10-19T15:00:00Z",
+        "end": "2023-10-19T16:00:00Z",
+        "minutesDuration": 60,
+        "slot": {
+          "id": "3230323331303139313530303A323032333130313931363030",
+          "start": "2023-10-19T15:00:00Z",
+          "end": "2023-10-19T16:00:00Z"
+        },
+        "created": "2023-11-01T00:00:00Z",
+        "cancellable": true,
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [
+            "ACT REQ/CHECKED OUT"
+          ],
           "preCheckinAllowed": false,
           "eCheckinAllowed": false,
           "clinic": {}
-      },
-      "localStartTime": "2025-01-14T09:00:00.000-05:00",
-      "avsPath": null,
-      "serviceName": "MID-V10 CRH MH PSY MD PT",
-      "friendlyName": "MID-V10 CRH MH PSY MD PT",
-      "location": {
-          "id": "984GA",
+        },
+        "localStartTime": "2023-10-19T09:00:00.000-06:00",
+        "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988639578151",
+        "serviceName": "CHY PC CASSIDY",
+        "physicalLocation": "ARROWHEAD WING, 2ND FLOOR",
+        "friendlyName": "CHY PC CASSIDY",
+        "location": {
+          "id": "983",
           "type": "appointments",
           "attributes": {
-              "id": "984GA",
-              "vistaSite": "984",
-              "vastParent": "984",
-              "type": "va_health_facility",
-              "name": "Middletown VA Clinic",
-              "classification": "Multi-Specialty CBOC",
-              "timezone": {
-                  "timeZoneId": "America/New_York"
-              },
-              "lat": 39.50603,
-              "long": -84.316475,
-              "website": "https://www.dayton.va.gov/locations/midtwn_cboc.asp",
-              "phone": {
-                  "main": "513-423-8387"
-              },
-              "physicalAddress": {
-                  "type": "physical",
-                  "line": [
-                      "4337 North Union Road"
-                  ],
-                  "city": "Middletown",
-                  "state": "OH",
-                  "postalCode": "45005-5211"
-              },
-              "healthService": [
-                  "Audiology",
-                  "MentalHealthCare",
-                  "Optometry",
-                  "Podiatry",
-                  "PrimaryCare",
-                  "SpecialtyCare"
-              ]
-          }
-      }
-  }
-},
-{
-    "id": "0fbc293324755816b690f11eab25c827b5e4fbea375ac06e8e9694205f95590e",
-    "type": "appointments",
-    "attributes": {
-        "id": "0fbc293324755816b690f11eab25c827b5e4fbea375ac06e8e9694205f95590e",
-        "identifier": [
-            {
-                "system": "http://med.va.gov/fhir/urn/vaos/vvs/id",
-                "value": "5c21ee08-7bc9-4cc3-b557-0fc543c40148"
-            }
-        ],
-        "kind": "telehealth",
-        "status": "booked",
-        "patientIcn": "1013124304V115761",
-        "locationId": "983",
-        "practitioners": [
-            {
-                "identifier": [
-                    {
-                        "system": "dfn-983",
-                        "value": "520647710"
-                    }
-                ],
-                "name": {
-                    "family": "Poldass",
-                    "given": [
-                        "Aarathi"
-                    ]
-                },
-                "practiceName": "Cheyenne VA Medical Center"
-            }
-        ],
-        "start": "2024-12-01T15:00:00Z",
-        "end": "2024-12-01T15:30:00Z",
-        "minutesDuration": 30,
-        "created": "2024-03-01T18:52:19.23Z",
-        "comment": "Testing ATLAS appt for VAOS team (Marcy)",
-        "cancellable": false,
-        "patientInstruction": "Medication Review\n\nAs part of your video visit, your provider will review all the medications, vitamins, herbs, and supplements you are taking\n(even items you get from a local store, another provider, or another VA clinic). Please have information about everything you\ntake available during the visit. Informing your provider about all these will help you get the best and safest care possible.\nRemember, it is your medications, your life. Play it safe by reviewing all your medications with your health care team.\n",
-        "telehealth": {
-            "url": "https://dev.care2.va.gov/vvc-app/?join=1&media=1&escalate=1&userType=guest&conference=VAC000003896@dev.care2.va.gov&pin=104039&aid=5c21ee08-7bc9-4cc3-b557-0fc543c40148#",
-            "atlas": {
-                "siteCode": "VFW-DC-20011-02",
-                "confirmationCode": "075041",
-                "address": {
-                    "streetAddress": "5929 Georgia Ave NW",
-                    "city": "Washington",
-                    "state": "DC",
-                    "zipCode": "20011",
-                    "country": "USA",
-                    "latitutde": 38.961979,
-                    "longitude": -77.027908,
-                    "additionalDetails": ""
-                }
-            },
-            "group": false,
-            "vvsKind": "ADHOC"
-        },
-        "extension": {
-            "ccLocation": {
-                "address": {}
-            },
-            "vistaStatus": [],
-            "patientHasMobileGfe": false
-        },
-        "localStartTime": "2024-12-01T08:00:00.000-07:00",
-        "location": {
             "id": "983",
-            "type": "appointments",
-            "attributes": {
-                "id": "983",
-                "vistaSite": "983",
-                "vastParent": "983",
-                "type": "va_facilities",
-                "name": "Cheyenne VA Medical Center",
-                "classification": "VA Medical Center (VAMC)",
-                "timezone": {
-                    "timeZoneId": "America/Denver"
-                },
-                "lat": 39.744507,
-                "long": -104.830956,
-                "website": "https://www.denver.va.gov/locations/directions.asp",
-                "phone": {
-                    "main": "307-778-7550",
-                    "fax": "307-778-7381",
-                    "pharmacy": "866-420-6337",
-                    "afterHours": "307-778-7550",
-                    "patientAdvocate": "307-778-7550 x7517",
-                    "mentalHealthClinic": "307-778-7349",
-                    "enrollmentCoordinator": "307-778-7550 x7579"
-                },
-                "physicalAddress": {
-                    "type": "physical",
-                    "line": [
-                        "2360 East Pershing Boulevard"
-                    ],
-                    "city": "Cheyenne",
-                    "state": "WY",
-                    "postalCode": "82001-5356"
-                },
-                "mobile": false,
-                "healthService": [
-                    "Audiology",
-                    "Cardiology",
-                    "DentalServices",
-                    "EmergencyCare",
-                    "Gastroenterology",
-                    "Gynecology",
-                    "MentalHealthCare",
-                    "Nutrition",
-                    "Ophthalmology",
-                    "Optometry",
-                    "Orthopedics",
-                    "Podiatry",
-                    "PrimaryCare",
-                    "SpecialtyCare",
-                    "UrgentCare",
-                    "Urology",
-                    "WomensHealth"
-                ],
-                "operatingStatus": {
-                    "code": "NORMAL"
-                }
+            "vistaSite": "983",
+            "vastParent": "983",
+            "type": "va_facilities",
+            "name": "Cheyenne VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/Denver"
+            },
+            "lat": 39.744507,
+            "long": -104.830956,
+            "website": "https://www.denver.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "307-778-7550",
+              "fax": "307-778-7381",
+              "pharmacy": "866-420-6337",
+              "afterHours": "307-778-7550",
+              "patientAdvocate": "307-778-7550 x7517",
+              "mentalHealthClinic": "307-778-7349",
+              "enrollmentCoordinator": "307-778-7550 x7579"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
+              "city": "Cheyenne",
+              "state": "WY",
+              "postalCode": "82001-5356"
+            },
+            "mobile": false,
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "EmergencyCare",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "UrgentCare",
+              "Urology",
+              "WomensHealth"
+            ],
+            "operatingStatus": {
+              "code": "NORMAL"
             }
+          }
         }
-    }
-},
+      }
+    },
+    {
+      "id": "04aa456vvs",
+      "type": "Appointment",
+      "attributes": {
+        "cancelationReason": null,
+        "clinic": "848",
+        "comment": "",
+        "contact": {
+          "telecom": [
+            {
+              "type": "email",
+              "value": null
+            }
+          ]
+        },
+        "description": "Upcoming at home telehealth appointment with instructions",
+        "end": "2022-11-09T20:30:00Z",
+        "id": "04aa456vvs",
+        "kind": "telehealth",
+        "locationId": "983",
+        "minutesDuration": 30,
+        "patientIcn": null,
+        "patientInstruction": "Medication Review to prepare patient",
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": null,
+                "value": "1801312053"
+              }
+            ],
+            "name": {
+              "family": "Smith",
+              "given": [
+                "Megan"
+              ]
+            },
+            "practiceName": null
+          },
+          {
+            "identifier": [
+              {
+                "system": null,
+                "value": "1801312053"
+              }
+            ],
+            "name": {
+              "family": "Dali",
+              "given": [
+                "Salvador"
+              ]
+            },
+            "practiceName": null
+          }
+        ],
+        "physicalLocation": "should not display",
+        "preferredTimesForPhoneCall": [],
+        "priority": 0,
+        "reasonCode": {},
+        "requestedPeriods": null,
+        "serviceType": "audiology",
+        "extension": {
+          "patientHasMobileGfe": true
+        },
+        "slot": null,
+        "start": "2023-11-09T20:30:00Z",
+        "localStartTime": "2023-11-13T09:00:00.000-06:00",
+        "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988663350853",
+        "status": "booked",
+        "telehealth": {
+          "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#",
+          "atlas": null,
+          "vvsKind": "MOBILE_ANY"
+        }
+      }
+    },
+    {
+      "id": "10aa456vvs",
+      "type": "Appointment",
+      "attributes": {
+        "cancelationReason": null,
+        "clinic": "848",
+        "comment": null,
+        "contact": {
+          "telecom": [
+            {
+              "type": "email",
+              "value": null
+            }
+          ]
+        },
+        "description": "Upcoming VA GFE telehealth appointment",
+        "end": "2022-12-27T18:19:34",
+        "id": "10aa456vvs",
+        "kind": "telehealth",
+        "locationId": "983",
+        "localStartTime": "2023-11-22T18:00:00.000-06:00",
+        "minutesDuration": 30,
+        "patientIcn": null,
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": null,
+                "value": "1801312053"
+              }
+            ],
+            "name": {
+              "family": "Nightingale",
+              "given": [
+                "Florence"
+              ]
+            }
+          }
+        ],
+        "preferredTimesForPhoneCall": [],
+        "priority": 0,
+        "reasonCode": {},
+        "requestedPeriods": null,
+        "serviceType": "primaryCare",
+        "slot": null,
+        "start": "2023-11-22T18:19:34",
+        "status": "booked",
+        "telehealth": {
+          "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#",
+          "atlas": null,
+          "vvsKind": "MOBILE_GFE"
+        }
+      }
+    },
+    {
+      "id": "00C893va",
+      "type": "Appointment",
+      "attributes": {
+        "cancelationReason": null,
+        "clinic": "437",
+        "comment": "Follow-up/Routine: I have a headache",
+        "contact": {
+          "telecom": [
+            {
+              "type": "email",
+              "value": null
+            }
+          ]
+        },
+        "description": "Upcoming COVID-19 appointment",
+        "end": "2023-12-21T18:19:34",
+        "id": "00C893va",
+        "kind": "clinic",
+        "locationId": "983",
+        "minutesDuration": 30,
+        "patientIcn": null,
+        "practitioners": [],
+        "preferredTimesForPhoneCall": [],
+        "priority": 0,
+        "reasonCode": {
+          "text": "Follow-up/Routine: Covid shot"
+        },
+        "requestedPeriods": null,
+        "serviceType": "covid",
+        "slot": null,
+        "start": "2023-12-21T18:19:34",
+        "status": "cancelled",
+        "cancellable": false,
+        "localStartTime": "2023-12-21T09:00:00.000-06:00",
+        "telehealth": null
+      }
+    },
     {
       "id": "167419",
       "type": "appointments",
@@ -2147,7 +703,7 @@
         "serviceType": "outpatientMentalHealth",
         "patientIcn": "1012845331V153043",
         "locationId": "984",
-        "physicalLocation" : "should not display",
+        "physicalLocation": "should not display",
         "practitioners": [
           {
             "identifier": [
@@ -2249,50 +805,12 @@
       }
     },
     {
-      "id": "00C891va",
-      "type": "Appointment",
-      "attributes": {
-        "clinic": "437",
-        "comment": "Follow-up/Routine: I have a headache",
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            }
-          ]
-        },
-        "description": "Upcoming COVID-19 appointment",
-        "end": "2024-10-13T16:00:00Z",
-        "id": "00C891va",
-        "kind": "clinic",
-        "locationId": "983",
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "practitioners": [],
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {
-          "text": "Follow-up/Routine: Covid shot"
-        },
-        "requestedPeriods": null,
-        "serviceType": "covid",
-        "start": "2023-10-13T15:00:00Z",
-        "status": "booked",
-        "created": "2024-11-01T00:00:00Z",
-        "cancellable": false,
-        "localStartTime": "2023-10-13T09:00:00.000-06:00",
-        "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988663350853",
-        "telehealth": null
-      }
-    },
-    {
-      "id": "00C893va",
+      "id": "09aa456vvs",
       "type": "Appointment",
       "attributes": {
         "cancelationReason": null,
-        "clinic": "437",
-        "comment": "Follow-up/Routine: I have a headache",
+        "clinic": "848",
+        "comment": null,
         "contact": {
           "telecom": [
             {
@@ -2301,824 +819,43 @@
             }
           ]
         },
-        "description": "Upcoming COVID-19 appointment",
-        "end": "2023-12-21T18:19:34",
-        "id": "00C893va",
-        "kind": "clinic",
+        "description": "upcoming at home telehealth appointment",
+        "end": "2024-06-08T17:30:00Z",
+        "id": "09aa456vvs",
+        "kind": "telehealth",
         "locationId": "983",
+        "localStartTime": "2024-06-08T17:00:00.000-06:00",
         "minutesDuration": 30,
         "patientIcn": null,
-        "practitioners": [],
+        "patientInstruction": "Video Visit Preparation",
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": null,
+                "value": "1801312053"
+              }
+            ],
+            "name": {
+              "family": "Jones",
+              "given": [
+                "Peter"
+              ]
+            }
+          }
+        ],
         "preferredTimesForPhoneCall": [],
         "priority": 0,
-        "reasonCode": {
-          "text": "Follow-up/Routine: Covid shot"
-        },
+        "reasonCode": {},
         "requestedPeriods": null,
-        "serviceType": "covid",
-        "slot": null,
-        "start": "2023-12-21T18:19:34",
-        "status": "cancelled",
-        "cancellable": false,
-        "localStartTime": "2023-12-21T09:00:00.000-06:00",
-        "telehealth": null
-      }
-    },
-    {
-      "id": "1150111CC",
-      "type": "appointments",
-      "attributes": {
-        "id": "1150111CC",
-        "identifier": [
-          {
-            "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
-            "value": "524669||4||1"
-          },
-          {
-            "system": "http://hl7.org/fhir/sid/us-npi",
-            "value": "1679635460"
-          }
-        ],
-        "kind": "cc",
-        "status": "booked",
-        "description": "Eye Care Examination SEOC 1.3.10 PRCT",
-        "patientIcn": "1013124304V115761",
-        "locationId": "984",
-        "practitioners": [
-          {
-            "name": {
-              "family": "BERMEL",
-              "given": [
-                "MICHAEL"
-              ]
-            }
-          }
-        ],
-        "start": "2024-08-21T12:00:00Z",
-        "created": "2024-08-21T20:33:54Z",
-        "localStartTime": "2024-08-21T09:00:00.000-06:00",
-        "avsPath": null,
-        "cancellable": false,
-        "extension": {
-          "ccLocation": {
-            "address": {
-              "line": [
-                "10640 MAIN ST ; STE 100"
-              ],
-              "city": "FAIRFAX",
-              "state": "VA",
-              "postalCode": "22030",
-              "text": "10640 MAIN ST ; STE 100\nFAIRFAX VA 22030"
-            },
-            "telecom": [
-              {
-                "system": "phone",
-                "value": "703-691-2020"
-              }
-            ]
-          },
-          "hsrmTaskId": "",
-          "hsrmConsultId": "984_644056",
-          "ccTreatingSpecialty": "Optometrist"
-        },
-        "location": {
-          "id": "984",
-          "type": "appointments",
-          "attributes": {
-            "id": "984",
-            "vistaSite": "984",
-            "vastParent": "984",
-            "type": "va_health_facility",
-            "name": "Dayton VA Medical Center",
-            "classification": "VA Medical Center (VAMC)",
-            "timezone": {
-              "timeZoneId": "America/New_York"
-            },
-            "lat": 39.74935,
-            "long": -84.2532,
-            "website": "https://www.dayton.va.gov/locations/directions.asp",
-            "phone": {
-              "main": "937-268-6511"
-            },
-            "physicalAddress": {
-              "type": "physical",
-              "line": [
-                "4100 West Third Street"
-              ],
-              "city": "Dayton",
-              "state": "OH",
-              "postalCode": "45428-9000"
-            },
-            "healthService": [
-              "Audiology",
-              "Cardiology",
-              "DentalServices",
-              "Dermatology",
-              "Gastroenterology",
-              "Gynecology",
-              "MentalHealthCare",
-              "Nutrition",
-              "Ophthalmology",
-              "Optometry",
-              "Orthopedics",
-              "Podiatry",
-              "PrimaryCare",
-              "SpecialtyCare",
-              "Urology",
-              "WomensHealth"
-            ]
-          }
-        }
-      }
-    },
-    {
-      "id": "1923055",
-      "type": "appointments",
-      "attributes": {
-        "id": "192308",
-        "identifier": [
-          {
-            "system": "Appointment/",
-            "value": "413938333131363637"
-          },
-          {
-            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
-            "value": "983:11667"
-          }
-        ],
-        "kind": "clinic",
-        "status": "booked",
-        "serviceType": "outpatientMentalHealth",
-        "serviceCategory": [
-          {
-            "coding": [
-              {
-                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
-                "code": "SERVICE CONNECTED",
-                "display": "SERVICE CONNECTED"
-              }
-            ],
-            "text": "SERVICE CONNECTED"
-          }
-        ],
-        "patientIcn": "1012845331V153043",
-        "locationId": "983",
-        "clinic": "1049",
-        "start": "2023-10-13T15:00:00Z",
-        "end": "2023-10-13T16:00:00Z",
-        "minutesDuration": 60,
-        "slot": {
-          "id": "3230323331303133313530303A323032333130313331363030",
-          "start": "2023-10-13T15:00:00Z",
-          "end": "2023-10-13T16:00:00Z"
-        },
-        "created": "2023-10-01T00:00:00Z",
-        "cancellable": true,
-        "extension": {
-          "ccLocation": {
-            "address": {}
-          },
-          "vistaStatus": [
-            "CHECKED OUT"
-          ],
-          "preCheckinAllowed": false,
-          "eCheckinAllowed": true
-        },
-        "localStartTime": "2023-10-13T09:00:00.000-06:00",
-        "avsPath": "Error retrieving AVS link",
-        "serviceName": "CHY MENTAL HEALTH ONE",
-        "friendlyName": "CHY MENTAL HEALTH ONE",
-        "location": {
-          "id": "983",
-          "type": "appointments",
-          "attributes": {
-            "id": "983",
-            "vistaSite": "983",
-            "vastParent": "983",
-            "type": "va_facilities",
-            "name": "Cheyenne VA Medical Center",
-            "classification": "VA Medical Center (VAMC)",
-            "timezone": {
-                "timeZoneId": "America/Denver"
-            },
-            "lat": 39.744507,
-            "long": -104.830956,
-            "website": "https://www.denver.va.gov/locations/directions.asp",
-            "phone": {
-              "main": "307-778-7550",
-              "fax": "307-778-7381",
-              "pharmacy": "866-420-6337",
-              "afterHours": "307-778-7550",
-              "patientAdvocate": "307-778-7550 x7517",
-              "mentalHealthClinic": "307-778-7349",
-              "enrollmentCoordinator": "307-778-7550 x7579"
-            },
-            "physicalAddress": {
-              "type": "physical",
-              "line": [
-                "2360 East Pershing Boulevard"
-              ],
-              "city": "Cheyenne",
-              "state": "WY",
-              "postalCode": "82001-5356"
-            },
-            "mobile": false,
-            "healthService": [
-              "Audiology",
-              "Cardiology",
-              "DentalServices",
-              "EmergencyCare",
-              "Gastroenterology",
-              "Gynecology",
-              "MentalHealthCare",
-              "Nutrition",
-              "Ophthalmology",
-              "Optometry",
-              "Orthopedics",
-              "Podiatry",
-              "PrimaryCare",
-              "SpecialtyCare",
-              "UrgentCare",
-              "Urology",
-              "WomensHealth"
-            ],
-            "operatingStatus": {
-              "code": "NORMAL"
-            }
-          }
-        }
-      }
-    },
-    {
-      "id": "115069",
-      "type": "appointments",
-      "attributes": {
-        "id": "115069",
-        "identifier": [
-          {
-            "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
-            "value": "524669||4||1"
-          },
-          {
-            "system": "http://hl7.org/fhir/sid/us-npi",
-            "value": "1679635460"
-          }
-        ],
-        "kind": "cc",
-        "status": "booked",
-        "description": "Eye Care Examination SEOC 1.3.10 PRCT",
-        "patientIcn": "1013124304V115761",
-        "locationId": "984",
-        "practitioners": [
-          {
-            "name": {
-              "family": "BERMEL",
-              "given": [
-                "MICHAEL"
-              ]
-            }
-          }
-        ],
-        "start": "2022-12-22T12:00:00Z",
-        "created": "2022-12-22T20:33:54Z",
-        "cancellable": true,
-        "extension": {
-          "ccLocation": {
-            "address": {
-              "line": [
-                "10640 MAIN ST ; STE 100"
-              ],
-              "city": "FAIRFAX",
-              "state": "VA",
-              "postalCode": "22030",
-              "text": "10640 MAIN ST ; STE 100\nFAIRFAX VA 22030"
-            },
-            "telecom": [
-              {
-                "system": "phone",
-                "value": "703-691-2020"
-              }
-            ]
-          },
-          "hsrmTaskId": "",
-          "hsrmConsultId": "984_644056",
-          "ccTreatingSpecialty": "Podiatrist"
-        },
-        "location": {
-          "id": "984",
-          "type": "appointments",
-          "attributes": {
-            "id": "984",
-            "vistaSite": "984",
-            "vastParent": "984",
-            "type": "va_health_facility",
-            "name": "Dayton VA Medical Center",
-            "classification": "VA Medical Center (VAMC)",
-            "timezone": {
-              "timeZoneId": "America/New_York"
-            },
-            "lat": 39.74935,
-            "long": -84.2532,
-            "website": "https://www.dayton.va.gov/locations/directions.asp",
-            "phone": {
-              "main": "937-268-6511"
-            },
-            "physicalAddress": {
-              "type": "physical",
-              "line": [
-                "4100 West Third Street"
-              ],
-              "city": "Dayton",
-              "state": "OH",
-              "postalCode": "45428-9000"
-            },
-            "healthService": [
-              "Audiology",
-              "Cardiology",
-              "DentalServices",
-              "Dermatology",
-              "Gastroenterology",
-              "Gynecology",
-              "MentalHealthCare",
-              "Nutrition",
-              "Ophthalmology",
-              "Optometry",
-              "Orthopedics",
-              "Podiatry",
-              "PrimaryCare",
-              "SpecialtyCare",
-              "Urology",
-              "WomensHealth"
-            ]
-          }
-        }
-      }
-    },
-    {
-      "id": "176889",
-      "type": "appointments",
-      "attributes": {
-        "id": "176889",
-        "identifier": [
-          {
-            "system": "Appointment/",
-            "value": "413938333131363637"
-          },
-          {
-            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
-            "value": "983:11667"
-          }
-        ],
-        "kind": "clinic",
-        "status": "booked",
-        "serviceCategory": [
-          {
-          "coding": [
-            {
-              "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
-              "code": "SERVICE CONNECTED",
-              "display": "SERVICE CONNECTED"
-            }
-          ],
-          "text": "SERVICE CONNECTED"
-          }
-        ],
-        "patientIcn": "1012845331V153043",
-        "locationId": "983",
-        "clinic": "1049",
-        "start": "2023-10-13T15:00:00Z",
-        "end": "2023-10-13T16:00:00Z",
-        "minutesDuration": 60,
-        "slot": {
-          "id": "3230323331303133313530303A323032333130313331363030",
-          "start": "2023-10-13T15:00:00Z",
-          "end": "2023-10-13T16:00:00Z"
-        },
-        "created": "2023-11-01T00:00:00Z",
-        "cancellable": true,
-        "extension": {
-          "ccLocation": {
-            "address": {}
-          },
-          "vistaStatus": [
-            "CHECKED OUT"
-          ],
-          "preCheckinAllowed": false,
-          "eCheckinAllowed": true
-        },
-        "localStartTime": "2023-10-13T09:00:00.000-06:00",
-        "avsPath": null,
-        "serviceName": "CHY MENTAL HEALTH ONE",
-        "friendlyName": "CHY MENTAL HEALTH ONE",
-        "location": {
-          "id": "983",
-          "type": "appointments",
-          "attributes": {
-            "id": "983",
-            "vistaSite": "983",
-            "vastParent": "983",
-            "type": "va_facilities",
-            "name": "Cheyenne VA Medical Center",
-            "classification": "VA Medical Center (VAMC)",
-            "timezone": {
-                "timeZoneId": "America/Denver"
-            },
-            "lat": 39.744507,
-            "long": -104.830956,
-            "website": "https://www.denver.va.gov/locations/directions.asp",
-            "phone": {
-              "main": "307-778-7550",
-              "fax": "307-778-7381",
-              "pharmacy": "866-420-6337",
-              "afterHours": "307-778-7550",
-              "patientAdvocate": "307-778-7550 x7517",
-              "mentalHealthClinic": "307-778-7349",
-              "enrollmentCoordinator": "307-778-7550 x7579"
-            },
-            "physicalAddress": {
-              "type": "physical",
-              "line": [
-                  "2360 East Pershing Boulevard"
-              ],
-              "city": "Cheyenne",
-              "state": "WY",
-              "postalCode": "82001-5356"
-            },
-            "mobile": false,
-            "healthService": [
-              "Audiology",
-              "Cardiology",
-              "DentalServices",
-              "EmergencyCare",
-              "Gastroenterology",
-              "Gynecology",
-              "MentalHealthCare",
-              "Nutrition",
-              "Ophthalmology",
-              "Optometry",
-              "Orthopedics",
-              "Podiatry",
-              "PrimaryCare",
-              "SpecialtyCare",
-              "UrgentCare",
-              "Urology",
-              "WomensHealth"
-            ],
-            "operatingStatus": {
-              "code": "NORMAL"
-            }
-          }
-        }
-      }
-    },
-    {
-      "id": "567678",
-      "type": "appointments",
-      "attributes": {
-        "id": "567678",
-        "identifier": [
-          {
-            "system": "Appointment/",
-            "value": "413938333131363637"
-          },
-          {
-            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
-            "value": "983:11667"
-          }
-        ],
-        "kind": "clinic",
-        "status": "booked",
-        "serviceCategory": [
-          {
-            "coding": [
-              {
-                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
-                "code": "SERVICE CONNECTED",
-                "display": "SERVICE CONNECTED"
-              }
-            ],
-            "text": "SERVICE CONNECTED"
-          }
-        ],
-        "patientIcn": "1012845331V153043",
-        "locationId": "983",
-        "clinic": "1049",
-        "start": "2023-10-13T15:00:00Z",
-        "end": "2023-10-13T16:00:00Z",
-        "minutesDuration": 60,
-        "slot": {
-          "id": "3230323331303133313530303A323032333130313331363030",
-          "start": "2023-10-13T15:00:00Z",
-          "end": "2023-10-13T16:00:00Z"
-        },
-        "created": "2023-11-01T00:00:00Z",
-        "cancellable": true,
-        "extension": {
-          "ccLocation": {
-            "address": {}
-          },
-          "vistaStatus": [
-            "CHECKED OUT"
-          ],
-          "preCheckinAllowed": false,
-          "eCheckinAllowed": true
-        },
-        "localStartTime": "2023-10-13T09:00:00.000-06:00",
-        "serviceName": "CHY MENTAL HEALTH ONE",
-        "friendlyName": "CHY MENTAL HEALTH ONE",
-        "location": {
-          "id": "983",
-          "type": "appointments",
-          "attributes": {
-            "id": "983",
-            "vistaSite": "983",
-            "vastParent": "983",
-            "type": "va_facilities",
-            "name": "Cheyenne VA Medical Center",
-            "classification": "VA Medical Center (VAMC)",
-            "timezone": {
-                "timeZoneId": "America/Denver"
-            },
-            "lat": 39.744507,
-            "long": -104.830956,
-            "website": "https://www.denver.va.gov/locations/directions.asp",
-            "phone": {
-              "main": "307-778-7550",
-              "fax": "307-778-7381",
-              "pharmacy": "866-420-6337",
-              "afterHours": "307-778-7550",
-              "patientAdvocate": "307-778-7550 x7517",
-              "mentalHealthClinic": "307-778-7349",
-              "enrollmentCoordinator": "307-778-7550 x7579"
-            },
-            "physicalAddress": {
-              "type": "physical",
-              "line": [
-                "2360 East Pershing Boulevard"
-              ],
-              "city": "Cheyenne",
-              "state": "WY",
-              "postalCode": "82001-5356"
-            },
-            "mobile": false,
-            "healthService": [
-              "Audiology",
-              "Cardiology",
-              "DentalServices",
-              "EmergencyCare",
-              "Gastroenterology",
-              "Gynecology",
-              "MentalHealthCare",
-              "Nutrition",
-              "Ophthalmology",
-              "Optometry",
-              "Orthopedics",
-              "Podiatry",
-              "PrimaryCare",
-              "SpecialtyCare",
-              "UrgentCare",
-              "Urology",
-              "WomensHealth"
-            ],
-            "operatingStatus": {
-            "code": "NORMAL"
-            }
-          }
-        }
-      }
-    },
-    {
-      "id": "193059",
-      "type": "appointments",
-      "attributes": {
-        "id": "193059",
-        "identifier": [
-          {
-            "system": "Appointment/",
-            "value": "413938333131363633"
-          },
-          {
-            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
-            "value": "983:11663"
-          }
-        ],
-        "kind": "phone",
-        "status": "booked",
         "serviceType": "primaryCare",
-        "serviceTypes": [
-          {
-            "coding": [
-              {
-                "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
-                "code": "primaryCare"
-              }
-            ]
-          }
-        ],
-        "serviceCategory": [
-          {
-            "coding": [
-              {
-                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
-                "code": "REGULAR",
-                "display": "REGULAR"
-              }
-            ],
-            "text": "REGULAR"
-          }
-        ],
-        "patientIcn": "1012845331V153043",
-        "locationId": "983",
-        "clinic": "455",
-        "start": "2023-10-19T15:00:00Z",
-        "end": "2023-10-19T16:00:00Z",
-        "minutesDuration": 60,
-        "slot": {
-          "id": "3230323331303139313530303A323032333130313931363030",
-          "start": "2023-10-19T15:00:00Z",
-          "end": "2023-10-19T16:00:00Z"
-        },
-        "created": "2023-11-01T00:00:00Z",
-        "cancellable": true,
-        "extension": {
-          "ccLocation": {
-              "address": {}
-          },
-          "vistaStatus": [
-              "ACT REQ/CHECKED OUT"
-          ],
-          "preCheckinAllowed": false,
-          "eCheckinAllowed": false,
-          "clinic": {}
-        },
-        "localStartTime": "2023-10-19T09:00:00.000-06:00",
-        "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988639578151",
-        "serviceName": "CHY PC CASSIDY",
-        "physicalLocation": "ARROWHEAD WING, 2ND FLOOR",
-        "friendlyName": "CHY PC CASSIDY",
-        "location": {
-          "id": "983",
-          "type": "appointments",
-          "attributes": {
-            "id": "983",
-            "vistaSite": "983",
-            "vastParent": "983",
-            "type": "va_facilities",
-            "name": "Cheyenne VA Medical Center",
-            "classification": "VA Medical Center (VAMC)",
-            "timezone": {
-              "timeZoneId": "America/Denver"
-            },
-            "lat": 39.744507,
-            "long": -104.830956,
-            "website": "https://www.denver.va.gov/locations/directions.asp",
-            "phone": {
-              "main": "307-778-7550",
-              "fax": "307-778-7381",
-              "pharmacy": "866-420-6337",
-              "afterHours": "307-778-7550",
-              "patientAdvocate": "307-778-7550 x7517",
-              "mentalHealthClinic": "307-778-7349",
-              "enrollmentCoordinator": "307-778-7550 x7579"
-            },
-            "physicalAddress": {
-              "type": "physical",
-              "line": [
-                "2360 East Pershing Boulevard"
-              ],
-              "city": "Cheyenne",
-              "state": "WY",
-              "postalCode": "82001-5356"
-            },
-            "mobile": false,
-            "healthService": [
-              "Audiology",
-              "Cardiology",
-              "DentalServices",
-              "EmergencyCare",
-              "Gastroenterology",
-              "Gynecology",
-              "MentalHealthCare",
-              "Nutrition",
-              "Ophthalmology",
-              "Optometry",
-              "Orthopedics",
-              "Podiatry",
-              "PrimaryCare",
-              "SpecialtyCare",
-              "UrgentCare",
-              "Urology",
-              "WomensHealth"
-            ],
-            "operatingStatus": {
-              "code": "NORMAL"
-            }
-          }
-        }
-      }
-    },
-    {
-      "id": "115069",
-      "type": "appointments",
-      "attributes": {
-        "id": "115069",
-        "identifier": [
-          {
-            "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
-            "value": "524669||4||1"
-          },
-          {
-            "system": "http://hl7.org/fhir/sid/us-npi",
-            "value": "1679635460"
-          }
-        ],
-        "kind": "cc",
+        "slot": null,
+        "start": "2024-06-08T17:30:00Z",
         "status": "booked",
-        "description": "Eye Care Examination SEOC 1.3.10 PRCT",
-        "patientIcn": "1013124304V115761",
-        "locationId": "984",
-        "practitioners": [
-          {
-            "name": {
-              "family": "BERMEL",
-              "given": [
-                "MICHAEL"
-              ]
-            }
-          }
-        ],
-        "start": "2022-12-22T12:00:00Z",
-        "created": "2022-12-22T20:33:54Z",
-        "cancellable": true,
-        "extension": {
-          "ccLocation": {
-            "address": {
-              "line": [
-                "10640 MAIN ST ; STE 100"
-              ],
-              "city": "FAIRFAX",
-              "state": "VA",
-              "postalCode": "22030",
-              "text": "10640 MAIN ST ; STE 100\nFAIRFAX VA 22030"
-            },
-            "telecom": [
-              {
-                "system": "phone",
-                "value": "703-691-2020"
-              }
-            ]
-          },
-          "hsrmTaskId": "",
-          "hsrmConsultId": "984_644056",
-          "ccTreatingSpecialty": "Podiatrist"
-        },
-        "location": {
-          "id": "984",
-          "type": "appointments",
-          "attributes": {
-            "id": "984",
-            "vistaSite": "984",
-            "vastParent": "984",
-            "type": "va_health_facility",
-            "name": "Dayton VA Medical Center",
-            "classification": "VA Medical Center (VAMC)",
-            "timezone": {
-              "timeZoneId": "America/New_York"
-            },
-            "lat": 39.74935,
-            "long": -84.2532,
-            "website": "https://www.dayton.va.gov/locations/directions.asp",
-            "phone": {
-              "main": "937-268-6511"
-            },
-            "physicalAddress": {
-              "type": "physical",
-              "line": [
-                "4100 West Third Street"
-              ],
-              "city": "Dayton",
-              "state": "OH",
-              "postalCode": "45428-9000"
-            },
-            "healthService": [
-              "Audiology",
-              "Cardiology",
-              "DentalServices",
-              "Dermatology",
-              "Gastroenterology",
-              "Gynecology",
-              "MentalHealthCare",
-              "Nutrition",
-              "Ophthalmology",
-              "Optometry",
-              "Orthopedics",
-              "Podiatry",
-              "PrimaryCare",
-              "SpecialtyCare",
-              "Urology",
-              "WomensHealth"
-            ]
-          }
+        "telehealth": {
+          "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#",
+          "atlas": null,
+          "vvsKind": "MOBILE_ANY"
         }
       }
     },
@@ -3243,6 +980,243 @@
       }
     },
     {
+      "id": "d25610df3e30a8d6701e6ed42ee661890bbc198c33b4e996be6bb96ddb4363e7",
+      "type": "appointments",
+      "attributes": {
+        "id": "d25610df3e30a8d6701e6ed42ee661890bbc198c33b4e996be6bb96ddb4363e7",
+        "identifier": [
+          {
+            "system": "Appointment/",
+            "value": "4139383435363538"
+          },
+          {
+            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+            "value": "984:5658"
+          }
+        ],
+        "kind": "telehealth",
+        "status": "booked",
+        "serviceType": "outpatientMentalHealth",
+        "serviceTypes": [
+          {
+            "coding": [
+              {
+                "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                "code": "outpatientMentalHealth"
+              }
+            ]
+          }
+        ],
+        "serviceCategory": [
+          {
+            "coding": [
+              {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                "code": "REGULAR",
+                "display": "REGULAR"
+              }
+            ],
+            "text": "REGULAR"
+          }
+        ],
+        "patientIcn": "1012845331V153043",
+        "locationId": "984GA",
+        "clinic": "4284",
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
+                "value": "0000546167"
+              }
+            ],
+            "name": {
+              "family": "ZZZPPP",
+              "given": [
+                "LLL"
+              ]
+            }
+          }
+        ],
+        "start": "2024-08-16T15:30:00Z",
+        "end": "2024-08-16T16:00:00Z",
+        "minutesDuration": 30,
+        "slot": {
+          "id": "3230323430383134313533303A323032343038313431363030",
+          "start": "2024-08-16T15:30:00Z",
+          "end": "2024-08-16T16:00:00Z"
+        },
+        "created": "2023-07-25T00:00:00Z",
+        "cancellable": false,
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [
+            "NO ACTION TAKEN"
+          ],
+          "preCheckinAllowed": false,
+          "eCheckinAllowed": false,
+          "clinic": {
+            "physicalLocation": "",
+            "phoneNumber": "",
+            "phoneNumberExtension": ""
+          }
+        },
+        "localStartTime": "2024-08-16T14:00:00.000-04:00",
+        "station": "984",
+        "ien": "5658",
+        "avsPath": null,
+        "serviceName": "MID-V10 CRH MH PSY MD PT",
+        "friendlyName": "MID-V10 CRH MH PSY MD PT",
+        "location": {
+          "id": "984GA",
+          "type": "appointments",
+          "attributes": {
+            "id": "984GA",
+            "vistaSite": "984",
+            "vastParent": "984",
+            "type": "va_health_facility",
+            "name": "Middletown VA Clinic",
+            "classification": "Multi-Specialty CBOC",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.50603,
+            "long": -84.316475,
+            "website": "https://www.dayton.va.gov/locations/midtwn_cboc.asp",
+            "phone": {
+              "main": "513-423-8387"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "4337 North Union Road"
+              ],
+              "city": "Middletown",
+              "state": "OH",
+              "postalCode": "45005-5211"
+            },
+            "healthService": [
+              "Audiology",
+              "MentalHealthCare",
+              "Optometry",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "1150111CC",
+      "type": "appointments",
+      "attributes": {
+        "id": "1150111CC",
+        "identifier": [
+          {
+            "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
+            "value": "524669||4||1"
+          },
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "1679635460"
+          }
+        ],
+        "kind": "cc",
+        "status": "booked",
+        "description": "Eye Care Examination SEOC 1.3.10 PRCT",
+        "patientIcn": "1013124304V115761",
+        "locationId": "984",
+        "practitioners": [
+          {
+            "name": {
+              "family": "BERMEL",
+              "given": [
+                "MICHAEL"
+              ]
+            }
+          }
+        ],
+        "start": "2024-08-21T12:00:00Z",
+        "created": "2024-08-21T20:33:54Z",
+        "localStartTime": "2024-08-21T09:00:00.000-06:00",
+        "avsPath": null,
+        "cancellable": false,
+        "extension": {
+          "ccLocation": {
+            "address": {
+              "line": [
+                "10640 MAIN ST ; STE 100"
+              ],
+              "city": "FAIRFAX",
+              "state": "VA",
+              "postalCode": "22030",
+              "text": "10640 MAIN ST ; STE 100\nFAIRFAX VA 22030"
+            },
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "703-691-2020"
+              }
+            ]
+          },
+          "hsrmTaskId": "",
+          "hsrmConsultId": "984_644056",
+          "ccTreatingSpecialty": "Optometrist"
+        },
+        "location": {
+          "id": "984",
+          "type": "appointments",
+          "attributes": {
+            "id": "984",
+            "vistaSite": "984",
+            "vastParent": "984",
+            "type": "va_health_facility",
+            "name": "Dayton VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.74935,
+            "long": -84.2532,
+            "website": "https://www.dayton.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "937-268-6511"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "4100 West Third Street"
+              ],
+              "city": "Dayton",
+              "state": "OH",
+              "postalCode": "45428-9000"
+            },
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "Dermatology",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "Urology",
+              "WomensHealth"
+            ]
+          }
+        }
+      }
+    },
+    {
       "id": "124063",
       "type": "appointments",
       "attributes": {
@@ -3263,8 +1237,7 @@
         "patientIcn": "1013124304V115761",
         "locationId": "984",
         "practitioners": [
-          {
-          }
+          {}
         ],
         "start": "2024-08-22T12:00:00Z",
         "created": "2024-08-22T20:33:54Z",
@@ -3340,710 +1313,6 @@
               "WomensHealth"
             ]
           }
-        }
-      }
-    },
-    {
-      "id": "124999CC",
-      "type": "appointments",
-      "attributes": {
-        "id": "124999CC",
-        "identifier": [
-          {
-            "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
-            "value": "524669||4||1"
-          },
-          {
-            "system": "http://hl7.org/fhir/sid/us-npi",
-            "value": "1679635460"
-          }
-        ],
-        "kind": "cc",
-        "status": "cancelled",
-        "description": "Podiatry DS SEOC 1.0.8 PRCT",
-        "patientIcn": "1013124304V115761",
-        "locationId": "984",
-        "practitioners": [
-          {
-            "name": {
-              "family": "RICHMOND",
-              "given": [
-                "TANISHA R"
-              ]
-            }
-          }
-        ],
-        "start": "2022-06-22T12:00:00Z",
-        "created": "2022-06-22T20:33:54Z",
-        "cancellable": false,
-        "extension": {
-          "ccLocation": {
-            "address": {
-              "line": [
-                "1323 W 3RD ST"
-              ],
-              "city": "DAYTON",
-              "state": "OH",
-              "postalCode": "45402",
-              "text": "1323 W 3RD ST\nDAYTON OH 45402"
-            },
-            "telecom": [
-              {
-                "system": "phone",
-                "value": "937-228-3668"
-              }
-            ]
-          },
-          "hsrmTaskId": "12881",
-          "hsrmConsultId": "984_644233",
-          "ccTreatingSpecialty": "Podiatrist"
-        },
-        "location": {
-          "id": "984",
-          "type": "appointments",
-          "attributes": {
-            "id": "984",
-            "vistaSite": "984",
-            "vastParent": "984",
-            "type": "va_health_facility",
-            "name": "Dayton VA Medical Center",
-            "classification": "VA Medical Center (VAMC)",
-            "timezone": {
-              "timeZoneId": "America/New_York"
-            },
-            "lat": 39.74935,
-            "long": -84.2532,
-            "website": "https://www.dayton.va.gov/locations/directions.asp",
-            "phone": {
-              "main": "937-268-6511"
-            },
-            "physicalAddress": {
-              "type": "physical",
-              "line": [
-                "4100 West Third Street"
-              ],
-              "city": "Dayton",
-              "state": "OH",
-              "postalCode": "45428-9000"
-            },
-            "healthService": [
-              "Audiology",
-              "Cardiology",
-              "DentalServices",
-              "Dermatology",
-              "Gastroenterology",
-              "Gynecology",
-              "MentalHealthCare",
-              "Nutrition",
-              "Ophthalmology",
-              "Optometry",
-              "Orthopedics",
-              "Podiatry",
-              "PrimaryCare",
-              "SpecialtyCare",
-              "Urology",
-              "WomensHealth"
-            ]
-          }
-        }
-      }
-    },
-    {
-      "id": "110143CC",
-      "type": "appointments",
-      "attributes": {
-        "id": "110143",
-        "identifier": [
-          {
-            "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
-            "value": "524641||2||1"
-          }
-        ],
-        "kind": "cc",
-        "status": "booked",
-        "patientIcn": "1013120820V528557",
-        "locationId": "984",
-        "start": "2024-11-22T12:00:00Z",
-        "created": "2024-11-22T20:33:54Z",
-        "localStartTime": "2024-11-22T09:00:00.000-06:00",
-        "reasonCode":
-        {
-          "text": "\nNew Problem: VAOS AUTOMATED SMOKE TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        "patientComments": "\nNew Problem: VAOS AUTOMATED SMOKE TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        "extension": {
-          "ccLocation": {
-            "address": {
-              "line": [
-                "1 E NATIONAL RD ; STE 300"
-              ],
-              "city": "VANDALIA",
-              "state": "OH",
-              "postalCode": "45377",
-              "text": "1 E NATIONAL RD ; STE 300\nVANDALIA OH 45377"
-            },
-            "telecom": []
-          },
-          "hsrmTaskId": "",
-          "ccTreatingSpecialty": ""
-        },
-        "location": {
-          "id": "984",
-          "type": "appointments",
-          "attributes": {
-            "id": "984",
-            "vistaSite": "984",
-            "vastParent": "984",
-            "type": "va_health_facility",
-            "name": "Dayton VA Medical Center",
-            "classification": "VA Medical Center (VAMC)",
-            "timezone": {
-              "timeZoneId": "America/New_York"
-            },
-            "lat": 39.74935,
-            "long": -84.2532,
-            "website": "https://www.dayton.va.gov/locations/directions.asp",
-            "phone": {
-              "main": "937-268-6511"
-            },
-            "physicalAddress": {
-              "type": "physical",
-              "line": [
-                "4100 West Third Street"
-              ],
-              "city": "Dayton",
-              "state": "OH",
-              "postalCode": "45428-9000"
-            },
-            "healthService": [
-              "Audiology",
-              "Cardiology",
-              "DentalServices",
-              "Dermatology",
-              "Gastroenterology",
-              "Gynecology",
-              "MentalHealthCare",
-              "Nutrition",
-              "Ophthalmology",
-              "Optometry",
-              "Orthopedics",
-              "Podiatry",
-              "PrimaryCare",
-              "SpecialtyCare",
-              "Urology",
-              "WomensHealth"
-            ]
-          }
-        }
-      }
-    },
-    {
-      "id": "110143CD",
-      "type": "appointments",
-      "attributes": {
-        "id": "110144",
-        "identifier": [
-          {
-            "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
-            "value": "524641||2||1"
-          }
-        ],
-        "kind": "cc",
-        "status": "cancelled",
-        "patientIcn": "1013120820V528557",
-        "locationId": "984",
-        "start": "2024-11-22T13:00:00Z",
-        "created": "2024-11-22T21:33:54Z",
-        "localStartTime": "2024-11-22T10:00:00.000-06:00",
-        "extension": {
-          "ccLocation": {
-            "address": {
-              "line": [
-                "1 E NATIONAL RD ; STE 300"
-              ],
-              "city": "VANDALIA",
-              "state": "OH",
-              "postalCode": "45377",
-              "text": "1 E NATIONAL RD ; STE 300\nVANDALIA OH 45377"
-            },
-            "telecom": []
-          },
-          "hsrmTaskId": "",
-          "ccTreatingSpecialty": ""
-        },
-        "location": {
-          "id": "984",
-          "type": "appointments",
-          "attributes": {
-            "id": "984",
-            "vistaSite": "984",
-            "vastParent": "984",
-            "type": "va_health_facility",
-            "name": "Dayton VA Medical Center",
-            "classification": "VA Medical Center (VAMC)",
-            "timezone": {
-              "timeZoneId": "America/New_York"
-            },
-            "lat": 39.74935,
-            "long": -84.2532,
-            "website": "https://www.dayton.va.gov/locations/directions.asp",
-            "phone": {
-              "main": "937-268-6511"
-            },
-            "physicalAddress": {
-              "type": "physical",
-              "line": [
-                "4100 West Third Street"
-              ],
-              "city": "Dayton",
-              "state": "OH",
-              "postalCode": "45428-9000"
-            },
-            "healthService": [
-              "Audiology",
-              "Cardiology",
-              "DentalServices",
-              "Dermatology",
-              "Gastroenterology",
-              "Gynecology",
-              "MentalHealthCare",
-              "Nutrition",
-              "Ophthalmology",
-              "Optometry",
-              "Orthopedics",
-              "Podiatry",
-              "PrimaryCare",
-              "SpecialtyCare",
-              "Urology",
-              "WomensHealth"
-            ]
-          }
-        }
-      }
-    },
-    {
-      "id": "00aa456va",
-      "type": "Appointment",
-      "attributes": {
-        "cancelationReason": null,
-        "clinic": "437",
-        "comment": "Follow-up/Routine: I have a headache",
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            }
-          ]
-        },
-        "description": "Upcoming in person appointment",
-        "end": "2022-12-21T18:19:34",
-        "id": "00aa456va",
-        "kind": "clinic",
-        "locationId": "983",
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "practitioners": [],
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {
-          "text": "Follow-up/Routine: I have a headache"
-        },
-        "requestedPeriods": null,
-        "serviceType": "primaryCare",
-        "slot": null,
-        "start": "2022-12-21T18:19:34",
-        "status": "booked",
-        "telehealth": null
-      }
-    },
-    {
-      "id": "00C19456va",
-      "type": "Appointment",
-      "attributes": {
-        "cancelationReason": null,
-        "clinic": "437",
-        "comment": "Follow-up/Routine: I have a headache",
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            }
-          ]
-        },
-        "description": "Upcoming COVID-19 appointment",
-        "end": "2022-11-21T18:19:34",
-        "id": "00aa456va",
-        "kind": "clinic",
-        "locationId": "983",
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "practitioners": [],
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {
-          "text": "Follow-up/Routine: Covid shot"
-        },
-        "requestedPeriods": null,
-        "serviceType": "covid",
-        "slot": null,
-        "start": "2022-11-21T18:19:34",
-        "status": "booked",
-        "telehealth": null
-      }
-    },
-    {
-      "id": "02aa456vvs",
-      "type": "Appointment",
-      "attributes": {
-        "cancelationReason": null,
-        "clinic": "848",
-        "comment": "New issue: Video Visit Preparation",
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            }
-          ]
-        },
-        "description": "Upcoming Home telehealth ADHOC appointment with instructions",
-        "end": "2024-09-23T20:00:00Z",
-        "id": "02aa456vvs",
-        "kind": "telehealth",
-        "locationId": "983",
-        "localStartTime": "2024-09-22T09:00:00.000-06:00",
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "patientInstruction": "Video Visit Preparation contains extraneous stuff",
-        "practitioners": [
-          {
-            "identifier": [
-              {
-                "system": null,
-                "value": "1801312053"
-              }
-            ],
-            "name": {
-              "family": "Normal",
-              "given": [
-                "Abbey"
-              ]
-            }
-          }
-        ],
-        "physicalLocation" : "should not display",
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {
-          "coding": [
-            {
-              "code": "New Issue"
-            }
-          ]
-        },
-        "requestedPeriods": null,
-        "serviceType": "outpatientMentalHealth",
-        "slot": null,
-        "start": "2024-09-22T12:00:00Z",
-        "created": "2024-09-22T20:33:54Z",
-        "avsPath": null,
-        "status": "booked",
-        "extension": {
-          "patientHasMobileGfe": false
-        },
-        "telehealth": {
-          "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#",
-          "atlas": null,
-          "vvsKind": "ADHOC"
-        }
-      }
-    },
-    {
-      "id": "02aa456vvt",
-      "type": "Appointment",
-      "attributes": {
-        "cancelationReason": null,
-        "clinic": "848",
-        "comment": "New issue: Video Visit Preparation",
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            }
-          ]
-        },
-        "description": "Upcoming Home telehealth ADHOC appointment with instructions",
-        "end": "2024-09-23T21:00:00Z",
-        "id": "02aa456vvt",
-        "kind": "telehealth",
-        "locationId": "983",
-        "localStartTime": "2024-09-22T10:00:00.000-06:00",
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "patientInstruction": "Video Visit Preparation contains extraneous stuff",
-        "practitioners": [
-          {
-            "identifier": [
-              {
-                "system": null,
-                "value": "1801312053"
-              }
-            ],
-            "name": {
-              "family": "Normal",
-              "given": [
-                "Abbey"
-              ]
-            }
-          }
-        ],
-        "physicalLocation" : "should not display",
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {
-          "coding": [
-            {
-              "code": "New Issue"
-            }
-          ]
-        },
-        "requestedPeriods": null,
-        "serviceType": "outpatientMentalHealth",
-        "slot": null,
-        "start": "2024-09-22T13:00:00Z",
-        "created": "2024-09-22T21:33:54Z",
-        "avsPath": null,
-        "status": "cancelled",
-        "extension": {
-          "patientHasMobileGfe": false
-        },
-        "telehealth": {
-          "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#",
-          "atlas": null,
-          "vvsKind": "ADHOC"
-        }
-      }
-    },
-    {
-      "id": "03aa456vvs",
-      "type": "Appointment",
-      "attributes": {
-        "cancelationReason": null,
-        "clinic": "848",
-        "comment": null,
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            }
-          ]
-        },
-        "description": "Upcoming Atlas telehealth appointment",
-        "end": "2025-01-13T20:00:00Z",
-        "id": "03aa456vvs",
-        "kind": "telehealth",
-        "locationId": "983",
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "patientInstruction": "Medication Review",
-        "practitioners": [
-          {
-            "identifier": [
-              {
-                "system": null,
-                "value": "1801312053"
-              }
-            ],
-            "name": {
-              "family": "Smith",
-              "given": [
-                "Meg"
-              ]
-            }
-          }
-        ],
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {},
-        "requestedPeriods": null,
-        "serviceType": "amputation",
-        "slot": null,
-        "start": "2025-01-13T20:00:00Z",
-        "localStartTime": "2025-01-13T09:00:00.000-06:00",
-        "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988663350853",
-        "status": "booked",
-        "telehealth": {
-          "url": null,
-          "atlas": {
-            "siteCode": "9931",
-            "confirmationCode": "7VBBCA",
-            "address": {
-              "streetAddress": "114 Dewey Ave",
-              "city": "Eureka",
-              "state": "MT",
-              "zipCode": "59917",
-              "country": "USA",
-              "longitude": -115.1,
-              "latitude": 48.8,
-              "additionalDetails": ""
-            }
-          },
-          "vvsKind": "MOBILE_ANY"
-        },
-        "extension": {
-          "patientHasMobileGfe": true
-        }
-      }
-    },
-    {
-      "id": "03aa456vvt",
-      "type": "Appointment",
-      "attributes": {
-        "cancelationReason": null,
-        "clinic": "848",
-        "comment": null,
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            }
-          ]
-        },
-        "description": "Upcoming Atlas telehealth appointment",
-        "end": "2025-01-13T21:00:00Z",
-        "id": "03aa456vvt",
-        "kind": "telehealth",
-        "locationId": "983",
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "patientInstruction": "Medication Review",
-        "practitioners": [
-          {
-            "identifier": [
-              {
-                "system": null,
-                "value": "1801312053"
-              }
-            ],
-            "name": {
-              "family": "Smith",
-              "given": [
-                "Meg"
-              ]
-            }
-          }
-        ],
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {},
-        "requestedPeriods": null,
-        "serviceType": "amputation",
-        "slot": null,
-        "start": "2025-01-13T21:00:00Z",
-        "localStartTime": "2025-01-13T10:00:00.000-06:00",
-        "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988663350853",
-        "status": "cancelled",
-        "telehealth": {
-          "url": null,
-          "atlas": {
-            "siteCode": "9931",
-            "confirmationCode": "7VBBCA",
-            "address": {
-              "streetAddress": "114 Dewey Ave",
-              "city": "Eureka",
-              "state": "MT",
-              "zipCode": "59917",
-              "country": "USA",
-              "longitude": -115.1,
-              "latitude": 48.8,
-              "additionalDetails": ""
-            }
-          },
-          "vvsKind": "MOBILE_ANY"
-        },
-        "extension": {
-          "patientHasMobileGfe": true
-        }
-      }
-    },
-    {
-      "id": "04aa456vvs",
-      "type": "Appointment",
-      "attributes": {
-        "cancelationReason": null,
-        "clinic": "848",
-        "comment": "",
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            }
-          ]
-        },
-        "description": "Upcoming at home telehealth appointment with instructions",
-        "end": "2022-11-09T20:30:00Z",
-        "id": "04aa456vvs",
-        "kind": "telehealth",
-        "locationId": "983",
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "patientInstruction": "Medication Review to prepare patient",
-        "practitioners": [
-          {
-            "identifier": [
-              {
-                "system": null,
-                "value": "1801312053"
-              }
-            ],
-            "name": {
-              "family": "Smith",
-              "given": [
-                "Megan"
-              ]
-            },
-            "practiceName": null
-          },
-          {
-            "identifier": [
-              {
-                "system": null,
-                "value": "1801312053"
-              }
-            ],
-            "name": {
-              "family": "Dali",
-              "given": [
-                "Salvador"
-              ]
-            },
-            "practiceName": null
-          }
-        ],
-        "physicalLocation" : "should not display",
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {},
-        "requestedPeriods": null,
-        "serviceType": "audiology",
-        "extension": {
-          "patientHasMobileGfe": true
-        },
-        "slot": null,
-        "start": "2023-11-09T20:30:00Z",
-        "localStartTime": "2023-11-13T09:00:00.000-06:00",
-        "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988663350853",
-        "status": "booked",
-        "telehealth": {
-          "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#",
-          "atlas": null,
-          "vvsKind": "MOBILE_ANY"
         }
       }
     },
@@ -4127,313 +1396,6 @@
           "atlas": null,
           "vvsKind": "CLINIC_BASED"
         }
-      }
-    },
-    {
-      "id": "10aa456vvs",
-      "type": "Appointment",
-      "attributes": {
-        "cancelationReason": null,
-        "clinic": "848",
-        "comment": null,
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            }
-          ]
-        },
-        "description": "Upcoming VA GFE telehealth appointment",
-        "end": "2022-12-27T18:19:34",
-        "id": "10aa456vvs",
-        "kind": "telehealth",
-        "locationId": "983",
-        "localStartTime": "2023-11-22T18:00:00.000-06:00",
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "practitioners": [
-          {
-            "identifier": [
-              {
-                "system": null,
-                "value": "1801312053"
-              }
-            ],
-            "name": {
-              "family": "Nightingale",
-              "given": [
-                "Florence"
-              ]
-            }
-          }
-        ],
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {},
-        "requestedPeriods": null,
-        "serviceType": "primaryCare",
-        "slot": null,
-        "start": "2023-11-22T18:19:34",
-        "status": "booked",
-        "telehealth": {
-          "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#",
-          "atlas": null,
-          "vvsKind": "MOBILE_GFE"
-        }
-      }
-    },
-    {
-      "id": "06aa456va",
-      "type": "Appointment",
-      "attributes": {
-        "cancelationReason": null,
-        "clinic": "308",
-        "comment": "New issue: Phone appointment",
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            }
-          ]
-        },
-        "description": "Upcoming phone appointment",
-        "end": "2023-07-27T18:19:34",
-        "id": "06aa456va",
-        "kind": "phone",
-        "locationId": "983",
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "practitioners": [],
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {
-          "text": "New issue: Phone appointment"
-        },
-        "requestedPeriods": null,
-        "serviceType": "primaryCare",
-        "slot": null,
-        "start": "2023-07-27T18:19:34",
-        "status": "booked",
-        "telehealth": null
-      }
-    },
-    {
-      "id": "11aa456ph",
-      "type": "Appointment",
-      "attributes": {
-        "cancelationReason": {
-          "coding": [
-            {
-              "code": "pat"
-            }
-          ]
-        },
-        "clinic": "308",
-        "comment": "New issue: Phone appointment",
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            }
-          ]
-        },
-        "description": "Cancelled phone appointment",
-        "end": "2022-12-28T18:19:34",
-        "id": "11aa456ph",
-        "kind": "phone",
-        "locationId": "983",
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "practitioners": [],
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {
-          "text": "New issue: Phone appointment"
-        },
-        "requestedPeriods": null,
-        "serviceType": "primaryCare",
-        "slot": null,
-        "start": "2022-12-28T18:19:34",
-        "status": "cancelled",
-        "telehealth": null
-      }
-    },
-    {
-      "id": "07aa456va",
-      "type": "Appointment",
-      "attributes": {
-        "cancelationReason": null,
-        "clinic": null,
-        "comment": "Medication concern: I ran out of meds",
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            }
-          ]
-        },
-        "description": "Past appointment",
-        "end": "2022-06-28T18:19:34.954Z",
-        "id": "07aa456va",
-        "kind": "clinic",
-        "locationId": "983",
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "practitioners": [],
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {
-          "text": "Medication concern: I ran out of meds"
-        },
-        "requestedPeriods": null,
-        "serviceType": "primaryCare",
-        "slot": null,
-        "start": "2022-06-27T18:19:34",
-        "status": "booked",
-        "telehealth": null
-      }
-    },
-    {
-      "id": "09aa456vvs",
-      "type": "Appointment",
-      "attributes": {
-        "cancelationReason": null,
-        "clinic": "848",
-        "comment": null,
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            }
-          ]
-        },
-        "description": "upcoming at home telehealth appointment",
-        "end": "2024-06-08T17:30:00Z",
-        "id": "09aa456vvs",
-        "kind": "telehealth",
-        "locationId": "983",
-        "localStartTime": "2024-06-08T17:00:00.000-06:00",
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "patientInstruction": "Video Visit Preparation",
-        "practitioners": [
-          {
-            "identifier": [
-              {
-                "system": null,
-                "value": "1801312053"
-              }
-            ],
-            "name": {
-              "family": "Jones",
-              "given": [
-                "Peter"
-              ]
-            }
-          }
-        ],
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {},
-        "requestedPeriods": null,
-        "serviceType": "primaryCare",
-        "slot": null,
-        "start": "2024-06-08T17:30:00Z",
-        "status": "booked",
-        "telehealth": {
-          "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#",
-          "atlas": null,
-          "vvsKind": "MOBILE_ANY"
-        }
-      }
-    },
-    {
-      "id": "08aa456va",
-      "type": "Appointment",
-      "attributes": {
-        "cancelationReason": {
-          "coding": [
-            {
-              "code": "prov"
-            }
-          ]
-        },
-        "clinic": null,
-        "comment": "Follow-up/Routine: comment test",
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            }
-          ]
-        },
-        "description": "Cancelled appointment",
-        "end": "2022-11-28T18:19:34.954Z",
-        "id": "08aa456va",
-        "kind": "clinic",
-        "locationId": "983GC",
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "practitioners": [],
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {
-          "text": "Follow-up/Routine: comment test"
-        },
-        "requestedPeriods": null,
-        "serviceType": "primaryCare",
-        "slot": null,
-        "start": "2022-12-27T18:19:34",
-        "status": "cancelled",
-        "telehealth": null
-      }
-    },
-    {
-      "id": "08aa457va",
-      "type": "Appointment",
-      "attributes": {
-        "cancelationReason": {
-          "coding": [
-            {
-              "code": "pat"
-            }
-          ]
-        },
-        "clinic": null,
-        "comment": "Follow-up/Routine: comment test",
-        "contact": {
-          "telecom": [
-            {
-              "type": "email",
-              "value": null
-            }
-          ]
-        },
-        "description": "Cancelled appointment",
-        "end": "2022-11-28T18:19:34.954Z",
-        "id": "08aa456va",
-        "kind": "clinic",
-        "locationId": "983GC",
-        "minutesDuration": 30,
-        "patientIcn": null,
-        "practitioners": [],
-        "preferredTimesForPhoneCall": [],
-        "priority": 0,
-        "reasonCode": {
-          "text": "Follow-up/Routine: comment test"
-        },
-        "requestedPeriods": null,
-        "serviceType": "primaryCare",
-        "slot": null,
-        "start": "2022-12-28T18:19:34",
-        "status": "cancelled",
-        "telehealth": null
       }
     },
     {
@@ -4623,45 +1585,1353 @@
       }
     },
     {
-      "id": "147685",
+      "id": "02aa456vvs",
+      "type": "Appointment",
+      "attributes": {
+        "cancelationReason": null,
+        "clinic": "848",
+        "comment": "New issue: Video Visit Preparation",
+        "contact": {
+          "telecom": [
+            {
+              "type": "email",
+              "value": null
+            }
+          ]
+        },
+        "description": "Upcoming Home telehealth ADHOC appointment with instructions",
+        "end": "2024-09-23T20:00:00Z",
+        "id": "02aa456vvs",
+        "kind": "telehealth",
+        "locationId": "983",
+        "localStartTime": "2024-09-22T09:00:00.000-06:00",
+        "minutesDuration": 30,
+        "patientIcn": null,
+        "patientInstruction": "Video Visit Preparation contains extraneous stuff",
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": null,
+                "value": "1801312053"
+              }
+            ],
+            "name": {
+              "family": "Normal",
+              "given": [
+                "Abbey"
+              ]
+            }
+          }
+        ],
+        "physicalLocation": "should not display",
+        "preferredTimesForPhoneCall": [],
+        "priority": 0,
+        "reasonCode": {
+          "coding": [
+            {
+              "code": "New Issue"
+            }
+          ]
+        },
+        "requestedPeriods": null,
+        "serviceType": "outpatientMentalHealth",
+        "slot": null,
+        "start": "2024-09-22T12:00:00Z",
+        "created": "2024-09-22T20:33:54Z",
+        "avsPath": null,
+        "status": "booked",
+        "extension": {
+          "patientHasMobileGfe": false
+        },
+        "telehealth": {
+          "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#",
+          "atlas": null,
+          "vvsKind": "ADHOC"
+        }
+      }
+    },
+    {
+      "id": "02aa456vvt",
+      "type": "Appointment",
+      "attributes": {
+        "cancelationReason": null,
+        "clinic": "848",
+        "comment": "New issue: Video Visit Preparation",
+        "contact": {
+          "telecom": [
+            {
+              "type": "email",
+              "value": null
+            }
+          ]
+        },
+        "description": "Upcoming Home telehealth ADHOC appointment with instructions",
+        "end": "2024-09-23T21:00:00Z",
+        "id": "02aa456vvt",
+        "kind": "telehealth",
+        "locationId": "983",
+        "localStartTime": "2024-09-22T10:00:00.000-06:00",
+        "minutesDuration": 30,
+        "patientIcn": null,
+        "patientInstruction": "Video Visit Preparation contains extraneous stuff",
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": null,
+                "value": "1801312053"
+              }
+            ],
+            "name": {
+              "family": "Normal",
+              "given": [
+                "Abbey"
+              ]
+            }
+          }
+        ],
+        "physicalLocation": "should not display",
+        "preferredTimesForPhoneCall": [],
+        "priority": 0,
+        "reasonCode": {
+          "coding": [
+            {
+              "code": "New Issue"
+            }
+          ]
+        },
+        "requestedPeriods": null,
+        "serviceType": "outpatientMentalHealth",
+        "slot": null,
+        "start": "2024-09-22T13:00:00Z",
+        "created": "2024-09-22T21:33:54Z",
+        "avsPath": null,
+        "status": "cancelled",
+        "extension": {
+          "patientHasMobileGfe": false
+        },
+        "telehealth": {
+          "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VAC00064b6f@care2.evn.va.gov&pin=4569928835#",
+          "atlas": null,
+          "vvsKind": "ADHOC"
+        }
+      }
+    },
+    {
+      "id": "110143CC",
       "type": "appointments",
       "attributes": {
-        "id": "147685",
+        "id": "110143",
         "identifier": [
           {
-            "system": "http://med.va.gov/fhir/urn/vaos/vista/983/appointment/id",
-            "value": "1081;20221214.080000"
+            "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
+            "value": "524641||2||1"
+          }
+        ],
+        "kind": "cc",
+        "status": "booked",
+        "patientIcn": "1013120820V528557",
+        "locationId": "984",
+        "start": "2024-11-22T12:00:00Z",
+        "created": "2024-11-22T20:33:54Z",
+        "localStartTime": "2024-11-22T09:00:00.000-06:00",
+        "reasonCode": {
+          "text": "\nNew Problem: VAOS AUTOMATED SMOKE TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "patientComments": "\nNew Problem: VAOS AUTOMATED SMOKE TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "extension": {
+          "ccLocation": {
+            "address": {
+              "line": [
+                "1 E NATIONAL RD ; STE 300"
+              ],
+              "city": "VANDALIA",
+              "state": "OH",
+              "postalCode": "45377",
+              "text": "1 E NATIONAL RD ; STE 300\nVANDALIA OH 45377"
+            },
+            "telecom": []
+          },
+          "hsrmTaskId": "",
+          "ccTreatingSpecialty": ""
+        },
+        "location": {
+          "id": "984",
+          "type": "appointments",
+          "attributes": {
+            "id": "984",
+            "vistaSite": "984",
+            "vastParent": "984",
+            "type": "va_health_facility",
+            "name": "Dayton VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.74935,
+            "long": -84.2532,
+            "website": "https://www.dayton.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "937-268-6511"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "4100 West Third Street"
+              ],
+              "city": "Dayton",
+              "state": "OH",
+              "postalCode": "45428-9000"
+            },
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "Dermatology",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "Urology",
+              "WomensHealth"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "110143CD",
+      "type": "appointments",
+      "attributes": {
+        "id": "110144",
+        "identifier": [
+          {
+            "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
+            "value": "524641||2||1"
+          }
+        ],
+        "kind": "cc",
+        "status": "cancelled",
+        "patientIcn": "1013120820V528557",
+        "locationId": "984",
+        "start": "2024-11-22T13:00:00Z",
+        "created": "2024-11-22T21:33:54Z",
+        "localStartTime": "2024-11-22T10:00:00.000-06:00",
+        "reasonCode": {
+          "text": "\nNew Problem: VAOS AUTOMATED SMOKE TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "patientComments": "\nNew Problem: VAOS AUTOMATED SMOKE TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "extension": {
+          "ccLocation": {
+            "address": {
+              "line": [
+                "1 E NATIONAL RD ; STE 300"
+              ],
+              "city": "VANDALIA",
+              "state": "OH",
+              "postalCode": "45377",
+              "text": "1 E NATIONAL RD ; STE 300\nVANDALIA OH 45377"
+            },
+            "telecom": []
+          },
+          "hsrmTaskId": "",
+          "ccTreatingSpecialty": ""
+        },
+        "location": {
+          "id": "984",
+          "type": "appointments",
+          "attributes": {
+            "id": "984",
+            "vistaSite": "984",
+            "vastParent": "984",
+            "type": "va_health_facility",
+            "name": "Dayton VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.74935,
+            "long": -84.2532,
+            "website": "https://www.dayton.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "937-268-6511"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "4100 West Third Street"
+              ],
+              "city": "Dayton",
+              "state": "OH",
+              "postalCode": "45428-9000"
+            },
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "Dermatology",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "Urology",
+              "WomensHealth"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "CERN53943037",
+      "type": "appointments",
+      "attributes": {
+        "id": "CERN53943037",
+        "kind": "clinic",
+        "status": "booked",
+        "reasonCode": {
+          "coding": [],
+          "text": "VEText Manually Created Appointment"
+        },
+        "locationId": "668",
+        "start": "2024-11-21T17:00:00Z",
+        "end": "2024-08-21T17:30:00Z",
+        "requestedPeriods": [
+          {
+            "start": "2024-08-21T17:00:00Z",
+            "end": "2024-08-21T17:30:00Z"
+          }
+        ],
+        "cancellable": true,
+        "patientInstruction": "Preparations:\n- If you have any non-VA medical records, including radiology images, related to this appointment, please bring them with you.\r\nIf you have other health insurance, please bring your insurance card.\r\nYou can log into the patient portal, My VA Health to view or cancel your appointment.\r\nIf you need to cancel or reschedule your appointment, please call us at (509) 434-7026.\r\nOur clinic is located on the 1st floor, Bldg 27, Primary Care",
+        "localStartTime": "2024-08-21T10:00:00.000-07:00",
+        "station": null,
+        "ien": null,
+        "avsPath": null,
+        "preferredDates": [
+          "Wed, August 21, 2024 in the afternoon"
+        ],
+        "location": {
+          "id": "668",
+          "type": "appointments",
+          "attributes": {
+            "id": "668",
+            "facilitiesApiId": "vha_668",
+            "vistaSite": "668",
+            "vastParent": "668",
+            "type": "va_health_facility",
+            "name": "Mann-Grandstaff Department of Veterans Affairs Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/Los_Angeles"
+            },
+            "lat": 47.701927,
+            "long": -117.475624,
+            "website": "https://www.va.gov/spokane-health-care/locations/mann-grandstaff-department-of-veterans-affairs-medical-center/",
+            "phone": {
+              "main": "509-434-7000",
+              "fax": "509-434-7100",
+              "pharmacy": "509-434-7011",
+              "afterHours": "509-434-7000",
+              "patientAdvocate": "509-434-7504",
+              "mentalHealthClinic": "1-509-434-7013",
+              "enrollmentCoordinator": "509-434-7506"
+            },
+            "hoursOfOperation": [
+              {
+                "daysOfWeek": "sun",
+                "openingTime": "24/7",
+                "closingTime": "24/7"
+              },
+              {
+                "daysOfWeek": "mon",
+                "openingTime": "24/7",
+                "closingTime": "24/7"
+              },
+              {
+                "daysOfWeek": "tue",
+                "openingTime": "24/7",
+                "closingTime": "24/7"
+              },
+              {
+                "daysOfWeek": "wed",
+                "openingTime": "24/7",
+                "closingTime": "24/7"
+              },
+              {
+                "daysOfWeek": "thu",
+                "openingTime": "24/7",
+                "closingTime": "24/7"
+              },
+              {
+                "daysOfWeek": "fri",
+                "openingTime": "24/7",
+                "closingTime": "24/7"
+              },
+              {
+                "daysOfWeek": "sat",
+                "openingTime": "24/7",
+                "closingTime": "24/7"
+              }
+            ],
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "4815 North Assembly Street",
+                null,
+                null
+              ],
+              "city": "Spokane",
+              "state": "WA",
+              "postalCode": "99205-6185"
+            },
+            "mobile": false,
+            "healthService": [
+              "Addiction",
+              "AdviceNurse",
+              "Audiology",
+              "Cardiology",
+              "CaregiverSupport",
+              "Chiropractic",
+              "ColonSurgery",
+              "ComplementaryHealth",
+              "Covid19Vaccine",
+              "CriticalCare",
+              "Dental",
+              "Dermatology",
+              "Diabetic",
+              "EmploymentPrograms",
+              "Gastroenterology",
+              "Geriatrics",
+              "Gynecology",
+              "Hematology",
+              "Homeless",
+              "Hospice",
+              "HospitalMedicine",
+              "Laboratory",
+              "Lgbtq",
+              "MilitarySexualTrauma",
+              "MinorityCare",
+              "MyHealtheVetCoordinator",
+              "Neurology",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "OutpatientSurgery",
+              "PatientAdvocates",
+              "Pharmacy",
+              "PhysicalTherapy",
+              "Podiatry",
+              "PrimaryCare",
+              "Prosthetics",
+              "Psychiatry",
+              "Ptsd",
+              "PulmonaryMedicine",
+              "Radiology",
+              "RegistryExams",
+              "Rehabilitation",
+              "Rheumatology",
+              "SleepMedicine",
+              "Smoking",
+              "SocialWork",
+              "SuicidePrevention",
+              "Surgery",
+              "Telehealth",
+              "ToxicExposureScreening",
+              "TransitionCounseling",
+              "TravelReimbursement",
+              "UrgentCare",
+              "Urology",
+              "Vision",
+              "WeightManagement",
+              "WholeHealth",
+              "WomensHealth",
+              "Wound"
+            ],
+            "operatingStatus": {
+              "code": "NORMAL"
+            },
+            "visn": "20",
+            "ehrSystem": "Oracle"
+          }
+        }
+      }
+    },
+    {
+      "id": "aa6bb54b5f8ba22a82720a30abdfa3efe0805cc0dc1b6b248815e942ad61847e",
+      "type": "appointments",
+      "attributes": {
+        "id": "aa6bb54b5f8ba22a82720a30abdfa3efe0805cc0dc1b6b248815e942ad61847e",
+        "identifier": [
+          {
+            "system": "Appointment/",
+            "value": "413938333133353533"
+          },
+          {
+            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+            "value": "983:13553"
           }
         ],
         "kind": "clinic",
         "status": "booked",
-        "serviceType": "amputation",
-        "reasonCode": {
-          "text": "test"
-        },
-        "patientIcn": "1012845943V900681",
-        "locationId": "983GC",
-        "clinic": "1081",
-        "start": "2022-12-14T15:00:00Z",
-        "end": "2022-12-14T15:30:00Z",
-        "minutesDuration": 30,
+        "serviceType": "covid",
+        "serviceTypes": [
+          {
+            "coding": [
+              {
+                "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                "code": "covid"
+              }
+            ]
+          }
+        ],
+        "serviceCategory": [
+          {
+            "coding": [
+              {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                "code": "REGULAR",
+                "display": "REGULAR"
+              }
+            ],
+            "text": "REGULAR"
+          }
+        ],
+        "patientIcn": "1012846043V576341",
+        "locationId": "983",
+        "clinic": "1038",
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
+                "value": null
+              }
+            ],
+            "name": {
+              "family": "BERNARDO",
+              "given": [
+                "KENNETH J"
+              ]
+            }
+          }
+        ],
+        "start": "2024-12-01T14:00:00Z",
+        "end": "2024-08-01T14:15:00Z",
+        "minutesDuration": 15,
         "slot": {
-          "id": "3230323231323134313530303A323032323132313431353330",
-          "start": "2022-12-14T15:00:00Z",
-          "end": "2022-12-14T15:30:00Z"
+          "id": "3230323430383031313430303A323032343038303131343135",
+          "start": "2024-12-01T14:00:00Z",
+          "end": "2024-12-01T14:15:00Z"
         },
-        "comment": "test",
-        "cancellable": true,
+        "created": "2024-12-09T00:00:00Z",
+        "cancellable": false,
         "extension": {
           "ccLocation": {
             "address": {}
           },
           "vistaStatus": [
             "FUTURE"
-          ]
+          ],
+          "preCheckinAllowed": true,
+          "eCheckinAllowed": true,
+          "clinic": {
+            "physicalLocation": "MHC"
+          }
         },
-        "serviceName": "FTC AMPUTATION",
-        "friendlyName": "Friendly Name FTC Amputation",
+        "localStartTime": "2024-12-01T08:00:00.000-06:00",
+        "serviceName": "COVID VACCINE CLIN1",
+        "friendlyName": "COVID VACCINE CLIN1",
+        "physicalLocation": "MHC",
+        "location": {
+          "id": "983",
+          "type": "appointments",
+          "attributes": {
+            "id": "983",
+            "vistaSite": "983",
+            "vastParent": "983",
+            "type": "va_facilities",
+            "name": "Cheyenne VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/Denver"
+            },
+            "lat": 39.744507,
+            "long": -104.830956,
+            "website": "https://www.denver.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "307-778-7550",
+              "fax": "307-778-7381",
+              "pharmacy": "866-420-6337",
+              "afterHours": "307-778-7550",
+              "patientAdvocate": "307-778-7550 x7517",
+              "mentalHealthClinic": "307-778-7349",
+              "enrollmentCoordinator": "307-778-7550 x7579"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
+              "city": "Cheyenne",
+              "state": "WY",
+              "postalCode": "82001-5356"
+            },
+            "mobile": false,
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "EmergencyCare",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "UrgentCare",
+              "Urology",
+              "WomensHealth"
+            ],
+            "operatingStatus": {
+              "code": "NORMAL"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "0fbc293324755816b690f11eab25c827b5e4fbea375ac06e8e9694205f95590e",
+      "type": "appointments",
+      "attributes": {
+        "id": "0fbc293324755816b690f11eab25c827b5e4fbea375ac06e8e9694205f95590e",
+        "identifier": [
+          {
+            "system": "http://med.va.gov/fhir/urn/vaos/vvs/id",
+            "value": "5c21ee08-7bc9-4cc3-b557-0fc543c40148"
+          }
+        ],
+        "kind": "telehealth",
+        "status": "booked",
+        "patientIcn": "1013124304V115761",
+        "locationId": "983",
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": "dfn-983",
+                "value": "520647710"
+              }
+            ],
+            "name": {
+              "family": "Poldass",
+              "given": [
+                "Aarathi"
+              ]
+            },
+            "practiceName": "Cheyenne VA Medical Center"
+          }
+        ],
+        "start": "2024-12-01T15:00:00Z",
+        "end": "2024-12-01T15:30:00Z",
+        "minutesDuration": 30,
+        "created": "2024-03-01T18:52:19.23Z",
+        "comment": "Testing ATLAS appt for VAOS team (Marcy)",
+        "cancellable": false,
+        "patientInstruction": "Medication Review\n\nAs part of your video visit, your provider will review all the medications, vitamins, herbs, and supplements you are taking\n(even items you get from a local store, another provider, or another VA clinic). Please have information about everything you\ntake available during the visit. Informing your provider about all these will help you get the best and safest care possible.\nRemember, it is your medications, your life. Play it safe by reviewing all your medications with your health care team.\n",
+        "telehealth": {
+          "url": "https://dev.care2.va.gov/vvc-app/?join=1&media=1&escalate=1&userType=guest&conference=VAC000003896@dev.care2.va.gov&pin=104039&aid=5c21ee08-7bc9-4cc3-b557-0fc543c40148#",
+          "atlas": {
+            "siteCode": "VFW-DC-20011-02",
+            "confirmationCode": "075041",
+            "address": {
+              "streetAddress": "5929 Georgia Ave NW",
+              "city": "Washington",
+              "state": "DC",
+              "zipCode": "20011",
+              "country": "USA",
+              "latitutde": 38.961979,
+              "longitude": -77.027908,
+              "additionalDetails": ""
+            }
+          },
+          "group": false,
+          "vvsKind": "ADHOC"
+        },
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [],
+          "patientHasMobileGfe": false
+        },
+        "localStartTime": "2024-12-01T08:00:00.000-07:00",
+        "location": {
+          "id": "983",
+          "type": "appointments",
+          "attributes": {
+            "id": "983",
+            "vistaSite": "983",
+            "vastParent": "983",
+            "type": "va_facilities",
+            "name": "Cheyenne VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/Denver"
+            },
+            "lat": 39.744507,
+            "long": -104.830956,
+            "website": "https://www.denver.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "307-778-7550",
+              "fax": "307-778-7381",
+              "pharmacy": "866-420-6337",
+              "afterHours": "307-778-7550",
+              "patientAdvocate": "307-778-7550 x7517",
+              "mentalHealthClinic": "307-778-7349",
+              "enrollmentCoordinator": "307-778-7550 x7579"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
+              "city": "Cheyenne",
+              "state": "WY",
+              "postalCode": "82001-5356"
+            },
+            "mobile": false,
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "EmergencyCare",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "UrgentCare",
+              "Urology",
+              "WomensHealth"
+            ],
+            "operatingStatus": {
+              "code": "NORMAL"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "aa6bb54b5f8ba22a82720a30abdfa3efe0805cc0dc1b6b248815e942ad61847f",
+      "type": "appointments",
+      "attributes": {
+        "id": "aa6bb54b5f8ba22a82720a30abdfa3efe0805cc0dc1b6b248815e942ad61847f",
+        "identifier": [
+          {
+            "system": "Appointment/",
+            "value": "413938333133353534"
+          },
+          {
+            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+            "value": "983:13553"
+          }
+        ],
+        "kind": "clinic",
+        "status": "cancelled",
+        "serviceType": "covid",
+        "serviceTypes": [
+          {
+            "coding": [
+              {
+                "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                "code": "covid"
+              }
+            ]
+          }
+        ],
+        "serviceCategory": [
+          {
+            "coding": [
+              {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                "code": "REGULAR",
+                "display": "REGULAR"
+              }
+            ],
+            "text": "REGULAR"
+          }
+        ],
+        "patientIcn": "1012846043V576341",
+        "locationId": "983",
+        "clinic": "1038",
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
+                "value": null
+              }
+            ],
+            "name": {
+              "family": "BERNARDO",
+              "given": [
+                "KENNETH J"
+              ]
+            }
+          }
+        ],
+        "start": "2024-12-01T15:00:00Z",
+        "end": "2024-08-01T15:15:00Z",
+        "minutesDuration": 15,
+        "slot": {
+          "id": "3230323430383031313430303A323032343038303131343135",
+          "start": "2024-12-01T15:00:00Z",
+          "end": "2024-12-01T15:15:00Z"
+        },
+        "created": "2024-12-09T00:00:00Z",
+        "cancellable": false,
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [
+            "FUTURE"
+          ],
+          "preCheckinAllowed": true,
+          "eCheckinAllowed": true,
+          "clinic": {
+            "physicalLocation": "MHC"
+          }
+        },
+        "localStartTime": "2024-12-01T09:00:00.000-06:00",
+        "serviceName": "COVID VACCINE CLIN1",
+        "friendlyName": "COVID VACCINE CLIN1",
+        "physicalLocation": "MHC",
+        "location": {
+          "id": "983",
+          "type": "appointments",
+          "attributes": {
+            "id": "983",
+            "vistaSite": "983",
+            "vastParent": "983",
+            "type": "va_facilities",
+            "name": "Cheyenne VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/Denver"
+            },
+            "lat": 39.744507,
+            "long": -104.830956,
+            "website": "https://www.denver.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "307-778-7550",
+              "fax": "307-778-7381",
+              "pharmacy": "866-420-6337",
+              "afterHours": "307-778-7550",
+              "patientAdvocate": "307-778-7550 x7517",
+              "mentalHealthClinic": "307-778-7349",
+              "enrollmentCoordinator": "307-778-7550 x7579"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
+              "city": "Cheyenne",
+              "state": "WY",
+              "postalCode": "82001-5356"
+            },
+            "mobile": false,
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "EmergencyCare",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "UrgentCare",
+              "Urology",
+              "WomensHealth"
+            ],
+            "operatingStatus": {
+              "code": "NORMAL"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "e01555000d5c7ce9b754ea7ad8fa1d481298fec531ff43919734d31eb34ceb46",
+      "type": "appointments",
+      "attributes": {
+        "id": "e01555000d5c7ce9b754ea7ad8fa1d481298fec531ff43919734d31eb34ceb46",
+        "identifier": [
+          {
+            "system": "Appointment/",
+            "value": "4139383436333437"
+          },
+          {
+            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+            "value": "984:6347"
+          }
+        ],
+        "kind": "phone",
+        "status": "booked",
+        "serviceCategory": [
+          {
+            "coding": [
+              {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                "code": "REGULAR",
+                "display": "REGULAR"
+              }
+            ],
+            "text": "REGULAR"
+          }
+        ],
+        "patientIcn": "1013678363V916823",
+        "locationId": "984",
+        "clinic": "4570",
+        "reasonCode": {
+          "text": "reasonCode:QUESTIONMEDS|comments:test appointment scheduling TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "patientComments": "test appointment scheduling TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "reasonForAppointment": "Medication concern",
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
+                "value": null
+              }
+            ],
+            "name": {
+              "family": "ISS",
+              "given": [
+                "PROVIDERONE"
+              ]
+            }
+          }
+        ],
+        "start": "2024-12-05T18:00:00Z",
+        "end": "2024-12-05T18:15:00Z",
+        "minutesDuration": 15,
+        "slot": {
+          "id": "3230323331323035313830303A323032333132303531383135",
+          "start": "2024-12-05T18:00:00Z",
+          "end": "2024-12-05T18:15:00Z"
+        },
+        "created": "2024-11-28T00:00:00Z",
+        "cancellable": true,
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [
+            "NO ACTION TAKEN"
+          ],
+          "preCheckinAllowed": false,
+          "eCheckinAllowed": false,
+          "clinic": {
+            "physicalLocation": "DAYTSHR PHONE Provider",
+            "phoneNumber": "555-555-6551",
+            "phoneNumberExtension": "6001"
+          }
+        },
+        "localStartTime": "2024-12-05T13:00:00.000-05:00",
+        "serviceName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
+        "friendlyName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
+        "physicalLocation": "DAYTSHR PHONE Provider",
+        "location": {
+          "id": "984",
+          "type": "appointments",
+          "attributes": {
+            "id": "984",
+            "vistaSite": "984",
+            "vastParent": "984",
+            "type": "va_health_facility",
+            "name": "Dayton VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.74935,
+            "long": -84.2532,
+            "website": "https://www.dayton.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "937-268-6511"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "4100 West Third Street"
+              ],
+              "city": "Dayton",
+              "state": "OH",
+              "postalCode": "45428-9000"
+            },
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "Dermatology",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "Urology",
+              "WomensHealth"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "e01555000d5c7ce9b754ea7ad8fa1d481298fec531ff43919734d31eb34ceb47",
+      "type": "appointments",
+      "attributes": {
+        "id": "e01555000d5c7ce9b754ea7ad8fa1d481298fec531ff43919734d31eb34ceb47",
+        "identifier": [
+          {
+            "system": "Appointment/",
+            "value": "4139383436333438"
+          },
+          {
+            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+            "value": "984:6347"
+          }
+        ],
+        "kind": "phone",
+        "status": "cancelled",
+        "serviceCategory": [
+          {
+            "coding": [
+              {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                "code": "REGULAR",
+                "display": "REGULAR"
+              }
+            ],
+            "text": "REGULAR"
+          }
+        ],
+        "patientIcn": "1013678363V916823",
+        "locationId": "984",
+        "clinic": "4570",
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
+                "value": null
+              }
+            ],
+            "name": {
+              "family": "ISS",
+              "given": [
+                "PROVIDERONE"
+              ]
+            }
+          }
+        ],
+        "start": "2024-12-05T19:00:00Z",
+        "end": "2024-12-05T19:15:00Z",
+        "minutesDuration": 15,
+        "slot": {
+          "id": "3230323331323035313830303A323032333132303531383135",
+          "start": "2024-12-05T19:00:00Z",
+          "end": "2024-12-05T19:15:00Z"
+        },
+        "created": "2024-11-28T00:00:00Z",
+        "cancellable": false,
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [
+            "NO ACTION TAKEN"
+          ],
+          "preCheckinAllowed": false,
+          "eCheckinAllowed": false,
+          "clinic": {
+            "physicalLocation": "DAYTSHR PHONE Provider",
+            "phoneNumber": "555-555-6551",
+            "phoneNumberExtension": "6001"
+          }
+        },
+        "localStartTime": "2024-12-05T14:00:00.000-05:00",
+        "serviceName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
+        "friendlyName": "ISS UAT DAYTSHR TELEPHONE MENTAL HEALTH PROVIDER CLINIC",
+        "physicalLocation": "DAYTSHR PHONE Provider",
+        "location": {
+          "id": "984",
+          "type": "appointments",
+          "attributes": {
+            "id": "984",
+            "vistaSite": "984",
+            "vastParent": "984",
+            "type": "va_health_facility",
+            "name": "Dayton VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.74935,
+            "long": -84.2532,
+            "website": "https://www.dayton.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "937-268-6511"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "4100 West Third Street"
+              ],
+              "city": "Dayton",
+              "state": "OH",
+              "postalCode": "45428-9000"
+            },
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "Dermatology",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "Urology",
+              "WomensHealth"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "d9faffb0d9cf0c641e53faf221fb0a08b2f6c661cc470a94817556dc0ce3589a",
+      "type": "appointments",
+      "attributes": {
+        "id": "d9faffb0d9cf0c641e53faf221fb0a08b2f6c661cc470a94817556dc0ce3589a",
+        "identifier": [
+          {
+            "system": "http://med.va.gov/fhir/urn/vaos/vvs/id",
+            "value": "381ba035-c30a-4f21-ad0e-1204a6ef3fc8"
+          }
+        ],
+        "kind": "telehealth",
+        "status": "booked",
+        "patientIcn": "1012846043V576341",
+        "locationId": "983",
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": "dfn-983",
+                "value": "520648070"
+              }
+            ],
+            "name": {
+              "family": "Chapman",
+              "given": [
+                "Jeremy"
+              ]
+            },
+            "practiceName": "Cheyenne VA Medical Center"
+          }
+        ],
+        "start": "2024-12-12T19:55:00Z",
+        "end": "2024-12-12T20:15:00Z",
+        "minutesDuration": 20,
+        "created": "2024-12-12T19:57:42.025Z",
+        "cancellable": false,
+        "patientInstruction": "",
+        "telehealth": {
+          "url": "https://pexip.mapsandbox.net/vvc-app/?join=1&media=1&escalate=1&userType=guest&conference=VAC000005810@pexip.mapsandbox.net&pin=356403&aid=381ba035-c30a-4f21-ad0e-1204a6ef3fc8#",
+          "group": false,
+          "vvsKind": "ADHOC"
+        },
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [],
+          "patientHasMobileGfe": true
+        },
+        "localStartTime": "2024-12-12T13:55:00.000-06:00",
+        "location": {
+          "id": "983",
+          "type": "appointments",
+          "attributes": {
+            "id": "983",
+            "vistaSite": "983",
+            "vastParent": "983",
+            "type": "va_facilities",
+            "name": "Cheyenne VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/Denver"
+            },
+            "lat": 39.744507,
+            "long": -104.830956,
+            "website": "https://www.denver.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "307-778-7550",
+              "fax": "307-778-7381",
+              "pharmacy": "866-420-6337",
+              "afterHours": "307-778-7550",
+              "patientAdvocate": "307-778-7550 x7517",
+              "mentalHealthClinic": "307-778-7349",
+              "enrollmentCoordinator": "307-778-7550 x7579"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
+              "city": "Cheyenne",
+              "state": "WY",
+              "postalCode": "82001-5356"
+            },
+            "mobile": false,
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "EmergencyCare",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "UrgentCare",
+              "Urology",
+              "WomensHealth"
+            ],
+            "operatingStatus": {
+              "code": "NORMAL"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "9726bd1ca2a1cf349d6d56071140e02c3883fc275bde03dd3c44e855b19b3a67",
+      "type": "appointments",
+      "attributes": {
+        "id": "9726bd1ca2a1cf349d6d56071140e02c3883fc275bde03dd3c44e855b19b3a67",
+        "identifier": [
+          {
+            "system": "Appointment/",
+            "value": "413938333132333035"
+          },
+          {
+            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+            "value": "983:12305"
+          }
+        ],
+        "kind": "clinic",
+        "status": "booked",
+        "serviceType": "audiology",
+        "serviceTypes": [
+          {
+            "coding": [
+              {
+                "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                "code": "audiology"
+              }
+            ]
+          }
+        ],
+        "serviceCategory": [
+          {
+            "coding": [
+              {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                "code": "COMPENSATION & PENSION",
+                "display": "COMPENSATION & PENSION"
+              }
+            ],
+            "text": "COMPENSATION & PENSION"
+          }
+        ],
+        "patientIcn": "1013678363V916823",
+        "locationId": "983GC",
+        "clinic": "945",
+        "start": "2024-12-19T15:40:00Z",
+        "end": "2024-12-19T16:40:00Z",
+        "minutesDuration": 60,
+        "slot": {
+          "id": "3230323431323139313534303A323032343132313931363430",
+          "start": "2024-12-19T15:40:00Z",
+          "end": "2024-12-19T16:40:00Z"
+        },
+        "created": "2024-01-08T00:00:00Z",
+        "cancellable": false,
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [
+            "FUTURE"
+          ],
+          "preCheckinAllowed": false,
+          "eCheckinAllowed": false,
+          "clinic": {
+            "physicalLocation": "FORT COLLINS AUDIO"
+          }
+        },
+        "localStartTime": "2024-12-19T08:40:00.000-07:00",
+        "serviceName": "C&P BEV AUDIO FTC",
+        "friendlyName": "C&P BEV AUDIO FTC",
+        "physicalLocation": "FORT COLLINS AUDIO",
         "location": {
           "id": "983GC",
           "type": "appointments",
@@ -4701,210 +2971,1191 @@
       }
     },
     {
-      "id": "CERN53943037",
+      "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44ce",
       "type": "appointments",
       "attributes": {
-          "id": "CERN53943037",
-          "kind": "clinic",
-          "status": "booked",
-          "reasonCode": {
-              "coding": [],
-              "text": "VEText Manually Created Appointment"
-          },
-          "locationId": "668",
-          "start": "2024-11-21T17:00:00Z",
-          "end": "2024-08-21T17:30:00Z",
-          "requestedPeriods": [
-              {
-                  "start": "2024-08-21T17:00:00Z",
-                  "end": "2024-08-21T17:30:00Z"
-              }
-          ],
-          "cancellable": true,
-          "patientInstruction": "Preparations:\n- If you have any non-VA medical records, including radiology images, related to this appointment, please bring them with you.\r\nIf you have other health insurance, please bring your insurance card.\r\nYou can log into the patient portal, My VA Health to view or cancel your appointment.\r\nIf you need to cancel or reschedule your appointment, please call us at (509) 434-7026.\r\nOur clinic is located on the 1st floor, Bldg 27, Primary Care",
-          "localStartTime": "2024-08-21T10:00:00.000-07:00",
-          "station": null,
-          "ien": null,
-          "avsPath": null,
-          "preferredDates": [
-              "Wed, August 21, 2024 in the afternoon"
-          ],
-          "location": {
-              "id": "668",
-              "type": "appointments",
-              "attributes": {
-                  "id": "668",
-                  "facilitiesApiId": "vha_668",
-                  "vistaSite": "668",
-                  "vastParent": "668",
-                  "type": "va_health_facility",
-                  "name": "Mann-Grandstaff Department of Veterans Affairs Medical Center",
-                  "classification": "VA Medical Center (VAMC)",
-                  "timezone": {
-                      "timeZoneId": "America/Los_Angeles"
-                  },
-                  "lat": 47.701927,
-                  "long": -117.475624,
-                  "website": "https://www.va.gov/spokane-health-care/locations/mann-grandstaff-department-of-veterans-affairs-medical-center/",
-                  "phone": {
-                      "main": "509-434-7000",
-                      "fax": "509-434-7100",
-                      "pharmacy": "509-434-7011",
-                      "afterHours": "509-434-7000",
-                      "patientAdvocate": "509-434-7504",
-                      "mentalHealthClinic": "1-509-434-7013",
-                      "enrollmentCoordinator": "509-434-7506"
-                  },
-                  "hoursOfOperation": [
-                      {
-                          "daysOfWeek": "sun",
-                          "openingTime": "24/7",
-                          "closingTime": "24/7"
-                      },
-                      {
-                          "daysOfWeek": "mon",
-                          "openingTime": "24/7",
-                          "closingTime": "24/7"
-                      },
-                      {
-                          "daysOfWeek": "tue",
-                          "openingTime": "24/7",
-                          "closingTime": "24/7"
-                      },
-                      {
-                          "daysOfWeek": "wed",
-                          "openingTime": "24/7",
-                          "closingTime": "24/7"
-                      },
-                      {
-                          "daysOfWeek": "thu",
-                          "openingTime": "24/7",
-                          "closingTime": "24/7"
-                      },
-                      {
-                          "daysOfWeek": "fri",
-                          "openingTime": "24/7",
-                          "closingTime": "24/7"
-                      },
-                      {
-                          "daysOfWeek": "sat",
-                          "openingTime": "24/7",
-                          "closingTime": "24/7"
-                      }
-                  ],
-                  "physicalAddress": {
-                      "type": "physical",
-                      "line": [
-                          "4815 North Assembly Street",
-                          null,
-                          null
-                      ],
-                      "city": "Spokane",
-                      "state": "WA",
-                      "postalCode": "99205-6185"
-                  },
-                  "mobile": false,
-                  "healthService": [
-                      "Addiction",
-                      "AdviceNurse",
-                      "Audiology",
-                      "Cardiology",
-                      "CaregiverSupport",
-                      "Chiropractic",
-                      "ColonSurgery",
-                      "ComplementaryHealth",
-                      "Covid19Vaccine",
-                      "CriticalCare",
-                      "Dental",
-                      "Dermatology",
-                      "Diabetic",
-                      "EmploymentPrograms",
-                      "Gastroenterology",
-                      "Geriatrics",
-                      "Gynecology",
-                      "Hematology",
-                      "Homeless",
-                      "Hospice",
-                      "HospitalMedicine",
-                      "Laboratory",
-                      "Lgbtq",
-                      "MilitarySexualTrauma",
-                      "MinorityCare",
-                      "MyHealtheVetCoordinator",
-                      "Neurology",
-                      "Nutrition",
-                      "Ophthalmology",
-                      "Optometry",
-                      "Orthopedics",
-                      "OutpatientSurgery",
-                      "PatientAdvocates",
-                      "Pharmacy",
-                      "PhysicalTherapy",
-                      "Podiatry",
-                      "PrimaryCare",
-                      "Prosthetics",
-                      "Psychiatry",
-                      "Ptsd",
-                      "PulmonaryMedicine",
-                      "Radiology",
-                      "RegistryExams",
-                      "Rehabilitation",
-                      "Rheumatology",
-                      "SleepMedicine",
-                      "Smoking",
-                      "SocialWork",
-                      "SuicidePrevention",
-                      "Surgery",
-                      "Telehealth",
-                      "ToxicExposureScreening",
-                      "TransitionCounseling",
-                      "TravelReimbursement",
-                      "UrgentCare",
-                      "Urology",
-                      "Vision",
-                      "WeightManagement",
-                      "WholeHealth",
-                      "WomensHealth",
-                      "Wound"
-                  ],
-                  "operatingStatus": {
-                      "code": "NORMAL"
-                  },
-                  "visn": "20",
-                  "ehrSystem": "Oracle"
-              }
-          }
-      }
-  },
-    {
-      "id": "50096",
-      "type": "appointments",
-      "attributes": {
-        "id": "50096",
+        "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44ce",
         "identifier": [
           {
-            "system": "http://med.va.gov/fhir/urn/vaos/vista/983/appointment/id",
-            "value": "308;20210907.140000"
+            "system": "urn:va.gov:masv2:cerner:appointment",
+            "value": "Appointment/52499027"
           }
         ],
         "kind": "clinic",
-        "serviceType": "primaryCare",
+        "status": "booked",
+        "serviceTypes": [
+          {
+            "coding": [
+              {
+                "system": "https://fhir.cerner.com/d45741b3-8335-463d-ab16-8c5f0bcf78ed/codeSet/14249",
+                "code": "381456583"
+              }
+            ]
+          }
+        ],
+        "description": "PC Established Patient",
+        "reasonCode": {
+          "text": "reasonCode:QUESTIONMEDS|comments:test appointment scheduling TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        "patientComments": "test appointment scheduling TESTaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "reasonForAppointment": "Medication concern",
         "patientIcn": "1012845331V153043",
+        "locationId": "757",
+        "practitioners": [
+          {
+            "name": {
+              "family": "Everett",
+              "given": [
+                "CERNER",
+                "DO"
+              ]
+            }
+          }
+        ],
+        "start": "2024-12-23T13:30:00Z",
+        "end": "2024-12-23T14:00:00Z",
+        "minutesDuration": 30,
+        "comment": "\nContact preference: Secure message",
+        "cancellable": false,
+        "patientInstruction": "Preparations:\n- If you have any new non-VA medical records since your last visit, please bring them.\r\nIf you need to cancel or reschedule your appointment, please call our Contact Center at 614-257-5200 or visit the patient portal.",
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          }
+        },
+        "requestedPeriods": null,
+        "localStartTime": "2024-12-23T09:30:00.000-04:00",
+        "location": {
+          "id": "757",
+          "type": "appointments",
+          "attributes": {
+            "id": "757",
+            "facilitiesApiId": "vha_757",
+            "vistaSite": "757",
+            "vastParent": "757",
+            "type": "va_health_facility",
+            "name": "Chalmers P. Wylie Veterans CERNER Clinic",
+            "classification": "Health Care Center (HCC)",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.98048,
+            "long": -82.9123,
+            "website": "https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/",
+            "phone": {
+              "main": "614-257-5200",
+              "fax": "614-257-5460",
+              "pharmacy": "614-257-5230",
+              "afterHours": "614-257-5512",
+              "patientAdvocate": "614-257-5290",
+              "mentalHealthClinic": "614-257-5631",
+              "enrollmentCoordinator": "614-257-5628"
+            },
+            "hoursOfOperation": [
+              {
+                "daysOfWeek": "sun",
+                "openingTime": "800AM",
+                "closingTime": "400PM"
+              },
+              {
+                "daysOfWeek": "mon",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "tue",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "wed",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "thu",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "fri",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "sat",
+                "openingTime": "800AM",
+                "closingTime": "400PM"
+              }
+            ],
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "420 North James Road",
+                null,
+                null
+              ],
+              "city": "Columbus",
+              "state": "OH",
+              "postalCode": "43219-1834"
+            },
+            "mobile": false,
+            "healthService": [
+              "Allergy",
+              "Audiology",
+              "Cardiology",
+              "CaregiverSupport",
+              "Covid19Vaccine",
+              "Dental",
+              "Dermatology",
+              "Diabetic",
+              "Endocrinology",
+              "Gastroenterology",
+              "Geriatrics",
+              "Gynecology",
+              "Hematology",
+              "Homeless",
+              "Hospice",
+              "Laboratory",
+              "Lgbtq",
+              "MinorityCare",
+              "Nephrology",
+              "Neurology",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Otolaryngology",
+              "PainManagement",
+              "PatientAdvocates",
+              "Pharmacy",
+              "PhysicalMedicine",
+              "PlasticSurgery",
+              "Podiatry",
+              "PrimaryCare",
+              "Prosthetics",
+              "Ptsd",
+              "PulmonaryMedicine",
+              "Radiology",
+              "Rheumatology",
+              "Smoking",
+              "SocialWork",
+              "SpinalInjury",
+              "SuicidePrevention",
+              "Surgery",
+              "TransitionCounseling",
+              "UrgentCare",
+              "Urology",
+              "VascularSurgery",
+              "Vision",
+              "WeightManagement",
+              "WomensHealth",
+              "Wound"
+            ],
+            "operatingStatus": {
+              "code": "NORMAL"
+            },
+            "visn": "10"
+          }
+        }
+      }
+    },
+    {
+      "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44cf",
+      "type": "appointments",
+      "attributes": {
+        "id": "38eb82d7451c9036df43fa75318a5453d1a66e3055ce09ebcec16821949e44cf",
+        "identifier": [
+          {
+            "system": "urn:va.gov:masv2:cerner:appointment",
+            "value": "Appointment/52499028"
+          }
+        ],
+        "kind": "clinic",
+        "status": "cancelled",
+        "serviceTypes": [
+          {
+            "coding": [
+              {
+                "system": "https://fhir.cerner.com/d45741b3-8335-463d-ab16-8c5f0bcf78ed/codeSet/14249",
+                "code": "381456583"
+              }
+            ]
+          }
+        ],
+        "description": "PC Established Patient",
+        "patientIcn": "1012845331V153043",
+        "locationId": "757",
+        "practitioners": [
+          {
+            "name": {
+              "family": "Everett",
+              "given": [
+                "CERNER",
+                "DO"
+              ]
+            }
+          }
+        ],
+        "start": "2024-12-23T14:30:00Z",
+        "end": "2024-12-23T15:00:00Z",
+        "minutesDuration": 30,
+        "comment": "\nContact preference: Secure message",
+        "cancellable": false,
+        "patientInstruction": "Preparations:\n- If you have any new non-VA medical records since your last visit, please bring them.\r\nIf you need to cancel or reschedule your appointment, please call our Contact Center at 614-257-5200 or visit the patient portal.",
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          }
+        },
+        "requestedPeriods": null,
+        "localStartTime": "2024-12-23T10:30:00.000-04:00",
+        "location": {
+          "id": "757",
+          "type": "appointments",
+          "attributes": {
+            "id": "757",
+            "facilitiesApiId": "vha_757",
+            "vistaSite": "757",
+            "vastParent": "757",
+            "type": "va_health_facility",
+            "name": "Chalmers P. Wylie Veterans CERNER Clinic",
+            "classification": "Health Care Center (HCC)",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.98048,
+            "long": -82.9123,
+            "website": "https://www.va.gov/central-ohio-health-care/locations/chalmers-p-wylie-veterans-outpatient-clinic/",
+            "phone": {
+              "main": "614-257-5200",
+              "fax": "614-257-5460",
+              "pharmacy": "614-257-5230",
+              "afterHours": "614-257-5512",
+              "patientAdvocate": "614-257-5290",
+              "mentalHealthClinic": "614-257-5631",
+              "enrollmentCoordinator": "614-257-5628"
+            },
+            "hoursOfOperation": [
+              {
+                "daysOfWeek": "sun",
+                "openingTime": "800AM",
+                "closingTime": "400PM"
+              },
+              {
+                "daysOfWeek": "mon",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "tue",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "wed",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "thu",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "fri",
+                "openingTime": "730AM",
+                "closingTime": "600PM"
+              },
+              {
+                "daysOfWeek": "sat",
+                "openingTime": "800AM",
+                "closingTime": "400PM"
+              }
+            ],
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "420 North James Road",
+                null,
+                null
+              ],
+              "city": "Columbus",
+              "state": "OH",
+              "postalCode": "43219-1834"
+            },
+            "mobile": false,
+            "healthService": [
+              "Allergy",
+              "Audiology",
+              "Cardiology",
+              "CaregiverSupport",
+              "Covid19Vaccine",
+              "Dental",
+              "Dermatology",
+              "Diabetic",
+              "Endocrinology",
+              "Gastroenterology",
+              "Geriatrics",
+              "Gynecology",
+              "Hematology",
+              "Homeless",
+              "Hospice",
+              "Laboratory",
+              "Lgbtq",
+              "MinorityCare",
+              "Nephrology",
+              "Neurology",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Otolaryngology",
+              "PainManagement",
+              "PatientAdvocates",
+              "Pharmacy",
+              "PhysicalMedicine",
+              "PlasticSurgery",
+              "Podiatry",
+              "PrimaryCare",
+              "Prosthetics",
+              "Ptsd",
+              "PulmonaryMedicine",
+              "Radiology",
+              "Rheumatology",
+              "Smoking",
+              "SocialWork",
+              "SpinalInjury",
+              "SuicidePrevention",
+              "Surgery",
+              "TransitionCounseling",
+              "UrgentCare",
+              "Urology",
+              "VascularSurgery",
+              "Vision",
+              "WeightManagement",
+              "WomensHealth",
+              "Wound"
+            ],
+            "operatingStatus": {
+              "code": "NORMAL"
+            },
+            "visn": "10"
+          }
+        }
+      }
+    },
+    {
+      "id": "03aa456vvs",
+      "type": "Appointment",
+      "attributes": {
+        "cancelationReason": null,
+        "clinic": "848",
+        "comment": null,
+        "contact": {
+          "telecom": [
+            {
+              "type": "email",
+              "value": null
+            }
+          ]
+        },
+        "description": "Upcoming Atlas telehealth appointment",
+        "end": "2025-01-13T20:00:00Z",
+        "id": "03aa456vvs",
+        "kind": "telehealth",
         "locationId": "983",
-        "clinic": "308",
-        "start": "2022-01-27T20:00:00Z",
-        "end": "2022-01-27T20:20:00Z",
-        "minutesDuration": 20,
+        "minutesDuration": 30,
+        "patientIcn": null,
+        "patientInstruction": "Medication Review",
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": null,
+                "value": "1801312053"
+              }
+            ],
+            "name": {
+              "family": "Smith",
+              "given": [
+                "Meg"
+              ]
+            }
+          }
+        ],
+        "preferredTimesForPhoneCall": [],
+        "priority": 0,
+        "reasonCode": {},
+        "requestedPeriods": null,
+        "serviceType": "amputation",
+        "slot": null,
+        "start": "2025-01-13T20:00:00Z",
+        "localStartTime": "2025-01-13T09:00:00.000-06:00",
+        "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988663350853",
+        "status": "booked",
+        "telehealth": {
+          "url": null,
+          "atlas": {
+            "siteCode": "9931",
+            "confirmationCode": "7VBBCA",
+            "address": {
+              "streetAddress": "114 Dewey Ave",
+              "city": "Eureka",
+              "state": "MT",
+              "zipCode": "59917",
+              "country": "USA",
+              "longitude": -115.1,
+              "latitude": 48.8,
+              "additionalDetails": ""
+            }
+          },
+          "vvsKind": "MOBILE_ANY"
+        },
+        "extension": {
+          "patientHasMobileGfe": true
+        }
+      }
+    },
+    {
+      "id": "03aa456vvt",
+      "type": "Appointment",
+      "attributes": {
+        "cancelationReason": null,
+        "clinic": "848",
+        "comment": null,
+        "contact": {
+          "telecom": [
+            {
+              "type": "email",
+              "value": null
+            }
+          ]
+        },
+        "description": "Upcoming Atlas telehealth appointment",
+        "end": "2025-01-13T21:00:00Z",
+        "id": "03aa456vvt",
+        "kind": "telehealth",
+        "locationId": "983",
+        "minutesDuration": 30,
+        "patientIcn": null,
+        "patientInstruction": "Medication Review",
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": null,
+                "value": "1801312053"
+              }
+            ],
+            "name": {
+              "family": "Smith",
+              "given": [
+                "Meg"
+              ]
+            }
+          }
+        ],
+        "preferredTimesForPhoneCall": [],
+        "priority": 0,
+        "reasonCode": {},
+        "requestedPeriods": null,
+        "serviceType": "amputation",
+        "slot": null,
+        "start": "2025-01-13T21:00:00Z",
+        "localStartTime": "2025-01-13T10:00:00.000-06:00",
+        "avsPath": "/my-health/medical-records/summaries-and-notes/visit-summary/C46E12AA7582F5714716988663350853",
+        "status": "cancelled",
+        "telehealth": {
+          "url": null,
+          "atlas": {
+            "siteCode": "9931",
+            "confirmationCode": "7VBBCA",
+            "address": {
+              "streetAddress": "114 Dewey Ave",
+              "city": "Eureka",
+              "state": "MT",
+              "zipCode": "59917",
+              "country": "USA",
+              "longitude": -115.1,
+              "latitude": 48.8,
+              "additionalDetails": ""
+            }
+          },
+          "vvsKind": "MOBILE_ANY"
+        },
+        "extension": {
+          "patientHasMobileGfe": true
+        }
+      }
+    },
+    {
+      "id": "805eb1710aefb85bcc07813ae36a744f1467fd4306c0a950ba16e023fb514ce9",
+      "type": "appointments",
+      "attributes": {
+        "id": "805eb1710aefb85bcc07813ae36a744f1467fd4306c0a950ba16e023fb514ce9",
+        "identifier": [
+          {
+            "system": "Appointment/",
+            "value": "4139383436323830"
+          },
+          {
+            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+            "value": "984:6280"
+          },
+          {
+            "system": "http://med.va.gov/fhir/urn/vaos/vvs/id",
+            "value": "6641d9ca-bcf0-4040-947a-ed9ed822e495"
+          }
+        ],
+        "kind": "telehealth",
+        "status": "booked",
+        "serviceType": "outpatientMentalHealth",
+        "serviceTypes": [
+          {
+            "coding": [
+              {
+                "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                "code": "outpatientMentalHealth"
+              }
+            ]
+          }
+        ],
+        "serviceCategory": [
+          {
+            "coding": [
+              {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                "code": "REGULAR",
+                "display": "REGULAR"
+              }
+            ],
+            "text": "REGULAR"
+          }
+        ],
+        "patientIcn": "1012845331V153043",
+        "locationId": "984GA",
+        "clinic": "4284",
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
+                "value": "1034242903"
+              }
+            ],
+            "name": {
+              "family": "ALSAHHAR",
+              "given": [
+                "SAMI"
+              ]
+            }
+          }
+        ],
+        "start": "2025-01-14T13:00:00Z",
+        "end": "2025-01-14T13:30:00Z",
+        "minutesDuration": 30,
         "slot": {
-          "id": "3230323130393037323030303A323032313039303732303230",
-          "start": "2022-01-27T20:00:00Z",
-          "end": "2022-01-27T20:20:00Z"
+          "id": "3230323331313134313330303A323032333131313431333330",
+          "start": "2025-01-14T13:00:00Z",
+          "end": "2025-01-14T13:30:00Z"
         },
-        "cancellationReason": {
-          "code": "other"
+        "created": "2025-01-07T00:00:00Z",
+        "cancellable": false,
+        "telehealth": {
+          "url": "https://dev.care.va.gov/vvc-app/?join=1&media=1&escalate=1&userType=guest&conference=VAC000001440@dev.care.va.gov&pin=590094&aid=6641d9ca-bcf0-4040-947a-ed9ed822e495#",
+          "group": false,
+          "vvsKind": "CLINIC_BASED"
         },
-        "friendlyName": "Friendly Name CHY PC KILPATRICK",
-        "serviceName": "CHY PC KILPATRICK",
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [
+            "NO ACTION TAKEN"
+          ],
+          "patientHasMobileGfe": true,
+          "preCheckinAllowed": false,
+          "eCheckinAllowed": false,
+          "clinic": {}
+        },
+        "localStartTime": "2025-01-14T08:00:00.000-05:00",
+        "avsPath": null,
+        "serviceName": "MID-V10 CRH MH PSY MD PT",
+        "friendlyName": "MID-V10 CRH MH PSY MD PT",
+        "location": {
+          "id": "984GA",
+          "type": "appointments",
+          "attributes": {
+            "id": "984GA",
+            "vistaSite": "984",
+            "vastParent": "984",
+            "type": "va_health_facility",
+            "name": "Middletown VA Clinic",
+            "classification": "Multi-Specialty CBOC",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.50603,
+            "long": -84.316475,
+            "website": "https://www.dayton.va.gov/locations/midtwn_cboc.asp",
+            "phone": {
+              "main": "513-423-8387"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "4337 North Union Road"
+              ],
+              "city": "Middletown",
+              "state": "OH",
+              "postalCode": "45005-5211"
+            },
+            "healthService": [
+              "Audiology",
+              "MentalHealthCare",
+              "Optometry",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "805eb1710aefb85bcc07813ae36a744f1467fd4306c0a950ba16e023fb514cea",
+      "type": "appointments",
+      "attributes": {
+        "id": "805eb1710aefb85bcc07813ae36a744f1467fd4306c0a950ba16e023fb514cea",
+        "identifier": [
+          {
+            "system": "Appointment/",
+            "value": "4139383436323830"
+          },
+          {
+            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+            "value": "984:6280"
+          },
+          {
+            "system": "http://med.va.gov/fhir/urn/vaos/vvs/id",
+            "value": "6641d9ca-bcf0-4040-947a-ed9ed822e495"
+          }
+        ],
+        "kind": "telehealth",
+        "status": "cancelled",
+        "serviceType": "outpatientMentalHealth",
+        "serviceTypes": [
+          {
+            "coding": [
+              {
+                "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                "code": "outpatientMentalHealth"
+              }
+            ]
+          }
+        ],
+        "serviceCategory": [
+          {
+            "coding": [
+              {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                "code": "REGULAR",
+                "display": "REGULAR"
+              }
+            ],
+            "text": "REGULAR"
+          }
+        ],
+        "patientIcn": "1012845331V153043",
+        "locationId": "984GA",
+        "clinic": "4284",
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": "https://veteran.apps.va.gov/terminology/fhir/sid/secid",
+                "value": "1034242903"
+              }
+            ],
+            "name": {
+              "family": "ALSAHHAR",
+              "given": [
+                "SAMI"
+              ]
+            }
+          }
+        ],
+        "start": "2025-01-14T14:00:00Z",
+        "end": "2025-01-14T14:30:00Z",
+        "minutesDuration": 30,
+        "slot": {
+          "id": "3230323331313134313330303A323032333131313431333330",
+          "start": "2025-01-14T14:00:00Z",
+          "end": "2025-01-14T14:30:00Z"
+        },
+        "created": "2025-01-07T00:00:00Z",
+        "cancellable": false,
+        "telehealth": {
+          "url": "https://dev.care.va.gov/vvc-app/?join=1&media=1&escalate=1&userType=guest&conference=VAC000001440@dev.care.va.gov&pin=590094&aid=6641d9ca-bcf0-4040-947a-ed9ed822e495#",
+          "group": false,
+          "vvsKind": "CLINIC_BASED"
+        },
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [
+            "NO ACTION TAKEN"
+          ],
+          "patientHasMobileGfe": true,
+          "preCheckinAllowed": false,
+          "eCheckinAllowed": false,
+          "clinic": {}
+        },
+        "localStartTime": "2025-01-14T09:00:00.000-05:00",
+        "avsPath": null,
+        "serviceName": "MID-V10 CRH MH PSY MD PT",
+        "friendlyName": "MID-V10 CRH MH PSY MD PT",
+        "location": {
+          "id": "984GA",
+          "type": "appointments",
+          "attributes": {
+            "id": "984GA",
+            "vistaSite": "984",
+            "vastParent": "984",
+            "type": "va_health_facility",
+            "name": "Middletown VA Clinic",
+            "classification": "Multi-Specialty CBOC",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.50603,
+            "long": -84.316475,
+            "website": "https://www.dayton.va.gov/locations/midtwn_cboc.asp",
+            "phone": {
+              "main": "513-423-8387"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "4337 North Union Road"
+              ],
+              "city": "Middletown",
+              "state": "OH",
+              "postalCode": "45005-5211"
+            },
+            "healthService": [
+              "Audiology",
+              "MentalHealthCare",
+              "Optometry",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "id": "9c6a43ce99d9d8406d3cd3b463f4d383d4f6f08d91b56d7ed8282928f9a58957",
+      "type": "appointments",
+      "attributes": {
+        "id": "9c6a43ce99d9d8406d3cd3b463f4d383d4f6f08d91b56d7ed8282928f9a58957",
+        "identifier": [
+          {
+            "system": "http://med.va.gov/fhir/urn/vaos/hsrm/id",
+            "value": "524670||158||1"
+          },
+          {
+            "system": "http://hl7.org/fhir/sid/us-npi",
+            "value": "1346206547"
+          }
+        ],
+        "kind": "cc",
+        "status": "booked",
+        "serviceTypes": [
+          {
+            "text": "Cardiology Cath - PCI_REV_PRCT SEOC 1.1.14"
+          }
+        ],
+        "description": "Cardiology Cath - PCI_REV_PRCT SEOC 1.1.14",
+        "patientIcn": "1012845331V153043",
+        "locationId": "552",
+        "practitioners": [
+          {
+            "name": {
+              "family": "HEALTH CARE PROFS",
+              "given": [
+                "A & D"
+              ]
+            }
+          }
+        ],
+        "start": "2025-02-02T13:00:00Z",
+        "created": "2025-02-02T20:29:46Z",
+        "cancellable": false,
+        "extension": {
+          "ccLocation": {
+            "address": {
+              "line": [
+                "1601 NEEDMORE RD ; STE 1 &amp; 2"
+              ],
+              "city": "DAYTON",
+              "state": "OH",
+              "postalCode": "45414",
+              "text": "1601 NEEDMORE RD ; STE 1 &amp; 2\nDAYTON OH 45414"
+            },
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "937-236-6750"
+              }
+            ]
+          },
+          "hsrmTaskId": "",
+          "hsrmConsultId": "984_646372",
+          "ccTreatingSpecialty": "Home Health"
+        },
+        "localStartTime": "2025-02-02T09:00:00.000-04:00",
+        "avsPath": null,
+        "location": {
+          "id": "552",
+          "type": "appointments",
+          "attributes": {
+            "id": "552",
+            "facilitiesApiId": "vha_552",
+            "vistaSite": "552",
+            "vastParent": "552",
+            "type": "va_health_facility",
+            "name": "Dayton VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/New_York"
+            },
+            "lat": 39.74935,
+            "long": -84.2532,
+            "website": "https://www.va.gov/dayton-health-care/locations/dayton-va-medical-center/",
+            "phone": {
+              "main": "937-268-6511",
+              "fax": "937-262-2179",
+              "pharmacy": "800-368-8262 x1",
+              "afterHours": "888-838-6446",
+              "patientAdvocate": "800-368-8262 x2164",
+              "mentalHealthClinic": "937-262-2186",
+              "enrollmentCoordinator": "800-368-8262 x5336"
+            },
+            "hoursOfOperation": [
+              {
+                "daysOfWeek": "sun",
+                "openingTime": "24/7",
+                "closingTime": "24/7"
+              },
+              {
+                "daysOfWeek": "mon",
+                "openingTime": "24/7",
+                "closingTime": "24/7"
+              },
+              {
+                "daysOfWeek": "tue",
+                "openingTime": "24/7",
+                "closingTime": "24/7"
+              },
+              {
+                "daysOfWeek": "wed",
+                "openingTime": "24/7",
+                "closingTime": "24/7"
+              },
+              {
+                "daysOfWeek": "thu",
+                "openingTime": "24/7",
+                "closingTime": "24/7"
+              },
+              {
+                "daysOfWeek": "fri",
+                "openingTime": "24/7",
+                "closingTime": "24/7"
+              },
+              {
+                "daysOfWeek": "sat",
+                "openingTime": "24/7",
+                "closingTime": "24/7"
+              }
+            ],
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "4100 West Third Street",
+                null,
+                null
+              ],
+              "city": "Dayton",
+              "state": "OH",
+              "postalCode": "45428-9000"
+            },
+            "mobile": false,
+            "healthService": [
+              "Addiction",
+              "Anesthesia",
+              "Audiology",
+              "Cardiology",
+              "CaregiverSupport",
+              "Chiropractic",
+              "CriticalCare",
+              "Dental",
+              "Dermatology",
+              "EmergencyCare",
+              "EmploymentPrograms",
+              "Endocrinology",
+              "Gastroenterology",
+              "Gynecology",
+              "Hematology",
+              "Homeless",
+              "Hospice",
+              "InfectiousDisease",
+              "Laboratory",
+              "Lgbtq",
+              "MentalHealth",
+              "MilitarySexualTrauma",
+              "MinorityCare",
+              "MyHealtheVetCoordinator",
+              "Nephrology",
+              "Neurology",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Otolaryngology",
+              "PainManagement",
+              "PatientAdvocates",
+              "Pharmacy",
+              "PhysicalMedicine",
+              "PhysicalTherapy",
+              "Podiatry",
+              "Polytrauma",
+              "PrimaryCare",
+              "Prosthetics",
+              "Psychiatry",
+              "Psychology",
+              "Ptsd",
+              "PulmonaryMedicine",
+              "RadiationOncology",
+              "Radiology",
+              "RecreationTherapy",
+              "RegistryExams",
+              "Rehabilitation",
+              "Rheumatology",
+              "SleepMedicine",
+              "Smoking",
+              "SocialWork",
+              "SpinalInjury",
+              "SuicidePrevention",
+              "Surgery",
+              "Telehealth",
+              "ThoracicSurgery",
+              "TransitionCounseling",
+              "TransplantSurgery",
+              "TravelReimbursement",
+              "UrgentCare",
+              "Urology",
+              "VascularSurgery",
+              "Vision",
+              "WeightManagement",
+              "WomensHealth",
+              "Wound"
+            ],
+            "operatingStatus": {
+              "code": "NORMAL"
+            },
+            "visn": "10"
+          }
+        }
+      }
+    },
+    {
+      "id": "7e5cab9523b99cbe1ca941399ef419f942837cda5dda71bbf95f6e5a375d2710",
+      "type": "appointments",
+      "attributes": {
+        "id": "7e5cab9523b99cbe1ca941399ef419f942837cda5dda71bbf95f6e5a375d2710",
+        "identifier": [
+          {
+            "system": "Appointment/",
+            "value": "413938333133333234"
+          },
+          {
+            "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_84",
+            "value": "983:13324"
+          }
+        ],
+        "kind": "clinic",
+        "status": "booked",
+        "serviceType": "optometry",
+        "serviceTypes": [
+          {
+            "coding": [
+              {
+                "system": "http://veteran.apps.va.gov/terminologies/fhir/CodeSystem/vats-service-type",
+                "code": "optometry"
+              }
+            ]
+          }
+        ],
+        "serviceCategory": [
+          {
+            "coding": [
+              {
+                "system": "http://www.va.gov/Terminology/VistADefinedTerms/409_1",
+                "code": "REGULAR",
+                "display": "REGULAR"
+              }
+            ],
+            "text": "REGULAR"
+          }
+        ],
+        "reasonCode": {
+          "text": "reasonCode:ROUTINEVISIT|comments:test  vaos-7661"
+        },
+        "reasonForAppointment": "Routine/Follow-up",
+        "patientComments": "test  vaos-7661",
+        "patientIcn": "1013678363V916823",
+        "locationId": "983",
+        "clinic": "437",
+        "start": "2025-02-25T16:25:00Z",
+        "end": "2025-02-25T16:40:00Z",
+        "minutesDuration": 15,
+        "slot": {
+          "id": "3230323431303235313632353A323032343130323531363430",
+          "start": "2025-02-25T16:25:00Z",
+          "end": "2025-02-25T16:40:00Z"
+        },
+        "created": "2024-11-16T00:00:00Z",
+        "cancellable": true,
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [
+            "FUTURE"
+          ],
+          "preCheckinAllowed": false,
+          "eCheckinAllowed": false,
+          "clinic": {}
+        },
+        "localStartTime": "2025-02-25T10:25:00.000-06:00",
+        "serviceName": "VISUAL FIELD",
+        "friendlyName": "VISUAL FIELD",
+        "location": {
+          "id": "983",
+          "type": "appointments",
+          "attributes": {
+            "id": "983",
+            "vistaSite": "983",
+            "vastParent": "983",
+            "type": "va_facilities",
+            "name": "Cheyenne VA Medical Center",
+            "classification": "VA Medical Center (VAMC)",
+            "timezone": {
+              "timeZoneId": "America/Denver"
+            },
+            "lat": 39.744507,
+            "long": -104.830956,
+            "website": "https://www.denver.va.gov/locations/directions.asp",
+            "phone": {
+              "main": "307-778-7550",
+              "fax": "307-778-7381",
+              "pharmacy": "866-420-6337",
+              "afterHours": "307-778-7550",
+              "patientAdvocate": "307-778-7550 x7517",
+              "mentalHealthClinic": "307-778-7349",
+              "enrollmentCoordinator": "307-778-7550 x7579"
+            },
+            "physicalAddress": {
+              "type": "physical",
+              "line": [
+                "2360 East Pershing Boulevard"
+              ],
+              "city": "Cheyenne",
+              "state": "WY",
+              "postalCode": "82001-5356"
+            },
+            "mobile": false,
+            "healthService": [
+              "Audiology",
+              "Cardiology",
+              "DentalServices",
+              "EmergencyCare",
+              "Gastroenterology",
+              "Gynecology",
+              "MentalHealthCare",
+              "Nutrition",
+              "Ophthalmology",
+              "Optometry",
+              "Orthopedics",
+              "Podiatry",
+              "PrimaryCare",
+              "SpecialtyCare",
+              "UrgentCare",
+              "Urology",
+              "WomensHealth"
+            ],
+            "operatingStatus": {
+              "code": "NORMAL"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "cbc61b77eab168d7bb886649c0d42f6f2951b912e358cab744ca65b2296468a2",
+      "type": "appointments",
+      "attributes": {
+        "id": "cbc61b77eab168d7bb886649c0d42f6f2951b912e358cab744ca65b2296468a2",
+        "identifier": [
+          {
+            "system": "http://med.va.gov/fhir/urn/vaos/vvs/id",
+            "value": "38fc7910-fa4a-4973-8a50-c9533fb0e3c0"
+          }
+        ],
+        "kind": "telehealth",
+        "status": "booked",
+        "patientIcn": "1013124304V115761",
+        "locationId": "983",
+        "practitioners": [
+          {
+            "identifier": [
+              {
+                "system": "dfn-983",
+                "value": "520647363"
+              }
+            ],
+            "name": {
+              "family": "NADEAU",
+              "given": [
+                "MARCY"
+              ]
+            },
+            "practiceName": "Cheyenne VA Medical Center"
+          }
+        ],
+        "start": "2025-02-25T19:00:00Z",
+        "end": "2025-02-25T19:20:00Z",
+        "minutesDuration": 20,
+        "created": "2024-02-29T18:22:31.642Z",
+        "cancellable": false,
+        "patientInstruction": "Medication Review\n\nAs part of your video visit, your provider will review all the medications, vitamins, herbs, and supplements you are taking\n(even items you get from a local store, another provider, or another VA clinic). Please have information about everything you\ntake available during the visit. Informing your provider about all these will help you get the best and safest care possible.\nRemember, it is your medications, your life. Play it safe by reviewing all your medications with your health care team.\n",
+        "telehealth": {
+          "url": "https://pexip.mapsandbox.net/vvc-app/?join=1&media=1&escalate=1&userType=guest&conference=VAC000003848@pexip.mapsandbox.net&pin=111200&aid=38fc7910-fa4a-4973-8a50-c9533fb0e3c0#",
+          "group": false,
+          "vvsKind": "ADHOC"
+        },
+        "extension": {
+          "ccLocation": {
+            "address": {}
+          },
+          "vistaStatus": [],
+          "patientHasMobileGfe": false
+        },
+        "localStartTime": "2025-02-25T12:00:00.000-07:00",
         "location": {
           "id": "983",
           "type": "appointments",


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR primarily addresses the [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/94339) for removing duplicate  logic for displaying comments on appointment details.
- After some discussion with the team, we felt that after moving the parsing logic to the BE, we no longer need to maintain complicated null state logic (e.g. falling back to "none" for CC appointments) and conjunction/partition logic (joining and splitting by ":") and instead rely on the `reasonForAppointment` and `patientComments` fields provided by the backend.
- Note that this change doesn't change the [behavior for handling v0 appointments](https://github.com/department-of-veterans-affairs/vets-website/blob/cc0e9917b4738afabae6d34ed09ab865b846fd36/src/applications/vaos/services/appointment/transformers.js#L216-L223) in the transformer.
- As a side effect of streamlining the logic, we also end up addressing three existing bugs:
  -  [92704](https://github.com/department-of-veterans-affairs/va.gov-team/issues/92704) is fixed because once we switch to the new logic there's no conjoining/splitting by ":" so colons in patient comments will automatically be preserved.
  - [94689](https://github.com/department-of-veterans-affairs/va.gov-team/issues/94689) is fixed because we no longer have null state logic fallback to "none" for CC appointments that's currently in `selectComment` and `selectAppointmentDetails`
  - I also found a bug where in CC appointments, if the patient comment contains a colon, only the content after the colon is displayed. This was caused by the layout component splitting the comment by colon when it shouldn't.
- Appointments (VAOS) Team
- This is not behind a Flipper toggle

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/94339
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/92704
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/94689

## Testing done

- Tested locally for the affected appointment types, see screenshots below
- Updated existing unit tests for the updated behaviors

## Screenshots

|         | Before | After |
| ------- | ------ | ----- |
| Colon in comments (fixed) |    ![image](https://github.com/user-attachments/assets/4428b32d-80d5-453f-af67-ada67905b9c7)   |  ![image](https://github.com/user-attachments/assets/ee5ffdd8-b883-47e7-a810-668709814542)   |
| CC null state (fixed) |    ![image](https://github.com/user-attachments/assets/b0e744eb-90ac-4e1e-b3b7-191e9dff1365)   | ![image](https://github.com/user-attachments/assets/4457c883-29d7-4683-8a21-315da0010502) |
| CC Details (bug fixed) |     ![image](https://github.com/user-attachments/assets/6d5c1c13-a040-473e-9b5f-5ad3deacce4e)  |  ![image](https://github.com/user-attachments/assets/e86c0ffb-a569-45c5-960e-a8af221b4a32)  |
| CC Request Details (other details only) |   ![image](https://github.com/user-attachments/assets/81b2a78f-00de-48d5-bd60-6ec5f2ba2156)    |  ![image](https://github.com/user-attachments/assets/302f17f5-c7c6-48e3-a2fa-7f732c3b8075)   |
| CC Request Cancellation (other details only) |   ![image](https://github.com/user-attachments/assets/88ce1036-3f4f-4c35-a512-d9fadfb3d02f)    |   ![image](https://github.com/user-attachments/assets/0e426291-e1be-4917-9f66-d07d5115396b)  |
| VA Request Details (no change) |    ![image](https://github.com/user-attachments/assets/e2c58591-4780-4ac1-8148-28eaafc5128f)   |   ![image](https://github.com/user-attachments/assets/62cb3f33-037f-4ff7-9ecf-85f8b0507a77)   |
| VA Request Cancellation (no change) |   ![image](https://github.com/user-attachments/assets/e48c94e6-58b4-4f3b-ab91-0a92e260c9b9)    |    ![image](https://github.com/user-attachments/assets/f36ceab8-a1ed-4197-9193-480f8b99c162)  |
| In Person Details (no change) |   ![image](https://github.com/user-attachments/assets/172447ef-a4ae-43e3-ac0b-8dabb48d3fe3)    |  ![image](https://github.com/user-attachments/assets/70d47927-46f7-429a-becd-6bdebad2e915)    |
| In Person Cancellation (no change) |    ![image](https://github.com/user-attachments/assets/b47cc12c-cf22-4e7e-a99b-5acfe08775f9)   |   ![image](https://github.com/user-attachments/assets/d9bdc7b4-8720-4b95-b82d-39e7ed05488b)   |
| Phone Details (no change) |   ![image](https://github.com/user-attachments/assets/4abd8b67-a70e-44f7-a91b-344ba9f3e847)    |   ![image](https://github.com/user-attachments/assets/62b46aa8-611e-474e-9ab5-fd99e7a0b793)   |
| Phone Cancellation (no change) |   ![image](https://github.com/user-attachments/assets/62ac9201-d8b2-4793-9f63-e60d1d40725f)    |   ![image](https://github.com/user-attachments/assets/37ef3f6d-df72-4a1c-9fbd-31cc96b15fff)   |


## What areas of the site does it impact?

Appointments (VAOS)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [x] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [x] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

