### PR TITLE
send claimant name and correct vet name

### DIFF
--- a/src/applications/survivor-dependent-education-benefit/22-5490/utils/form-submit-transform.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/utils/form-submit-transform.js
@@ -367,8 +367,9 @@ export function getAddressType(mailingAddress) {
 }
 
 export function transform5490Form(_formConfig, form) {
-  const formFieldUserFullName = form?.data?.fullName;
-  const viewComponentUserFullName = form?.loadedData?.formData?.fullName;
+  const formFieldUserFullName = form?.data?.claimantFullName;
+  const viewComponentUserFullName =
+    form?.loadedData?.formData?.claimantFullName;
   // const formFieldDateOfBirth = form?.data?.dateOfBirth;
   // const viewComponentDateOfBirth = form?.loadedData?.formData.dateOfBirth;
 
@@ -383,6 +384,9 @@ export function transform5490Form(_formConfig, form) {
     '@type': 'Chapter35Submission',
     chosenBenefit: form?.data?.chosenBenefit,
     claimant: {
+      firstName: userFullName?.first,
+      middleName: userFullName?.middle,
+      lastName: userFullName?.last,
       suffix: userFullName?.suffix,
       notificationMethod: getNotificationMethod(form?.data?.notificationMethod),
       contactInfo: {
@@ -402,10 +406,10 @@ export function transform5490Form(_formConfig, form) {
       preferredContact: form?.data?.contactMethod,
     },
     serviceMember: {
-      firstName: userFullName?.first,
-      lastName: userFullName?.last,
-      middleName: userFullName?.middle,
-      relationship: form?.data?.relationShipToMember,
+      firstName: form?.data?.fullName?.first,
+      lastName: form?.data?.fullName?.last,
+      middleName: form?.data?.fullName?.middle,
+      sponsorRelationship: form?.data?.relationShipToMember,
       dateOfBirth: form?.data?.relativeDateOfBirth,
       ssn: form?.data?.relativeSocialSecurityNumber,
     },


### PR DESCRIPTION
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- Send claimant name in payload
- update service member name to use correct name

