### PR TITLE
MHV-62897 & MHV-63620: Minor accessbility updates to Medications List page

### DIFF
--- a/src/applications/mhv-medications/components/MedicationsList/MedicationsList.jsx
+++ b/src/applications/mhv-medications/components/MedicationsList/MedicationsList.jsx
@@ -47,7 +47,8 @@ const MedicationsList = props => {
 
   return (
     <>
-      <h2
+      <h2 className="sr-only no-print">List of Medications</h2>
+      <p
         className="rx-page-total-info vads-u-font-family--sans"
         data-testid="page-total-info"
         id="showingRx"
@@ -60,7 +61,7 @@ const MedicationsList = props => {
         <span className="print-only">
           {`Showing ${totalMedications} medications, ${sortOptionLowercase}`}
         </span>
-      </h2>
+      </p>
       <div className="no-print rx-page-total-info vads-u-border-bottom--2px vads-u-border-color--gray-lighter" />
       <div className="print-only vads-u-margin--0 vads-u-width--full">
         {rxList?.length > 0 &&

--- a/src/applications/mhv-medications/components/shared/ExtraDetails.jsx
+++ b/src/applications/mhv-medications/components/shared/ExtraDetails.jsx
@@ -66,11 +66,11 @@ const ExtraDetails = rx => {
           data-testid="submitted-refill-request"
         >
           <va-icon icon="fact_check" size={3} aria-hidden="true" />
-          <div className="vads-u-padding-left--2">
+          <span className="vads-u-padding-left--2">
             We got your request on{' '}
             {dateFormat(rx.refillSubmitDate, 'MMMM D, YYYY')}. Check back for
             updates.
-          </div>
+          </span>
         </p>
       )}
       {dispStatus === dispStatusObj.activeParked && (


### PR DESCRIPTION
## Summary

1. Added sr-only `H2` to Medications List page
2. Changed "Showing x to x..." phrase from `H2` to `P`
3. Fixed `div` inside `p` for Active: Submitted medications 

## Related issue(s)

https://jira.devops.va.gov/browse/MHV-63620
https://jira.devops.va.gov/browse/MHV-62897

<img width="944" alt="image" src="https://github.com/user-attachments/assets/26dbb2e4-25b5-4664-aaa7-0d95e092cbe0">
<img width="969" alt="image" src="https://github.com/user-attachments/assets/bb4dce5b-0552-4820-8a1c-3150ac9de367">

## Testing done

- Manual testing

## Screenshots

<img width="515" alt="Screenshot 2024-10-23 at 3 01 17 PM" src="https://github.com/user-attachments/assets/59b92963-6e60-413f-a42c-6549764d1705">

## What areas of the site does it impact?

/my-health/medications

## Acceptance criteria

AC1 Semantic bug that is being displayed is fixed
AC2 Checked over by accessibility 

AC1: Implement sr-only headings so that the H1 is Medications and add an H2 that is visually hidden but accessible for screen readers, labeled as "List of Medications." This will be right before the text of "Showing x to x..." in the DOM
AC2: The "Showing x to x...." phrase will be changed to a p-tag in the HTML so it remains visible
AC3: Accessibility has verified these changes

### Quality Assurance & Testing

- [ ] I fixed|updated|added unit tests and integration tests for each feature (if applicable).
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
- [X] Linting warnings have been addressed
- [ ] Documentation has been updated ([link to documentation](#) \*if necessary)
- [X] Screenshot of the developed feature is added
- [ ] [Accessibility testing](https://depo-platform-documentation.scrollhelp.site/developer-docs/wcag-2-1-success-criteria-and-foundational-testing) has been performed

### Error Handling

- [X] Browser console contains no warnings or errors.
- [ ] Events are being sent to the appropriate logging solution
- [ ] Feature/bug has a monitor built into Datadog or Grafana (if applicable)

### Authentication

- [ ] Did you login to a local build and verify all authenticated routes work as expected with a test user
