### PR TITLE
make claimant info call when chapter is selected when meb160630Automa…

### DIFF
--- a/src/applications/my-education-benefits/actions/index.js
+++ b/src/applications/my-education-benefits/actions/index.js
@@ -73,12 +73,12 @@ const FIVE_SECONDS = 5000;
 const ONE_MINUTE_IN_THE_FUTURE = () => {
   return new Date(new Date().getTime() + 60000);
 };
-export function fetchPersonalInformation(showMebEnhancements09) {
+export function fetchPersonalInformation(selectedChapter) {
   return async dispatch => {
     dispatch({ type: FETCH_PERSONAL_INFORMATION });
-    return apiRequest(CLAIMANT_INFO_ENDPOINT)
+    return apiRequest(`${CLAIMANT_INFO_ENDPOINT}?type=${selectedChapter}`)
       .then(response => {
-        if (!response?.data?.attributes?.claimant && !showMebEnhancements09) {
+        if (!response?.data?.attributes?.claimant) {
           window.location.href =
             '/education/apply-for-education-benefits/application/1990/';
         }
@@ -92,10 +92,6 @@ export function fetchPersonalInformation(showMebEnhancements09) {
           type: FETCH_PERSONAL_INFORMATION_FAILED,
           errors,
         });
-        if (!showMebEnhancements09) {
-          window.location.href =
-            '/education/apply-for-education-benefits/application/1990/';
-        }
       });
   };
 }

--- a/src/applications/my-education-benefits/actions/index.js
+++ b/src/applications/my-education-benefits/actions/index.js
@@ -157,9 +157,9 @@ export function fetchClaimStatus() {
     });
   };
 }
