### PR TITLE
93285 - remove unneeded aria labels from appointment list

### DIFF
--- a/src/applications/vaos/appointment-list/components/AppointmentsPage/AppointmentColumnLayout.jsx
+++ b/src/applications/vaos/appointment-list/components/AppointmentsPage/AppointmentColumnLayout.jsx
@@ -51,8 +51,8 @@ export default function AppointmentColumnLayout({
           'mobile:vads-u-padding-top--1',
           'medium-screen:vads-u-padding-top--0',
         )}
-        aria-label={dateAriaLabel}
       >
+        <span className="sr-only">{dateAriaLabel}</span>
         <AppointmentRow
           className={classNames(
             'vaos-appts__column--alignItems',

--- a/src/applications/vaos/appointment-list/components/PastAppointmentsList/index.jsx
+++ b/src/applications/vaos/appointment-list/components/PastAppointmentsList/index.jsx
@@ -228,14 +228,10 @@ export default function PastAppointmentsListNew() {
               data-cy="past-appointment-list-header"
               className="vads-u-margin-top--0 vads-u-font-size--h3"
             >
-              <span className="sr-only">Appointments in </span>
               {monthDate.format('MMMM YYYY')}
             </h2>
             {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
             <ul
-              aria-labelledby={`appointment_list_${monthDate.format(
-                'YYYY-MM',
-              )}`}
               className={classNames(
                 'usa-unstyled-list',
                 'vads-u-padding-left--0',

--- a/src/applications/vaos/appointment-list/components/PastAppointmentsList/index.jsx
+++ b/src/applications/vaos/appointment-list/components/PastAppointmentsList/index.jsx
@@ -229,7 +229,6 @@ export default function PastAppointmentsListNew() {
               data-cy="past-appointment-list-header"
               className="vads-u-margin-top--0 vads-u-font-size--h3"
             >
-              <span className="sr-only">Appointments in </span>
               {monthDate.format('MMMM YYYY')}
             </h2>
             {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}

--- a/src/applications/vaos/appointment-list/components/PastAppointmentsList/index.jsx
+++ b/src/applications/vaos/appointment-list/components/PastAppointmentsList/index.jsx
@@ -225,14 +225,18 @@ export default function PastAppointmentsListNew() {
         return (
           <React.Fragment key={key}>
             <h2
-              // id={`appointment_list_${monthDate.format('YYYY-MM')}`}
+              id={`appointment_list_${monthDate.format('YYYY-MM')}`}
               data-cy="past-appointment-list-header"
               className="vads-u-margin-top--0 vads-u-font-size--h3"
             >
+              <span className="sr-only">Appointments in </span>
               {monthDate.format('MMMM YYYY')}
             </h2>
             {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
             <ul
+              aria-labelledby={`appointment_list_${monthDate.format(
+                'YYYY-MM',
+              )}`}
               className={classNames(
                 'usa-unstyled-list',
                 'vads-u-padding-left--0',

--- a/src/applications/vaos/appointment-list/components/PastAppointmentsList/index.jsx
+++ b/src/applications/vaos/appointment-list/components/PastAppointmentsList/index.jsx
@@ -225,7 +225,6 @@ export default function PastAppointmentsListNew() {
         return (
           <React.Fragment key={key}>
             <h2
-              id={`appointment_list_${monthDate.format('YYYY-MM')}`}
               data-cy="past-appointment-list-header"
               className="vads-u-margin-top--0 vads-u-font-size--h3"
             >

--- a/src/applications/vaos/appointment-list/components/PastAppointmentsList/index.jsx
+++ b/src/applications/vaos/appointment-list/components/PastAppointmentsList/index.jsx
@@ -225,7 +225,7 @@ export default function PastAppointmentsListNew() {
         return (
           <React.Fragment key={key}>
             <h2
-              id={`appointment_list_${monthDate.format('YYYY-MM')}`}
+              // id={`appointment_list_${monthDate.format('YYYY-MM')}`}
               data-cy="past-appointment-list-header"
               className="vads-u-margin-top--0 vads-u-font-size--h3"
             >
@@ -233,9 +233,6 @@ export default function PastAppointmentsListNew() {
             </h2>
             {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
             <ul
-              aria-labelledby={`appointment_list_${monthDate.format(
-                'YYYY-MM',
-              )}`}
               className={classNames(
                 'usa-unstyled-list',
                 'vads-u-padding-left--0',

--- a/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
+++ b/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
@@ -105,9 +105,6 @@ export default function UpcomingAppointmentsList() {
             </h2>
             {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
             <ul
-              aria-labelledby={`appointment_list_${monthDate.format(
-                'YYYY-MM',
-              )}`}
               className={classNames(
                 'usa-unstyled-list',
                 'vads-u-padding-left--0',

--- a/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
+++ b/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
@@ -98,7 +98,6 @@ export default function UpcomingAppointmentsList() {
               className={classNames('vads-u-font-size--h3', {
                 'vads-u-margin-top--0': index === 0,
               })}
-              id={`appointment_list_${monthDate.format('YYYY-MM')}`}
               data-testid="appointment-list-header"
             >
               {monthDate.format('MMMM YYYY')}

--- a/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
+++ b/src/applications/vaos/appointment-list/components/UpcomingAppointmentsList.jsx
@@ -101,7 +101,6 @@ export default function UpcomingAppointmentsList() {
               id={`appointment_list_${monthDate.format('YYYY-MM')}`}
               data-testid="appointment-list-header"
             >
-              <span className="sr-only">Appointments in </span>
               {monthDate.format('MMMM YYYY')}
             </h2>
             {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}

--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -483,11 +483,13 @@ export function selectIsClinicVideo(appointment) {
 export function selectVideoData(appointment) {
   return appointment?.videoData || {};
 }
+
 export function selectVideoProviderName(appointment) {
   const videoData = selectVideoData(appointment);
   const [first] = videoData?.providers || [];
   return first?.display;
 }
+
 export function selectVideoProviderAddress(appointment) {
   const videoData = selectVideoData(appointment);
   return videoData?.atlasLocation?.address;
@@ -596,16 +598,19 @@ export function selectApptDetailAriaText(appointment, isRequest = false) {
 
   return `${fillin1} ${modality} ${fillin2} ${fillin3}`;
 }
+
 export function selectApptDateAriaText(appointment) {
   const appointmentDate = selectStartDate(appointment);
   const timezoneName = getTimezoneNameFromAbbr(selectTimeZoneAbbr(appointment));
   return `${appointmentDate.format(`dddd, MMMM D h:mm a, [${timezoneName}]`)}`;
 }
+
 export function selectTypeOfCareAriaText(appointment) {
   const typeOfCareText = selectAppointmentLocality(appointment);
   const isCanceled = selectIsCanceled(appointment);
   return `${isCanceled ? 'canceled ' : ''}${typeOfCareText}`;
 }
+
 export function selectModalityAriaText(appointment) {
   const modalityText = selectModalityText(appointment);
   const isCanceled = selectIsCanceled(appointment);

--- a/src/applications/vaos/appointment-list/redux/selectors.js
+++ b/src/applications/vaos/appointment-list/redux/selectors.js
@@ -598,13 +598,8 @@ export function selectApptDetailAriaText(appointment, isRequest = false) {
 }
 export function selectApptDateAriaText(appointment) {
   const appointmentDate = selectStartDate(appointment);
-  const isCanceled = selectIsCanceled(appointment);
   const timezoneName = getTimezoneNameFromAbbr(selectTimeZoneAbbr(appointment));
-  return `${
-    isCanceled ? 'canceled ' : ''
-  } appointment on ${appointmentDate.format(
-    `dddd, MMMM D h:mm a, [${timezoneName}]`,
-  )}`;
+  return `${appointmentDate.format(`dddd, MMMM D h:mm a, [${timezoneName}]`)}`;
 }
 export function selectTypeOfCareAriaText(appointment) {
   const typeOfCareText = selectAppointmentLocality(appointment);

--- a/src/applications/vaos/tests/appointment-list/components/PastAppointmentsListV2.unit.spec.js
+++ b/src/applications/vaos/tests/appointment-list/components/PastAppointmentsListV2.unit.spec.js
@@ -144,7 +144,7 @@ describe('VAOS Page: PastAppointmentsList V2 api', () => {
     const firstCard = screen.getAllByRole('listitem')[0];
 
     const timeHeader = within(firstCard).getAllByText(
-      new RegExp(pastDate.format('h:mm'), 'i'),
+      new RegExp(`^${pastDate.format('h:mm')}`, 'i'),
     )[0];
 
     expect(screen.queryByText(/You don’t have any appointments/i)).not.to.exist;
@@ -229,7 +229,9 @@ describe('VAOS Page: PastAppointmentsList V2 api', () => {
     const firstCard = screen.getAllByRole('listitem')[0];
 
     expect(
-      within(firstCard).getByText(new RegExp(pastDate.format('h:mm'), 'i')),
+      within(firstCard).getByText(
+        new RegExp(`^${pastDate.format('h:mm')}`, 'i'),
+      ),
     ).to.exist;
     // TODO: Skipping until api call is made to get facility data on page load.
     // Currently, facility data is only retrieved when viewing appointment details
@@ -325,7 +327,9 @@ describe('VAOS Page: PastAppointmentsList V2 api', () => {
     ).to.exist;
 
     expect(
-      within(firstCard).getByText(new RegExp(pastDate.format('h:mm'), 'i')),
+      within(firstCard).getByText(
+        new RegExp(`^${pastDate.format('h:mm')}`, 'i'),
+      ),
     ).to.exist;
 
     expect(within(firstCard).getByText(/MT/i)).to.exist;


### PR DESCRIPTION
## Summary

This PR corrects some aria labelling on the appointment list screens and addresses the feedback that came out of a staging review.

See https://github.com/department-of-veterans-affairs/va.gov-team/issues/55864 and https://github.com/department-of-veterans-affairs/va.gov-team/issues/55851 for the full context.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/93285

## Testing done

- Unit tests
- e2e tests
- Manual inspection of elements

## Acceptance criteria

- [ ] For the aria-label on a div in the first column of each appointment:
   - Remove the `aria-label` attribute, and move its content into `<span class="sr-only">` tags inside the div it's currently attached to. (`aria-label` isn't a valid attribute for `div`s)
   - Remove the text ` appointment on` from the content. The span should just contain the date information, i.e.: `<span class="sr-only">Friday, September 20, 9:40 a.m. Pacific Time</span>`

![image](https://github.com/user-attachments/assets/97acd9ac-a8ac-480c-bfb6-6b3411c48c52)

---

- [ ] Remove `<span class="sr-only">Appointments in</span>` from the H2 month/year headings:

![image](https://github.com/user-attachments/assets/a004f546-20c7-4822-b048-95c7c297a76f)

---

- [ ] Remove the `aria-labelledby` attribute from the ul that follows the heading. The context of the heading is enough to create the association. (Also remove the ID on the heading if this isn't being used for other functionality).

![image](https://github.com/user-attachments/assets/b108a13f-214a-40f7-8b3f-06ac8179eeb1)


---

### Quality Assurance & Testing

- [ ] I updated unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed

### Error Handling

- [ ] Browser console contains no warnings or errors.

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
