### PR TITLE
VACMS-18797: Updates for disabling analytics for VA search results page

### DIFF
--- a/src/applications/resources-and-support/components/SearchBar.jsx
+++ b/src/applications/resources-and-support/components/SearchBar.jsx
@@ -219,7 +219,6 @@ function SearchBar({ onInputChange, previousValue, setSearchData, userInput }) {
           )}
           <VaSearchInput
             buttonText="Search"
-            disableAnalytics
             label="Enter a keyword, phrase, or question"
             onInput={handleInputChange}
             onSubmit={e => handleSubmit(e)}

--- a/src/applications/resources-and-support/components/SearchBar.jsx
+++ b/src/applications/resources-and-support/components/SearchBar.jsx
@@ -219,6 +219,7 @@ function SearchBar({ onInputChange, previousValue, setSearchData, userInput }) {
           )}
           <VaSearchInput
             buttonText="Search"
+            disableAnalytics
             label="Enter a keyword, phrase, or question"
             onInput={handleInputChange}
             onSubmit={e => handleSubmit(e)}

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -332,6 +332,7 @@ const SearchApp = ({
               <div className="va-flex search-box vads-u-margin-top--1 vads-u-margin-bottom--0">
                 <VaSearchInput
                   class="vads-u-width--full"
+                  disableAnalytics
                   id="search-results-page-dropdown-input-field"
                   data-e2e-id="search-results-page-dropdown-input-field"
                   label="Enter a keyword, phrase, or question"


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary
Disable analytics from firing from the DST search component on results search

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/18797

## Testing done
Tested locally using adswerve only one event is shown now

## Screenshots

<img width="1507" alt="Search_Results___Veterans_Affairs" src="https://github.com/user-attachments/assets/92b089cb-8959-421c-83cb-f6f242267ffe">

## What areas of the site does it impact?
Search results

## Acceptance criteria

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [x] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

