### PR TITLE
SC | Update missing primary phone message on review page

### DIFF
--- a/src/applications/appeals/995/components/PrimaryPhoneReview.jsx
+++ b/src/applications/appeals/995/components/PrimaryPhoneReview.jsx
@@ -17,12 +17,10 @@ const PrimaryPhoneReview = ({ data, editPage }) => {
   const error =
     getPhoneString(phone).trim() === '' || label === '' ? (
       <strong className="usa-input-error-message">
-        {errorMessages.missingPrimaryPhone}
+        {errorMessages.missingPrimaryPhoneReview}
       </strong>
     ) : null;
-  const labelWrapClasses = error
-    ? 'vads-u-border-left--4px vads-u-border-color--secondary-dark vads-u-padding-left--1p5'
-    : '';
+
   return hasHomeAndMobilePhone(data) ? (
     <div className="form-review-panel-page">
       <div className="form-review-panel-page-header-row">
@@ -40,9 +38,9 @@ const PrimaryPhoneReview = ({ data, editPage }) => {
       </div>
       <dl className="review">
         <div className="review-row">
-          <dt className={labelWrapClasses}>{error || label}</dt>
+          <dt>{label || 'Primary phone number'}</dt>
           <dd className="dd-privacy-hidden" data-dd-action-name="primary phone">
-            <strong>{error ? '' : getFormattedPhone(phone)}</strong>
+            {error ?? <strong>{getFormattedPhone(phone)}</strong>}
           </dd>
         </div>
       </dl>

--- a/src/applications/appeals/995/constants.js
+++ b/src/applications/appeals/995/constants.js
@@ -75,6 +75,7 @@ export const errorMessages = {
   },
 
   missingPrimaryPhone: 'You must choose a primary phone number',
+  missingPrimaryPhoneReview: 'Missing primary phone',
 };
 
 export const NULL_CONDITION_STRING = 'Unknown Condition';

--- a/src/applications/appeals/995/content/reviewErrors.js
+++ b/src/applications/appeals/995/content/reviewErrors.js
@@ -20,7 +20,7 @@ const reviewErrors = {
       if (err.includes(PRIMARY_PHONE)) {
         return {
           chapterKey: 'infoPages',
-          pageKey: 'confirmContactInfo',
+          pageKey: 'choosePrimaryPhone',
         };
       }
     }

--- a/src/applications/appeals/995/tests/components/PrimaryPhoneReview.unit.spec.jsx
+++ b/src/applications/appeals/995/tests/components/PrimaryPhoneReview.unit.spec.jsx
@@ -54,9 +54,9 @@ describe('<PrimaryPhoneReview>', () => {
 
   it('should show an error message when the primary phone value isn’t defined', () => {
     const { container } = render(setup({ primary: '' }));
-    expect($('dt', container).textContent).to.eq(
-      errorMessages.missingPrimaryPhone,
+    expect($('dt', container).textContent).to.eq('Primary phone number');
+    expect($('dd', container).textContent).to.eq(
+      errorMessages.missingPrimaryPhoneReview,
     );
-    expect($('dd', container).textContent).to.eq('');
   });
 });

--- a/src/applications/appeals/995/tests/content/reviewErrors.unit.spec.js
+++ b/src/applications/appeals/995/tests/content/reviewErrors.unit.spec.js
@@ -29,17 +29,10 @@ describe('reviewErrors override', () => {
     });
   });
 
-  it('should return contact info keys for contact info pages', () => {
-    expect(override('veteran')).to.be.deep.equal({
-      chapterKey: 'infoPages',
-      pageKey: 'confirmContactInfo',
-    });
-  });
-
   it('should return contact info keys for primary phone question', () => {
     expect(override(PRIMARY_PHONE)).to.be.deep.equal({
       chapterKey: 'infoPages',
-      pageKey: 'confirmContactInfo',
+      pageKey: 'choosePrimaryPhone',
     });
   });
 });

--- a/src/applications/appeals/testing/sc/components/PrimaryPhoneReview.jsx
+++ b/src/applications/appeals/testing/sc/components/PrimaryPhoneReview.jsx
@@ -17,12 +17,10 @@ const PrimaryPhoneReview = ({ data, editPage }) => {
   const error =
     getPhoneString(phone).trim() === '' || label === '' ? (
       <strong className="usa-input-error-message">
-        {errorMessages.missingPrimaryPhone}
+        {errorMessages.missingPrimaryPhoneReview}
       </strong>
     ) : null;
-  const labelWrapClasses = error
-    ? 'vads-u-border-left--4px vads-u-border-color--secondary-dark vads-u-padding-left--1p5'
-    : '';
+
   return hasHomeAndMobilePhone(data) ? (
     <div className="form-review-panel-page">
       <div className="form-review-panel-page-header-row">
@@ -40,9 +38,9 @@ const PrimaryPhoneReview = ({ data, editPage }) => {
       </div>
       <dl className="review">
         <div className="review-row">
-          <dt className={labelWrapClasses}>{error || label}</dt>
+          <dt>{label || 'Primary phone number'}</dt>
           <dd className="dd-privacy-hidden" data-dd-action-name="primary phone">
-            <strong>{error ? '' : getFormattedPhone(phone)}</strong>
+            {error ?? <strong>{getFormattedPhone(phone)}</strong>}
           </dd>
         </div>
       </dl>

--- a/src/applications/appeals/testing/sc/constants.js
+++ b/src/applications/appeals/testing/sc/constants.js
@@ -78,6 +78,7 @@ export const errorMessages = {
   },
 
   missingPrimaryPhone: 'You must choose a primary phone number',
+  missingPrimaryPhoneReview: 'Missing primary phone',
 };
 
 export const NULL_CONDITION_STRING = 'Unknown Condition';

--- a/src/applications/appeals/testing/sc/content/reviewErrors.js
+++ b/src/applications/appeals/testing/sc/content/reviewErrors.js
@@ -20,7 +20,7 @@ const reviewErrors = {
       if (err.includes(PRIMARY_PHONE)) {
         return {
           chapterKey: 'infoPages',
-          pageKey: 'confirmContactInfo',
+          pageKey: 'choosePrimaryPhone',
         };
       }
     }


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > When a primary phone choice is missing, the review page error message that is shown does not match the pattern of other "missing" values (see screenshots). This PR updates the review page in both the Supplemental Claim (SC) form and the SC prototype.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
  > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/95117

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

|         | Before | After |
| ------- | ------ | :-----: |
| Contact info errors | <img width="500" src="https://github.com/user-attachments/assets/d9a341e6-614f-48f3-92b9-9e3997b425d8" alt="missing all contact info with the left column showing the label name and the right showing red text with a missing value message, e.g. 'Missing phone number' error" /> | Unchanged |
| Primary phone error  | <img width="500" alt="primary phone page with no columns and the error message 'you must choose a primary phone number' message aligned to the left side with a red border" src="https://github.com/user-attachments/assets/09a12b11-d3c4-4e8c-bce9-3d29f1dffb4e"> | <img width="500" alt="missing primary phone error that matches the missing contact info pattern. There's a 'Primary phone number' text on the left and 'Missing primary phone' message in red on the right" src="https://github.com/user-attachments/assets/0244189d-cffb-4e5a-9341-7b033083d7e0"> |

## What areas of the site does it impact?

Supplemental Claim (and prototype)

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