-export function fetchEligibility() {
+export function fetchEligibility(selectedChapter) {
   return async dispatch => {
-    dispatch({ type: FETCH_ELIGIBILITY });
+    dispatch({ type: `${FETCH_ELIGIBILITY}?type=${selectedChapter}` });
     return apiRequest(ELIGIBILITY_ENDPOINT)
       .then(response =>
         dispatch({
@@ -242,9 +242,9 @@ export function fetchDuplicateContactInfo(email, phoneNumber) {
       );
   };
 }
-export function fetchExclusionPeriods() {
+export function fetchExclusionPeriods(selectedChapter) {
   return async dispatch => {
-    dispatch({ type: FETCH_EXCLUSION_PERIODS });
+    dispatch({ type: `${FETCH_EXCLUSION_PERIODS}?=type=${selectedChapter}` });
     try {
       const response = await apiRequest(EXCLUSION_PERIODS_ENDPOINT);
       dispatch({

--- a/src/applications/my-education-benefits/containers/App.jsx
+++ b/src/applications/my-education-benefits/containers/App.jsx
@@ -109,7 +109,7 @@ export const App = ({
         getPersonalInfo(formData?.chosenBenefit);
       } else if (
         !formData[formFields.claimantId] &&
-        claimantInfo?.claimantId &&
+        claimantInfo &&
         meb160630Automation
       ) {
         setFormData({

--- a/src/applications/my-education-benefits/containers/App.jsx
+++ b/src/applications/my-education-benefits/containers/App.jsx
@@ -80,11 +80,38 @@ export const App = ({
         return;
       }
 
-      if (!fetchedPersonalInfo || !fetchedContactInfo) {
+      if (
+        (!fetchedPersonalInfo && !meb160630Automation) ||
+        (!fetchedContactInfo && !meb160630Automation)
+      ) {
         setFetchedPersonalInfo(true);
         setFetchedContactInfo(true);
-        getPersonalInfo(showMebEnhancements09);
-      } else if (!formData[formFields.claimantId] && claimantInfo?.claimantId) {
+        getPersonalInfo('Chapter33');
+      } else if (
+        !formData[formFields.claimantId] &&
+        claimantInfo?.claimantId &&
+        !meb160630Automation
+      ) {
+        setFormData({
+          ...formData,
+          ...claimantInfo,
+        });
+      }
+      if (
+        (!fetchedPersonalInfo &&
+          meb160630Automation &&
+          formData?.chosenBenefit) ||
+        (!fetchedContactInfo &&
+          (meb160630Automation && formData?.chosenBenefit))
+      ) {
+        setFetchedPersonalInfo(true);
+        setFetchedContactInfo(true);
+        getPersonalInfo(formData?.chosenBenefit);
+      } else if (
+        !formData[formFields.claimantId] &&
+        claimantInfo?.claimantId &&
+        meb160630Automation
+      ) {
         setFormData({
           ...formData,
           ...claimantInfo,
@@ -101,9 +128,7 @@ export const App = ({
       isLOA3,
       isLoggedIn,
       setFormData,
-      showMeb1990EZMaintenanceAlert,
-      showMeb1990EZR6MaintenanceMessage,
-      showMebEnhancements09,
+      meb160630Automation,
     ],
   );
 

--- a/src/applications/my-education-benefits/containers/App.jsx
+++ b/src/applications/my-education-benefits/containers/App.jsx
@@ -141,8 +141,11 @@ export const App = ({
       // the firstName check ensures that eligibility only gets called after we have obtained claimant info
       // we need this to avoid a race condition when a user is being loaded freshly from VADIR on DGIB
       if (firstName && !fetchedEligibility) {
+        const chosenBenefit = meb160630Automation
+          ? formData?.chosenBenefit
+          : 'Chapter33';
         setFetchedEligibility(true);
-        getEligibility();
+        getEligibility(chosenBenefit);
       } else if (eligibility && !formData.eligibility) {
         setFormData({
           ...formData,
@@ -194,8 +197,12 @@ export const App = ({
       // the firstName check ensures that exclusion periods only gets called after we have obtained claimant info
       // we need this to avoid a race condition when a user is being loaded freshly from VADIR on DGIB
       if (mebExclusionPeriodEnabled && firstName && !fetchedExclusionPeriods) {
+        const chosenBenefit = meb160630Automation
+          ? formData?.chosenBenefit
+          : 'Chapter33';
+
         setFetchedExclusionPeriods(true);
-        getExclusionPeriods();
+        getExclusionPeriods(chosenBenefit);
       }
       if (exclusionPeriods && !formData.exclusionPeriods) {
         const updatedFormData = {

--- a/src/applications/survivor-dependent-education-benefit/22-5490/actions.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/actions.js
@@ -3,7 +3,7 @@ import environment from 'platform/utilities/environment';
 
 export const CLAIMANT_INFO_ENDPOINT = `${
   environment.API_URL
-}/meb_api/v0/forms_claimant_info`;
+}/meb_api/v0/forms_claimant_info?type=Chapter35`;
 
 export const FETCH_PERSONAL_INFORMATION = 'FETCH_PERSONAL_INFORMATION';
 export const FETCH_PERSONAL_INFORMATION_SUCCESS =

--- a/src/applications/survivor-dependent-education-benefit/22-5490/utils/form-submit-transform.js
+++ b/src/applications/survivor-dependent-education-benefit/22-5490/utils/form-submit-transform.js
@@ -365,10 +365,10 @@ export function transform5490Form(_formConfig, form) {
       middleName: form?.data?.fullName?.middle,
       relationship: form?.data?.relationShipToMember,
       dateOfBirth: form?.data?.dateOfBirth,
-      ssn: form?.data?.relativeSocialSecurityNumber,
+      ssn: form?.data?.ssn,
     },
     highSchoolDiplomaInfo: {
-      highSchoolDiplomaOrCertificate: form?.data?.highSchoolDiploma === 'Yes',
+      highSchoolDiplomaOrCertificate: form?.data?.highSchoolDiploma === 'yes',
       highSchoolDiplomaOrCertificateDate: form?.data?.graduationDate,
     },
     directDeposit: {


### PR DESCRIPTION
### :warning: TeamSites :warning:
Examples of a TeamSite: https://va.gov/health and https://benefits.va.gov/benefits/. This scenario is also referred to as the "injected" header and footer. You can reach out in the `#sitewide-public-websites` Slack channel for questions.

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- When meb_1606_60_automation flag is on send selected form type on claimant info call

