### PR TITLE
VAGT-95711 Search only displays the maintenance banner when enabled and searches error

### DIFF
--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -321,7 +321,8 @@ const SearchApp = ({
           >
             {// Search API returned errors OR
             // errors with user input before submitting
-            shouldShowErrorMessage && <Errors userInput={userInput} />}
+            shouldShowErrorMessage &&
+              !searchGovIssues && <Errors userInput={userInput} />}
             {searchGovIssues && (
               <SearchMaintenance unexpectedMaintenance={searchGovMaintenance} />
             )}

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -300,7 +300,7 @@ const SearchApp = ({
     !hasErrors &&
     !searchIsLoading;
 
-  const searchGovIssues =
+  const shouldShowMaintenanceBanner =
     searchGovIssuesWithinMaintenanceWindow || searchGovMaintenance;
 
   return (
@@ -322,8 +322,8 @@ const SearchApp = ({
             {// Search API returned errors OR
             // errors with user input before submitting
             shouldShowErrorMessage &&
-              !searchGovIssues && <Errors userInput={userInput} />}
-            {searchGovIssues && (
+              !shouldShowMaintenanceBanner && <Errors userInput={userInput} />}
+            {shouldShowMaintenanceBanner && (
               <SearchMaintenance unexpectedMaintenance={searchGovMaintenance} />
             )}
             <div className="vads-u-background-color--gray-lightest vads-u-padding-x--3 vads-u-padding-bottom--3 vads-u-padding-top--1p5 vads-u-margin-bottom--4">

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -319,11 +319,13 @@ const SearchApp = ({
             appTitle="Search App"
             dependencies={[externalServices.search]}
           >
-            {// Search API returned errors OR
-            // errors with user input before submitting
+            {// Search API returned errors OR errors with user input before
+            //  submitting AND the maintenance banner is NOT going to be displayed
             shouldShowErrorMessage &&
               !shouldShowMaintenanceBanner && <Errors userInput={userInput} />}
-            {shouldShowMaintenanceBanner && (
+            {// Search API is either within the maintenance window AND has returned
+            //  no results OR the search_gov_maintenance Flipper has been enabled
+            shouldShowMaintenanceBanner && (
               <SearchMaintenance unexpectedMaintenance={searchGovMaintenance} />
             )}
             <div className="vads-u-background-color--gray-lightest vads-u-padding-x--3 vads-u-padding-bottom--3 vads-u-padding-top--1p5 vads-u-margin-bottom--4">

--- a/src/applications/search/tests/e2e/unexpected-outage.cypress.spec.js
+++ b/src/applications/search/tests/e2e/unexpected-outage.cypress.spec.js
@@ -70,8 +70,8 @@ describe('Unexpected outage from Search.gov', () => {
     cy.get(s.APP).within(() => {
       cy.get(s.OUTAGE_BOX)
         .should('exist')
-        .and('contain', 'We’re working on Search VA.gov right now.')
-        .and('not.contain', 'Something went wrong on our end,');
+        .and('contain', 'We’re working on Search VA.gov right now.');
+      cy.get(s.ERROR_ALERT_BOX).should('not.exist');
     });
   };
 
@@ -84,10 +84,10 @@ describe('Unexpected outage from Search.gov', () => {
 
   const verifySearchFailureBanner = () => {
     cy.get(s.APP).within(() => {
-      cy.get(s.OUTAGE_BOX)
+      cy.get(s.ERROR_ALERT_BOX)
         .should('exist')
-        .and('contain', 'Something went wrong on our end,')
-        .and('not.contain', 'We’re working on Search VA.gov right now.');
+        .and('contain', 'Something went wrong on our end,');
+      cy.get(s.OUTAGE_BOX).should('not.exist');
     });
   };
 

--- a/src/applications/search/tests/e2e/unexpected-outage.cypress.spec.js
+++ b/src/applications/search/tests/e2e/unexpected-outage.cypress.spec.js
@@ -53,7 +53,7 @@ describe('Unexpected outage from Search.gov', () => {
     });
   };
 
-  const verifyBanner = () => {
+  const verifyMaintanenceBanner = () => {
     cy.get(s.APP).within(() => {
       cy.get(s.OUTAGE_BOX)
         .should('exist')
@@ -68,12 +68,21 @@ describe('Unexpected outage from Search.gov', () => {
     });
   };
 
+  const verifySearchFailureBanner = () => {
+    cy.get(s.APP).within(() => {
+      cy.get(s.OUTAGE_BOX)
+        .should('exist')
+        .and('contain', 'Something went wrong on our end,');
+    });
+  };
+
   it('should show the outage banner and results when the toggle is on and results are returned', () => {
     enableToggle();
     mockResults();
     cy.visit('/search?query=benefits');
     cy.injectAxeThenAxeCheck();
-    verifyBanner();
+    verifyMaintanenceBanner();
+    verifySearchFailureBanner();
     checkForResults();
   });
 
@@ -82,7 +91,8 @@ describe('Unexpected outage from Search.gov', () => {
     mockResultsEmpty();
     cy.visit('/search?query=benefits');
     cy.injectAxeThenAxeCheck();
-    verifyBanner();
+    verifyMaintanenceBanner();
+    verifySearchFailureBanner();
     verifyNoResults();
   });
 
@@ -91,7 +101,8 @@ describe('Unexpected outage from Search.gov', () => {
     mockResultsFailure();
     cy.visit('/search?query=benefits');
     cy.injectAxeThenAxeCheck();
-    verifyBanner();
+    verifyMaintanenceBanner();
+    verifySearchFailureBanner();
     verifyNoResults();
   });
 });


### PR DESCRIPTION
## Are you removing, renaming or moving a folder in this PR?
- [x] No, I'm not changing any folders (skip to TeamSites and delete the rest of this section)
- [ ] Yes, I'm removing, renaming or moving a folder

Did you change site-wide styles, platform utilities or other infrastructure?
- [x] No
- [ ] Yes, and I used the [proxy-rewrite steps](https://github.com/department-of-veterans-affairs/vets-website/tree/main/src/applications/proxy-rewrite#that-sounds-normal-so-whats-the-proxy-all-about) to test the injected header scenario

## Summary

- This makes it so that search errors will only display the maintenance banner if it is enabled via the flipper flag
- Currently if a search fails while the maintenance banner, the user sees both an error message and maintenance message
- This solution allows the error message to still display when maintenance banner is disabled while keeping the maintenance banner always displaying when enabled so that the user receives the banner regardless of search results.
- Sitewide, yes
- `search_gov_maintenance` flipper

## Related issue(s)

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95711
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/95596

## Testing done

- Due to this requiring search API failure and staging banners this was unable to be tested on local environments

## What areas of the site does it impact?

Search results error and maintenance banners

## Acceptance criteria
- [x] When any Search.gov maintenance banner is present, the results should display if successful search
- [x]When the maintenance banner is present and search fails, ONLY the maintenance banner should display to the user

### Quality Assurance & Testing

- [x] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [x] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [ ] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [x] Browser console contains no warnings or errors.
- [x] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)


