### PR TITLE
Remove unnecessary event listeners from Caregivers application

### DIFF
--- a/src/applications/caregivers/containers/App.jsx
+++ b/src/applications/caregivers/containers/App.jsx
@@ -1,9 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
-
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
-import recordEvent from 'platform/monitoring/record-event';
 import { setData } from 'platform/forms-system/src/js/actions';
 import { selectFeatureToggles } from '../utils/selectors/feature-toggles';
 import { useBrowserMonitoring } from '../hooks/useBrowserMonitoring';
@@ -17,26 +15,6 @@ const App = props => {
     selectFeatureToggles,
   );
   const dispatch = useDispatch();
-
-  // find all yes/no check boxes and attach analytics events
-  useEffect(
-    () => {
-      if (!loading) {
-        const radios = document.querySelectorAll('input[type="radio"]');
-        for (const radio of radios) {
-          radio.onclick = e => {
-            const label = e.target.nextElementSibling.innerText;
-            recordEvent({
-              'caregivers-radio-label': label,
-              'caregivers-radio-clicked': e.target,
-              'caregivers-radio-value-selected': e.target.value,
-            });
-          };
-        }
-      }
-    },
-    [loading, location],
-  );
 
   // set feature toggle values in form data
   useEffect(


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

This PR removes event listeners that had been previously applied to radio inputs when the Caregivers application utilized React-based components in the form. Since the form has been updated to utilize the DSTs web component patterns, those patterns have analytics built in, making these listeners obsolete.

## Related issue(s)

department-of-veterans-affairs/va.gov-team#92834

## Testing done

- Fill form until a page comes up with radio inputs
- Open network tab and click on one of the radio inputs
- Notice the network call to `collect?...` for the GA event

## Acceptance criteria

- Events are properly being collected for radio inputs
- Duplicate events are not being called for these same inputs

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution