### PR TITLE
Update Profile's Hub and Spoke Page to Handle Blocked v0/user Endpoint

### DIFF
--- a/src/applications/personalization/profile/components/Profile.jsx
+++ b/src/applications/personalization/profile/components/Profile.jsx
@@ -211,6 +211,7 @@ class Profile extends Component {
       <RequiredLoginView
         serviceRequired={backendServices.USER_PROFILE}
         user={this.props.user}
+        showProfileErrorMessage
       >
         <DowntimeNotification
           appTitle="profile"


### PR DESCRIPTION
## Summary

This PR updates the **Profile's**  _Hub and Spoke_ pages to handle scenarios where the `v0/user` endpoint is blocked or times out. Previously, the Profile page remained in a loading state indefinitely when this endpoint was unavailable. This update brings the Profile page's behavior in line with the **My VA** page, displaying a user-friendly error message instead of hanging.

The error message displayed will now be:

> "We're sorry. Something went wrong on our end.  
> Please refresh this page or try again later."

I also passed the `showProfileErrorMessage` prop to the `RequiredLoginView` component to ensure this issue is handled for both the **Hub** and **Spoke** pages.

### Changes

- Updated the **Profile** page to display a user-friendly error message when the `v0/user` endpoint is blocked or times out, similar to the My VA page.
- Passed the `showProfileErrorMessage` prop to the `RequiredLoginView` component.
- No additional unit tests were necessary as the component responsible for displaying the error message is already fully tested.

### Testing

- Manually tested by blocking the `v0/user` endpoint via the network tab and verifying the error message is displayed correctly.
- Verified that the Profile page no longer hangs indefinitely when the `v0/user` endpoint is blocked or times out.
- Ensured that passing `showProfileErrorMessage` works for both the **Hub** and **Spoke** pages.

## Related issue(s)

- **Ticket:** department-of-veterans-affairs/va.gov-team#95097

## What areas of the site does it impact?

- Profile > Loading/Error State

## Acceptance Criteria

1. The Profile page should display a user-friendly error message similar to the My VA page when the `v0/user` endpoint is blocked or times out.
2. The page should no longer remain in a loading state indefinitely when the endpoint fails.
3. No new unit tests were necessary as the component displaying the error is already fully covered.

## Quality Assurance & Testing

- [x] I manually blocked the `v0/user` endpoint in the network tab and verified the error message is displayed correctly.
- [x] No sensitive information (i.e., PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs.
- [x] Linting warnings have been addressed.
- [ ] Documentation has been updated ([link to documentation](#) *if necessary).
- [ ] Screenshot of the developed feature is added.
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed.

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution.
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable).

### Authentication

- [x] Did you log in to a local build and verify all authenticated routes work as expected with a test user?