### PR TITLE
VAGOV-TEAM-94367: Removes unauthed link from Introduction page

### DIFF
--- a/src/applications/form-renderer/containers/IntroductionPage.jsx
+++ b/src/applications/form-renderer/containers/IntroductionPage.jsx
@@ -26,6 +26,7 @@ const IntroductionPage = props => {
         messages={formConfig.savedFormMessages}
         pageList={pageList}
         startText="Start the Application"
+        hideUnauthedStartLink
       >
         Please complete the form to apply for benefits.
       </SaveInProgressIntro>
@@ -79,6 +80,7 @@ const IntroductionPage = props => {
         messages={formConfig.savedFormMessages}
         pageList={pageList}
         startText="Start the Application"
+        hideUnauthedStartLink
       />
       <p />
       {ombInfo && (

--- a/src/applications/form-renderer/tests/unit/containers/IntroductionPage.unit.spec.js
+++ b/src/applications/form-renderer/tests/unit/containers/IntroductionPage.unit.spec.js
@@ -1,16 +1,59 @@
 import React from 'react';
 import { expect } from 'chai';
 import { render } from '@testing-library/react';
-import sinon from 'sinon';
+import { Provider } from 'react-redux';
 
-import * as SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import IntroductionPage from '../../../containers/IntroductionPage';
 import { formConfig1 } from '../../../_config/formConfig';
 
+const mockStore = {
+  getState: () => ({
+    user: {
+      login: {
+        currentlyLoggedIn: false,
+      },
+      profile: {
+        savedForms: [],
+        prefillsAvailable: [],
+        userFullName: {
+          first: 'John',
+          middle: 'A',
+          last: 'Doe',
+        },
+      },
+    },
+    form: {
+      loadedData: {
+        metadata: {},
+      },
+    },
+  }),
+  subscribe: () => {},
+  dispatch: () => {},
+};
+
+const renderWithProvider = (Component, store = mockStore) => {
+  return render(<Provider store={store}>{Component}</Provider>);
+};
+
 describe('<IntroductionPage /> component', () => {
-  // React Testing Library does not currently want to render the
-  // SaveInProgressIntro component.
-  beforeEach(() => sinon.stub(SaveInProgressIntro, 'default').value('div'));
+  describe('hides links for proceeding without logging in', () => {
+    it('does not render the link anywhere on the page', () => {
+      const screen = renderWithProvider(
+        <IntroductionPage
+          route={{
+            formConfig: formConfig1,
+            pageList: [],
+          }}
+        />,
+      );
+
+      const unauthedLink = screen.queryByText(
+        'Start your application without signing in',
+      );
+      expect(unauthedLink).to.not.exist;
+    });
+  });
 
   describe('ombInfo', () => {
     context('when ombInfo is present', () => {
@@ -21,7 +64,7 @@ describe('<IntroductionPage /> component', () => {
           resBurden: 30,
         };
 
-        const screen = render(
+        const screen = renderWithProvider(
           <IntroductionPage
             ombInfo={ombInfo}
             route={{
@@ -44,7 +87,7 @@ describe('<IntroductionPage /> component', () => {
 
     context('when ombInfo is missing', () => {
       it('omits the va-omb-info component', () => {
-        const screen = render(
+        const screen = renderWithProvider(
           <IntroductionPage
             route={{
               formConfig: formConfig1,


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
This PR removes the link from the Introduction page that allows navigating to the form without logging in. This is in alignment with a decision to require authentication in an effort to better avoid silent failures (we need to know who is filling out the form).

It's a very small change accomplished by passing the `hideUnauthedStartLink` property to the `SaveInProgressIntro` component.

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/94367

## Testing done
- Adds test to ensure link is not rendered
- Manually tests to ensure link is not rendered

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/b5b3a718-c053-4d60-a94e-5bbc64207f40)

### After
![image](https://github.com/user-attachments/assets/7c375650-fd74-40b2-af72-2a9aac1402ce)

## What areas of the site does it impact?

This change is limited to the `form-renderer` app.

## Acceptance criteria


### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication
N/A
- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
