### PR TITLE
Edm 180 currency message

### DIFF
--- a/src/applications/gi/components/profile/InstitutionProfile.jsx
+++ b/src/applications/gi/components/profile/InstitutionProfile.jsx
@@ -196,7 +196,7 @@ export default function InstitutionProfile({
             <p>
               The Yellow Ribbon program can be paid towards net tuition and fee
               costs not covered by the Post-9/11 GI Bill at participating
-              institutions of higher learning. Schools that choose to
+              institutions of higher learning (IHL). Schools that choose to
               participate in the Yellow Ribbon program will contribute up to a
               certain dollar amount toward the extra tuition. VA will match the
               participating school’s contribution
@@ -209,13 +209,41 @@ export default function InstitutionProfile({
               href="/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program/"
               text="Find out if you qualify for the Yellow Ribbon Program"
             />
+
+            <div className="additional-info-wrapper vads-u-padding-top--4">
+              <p className="vads-u-font-weight--bold ">
+                What to know about the content displayed in this table
+              </p>
+              <ul>
+                <li>
+                  Degree level: Type of degree such as Undergraduate, Graduate,
+                  Masters, or Doctorate.
+                </li>
+                <li>
+                  College or professional school: A school within a college or
+                  university that has a specialized professional or academic
+                  focus.
+                </li>
+                <li>
+                  Funding available: Total number of students eligible to
+                  receive funding.
+                </li>
+                <li>
+                  School contribution: Maximum amount the IHL will contribute
+                  per student each academic year toward unmet tuition and fee
+                  costs.
+                </li>
+              </ul>
+            </div>
             {institution.yellowRibbonPrograms.length > 0 ? (
               <YellowRibbonTable
                 programs={institution.yellowRibbonPrograms}
                 smallScreen={smallScreen}
               />
             ) : (
-              <p className="vads-u-font-weight--bold">No programs to display</p>
+              <p className="vads-u-font-weight--bold vads-u-padding-top--3">
+                No programs to display
+              </p>
             )}
           </ProfileSection>
         )}

--- a/src/applications/gi/components/profile/InstitutionProfile.jsx
+++ b/src/applications/gi/components/profile/InstitutionProfile.jsx
@@ -174,31 +174,6 @@ export default function InstitutionProfile({
           </ProfileSection>
         )}
 
-      {institution.yr === true &&
-        toggleValue && (
-          <ProfileSection
-            label="Yellow ribbon program information"
-            id="yellow-ribbon-program-information"
-          >
-            <p>
-              The Yellow Ribbon Program can help you pay for out-of-state,
-              private school, or graduate school tuition that the Post-9/11 GI
-              Bill doesn't cover. Schools that choose to participate in the
-              Yellow Ribbon program will contribute a certain amount toward the
-              extra tutition. VA will match the participating school's
-              contribution, up to the total cost of the tuition and fees.
-            </p>
-            <va-link
-              href="/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program/"
-              text="Find out if you qualify for the Yellow Ribbon Program"
-            />
-            <YellowRibbonTable
-              programs={institution.yellowRibbonPrograms}
-              smallScreen={smallScreen}
-            />
-          </ProfileSection>
-        )}
-
       {type === 'FOREIGN' && (
         <p>
           Limited programs are approved at foreign schools, please contact
@@ -212,6 +187,38 @@ export default function InstitutionProfile({
           location.
         </p>
       )}
+      {institution.yr === true &&
+        toggleValue && (
+          <ProfileSection
+            label="Yellow ribbon program information"
+            id="yellow-ribbon-program-information"
+          >
+            <p>
+              The Yellow Ribbon program can be paid towards net tuition and fee
+              costs not covered by the Post-9/11 GI Bill at participating
+              institutions of higher learning. Schools that choose to
+              participate in the Yellow Ribbon program will contribute up to a
+              certain dollar amount toward the extra tuition. VA will match the
+              participating school’s contribution
+              {type === 'FOREIGN' && `${` `}in United States Dollars (USD)`}, up
+              to the total cost of the tuition and fees. Please contact the
+              individual school to validate the number of students remaining to
+              receive funding.
+            </p>
+            <va-link
+              href="/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program/"
+              text="Find out if you qualify for the Yellow Ribbon Program"
+            />
+            {institution.yellowRibbonPrograms.length > 0 ? (
+              <YellowRibbonTable
+                programs={institution.yellowRibbonPrograms}
+                smallScreen={smallScreen}
+              />
+            ) : (
+              <p className="vads-u-font-weight--bold">No programs to display</p>
+            )}
+          </ProfileSection>
+        )}
       <ProfileSection
         label="Getting started with benefits"
         id="getting-started-with-benefits"

--- a/src/applications/gi/components/profile/YellowRibbonTable.jsx
+++ b/src/applications/gi/components/profile/YellowRibbonTable.jsx
@@ -124,6 +124,6 @@ function YellowRibbonTable({ programs }) {
   );
 }
 
-YellowRibbonTable.propTypes = { programs: PropTypes.array };
+YellowRibbonTable.propTypes = { programs: PropTypes.array.isRequired };
 
 export default YellowRibbonTable;


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This PR conditionally updates the verbiage used in the yellow ribbon section of an institution profile in Comparison Tool, based on whether the institution is foreign or not.
- I work for the Education Data Migration team, but VEBT has ownership of Comparison Tool
- All changes are still located behind a feature toggle, along with the rest of the yellow ribbon section, likely until this project's contract expiration in the spring.

## Related issue(s)

- EDM-180: Add United States/US Dollars (USD) to foreign currency message.

## Testing done

- No additional testing performed as these were updates to the static UI.

## Screenshots

All changes currently behind a feature flag and will likely be refactored again before releasing on production.

## What areas of the site does it impact?

GI Bill Comparison Tool

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- No authenticated user required for these changes.