### PR TITLE
Global | Update profile save button

### DIFF
--- a/src/applications/appeals/10182/tests/10182-contact-loop.cypress.spec.js
+++ b/src/applications/appeals/10182/tests/10182-contact-loop.cypress.spec.js
@@ -165,7 +165,7 @@ describe('NOD contact info loop', () => {
 
     cy.get('va-text-input[value="5109224444"]');
 
-    cy.findAllByText(/save/i, { selector: 'button' })
+    cy.findAllByText(/update/i, { selector: 'button' })
       .first()
       .click({ waitForAnimations: true });
 

--- a/src/applications/appeals/995/tests/995-contact-loop.cypress.spec.js
+++ b/src/applications/appeals/995/tests/995-contact-loop.cypress.spec.js
@@ -147,7 +147,7 @@ describe('995 contact info loop', () => {
 
     cy.get('va-text-input[value="5109224444"]');
 
-    cy.findAllByText(/save/i, { selector: 'button' })
+    cy.findAllByText(/update/i, { selector: 'button' })
       .first()
       .click();
 

--- a/src/applications/appeals/996/tests/hlr-contact-loop.cypress.spec.js
+++ b/src/applications/appeals/996/tests/hlr-contact-loop.cypress.spec.js
@@ -123,7 +123,7 @@ describe('HLR contact info loop', () => {
 
     cy.get('va-text-input[value="5109224444"]');
 
-    cy.findAllByText(/save/i, { selector: 'button' })
+    cy.findAllByText(/update/i, { selector: 'button' })
       .first()
       .click();
 

--- a/src/platform/forms-system/src/js/components/EditContactInfo.jsx
+++ b/src/platform/forms-system/src/js/components/EditContactInfo.jsx
@@ -81,6 +81,7 @@ export const BuildPage = ({ title, field, id, goToPath, contactPath }) => {
           isDeleteDisabled
           cancelCallback={handlers.cancel}
           successCallback={handlers.success}
+          saveButtonText="Update"
         />
       </InitializeVAPServiceID>
     </div>

--- a/src/platform/forms-system/test/js/components/EditContactInfo.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/EditContactInfo.unit.spec.jsx
@@ -49,7 +49,7 @@ describe('EditContactInfo', () => {
       expect(phoneNumber.required).to.be.true;
       const extension = $('va-text-input[label^="Extension"]', container);
       expect(extension).to.exist;
-      expect(getByText('Save')).to.exist;
+      expect(getByText('Update')).to.exist;
       expect($('va-button[text="Cancel"]', container)).to.exist;
     });
 

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -751,3 +751,8 @@ va-checkbox.statement-of-truth-va-checkbox::part(checkbox) {
 @include header-style("rjsf-wc-header--h2", $h2-font-size, $h3-font-size);
 @include header-style("rjsf-wc-header--h3", $h3-font-size, $h4-font-size);
 @include header-style("rjsf-wc-header--h4", $h4-font-size, $h5-font-size);
+
+/* Edit contact info save button */
+.va-profile-wrapper button[data-action="save-edit"] {
+  padding: 0.45rem 1.25rem;
+}


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- _(Summarize the changes that have been made to the platform)_
  > During staging review, one issues was found on the profile edit pages. The "Save" button text should be changed to "Update" and make the button size match the "Cancel" button.
- _(If bug, how to reproduce)_
- _(What is the solution, why is this the solution)_
- _(Which team do you work for, does your team own the maintenance of this component?)_
 > Benefits Decision Reviews
- _(If using a flipper, what is the end date of the flipper being required/success criteria being targeted)_

## Related issue(s)

https://github.com/department-of-veterans-affairs/va.gov-team/issues/95170

## Testing done

- _Describe what the old behavior was prior to the change_
- _Describe the steps required to verify your changes are working as expected_
- _Describe the tests completed and the results_
- _Exclusively stating 'Specs and automated tests passing' is NOT acceptable as appropriate testing
- _Optionally, provide a link to your [test plan](https://depo-platform-documentation.scrollhelp.site/developer-docs/create-a-test-plan-in-testrail) and [test execution records](https://depo-platform-documentation.scrollhelp.site/developer-docs/execute-tests-in-testrail)_

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  | <img width="500" alt="Mobile number editing page with save button being slightly larger than the cancel button" src="https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/working-with-vsp/vsp-collaboration-cycle/staging-review-images/90188-Allison-2.png?raw=true" /> | <img width="500" alt="mobile number editing page with a button renamed to 'update' and is now the same size as the cancel button" src="https://github.com/user-attachments/assets/9223c3e9-59c5-4b06-a2a2-6bc61e3d07d7">


## What areas of the site does it impact?

*(Describe what parts of the site are impacted **if** code touched other areas)*

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
