### PR TITLE
Mhv 59706 blocked tg alert fix

### DIFF
--- a/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/ComposeForm.jsx
@@ -22,7 +22,6 @@ import {
   setCaretToPos,
   navigateToFolderByFolderId,
   resetUserSession,
-  updateTriageGroupRecipientStatus,
   dateFormat,
   scrollToTop,
 } from '../../util/helpers';
@@ -100,11 +99,7 @@ const ComposeForm = props => {
   const [attachFileSuccess, setAttachFileSuccess] = useState(false);
   const [deleteButtonClicked, setDeleteButtonClicked] = useState(false);
   const [savedDraft, setSavedDraft] = useState(false);
-  const [
-    showBlockedTriageGroupAlert,
-    setShowBlockedTriageGroupAlert,
-  ] = useState(false);
-  const [blockedTriageGroupList, setBlockedTriageGroupList] = useState([]);
+  const [currentRecipient, setCurrentRecipient] = useState(null);
 
   const { isSaving } = useSelector(state => state.sm.threadDetails);
   const categories = useSelector(state => state.sm.categories?.categories);
@@ -203,40 +198,22 @@ const ComposeForm = props => {
     [recipients, draft, allowedRecipients],
   );
 
-  useEffect(() => {
-    if (draft) {
-      const tempRecipient = {
-        recipientId: draft.recipientId,
-        name: draft.triageGroupName,
-        type: Recipients.CARE_TEAM,
-        status: RecipientStatus.ALLOWED,
-      };
+  useEffect(
+    () => {
+      if (draft) {
+        const tempRecipient = {
+          recipientId: draft.recipientId,
+          name: draft.triageGroupName,
+          type: Recipients.CARE_TEAM,
+          status: RecipientStatus.ALLOWED,
+        };
 
-      const {
-        isAssociated,
-        isBlocked,
-        formattedRecipient,
-      } = updateTriageGroupRecipientStatus(recipients, tempRecipient);
-
-      if (!isAssociated) {
-        setShowBlockedTriageGroupAlert(true);
-        setBlockedTriageGroupList([
-          formattedRecipient,
-          ...recipients.blockedRecipients,
-        ]);
-      } else if (isBlocked) {
-        setShowBlockedTriageGroupAlert(true);
-        setBlockedTriageGroupList(recipients.blockedRecipients);
+        setCurrentRecipient(tempRecipient);
       }
-    } else {
-      setShowBlockedTriageGroupAlert(
-        recipients.associatedBlockedTriageGroupsQty > 0,
-      );
-      setBlockedTriageGroupList(recipients.blockedRecipients);
-    }
-
-    // The Blocked Triage Group alert should stay visible until the draft is sent or user navigates away
-  }, []);
+      // The Blocked Triage Group alert should stay visible until the draft is sent or user navigates away
+    },
+    [draft],
+  );
 
   useEffect(
     () => {
@@ -722,12 +699,11 @@ const ComposeForm = props => {
         render={renderMHVDowntime}
       />
 
-      {showBlockedTriageGroupAlert &&
-      (noAssociations || allTriageGroupsBlocked) ? (
+      {noAssociations || allTriageGroupsBlocked ? (
         <BlockedTriageGroupAlert
-          blockedTriageGroupList={blockedTriageGroupList}
           alertStyle={BlockedTriageAlertStyles.ALERT}
           parentComponent={ParentComponent.COMPOSE_FORM}
+          currentRecipient={currentRecipient}
         />
       ) : (
         <EmergencyNote dropDownFlag />
@@ -791,8 +767,8 @@ const ComposeForm = props => {
           saveDraftHandler={saveDraftHandler}
         />
         <div>
-          {showBlockedTriageGroupAlert &&
-            (!noAssociations && !allTriageGroupsBlocked) && (
+          {!noAssociations &&
+            !allTriageGroupsBlocked && (
               <div
                 className="
                   vads-u-border-top--1px
@@ -801,9 +777,9 @@ const ComposeForm = props => {
                   vads-u-margin-bottom--neg2"
               >
                 <BlockedTriageGroupAlert
-                  blockedTriageGroupList={blockedTriageGroupList}
                   alertStyle={BlockedTriageAlertStyles.ALERT}
                   parentComponent={ParentComponent.COMPOSE_FORM}
+                  currentRecipient={currentRecipient}
                 />
               </div>
             )}

--- a/src/applications/mhv-secure-messaging/components/ComposeForm/ReplyForm.jsx
+++ b/src/applications/mhv-secure-messaging/components/ComposeForm/ReplyForm.jsx
@@ -9,7 +9,6 @@ import {
 
 import { updatePageTitle } from '@department-of-veterans-affairs/mhv/exports';
 import EmergencyNote from '../EmergencyNote';
-import { updateTriageGroupRecipientStatus } from '../../util/helpers';
 import CannotReplyAlert from '../shared/CannotReplyAlert';
 import BlockedTriageGroupAlert from '../shared/BlockedTriageGroupAlert';
 import ReplyDrafts from './ReplyDrafts';
@@ -54,33 +53,29 @@ const ReplyForm = props => {
     showBlockedTriageGroupAlert,
     setShowBlockedTriageGroupAlert,
   ] = useState(false);
-  const [blockedTriageGroupList, setBlockedTriageGroupList] = useState([]);
   const [hideDraft, setHideDraft] = useState(false);
+  const [currentRecipient, setCurrentRecipient] = useState(null);
 
-  useEffect(() => {
-    const draftToEdit = drafts?.[0];
-    if (draftToEdit) {
-      const tempRecipient = {
-        recipientId: draftToEdit.recipientId,
-        name:
-          messages.find(m => m.triageGroupName === draftToEdit.triageGroupName)
-            ?.triageGroupName || draftToEdit.triageGroupName,
-        type: Recipients.CARE_TEAM,
-        status: RecipientStatus.ALLOWED,
-      };
-      const {
-        isAssociated,
-        isBlocked,
-        formattedRecipient,
-      } = updateTriageGroupRecipientStatus(recipients, tempRecipient);
+  useEffect(
+    () => {
+      const draftToEdit = drafts?.[0];
+      if (draftToEdit) {
+        const tempRecipient = {
+          recipientId: draftToEdit.recipientId,
+          name:
+            messages.find(
+              m => m.triageGroupName === draftToEdit.triageGroupName,
+            )?.triageGroupName || draftToEdit.triageGroupName,
+          type: Recipients.CARE_TEAM,
+          status: RecipientStatus.ALLOWED,
+        };
 
-      if (!isAssociated || isBlocked) {
-        setShowBlockedTriageGroupAlert(true);
-        setBlockedTriageGroupList([formattedRecipient]);
+        setCurrentRecipient(tempRecipient);
       }
-    }
-    // The Blocked Triage Group alert should stay visible until the draft is sent or user navigates away
-  }, []);
+      // The Blocked Triage Group alert should stay visible until the draft is sent or user navigates away
+    },
+    [drafts, recipients],
+  );
 
   useEffect(
     () => {
@@ -144,11 +139,12 @@ const ReplyForm = props => {
           visible={cannotReply && !showBlockedTriageGroupAlert}
         />
 
-        {showBlockedTriageGroupAlert && (
+        {currentRecipient && (
           <BlockedTriageGroupAlert
-            blockedTriageGroupList={blockedTriageGroupList}
             alertStyle={BlockedTriageAlertStyles.ALERT}
             parentComponent={ParentComponent.REPLY_FORM}
+            currentRecipient={currentRecipient}
+            setShowBlockedTriageGroupAlert={setShowBlockedTriageGroupAlert}
           />
         )}
 

--- a/src/applications/mhv-secure-messaging/components/MessageList/FolderHeader.jsx
+++ b/src/applications/mhv-secure-messaging/components/MessageList/FolderHeader.jsx
@@ -125,7 +125,6 @@ const FolderHeader = props => {
                   ? BlockedTriageAlertStyles.INFO
                   : BlockedTriageAlertStyles.WARNING
               }
-              blockedTriageGroupList={[]}
               parentComponent={ParentComponent.FOLDER_HEADER}
             />
           )}

--- a/src/applications/mhv-secure-messaging/components/MessageThreadHeader.jsx
+++ b/src/applications/mhv-secure-messaging/components/MessageThreadHeader.jsx
@@ -15,10 +15,7 @@ import {
   RecipientStatus,
   BlockedTriageAlertStyles,
 } from '../util/constants';
-import {
-  scrollIfFocusedAndNotInView,
-  updateTriageGroupRecipientStatus,
-} from '../util/helpers';
+import { scrollIfFocusedAndNotInView } from '../util/helpers';
 import { closeAlert } from '../actions/alerts';
 import CannotReplyAlert from './shared/CannotReplyAlert';
 import BlockedTriageGroupAlert from './shared/BlockedTriageGroupAlert';
@@ -31,6 +28,7 @@ const MessageThreadHeader = props => {
     setIsCreateNewModalVisible,
     recipients,
   } = props;
+
   const {
     threadId,
     messageId,
@@ -50,7 +48,7 @@ const MessageThreadHeader = props => {
     showBlockedTriageGroupAlert,
     setShowBlockedTriageGroupAlert,
   ] = useState(false);
-  const [blockedTriageGroupList, setBlockedTriageGroupList] = useState([]);
+  const [currentRecipient, setCurrentRecipient] = useState(null);
 
   const messages = useSelector(state => state.sm.threadDetails.messages);
 
@@ -61,31 +59,25 @@ const MessageThreadHeader = props => {
     [history, messageId],
   );
 
-  useEffect(() => {
-    if (message) {
-      const tempRecipient = {
-        recipientId,
-        name:
-          messages.find(m => m.triageGroupName === message.triageGroupName)
-            ?.triageGroupName || message.triageGroupName,
-        type: Recipients.CARE_TEAM,
-        status: RecipientStatus.ALLOWED,
-      };
+  useEffect(
+    () => {
+      if (message) {
+        const tempRecipient = {
+          recipientId,
+          name:
+            messages.find(m => m.triageGroupName === message.triageGroupName)
+              ?.triageGroupName || message.triageGroupName,
+          type: Recipients.CARE_TEAM,
+          status: RecipientStatus.ALLOWED,
+        };
 
-      const {
-        isAssociated,
-        isBlocked,
-        formattedRecipient,
-      } = updateTriageGroupRecipientStatus(recipients, tempRecipient);
-
-      if (!isAssociated || isBlocked) {
-        setShowBlockedTriageGroupAlert(true);
-        setBlockedTriageGroupList([formattedRecipient]);
+        setCurrentRecipient(tempRecipient);
       }
-    }
 
-    // The Blocked Triage Group alert should stay visible until the user navigates away
-  }, []);
+      // The Blocked Triage Group alert should stay visible until the user navigates away
+    },
+    [message, recipients],
+  );
 
   useEffect(
     () => {
@@ -140,12 +132,13 @@ const MessageThreadHeader = props => {
         />
       </header>
 
-      {showBlockedTriageGroupAlert && (
+      {currentRecipient && (
         <div className="vads-u-margin-top--3 vads-u-margin-bottom--2">
           <BlockedTriageGroupAlert
-            blockedTriageGroupList={blockedTriageGroupList}
             alertStyle={BlockedTriageAlertStyles.ALERT}
             parentComponent={ParentComponent.MESSAGE_THREAD}
+            currentRecipient={currentRecipient}
+            setShowBlockedTriageGroupAlert={setShowBlockedTriageGroupAlert}
           />
         </div>
       )}

--- a/src/applications/mhv-secure-messaging/components/shared/BlockedTriageGroupAlert.jsx
+++ b/src/applications/mhv-secure-messaging/components/shared/BlockedTriageGroupAlert.jsx
@@ -88,14 +88,21 @@ const BlockedTriageGroupAlert = props => {
           );
 
           if (formattedRecipient.status === RecipientStatus.NOT_ASSOCIATED) {
-            setBlockedTriageList([formattedRecipient]);
+            if (blockedRecipients.length > 0) {
+              const organizedList = organizeBlockedList(
+                blockedRecipients,
+                blockedFacilityNames,
+              );
+              setBlockedTriageList(
+                sortTriageList([...organizedList, formattedRecipient]),
+              );
+            } else {
+              setBlockedTriageList([formattedRecipient]);
+            }
             setShowAlert(true);
             setShowBlockedTriageGroupAlert(true);
           } else if (formattedRecipient.status === RecipientStatus.BLOCKED) {
-            if (
-              parentComponent === ParentComponent.COMPOSE_FORM ||
-              parentComponent === ParentComponent.CONTACT_LIST
-            ) {
+            if (parentComponent === ParentComponent.COMPOSE_FORM) {
               const organizedList = organizeBlockedList(
                 blockedRecipients,
                 blockedFacilityNames,
@@ -112,6 +119,9 @@ const BlockedTriageGroupAlert = props => {
               setShowBlockedTriageGroupAlert(true);
             }
           }
+        } else if (noAssociations || allTriageGroupsBlocked) {
+          setShowAlert(true);
+          setShowBlockedTriageGroupAlert(true);
         } else if (
           parentComponent === ParentComponent.COMPOSE_FORM ||
           parentComponent === ParentComponent.CONTACT_LIST
@@ -126,9 +136,6 @@ const BlockedTriageGroupAlert = props => {
             setShowAlert(true);
             setShowBlockedTriageGroupAlert(true);
           }
-        } else if (noAssociations || allTriageGroupsBlocked) {
-          setShowAlert(true);
-          setShowBlockedTriageGroupAlert(true);
         }
       }
     },

--- a/src/applications/mhv-secure-messaging/components/shared/BlockedTriageGroupAlert.jsx
+++ b/src/applications/mhv-secure-messaging/components/shared/BlockedTriageGroupAlert.jsx
@@ -202,6 +202,8 @@ const BlockedTriageGroupAlert = props => {
             );
             if (blockedTriageList[0].status === RecipientStatus.BLOCKED) {
               setAlertInfoText(alertMessage.SINGLE_TEAM_BLOCKED);
+            } else {
+              setAlertInfoText(alertMessage.NO_ASSOCIATIONS);
             }
           }
         } else {

--- a/src/applications/mhv-secure-messaging/containers/EditContactList.jsx
+++ b/src/applications/mhv-secure-messaging/containers/EditContactList.jsx
@@ -50,13 +50,7 @@ const EditContactList = () => {
   );
 
   const recipients = useSelector(state => state.sm.recipients);
-  const {
-    allFacilities,
-    blockedFacilities,
-    blockedRecipients,
-    allRecipients,
-    error,
-  } = recipients;
+  const { allFacilities, blockedFacilities, allRecipients, error } = recipients;
 
   const ehrDataByVhaId = useSelector(selectEhrDataByVhaId);
 
@@ -133,15 +127,6 @@ const EditContactList = () => {
       setAllTriageTeams(allRecipients);
     },
     [allRecipients],
-  );
-
-  useEffect(
-    () => {
-      if (blockedRecipients?.length > 0) {
-        setShowBlockedTriageGroupAlert(true);
-      }
-    },
-    [blockedRecipients],
   );
 
   useEffect(() => {
@@ -247,18 +232,16 @@ const EditContactList = () => {
       )}
       {allTriageTeams?.length > 0 && (
         <>
-          {showBlockedTriageGroupAlert && (
-            <div
-              className={`${allFacilities?.length > 1 &&
-                'vads-u-margin-bottom--4'}`}
-            >
-              <BlockedTriageGroupAlert
-                blockedTriageGroupList={blockedRecipients}
-                alertStyle={BlockedTriageAlertStyles.ALERT}
-                parentComponent={ParentComponent.CONTACT_LIST}
-              />
-            </div>
-          )}
+          <div
+            className={`${allFacilities?.length > 1 &&
+              'vads-u-margin-bottom--4'}`}
+          >
+            <BlockedTriageGroupAlert
+              alertStyle={BlockedTriageAlertStyles.ALERT}
+              parentComponent={ParentComponent.CONTACT_LIST}
+              setShowBlockedTriageGroupAlert={setShowBlockedTriageGroupAlert}
+            />
+          </div>
 
           <form className="contactListForm">
             {allFacilities.map(stationNumber => {

--- a/src/applications/mhv-secure-messaging/containers/ThreadDetails.jsx
+++ b/src/applications/mhv-secure-messaging/containers/ThreadDetails.jsx
@@ -66,7 +66,7 @@ const ThreadDetails = props => {
 
   useEffect(
     () => {
-      if (threadId) {
+      if (threadId && recipients.associatedTriageGroupsQty !== undefined) {
         dispatch(retrieveMessageThread(threadId))
           .then(() => {
             setIsLoaded(true);
@@ -79,7 +79,7 @@ const ThreadDetails = props => {
         dispatch(closeAlert());
       };
     },
-    [dispatch, threadId, location.pathname],
+    [dispatch, threadId, location.pathname, recipients],
   );
 
   useEffect(
@@ -147,7 +147,11 @@ const ThreadDetails = props => {
         </>
       );
     }
-    if (drafts?.length === 1 && !messages?.length) {
+    if (
+      drafts?.length === 1 &&
+      !messages?.length
+      // recipients.allowedRecipients.length > 0
+    ) {
       updatePageTitle(PageTitles.EDIT_DRAFT_PAGE_TITLE_TAG);
       return (
         <div className="compose-container">

--- a/src/applications/mhv-secure-messaging/containers/ThreadDetails.jsx
+++ b/src/applications/mhv-secure-messaging/containers/ThreadDetails.jsx
@@ -66,7 +66,7 @@ const ThreadDetails = props => {
 
   useEffect(
     () => {
-      if (threadId && recipients.associatedTriageGroupsQty !== undefined) {
+      if (threadId) {
         dispatch(retrieveMessageThread(threadId))
           .then(() => {
             setIsLoaded(true);
@@ -79,7 +79,7 @@ const ThreadDetails = props => {
         dispatch(closeAlert());
       };
     },
-    [dispatch, threadId, location.pathname, recipients],
+    [dispatch, threadId, location.pathname],
   );
 
   useEffect(
@@ -147,11 +147,7 @@ const ThreadDetails = props => {
         </>
       );
     }
-    if (
-      drafts?.length === 1 &&
-      !messages?.length
-      // recipients.allowedRecipients.length > 0
-    ) {
+    if (drafts?.length === 1 && !messages?.length) {
       updatePageTitle(PageTitles.EDIT_DRAFT_PAGE_TITLE_TAG);
       return (
         <div className="compose-container">

--- a/src/applications/mhv-secure-messaging/reducers/recipients.js
+++ b/src/applications/mhv-secure-messaging/reducers/recipients.js
@@ -34,7 +34,8 @@ export const recipientsReducer = (state = initialState, action) => {
 
       return {
         ...state,
-        associatedTriageGroupsQty: associatedTriageGroups,
+        associatedTriageGroupsQty:
+          associatedTriageGroups === undefined ? null : associatedTriageGroups,
 
         associatedBlockedTriageGroupsQty: associatedBlockedTriageGroups,
 

--- a/src/applications/mhv-secure-messaging/tests/components/Compose/BlockedTriageGroupAlert.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/Compose/BlockedTriageGroupAlert.unit.spec.jsx
@@ -204,4 +204,43 @@ describe('BlockedTriageGroupAlert component', () => {
       expect(blockedTGs[2].textContent).to.equal('lost-association-team');
     });
   });
+
+  it('lost-association team appears in title of alert if only one team is not associated and no other groups are blocked', async () => {
+    const customState = {
+      ...initialState,
+      sm: {
+        ...initialState.sm,
+        recipients: {
+          associatedTriageGroupsQty: 4,
+          associatedBlockedTriageGroupsQty: 0,
+          blockedRecipients: [],
+        },
+      },
+    };
+
+    const screen = setup(customState, {
+      alertStyle: BlockedTriageAlertStyles.ALERT,
+      parentComponent: ParentComponent.COMPOSE_FORM,
+      currentRecipient: {
+        recipientId: 223344,
+        name: 'lost-association-team',
+        type: Recipients.CARE_TEAM,
+        status: RecipientStatus.ALLOWED,
+      },
+    });
+    screen.debug(undefined, 10000);
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('blocked-triage-group-alert'),
+      ).to.have.attribute(
+        'trigger',
+        'Your account is no longer connected to lost-association-team',
+      );
+      expect(
+        screen.getByText(
+          'If you need to contact your care team, call your VA health facility.',
+        ),
+      ).to.exist;
+    });
+  });
 });

--- a/src/applications/mhv-secure-messaging/tests/components/Compose/BlockedTriageGroupAlert.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/Compose/BlockedTriageGroupAlert.unit.spec.jsx
@@ -53,15 +53,26 @@ describe('BlockedTriageGroupAlert component', () => {
   });
 
   it('does not render a list of care teams if there is only 1', async () => {
-    const screen = setup(initialState, {
-      blockedTriageGroupList: [
-        {
-          name: '###PQR TRIAGE_TEAM 747###',
-          type: Recipients.CARE_TEAM,
-          status: RecipientStatus.BLOCKED,
+    const customState = {
+      ...initialState,
+      sm: {
+        ...initialState.sm,
+        recipients: {
+          associatedBlockedTriageGroupsQty: 1,
+          blockedRecipients: [{ id: 222333 }],
+          allRecipients: [{ id: 222333 }],
         },
-      ],
+      },
+    };
+    const screen = setup(customState, {
+      currentRecipient: {
+        recipientId: 222333,
+        name: '###PQR TRIAGE_TEAM 747###',
+        type: Recipients.CARE_TEAM,
+        status: RecipientStatus.BLOCKED,
+      },
       alertStyle: BlockedTriageAlertStyles.ALERT,
+      setShowBlockedTriageGroupAlert: () => {},
     });
     expect(screen.queryByTestId('blocked-triage-group')).to.not.exist;
     await waitFor(() => {
@@ -83,26 +94,27 @@ describe('BlockedTriageGroupAlert component', () => {
         recipients: {
           associatedTriageGroupsQty: 4,
           associatedBlockedTriageGroupsQty: 2,
+          blockedRecipients: [
+            {
+              name: '***Jeasmitha-Cardio-Clinic***',
+              type: Recipients.CARE_TEAM,
+              stationNumber: '662',
+              status: RecipientStatus.BLOCKED,
+            },
+            {
+              name: '###PQR TRIAGE_TEAM 747###',
+              type: Recipients.CARE_TEAM,
+              stationNumber: '636',
+              status: RecipientStatus.BLOCKED,
+            },
+          ],
         },
       },
     };
     const screen = setup(customState, {
-      blockedTriageGroupList: [
-        {
-          name: '***Jeasmitha-Cardio-Clinic***',
-          type: Recipients.CARE_TEAM,
-          stationNumber: '662',
-          status: RecipientStatus.BLOCKED,
-        },
-        {
-          name: '###PQR TRIAGE_TEAM 747###',
-          type: Recipients.CARE_TEAM,
-          stationNumber: '636',
-          status: RecipientStatus.BLOCKED,
-        },
-      ],
       alertStyle: BlockedTriageAlertStyles.ALERT,
       parentComponent: ParentComponent.COMPOSE_FORM,
+      setShowBlockedTriageGroupAlert: () => {},
     });
     await waitFor(() => {
       expect(
@@ -123,6 +135,7 @@ describe('BlockedTriageGroupAlert component', () => {
         recipients: {
           noAssociations: true,
           allTriageGroupsBlocked: false,
+          associatedBlockedTriageGroupsQty: 0,
         },
       },
     };
@@ -130,14 +143,18 @@ describe('BlockedTriageGroupAlert component', () => {
     const screen = setup(customState, {
       parentComponent: ParentComponent.FOLDER_HEADER,
       alertStyle: BlockedTriageAlertStyles.INFO,
+      setShowBlockedTriageGroupAlert: () => {},
     });
-    expect(
-      screen.queryByTestId('blocked-triage-group-alert'),
-    ).to.have.attribute('status', BlockedTriageAlertStyles.INFO);
-    expect(
-      screen.getByText(
-        "You're not connected to any care teams in this messaging tool",
-      ),
-    ).to.exist;
+    screen.debug(undefined, 10000);
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('blocked-triage-group-alert'),
+      ).to.have.attribute('status', BlockedTriageAlertStyles.INFO);
+      expect(
+        screen.getByText(
+          "You're not connected to any care teams in this messaging tool",
+        ),
+      ).to.exist;
+    });
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/components/Compose/BlockedTriageGroupAlert.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/Compose/BlockedTriageGroupAlert.unit.spec.jsx
@@ -228,7 +228,7 @@ describe('BlockedTriageGroupAlert component', () => {
         status: RecipientStatus.ALLOWED,
       },
     });
-    screen.debug(undefined, 10000);
+
     await waitFor(() => {
       expect(
         screen.queryByTestId('blocked-triage-group-alert'),

--- a/src/applications/mhv-secure-messaging/tests/components/Compose/BlockedTriageGroupAlert.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/Compose/BlockedTriageGroupAlert.unit.spec.jsx
@@ -72,7 +72,6 @@ describe('BlockedTriageGroupAlert component', () => {
         status: RecipientStatus.BLOCKED,
       },
       alertStyle: BlockedTriageAlertStyles.ALERT,
-      setShowBlockedTriageGroupAlert: () => {},
     });
     expect(screen.queryByTestId('blocked-triage-group')).to.not.exist;
     await waitFor(() => {
@@ -114,7 +113,6 @@ describe('BlockedTriageGroupAlert component', () => {
     const screen = setup(customState, {
       alertStyle: BlockedTriageAlertStyles.ALERT,
       parentComponent: ParentComponent.COMPOSE_FORM,
-      setShowBlockedTriageGroupAlert: () => {},
     });
     await waitFor(() => {
       expect(
@@ -143,7 +141,6 @@ describe('BlockedTriageGroupAlert component', () => {
     const screen = setup(customState, {
       parentComponent: ParentComponent.FOLDER_HEADER,
       alertStyle: BlockedTriageAlertStyles.INFO,
-      setShowBlockedTriageGroupAlert: () => {},
     });
     screen.debug(undefined, 10000);
     await waitFor(() => {
@@ -155,6 +152,56 @@ describe('BlockedTriageGroupAlert component', () => {
           "You're not connected to any care teams in this messaging tool",
         ),
       ).to.exist;
+    });
+  });
+
+  it('On editing a saved draft, includes a lost-association group in the alert if other teams are blocked', async () => {
+    const customState = {
+      ...initialState,
+      sm: {
+        ...initialState.sm,
+        recipients: {
+          associatedTriageGroupsQty: 4,
+          associatedBlockedTriageGroupsQty: 2,
+          blockedRecipients: [
+            {
+              name: '***Jeasmitha-Cardio-Clinic***',
+              type: Recipients.CARE_TEAM,
+              stationNumber: '662',
+              status: RecipientStatus.BLOCKED,
+            },
+            {
+              name: '###PQR TRIAGE_TEAM 747###',
+              type: Recipients.CARE_TEAM,
+              stationNumber: '636',
+              status: RecipientStatus.BLOCKED,
+            },
+          ],
+        },
+      },
+    };
+
+    const screen = setup(customState, {
+      alertStyle: BlockedTriageAlertStyles.ALERT,
+      parentComponent: ParentComponent.COMPOSE_FORM,
+      currentRecipient: {
+        recipientId: 223344,
+        name: 'lost-association-team',
+        type: Recipients.CARE_TEAM,
+        status: RecipientStatus.ALLOWED,
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('blocked-triage-group-alert'),
+      ).to.have.attribute(
+        'trigger',
+        "You can't send messages to some of your care teams",
+      );
+      const blockedTGs = screen.queryAllByTestId('blocked-triage-group');
+      expect(blockedTGs.length).to.equal(3);
+      expect(blockedTGs[2].textContent).to.equal('lost-association-team');
     });
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/components/Compose/ReplyDraftItem.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/components/Compose/ReplyDraftItem.unit.spec.jsx
@@ -185,6 +185,7 @@ describe('ReplyDraftItem component', () => {
     });
     await waitFor(() => {
       expect(refreshThreadCallbackSpy.calledOnce).to.be.true;
+      refreshThreadCallbackSpy.restore();
     });
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/containers/ThreadDetails.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/ThreadDetails.unit.spec.jsx
@@ -26,6 +26,7 @@ import oneBlockedRecipient from '../fixtures/json-triage-mocks/triage-teams-one-
 import noBlockedRecipients from '../fixtures/json-triage-mocks/triage-teams-mock.json';
 import noAssociationsAtAll from '../fixtures/json-triage-mocks/triage-teams-no-associations-at-all-mock.json';
 import lostAssociation from '../fixtures/json-triage-mocks/triage-teams-lost-association.json';
+import * as messagesActions from '../../actions/messages';
 
 describe('Thread Details container', () => {
   const setup = state => {
@@ -759,5 +760,54 @@ describe('Thread Details container', () => {
       'trigger',
       'Your account is no longer connected to SM_TO_VA_GOV_TRIAGE_GROUP_TEST',
     );
+  });
+
+  it('does not load if recipients.associatedTriageGroupsQty is undefined', async () => {
+    const state = {
+      sm: {
+        folders: {
+          folder: inbox,
+        },
+        threadDetails,
+        recipients: {
+          allRecipients: [],
+          allowedRecipients: [],
+          blockedRecipients: [],
+          associatedTriageGroupsQty: undefined,
+          associatedBlockedTriageGroupsQty: undefined,
+          noAssociations: undefined,
+          allTriageGroupsBlocked: undefined,
+        },
+      },
+      drupalStaticData: {
+        vamcEhrData: {
+          data: {
+            ehrDataByVhaId: [
+              {
+                facilityId: '662',
+                isCerner: false,
+              },
+              {
+                facilityId: '636',
+                isCerner: false,
+              },
+            ],
+          },
+        },
+      },
+      featureToggles: {},
+    };
+
+    const retrieveMessageThreadSpy = sinon.spy(
+      messagesActions,
+      'retrieveMessageThread',
+    );
+
+    setup(state);
+
+    await waitFor(() => {
+      expect(retrieveMessageThreadSpy.calledOnce).not.to.be.true;
+      retrieveMessageThreadSpy.restore();
+    });
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/containers/ThreadDetails.unit.spec.jsx
+++ b/src/applications/mhv-secure-messaging/tests/containers/ThreadDetails.unit.spec.jsx
@@ -26,7 +26,6 @@ import oneBlockedRecipient from '../fixtures/json-triage-mocks/triage-teams-one-
 import noBlockedRecipients from '../fixtures/json-triage-mocks/triage-teams-mock.json';
 import noAssociationsAtAll from '../fixtures/json-triage-mocks/triage-teams-no-associations-at-all-mock.json';
 import lostAssociation from '../fixtures/json-triage-mocks/triage-teams-lost-association.json';
-import * as messagesActions from '../../actions/messages';
 
 describe('Thread Details container', () => {
   const setup = state => {
@@ -762,7 +761,7 @@ describe('Thread Details container', () => {
     );
   });
 
-  it('does not load if recipients.associatedTriageGroupsQty is undefined', async () => {
+  it('does not display BlockedTriageGroupAlert if recipients API call is incomplete (meaning recipient values will be undefined)', async () => {
     const state = {
       sm: {
         folders: {
@@ -798,16 +797,11 @@ describe('Thread Details container', () => {
       featureToggles: {},
     };
 
-    const retrieveMessageThreadSpy = sinon.spy(
-      messagesActions,
-      'retrieveMessageThread',
+    const screen = setup(state);
+
+    const blockedTriageGroupAlert = await screen.queryByTestId(
+      'blocked-triage-group-alert',
     );
-
-    setup(state);
-
-    await waitFor(() => {
-      expect(retrieveMessageThreadSpy.calledOnce).not.to.be.true;
-      retrieveMessageThreadSpy.restore();
-    });
+    expect(blockedTriageGroupAlert).not.to.exist;
   });
 });

--- a/src/applications/mhv-secure-messaging/tests/e2e/fixtures/no-goups-association.json
+++ b/src/applications/mhv-secure-messaging/tests/e2e/fixtures/no-goups-association.json
@@ -3,6 +3,8 @@
        
     ],
     "meta": {
+        "associatedTriageGroups": 0,
+        "associatedBlockedTriageGroups": 0,
         "sort": {
             "name": "ASC"
         }

--- a/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientInboxPage.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/pages/PatientInboxPage.js
@@ -7,7 +7,6 @@ import mockRecipients from '../fixtures/recipients-response.json';
 import mockSpecialCharsMessage from '../fixtures/message-response-specialchars.json';
 import mockMessageDetails from '../fixtures/message-response.json';
 import mockThread from '../fixtures/thread-response.json';
-import mockNoRecipients from '../fixtures/no-recipients-response.json';
 import PatientInterstitialPage from './PatientInterstitialPage';
 import { AXE_CONTEXT, Locators, Assertions, Paths } from '../utils/constants';
 import mockSingleMessage from '../fixtures/inboxResponse/single-message-response.json';
@@ -237,7 +236,7 @@ class PatientInboxPage {
     return newMessage;
   };
 
-  loadPageForNoProvider = (doAxeCheck = false) => {
+  loadPageForNoProvider = (mockRecipientsResponse, doAxeCheck = false) => {
     const date = new Date();
     date.setDate(date.getDate() - 1);
     mockMessages.data.at(
@@ -291,7 +290,7 @@ class PatientInboxPage {
     cy.intercept(
       'GET',
       `${Paths.SM_API_BASE + Paths.RECIPIENTS}*`,
-      mockNoRecipients,
+      mockRecipientsResponse,
     ).as('recipients');
 
     cy.visit(Paths.UI_MAIN + Paths.INBOX);

--- a/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-all-groups-alerts.cypress.spec.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/triage-team-tests/secure-messaging-all-groups-alerts.cypress.spec.js
@@ -1,7 +1,7 @@
-import PatientInboxPage from './pages/PatientInboxPage';
-import SecureMessagingSite from './sm_site/SecureMessagingSite';
-import noAssociationResponse from './fixtures/no-goups-association.json';
-import { AXE_CONTEXT, Locators, Paths, Alerts } from './utils/constants';
+import PatientInboxPage from '../pages/PatientInboxPage';
+import SecureMessagingSite from '../sm_site/SecureMessagingSite';
+import noAssociationResponse from '../fixtures/no-goups-association.json';
+import { AXE_CONTEXT, Locators, Paths, Alerts } from '../utils/constants';
 
 describe('SM TRIAGE GROUPS ALERTS', () => {
   it('user not associated with any group', () => {

--- a/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
+++ b/src/applications/mhv-secure-messaging/tests/e2e/utils/constants.js
@@ -159,7 +159,7 @@ export const Locators = {
     HEADER: `#heading`,
     MODEL_TITLE_ALERT: '.va-modal-alert-title',
     TRIAGE_ALERT: '[data-testid="blocked-triage-group-alert"] > div > a',
-    TRIAGE_GROUP: '[data-testid="blocked-triage-group-alert"]>h2',
+    TRIAGE_GROUP: '[data-testid="blocked-triage-group-alert"]',
     CLOSE_NOTIFICATION: '.va-alert',
     REPT_SELECT: '[data-testid="compose-recipient-select"]',
     DRAFT_MODAL: '[data-testid="delete-draft-modal"]',
@@ -262,6 +262,8 @@ export const Alerts = {
     HEADER: `You can't send messages to`,
     PARAGRAPH:
       'If you need to contact this care team, call your VA health facility.',
+    ALL_PARAGRAPH:
+      'If you need to contact your care teams, call your VA health facility.',
     LINK: 'Find your VA health facility',
   },
   CONTACT_LIST: {

--- a/src/applications/mhv-secure-messaging/util/helpers.js
+++ b/src/applications/mhv-secure-messaging/util/helpers.js
@@ -337,10 +337,14 @@ export const updateTriageGroupRecipientStatus = (recipients, tempRecipient) => {
   );
 
   // if TG is not associated or is blocked, formattedRecipient will include status of "not associated" or "blocked"
-  if (!isAssociated) {
-    formattedRecipient.status = RecipientStatus.NOT_ASSOCIATED;
-  } else if (isBlocked) {
-    formattedRecipient.status = RecipientStatus.BLOCKED;
+  if (formattedRecipient) {
+    if (!isAssociated) {
+      formattedRecipient.status = RecipientStatus.NOT_ASSOCIATED;
+    } else if (isBlocked) {
+      formattedRecipient.status = RecipientStatus.BLOCKED;
+    } else {
+      formattedRecipient.status = RecipientStatus.ALLOWED;
+    }
   }
 
   return { isAssociated, isBlocked, formattedRecipient };


### PR DESCRIPTION
**Note**: Delete the description statements, complete each step. **None are optional**, but can be justified as to why they cannot be completed as written. Provide known gaps to testing that may raise the risk of merging to production.

## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

## Summary

- bug:  on an edit draft, if the page is refreshed, the blocked triage group alert would occasionally appear, even though there were no blocked triage groups.  This was happening because the Edit draft page would load before the recipients api call would finish.
fix: adding a condition to the useEffect where "isLoaded" is set to check whether or not the values in the recipients slice of redux have been set, and only loading the draft it it is not "undefined"

## Related issue(s)

### [MHV-59706](https://jira.devops.va.gov/browse/MHV-59706) - Blocked TG warning message in mobile and desktop view, even when user is not blocked from TG. ###

> User see the blocked TG waring message in mobile AND DESKTOP view, even when user is not blocked from TG. This happening only in the Draft folder.
> 
> TG Alert identifier: "blocked-triage-group-alert"
> 
> Step to Reproduce.
> 1) Login to va.gov SM
> 2) Navigate to Drafts folder
> 3) Open any draft message.
> 4) Change web view from mobile view
> 5) Refresh the page
> 6) User see the warning message "Your account is no longer connected to TG "
> 
> Feature Flag Y/N ? N
> 
> Manual Testing Y/N ? Y-Rakesh
> 
> Automated Testing Y/N ? N
> 
> Accessibility Testing Y/N ? N
> 
> UCD Validation Y/N N
> 
> Acceptance Criteria:
> 
> AC1 User does not see the blocked triage group warning message in the scenario described above

## Testing done

- manual testing, updated unit test

## Screenshots

_Note: This field is mandatory for UI changes (non-component work should NOT have screenshots)._

|         | Before | After |
| ------- | ------ | ----- |
| Mobile  |        |       |
| Desktop |        |       |

## What areas of the site does it impact?

va.gov - secure messaging

## Acceptance criteria

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user

## Requested Feedback

(OPTIONAL) _What should the reviewers know in addition to the above. Is there anything specific you wish the reviewer to assist with. Do you have any concerns with this PR, why?_
