### PR TITLE
Global | Change profile success alert

### DIFF
--- a/src/platform/forms-system/src/js/components/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/components/ContactInfo.jsx
@@ -226,8 +226,7 @@ const ContactInfo = ({
       visible={editState === `${id},updated`}
       class="vads-u-margin-y--1"
       status="success"
-      background-only
-      role="alert"
+      slim
     >
       {`${text} ${content.updated}`}
     </va-alert>

--- a/src/platform/forms-system/src/js/components/ContactInfo.jsx
+++ b/src/platform/forms-system/src/js/components/ContactInfo.jsx
@@ -356,7 +356,7 @@ const ContactInfo = ({
             missingInfo.length === 0 &&
             validationErrors.length === 0 && (
               <div className="vads-u-margin-top--1p5">
-                <va-alert status="success" background-only>
+                <va-alert status="success" slim>
                   <div className="vads-u-font-size--base">
                     {content.alertContent}
                   </div>
@@ -372,7 +372,7 @@ const ContactInfo = ({
               </p>
               {submitted && (
                 <div className="vads-u-margin-top--1p5" role="alert">
-                  <va-alert status="error" background-only>
+                  <va-alert status="error" slim>
                     <div className="vads-u-font-size--base">
                       We still don’t have your {list}. Please edit and update
                       the field.
@@ -381,7 +381,7 @@ const ContactInfo = ({
                 </div>
               )}
               <div className="vads-u-margin-top--1p5" role="alert">
-                <va-alert status="warning" background-only>
+                <va-alert status="warning" slim>
                   <div className="vads-u-font-size--base">
                     Your {list} {plural ? 'are' : 'is'} missing. Please edit and
                     update the {plural ? 'fields' : 'field'}.
@@ -394,7 +394,7 @@ const ContactInfo = ({
             missingInfo.length === 0 &&
             validationErrors.length > 0 && (
               <div className="vads-u-margin-top--1p5" role="alert">
-                <va-alert status="error" background-only>
+                <va-alert status="error" slim>
                   <div className="vads-u-font-size--base">
                     {validationErrors[0]}
                   </div>


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > On the profile contact info page and after a successful profile update, a successful alert appears.
  > - This alert is currently set as with background-only, but needs to be set as `slim`
  > - This alert also includes a `role="alert"` which causes screen readers to announce multiple non-visible alerts (See https://github.com/department-of-veterans-affairs/va.gov-team/issues/95187)
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

- Use slim alert - https://github.com/department-of-veterans-affairs/va.gov-team/issues/95171
- Remove `role="alert"` - https://github.com/department-of-veterans-affairs/va.gov-team/issues/95187

## Testing done

- _Describe what the old behavior was prior to the change_
  > - Check icon is too large because a slim alert isn't being used
  > - Screen reader announces multiple alerts that aren't yet visible
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Contact successful update  | <img width="400" alt="Profile successful update with background-only alert" src="https://github.com/user-attachments/assets/175a5cf0-9e8e-4819-aef8-57ec138f86cf"> | <img width="400" alt="Profile successful update with slim alert" src="https://github.com/user-attachments/assets/274d9031-bbbc-41d1-8e74-634be6ffc8c7"> |

## What areas of the site does it impact?

All apps that use platform contact info component

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [x] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
