### PR TITLE
[21-0972] Require email address for the preparer

### DIFF
--- a/src/applications/simple-forms/21-0972/pages/preparerContactInformation.js
+++ b/src/applications/simple-forms/21-0972/pages/preparerContactInformation.js
@@ -17,6 +17,6 @@ export default {
       preparerPhone: phoneSchema,
       preparerEmail: emailSchema,
     },
-    required: ['preparerPhone'],
+    required: ['preparerPhone', 'preparerEmail'],
   },
 };

--- a/src/applications/simple-forms/21-0972/tests/e2e/fixtures/data/minimal-test.json
+++ b/src/applications/simple-forms/21-0972/tests/e2e/fixtures/data/minimal-test.json
@@ -11,6 +11,7 @@
     "postalCode": "12345"
   },
   "preparerPhone": "9876054321",
+  "preparerEmail": "arthur.k.preparer@email.com",
   "claimantIdentification": "VETERAN",
   "preparerQualifications": {
     "courtAppointedRep": true

--- a/src/applications/simple-forms/21-0972/tests/pages/preparerContactInformation.unit.spec.jsx
+++ b/src/applications/simple-forms/21-0972/tests/pages/preparerContactInformation.unit.spec.jsx
@@ -20,7 +20,7 @@ testNumberOfWebComponentFields(
   pageTitle,
 );
 
-const expectedNumberOfErrors = 1;
+const expectedNumberOfErrors = 2;
 testNumberOfErrorsOnSubmitForWebComponents(
   formConfig,
   schema,


### PR DESCRIPTION
## Summary
This updates the preparer's email address in 21-0972 to be required.

## Related issue(s)
department-of-veterans-affairs/va.gov-team-forms#1757

## Testing done
Minimal E2E test updated

## Screenshots
![image](https://github.com/user-attachments/assets/5c9a5a93-9ba1-44a7-a489-269327ffdb41)
