### PR TITLE
Adds renderAriaLabel prop to NewTabAnchor in VAOS

### DIFF
--- a/src/applications/vaos/components/FacilityDirectionsLink.jsx
+++ b/src/applications/vaos/components/FacilityDirectionsLink.jsx
@@ -49,6 +49,7 @@ export default function FacilityDirectionsLink({ location, icon }) {
     <span>
       <NewTabAnchor
         href={`https://maps.google.com?saddr=Current+Location&daddr=${address}`}
+        renderAriaLabel={false}
       >
         {icon && <va-icon icon="directions" size="3" />}
         Directions

--- a/src/applications/vaos/components/NewTabAnchor.jsx
+++ b/src/applications/vaos/components/NewTabAnchor.jsx
@@ -13,17 +13,27 @@ import PropTypes from 'prop-types';
  * @param {Object} params
  * @param {String} params.href The URL that the hyperlink points to.
  * @param {String} params.children Text describing the link destination.
+ * @param {Boolean} [params.renderAriaLabel=true] Whether to render an aria-label attribute
+
  * @returns Wrapped anchor tag
  */
-function NewTabAnchor({ href, 'aria-label': label, ...props }) {
+function NewTabAnchor({
+  href,
+  renderAriaLabel = true,
+  'aria-label': label,
+  ...props
+}) {
   const msg = 'Link opens in a new tab.';
+  const ariaLabelContent = label
+    ? `${label} ${msg}`
+    : `${props.children} ${msg}`;
 
   return (
     <a
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      aria-label={label ? `${label} ${msg}` : `${props.children} ${msg}`}
+      {...(renderAriaLabel ? { 'aria-label': ariaLabelContent } : {})}
       {...props}
     >
       {props.children}
@@ -34,6 +44,8 @@ function NewTabAnchor({ href, 'aria-label': label, ...props }) {
 NewTabAnchor.propTypes = {
   children: PropTypes.any.isRequired,
   href: PropTypes.string.isRequired,
+  'aria-label': PropTypes.string,
+  renderAriaLabel: PropTypes.bool,
 };
 
 export default NewTabAnchor;


### PR DESCRIPTION
## Summary

This adds an new optional prop to the `NewTabAnchor` component, the default value is `true` and does not impact any existing uses of this component. Because we construct the rendered `aria-label` value from either a passed prop or passed children there was no way to not render the `aria-label` attribute if we wanted to, such is the case in the issue mentioned below.

This resolves and issue associated with a previous PR: https://github.com/department-of-veterans-affairs/vets-website/pull/32609

## Related issue(s)
https://github.com/department-of-veterans-affairs/va.gov-team/issues/93260

## Testing done
- Unit testing
- e2e testing
- Source inspection



## Screenshots

**When `renderAriaLabel = false`**
<img width="688" alt="image" src="https://github.com/user-attachments/assets/d83a5de1-c4de-4244-bc1f-dfb85c380b60">

**When `renderAriaLabel = true` (default)**
<img width="624" alt="image" src="https://github.com/user-attachments/assets/01266618-6573-419f-904d-7da4eda902d0">


## Acceptance criteria
- [ ] The `aria-label` attribute should not be rendered on the facilities direction link on the appointment details page
- [ ] Other instances of `NewTabAnchor` should render the `aria-label` attribute

### Quality Assurance & Testing

- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [ ] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [ ] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
