### PR TITLE
Pre-check-in tweaks to address drops in useage

### DIFF
--- a/src/applications/check-in/components/ActionLink.jsx
+++ b/src/applications/check-in/components/ActionLink.jsx
@@ -11,7 +11,7 @@ const ActionLink = props => {
 
   const linkText =
     app === APP_NAMES.PRE_CHECK_IN
-      ? t('review-your-information-now')
+      ? t('review-your-information-now-to-complete-pre-check-in')
       : t('check-in-now');
 
   let label = false;

--- a/src/applications/check-in/components/UpcomingAppointmentsVista.jsx
+++ b/src/applications/check-in/components/UpcomingAppointmentsVista.jsx
@@ -15,7 +15,7 @@ const UpcomingAppointments = props => {
   const heading =
     app === APP_NAMES.CHECK_IN
       ? t('todays-appointments-at-this-facility')
-      : t('your-appointments', { count: appointments.length });
+      : t('your-appointments-for-pre-check-in');
   return (
     <section data-testid="upcoming-appointments-vista">
       <h2 data-testid="upcoming-appointments-header-vista">{heading}</h2>

--- a/src/applications/check-in/components/pages/Appointments/AppointmentsPage.unit.spec.jsx
+++ b/src/applications/check-in/components/pages/Appointments/AppointmentsPage.unit.spec.jsx
@@ -65,7 +65,7 @@ describe('unified check-in experience', () => {
     });
     it('shows the date & time the appointments were loaded & a refresh link', () => {
       const checkIn = render(
-        <CheckInProvider store={{ features: appointmentsOn }}>
+        <CheckInProvider store={{ features: appointmentsOn, app: 'dayOf' }}>
           <AppointmentsPage />
         </CheckInProvider>,
       );

--- a/src/applications/check-in/components/pages/Appointments/index.jsx
+++ b/src/applications/check-in/components/pages/Appointments/index.jsx
@@ -146,14 +146,16 @@ const AppointmentsPage = props => {
             values={{ date: new Date() }}
           />
         </p>
-        <va-button
-          uswds
-          text={t('refresh')}
-          big
-          onClick={() => setRefresh(true)}
-          secondary
-          data-testid="refresh-appointments-button"
-        />
+        {app === APP_NAMES.CHECK_IN && (
+          <va-button
+            uswds
+            text={t('refresh')}
+            big
+            onClick={() => setRefresh(true)}
+            secondary
+            data-testid="refresh-appointments-button"
+          />
+        )}
         {isUpcomingAppointmentsEnabled && <LinkList router={router} />}
       </div>
       <AppointmentListInfoBlock />

--- a/src/applications/check-in/components/tests/ActionLink.unit.spec.jsx
+++ b/src/applications/check-in/components/tests/ActionLink.unit.spec.jsx
@@ -24,10 +24,7 @@ describe('unified check-in experience', () => {
           />
         </CheckInProvider>,
       );
-      expect(getByTestId('action-link')).to.have.attribute(
-        'text',
-        'Review your information now',
-      );
+      expect(getByTestId('review-information-button')).to.exist;
     });
     it('display the correct label for dayOf', () => {
       const { getByTestId } = render(
@@ -39,10 +36,7 @@ describe('unified check-in experience', () => {
           />
         </CheckInProvider>,
       );
-      expect(getByTestId('action-link')).to.have.attribute(
-        'text',
-        'Check in now',
-      );
+      expect(getByTestId('check-in-button')).to.exist;
     });
     it('calls action method once when clicked', () => {
       const actionSpy = sinon.spy();

--- a/src/applications/check-in/locales/en/translation.json
+++ b/src/applications/check-in/locales/en/translation.json
@@ -452,5 +452,7 @@
   "claims-for-past-va-appointments": "Claims for past VA appointments that happened before today",
   "claims-for-community-care-appointments": "Claims for community care appointments",
   "claims-for-other-expenses": "Claims for other expenses, like lodging, meals, or tolls",
-  "learn-how-to-file-other-types-of-claims": "Learn how to file other types of claims"
+  "learn-how-to-file-other-types-of-claims": "Learn how to file other types of claims",
+  "review-your-information-now-to-complete-pre-check-in": "Review your information now to complete pre-check-in",
+  "your-appointments-for-pre-check-in": "Your appointments for pre-check-in"
 }


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

If the folder you changed contains a `manifest.json`, search for its `entryName` in the content-build [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) (the `entryName` there will match).

If an entry for this folder exists in content-build and you are:
1. **Deleting a folder**:
   1. First search `vets-website` for _all_ instances of the `entryName` in your `manifest.json` and remove them in a separate PR. Look particularly for references in `src/applications/static-pages/static-pages-entry.js` and `src/platform/forms/constants.js`. _**If you do not do this, other applications will break!**_
      - _Add the link to your merged vets-website PR here_
   2. Then, Delete the application entry in [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json) and merge that PR **before** this one
      - _Add the link to your merged content-build PR here_

2. **Renaming or moving a folder**: Update the entry in the [registry.json](https://github.com/department-of-veterans-affairs/content-build/blob/main/src/applications/registry.json), but do not merge it until your vets-website changes here are merged. The content-build PR must be merged immediately after your vets-website change is merged in to avoid CI errors with content-build (and Tugboat).

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

Various changes to address drop in usage of pre-check-in.

## Related issue(s)

- _Link to ticket created in va.gov-team repo_
department-of-veterans-affairs/va.gov-team#94164

## Testing done

- visual
- updates to unit tests

## Screenshots
![localhost_3001_health-care_appointment-pre-check-in_appointment-details_0003-0001 (3)](https://github.com/user-attachments/assets/93862084-54ee-4e62-85c0-c444343d17b5)

## What areas of the site does it impact?

Pre-check-in

## Acceptance criteria
 - [ ] all items in ticket have been addressed according to figma
### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)


