### PR TITLE
Remove check for Search.gov maintenance for displaying results

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -343,7 +343,7 @@ const SearchApp = ({
                 />
               </div>
             </div>
-            {!shouldShowErrorMessage && !searchGovIssues && renderResults()}
+            {!shouldShowErrorMessage && renderResults()}
           </DowntimeNotification>
         </div>
         <div className="vads-u-margin-top--3 medium-screen:vads-u-margin-top--0 usa-width-one-fourth columns">


### PR DESCRIPTION
## Summary
We have been seeing some downtime from the Search.gov service causing our VA.gov searches to fail. We turned on the `search_gov_maintenance` flipper in prod which correctly showed the banner. But when results were being returned successfully with the banner on, the results weren't showing. This is due to an oversight in rendering the results list - currently it doesn't render if one of the Search.gov maintenance banners is present.

This removes the check for the Search.gov maintenance banners in order to show results.

## Related issue(s)
Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/95596

## Testing done
Tested locally against the staging environment. `search_gov_maintenance` flipper is on in staging: https://staging-api.va.gov/flipper/features/search_gov_maintenance

## Screenshots
| Search banner is on, search call is successful and results are returned |
| --- |
| <img width="1110" alt="Screenshot 2024-10-22 at 11 55 55 AM" src="https://github.com/user-attachments/assets/ba1b52b5-a752-45c5-bb74-1c2e7e8b80e9"> |

Screenshot below shows a successful call to the search endpoint

<img width="616" alt="Screenshot 2024-10-22 at 11 56 03 AM" src="https://github.com/user-attachments/assets/f3a836c2-01fe-48cd-b367-b5e16dbbfeb4">

### Cypress test screenshots 
<details><summary>I adjusted the Cypress tests and took screenshots of those as well:</summary>

| Search banner is on, search call is successful and results are returned |
| --- |
| <img width="1001" alt="Screenshot 2024-10-22 at 12 08 53 PM" src="https://github.com/user-attachments/assets/a7b1212b-e9bd-4e54-94c7-af68dbe21ec1"> |

| Search banner is on, search call is successful but results are empty |
| --- |
| <img width="1000" alt="Screenshot 2024-10-22 at 12 09 09 PM" src="https://github.com/user-attachments/assets/5bd1b52c-f2e8-4ebb-99ac-3c4e5e2c1052"> |

| Search banner is on, search call fails (server error) |
| --- |
| <img width="1003" alt="Screenshot 2024-10-22 at 12 09 18 PM" src="https://github.com/user-attachments/assets/30479cee-407d-4c09-9b2f-c11e9470ef19"> |

</details>


## What areas of the site does it impact?

Global search only.

## Acceptance criteria

- [x] When any Search.gov maintenance banner is present, the results should display

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] Linting warnings have been addressed
- [x] Screenshot of the developed feature is added

### Error Handling

- [x] Browser console contains no warnings or errors.