### PR TITLE
93260 - Removes aria-label attribute

### DIFF
--- a/src/applications/vaos/components/FacilityDirectionsLink.jsx
+++ b/src/applications/vaos/components/FacilityDirectionsLink.jsx
@@ -49,8 +49,6 @@ export default function FacilityDirectionsLink({ location, icon }) {
     <span>
       <NewTabAnchor
         href={`https://maps.google.com?saddr=Current+Location&daddr=${address}`}
-        aria-label={`Directions to ${location.name ||
-          location.providerPractice}`}
       >
         {icon && <va-icon icon="directions" size="3" />}
         Directions


### PR DESCRIPTION
## Summary

This PR removes an unneeded `aria-label` attribute on the facilities directions link as recommended during the collab cycle.
 
## Related issue(s)
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/93260
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/88451

## Testing done

- Unit tests
- e2e tests
- Manual testing locally


## Acceptance criteria

### Quality Assurance & Testing

- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)


