### PR TITLE
Focus element on save results modal close

### DIFF
--- a/src/applications/benefit-eligibility-questionnaire/components/SaveResultsModal.jsx
+++ b/src/applications/benefit-eligibility-questionnaire/components/SaveResultsModal.jsx
@@ -17,6 +17,12 @@ const SaveResultsModal = () => {
     focusElement('#copy-alert');
   };
 
+  const handleClose = () => {
+    setShowAlert(false);
+    toggleModal(false);
+    focusElement('#save-your-results');
+  };
+
   return (
     <div className="vads-u-margin-bottom--2">
       <va-button
@@ -27,10 +33,7 @@ const SaveResultsModal = () => {
       />
       <VaModal
         id="save-results-modal"
-        onCloseEvent={() => {
-          setShowAlert(false);
-          toggleModal(false);
-        }}
+        onCloseEvent={handleClose}
         modalTitle="Save your results"
         initialFocusSelector="#va-modal-title"
         visible={isOpen}

--- a/src/applications/benefit-eligibility-questionnaire/tests/unit/components/SaveResultsModal.unit.spec.js
+++ b/src/applications/benefit-eligibility-questionnaire/tests/unit/components/SaveResultsModal.unit.spec.js
@@ -20,7 +20,7 @@ describe('<SaveResultsModal>', () => {
     navigator.clipboard = { writeText };
     sinon.stub(window, 'location').returns({ href: 'test' });
     const { container } = render(<SaveResultsModal />);
-    const button = container.querySelector('va-button');
+    const button = container.querySelector('#save-your-results');
 
     fireEvent.click(button);
 
@@ -36,6 +36,28 @@ describe('<SaveResultsModal>', () => {
       const alertFocus = container.querySelector('#copy-alert:focus');
       expect(alert).to.exist;
       expect(alertFocus).to.exist;
+    });
+  });
+
+  it('closes modal', async () => {
+    const view = render(<SaveResultsModal />);
+    const { container } = view;
+
+    const button = container.querySelector('#save-your-results');
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(container.querySelector('#url-input')).to.exist;
+    });
+
+    const modal = container.querySelector('#save-results-modal');
+
+    modal.__events.closeEvent();
+
+    await waitFor(() => {
+      const buttonFocus = container.querySelector('#save-your-results:focus');
+      expect(buttonFocus).to.exist;
     });
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Description: When closing the "Save your results" modal, keyboard focus is lost. For keyboard-only users, it's not too difficult to recover from this. For screen reader users, closing the modal results in the breadcrumb navigation being announced, which is a different spot on the page from where they were when they opened the modal. It may be confusing to screen reader users trying to re-orient themselves after closing the modal.

Recommended Action: When closing a modal, we want to move keyboard focus to the next place on the page that might make sense for what a user is trying to do. For an interaction like this (sort of a side quest from the main purpose of the page), that would typically mean returning focus to the button that triggered the modal in the first place.

Steps to reproduce:
1. Navigate to the results page of the product.
2. Activate a screen reader. (Easiest options for testing: VoiceOver on Mac or NVDA on Windows.)
3. Press [tab] until focus moves to the "Save your results" button.
4. Press [enter] to open the modal.
5. Press [esc] to close the modal.
6. Note that the screen reader announces the breadcrumb navigation.

## Related issue(s)

[https://jira.devops.va.gov/browse/PTEMSVT-233](https://jira.devops.va.gov/browse/PTEMSVT-233)

## Testing done

Local testing and unit testing.

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

Benefit Eligibility Questionnaire.

## Acceptance criteria

### Quality Assurance & Testing

- [X] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [X] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
