### PR TITLE
9509 Add external service to list of dependencies - form 10-7959f-1

### DIFF
--- a/src/applications/ivc-champva/10-7959f-1/config/form.js
+++ b/src/applications/ivc-champva/10-7959f-1/config/form.js
@@ -56,7 +56,7 @@ const formConfig = {
     submitButtonText: 'Submit',
   },
   downtime: {
-    dependencies: [externalServices.pega],
+    dependencies: [externalServices.pega, externalServices.form107959f1],
   },
   preSubmitInfo: {
     statementOfTruth: {

--- a/src/applications/ivc-champva/10-7959f-1/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/App.jsx
@@ -37,7 +37,10 @@ export default function App({ location, children }) {
             >
               <DowntimeNotification
                 appTitle={`CHAMPVA Form ${formConfig.formId}`}
-                dependencies={[externalServices.pega]}
+                dependencies={[
+                  externalServices.pega,
+                  externalServices.form107959F1,
+                ]}
               >
                 {children}
               </DowntimeNotification>

--- a/src/applications/ivc-champva/10-7959f-1/containers/App.jsx
+++ b/src/applications/ivc-champva/10-7959f-1/containers/App.jsx
@@ -39,7 +39,7 @@ export default function App({ location, children }) {
                 appTitle={`CHAMPVA Form ${formConfig.formId}`}
                 dependencies={[
                   externalServices.pega,
-                  externalServices.form107959F1,
+                  externalServices.form107959f1,
                 ]}
               >
                 {children}

--- a/src/platform/monitoring/DowntimeNotification/config/externalServices.js
+++ b/src/platform/monitoring/DowntimeNotification/config/externalServices.js
@@ -17,6 +17,8 @@ export default {
   evss: 'evss',
   '1010ez': '1010ez',
   '1010ezr': '1010ezr',
+  // IVC CHAMPVA form controls
+  form107959f1: 'form107959f1',
   // global downtime, for scheduled downtime on apps that don't have specific dependencies documented
   global: 'global',
   // Intake, conversion, and mail handling services (central mail)


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [X] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [X] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Follow on PR to these others ([vsp-infra](https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3160), [vets-api](https://github.com/department-of-veterans-affairs/vets-api/pull/18968)) that bring in a new external service for form 10-7959f-1. This will allow for maintenance windows to be set on this form specifically.

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95059
- https://github.com/department-of-veterans-affairs/vets-api/pull/18968
- https://github.com/department-of-veterans-affairs/vsp-infra-application-manifests/pull/3160

## Testing done

- None yet - this is a production external service dependency so can't test until deployed

## Screenshots

NA

## What areas of the site does it impact?

This form only

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

NA
