### PR TITLE
Fix (opens in a new tab) appearing outside of link text

### DIFF
--- a/src/applications/benefit-eligibility-questionnaire/pages/characterOfDischarge.js
+++ b/src/applications/benefit-eligibility-questionnaire/pages/characterOfDischarge.js
@@ -29,9 +29,9 @@ export default {
               href="https://www.va.gov/discharge-upgrade-instructions"
               rel="noreferrer"
             >
-              Learn more about the discharge upgrade process
+              Learn more about the discharge upgrade process (opens in a new
+              tab)
             </a>{' '}
-            (opens in a new tab)
             <br />
             Not sure about this question? Call us at{' '}
             <va-telephone contact="8006982411" /> (

--- a/src/applications/benefit-eligibility-questionnaire/pages/disabilityRating.js
+++ b/src/applications/benefit-eligibility-questionnaire/pages/disabilityRating.js
@@ -20,9 +20,8 @@ export default {
             target="_blank"
             rel="noreferrer"
           >
-            Learn more about disability ratings
+            Learn more about disability ratings (opens in a new tab)
           </a>{' '}
-          <span> (opens in a new tab)</span>
         </div>
       ),
     },

--- a/src/applications/benefit-eligibility-questionnaire/tests/unit/pages/characterOfDischarge.unit.spec.js
+++ b/src/applications/benefit-eligibility-questionnaire/tests/unit/pages/characterOfDischarge.unit.spec.js
@@ -59,7 +59,8 @@ describe('Character of Discharge Form', () => {
 
   it('should render the correct link in the description for characterOfDischargeTWO', () => {
     const link = $('a', container);
-    const linkText = 'Learn more about the discharge upgrade process';
+    const linkText =
+      'Learn more about the discharge upgrade process (opens in a new tab)';
     const href = 'https://www.va.gov/discharge-upgrade-instructions';
 
     expect(link).to.exist;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

There are two instances in the application where links open in a new tab, and there is a plain-text (opens in a new tab) that appears after the link. This text should be included in the actual link text.

Recommended Action: Update link text to include (opens in a new tab) rather than showing the text after the link.

## Related issue(s)

[https://jira.devops.va.gov/browse/PTEMSVT-218](PTEMSVT-218)

## Testing done

Local testing and unit testing.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

[https://staging.va.gov/benefit-eligibility-questionnaire/discharge](https://staging.va.gov/benefit-eligibility-questionnaire/discharge)
[https://staging.va.gov/benefit-eligibility-questionnaire/disability](https://staging.va.gov/benefit-eligibility-questionnaire/disability)

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
